### PR TITLE
Update to Pandoc 2.7.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,6 +78,7 @@
 * Allow fuzzy matches in help topic search (#3316)
 * The diagnostics system better handles missing expressions (#5660)
 * Keyboard shortcuts for debugging commands can be customized (#3539)
+* Update Pandoc to 2.7.3 (#4512)
 * Update SumatraPDF to version 3.1.2 (#3155)
 * Allow previewing PDFs in fullscreen mode in Sumatra PDF (#4301)
 * RStudio Server runtime files are stored in `/var/run`, or another configurable location, instead of `/tmp` (#4666)

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -3,7 +3,7 @@
 #
 # install-pandoc
 #
-# Copyright (C) 2009-18 by RStudio, Inc.
+# Copyright (C) 2009-19 by RStudio, Inc.
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -20,7 +20,7 @@ set -e
 source rstudio-tools
 
 # variables that control download + installation process
-PANDOC_VERSION="2.3.1"
+PANDOC_VERSION="2.7.3"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
 PANDOC_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/pandoc/${PANDOC_VERSION}"
 

--- a/dependencies/tools/upload-pandoc.sh
+++ b/dependencies/tools/upload-pandoc.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# This script copies Pandoc release binaries into the RStudio Build Tools
+# (rstudio-buildtools) S3 bucket. Presumes you've already got AWS command line
+# tools (awscli) installed, and configured with a valid AWS account.
+# 
+# Pandoc is not shy about changing the formulation of their paths and download
+# filenames, so tweaking for new releases is expected.
+
+# Modify to set the Pandoc version to upload
+PANDOC_VERSION=2.7.3
+
+for PLATFORM in linux.tar.gz macOS.zip windows-x86_64.zip; do
+
+    # Form filename from version and platform
+    FILENAME=pandoc-$PANDOC_VERSION-$PLATFORM
+
+    # Download from Pandoc release site
+    wget https://github.com/jgm/pandoc/releases/download/$PANDOC_VERSION/$FILENAME
+
+    # Upload to S3 bucket
+    aws s3 cp $FILENAME s3://rstudio-buildtools/pandoc/$PANDOC_VERSION/ --acl public-read
+
+    # Clean up
+    rm $FILENAME
+done

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -19,7 +19,7 @@ set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 set OPENSSL_FILES=openssl-1.1.1b.zip
 set BOOST_FILES=boost-1.69.0-win-msvc141.zip
 
-set PANDOC_VERSION=2.7.2
+set PANDOC_VERSION=2.7.3
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%-windows-x86_64
 set PANDOC_FILE=%PANDOC_NAME%.zip
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -513,11 +513,7 @@ if (NOT RSTUDIO_SESSION_WIN32)
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
 
    # install pandoc
-   if(WIN32)
-      set(PANDOC_VERSION "2.7.2" CACHE INTERNAL "Pandoc version")
-   else()
-      set(PANDOC_VERSION "2.3.1" CACHE INTERNAL "Pandoc version")
-   endif()
+   set(PANDOC_VERSION "2.7.3" CACHE INTERNAL "Pandoc version")
 
    set(PANDOC_BIN "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc/${PANDOC_VERSION}")
    file(GLOB PANDOC_FILES "${PANDOC_BIN}/pandoc*")


### PR DESCRIPTION
This change updates Pandoc to 2.7.3 on all platforms. This isn't, strictly speaking, the latest version of Pandoc. However, it is the last release in the 2.7 series, and 2.8 was released very recently with lots of churn so probably not safe to pull it in yet. 

It also adds a script to upload new versions of Pandoc to the build tools folder, which will save seconds and seconds of developer time. 

We have been using 2.7.2 on Windows for a while without incident, so we don't expect any trouble. 

Closes #4512. 