### PR TITLE
use focus-visible polyfill on sign-in page

### DIFF
--- a/src/gwt/www/css/focus-visible.css
+++ b/src/gwt/www/css/focus-visible.css
@@ -14,3 +14,8 @@
     outline: #8AA9DB solid 2px !important;
     outline-offset: -1px !important;
 }
+
+/* button on sign-in page is solid blue, hard to see focus rectangle so offset it a bit */
+button.fancy.focus-visible {
+    outline-offset: 1px !important;
+}

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -41,11 +41,16 @@ function verifyMe()
 </script>
 
 <link rel="stylesheet" href="rstudio.css" type="text/css"/>
+<link rel="stylesheet" href="css/focus-visible.css" type="text/css"/>
 
 <style type="text/css">
 
 body, td {
    font-size: 12px;
+}
+
+#border {
+   margin: 0 auto;
 }
 
 #caption {
@@ -62,7 +67,6 @@ input[type=text], input[type=password] {
   padding: 3px;
   -moz-border-radius: 4px;
   -webkit-border-radius: 4px;
-  outline: none;
 }
 
 #buttonpanel {
@@ -82,10 +86,7 @@ button.fancy {
   border-radius: 4px;
   font-weight: bold;
   font-size: 14px;
-  padding-left: 15px;
-  padding-right: 15px;
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding: 10px 15px;
   cursor: pointer;
   outline: none;
   border: 0;
@@ -161,6 +162,7 @@ function submitRealForm() {
 </script>
 
 </head>
+<body>
 <div id="skipnav"><a href="#username">Skip navigation</a></div>
 <header role="banner" id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="27" alt="RStudio Logo (goes to external site)"/></a></header>
 <main role="main">
@@ -170,7 +172,7 @@ function submitRealForm() {
 <div role="alert" aria-atomic="true" class="visuallyhidden" id="live-error"></div>
 
 <form method="POST" #!formAction#>
-<table role="presentation" id="border" align="center">
+<table role="presentation" id="border">
   <tr>
     <td>
       <h1 id="caption">Sign in to RStudio</h1>
@@ -197,19 +199,18 @@ function submitRealForm() {
                 spellcheck='false'
                 value='' 
                 id='password' 
-                size='45'
-                autocomplete='off' /><br />
+                size='45'/><br />
       </p>
-      <p style="display: #staySignedInDisplay#;">
+      <div style="display: #staySignedInDisplay#;">
          <p style="display: #authTimeoutMinutesDisplay#;">
             <span style="font-size:10px">You will automatically be signed out after #authTimeoutMinutes# minutes of inactivity.</span>
          </p>
          <input type="checkbox" name="staySignedIn" id="staySignedIn" value="1"/>
          <label for="staySignedIn">Stay signed in when browser closes</label>
-      </p>
       </div>
        <input type="hidden" name="appUri" value="#appUri#"/>
        <div id="buttonpanel"><button class="fancy" type="submit">Sign In</button></div>
+      </div>
     </td>
   </tr>
 </table>
@@ -242,4 +243,6 @@ if (displayProp !== "none")
 }
 </script>
 </main>
+<script type="text/javascript" src="js/focus-visible.min.js"></script>
+</body>
 </html>


### PR DESCRIPTION
Fixes #5557 

- import the same polyfill used in the main IDE
- tweaked focus style for the Sign In button; it is solid blue and very hard to see our standard focus rectangle, so put in an offset
- fixed various html / css issues:
    - `align="center"` is deprecated on `<table>` so use css, instead
    - collapse padding-left/right/top/bottom to single-line form
    - added `<body>` to the page
    - removed duplicate `autocomplete` attribute on password `<input>`
    - fix nesting of `<p>` in another `<p>` (not allowed), replaced outer one with `<div>` and correct closing tags which were messing with the nesting (confusing to look at because this file isn't indented consistently, but same tool that saw the busted HTML nesting now confirms it is correct); after this checkin I may run an auto-indent on this file and check it in again

That last issue actually manifested in screen readers; they'd announce a confusing extra "group" due to that messed up nesting.

Here's the styling, same thing as in the IDE on text fields, and extra padding on the Sign In button:

<img width="300" alt="2019-12-12_21-21-34" src="https://user-images.githubusercontent.com/10569626/70771968-e7510c80-1d27-11ea-8f10-7672ea100ec9.png">

<img width="300" alt="2019-12-12_21-21-54" src="https://user-images.githubusercontent.com/10569626/70771978-ea4bfd00-1d27-11ea-9e76-e4f405b66427.png">
