### PR TITLE
provide string overloads when setting error

### DIFF
--- a/src/cpp/core/include/core/json/JsonRpc.hpp
+++ b/src/cpp/core/include/core/json/JsonRpc.hpp
@@ -489,6 +489,14 @@ public:
    
    void setError(const core::Error& error,
                  bool includeErrorProperties = false);
+   
+   void setError(const core::Error& error,
+                 const char* message,
+                 bool includeErrorProperties = false);
+   
+   void setError(const core::Error& error,
+                 const std::string& message,
+                 bool includeErrorProperties = false);
 
    void setError(const core::Error& error,
                  const Value& clientInfo,

--- a/src/cpp/core/json/JsonRpc.cpp
+++ b/src/cpp/core/json/JsonRpc.cpp
@@ -253,6 +253,21 @@ void JsonRpcResponse::setError(const Error& error,
 {   
    setError(error, Value(), includeErrorProperties);
 }
+
+void JsonRpcResponse::setError(const Error& error,
+                               const char* message,
+                               bool includeErrorProperties)
+{   
+   setError(error, Value(message), includeErrorProperties);
+}
+
+void JsonRpcResponse::setError(const Error& error,
+                               const std::string& message,
+                               bool includeErrorProperties)
+{   
+   setError(error, Value(message), includeErrorProperties);
+}
+
    
 void JsonRpcResponse::setError(const boost::system::error_code& ec,
                                const Value& clientInfo)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1201,6 +1201,7 @@ bool isTextFile(const FilePath& targetPath)
           boost::algorithm::ends_with(fileType, "+xml") ||
           boost::algorithm::ends_with(fileType, "/xml") ||
           boost::algorithm::ends_with(fileType, "x-empty") ||
+          boost::algorithm::equals(fileType, "application/json") ||
           boost::algorithm::equals(fileType, "application/postscript");
 #else
 


### PR DESCRIPTION
Otherwise, calls like `pResponse->setError(error, "a message")` will
have the const char* string implicitly converted to bool, unexpectedly
selecting the overload `setError(Error, bool)`.

Also fix an issue where RStudio would fail to open certain JSON files --
specifically, those detected as 'application/json' as opposed to
'text/json'. renv.lock is one such file that is sometimes detected in
this way.