### PR TITLE
fix links in Ask Secret and RS Connect dialogs to work with keyboard

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.java
@@ -19,8 +19,6 @@ import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.dom.client.KeyDownHandler;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -38,6 +36,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.Operation;
@@ -105,54 +104,52 @@ public class AskSecretDialog extends ModalDialog<AskSecretDialogResult>
       label_.setText(prompt);
       Roles.getTextboxRole().setAriaRequiredProperty(textbox_.getElement(), true);
 
-      install_.addClickHandler(new ClickHandler() {
-         @Override
-         public void onClick(ClickEvent event) {
-            VerticalPanel verticalPanel = new VerticalPanel();
-            verticalPanel.getElement().setAttribute(
-               "style",
-               "padding-left: 6px; width: 320px;"
-            );
-            
-            Label infoLabel = new Label(
-               "Keyring is an R package that provides access to " +
-               "the operating systems credential store to allow you " +
-               "to remember, securely, passwords and secrets. "
-            );
-            
-            HTML questionHtml = new HTML(
-               "<br>Would you like to install keyring?<br><br>"
-            );
-            
-            verticalPanel.add(infoLabel);
-            verticalPanel.add(questionHtml);
-            
-            MessageDialog dialog = new MessageDialog(
-               MessageDialog.QUESTION,
-               "Keyring",
-               verticalPanel);
-            
-            dialog.addButton("Install", ElementIds.DIALOG_OK_BUTTON, new Operation()
+      install_.setClickHandler(() ->
+      {
+         VerticalPanel verticalPanel = new VerticalPanel();
+         verticalPanel.getElement().setAttribute(
+            "style",
+            "padding-left: 6px; width: 320px;"
+         );
+
+         Label infoLabel = new Label(
+            "Keyring is an R package that provides access to " +
+            "the operating systems credential store to allow you " +
+            "to remember, securely, passwords and secrets. "
+         );
+
+         HTML questionHtml = new HTML(
+            "<br>Would you like to install keyring?<br><br>"
+         );
+
+         verticalPanel.add(infoLabel);
+         verticalPanel.add(questionHtml);
+
+         MessageDialog dialog = new MessageDialog(
+            MessageDialog.QUESTION,
+            "Keyring",
+            verticalPanel);
+
+         dialog.addButton("Install", ElementIds.DIALOG_OK_BUTTON, new Operation()
+         {
+            @Override
+            public void execute()
             {
-               @Override
-               public void execute()
-               {
-                  dependencyManager.withKeyring(
-                     new Command()
+               dependencyManager.withKeyring(
+                  new Command()
+                  {
+                     @Override
+                     public void execute()
                      {
-                        @Override
-                        public void execute()
-                        {
-                           enableKeyring(true);
-                        }
+                        enableKeyring(true);
                      }
-                  );
-               }
-            }, true, false);
-            
-            dialog.addButton("Cancel", ElementIds.DIALOG_CANCEL_BUTTON, (Operation)null, false, true);
-            dialog.showModal();
-         }
+                  }
+               );
+            }
+         }, true, false);
+
+         dialog.addButton("Cancel", ElementIds.DIALOG_CANCEL_BUTTON, (Operation)null, false, true);
+         dialog.showModal();
       });
 
 
@@ -240,7 +237,7 @@ public class AskSecretDialog extends ModalDialog<AskSecretDialogResult>
    @UiField FormLabel label_;
    @UiField PasswordTextBox textbox_;
    @UiField CheckBox remember_;
-   @UiField Label install_;
+   @UiField HyperlinkLabel install_;
 
    @UiField HTMLPanel rememberEnabled_;
    @UiField HTMLPanel rememberDisabled_;

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/ui/AskSecretDialog.ui.xml
@@ -15,7 +15,6 @@
          margin-bottom: 6px;
       }
       .disabled {
-         color: #777777;
          margin-bottom: 6px;
          display: inline-block;
       }
@@ -50,9 +49,9 @@
                              text="Remember with keyring"/>
                </g:HTMLPanel>
                <g:HTMLPanel ui:field="rememberDisabled_" stylePrimaryName="{style.disabled}">
-                 <g:CheckBox enabled="false" text=""/>
-                 <g:Label text="Remember with "/>
-                 <g:Label ui:field="install_" text="keyring" stylePrimaryName="{style.keyring}"/>
+                 <rw:HyperlinkLabel ui:field="install_"
+                                    text="Install keyring package to enable saving secrets"
+                                    stylePrimaryName="{style.keyring}"/>
                </g:HTMLPanel>
             </td>
          </tr>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -188,29 +189,18 @@ public class RSConnectDeploy extends Composite
       // Invoke the "add account" wizard
       if (contentType == RSConnect.CONTENT_TYPE_APP || rsConnectEnabled)
       {
-         addAccountAnchor_.addClickHandler(new ClickHandler()
+         addAccountAnchor_.setClickHandler(() ->
          {
-            @Override
-            public void onClick(ClickEvent event)
-            {
-               connector_.showAccountWizard(false, 
-                     contentType == RSConnect.CONTENT_TYPE_APP ||
-                     contentType == RSConnect.CONTENT_TYPE_APP_SINGLE, 
-                     new OperationWithInput<Boolean>() 
-               {
-                  @Override
-                  public void execute(Boolean successful)
+            connector_.showAccountWizard(false,
+                  contentType == RSConnect.CONTENT_TYPE_APP ||
+                  contentType == RSConnect.CONTENT_TYPE_APP_SINGLE,
+                  successful ->
                   {
                      if (successful)
                      {
                         accountList_.refreshAccountList();
                      }
-                  }
-               });
-               
-               event.preventDefault();
-               event.stopPropagation();
-            }
+                  });
          });
       }
       else
@@ -1296,7 +1286,7 @@ public class RSConnectDeploy extends Composite
       appErrorMessage_.setTitle(error);
    }
 
-   @UiField Anchor addAccountAnchor_;
+   @UiField HyperlinkLabel addAccountAnchor_;
    @UiField Anchor createNewAnchor_;
    @UiField Anchor urlAnchor_;
    @UiField HTMLPanel appDetailsPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -48,9 +48,8 @@
             <g:Label styleName="{res.style.firstControlLabel}" 
                      text="Publish From Account:">
             </g:Label>
-            <g:Anchor styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
-                       ui:field="addAccountAnchor_" text="Add New Account">
-            </g:Anchor>
+            <rw:HyperlinkLabel styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}"
+                       ui:field="addAccountAnchor_" text="Add New Account"/>
          </g:HorizontalPanel>
          <rsc:RSConnectAccountList styleName="{res.style.accountList}" 
                                    ui:field="accountList_">


### PR DESCRIPTION
Switched to using HyperlinkLabel to get full keyboard + mouse support. Prior to this you couldn't get focus on these links or activate them with keyboard.

In the Publish dialog, the Add New Account "link" can now be used via keyboard.

<img width="585" alt="2019-12-05_16-56-50" src="https://user-images.githubusercontent.com/10569626/70287725-df6ff600-1784-11ea-9920-c09eb3c5ce97.png">

In the Ask Secret dialog, the UI state when keyring package wasn't installed was awkward for screen readers (in addition to not working with keyboard), had low contrast, and a checkbox (always disabled) that failed automated accessibility tests because it had no associated label. Also, the hyperlink "keyring" didn't provide any context to explain what it is for (another a11y violation).

So changed this:

<img width="353" alt="2019-12-05_11-07-30" src="https://user-images.githubusercontent.com/10569626/70287686-b18ab180-1784-11ea-9e8d-ce929db677f5.png">

to this:

<img width="352" alt="2019-12-05_17-18-50" src="https://user-images.githubusercontent.com/10569626/70287691-b64f6580-1784-11ea-93ce-4f6536dec931.png">
