### PR TITLE
Install package dependencies using a script job

### DIFF
--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -32,6 +32,7 @@
 #include <session/projects/SessionProjects.hpp>
 #include <session/prefs/UserPrefs.hpp>
 
+#include "jobs/ScriptJob.hpp"
 
 using namespace rstudio::core;
 
@@ -310,106 +311,94 @@ Error installDependencies(const json::JsonRpcRequest& request,
    if (error)
       LOG_ERROR(error);
 
-   // R binary
-   FilePath rProgramPath;
-   error = module_context::rScriptPath(&rProgramPath);
-   if (error)
-      return error;
+   // Start script with all the CRAN download settings
+   std::string script = module_context::CRANDownloadOptions() + "\n\n";
 
-   // options
-   core::system::ProcessOptions options;
-   options.terminateChildren = true;
-   options.redirectStdErrToStdOut = true;
-
-   // build lists of cran packages and archives
-   std::vector<std::string> cranPackages;
-   std::vector<std::string> cranSourcePackages;
-   std::vector<std::string> embeddedPackages;
-   for (const Dependency& dep : deps)
+   // Emit a message to the user at the beginning of the script declaring what we're about to do
+   if (deps.size() > 1)
    {
+      script += "cat('Installing R packages: ";
+      for (size_t i = 0; i < deps.size(); i++)
+      {
+         script += "\\'" + deps[i].name + "\\'";
+         if (i < deps.size() - 1)
+            script += ", ";
+      }
+      script += "\\n\\n')\n";
+   }
+   else
+   {
+      script += "cat('Installing " + deps[0].name + "...\\n\\n')\n";
+   }
+
+   for (size_t i = 0; i < deps.size(); i++)
+   {
+      const Dependency& dep = deps[i];
+
+      // Add a comment header with the name of the package. This will result in better progress
+      // treatment, since comment headers are used to show the currently executing section of a
+      // script.
+      script += "# " + dep.name + " -------------\n\n";
+
+      // If there's more than one dependency, indicate which one is being installed.
+      if (deps.size() > 1)
+      {
+         script += "cat('\\n[" + 
+            safe_convert::numberToString(i + 1) + 
+            "/" + 
+            safe_convert::numberToString(deps.size()) +
+            "] Installing " + dep.name + "...\\n\\n')\n";
+      }
+
       if (dep.location == kCRANPackageDependency)
       {
-         if (dep.source)
-            cranSourcePackages.push_back("'" + dep.name + "'");
-         else
-            cranPackages.push_back("'" + dep.name + "'");
+         // Build install command for CRAN
+         script += "utils::install.packages('" + dep.name + "', " +
+                "repos = '"+ module_context::CRANReposURL() + "'";
+
+         if (dep.source) 
+         {
+            // Install from source if requested
+            script += ", type = 'source'";
+         }
+
+         script += ")";
       }
       else if (dep.location == kEmbeddedPackageDependency)
       {
          EmbeddedPackage pkg = embeddedPackageInfo(dep.name);
-         if (!pkg.empty())
-            embeddedPackages.push_back(pkg.archivePath);
+
+         // Build install command for bundled archive
+         script += "utils::install.packages('" + pkg.archivePath + 
+            "', repos = NULL, type = 'source')";
       }
+
+      script += "\n\n";
    }
 
-   // build install command
-   std::string cmd("{ " + module_context::CRANDownloadOptions() + "; ");
-   if (!cranPackages.empty())
-   {
-      std::string pkgList = boost::algorithm::join(cranPackages, ",");
-      cmd += "utils::install.packages(c(" + pkgList + "), " +
-             "repos = '"+ module_context::CRANReposURL() + "'";
-      cmd += ");";
-   }
-   if (!cranSourcePackages.empty())
-   {
-      std::string pkgList = boost::algorithm::join(cranSourcePackages, ",");
-      cmd += "utils::install.packages(c(" + pkgList + "), " +
-             "repos = '"+ module_context::CRANReposURL() + "', ";
-      cmd += "type = 'source');";
-   }
-   for (const std::string& pkg : embeddedPackages)
-   {
-      cmd += "utils::install.packages('" + pkg + "', "
-                                      "repos = NULL, type = 'source');";
-   }
-   cmd += "}";
+   jobs::ScriptLaunchSpec installJob(
+         // Job name: just the package name if we have one 
+         deps.size() == 1 ? 
+            ("Install '" + deps[0].name + "'") :
+            ("Install R packages"),
 
-   // build args
-   std::vector<std::string> args;
-   args.push_back("--slave");
+         // Script to run for job
+         script,
 
-   // for packrat projects we execute the profile and set the working
-   // directory to the project directory; for other contexts we just
-   // propagate the R_LIBS
-   if (module_context::packratContext().modeOn)
-   {
-      options.workingDir = projects::projectContext().directory();
-   }
-   else
-   {
-      args.push_back("--vanilla");
-      core::system::Options childEnv;
-      core::system::environment(&childEnv);
-      std::string libPaths = module_context::libPathsString();
-      if (!libPaths.empty())
-         core::system::setenv(&childEnv, "R_LIBS", libPaths);
-      options.environment = childEnv;
-   }
+         // Directory in which to run job
+         module_context::packratContext().modeOn ?
+            projects::projectContext().directory() :
+            FilePath(),
 
-   // for windows we need to forward setInternet2
-#ifdef _WIN32
-   if (!r::session::utils::isR3_3() && prefs::userPrefs().useInternet2())
-      args.push_back("--internet2");
-#endif
+         false, // Import environment
+         "");
 
-   args.push_back("-e");
-   args.push_back(cmd);
+   std::string jobId;
+   error = jobs::startScriptJob(installJob, &jobId);
 
-   boost::shared_ptr<console_process::ConsoleProcessInfo> pCPI =
-         boost::make_shared<console_process::ConsoleProcessInfo>(
-            "Installing Packages", console_process::InteractionNever);
+   // Return handle to script job
+   pResponse->setResult(jobId);
 
-   // create and execute console process
-   boost::shared_ptr<console_process::ConsoleProcess> pCP;
-   pCP = console_process::ConsoleProcess::create(
-            string_utils::utf8ToSystem(rProgramPath.getAbsolutePath()),
-            args,
-            options,
-            pCPI);
-
-   // return console process
-   pResponse->setResult(pCP->toJson(console_process::ClientSerialization));
    return Success();
 }
 

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -352,7 +352,10 @@ Error installDependencies(const json::JsonRpcRequest& request,
 
       if (dep.location == kCRANPackageDependency)
       {
-         // Build install command for CRAN
+         // Build install command for CRAN. We specify lock = TRUE (here and elsewhere) to ensure
+         // that the package directory is locked during installation; since this will run in the
+         // background we want reduce the odds of corruption via a competing package install attempt
+         // in another process.
          script += "utils::install.packages('" + dep.name + "', " +
                 "repos = '"+ module_context::CRANReposURL() + "'";
 
@@ -362,7 +365,7 @@ Error installDependencies(const json::JsonRpcRequest& request,
             script += ", type = 'source'";
          }
 
-         script += ")";
+         script += ", lock = TRUE)";
       }
       else if (dep.location == kEmbeddedPackageDependency)
       {
@@ -370,7 +373,7 @@ Error installDependencies(const json::JsonRpcRequest& request,
 
          // Build install command for bundled archive
          script += "utils::install.packages('" + pkg.archivePath + 
-            "', repos = NULL, type = 'source')";
+            "', repos = NULL, type = 'source', lock = TRUE)";
       }
 
       script += "\n\n";

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -158,8 +158,14 @@ private:
          "exportRdata = " + exportRdata + ");";
         
       core::system::Options environment;
+
+      // build options for async R process; default to no rdata unless we have other options (most
+      // common is a vanilla R process)
+      async_r::AsyncRProcessOptions options = 
+         spec_.procOptions() ? *spec_.procOptions() : async_r::R_PROCESS_NO_RDATA;
+
       async_r::AsyncRProcess::start(cmd.c_str(), environment, spec_.workingDir(),
-                                    async_r::R_PROCESS_NO_RDATA);
+                                    options);
    }
 
    void onStdout(const std::string& output)
@@ -404,6 +410,16 @@ bool ScriptLaunchSpec::importEnv()
 std::string ScriptLaunchSpec::encoding()
 {
    return encoding_;
+}
+
+void ScriptLaunchSpec::setProcOptions(async_r::AsyncRProcessOptions options)
+{
+   procOptions_ = options;
+}
+
+boost::optional<async_r::AsyncRProcessOptions> ScriptLaunchSpec::procOptions()
+{
+   return procOptions_;
 }
 
 Error startScriptJob(const ScriptLaunchSpec& spec, std::string* pId)

--- a/src/cpp/session/modules/jobs/ScriptJob.hpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.hpp
@@ -1,7 +1,7 @@
 /*
  * ScriptJob.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@
 #define SESSION_SCRIPT_JOB_HPP
 
 #include <session/jobs/Job.hpp>
+#include <session/SessionAsyncRProcess.hpp>
 
 namespace rstudio {
 namespace core {
@@ -57,6 +58,8 @@ public:
    core::FilePath workingDir();
    bool importEnv();
    std::string exportEnv();
+   void setProcOptions(async_r::AsyncRProcessOptions options);
+   boost::optional<async_r::AsyncRProcessOptions> procOptions();
 private:
    std::string name_;
    std::string code_;
@@ -65,6 +68,7 @@ private:
    core::FilePath workingDir_;
    bool importEnv_;
    std::string exportEnv_;
+   boost::optional<async_r::AsyncRProcessOptions> procOptions_;
 };
 
 core::Error startScriptJob(const ScriptLaunchSpec& spec, 

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -60,6 +60,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       DependencyRequest(
             String progressCaptionIn,
             String userActionIn,
+            String contextIn,
             CommandWith2Args<String,CommandWithArg<Boolean>> userPromptIn,
             List<Dependency> dependenciesIn,
             boolean silentEmbeddedUpdateIn,
@@ -68,12 +69,14 @@ public class DependencyManager implements InstallShinyEvent.Handler,
          progressCaption = progressCaptionIn;
          userAction = userActionIn;
          userPrompt = userPromptIn;
+         context = contextIn;
          dependencies = dependenciesIn;
          silentEmbeddedUpdate = silentEmbeddedUpdateIn;
          onComplete = onCompleteIn;
       }
       String progressCaption;
       String userAction;
+      String context;
       CommandWith2Args<String,CommandWithArg<Boolean>> userPrompt;
       List<Dependency> dependencies;
       boolean silentEmbeddedUpdate;
@@ -107,6 +110,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    {
       withDependencies(progressCaption,
                        null,
+                       null,
                        userPrompt,
                        dependencies,
                        silentEmbeddedUpdate,
@@ -115,12 +119,14 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    
    public void withDependencies(String progressCaption,
                                 String userAction,
+                                String context,
                                 List<Dependency> dependencies,
                                 boolean silentEmbeddedUpdate,
                                 final CommandWithArg<Boolean> onComplete)
    {
       withDependencies(progressCaption, 
                        userAction, 
+                       context,
                        null, 
                        dependencies, 
                        silentEmbeddedUpdate,
@@ -132,6 +138,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
             progressCaption,
             userAction,
+            getFeatureDescription("roxygen"),
             getFeatureDependencies("roxygen"),
             false,
             succeeded -> { if (succeeded) command.execute(); });
@@ -142,6 +149,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
          "Converting Theme",
          userAction,
+         getFeatureDescription("theme_conversion"),
          getFeatureDependencies("theme_conversion"),
          true,
          succeeded ->
@@ -156,6 +164,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "R2D3",
          userAction,
+         getFeatureDescription("r2d3"),
          getFeatureDependencies("r2d3"),
          true,
          succeeded ->
@@ -170,6 +179,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "Plumber",
          userAction,
+         getFeatureDescription("plumber"),
          getFeatureDependencies("plumber"),
          true,
          new CommandWithArg<Boolean>()
@@ -189,6 +199,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
          "Packrat",
          userAction,
+         getFeatureDescription("packrat"),
          getFeatureDependencies("packrat"),
          false,
          new CommandWithArg<Boolean>()
@@ -207,6 +218,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
             "renv",
             userAction,
+            getFeatureDescription("renv"),
             getFeatureDependencies("renv"),
             false,
             onSuccess);
@@ -225,6 +237,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "Publishing",
         userAction,
+        getFeatureDescription("rsconnect"),
         userPrompt,
         deps,
         true, // silently update any embedded packages needed (none at present)
@@ -257,6 +270,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         progressCaption,
         userAction, 
+        getFeatureDescription("rmarkdown"),
         getFeatureDependencies("rmarkdown"),
         true, // we want to update to the embedded version if needed
         succeeded -> 
@@ -335,6 +349,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "Checking installed packages",
         "Executing addins", 
+        getFeatureDescription("shiny_addins"),
         getFeatureDependencies("shiny_addins"),
         false,
         new CommandWithArg<Boolean>()
@@ -363,6 +378,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
             progressCaption,
             userPrompt,
+            getFeatureDescription("reticulate"),
             getFeatureDependencies("reticulate"),
             true,
             new CommandWithArg<Boolean>()
@@ -383,6 +399,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
             progressCaption,
             userPrompt,
+            getFeatureDescription("stan"),
             getFeatureDependencies("stan"),
             true,
             (Boolean success) -> { if (success) command.execute(); });
@@ -395,6 +412,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
             progressCaption,
             userPrompt,
+            getFeatureDescription("tinytex"),
             getFeatureDependencies("tinytex"),
             true,
             (Boolean success) -> { if (success) command.execute(); });
@@ -415,6 +433,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from CSV",
         userAction, 
+        getFeatureDescription("import_csv"),
         getFeatureDependencies("import_csv"),
         false,
         new CommandWithArg<Boolean>()
@@ -434,6 +453,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from SPSS, SAS and Stata",
         userAction, 
+        getFeatureDescription("import_sav"),
         getFeatureDependencies("import_sav"),
         false,
         new CommandWithArg<Boolean>()
@@ -453,6 +473,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from Excel",
         userAction, 
+        getFeatureDescription("import_xls"),
         getFeatureDependencies("import_xls"),
         false,
         new CommandWithArg<Boolean>()
@@ -472,6 +493,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from XML",
         userAction, 
+        getFeatureDescription("import_xml"),
         getFeatureDependencies("import_xml"),
         false,
         new CommandWithArg<Boolean>()
@@ -491,6 +513,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from JSON",
         userAction, 
+        getFeatureDescription("import_json"),
         getFeatureDependencies("import_json"),
         false,
         new CommandWithArg<Boolean>()
@@ -510,6 +533,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from JDBC",
         userAction, 
+        getFeatureDescription("import_jdbc"),
         getFeatureDependencies("import_jdbc"),
         false,
         new CommandWithArg<Boolean>()
@@ -529,6 +553,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from ODBC",
         userAction, 
+        getFeatureDescription("import_odbc"),
         getFeatureDependencies("import_odbc"),
         false,
         new CommandWithArg<Boolean>()
@@ -548,6 +573,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Import from Mongo DB",
         userAction, 
+        getFeatureDescription("import_mongo"),
         getFeatureDependencies("import_mongo"),
         false,
         new CommandWithArg<Boolean>()
@@ -567,6 +593,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Profiler",
         userAction, 
+        getFeatureDescription("profvis"),
         getFeatureDependencies("profvis"),
         true, // update profvis if needed
         new CommandWithArg<Boolean>()
@@ -589,6 +616,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Connection",
         connectionName, 
+        "Database Connectivity",
         connectionPackageDependencies(packageName, packageVersion), 
         false,
         new CommandWithArg<Boolean>()
@@ -608,6 +636,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing Keyring",
         "Using keyring", 
+        getFeatureDescription("keyring"),
         getFeatureDependencies("keyring"),
         true, // update keyring if needed
         new CommandWithArg<Boolean>()
@@ -627,6 +656,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
      withDependencies(
         "Preparing " + name,
         "Using " + name, 
+        getFeatureDescription("odbc"),
         getFeatureDependencies("odbc"),
         true, // update odbc if needed
         new CommandWithArg<Boolean>()
@@ -659,6 +689,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
          "Preparing Tests",
          message, 
+         "Testing Tools",
          dependencies, 
          true, // update package if needed
          new CommandWithArg<Boolean>()
@@ -679,6 +710,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "DBI",
          userAction,
+         getFeatureDescription("dbi"),
          getFeatureDependencies("dbi"),
          true,
          new CommandWithArg<Boolean>()
@@ -698,6 +730,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       withDependencies(
         "RSQLite",
          userAction,
+         getFeatureDescription("rsqlite"),
          getFeatureDependencies("rsqlite"),
          true,
          new CommandWithArg<Boolean>()
@@ -724,6 +757,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    
    private void withDependencies(String progressCaption,
          final String userAction,
+         final String context,
          final CommandWith2Args<String,CommandWithArg<Boolean>> userPrompt,
          List<Dependency> dependencies, 
          final boolean silentEmbeddedUpdate,
@@ -735,7 +769,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       // results, all such duplicate requests will return simultaneously, fed
       // by a single RPC)
       requestQueue_.add(new DependencyRequest(progressCaption, userAction, 
-            userPrompt, dependencies, silentEmbeddedUpdate, 
+            context, userPrompt, dependencies, silentEmbeddedUpdate, 
             new CommandWithArg<Boolean>()
             {
                @Override
@@ -873,6 +907,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
                         newArray.set(i, unsatisfiedDeps.get(i));
                      }
                      installDependencies(
+                           req.context,
                            newArray, 
                            req.silentEmbeddedUpdate, 
                            req.onComplete);
@@ -911,11 +946,13 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       
    }
    
-   private void installDependencies(final JsArray<Dependency> dependencies,
+   private void installDependencies(final String context,
+                                    final JsArray<Dependency> dependencies,
                                     final boolean silentEmbeddedUpdate,
                                     final CommandWithArg<Boolean> onComplete)
    {
       server_.installDependencies(
+         context,
          dependencies, 
          new ServerRequestCallback<String>() {
             @Override
@@ -1122,6 +1159,19 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       }
    }
    
+   /**
+    * Retrieves a user-friendly name for an IDE feature that requires
+    * dependencies
+    * 
+    * @param feature The identifier of the IDE feature.
+    * @return A string with a user-friendly name for the feature.
+    */
+   private String getFeatureDescription(String feature)
+   {
+      return session_.getSessionInfo().getPackageDependencies()
+            .getFeatureDescription(feature);
+   }
+
    /**
     * Retrieves a list of R package dependencies for an IDE feature.
     * 

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyList.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyList.java
@@ -36,4 +36,11 @@ public class DependencyList extends JavaScriptObject
          return packages["packages"];
       return [];
    }-*/;
+   
+   public final native String getFeatureDescription(String feature) /*-{
+      var feature = this.features[feature];
+      if (typeof feature !== "undefined")
+         return feature["description"];
+      return "";
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
@@ -28,6 +28,7 @@ public interface DependencyServerOperations extends CryptoServerOperations
        ServerRequestCallback<JsArray<Dependency>> requestCallback);
    
    void installDependencies(
+       String context,
        JsArray<Dependency> dependencies,
        ServerRequestCallback<String> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
@@ -1,7 +1,7 @@
 /*
  * DependencyServerOperations.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,7 +15,6 @@
 
 package org.rstudio.studio.client.common.dependencies.model;
 
-import org.rstudio.studio.client.common.console.ConsoleProcess;
 import org.rstudio.studio.client.common.crypto.CryptoServerOperations;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 
@@ -30,6 +29,6 @@ public interface DependencyServerOperations extends CryptoServerOperations
    
    void installDependencies(
        JsArray<Dependency> dependencies,
-       ServerRequestCallback<ConsoleProcess> requestCallback);
+       ServerRequestCallback<String> requestCallback);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -571,6 +571,7 @@ public class Projects implements OpenProjectFileHandler,
                   RStudioGinjector.INSTANCE.getDependencyManager().withDependencies(
                         "Creating project",
                         "Creating a project with " + pkg,
+                        pkg + " Project",
                         deps,
                         false,
                         (Boolean success) -> {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5298,12 +5298,12 @@ public class RemoteServer implements Server
    @Override
    public void installDependencies(
       JsArray<Dependency> dependencies,
-      ServerRequestCallback<ConsoleProcess> requestCallback)
+      ServerRequestCallback<String> requestCallback)
    {
       sendRequest(RPC_SCOPE,
                   "install_dependencies",
                   dependencies,
-                  new ConsoleProcessCallbackAdapter(requestCallback));
+                  requestCallback);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5297,12 +5297,16 @@ public class RemoteServer implements Server
      
    @Override
    public void installDependencies(
+      String context,
       JsArray<Dependency> dependencies,
       ServerRequestCallback<String> requestCallback)
    {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(context)));
+      params.set(1, new JSONArray(dependencies));
       sendRequest(RPC_SCOPE,
                   "install_dependencies",
-                  dependencies,
+                  params,
                   requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.google.gwt.animation.client.Animation;
@@ -33,6 +34,7 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.StringUtil;
@@ -52,7 +54,9 @@ import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.common.FilePathUtils;
 import org.rstudio.studio.client.common.ImageMenuItem;
+import org.rstudio.studio.client.common.dependencies.model.Dependency;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -888,20 +892,18 @@ public class TextEditingTargetWidget
       }
       
       Command onInstall = () -> {
-         StringBuilder builder = new StringBuilder();
-         if (packages.size() == 1)
-         {
-            builder.append("install.packages(\"")
-                   .append(packages.get(0))
-                   .append("\")");
-         }
-         else
-         {
-            builder.append("install.packages(c(\"")
-                   .append(StringUtil.join(packages, "\", \""))
-                   .append("\"))");
-         }
-         events_.fireEvent(new SendToConsoleEvent(builder.toString(), true));
+         // Form a list of all the dependencies to install
+         ArrayList<Dependency> deps = new ArrayList<Dependency>();
+         for (String pkg: packages)
+            deps.add(Dependency.cranPackage(pkg));
+         
+         // Install them using the dependency manager; provide a "prompt"
+         // function that just accepts the list (since the user has already been
+         // prompted here in the editor)
+         RStudioGinjector.INSTANCE.getDependencyManager().withDependencies(
+               "Install " + FilePathUtils.friendlyFileName(docUpdateSentinel_.getPath()) + " dependencies", 
+               (String dependencies, CommandWithArg<Boolean> result) -> result.execute(true),
+               deps, false, null);
          hideWarningBar();
       };
       


### PR DESCRIPTION
This change causes dependencies to be installed using a job instead of a modal dialog:

![image](https://user-images.githubusercontent.com/470418/70284039-7d5cc400-1777-11ea-94fa-68615c5d2e67.png)

This applies to the two areas where we most frequently install R packages on demand:

- When we detect missing packages in R scripts/R Markdown documents
- When we detect missing packages needed for IDE functionality

The primary motivation for this change is to make it possible to see what's gone wrong if a package installation fails, which is currently almost impossible since the modal disappears once the installation exits (regardless of success). A secondary benefit is that you can do other work while packages install. 
A downside is that because there's no longer a modal, the action that occurs when the packages are done installing may feel unexpected, especially if the packages take time to install. 

Closes https://github.com/rstudio/rstudio/issues/5584.