### PR TITLE
associate labels with controls in spelling dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -335,7 +335,13 @@ public class ElementIds
    // PackagesPane
    public final static String SW_PACKAGES = "sw_packages";
    public static String getSwPackages() { return getElementId(SW_PACKAGES); }
-   
+
+   // SpellingDialog
+   public final static String SPELLING_NOT_IN_DICT= "spelling_not_in_dict";
+   public static String getSpellingNotInDict() { return getElementId(SPELLING_NOT_IN_DICT); }
+   public final static String SPELLING_CHANGE_TO= "spelling_change_to";
+   public static String getSpellingChangeTo() { return getElementId(SPELLING_CHANGE_TO); }
+
    // HelpPane
    public final static String SW_HELP_FIND_IN_TOPIC = "sw_help_find_in_topic";
    public static String getSwHelpFindInTopic() { return getElementId(SW_HELP_FIND_IN_TOPIC); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingDialog.java
@@ -56,6 +56,7 @@ public class SpellingDialog extends ModalDialogBase implements CheckSpelling.Dis
             btnAdd_, btnIgnoreAll_, btnSkip_, btnChange_, btnChangeAll_
       };
 
+      Roles.getListboxRole().setAriaLabelProperty(lstSuggestions_.getElement(), "Suggestions");
       addCancelButton();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingDialog.ui.xml
@@ -1,7 +1,7 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
              xmlns:widget="urn:import:org.rstudio.core.client.widget">
-
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
       .outer input {
          height: 20px !important;
@@ -29,7 +29,7 @@
       }
 
       .start2 {
-         margin-left: 110px;
+         margin-left: 114px;
       }
 
       .col2_3 {
@@ -49,10 +49,10 @@
    <g:HTMLPanel styleName="{style.outer}">
 
       <div>
-         <div class="{style.label}">Not in dictionary:
-         </div><g:TextBox ui:field="txtDisplay_"
-                          styleName="{style.control}"
-                          readOnly="true"/>
+         <widget:InlineFormLabel forId="{ElementIds.getSpellingNotInDict}"
+                                 styleName="{style.label}" text="Not in dictionary:"/>
+         <widget:FormTextBox ui:field="txtDisplay_" styleName="{style.control}" readOnly="true"
+                             elementId="{ElementIds.getSpellingNotInDict}"/>
       </div>
       <div class="{style.smallTopMargin} {style.start2} {style.col2_3}">
          <widget:ThemedButton ui:field="btnSkip_"/><div style="display:inline-block;width:8px"/><widget:ThemedButton ui:field="btnIgnoreAll_"/>
@@ -61,8 +61,10 @@
          </div>
       </div>
       <div>
-         <div class="{style.bigTopMargin} {style.label}">Change to:
-         </div><g:TextBox ui:field="txtReplacement_" styleName="{style.control}" />
+         <widget:InlineFormLabel forId="{ElementIds.getSpellingChangeTo}"
+                                          styleName="{style.bigTopMargin} {style.label}" text="Change to:"/>
+         <widget:FormTextBox ui:field="txtReplacement_" styleName="{style.control}"
+                             elementId="{ElementIds.getSpellingChangeTo}"/>
       </div>
       <div class="{style.smallTopMargin} {style.start2} {style.col2_3}">
          <g:ListBox


### PR DESCRIPTION
Associate labels with the two textareas, and provide an aria-label for the unlabeled select control.

<img width="407" alt="2019-12-11_17-29-13" src="https://user-images.githubusercontent.com/10569626/70683106-d768f800-1c55-11ea-9273-937024ddab7c.png">
