### PR TITLE
Make console max line limit configurable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,7 @@
 * Increase maximum plot size for large, high-DPI displays (#4968; thanks to Jan Gleixner)
 * RStudio Server now uses 2048 bit RSA keys, for secure communication of encrypted credentials between server / session and client
 * Add support for running Shiny applications as background jobs (#5190)
+* Make maximum lines in R console configurable; was previously fixed at 1000 (#5919)
 
 ### Bugfixes
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -143,6 +143,7 @@ namespace prefs {
 #define kScrollPastEndOfDocument "scroll_past_end_of_document"
 #define kHighlightRFunctionCalls "highlight_r_function_calls"
 #define kConsoleLineLengthLimit "console_line_length_limit"
+#define kConsoleMaxLines "console_max_lines"
 #define kAnsiConsoleMode "ansi_console_mode"
 #define kAnsiConsoleModeOff "off"
 #define kAnsiConsoleModeOn "on"
@@ -736,6 +737,12 @@ public:
     */
    int consoleLineLengthLimit();
    core::Error setConsoleLineLengthLimit(int val);
+
+   /**
+    * The maximum number of console actions to store and display in the console scrollback buffer.
+    */
+   int consoleMaxLines();
+   core::Error setConsoleMaxLines(int val);
 
    /**
     * How to treat ANSI escape codes in the console.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -934,6 +934,19 @@ core::Error UserPrefValues::setConsoleLineLengthLimit(int val)
 }
 
 /**
+ * The maximum number of console actions to store and display in the console scrollback buffer.
+ */
+int UserPrefValues::consoleMaxLines()
+{
+   return readPref<int>("console_max_lines");
+}
+
+core::Error UserPrefValues::setConsoleMaxLines(int val)
+{
+   return writePref("console_max_lines", val);
+}
+
+/**
  * How to treat ANSI escape codes in the console.
  */
 std::string UserPrefValues::ansiConsoleMode()
@@ -2384,6 +2397,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kScrollPastEndOfDocument,
       kHighlightRFunctionCalls,
       kConsoleLineLengthLimit,
+      kConsoleMaxLines,
       kAnsiConsoleMode,
       kShowInlineToolbarForRCodeChunks,
       kHighlightCodeChunks,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -438,6 +438,11 @@
             "default": 1000,
             "description": "The maximum number of characters to display in a single line in the R console."
         },
+        "console_max_lines": {
+            "type": "integer",
+            "default": 1000,
+            "description": "The maximum number of console actions to store and display in the console scrollback buffer."
+        },
         "ansi_console_mode": {
             "type": "string",
             "enum": ["off", "on", "strip"],

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -705,6 +705,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * The maximum number of console actions to store and display in the console scrollback buffer.
+    */
+   public PrefValue<Integer> consoleMaxLines()
+   {
+      return integer("console_max_lines", 1000);
+   }
+
+   /**
     * How to treat ANSI escape codes in the console.
     */
    public PrefValue<String> ansiConsoleMode()
@@ -1791,6 +1799,8 @@ public class UserPrefsAccessor extends Prefs
          highlightRFunctionCalls().setValue(layer, source.getBool("highlight_r_function_calls"));
       if (source.hasKey("console_line_length_limit"))
          consoleLineLengthLimit().setValue(layer, source.getInteger("console_line_length_limit"));
+      if (source.hasKey("console_max_lines"))
+         consoleMaxLines().setValue(layer, source.getInteger("console_max_lines"));
       if (source.hasKey("ansi_console_mode"))
          ansiConsoleMode().setValue(layer, source.getString("ansi_console_mode"));
       if (source.hasKey("show_inline_toolbar_for_r_code_chunks"))


### PR DESCRIPTION
Inspired by https://community.rstudio.com/t/more-than-1000-lines-output-in-r-studio-console/3288 and a parallel conversation with @alandipert; this is a drive-by change which makes it possible to adjust the size of the console scrollback buffer, either down for performance on slow systems or up for capturing very long outputs. Obviously the best thing to do would be to virtualize the console entirely so performance isn't an issue, but that change won't make this release. 

This setting is intended for use only by power users who understand the implications of changing it, so it does not have UI. 