### PR TITLE
fix accessibility of SVN Resolve dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -343,5 +343,17 @@ public class ElementIds
    // HelpSearchWidget
    public final static String SW_HELP = "sw_help";
    public static String getSwHelp() { return getElementId(SW_HELP); }
-   
+
+   // SvnResolveDialog
+   public final static String SVN_RESOLVE_GROUP = "svn_resolve_group";
+   public final static String SVN_RESOLVE_MINE = "svn_resolve_mine";
+   public final static String SVN_RESOLVE_MINE_DESC = "svn_resolve_mine_desc";
+   public final static String SVN_RESOLVE_MINE_CONFLICT = "svn_resolve_mine_conflict";
+   public final static String SVN_RESOLVE_MINE_CONFLICT_DESC = "svn_resolve_mine_conflict_desc";
+   public final static String SVN_RESOLVE_THEIRS_CONFLICT = "svn_resolve_theirs_conflict";
+   public final static String SVN_RESOLVE_THEIRS_CONFLICT_DESC = "svn_resolve_theirs_conflict_desc";
+   public final static String SVN_RESOLVE_MINE_ALL = "svn_resolve_mine_all";
+   public final static String SVN_RESOLVE_MINE_ALL_DESC = "svn_resolve_mine_all_desc";
+   public final static String SVN_RESOLVE_THEIRS_ALL = "svn_resolve_theirs_all";
+   public final static String SVN_RESOLVE_THEIRS_ALL_DESC = "svn_resolve_theirs_all_desc";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNResolveDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNResolveDialog.java
@@ -14,15 +14,20 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.svn;
 
+import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.dom.client.TableCellElement;
+import com.google.gwt.dom.client.TableElement;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.HTMLPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 
@@ -62,6 +67,10 @@ public class SVNResolveDialog extends ModalDialog<String>
    {
       HTMLPanel widget = GWT.<Binder>create(Binder.class).createAndBindUi(this);
 
+      ElementIds.assignElementId(groupLabel_, ElementIds.SVN_RESOLVE_GROUP);
+      Roles.getGroupRole().set(layoutTable_);
+      Roles.getGroupRole().setAriaLabelledbyProperty(layoutTable_, Id.of(groupLabel_));
+
       inputElements_ = new InputElement[] {
             radioWorking_,
             radioMineConflict_,
@@ -72,37 +81,59 @@ public class SVNResolveDialog extends ModalDialog<String>
 
       spanTargetNoun_.setInnerText(fileCount_ == 1 ? "path" : "paths");
 
-      labelWorking_.setPropertyString("for", radioWorking_.getId());
-      labelMineConflict_.setPropertyString("for", radioMineConflict_.getId());
-      labelTheirsConflict_.setPropertyString("for", radioTheirsConflict_.getId());
-      labelMineAll_.setPropertyString("for", radioMineAll_.getId());
-      labelTheirsAll_.setPropertyString("for", radioTheirsAll_.getId());
+      ElementIds.assignElementId(radioWorking_, ElementIds.SVN_RESOLVE_MINE);
+      ElementIds.assignElementId(descriptionWorking_, ElementIds.SVN_RESOLVE_MINE_DESC);
+      Roles.getRadioRole().setAriaDescribedbyProperty(radioWorking_, Id.of(descriptionWorking_));
+
+      ElementIds.assignElementId(radioMineConflict_, ElementIds.SVN_RESOLVE_MINE_CONFLICT);
+      ElementIds.assignElementId(descriptionMineConflict_, ElementIds.SVN_RESOLVE_MINE_CONFLICT_DESC);
+      Roles.getRadioRole().setAriaDescribedbyProperty(radioMineConflict_, Id.of(descriptionMineConflict_));
+
+      ElementIds.assignElementId(radioTheirsConflict_, ElementIds.SVN_RESOLVE_THEIRS_CONFLICT);
+      ElementIds.assignElementId(descriptionTheirsConflict_, ElementIds.SVN_RESOLVE_THEIRS_CONFLICT_DESC);
+      Roles.getRadioRole().setAriaDescribedbyProperty(radioTheirsConflict_, Id.of(descriptionTheirsConflict_));
+
+      ElementIds.assignElementId(radioMineAll_, ElementIds.SVN_RESOLVE_MINE_ALL);
+      ElementIds.assignElementId(descriptionMineAll_, ElementIds.SVN_RESOLVE_MINE_ALL_DESC);
+      Roles.getRadioRole().setAriaDescribedbyProperty(radioMineAll_, Id.of(descriptionMineAll_));
+
+      ElementIds.assignElementId(radioTheirsAll_, ElementIds.SVN_RESOLVE_THEIRS_ALL);
+      ElementIds.assignElementId(descriptionTheirsAll_, ElementIds.SVN_RESOLVE_THEIRS_ALL_DESC);
+      Roles.getRadioRole().setAriaDescribedbyProperty(radioTheirsAll_, Id.of(descriptionTheirsAll_));
+
+      labelWorking_.setAttribute("for", radioWorking_.getId());
+      labelMineConflict_.setAttribute("for", radioMineConflict_.getId());
+      labelTheirsConflict_.setAttribute("for", radioTheirsConflict_.getId());
+      labelMineAll_.setAttribute("for", radioMineAll_.getId());
+      labelTheirsAll_.setAttribute("for", radioTheirsAll_.getId());
 
       return widget;
    }
 
-   @UiField
-   InputElement radioWorking_;
-   @UiField
-   InputElement radioMineConflict_;
-   @UiField
-   InputElement radioTheirsConflict_;
-   @UiField
-   InputElement radioMineAll_;
-   @UiField
-   InputElement radioTheirsAll_;
-   @UiField
-   SpanElement spanTargetNoun_;
-   @UiField
-   LabelElement labelWorking_;
-   @UiField
-   LabelElement labelMineConflict_;
-   @UiField
-   LabelElement labelTheirsConflict_;
-   @UiField
-   LabelElement labelMineAll_;
-   @UiField
-   LabelElement labelTheirsAll_;
+   @UiField DivElement groupLabel_;
+   @UiField SpanElement spanTargetNoun_;
+   @UiField TableElement layoutTable_;
+
+   @UiField InputElement radioWorking_;
+   @UiField LabelElement labelWorking_;
+   @UiField TableCellElement descriptionWorking_;
+
+   @UiField InputElement radioMineConflict_;
+   @UiField LabelElement labelMineConflict_;
+   @UiField TableCellElement descriptionMineConflict_;
+
+   @UiField InputElement radioTheirsConflict_;
+   @UiField LabelElement labelTheirsConflict_;
+   @UiField TableCellElement descriptionTheirsConflict_;
+
+   @UiField InputElement radioMineAll_;
+   @UiField LabelElement labelMineAll_;
+   @UiField TableCellElement descriptionMineAll_;
+
+   @UiField InputElement radioTheirsAll_;
+   @UiField LabelElement labelTheirsAll_;
+   @UiField TableCellElement descriptionTheirsAll_;
+
    private final int fileCount_;
    private InputElement[] inputElements_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNResolveDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNResolveDialog.ui.xml
@@ -14,7 +14,7 @@
       .description {
          padding-bottom: 12px !important;
          width: 240px;
-         color: #888;
+         color: #666;
       }
       .prompt {
          display: block;
@@ -24,10 +24,10 @@
    </ui:style>
 
    <g:HTMLPanel styleName="{style.resolvePanel}">
-      <div class="{style.prompt}">
+      <div ui:field="groupLabel_" class="{style.prompt}">
          Resolve the selected <span ui:field="spanTargetNoun_"></span> using:
       </div>
-      <table>
+      <table ui:field="layoutTable_">
          <tr>
             <td><input type="radio"
                        name="svnResolve"
@@ -38,7 +38,7 @@
          </tr>
          <tr>
             <td />
-            <td class="{style.description}">
+            <td ui:field="descriptionWorking_" class="{style.description}">
                Mark the working copy as resolved
             </td>
          </tr>
@@ -54,7 +54,7 @@
          </tr>
          <tr>
             <td />
-            <td class="{style.description}">
+            <td ui:field="descriptionMineConflict_" class="{style.description}">
                Accept my version for all conflicts
             </td>
          </tr>
@@ -70,7 +70,7 @@
          </tr>
          <tr>
             <td />
-            <td class="{style.description}">
+            <td ui:field="descriptionTheirsConflict_" class="{style.description}">
                Accept their version for all conflicts
             </td>
          </tr>
@@ -86,7 +86,7 @@
          </tr>
          <tr>
             <td />
-            <td class="{style.description}">
+            <td ui:field="descriptionMineAll_" class="{style.description}">
                Accept my version of the entire file, even non-conflicts
             </td>
          </tr>
@@ -102,7 +102,7 @@
          </tr>
          <tr>
             <td />
-            <td class="{style.description}">
+            <td ui:field="descriptionTheirsAll_" class="{style.description}">
                Accept their version of the entire file, even non-conflicts
             </td>
          </tr>


### PR DESCRIPTION
An example of a simple-looking dialog with a remarkable number of accessibility problems. Fixed by brute force in code. If I come across more examples following this same pattern I might consider creating a standard control that hides the gory details, but this does the trick for this case.

Problems:
- contrast too low on descriptions (bumped up contrast)
- radio buttons not associated with their labels (gave labels IDs, then associated radio buttons via `for`) 
- radio buttons not associated with their descriptions (gave descriptions IDs, then associated buttons with `aria-describedby`); a screen reader will typically read the label, pause, then read the description (depending on screen reader verbosity settings)
- group of radio buttons not associated with heading ("Resolve the selected path using"); gave the heading an ID, gave the group the "group" role, then associated label using `aria-labelledby`

<img width="310" alt="2019-12-11_16-34-31" src="https://user-images.githubusercontent.com/10569626/70672764-19357680-1c35-11ea-903d-c3d95c1de56f.png">
