### PR TITLE
bump RSA key size to 2048

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,7 @@
 * Command in to change terminal to current RStudio working directory (#2363)
 * Zoom Left/Right Column commands for keyboard users (#5874)
 * Increase maximum plot size for large, high-DPI displays (#4968; thanks to Jan Gleixner)
+* RStudio now uses 2048 bit RSA keys by default.
 
 ### Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -94,7 +94,7 @@
 * Command in to change terminal to current RStudio working directory (#2363)
 * Zoom Left/Right Column commands for keyboard users (#5874)
 * Increase maximum plot size for large, high-DPI displays (#4968; thanks to Jan Gleixner)
-* RStudio now uses 2048 bit RSA keys by default.
+* RStudio Server now uses 2048 bit RSA keys, for secure communication of encrypted credentials between server / session and client
 
 ### Bugfixes
 

--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -547,7 +547,7 @@ std::string s_exponent;
 
 core::Error rsaInit()
 {
-   const int KEY_SIZE = 1024;
+   const int KEY_SIZE = 2048;
    const int ENTROPY_BYTES = 4096;
 
    const BIGNUM *bn_n;


### PR DESCRIPTION
Note: worth considering making this configurable, but that's a larger change.