### PR TITLE
use html input type=number instead of emulating in JavaScript

### DIFF
--- a/src/cpp/desktop/DesktopInputDialog.cpp
+++ b/src/cpp/desktop/DesktopInputDialog.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopInputDialog.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,6 +50,7 @@ QString InputDialog::caption()
 void InputDialog::setCaption(const QString& caption)
 {
    ui->label->setText(caption);
+   ui->lineEdit->setAccessibleName(caption);
 }
 
 QString InputDialog::textValue()

--- a/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
@@ -1,7 +1,7 @@
 /*
  * NumericTextBox.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,74 +14,13 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.event.dom.client.*;
 import com.google.gwt.user.client.ui.TextBox;
-import org.rstudio.core.client.command.KeyboardShortcut;
 
 public class NumericTextBox extends TextBox
 {
    public NumericTextBox()
    {
       super();
-      init();
-   }
-
-   protected NumericTextBox(Element element)
-   {
-      super(element);
-      init();
-   }
-
-   private void init()
-   {
-      addFocusHandler(new FocusHandler()
-      {
-         @Override
-         public void onFocus(FocusEvent event)
-         {
-            selectAll();
-         }
-      });
-
-      addKeyDownHandler(new KeyDownHandler()
-      {
-         @Override
-         public void onKeyDown(KeyDownEvent event)
-         {
-            int modifiers = KeyboardShortcut.getModifierValue(event.getNativeEvent());
-            if (modifiers == KeyboardShortcut.NONE
-                && (event.isUpArrow() || event.isDownArrow()))
-            {
-               event.preventDefault();
-               event.stopPropagation();
-
-               try
-               {
-                  int value = Integer.parseInt(getText());
-                  value += event.isUpArrow() ? 1 : -1;
-                  setValue(value + "", true);
-                  selectAll();
-               }
-               catch (NumberFormatException nfe)
-               {
-                  // just ignore
-               }
-            }
-         }
-      });
-
-      addKeyPressHandler(new KeyPressHandler()
-      {
-         @Override
-         public void onKeyPress(KeyPressEvent event)
-         {
-            char charCode = event.getCharCode();
-            if (charCode >= '0' && charCode <= '9')
-               return;
-            if (Character.isLetterOrDigit(charCode))
-               event.preventDefault();
-         }
-      });
+      getElement().setAttribute("type", "number");
    }
 }


### PR DESCRIPTION
- all browsers we care about support input type=number; probably wasn't the case when this code was written (https://caniuse.com/#feat=input-number)
- better accessibility support by using the native html control, and makes it more obvious you can use up/down arrows to change numbers (bet hardly anybody knew it supported that, I didn't until I read the code)
- for desktop, associate textbox with label in native-Qt prompt-for-text messageboxes

Places the NumericTextBox control is used:

(prompting for a number, Server-only):
<img width="322" alt="2019-12-08_19-44-47" src="https://user-images.githubusercontent.com/10569626/70408993-02a5da00-19ff-11ea-99ed-13cc9fd6ade7.png">

(rmd numeric options)
<img width="472" alt="2019-12-08_19-45-15" src="https://user-images.githubusercontent.com/10569626/70409036-279a4d00-19ff-11ea-8f07-806cb902d0ad.png">

The desktop dialog used to prompt for strings and numbers:
<img width="400" alt="2019-12-08_20-54-51" src="https://user-images.githubusercontent.com/10569626/70409062-3b45b380-19ff-11ea-9fe3-c36a5a6f3086.png">
