### PR TITLE
Accessibility command to put focus on main toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -128,28 +128,6 @@ public class A11y
       Roles.getAlertRole().setAriaAtomicProperty(el, true);
    }
 
-   /**
-    * Mark a widget as an aria-live status
-    * @param widget
-    * @param assertive
-    */
-   public static void setStatusRole(Widget widget, boolean assertive)
-   {
-      setStatusRole(widget.getElement(), assertive);
-   }
-
-   /**
-    * Mark as widget as an aria-live status
-    * @param el
-    * @param assertive
-    */
-   public static void setStatusRole(Element el, boolean assertive)
-   {
-      Roles.getStatusRole().set(el);
-      Roles.getAlertRole().setAriaLiveProperty(el, assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
-      Roles.getAlertRole().setAriaAtomicProperty(el, true);
-   }
-
    public static void setVisuallyHidden(Widget widget)
    {
       setVisuallyHidden(widget.getElement());

--- a/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
@@ -49,6 +49,13 @@ public class AriaLiveStatusWidget extends Widget
       updateReaderTimer_.schedule(speakDelayMs);
    }
 
+   public void clearMessage()
+   {
+      if (updateReaderTimer_.isRunning())
+         updateReaderTimer_.cancel();
+      getElement().setInnerText("");
+   }
+
    /**
     * Timer for reporting the results via aria-live (to avoid interrupting typing)
     */

--- a/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
@@ -21,7 +21,7 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
 
 /**
- * A visually hidden panel for performing aria-live status announcements.
+ * A visually hidden widget for performing aria-live status announcements.
  */
 public class AriaLiveStatusWidget extends Widget
 {
@@ -34,8 +34,6 @@ public class AriaLiveStatusWidget extends Widget
 
    public void announce(String message, int speakDelayMs)
    {
-      // don't speak if negative delay, or if this element is currently
-      // inert (i.e. disabled by a modal dialog)
       if (speakDelayMs < 0)
       {
          if (updateReaderTimer_.isRunning())

--- a/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
@@ -1,5 +1,5 @@
 /*
- * LiveRegionWidget.java
+ * AriaLiveStatusWidget.java
  *
  * Copyright (C) 2019 by RStudio, Inc.
  *
@@ -14,7 +14,6 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.LiveValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Timer;
@@ -22,39 +21,21 @@ import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
 
 /**
- * A visually hidden panel for performing aria-live region announcements.
+ * A visually hidden panel for performing aria-live status announcements.
  */
-public class LiveRegionWidget extends Widget
+public class AriaLiveStatusWidget extends Widget
 {
-   public static boolean ASSERTIVE = true;
-   public static boolean POLITE = false;
-
-   public LiveRegionWidget()
-   {
-      commonInit();
-   }
-
-   public LiveRegionWidget(boolean assertive)
-   {
-      commonInit();
-      setAssertive(assertive);
-   }
-
-   private void commonInit()
+   public AriaLiveStatusWidget()
    {
       setElement(Document.get().createDivElement());
       A11y.setVisuallyHidden(getElement());
-      A11y.setStatusRole(getElement(), false /* non-assertive by default */);
-   }
-
-   public void setAssertive(boolean assertive)
-   {
-      Roles.getAlertRole().setAriaLiveProperty(getElement(),
-            assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
+      Roles.getStatusRole().set(getElement());
    }
 
    public void announce(String message, int speakDelayMs)
    {
+      // don't speak if negative delay, or if this element is currently
+      // inert (i.e. disabled by a modal dialog)
       if (speakDelayMs < 0)
       {
          if (updateReaderTimer_.isRunning())
@@ -82,4 +63,3 @@ public class LiveRegionWidget extends Widget
 
    private String resultsMessage_;
 }
-

--- a/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FilterWidget.java
@@ -47,10 +47,5 @@ public abstract class FilterWidget extends Composite
       return searchWidget_.getInputElement();
    }
 
-   public void speakResult(String message, int speakDelayMs)
-   {
-      searchWidget_.speakResult(message, speakDelayMs);
-   }
-
    private final SearchWidget searchWidget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/LiveRegionWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LiveRegionWidget.java
@@ -1,0 +1,85 @@
+/*
+ * LiveRegionWidget.java
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.LiveValue;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.a11y.A11y;
+
+/**
+ * A visually hidden panel for performing aria-live region announcements.
+ */
+public class LiveRegionWidget extends Widget
+{
+   public static boolean ASSERTIVE = true;
+   public static boolean POLITE = false;
+
+   public LiveRegionWidget()
+   {
+      commonInit();
+   }
+
+   public LiveRegionWidget(boolean assertive)
+   {
+      commonInit();
+      setAssertive(assertive);
+   }
+
+   private void commonInit()
+   {
+      setElement(Document.get().createDivElement());
+      A11y.setVisuallyHidden(getElement());
+      A11y.setStatusRole(getElement(), false /* non-assertive by default */);
+   }
+
+   public void setAssertive(boolean assertive)
+   {
+      Roles.getAlertRole().setAriaLiveProperty(getElement(),
+            assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
+   }
+
+   public void announce(String message, int speakDelayMs)
+   {
+      if (speakDelayMs < 0)
+      {
+         if (updateReaderTimer_.isRunning())
+            updateReaderTimer_.cancel();
+         return;
+      }
+
+      resultsMessage_ = message;
+      if (updateReaderTimer_.isRunning())
+         updateReaderTimer_.cancel();
+      updateReaderTimer_.schedule(speakDelayMs);
+   }
+
+   /**
+    * Timer for reporting the results via aria-live (to avoid interrupting typing)
+    */
+   private Timer updateReaderTimer_ = new Timer()
+   {
+      @Override
+      public void run()
+      {
+         getElement().setInnerText(resultsMessage_);
+      }
+   };
+
+   private String resultsMessage_;
+}
+

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -45,6 +45,7 @@ import com.google.gwt.user.client.ui.Widget;
 import elemental.client.Browser;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.a11y.A11y;
@@ -54,12 +55,17 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveClearStatusEvent;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.Timers;
 
 import java.util.ArrayList;
 
 public abstract class ModalDialogBase extends DialogBox
+                                      implements AriaLiveStatusEvent.Handler,
+                                                 AriaLiveClearStatusEvent.Handler
+   
 {
    private static final String firstFocusClass = "__rstudio_modal_first_focus";
    private static final String lastFocusClass = "__rstudio_modal_last_focus";
@@ -93,6 +99,12 @@ public abstract class ModalDialogBase extends DialogBox
       leftButtonPanel_ = new HorizontalPanel();
       bottomPanel_.add(leftButtonPanel_);
       bottomPanel_.add(buttonPanel_);
+
+      ariaLiveStatusWidget_ = new AriaLiveStatusWidget();
+      bottomPanel_.add(ariaLiveStatusWidget_);
+      handlers_.add(RStudioGinjector.INSTANCE.getEventBus().addHandler(AriaLiveStatusEvent.TYPE, this));
+      handlers_.add(RStudioGinjector.INSTANCE.getEventBus().addHandler(AriaLiveClearStatusEvent.TYPE, this));
+      
       setButtonAlignment(HasHorizontalAlignment.ALIGN_RIGHT);
       mainPanel_.add(bottomPanel_);
 
@@ -820,6 +832,29 @@ public abstract class ModalDialogBase extends DialogBox
       Styles styles();
    }
 
+   @Override
+   public void onAriaLiveStatus(AriaLiveStatusEvent event)
+   {
+      ariaLiveStatusWidget_.announce(event.getMessage(),
+            RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue());
+   }
+
+   @Override
+   public void onAriaLiveClearStatus(AriaLiveClearStatusEvent event)
+   {
+      ariaLiveStatusWidget_.clearMessage();
+   }
+
+   @Override
+   public void hide(boolean autoClosed)
+   {
+      handlers_.removeHandler();
+
+      // clear status we previously reported from other dialogs / main windows
+      RStudioGinjector.INSTANCE.getEventBus().fireEvent(new AriaLiveClearStatusEvent());
+      super.hide(autoClosed);
+   }
+
    private static Resources RES = GWT.create(Resources.class);
    static
    {
@@ -844,4 +879,6 @@ public abstract class ModalDialogBase extends DialogBox
    private com.google.gwt.dom.client.Element originallyActiveElement_;
    private Animation currentAnimation_ = null;
    private DialogRole role_;
+   private HandlerRegistrations handlers_ = new HandlerRegistrations();
+   private final AriaLiveStatusWidget ariaLiveStatusWidget_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.java
@@ -17,11 +17,19 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.LabelElement;
 import com.google.gwt.dom.client.NodeList;
-import com.google.gwt.event.dom.client.*;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
+import com.google.gwt.event.dom.client.HasAllFocusHandlers;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyDownHandler;
+import com.google.gwt.event.dom.client.KeyUpEvent;
+import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.SelectionHandler;
@@ -31,7 +39,6 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
-import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.gwt.user.client.ui.SuggestBox.DefaultSuggestionDisplay;
@@ -225,8 +232,6 @@ public class SearchWidget extends Composite implements SearchDisplay
       });
       
       focusTracker_ = new FocusTracker(suggestBox_);
-
-      A11y.setStatusRole(readerResultsLabel_, false);
    }
    
    public HandlerRegistration addFocusHandler(FocusHandler handler)
@@ -366,21 +371,6 @@ public class SearchWidget extends Composite implements SearchDisplay
       return inputEl;
    }
 
-   /**
-    * Report status using aria-live region, after a delay
-    * @param message
-    */
-   public void speakResult(String message, int speakDelayMs)
-   {
-      if (speakDelayMs <= 0)
-         return;
-
-      resultsMessage_ = message;
-      if (updateReaderTimer_.isRunning())
-         updateReaderTimer_.cancel();
-      updateReaderTimer_.schedule(speakDelayMs);
-   }
-
    @UiField(provided=true)
    FocusSuggestBox suggestBox_;
    @UiField
@@ -389,22 +379,7 @@ public class SearchWidget extends Composite implements SearchDisplay
    DecorativeImage icon_;
    @UiField
    LabelElement hiddenLabel_;
-   @UiField
-   DivElement readerResultsLabel_;
-
-   /**
-    * Timer for reporting the results via aria-live (to avoid interrupting typing)
-    */
-   private Timer updateReaderTimer_ = new Timer()
-   {
-      @Override
-      public void run()
-      {
-         readerResultsLabel_.setInnerText(resultsMessage_);
-      }
-   };
 
    private String lastValueSent_ = null;
    private final FocusTracker focusTracker_;
-   private String resultsMessage_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/SearchWidget.ui.xml
@@ -20,7 +20,6 @@
                            resource='{res.clearSearch2x}'
                            addStyleNames='{res.themeStyles.clearSearch}'/>
          </div>
-         <div class="{res.themeStyles.visuallyHidden}" ui:field="readerResultsLabel_"/>
          <div class="{res.themeStyles.right}"/>
       </div>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -158,7 +158,7 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(SwitchToRVersionEvent.TYPE, this);
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(FileUploadEvent.TYPE, this);
-      events.addHandler(AriaLiveAnnouncementEvent.TYPE, this);
+      events.addHandler(AriaLiveStatusEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -347,12 +347,9 @@ public class Application implements ApplicationEventHandlers
    }
    
    @Override
-   public void onAriaLiveAnnoucement(AriaLiveAnnouncementEvent event)
+   public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
-      if (event.getAssertive())
-         view_.reportStatusAssertive(event.getMessage());
-      else
-         view_.reportStatusPolite(event.getMessage());
+      view_.reportStatus(event.getMessage());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -157,6 +157,7 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(FileUploadEvent.TYPE, this);
       events.addHandler(AriaLiveStatusEvent.TYPE, this);
+      events.addHandler(AriaLiveClearStatusEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -348,6 +349,12 @@ public class Application implements ApplicationEventHandlers
    public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
       view_.reportStatus(event.getMessage());
+   }
+
+   @Override
+   public void onAriaLiveClearStatus(AriaLiveClearStatusEvent event)
+   {
+      view_.clearStatus();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -158,6 +158,7 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(SwitchToRVersionEvent.TYPE, this);
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(FileUploadEvent.TYPE, this);
+      events.addHandler(AriaLiveAnnouncementEvent.TYPE, this);
       
       // register for uncaught exceptions
       uncaughtExHandler.register();
@@ -285,6 +286,12 @@ public class Application implements ApplicationEventHandlers
    }
    
    @Handler
+   public void onFocusMainToolbar()
+   {
+      view_.focusToolbar();
+   }
+
+   @Handler
    void onShowAboutDialog()
    {
       server_.getProductInfo(new ServerRequestCallback<ProductInfo>()
@@ -321,6 +328,7 @@ public class Application implements ApplicationEventHandlers
       }
    }
    
+   @Override
    public void onUnauthorized(UnauthorizedEvent event)
    {
       // if the user is currently uploading a file (which potentially takes a long time)
@@ -332,17 +340,29 @@ public class Application implements ApplicationEventHandlers
       }
    }
 
+   @Override
    public void onFileUpload(FileUploadEvent event)
    {
       fileUploadInProgress_ = event.inProgress();
    }
    
+   @Override
+   public void onAriaLiveAnnoucement(AriaLiveAnnouncementEvent event)
+   {
+      if (event.getAssertive())
+         view_.reportStatusAssertive(event.getMessage());
+      else
+         view_.reportStatusPolite(event.getMessage());
+   }
+
+   @Override
    public void onServerOffline(ServerOfflineEvent event)
    {
       cleanupWorkbench();
       view_.showApplicationOffline();
    }
     
+   @Override
    public void onLogoutRequested(LogoutRequestedEvent event)
    {
       cleanupWorkbench();
@@ -459,6 +479,7 @@ public class Application implements ApplicationEventHandlers
       SuperDevMode.reload();
    }
    
+   @Override
    public void onSessionSerialization(SessionSerializationEvent event)
    {
       switch(event.getAction().getType())
@@ -505,6 +526,7 @@ public class Application implements ApplicationEventHandlers
       }
    }
 
+   @Override
    public void onSessionRelaunch(SessionRelaunchEvent event)
    {
       switch (event.getType())
@@ -539,6 +561,7 @@ public class Application implements ApplicationEventHandlers
       }
    }
    
+   @Override
    public void onServerUnavailable(ServerUnavailableEvent event)
    {
       view_.hideSerializationProgress();
@@ -565,6 +588,7 @@ public class Application implements ApplicationEventHandlers
       });
    }
 
+   @Override
    public void onReload(ReloadEvent event)
    {
       cleanupWorkbench();
@@ -572,6 +596,7 @@ public class Application implements ApplicationEventHandlers
       reloadWindowWithDelay(false);
    }
    
+   @Override
    public void onReloadWithLastChanceSave(ReloadWithLastChanceSaveEvent event)
    {
       Barrier barrier = new Barrier();
@@ -609,6 +634,7 @@ public class Application implements ApplicationEventHandlers
       }
    }
    
+   @Override
    public void onQuit(QuitEvent event)
    {
       cleanupWorkbench();
@@ -694,18 +720,21 @@ public class Application implements ApplicationEventHandlers
       }.schedule(100);
    }
    
+   @Override
    public void onSuicide(SuicideEvent event)
    { 
       cleanupWorkbench();
       view_.showApplicationSuicide(event.getMessage());
    }
    
+   @Override
    public void onClientDisconnected(ClientDisconnectedEvent event)
    {
       cleanupWorkbench();
       view_.showApplicationDisconnected();
    }
    
+   @Override
    public void onInvalidClientVersion(InvalidClientVersionEvent event)
    {
       cleanupWorkbench();
@@ -713,6 +742,7 @@ public class Application implements ApplicationEventHandlers
    }
    
 
+   @Override
    public void onInvalidSession(InvalidSessionEvent event)
    {
       // calculate the url without the scope
@@ -737,6 +767,7 @@ public class Application implements ApplicationEventHandlers
       navigateWindowWithDelay(baseURL);
    }
 
+   @Override
    public void onSessionAbendWarning(SessionAbendWarningEvent event)
    {
       view_.showSessionAbendWarning();

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -26,8 +26,6 @@ import com.google.gwt.dom.client.Style.Display;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.http.client.URL;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Timer;
@@ -1072,17 +1070,11 @@ public class Application implements ApplicationEventHandlers
       
       // toolbar (must be after call to showWorkbenchView because
       // showing the toolbar repositions the workbench view widget)
-      showToolbar( userPrefs_.get().toolbarVisible().getValue());
+      showToolbar(userPrefs_.get().toolbarVisible().getValue(), false);
       
       // sync to changes in the toolbar visibility state
       userPrefs_.get().toolbarVisible().addValueChangeHandler(
-                                          new ValueChangeHandler<Boolean>() {
-         @Override
-         public void onValueChange(ValueChangeEvent<Boolean> event)
-         {
-            showToolbar(event.getValue());
-         }
-      });
+            valueChangeEvent -> showToolbar(valueChangeEvent.getValue(), true));
    
       clientStateUpdaterInstance_ = clientStateUpdater_.get();
       
@@ -1152,10 +1144,10 @@ public class Application implements ApplicationEventHandlers
       userPrefs_.get().writeUserPrefs();
    }
    
-   private void showToolbar(boolean showToolbar)
+   private void showToolbar(boolean showToolbar, boolean announce)
    {
       // show or hide the toolbar
-      view_.showToolbar(showToolbar);
+      view_.showToolbar(showToolbar, announce);
          
       // manage commands
       commands_.showToolbar().setVisible(!showToolbar);

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -48,6 +48,7 @@ public interface ApplicationView
    // informative status message for screen reader users,
    // announced at next graceful opportunity
    void reportStatus(String message);
+   void clearStatus();
 
    // progress
    void showSerializationProgress(String message, 

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationView.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -32,6 +32,7 @@ public interface ApplicationView
    // toolbar
    void showToolbar(boolean showToolbar);
    boolean isToolbarShowing();
+   void focusToolbar();
    
    // application exit states
    void showApplicationQuit();
@@ -44,6 +45,12 @@ public interface ApplicationView
    // error messages
    void showSessionAbendWarning();
    
+   // informative status message announced at next graceful opportunity
+   void reportStatusPolite(String message);
+
+   // informative status message that should notify the user immediately
+   void reportStatusAssertive(String message);
+
    // progress
    void showSerializationProgress(String message, 
                                   boolean modal, 

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -30,7 +30,7 @@ public interface ApplicationView
    void showWorkbenchView(Widget widget);
    
    // toolbar
-   void showToolbar(boolean showToolbar);
+   void showToolbar(boolean showToolbar, boolean announce);
    boolean isToolbarShowing();
    void focusToolbar();
    

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -45,11 +45,9 @@ public interface ApplicationView
    // error messages
    void showSessionAbendWarning();
    
-   // informative status message announced at next graceful opportunity
-   void reportStatusPolite(String message);
-
-   // informative status message that should notify the user immediately
-   void reportStatusAssertive(String message);
+   // informative status message for screen reader users,
+   // announced at next graceful opportunity
+   void reportStatus(String message);
 
    // progress
    void showSerializationProgress(String message, 

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -33,6 +33,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedHandler,
                                                   InvalidSessionEvent.Handler,
                                                   SessionInitHandler,
                                                   RestartStatusEvent.Handler,
-                                                  FileUploadHandler
+                                                  FileUploadHandler,
+                                                  AriaLiveAnnouncementEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -34,6 +34,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedHandler,
                                                   SessionInitHandler,
                                                   RestartStatusEvent.Handler,
                                                   FileUploadHandler,
-                                                  AriaLiveStatusEvent.Handler
+                                                  AriaLiveStatusEvent.Handler,
+                                                  AriaLiveClearStatusEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -34,6 +34,6 @@ public interface ApplicationEventHandlers extends LogoutRequestedHandler,
                                                   SessionInitHandler,
                                                   RestartStatusEvent.Handler,
                                                   FileUploadHandler,
-                                                  AriaLiveAnnouncementEvent.Handler
+                                                  AriaLiveStatusEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveAnnouncementEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveAnnouncementEvent.java
@@ -1,0 +1,59 @@
+/*
+ * AriaLiveAnnouncementEvent.java
+ *
+ * Copyright (C) 2019 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class AriaLiveAnnouncementEvent extends GwtEvent<AriaLiveAnnouncementEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onAriaLiveAnnoucement(AriaLiveAnnouncementEvent event);
+   }
+
+   public AriaLiveAnnouncementEvent(boolean assertive, String message)
+   {
+      assertive_ = assertive;
+      message_ = message;
+   }
+
+   public boolean getAssertive()
+   {
+      return assertive_;
+   }
+
+   public String getMessage()
+   {
+      return message_;
+   }
+
+   @Override
+   protected void dispatch(AriaLiveAnnouncementEvent.Handler handler)
+   {
+      handler.onAriaLiveAnnoucement(this);
+   }
+
+   @Override
+   public Type<AriaLiveAnnouncementEvent.Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final boolean assertive_;
+   private final String message_;
+
+   public static final Type<AriaLiveAnnouncementEvent.Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveClearStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveClearStatusEvent.java
@@ -1,0 +1,44 @@
+/*
+ * AriaLiveClearStatusEvent.java
+ *
+ * Copyright (C) 2009-19 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class AriaLiveClearStatusEvent extends GwtEvent<AriaLiveClearStatusEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onAriaLiveClearStatus(AriaLiveClearStatusEvent event);
+   }
+
+   public AriaLiveClearStatusEvent()
+   {
+   }
+
+   @Override
+   protected void dispatch(AriaLiveClearStatusEvent.Handler handler)
+   {
+      handler.onAriaLiveClearStatus(this);
+   }
+
+   @Override
+   public Type<AriaLiveClearStatusEvent.Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   public static final Type<AriaLiveClearStatusEvent.Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
@@ -1,5 +1,5 @@
 /*
- * AriaLiveAnnouncementEvent.java
+ * AriaLiveStatusEvent.java
  *
  * Copyright (C) 2019 by RStudio, Inc.
  *
@@ -17,22 +17,16 @@ package org.rstudio.studio.client.application.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-public class AriaLiveAnnouncementEvent extends GwtEvent<AriaLiveAnnouncementEvent.Handler>
+public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
 {
    public interface Handler extends EventHandler
    {
-      void onAriaLiveAnnoucement(AriaLiveAnnouncementEvent event);
+      void onAriaLiveStatus(AriaLiveStatusEvent event);
    }
 
-   public AriaLiveAnnouncementEvent(boolean assertive, String message)
+   public AriaLiveStatusEvent(String message)
    {
-      assertive_ = assertive;
       message_ = message;
-   }
-
-   public boolean getAssertive()
-   {
-      return assertive_;
    }
 
    public String getMessage()
@@ -41,19 +35,18 @@ public class AriaLiveAnnouncementEvent extends GwtEvent<AriaLiveAnnouncementEven
    }
 
    @Override
-   protected void dispatch(AriaLiveAnnouncementEvent.Handler handler)
+   protected void dispatch(AriaLiveStatusEvent.Handler handler)
    {
-      handler.onAriaLiveAnnoucement(this);
+      handler.onAriaLiveStatus(this);
    }
 
    @Override
-   public Type<AriaLiveAnnouncementEvent.Handler> getAssociatedType()
+   public Type<AriaLiveStatusEvent.Handler> getAssociatedType()
    {
       return TYPE;
    }
 
-   private final boolean assertive_;
    private final String message_;
 
-   public static final Type<AriaLiveAnnouncementEvent.Handler> TYPE = new Type<>();
+   public static final Type<AriaLiveStatusEvent.Handler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationHeader.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationHeader.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -22,6 +22,7 @@ public interface ApplicationHeader extends IsWidget
    
    void showToolbar(boolean showToolbar);  
    boolean isToolbarVisible();
+   void focusToolbar();
    
    void focusGoToFunction();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -23,12 +23,11 @@ import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.a11y.A11y;
-import org.rstudio.core.client.widget.LiveRegionWidget;
+import org.rstudio.core.client.widget.AriaLiveStatusWidget;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.ApplicationView;
-import org.rstudio.studio.client.application.events.AriaLiveAnnouncementEvent;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.ui.appended.ApplicationEndedPopupPanel;
 import org.rstudio.studio.client.application.ui.serializationprogress.ApplicationSerializationProgress;
@@ -67,14 +66,11 @@ public class ApplicationWindow extends Composite
       updateHeaderTopBottom();
       applicationHeaderWidget.setVisible(false);
 
-      // aria-live announcements
-      ariaPoliteStatus_ = new LiveRegionWidget(LiveRegionWidget.POLITE);
+      // aria-live status announcements
+      ariaPoliteStatus_ = new AriaLiveStatusWidget();
       applicationPanel_.add(ariaPoliteStatus_);
       A11y.setVisuallyHidden(applicationPanel_.getWidgetContainerElement(ariaPoliteStatus_));
-      ariaAssertiveStatus_ = new LiveRegionWidget(LiveRegionWidget.ASSERTIVE);
-      applicationPanel_.add(ariaAssertiveStatus_);
-      A11y.setVisuallyHidden(applicationPanel_.getWidgetContainerElement(ariaAssertiveStatus_));
-      
+
       // main view container
       initWidget(applicationPanel_);
    }
@@ -87,8 +83,8 @@ public class ApplicationWindow extends Composite
       updateWorkbenchTopBottom();
       applicationPanel_.forceLayout();  
       if (showToolbar != currentVisibility)
-         pEvents_.get().fireEvent(new AriaLiveAnnouncementEvent(
-               false, showToolbar ? "Main toolbar now visible." : "Main toolbar now hidden."));
+         pEvents_.get().fireEvent(new AriaLiveStatusEvent(
+               showToolbar ? "Main toolbar now visible." : "Main toolbar now hidden."));
    }
    
    public boolean isToolbarShowing()
@@ -100,8 +96,7 @@ public class ApplicationWindow extends Composite
    {
       if (!isToolbarShowing())
       {
-         pEvents_.get().fireEvent(new AriaLiveAnnouncementEvent(
-               false, "Toolbar hidden, unable to focus."));
+         pEvents_.get().fireEvent(new AriaLiveStatusEvent("Toolbar hidden, unable to focus."));
          return;
       }
       applicationHeader_.focusToolbar();
@@ -265,14 +260,9 @@ public class ApplicationWindow extends Composite
             "You may have lost workspace data as a result of this crash.");
    }
    
-   public void reportStatusPolite(String message)
+   public void reportStatus(String message)
    {
       ariaPoliteStatus_.announce(message, pPrefs_.get().typingStatusDelayMs().getValue());
-   }
-
-   public void reportStatusAssertive(String message)
-   {
-      ariaAssertiveStatus_.announce(message, pPrefs_.get().typingStatusDelayMs().getValue());
    }
 
    public void showSerializationProgress(String msg, 
@@ -330,8 +320,7 @@ public class ApplicationWindow extends Composite
    private static final int COMPONENT_SPACING = 6;
    private Widget workbenchScreen_;
    private WarningBar warningBar_;
-   private final LiveRegionWidget ariaPoliteStatus_;
-   private final LiveRegionWidget ariaAssertiveStatus_;
+   private final AriaLiveStatusWidget ariaPoliteStatus_;
    private int workbenchBottom_ = COMPONENT_SPACING;
    private final GlobalDisplay globalDisplay_;
    private final Provider<UserPrefs> pPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -74,24 +74,27 @@ public class ApplicationWindow extends Composite
       // main view container
       initWidget(applicationPanel_);
    }
-      
-   public void showToolbar(boolean showToolbar)
+
+   @Override
+   public void showToolbar(boolean showToolbar, boolean announce)
    {
       boolean currentVisibility = isToolbarShowing();
       applicationHeader_.showToolbar(showToolbar);
       updateHeaderTopBottom();
       updateWorkbenchTopBottom();
       applicationPanel_.forceLayout();  
-      if (showToolbar != currentVisibility)
+      if (announce && showToolbar != currentVisibility)
          pEvents_.get().fireEvent(new AriaLiveStatusEvent(
                showToolbar ? "Main toolbar now visible." : "Main toolbar now hidden."));
    }
    
+   @Override
    public boolean isToolbarShowing()
    {
       return applicationHeader_.isToolbarVisible();
    }
    
+   @Override
    public void focusToolbar()
    {
       if (!isToolbarShowing())
@@ -102,6 +105,7 @@ public class ApplicationWindow extends Composite
       applicationHeader_.focusToolbar();
    }
 
+   @Override
    public void showApplicationAgreement(String title,
                                         String contents,
                                         Operation doNotAcceptOperation,
@@ -118,31 +122,37 @@ public class ApplicationWindow extends Composite
       return this ;
    }
    
+   @Override
    public void showApplicationQuit()
    {
       ApplicationEndedPopupPanel.showQuit();
    }
    
+   @Override
    public void showApplicationMultiSessionQuit()
    {
       ApplicationEndedPopupPanel.showMultiSessionQuit();
    }
    
+   @Override
    public void showApplicationSuicide(String reason)
    {
       ApplicationEndedPopupPanel.showSuicide(reason);
    }
    
+   @Override
    public void showApplicationDisconnected()
    {
       ApplicationEndedPopupPanel.showDisconnected();
    }
    
+   @Override
    public void showApplicationOffline()
    {
       ApplicationEndedPopupPanel.showOffline();
    }
    
+   @Override
    public void showApplicationUpdateRequired()
    {
       globalDisplay_.showMessage(
@@ -160,6 +170,7 @@ public class ApplicationWindow extends Composite
             });
    }
       
+   @Override
    public void showWorkbenchView(Widget workbenchScreen)
    {
       workbenchScreen_ = workbenchScreen;
@@ -201,11 +212,14 @@ public class ApplicationWindow extends Composite
       warningBar_.showLicenseButton(showLicenseButton);
    }
    
+   @Override
    public void showLicenseWarning(boolean severe, String message)
    {
       showWarning(severe, message, true);
       
    }
+
+   @Override
    public void showWarning(boolean severe, String message)
    {
       showWarning(severe, message, false);
@@ -236,6 +250,7 @@ public class ApplicationWindow extends Composite
             Unit.PX);
    }
 
+   @Override
    public void hideWarning()
    {
       if (warningBar_ != null)
@@ -251,6 +266,7 @@ public class ApplicationWindow extends Composite
       }
    }
 
+   @Override
    public void showSessionAbendWarning()
    {
       globalDisplay_.showErrorMessage(
@@ -260,11 +276,13 @@ public class ApplicationWindow extends Composite
             "You may have lost workspace data as a result of this crash.");
    }
    
+   @Override
    public void reportStatus(String message)
    {
       ariaPoliteStatus_.announce(message, pPrefs_.get().typingStatusDelayMs().getValue());
    }
 
+   @Override
    public void showSerializationProgress(String msg, 
                                          boolean modal, 
                                          int delayMs,
@@ -296,6 +314,7 @@ public class ApplicationWindow extends Composite
       }
    }
    
+   @Override
    public void hideSerializationProgress()
    {
       if (activeSerializationProgress_ != null)
@@ -305,6 +324,7 @@ public class ApplicationWindow extends Composite
       }
    }
   
+   @Override
    public void onResize()
    {
       applicationPanel_.onResize();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -67,9 +67,9 @@ public class ApplicationWindow extends Composite
       applicationHeaderWidget.setVisible(false);
 
       // aria-live status announcements
-      ariaPoliteStatus_ = new AriaLiveStatusWidget();
-      applicationPanel_.add(ariaPoliteStatus_);
-      A11y.setVisuallyHidden(applicationPanel_.getWidgetContainerElement(ariaPoliteStatus_));
+      ariaLiveStatusWidget_ = new AriaLiveStatusWidget();
+      applicationPanel_.add(ariaLiveStatusWidget_);
+      A11y.setVisuallyHidden(applicationPanel_.getWidgetContainerElement(ariaLiveStatusWidget_));
 
       // main view container
       initWidget(applicationPanel_);
@@ -279,7 +279,13 @@ public class ApplicationWindow extends Composite
    @Override
    public void reportStatus(String message)
    {
-      ariaPoliteStatus_.announce(message, pPrefs_.get().typingStatusDelayMs().getValue());
+      ariaLiveStatusWidget_.announce(message, pPrefs_.get().typingStatusDelayMs().getValue());
+   }
+   
+   @Override
+   public void clearStatus()
+   {
+      ariaLiveStatusWidget_.clearMessage();
    }
 
    @Override
@@ -340,7 +346,7 @@ public class ApplicationWindow extends Composite
    private static final int COMPONENT_SPACING = 6;
    private Widget workbenchScreen_;
    private WarningBar warningBar_;
-   private final AriaLiveStatusWidget ariaPoliteStatus_;
+   private final AriaLiveStatusWidget ariaLiveStatusWidget_;
    private int workbenchBottom_ = COMPONENT_SPACING;
    private final GlobalDisplay globalDisplay_;
    private final Provider<UserPrefs> pPrefs_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -249,6 +249,11 @@ public class GlobalToolbar extends Toolbar
       FocusHelper.setFocusDeferred((CanFocus)searchWidget_);
    }
      
+   public void setFocus()
+   {
+      Scheduler.get().scheduleDeferred(() -> getElement().focus());
+   }
+   
    private final Commands commands_;
    private final ToolbarPopupMenu newMenu_;
    private final Provider<CodeSearch> pCodeSearch_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -74,12 +74,12 @@ public class GlobalToolbar extends Toolbar
       
       // create and add new menu
       StandardIcons icons = StandardIcons.INSTANCE;
-      ToolbarMenuButton newButton = new ToolbarMenuButton(ToolbarButton.NoText,
+      newButton_ = new ToolbarMenuButton(ToolbarButton.NoText,
                                                           "New File",
                                                           new ImageResource2x(icons.stock_new2x()),
                                                           newMenu_);
-      ElementIds.assignElementId(newButton, ElementIds.NEW_FILE_MENUBUTTON);
-      addLeftWidget(newButton);
+      ElementIds.assignElementId(newButton_, ElementIds.NEW_FILE_MENUBUTTON);
+      addLeftWidget(newButton_);
       addLeftSeparator();
       
       addLeftWidget(commands.newProject().createToolbarButton());
@@ -251,11 +251,12 @@ public class GlobalToolbar extends Toolbar
      
    public void setFocus()
    {
-      Scheduler.get().scheduleDeferred(() -> getElement().focus());
+      Scheduler.get().scheduleDeferred(() -> newButton_.setFocus(true));
    }
    
    private final Commands commands_;
    private final ToolbarPopupMenu newMenu_;
+   private final ToolbarMenuButton newButton_;
    private final Provider<CodeSearch> pCodeSearch_;
    private final Widget searchWidget_;
    private final FocusContext codeSearchFocusContext_ = new FocusContext();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/LauncherSessionStatus.java
@@ -1,7 +1,7 @@
 /*
  * LauncherSessionStatus.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.application.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
-import org.rstudio.core.client.a11y.A11y;
 
 public class LauncherSessionStatus extends Composite
 {
@@ -35,7 +35,7 @@ public class LauncherSessionStatus extends Composite
    public LauncherSessionStatus()
    {
       initWidget(uiBinder.createAndBindUi(this));
-      A11y.setStatusRole(status_, false);
+      Roles.getStatusRole().set(status_.getElement());
    }
 
    public String getMessage()

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -214,6 +214,11 @@ public class DesktopApplicationHeader implements ApplicationHeader,
    {
       return toolbar_.isVisible();
    }
+
+   public void focusToolbar()
+   {
+      toolbar_.setFocus();
+   }
    
    public void focusGoToFunction()
    {

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -205,21 +205,25 @@ public class DesktopApplicationHeader implements ApplicationHeader,
       toolbar_.addStyleName(styles.desktopGlobalToolbar());
    }
    
+   @Override
    public void showToolbar(boolean showToolbar)
    {
       toolbar_.setVisible(showToolbar);
    }
    
+   @Override
    public boolean isToolbarVisible()
    {
       return toolbar_.isVisible();
    }
 
+   @Override
    public void focusToolbar()
    {
       toolbar_.setFocus();
    }
    
+   @Override
    public void focusGoToFunction()
    {
       toolbar_.focusGoToFunction();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -233,6 +233,7 @@ public class WebApplicationHeader extends Composite
       initWidget(outerPanel_);
    }
     
+   @Override
    public void showToolbar(boolean showToolbar)
    {
       toolbarVisible_ = showToolbar;
@@ -268,16 +269,19 @@ public class WebApplicationHeader extends Composite
       overlay_.setGlobalToolbarVisible(this, showToolbar);
    }
    
+   @Override
    public boolean isToolbarVisible()
    {
       return toolbarVisible_;
    }
    
+   @Override
    public void focusToolbar()
    {
       toolbar_.setFocus();
    }
 
+   @Override
    public void focusGoToFunction()
    {
       toolbar_.focusGoToFunction();
@@ -373,6 +377,7 @@ public class WebApplicationHeader extends Composite
       commands.pasteWithIndentDummy().addHandler(useKeyboardNotification);
    }
 
+   @Override
    public int getPreferredHeight()
    {
       return preferredHeight_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -273,6 +273,11 @@ public class WebApplicationHeader extends Composite
       return toolbarVisible_;
    }
    
+   public void focusToolbar()
+   {
+      toolbar_.setFocus();
+   }
+
    public void focusGoToFunction()
    {
       toolbar_.focusGoToFunction();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
@@ -14,13 +14,13 @@
  */
 package org.rstudio.studio.client.application.ui.serializationprogress;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
-import org.rstudio.core.client.a11y.A11y;
 
 public class ApplicationSerializationProgressLabel extends Composite
 {
@@ -32,7 +32,7 @@ public class ApplicationSerializationProgressLabel extends Composite
    public ApplicationSerializationProgressLabel()
    {
       initWidget(binder.createAndBindUi(this));
-      A11y.setStatusRole(label_, false);
+      Roles.getStatusRole().set(label_.getElement());
    }
 
    public void setText(String text)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -1,5 +1,5 @@
 /*
- * ShowAddinsDialog.java
+ * BrowseAddinsDialog.java
  *
  * Copyright (C) 2009-19 by RStudio, Inc.
  *
@@ -52,12 +52,13 @@ import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.AddinsCommandManager;
-import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -167,10 +168,10 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    }
    
    @Inject
-   private void initialize(AddinsCommandManager addinsCommandManager, UserPrefs prefs)
+   private void initialize(AddinsCommandManager addinsCommandManager, EventBus events)
    {
       addinsCommandManager_ = addinsCommandManager;
-      prefs_ = prefs;
+      events_ = events;
    }
    
    private void addColumns()
@@ -289,8 +290,8 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       });
       dataProvider_.setList(data);
-      filterWidget_.speakResult("Found " + data.size() + " addins matching " +
-            StringUtil.spacedString(query), prefs_.typingStatusDelayMs().getValue());
+      events_.fireEvent(new AriaLiveStatusEvent(
+            "Found " + data.size() + " addins matching " + StringUtil.spacedString(query)));
    }
    
    @Override
@@ -366,7 +367,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
    
    // Injected ----
    private AddinsCommandManager addinsCommandManager_;
-   private UserPrefs prefs_;
+   private EventBus events_;
 
    // Resources, etc ----
    public interface Resources extends RStudioDataGridResources

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -848,6 +848,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showProfileMenu" value="Ctrl+Alt+O"/>
          <shortcut refid="showToolsMenu" value="Ctrl+Alt+T"/>
          <shortcut refid="showHelpMenu" value="Ctrl+Alt+H"/>
+         <shortcut refid="focusMainToolbar" value="Ctrl+Alt+L"/>
       </shortcutgroup>
 
       <!-- 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -500,6 +500,8 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="toggleScreenReaderSupport"/>
             <cmd refid="toggleTabKeyMovesFocus"/>
             <separator/>
+            <cmd refid="focusMainToolbar"/>
+            <separator/>
             <cmd refid="showAccessibilityOptions"/>
          </menu>
          <separator/>
@@ -3565,5 +3567,9 @@ well as menu structures (for main menu and popup menus).
    <cmd id="toggleTabKeyMovesFocus"
         menuLabel="_Tab Key Always Moves Focus"
         checkable="true"
+        windowMode="main"/>
+
+   <cmd id="focusMainToolbar"
+        menuLabel="Focus _Main Toolbar"
         windowMode="main"/>
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -628,6 +628,7 @@ public abstract class
    public abstract AppCommand toggleScreenReaderSupport();
    public abstract AppCommand toggleTabKeyMovesFocus();
    public abstract AppCommand showAccessibilityOptions();
+   public abstract AppCommand focusMainToolbar();
    
    // Internal
    public abstract AppCommand showDomElements();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.git.dialog;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -309,7 +310,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       A11y.setARIAHidden(lblCharCount_);
       
       // Expose a screen reader-only element with debounced updates
-      A11y.setStatusRole(lblReaderCharCount_, false);
+      Roles.getStatusRole().set(lblReaderCharCount_.getElement());
 
       unstagedCheckBox_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
       {


### PR DESCRIPTION
New command on accessibility menu for sending keyboard focus to main toolbar.

<img width="493" alt="2019-12-14_12-48-40" src="https://user-images.githubusercontent.com/10569626/70854408-25594800-1e70-11ea-819c-cb5e0e907656.png">

Fixes #5458

Also adds a framework to the main window so you can cause an aria-live polite announcement by firing an `AriaLiveStatusEvent` with the string you want spoken.

Hooked that up when main toolbar visibility is changed, and also to announce when main toolbar is hidden and thus cannot get focus. None of these are terribly important scenarios, mainly doing to test the new mechanism. Will be using in a bunch of other places in the future.

Also provided this mechanism in modal dialogs so same event can be used to announce things from a modal dialog.