### PR TITLE
fix text color of username when toolbar hidden

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.application.ui.impl;
 
 import java.util.ArrayList;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppMenuBar;
@@ -234,6 +235,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          usernameLabel.setTitle(userIdentity);
          userIdentity = userIdentity.split("@")[0];
          usernameLabel.setText(userIdentity);
+         Roles.getPresentationRole().setAriaLabelProperty(usernameLabel.getElement(), "Username");
 
          addRightCommand(usernameLabel);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.application.ui.impl;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.ImageElement;
@@ -411,6 +412,7 @@ public class WebApplicationHeader extends Composite
          usernameLabel.setTitle(userIdentity);
          userIdentity = userIdentity.split("@")[0];
          usernameLabel.setText(userIdentity);
+         Roles.getPresentationRole().setAriaLabelProperty(usernameLabel.getElement(), "Username");
          headerBarCommandsPanel_.add(usernameLabel);
          
          overlayUserCommandsPanel_ = new HorizontalPanel();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.css
@@ -1,4 +1,4 @@
-@external rstudio-themes-flat;
+@external rstudio-themes-flat, rstudio-themes-dark;
 
 @external rstudio-themes-default, rstudio-themes-dark-grey, rstudio-themes-alternate;
 
@@ -46,7 +46,6 @@
 }
 
 .rstudio-themes-flat .center {
-   color: #FFF;
    border-radius: 3px;
    border: solid 1px #000;
    height: 28px;
@@ -56,6 +55,10 @@
 .rstudio-themes-flat .center > table {
    padding: 0px;
    height: 27px;
+}
+
+.rstudio-themes-flat .rstudio-themes-dark .center {
+   color: white;
 }
 
 .rstudio-themes-flat .rstudio-themes-default .center {


### PR DESCRIPTION
- was hardcoded to white, which is almost invisible in light themes
- now it is black in light themes, white in dark themes (same as it is when toolbar is visible)
- Fixes #5651
- also added invisible aria-label of "Username" so screen reader has something to describe this text

Tested on light and dark themes:
<img width="174" alt="2019-12-12_15-37-34" src="https://user-images.githubusercontent.com/10569626/70757788-bc4dc500-1cf5-11ea-8d5d-20e28d29c3d4.png">
<img width="182" alt="2019-12-12_15-38-04" src="https://user-images.githubusercontent.com/10569626/70757797-c40d6980-1cf5-11ea-8d2d-d4c538c83cb8.png">
