### PR TITLE
(cleanup) use GWT roles for alerts instead of custom code

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.core.client.a11y;
 
-import com.google.gwt.aria.client.LiveValue;
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
@@ -102,30 +100,6 @@ public class A11y
    public static void setARIAHidden(Element el)
    {
       el.setAttribute("aria-hidden", "true");
-   }
-
-   /**
-    * Mark as widget as an aria-live alert
-    *
-    * @param widget
-    * @param assertive
-    */
-   public static void setAlertRole(Widget widget, boolean assertive)
-   {
-      setAlertRole(widget.getElement(), assertive);
-   }
-
-   /**
-    * Mark an element as an aria-live alert
-    *
-    * @param el
-    * @param assertive
-    */
-   public static void setAlertRole(Element el, boolean assertive)
-   {
-      Roles.getAlertRole().set(el);
-      Roles.getAlertRole().setAriaLiveProperty(el, assertive ? LiveValue.ASSERTIVE : LiveValue.POLITE);
-      Roles.getAlertRole().setAriaAtomicProperty(el, true);
    }
 
    public static void setVisuallyHidden(Widget widget)

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Cursor;
@@ -73,7 +74,10 @@ public class InfoBar extends Composite
       initWidget(binder.createAndBindUi(this));
 
       A11y.setARIAHidden(label_);
-      A11y.setAlertRole(live_, mode == ERROR);
+      if (mode == ERROR)
+         Roles.getAlertRole().set(live_.getElement());
+      else
+         Roles.getStatusRole().set(live_.getElement());
       dismiss_.addStyleName(ThemeResources.INSTANCE.themeStyles().handCursor());
       
       if (dismissHandler != null)

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.EntryPoint;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
@@ -124,7 +125,7 @@ public class RStudio implements EntryPoint
    {
       final Label background = new Label();
       ariaLoadingMessage_ = new Label();
-      A11y.setAlertRole(ariaLoadingMessage_, true);
+      Roles.getAlertRole().set(ariaLoadingMessage_.getElement());
       A11y.setVisuallyHidden(ariaLoadingMessage_);
 
       background.getElement().getStyle().setZIndex(1000);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.application.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.a11y.A11y;
@@ -81,7 +82,7 @@ public class WarningBar extends Composite
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
       A11y.setARIAHidden(label_);
-      A11y.setAlertRole(live_, true);
+      Roles.getAlertRole().set(live_);
    }
 
    public void setText(String value)


### PR DESCRIPTION
- alerts default to atomic and assertive, no need to set
- also, status defaults to atomic and polite