### PR TITLE
change background of read-only textboxes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -28,6 +28,7 @@
 @external gwt-TabLayoutPanelTabs;
 @external gwt-DecoratedPopupPanel;
 @external editor_dark;
+@external gwt-TextBox-readonly;
 
 /* These are exposed to allow users to customize RStudio further with their rsthemes. */
 @external rstheme_tabLayoutCenter;
@@ -267,6 +268,10 @@ button, input[type="reset"], input[type="button"], input[type="submit"] {
    margin: -1px;
    overflow: hidden;
    padding: 0;
+}
+
+.gwt-TextBox-readonly {
+   background: #f3f4f4;
 }
 
 .gwt-Label {


### PR DESCRIPTION
- Fixes #5811 (at least partially)

In places where we show read-only text boxes, most commonly in file/directory pickers, make background the same as the dialog color to give a hint of its read-only-ness. Can still get keyboard focus allowing selection and copying (and screen reader ... reading).

Making these editable is deemed too much work at this stage due to need to revisit each usage and potentially relocate validation code, etc.

<img width="535" alt="2019-12-04_12-17-52" src="https://user-images.githubusercontent.com/10569626/70178227-c38b2800-1690-11ea-8526-538a4d3224dd.png">

Here's an example of an editable picker, for contrast.

<img width="782" alt="2019-12-04_12-23-32" src="https://user-images.githubusercontent.com/10569626/70178333-f1706c80-1690-11ea-8fb7-c5caf753f28e.png">
