### PR TITLE
add more control over terminal behavior after shell exits (user pref)

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -651,7 +651,7 @@ void ConsoleProcess::onExit(int exitCode)
    if (procInfo_->getAutoClose() == DefaultAutoClose)
    {
       procInfo_->setAutoClose(
-            prefs::userPrefs().terminalAutoClose() ? AlwaysAutoClose :  NeverAutoClose);
+            ConsoleProcessInfo::closeModeFromPref(prefs::userPrefs().terminalCloseBehavior()));
    }
 
    if (procInfo_->getAutoClose() == NeverAutoClose)

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -28,6 +28,7 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionPersistentState.hpp>
 #include <session/SessionOptions.hpp>
+#include <session/prefs/UserPrefs.hpp>
 
 using namespace rstudio::core;
 
@@ -372,6 +373,18 @@ void ConsoleProcessInfo::saveConsoleEnvironment(const core::system::Options& env
 void ConsoleProcessInfo::loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv)
 {
    console_persist::loadConsoleEnvironment(handle, pEnv);
+}
+
+AutoCloseMode ConsoleProcessInfo::closeModeFromPref(std::string prefValue)
+{
+   if (prefValue == kTerminalCloseBehaviorAlways)
+      return AlwaysAutoClose;
+   else if (prefValue == kTerminalCloseBehaviorClean)
+      return CleanExitAutoClose;
+   else if (prefValue == kTerminalCloseBehaviorNever)
+      return NeverAutoClose;
+   else
+      return NeverAutoClose;
 }
 
 } // namespace console_process_info

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -53,6 +53,7 @@ enum AutoCloseMode
    DefaultAutoClose = 0, // obey user preference
    AlwaysAutoClose = 1, // always auto-close
    NeverAutoClose = 2, // never auto-close
+   CleanExitAutoClose = 3, // auto-close only if shell returned zero exit code
 };
 
 enum SerializationMode
@@ -202,6 +203,8 @@ public:
    static void deleteOrphanedLogs(bool (*validHandle)(const std::string&));
    static void saveConsoleProcesses(const std::string& metadata);
    static void loadConsoleEnvironment(const std::string& handle, core::system::Options* pEnv);
+
+   static AutoCloseMode closeModeFromPref(std::string prefValue);
 
 private:
    std::string caption_;

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -219,7 +219,10 @@ namespace prefs {
 #define kShowTerminalTab "show_terminal_tab"
 #define kTerminalLocalEcho "terminal_local_echo"
 #define kTerminalWebsockets "terminal_websockets"
-#define kTerminalAutoClose "terminal_auto_close"
+#define kTerminalCloseBehavior "terminal_close_behavior"
+#define kTerminalCloseBehaviorAlways "always"
+#define kTerminalCloseBehaviorClean "clean"
+#define kTerminalCloseBehaviorNever "never"
 #define kTerminalTrackEnvironment "terminal_track_environment"
 #define kTerminalBellStyle "terminal_bell_style"
 #define kTerminalBellStyleNone "none"
@@ -1046,10 +1049,10 @@ public:
    core::Error setTerminalWebsockets(bool val);
 
    /**
-    * Whether to automatically close the Terminal tab.
+    * Whether to close the terminal pane after the shell exits.
     */
-   bool terminalAutoClose();
-   core::Error setTerminalAutoClose(bool val);
+   std::string terminalCloseBehavior();
+   core::Error setTerminalCloseBehavior(std::string val);
 
    /**
     * Whether to track and save changes to system environment variables in the Terminal.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1610,16 +1610,16 @@ core::Error UserPrefValues::setTerminalWebsockets(bool val)
 }
 
 /**
- * Whether to automatically close the Terminal tab.
+ * Whether to close the terminal pane after the shell exits.
  */
-bool UserPrefValues::terminalAutoClose()
+std::string UserPrefValues::terminalCloseBehavior()
 {
-   return readPref<bool>("terminal_auto_close");
+   return readPref<std::string>("terminal_close_behavior");
 }
 
-core::Error UserPrefValues::setTerminalAutoClose(bool val)
+core::Error UserPrefValues::setTerminalCloseBehavior(std::string val)
 {
-   return writePref("terminal_auto_close", val);
+   return writePref("terminal_close_behavior", val);
 }
 
 /**
@@ -2423,7 +2423,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kShowTerminalTab,
       kTerminalLocalEcho,
       kTerminalWebsockets,
-      kTerminalAutoClose,
+      kTerminalCloseBehavior,
       kTerminalTrackEnvironment,
       kTerminalBellStyle,
       kTerminalRenderer,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -704,10 +704,11 @@
             "default": true,
             "description": "Whether to use websockets to communicate with the shell in the Terminal tab."
         },
-        "terminal_auto_close": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether to automatically close the Terminal tab."
+        "terminal_close_behavior": {
+            "type": "string",
+            "enum": ["always", "clean", "never"],
+            "default": "always",
+            "description": "Whether to close the terminal pane after the shell exits."
         },
         "terminal_track_environment": {
             "type": "boolean",

--- a/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/console/ConsoleProcessInfo.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleProcessInfo.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,6 +35,7 @@ public class ConsoleProcessInfo extends JavaScriptObject
    public static final int AUTOCLOSE_DEFAULT = 0;
    public static final int AUTOCLOSE_ALWAYS = 1;
    public static final int AUTOCLOSE_NEVER = 2;
+   public static final int AUTOCLOSE_CLEAN_EXIT = 3;
 
    public static final int SEQUENCE_NO_TERMINAL = 0;
    public static final int SEQUENCE_NEW_TERMINAL = -1;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1151,12 +1151,16 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to automatically close the Terminal tab.
+    * Whether to close the terminal pane after the shell exits.
     */
-   public PrefValue<Boolean> terminalAutoClose()
+   public PrefValue<String> terminalCloseBehavior()
    {
-      return bool("terminal_auto_close", true);
+      return string("terminal_close_behavior", "always");
    }
+
+   public final static String TERMINAL_CLOSE_BEHAVIOR_ALWAYS = "always";
+   public final static String TERMINAL_CLOSE_BEHAVIOR_CLEAN = "clean";
+   public final static String TERMINAL_CLOSE_BEHAVIOR_NEVER = "never";
 
    /**
     * Whether to track and save changes to system environment variables in the Terminal.
@@ -1883,8 +1887,8 @@ public class UserPrefsAccessor extends Prefs
          terminalLocalEcho().setValue(layer, source.getBool("terminal_local_echo"));
       if (source.hasKey("terminal_websockets"))
          terminalWebsockets().setValue(layer, source.getBool("terminal_websockets"));
-      if (source.hasKey("terminal_auto_close"))
-         terminalAutoClose().setValue(layer, source.getBool("terminal_auto_close"));
+      if (source.hasKey("terminal_close_behavior"))
+         terminalCloseBehavior().setValue(layer, source.getString("terminal_close_behavior"));
       if (source.hasKey("terminal_track_environment"))
          terminalTrackEnvironment().setValue(layer, source.getBool("terminal_track_environment"));
       if (source.hasKey("terminal_bell_style"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/TerminalPreferencesPane.java
@@ -181,10 +181,23 @@ public class TerminalPreferencesPane extends PreferencesPane
       closing.add(miscLabel);
       miscLabel.setVisible(true);
 
-      CheckBox chkTerminalAutoClose = checkboxPref("Close terminal when shell exits",
-            prefs_.terminalAutoClose(),
-            "Deselect this option to keep terminal pane open after shell exits.");
-      closing.add(chkTerminalAutoClose);
+      autoClosePref_ = new SelectWidget(
+            "When shell exits:",
+            new String[]
+                  {
+                        "Close the pane",
+                        "Don't close the pane",
+                        "Close pane if shell exits cleanly"
+                  },
+            new String[]
+                  {
+                        UserPrefs.TERMINAL_CLOSE_BEHAVIOR_ALWAYS,
+                        UserPrefs.TERMINAL_CLOSE_BEHAVIOR_NEVER,
+                        UserPrefs.TERMINAL_CLOSE_BEHAVIOR_CLEAN
+                  },
+            false, true, false);
+      spaced(autoClosePref_);
+      closing.add(autoClosePref_);
 
       if (haveCaptureEnvPref())
       {
@@ -326,21 +339,11 @@ public class TerminalPreferencesPane extends PreferencesPane
       chkAudibleBell_.setValue(prefs_.terminalBellStyle().getValue() == UserPrefsAccessor.TERMINAL_BELL_STYLE_SOUND);
       chkHardwareAcceleration_.setValue(prefs_.terminalRenderer().getValue() == UserPrefsAccessor.TERMINAL_RENDERER_CANVAS);
 
-      int terminalInitialDirIndex;
-      switch (prefs.terminalInitialDirectory().getValue())
-      {
-      case UserPrefs.TERMINAL_INITIAL_DIRECTORY_PROJECT:
-      default:
-         terminalInitialDirIndex = 0;
-         break;
-      case UserPrefs.TERMINAL_INITIAL_DIRECTORY_CURRENT:
-         terminalInitialDirIndex = 1;
-         break;
-      case UserPrefs.TERMINAL_INITIAL_DIRECTORY_HOME:
-         terminalInitialDirIndex = 2;
-         break;
-      }
-      initialDirectory_.getListBox().setSelectedIndex(terminalInitialDirIndex);
+      if (!initialDirectory_.setValue(prefs.terminalInitialDirectory().getValue()))
+         initialDirectory_.getListBox().setSelectedIndex(0);
+
+      if (!autoClosePref_.setValue(prefs.terminalCloseBehavior().getValue()))
+         autoClosePref_.getListBox().setSelectedIndex(0);
    }
 
    @Override
@@ -368,6 +371,7 @@ public class TerminalPreferencesPane extends PreferencesPane
             UserPrefsAccessor.TERMINAL_RENDERER_CANVAS : UserPrefsAccessor.TERMINAL_RENDERER_DOM);
 
       prefs_.terminalInitialDirectory().setGlobalValue(initialDirectory_.getValue());
+      prefs_.terminalCloseBehavior().setGlobalValue(autoClosePref_.getValue());
 
       return restartRequirement;
    }
@@ -447,6 +451,7 @@ public class TerminalPreferencesPane extends PreferencesPane
    private final CheckBox chkHardwareAcceleration_;
    private final CheckBox chkAudibleBell_;
 
+   private SelectWidget autoClosePref_;
    private SelectWidget busyMode_;
    private FormLabel busyWhitelistLabel_;
    private TextBox busyWhitelist_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -46,6 +46,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
+import org.rstudio.studio.client.workbench.views.console.Console;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.NewWorkingCopyEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.terminal.events.TerminalSessionStartedEvent;
@@ -756,15 +757,21 @@ public class TerminalPane extends WorkbenchPane
          int autoCloseMode = terminals_.autoCloseForHandle(handle);
          if (autoCloseMode == ConsoleProcessInfo.AUTOCLOSE_DEFAULT)
          {
-            if (uiPrefs_.terminalAutoClose().getValue())
+            // map default to current user preference setting
+            String autoCloseSetting = uiPrefs_.terminalCloseBehavior().getValue();
+            if (autoCloseSetting == UserPrefs.TERMINAL_CLOSE_BEHAVIOR_ALWAYS)
                autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_ALWAYS;
+            else if (autoCloseSetting == UserPrefs.TERMINAL_CLOSE_BEHAVIOR_NEVER)
+               autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_NEVER;
+            else if (autoCloseSetting == UserPrefs.TERMINAL_CLOSE_BEHAVIOR_CLEAN)
+               autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_CLEAN_EXIT;
             else
                autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_NEVER;
          }
 
-         // always keep pane open for non-zero exit code so user can see what happened
-         if (exitCode != 0)
+         if (exitCode != 0 && autoCloseMode == ConsoleProcessInfo.AUTOCLOSE_CLEAN_EXIT)
          {
+            // keep pane open for non-zero exit code so user can see what happened
             autoCloseMode = ConsoleProcessInfo.AUTOCLOSE_NEVER;
          }
 


### PR DESCRIPTION
- previously, there was a boolean option to either keep the pane open, or close it, but behind the scenes was another check that would keep the pane open if shell exited with non-zero code, and the user had no way to override that (this was added in 1.3)

<img width="213" alt="2019-12-12_09-40-55" src="https://user-images.githubusercontent.com/10569626/70753138-ecdb3200-1ce8-11ea-90ac-9888dd57816d.png">

- new option has three choices, always close, never close, close if shell exits cleanly; this gives user control over this new behavior I added in 1.3 (checking exit code)

<img width="445" alt="2019-12-12_14-10-30" src="https://user-images.githubusercontent.com/10569626/70753250-3035a080-1ce9-11ea-9867-81331545acce.png">

- I didn't bother migrating the old setting forward, if user had changed it, they will need to do so again on 1.3 upgrade

- Here's what an exited, non-closed terminal pane shows (this isn't new, but just FYI):

<img width="381" alt="2019-12-12_14-01-26" src="https://user-images.githubusercontent.com/10569626/70753307-52c7b980-1ce9-11ea-9418-4f7267cbe71f.png">

- Also simplified setting of another recently added terminal preference in the UI (I was setting state via bruce force if/then/else instead of letting the SelectWidget do it for me)