### PR TITLE
forward R_LIBS during roxygenize

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,7 @@
 * Fix an issue where Git did not work within projects whose paths contained multibyte characters (#2194)
 * Fix an issue where RStudio would fail to preview self-contained bookdown books (#5371)
 * Fix modal dialog boundaries extending out of the app window in certain cases (#1605)
+* Fix issue where library paths were not forwarded when building package documentation
 * Restore ability to select and copy text in version control diffs (#4734)
 
 ### RStudio Professional

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -565,6 +565,20 @@ private:
                             "generate documentation");
       }
 
+      // make a copy of options so we can customize the environment
+      core::system::Options childEnv;
+      if (options.environment)
+         childEnv = *options.environment;
+      else
+         core::system::environment(&childEnv);
+
+      // allow child process to inherit our R_LIBS
+      std::string libPaths = module_context::libPathsString();
+      if (!libPaths.empty())
+         core::system::setenv(&childEnv, "R_LIBS", libPaths);
+      
+      options.environment = childEnv;
+      
       // build the roxygenize command
       shell_utils::ShellCommand cmd(rScriptPath);
       cmd << "--slave";


### PR DESCRIPTION
This PR fixes an issue where library paths set in e.g. a `.Rprofile` are not respected during a package build (in the roxygenize stage).

Note that we also forward R_LIBS for the actual build here:

https://github.com/rstudio/rstudio/blob/ac3f63134911ff61451e6159997c0b87f3e3732d/src/cpp/session/modules/build/SessionBuild.cpp#L692-L695

so I believe it makes sense to forward `R_LIBS` for both stages of the build.

(We could also consider forwarding `R_LIBS` universally, but that's a larger change that I didn't feel comfortable making)