### PR TITLE
Fix disconnect between Shiny viewer type and associated pref

### DIFF
--- a/src/cpp/session/modules/SessionErrors.cpp
+++ b/src/cpp/session/modules/SessionErrors.cpp
@@ -208,7 +208,7 @@ Error initialize()
    events().onDeferredInit.connect(bind(detectHandlerChange,
                                         pErrorHandler, true));
    prefs::userState().onChanged.connect(bind(onUserSettingsChanged,
-                                         _1,
+                                         _2,
                                          pErrorHandler,
                                          pHandleUserErrorsOnly));
 

--- a/src/cpp/session/modules/SessionPlumberViewer.cpp
+++ b/src/cpp/session/modules/SessionPlumberViewer.cpp
@@ -211,7 +211,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_plumberviewer);
 
    prefs::userPrefs().onChanged.connect(bind(
-            onUserSettingsChanged, _1, pPlumberViewerType));
+            onUserSettingsChanged, _2, pPlumberViewerType));
 
    ExecBlock initBlock;
    initBlock.addFunctions()

--- a/src/cpp/session/modules/SessionShinyViewer.cpp
+++ b/src/cpp/session/modules/SessionShinyViewer.cpp
@@ -358,7 +358,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_shinyviewer);
 
    events().onConsoleInput.connect(onConsoleInput);
-   prefs::userPrefs().onChanged.connect(bind(onUserSettingsChanged, _1,
+   prefs::userPrefs().onChanged.connect(bind(onUserSettingsChanged, _2,
                                          pShinyViewerType));
 
    ExecBlock initBlock;

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -100,7 +100,7 @@ void Preferences::destroyLayers()
 {
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
-      // Give each layer a chance to destoy itself
+      // Give each layer a chance to destroy itself
       for (auto layer: layers_)
       {
          layer->destroy();

--- a/src/cpp/tests/testthat/test-shiny.R
+++ b/src/cpp/tests/testthat/test-shiny.R
@@ -1,0 +1,38 @@
+#
+# test-shiny.R
+#
+# Copyright (C) 2009-19 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("shiny")
+
+test_that("shiny viewer type set by preference sticks", {
+   # read the current value of the preference
+   old <- .rs.api.readRStudioPreference("shiny_viewer_type")
+
+   # set the viewer type to external browser (via pref)
+   .rs.api.writeRStudioPreference("shiny_viewer_type", "browser")
+
+   # set the viewer type to browser and verify that it was done as we requested
+   .rs.setShinyViewerType("browser")
+   expect_equal(.rs.getShinyViewerType(), "browser")
+
+   # set the viewer type to external window (via pref)
+   .rs.api.writeRStudioPreference("shiny_viewer_type", "window")
+
+   # setting the type via the pref should trigger an update of the underlying R viewer function
+   expect_equal(.rs.getShinyViewerType(), "window")
+
+   # restore old value
+   .rs.api.writeRStudioPreference("shiny_viewer_type", old)
+})
+


### PR DESCRIPTION
This change fixes an issue in which changing the Shiny viewer type preference does not actually change the Shiny viewer type. The cause is a typo-level problem; the preference change handler was accidentally bound to the preference layer name instead of the preference key name, with the result that the preference was never detected as changed. 

Also opportunistically fixes a couple other instances of this problem, and adds a unit test to ensure the problem does not regress. 

Fixes #5920. 