### PR TITLE
add commands for zooming left/right UI columns

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -92,6 +92,7 @@
 * Command to insert the full path and filename of current editor file into terminal
 * Command in File pane to open a new terminal at File pane's current location
 * Command in to change terminal to current RStudio working directory (#2363)
+* Zoom Left/Right Column commands for keyboard users (#5874)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/core/client/MathUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/MathUtil.java
@@ -1,7 +1,7 @@
 /*
  * MathUtil.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -47,4 +47,8 @@ public class MathUtil
        return (value <= max) && (value >= min);
    }
 
+   public static boolean isEqual(double d1, double d2, double threshold)
+   {
+      return Math.abs(d1 - d2) < threshold;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -270,7 +270,8 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="layoutConsoleOnLeft"/>
             <cmd refid="layoutConsoleOnRight"/>
             <separator/>
-            <cmd refid="paneLayout"/>
+            <cmd refid="layoutZoomLeftColumn"/>
+            <cmd refid="layoutZoomRightColumn"/>
             <separator/>
             <cmd refid="layoutZoomSource"/>
             <cmd refid="layoutZoomConsole"/>
@@ -286,6 +287,8 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="layoutZoomTutorial"/>
             <cmd refid="layoutZoomBuild"/>
             <cmd refid="layoutZoomConnections"/>
+            <separator/>
+            <cmd refid="paneLayout"/>
          </menu>
          
          <separator/>
@@ -681,7 +684,7 @@ well as menu structures (for main menu and popup menus).
       <shortcutgroup name="Panes">
          <shortcut refid="switchFocusSourceConsole" value="Ctrl+X O|Ctrl+X Ctrl+O" disableModes="default,vim,sublime"/>
          <shortcut refid="activateConsole" value="Alt+X" disableModes="default,vim,sublime"/>
-         
+
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
          <shortcut refid="activateTerminal" value="Alt+Shift+T"/>
@@ -862,6 +865,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="layoutZoomBuild" value="Ctrl+Shift+F2"/>
          <shortcut refid="layoutZoomConnections" value="Ctrl+Shift+F5"/>
          <shortcut refid="layoutZoomTutorial" value="Ctrl+Shift+F6"/>
+         <shortcut refid="layoutZoomLeftColumn" value="Ctrl+Alt+Shift+F12"/>
+         <shortcut refid="layoutZoomRightColumn" value="Ctrl+Alt+Shift+F11"/>
       </shortcutgroup>
          
    </shortcuts>
@@ -1450,10 +1455,20 @@ well as menu structures (for main menu and popup menus).
         label="Console on Right"
         menuLabel="Console on _Right"
         windowMode="main"/>
-        
+
+   <cmd id="layoutZoomLeftColumn"
+        checkable="true"
+        label="Zoom Left Column"
+        menuLabel="_Zoom Left Column"/>
+
+   <cmd id="layoutZoomRightColumn"
+        checkable="true"
+        label="Zoom Right Column"
+        menuLabel="Zoo_m Right Column"/>
+
    <cmd id="paneLayout"
         menuLabel="Pane Layo_ut..."
-        windowMode="main"/>     
+        windowMode="main"/>
         
    <cmd id="jumpTo"
         label="Jump To..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -608,7 +608,9 @@ public abstract class
    public abstract AppCommand paneLayout();
    public abstract AppCommand maximizeConsole();
    public abstract AppCommand toggleEditorTokenInfo();
-   
+   public abstract AppCommand layoutZoomLeftColumn();
+   public abstract AppCommand layoutZoomRightColumn();
+
    // Main menu (server)
    public abstract AppCommand showFileMenu();
    public abstract AppCommand showEditMenu();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -373,6 +373,12 @@ public class WorkbenchScreen extends Composite
    void onLayoutZoomConnections() { paneManager_.zoomTab(Tab.Connections); }
 
    @Handler
+   void onLayoutZoomLeftColumn() { paneManager_.zoomColumn(PaneManager.LEFT_COLUMN); }
+
+   @Handler
+   void onLayoutZoomRightColumn() { paneManager_.zoomColumn(PaneManager.RIGHT_COLUMN); }
+
+   @Handler
    void onMacPreferences()
    {
       onShowOptions();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.terminal.xterm;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import org.rstudio.core.client.ColorUtil;
+import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.dom.DomUtils;
 
 /**
@@ -85,7 +86,7 @@ public class XTermTheme extends JavaScriptObject
 
    private static boolean doubleEqualish(double d1, double d2)
    {
-      return Math.abs(d1 - d2) < 0.0001;
+      return MathUtil.isEqual(d1, d2, 0.0001);
    }
 
    public static double adjustFontSize(double size)


### PR DESCRIPTION
- essentially shortcuts for dragging vertical splitter all the way to left or right, and will toggle back to previous position if you select command again
- doesn't change zoom state of panes within the left/right column
- especially handy for keyboard-only users

Partially addresses #5498 but that issue is also requesting ability to switch to Source/Console only view from any other configuration, which this doesn't quite address (e.g. if Console was zoomed, this command wouldn't unzoom it).

<img width="1129" alt="2019-12-11_14-03-32" src="https://user-images.githubusercontent.com/10569626/70665296-22b4e380-1c21-11ea-8b0e-edabfd656844.png">
