### PR TITLE
rebuild pre-compiled headers when Makevars changes

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -126,6 +126,7 @@ private:
    std::string packageBuildFileHash_;
    CompilationConfig packageCompilationConfig_;
    bool usePrecompiledHeaders_;
+   bool forceRebuildPrecompiledHeaders_;
    bool restoredCompilationConfig_;
 };
 


### PR DESCRIPTION
This PR forces RStudio to rebuild precompiled headers (as well as the cached compilation arguments) when `~/.R/Makevars[.win]` has changed.

Closes #5806.