### PR TITLE
enable target directory selection in Upload Files dialog

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,7 @@
 * Enable copying images to the clipboard from the Plots pane (#3142)
 * Update minimum supported browser versions (#5593)
 * Automatic refresh of the Git pane can now be enabled / disabled as required. (#4368)
+* Target directory can be changed from within the 'Upload Files' dialog (RStudio Server)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -141,6 +141,7 @@ public interface ThemeStyles extends CssResource
    
    String fileUploadPanel();
    String fileUploadField();
+   String fileUploadLabel();
    String fileUploadTipLabel();
    
    String fileList();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1759,9 +1759,14 @@ body.ubuntu_mono .searchBox {
    width: 350px;
 }
 
+.fileUploadPanel .fileUploadLabel {
+   margin-left: 7px;
+   margin-top: 6px;
+}
+
 .fileUploadPanel .fileUploadField {
    margin-left: 7px;
-   margin-top: 10px;
+   margin-top: 4px;
    margin-bottom: 8px;
 }
 

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -83,6 +83,9 @@ public class TextBoxWithButton extends Composite
 
       themedButton_ = new ThemedButton(action, handler);
 
+      // prevent button from triggering "submit" when hosted in a form, such as in FileUploadDialog
+      themedButton_.getElement().setAttribute("type", "button");
+
       inner_ = new HorizontalPanel();
       inner_.add(textBox_);
       inner_.add(themedButton_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileUploadDialog.java
@@ -155,7 +155,9 @@ public class FileUploadDialog extends HtmlFormModalDialog<PendingFileUpload>
       fileUpload_ = new FileUpload();
       fileUpload_.setStyleName(ThemeStyles.INSTANCE.fileUploadField());
       fileUpload_.setName("file");
-      panel.add(new FormLabel("File to upload:", fileUpload_));
+      FormLabel uploadLabel = new FormLabel("File to upload:", fileUpload_);
+      uploadLabel.addStyleName(ThemeStyles.INSTANCE.fileUploadLabel());
+      panel.add(uploadLabel);
       panel.add(fileUpload_);
       
       // zip file tip field


### PR DESCRIPTION
While evaluating accessibility of the Upload Files dialog, noticed that there was orphaned code indicating an intent to supporting choosing target folder from the dialog.

As it stands, the target folder is set to match Files Pane location when the dialog is shown.

Relatively easy to swap in our DirectoryChooser control. One small tweak was needed (setting type="button" on a `<button>`) to prevent the Browse button from causing form submission on some browsers.

I considered also working on accessibility of the "File to upload" part of the dialog, but captured that in #5856 for future consideration.

# Before

<img width="372" alt="2019-12-07_14-49-59 copy" src="https://user-images.githubusercontent.com/10569626/70382448-5c2fdb00-1911-11ea-9d72-23bf266962af.png">

# After

<img width="373" alt="2019-12-07_17-10-46" src="https://user-images.githubusercontent.com/10569626/70382704-a5355e80-1914-11ea-8c54-f184ca0add7d.png">
