### PR TITLE
Distinguish between failed and cancelled job states

### DIFF
--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -293,7 +293,6 @@ private:
          setJobStatus(job_, "");
       }
 
-      // !!! STATE SET HERE
       // mark job state
       if (job_)
       {

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -62,9 +62,11 @@ public:
    void cancel()
    {
       if (job_)
+      {
          cancelled_ = true;
-      // request terminate
-      terminate();
+         // request terminate
+         terminate();
+      }
    }
 
 private:


### PR DESCRIPTION
Fixes #5199 
Previously a completed job was set to a Failed or Completed state. This feature marks the job as Cancelled when the user requests a stop. 