### PR TITLE
fix tab-trap in gitignore edit field

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/IgnoreDialog.java
@@ -51,6 +51,7 @@ public class IgnoreDialog extends ModalDialogBase
       editor_ = new AceEditor();
       editor_.setUseWrapMode(false);
       editor_.setShowLineNumbers(false);
+      editor_.setTabAlwaysMovesFocus();
       editor_.setTextInputAriaLabel("Ignored files");
       
       ignoresCaption_ = new CaptionWithHelp("Ignore:",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -100,6 +100,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEdito
 import org.rstudio.studio.client.workbench.views.output.lint.DiagnosticsBackgroundPopup;
 import org.rstudio.studio.client.workbench.views.output.lint.model.AceAnnotation;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget.TabKeyMode;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceAfterCommandExecutedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceBackgroundHighlighter;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceClickEvent.Handler;
@@ -4019,7 +4020,12 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().setTextInputAriaLabel(label);
    }
-   
+
+   public void setTabAlwaysMovesFocus()
+   {
+      widget_.setTabKeyMode(TabKeyMode.AlwaysMoveFocus);
+   }
+
    public final void setScrollSpeed(double speed)
    {
       widget_.getEditor().setScrollSpeed(speed);


### PR DESCRIPTION
- Tab and Shift+Tab will now always move focus out of the text editor for gitignore files; ability to indent/outdent seems unnecessary in this particular Ace instance

<img width="424" alt="2019-12-04_12-11-12" src="https://user-images.githubusercontent.com/10569626/70177530-680c6a80-168f-11ea-9d80-af65980802c9.png">
