### PR TITLE
hide "Run Selection as Job" commands on Code menu when not supported

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -1,7 +1,7 @@
 /*
  * TextFileType.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -437,11 +437,13 @@ public class TextFileType extends EditableFileType
       results.add(commands.popoutDoc());
       if (!SourceWindowManager.isMainSourceWindow())
          results.add(commands.returnDocToMain());
-      
+
       if (isR())
       {
          results.add(commands.sourceAsLauncherJob());
          results.add(commands.sourceAsJob());
+         results.add(commands.runSelectionAsJob());
+         results.add(commands.runSelectionAsLauncherJob());
       }
 
       results.add(commands.sendToTerminal());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -411,6 +411,8 @@ public class TextFileType extends EditableFileType
          results.add(commands.executeSubsequentChunks());
          results.add(commands.executeCurrentChunk());
          results.add(commands.executeNextChunk());
+         results.add(commands.runSelectionAsJob());
+         results.add(commands.runSelectionAsLauncherJob());
       }
       if (canCheckSpelling())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -391,6 +391,8 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.renameSourceDoc());
       dynamicCommands_.add(commands.sourceAsLauncherJob());
       dynamicCommands_.add(commands.sourceAsJob());
+      dynamicCommands_.add(commands.runSelectionAsJob());
+      dynamicCommands_.add(commands.runSelectionAsLauncherJob());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -1,7 +1,7 @@
 /*
  * EditingTargetCodeExecution.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -194,10 +194,11 @@ public class EditingTargetCodeExecution
          return;
       }
       String code = codeExtractor_.extractCode(docDisplay_, selectionRange);
+      String targetPath = target_ == null ? null : target_.getPath();
       if (useJobLauncher)
-         events_.fireEvent(new LauncherJobRunSelectionEvent(target_.getPath(), code));
+         events_.fireEvent(new LauncherJobRunSelectionEvent(targetPath, code));
       else
-         events_.fireEvent(new JobRunSelectionEvent(target_.getPath(), code));
+         events_.fireEvent(new JobRunSelectionEvent(targetPath, code));
    }
    
    public void executeRange(Range range)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -255,9 +255,21 @@ public class CodeBrowserEditingTarget implements EditingTarget
       
       codeExecution_.executeLastCode();
    }
-   
-   @Handler 
-   void onSendToTerminal() 
+
+   @Handler
+   void onRunSelectionAsJob()
+   {
+      codeExecution_.runSelectionAsJob(false /*useLauncher*/);
+   }
+
+   @Handler
+   void onRunSelectionAsLauncherJob()
+   {
+      codeExecution_.runSelectionAsJob(true /*useLauncher*/);
+   }
+
+   @Handler
+   void onSendToTerminal()
    { 
       codeExecution_.sendSelectionToTerminal(false);
    } 
@@ -440,6 +452,8 @@ public class CodeBrowserEditingTarget implements EditingTarget
       commands.add(commands_.executeCode());
       commands.add(commands_.executeCodeWithoutFocus());
       commands.add(commands_.executeLastCode());
+      commands.add(commands_.runSelectionAsJob());
+      commands.add(commands_.runSelectionAsLauncherJob());
       commands.add(commands_.sendToTerminal());
 
       if (SourceWindowManager.isMainSourceWindow())


### PR DESCRIPTION
- Also enables running selection-as-job from code-browser tabs
- Fixes #5863