### PR TITLE
Use html numeric textfield for integer input in preferences panes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
@@ -23,4 +23,14 @@ public class NumericTextBox extends TextBox
       super();
       getElement().setAttribute("type", "number");
    }
+
+   public void setMax(int max)
+   {
+      getElement().setAttribute("max", String.valueOf(max));
+   }
+
+   public void setMin(int min)
+   {
+      getElement().setAttribute("min", String.valueOf(min));
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
@@ -27,12 +27,30 @@ public class NumericValueWidget extends Composite
       implements HasValue<String>,
                  HasEnsureVisibleHandlers
 {
-   public NumericValueWidget(String label)
+   public static final Integer ZeroMinimum = null;
+   public static final Integer NoMaximum = null;
+
+   /**
+    * Prompt for an integer in the range [min, max]
+    * 
+    * @param label
+    * @param minValue minimum, if null (ZeroMinimum), zero assumed
+    * @param maxValue maximum, if null (NoMaximum), no maximum assumed
+    */
+   public NumericValueWidget(String label, Integer minValue, Integer maxValue)
    {
       FlowPanel flowPanel = new FlowPanel();
 
-      textBox_ = new TextBox();
-      textBox_.setWidth("30px");
+      textBox_ = new NumericTextBox();
+      textBox_.setWidth("48px");
+      minValue_ = minValue;
+      maxValue_ = maxValue;
+      if (minValue == ZeroMinimum)
+         textBox_.setMin(0);
+      else
+         textBox_.setMin(minValue);
+      if (maxValue != NoMaximum)
+         textBox_.setMax(maxValue);
       textBox_.getElement().getStyle().setMarginLeft(0.6, Unit.EM);
 
       flowPanel.add(new SpanLabel(label, textBox_, true));
@@ -66,21 +84,11 @@ public class NumericValueWidget extends Composite
       return textBox_.addValueChangeHandler(handler);
    }
 
-   public boolean validate(String fieldName)
-   {
-      return validateRange(fieldName, null, null);
-   }
-
-   public boolean validatePositive(String fieldName)
-   {
-      return validateRange(fieldName, 1, null);
-   }
-
    /**
-    * Make sure field is a valid integer in the range [min, max). If min or max
+    * Make sure field is a valid integer in the range [min, max]. If min or max
     * are null, then 0 and infinity are assumed, respectively.
     */
-   public boolean validateRange(String fieldName, Integer min, Integer max)
+   public boolean validate(String fieldName)
    {
       String value = textBox_.getValue().trim();
       if (!value.matches("^\\d+$"))
@@ -89,24 +97,27 @@ public class NumericValueWidget extends Composite
          textBox_.getElement().focus();
          RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                "Error",
-               fieldName + " must be a valid number.");
+               fieldName + " must be a valid number.",
+               textBox_);
          return false;
       }
-      if (min != null || max != null)
+      if (minValue_ != null || maxValue_ != null)
       {
          int intVal = Integer.parseInt(value);
-         if (min != null && intVal < min)
+         if (minValue_ != null && intVal < minValue_)
          {
             RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                   "Error",
-                  fieldName + " must be greater than or equal to " + min + ".");
+                  fieldName + " must be greater than or equal to " + minValue_ + ".",
+                  textBox_);
             return false;
          }
-         if (max != null && intVal >= max)
+         if (maxValue_ != null && intVal > maxValue_)
          {
             RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                   "Error",
-                  fieldName + " must be less than " + max + ".");
+                  fieldName + " must be less than or equal to " + maxValue_ + ".",
+                  textBox_);
             return false;
          }
       }
@@ -118,5 +129,7 @@ public class NumericValueWidget extends Composite
       return addHandler(handler, EnsureVisibleEvent.TYPE);
    }
 
-   private TextBox textBox_;
+   private final NumericTextBox textBox_;
+   private final Integer minValue_;
+   private final Integer maxValue_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
@@ -24,6 +24,7 @@ import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.workbench.prefs.model.ProjectPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.views.LineEndingsSelectWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.IconvListResult;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ui.ChooseEncodingDialog;
@@ -49,8 +50,9 @@ public class ProjectEditingPreferencesPane extends ProjectPreferencesPane
       chkSpacesForTab_.addStyleName(RESOURCES.styles().useSpacesForTab());
       add(chkSpacesForTab_);
       
-      numSpacesForTab_ = new NumericValueWidget("Tab width");
+      numSpacesForTab_ = new NumericValueWidget("Tab width", 1, UserPrefs.MAX_TAB_WIDTH);
       numSpacesForTab_.addStyleName(RESOURCES.styles().numberOfTabs());
+      numSpacesForTab_.setWidth("36px");
       add(numSpacesForTab_);
       
       chkAutoAppendNewline_ = new CheckBox("Ensure that source files end with newline");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -341,7 +341,9 @@ public class UserPrefs extends UserPrefsComputed
    public static final int LAYER_COMPUTED = 2;
    public static final int LAYER_USER     = 3;
    public static final int LAYER_PROJECT  = 4;
-   
+
+   public static final int MAX_TAB_WIDTH = 64;
+
    private final Session session_;
    private final PrefsServerOperations server_;
    private final SatelliteManager satelliteManager_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -42,7 +42,7 @@ public class AccessibilityPreferencesPane extends PreferencesPane
             prefs.ariaApplicationRole()));
 
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
-            prefs.typingStatusDelayMs());
+            1, 9999, prefs.typingStatusDelayMs());
       add(indent(typingStatusDelay_));
 
       Label displayLabel = headerLabel("Other");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -68,7 +68,9 @@ public class EditingPreferencesPane extends PreferencesPane
       editingPanel.add(headerLabel("General"));
       editingPanel.add(tight(spacesForTab_ = checkboxPref("Insert spaces for tab", prefs.useSpacesForTab(), 
             false /*defaultSpace*/)));
-      editingPanel.add(indent(tabWidth_ = numericPref("Tab width", prefs.numSpacesForTab())));
+      editingPanel.add(indent(tabWidth_ = numericPref("Tab width", 1, UserPrefs.MAX_TAB_WIDTH,
+            prefs.numSpacesForTab())));
+      tabWidth_.setWidth("36px");
       editingPanel.add(checkboxPref(
             "Auto-detect code indentation",
             prefs_.autoDetectIndentation(),
@@ -225,7 +227,6 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(headerLabel("Console"));
       NumericValueWidget limitLengthPref =
             numericPref("Limit length of lines displayed in console to:", prefs_.consoleLineLengthLimit());
-      limitLengthPref.setWidth("36px");
       displayPanel.add(nudgeRightPlus(limitLengthPref));
 
       consoleColorMode_ = new SelectWidget(
@@ -439,10 +440,10 @@ public class EditingPreferencesPane extends PreferencesPane
       completionPanel.add(delayLabel);
       
       completionPanel.add(nudgeRightPlus(alwaysCompleteChars_ =
-          numericPref("Show completions after characters entered:",
+          numericPref("Show completions after characters entered:", 1, 99,
                       prefs.codeCompletionCharacters())));
       completionPanel.add(nudgeRightPlus(alwaysCompleteDelayMs_ = 
-          numericPref("Show completions after keyboard idle (ms):",
+          numericPref("Show completions after keyboard idle (ms):", 0, 9999,
                       prefs.codeCompletionDelay())));
         
       
@@ -481,7 +482,7 @@ public class EditingPreferencesPane extends PreferencesPane
       diagnosticsPanel.add(tight(checkboxPref("Show diagnostics after keyboard is idle for a period of time", 
             prefs.backgroundDiagnostics(), false /*defaultSpace*/)));
       diagnosticsPanel.add(indent(backgroundDiagnosticsDelayMs_ =
-            numericPref("Keyboard idle time (ms):", prefs.backgroundDiagnosticsDelayMs())));
+            numericPref("Keyboard idle time (ms):", 0, 9999, prefs.backgroundDiagnosticsDelayMs())));
       
       HelpLink diagnosticsHelpLink = new DiagnosticsHelpLink();
       diagnosticsHelpLink.getElement().getStyle().setMarginTop(12, Unit.PX);
@@ -605,11 +606,11 @@ public class EditingPreferencesPane extends PreferencesPane
    @Override
    public boolean validate()
    {
-      return (!spacesForTab_.getValue() || tabWidth_.validatePositive("Tab width")) && 
+      return (!spacesForTab_.getValue() || tabWidth_.validate("Tab width")) && 
              (!showMargin_.getValue() || marginCol_.validate("Margin column")) &&
-             alwaysCompleteChars_.validateRange("Characters entered", 1, 100) &&
-             alwaysCompleteDelayMs_.validateRange("Completion keyboard idle (ms)", 0, 10000) &&
-             backgroundDiagnosticsDelayMs_.validateRange("Diagnostics keyboard idle (ms):", 0, 10000);
+             alwaysCompleteChars_.validate("Characters entered") &&
+             alwaysCompleteDelayMs_.validate("Completion keyboard idle (ms)") &&
+             backgroundDiagnosticsDelayMs_.validate("Diagnostics keyboard idle (ms):");
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesPane.java
@@ -111,10 +111,32 @@ public abstract class PreferencesPane extends PreferencesDialogPaneBase<UserPref
       return checkBox;
    }
 
+   /**
+    * Prompt for integer preference value in range [0 - maxint]
+    */
    protected NumericValueWidget numericPref(String label,
                                             final PrefValue<Integer> prefValue)
    {
-      final NumericValueWidget widget = new NumericValueWidget(label);
+      return numericPref(label, NumericValueWidget.ZeroMinimum,
+            NumericValueWidget.NoMaximum,
+            prefValue);
+   }
+
+   /**
+    * Prompt for integer preference value in range [min, max]
+    * 
+    * @param label
+    * @param minValue minimum value or NumericValueWidget.ZeroMinimum
+    * @param maxValue maximum value or NumericValueWidget.NoMaximum
+    * @param prefValue
+    * @return
+    */
+   protected NumericValueWidget numericPref(String label,
+                                            Integer minValue,
+                                            Integer maxValue,
+                                            final PrefValue<Integer> prefValue)
+   {
+      final NumericValueWidget widget = new NumericValueWidget(label, minValue, maxValue);
       lessSpaced(widget);
       registerEnsureVisibleHandler(widget);
       widget.setValue(prefValue.getGlobalValue() + "");


### PR DESCRIPTION
- provides native spin-button UI and range-checking
- needs slightly more horizontal space due to spin-button UI
- moved tracking of min/max into the NumericValueWidget control so it can be supplied via constructor
- if there is a validation error when "OK-ing" the preferences, attempt to put focus on the offending control after error message (limitation, if error is on a different property page, won't change back, just leave focus on the OK button)