### PR TITLE
Keep pref layers around during shutdown

### DIFF
--- a/src/cpp/session/prefs/PrefLayer.cpp
+++ b/src/cpp/session/prefs/PrefLayer.cpp
@@ -92,16 +92,6 @@ void PrefLayer::destroy()
       core::system::file_monitor::unregisterMonitor(*handle_);
       handle_ = boost::none;
    }
-
-   // Clear prefs cache
-   RECURSIVE_LOCK_MUTEX(mutex_)
-   {
-      if (cache_)
-      {
-         cache_.reset();
-      }
-   }
-   END_LOCK_MUTEX;
 }
 
 core::json::Object PrefLayer::allPrefs()

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -105,9 +105,6 @@ void Preferences::destroyLayers()
       {
          layer->destroy();
       }
-
-      // Remove all the destroyed layers
-      layers_.clear();
    }
    END_LOCK_MUTEX
 }


### PR DESCRIPTION
We currently clean up pref layers during shutdown, but this turns out to introduce some ordering problems because in some situations prefs are read *during shutdown*, so we need to keep them around for the whole shutdown process.

The motivation for destroying prefs during shutdown was to clean up the file monitor at the right point in the shutdown sequence; this change preserves that behavior while leaving the layers otherwise intact.

Fixes https://github.com/rstudio/rstudio/issues/5872.