### PR TITLE
Update RCNTXT copy for R 4.0

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -39,6 +39,9 @@ RCntxt::RCntxt(void *rawCntxt)
 {
    if (rawCntxt == nullptr)
       return;
+   else if (contextVersion() == RVersion40)
+      pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_40> >(
+                                   static_cast<RCNTXT_40*>(rawCntxt));
    else if (contextVersion() == RVersion34)
       pCntxt_ = boost::make_shared<RIntCntxt<RCNTXT_34> >(
                                    static_cast<RCNTXT_34*>(rawCntxt));

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -34,7 +34,9 @@ RCntxtVersion contextVersion()
    if (s_rCntxtVersion == RVersionUnknown)
    {
       // use current R version to divine the memory layout 
-      if (r::util::hasRequiredVersion("3.4"))
+      if (r::util::hasRequiredVersion("4.0"))
+         s_rCntxtVersion = RVersion40;
+      else if (r::util::hasRequiredVersion("3.4"))
          s_rCntxtVersion = RVersion34;
       else if (r::util::hasRequiredVersion("3.3"))
          s_rCntxtVersion = RVersion33;

--- a/src/cpp/r/include/r/RCntxtUtils.hpp
+++ b/src/cpp/r/include/r/RCntxtUtils.hpp
@@ -28,7 +28,8 @@ namespace context {
 // represents the version of the memory layout of the RCNTXT structure
 enum RCntxtVersion
 {
-   RVersion34, // R 3.4 and above
+   RVersion40, // R 4.0 and above
+   RVersion34, // R 3.4 until R 4.0 (exclusive)
    RVersion33, // R 3.3 (all versions)
    RVersion32, // R 3.2.5 and below
    RVersionUnknown 

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -51,6 +51,59 @@ typedef struct SEXPREC *SEXP;
 
 #endif
 
+typedef struct R_BCSTACK_T {
+   int tag;
+   union {
+      int ival;
+      double dval;
+      SEXP sxpval;
+   } u;
+} R_BCSTACK_T;
+
+typedef struct RCNTXT_40 {
+    struct RCNTXT_40 *nextcontext;
+    int callflag;
+#ifdef _WIN32
+    struct
+    {
+      jmp_buf buf;
+      int sigmask;
+      int savedmask;
+    } cjumpbuf;
+#else
+    sigjmp_buf cjmpbuf;
+#endif
+    int cstacktop;
+    int evaldepth;
+    SEXP promargs;
+    SEXP callfun;
+    SEXP sysparent;
+    SEXP call;
+    SEXP cloenv;
+    SEXP conexit;
+    void (*cend)(void *);
+    void *cenddata;
+    void *vmax;
+    int intsusp;
+    int gcenabled;
+    int bcintactive;
+    SEXP bcbody;
+    void *bcpc;
+    SEXP handlerstack;
+    SEXP restartstack;
+    struct RPRSTACK *prstack;
+    R_BCSTACK_T *nodestack;
+    R_BCSTACK_T *bcprottop; // new in R 4.0
+#ifdef BC_INT_STACK
+    IStackval *intstack;
+#endif
+    SEXP srcref;
+    int browserfinish;
+    SEXP returnValue;
+    struct RCNTXT_40 *jumptarget;
+    int jumpmask;
+} RCNTXT_40;
+
 typedef struct RCNTXT_34 {
     struct RCNTXT_34 *nextcontext;
     int callflag;
@@ -83,14 +136,7 @@ typedef struct RCNTXT_34 {
     SEXP handlerstack;
     SEXP restartstack;
     struct RPRSTACK *prstack;
-    struct {
-       int tag;
-       union {
-          int ival;
-          double dval;
-          SEXP sxpval;
-       } u;
-    } *nodestack;
+    R_BCSTACK_T *nodestack;
 #ifdef BC_INT_STACK
     IStackval *intstack;
 #endif

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -1,7 +1,7 @@
 /*
  * RInterface.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -53,6 +53,7 @@ typedef struct SEXPREC *SEXP;
 
 typedef struct R_BCSTACK_T {
    int tag;
+   int flags;
    union {
       int ival;
       double dval;
@@ -94,9 +95,6 @@ typedef struct RCNTXT_40 {
     struct RPRSTACK *prstack;
     R_BCSTACK_T *nodestack;
     R_BCSTACK_T *bcprottop; // new in R 4.0
-#ifdef BC_INT_STACK
-    IStackval *intstack;
-#endif
     SEXP srcref;
     int browserfinish;
     SEXP returnValue;
@@ -136,7 +134,14 @@ typedef struct RCNTXT_34 {
     SEXP handlerstack;
     SEXP restartstack;
     struct RPRSTACK *prstack;
-    R_BCSTACK_T *nodestack;
+    struct {
+       int tag;
+       union {
+          int ival;
+          double dval;
+          SEXP sxpval;
+       } u;
+    } *nodestack;
 #ifdef BC_INT_STACK
     IStackval *intstack;
 #endif


### PR DESCRIPTION
This change fixes a crash that occurs every time RStudio's debugger is used in R 4.0. The R team introduced a new item in the middle of the context stack data structure, so our memory offsets are wrong. 

The fix is pretty simple, and we've had to do this several times before: we now detect R 4.0 and use an updated version of the RCNTXT structure if it's present. 

Fixes https://github.com/rstudio/rstudio/issues/5888. Candidate for 1.2-patch backport.