### PR TITLE
reduce chances of duplicate terminal prompt with complex dynamic prompt

### DIFF
--- a/src/cpp/core/include/core/terminal/PrivateCommand.hpp
+++ b/src/cpp/core/include/core/terminal/PrivateCommand.hpp
@@ -1,7 +1,7 @@
 /*
  * PrivateCommand.hpp
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -67,7 +67,7 @@ public:
          int privateCommandDelayMs = 3000, // min delay between private commands
          int waitAfterCommandDelayMs = 2000, // min delay after user command
          int privateCommandTimeoutMs = 1200, // timeout for private command
-         int postCommandTimeoutMs = 120, // how long to suppress output after private command done
+         int postCommandTimeoutMs = 300, // how long to suppress output after private command done
          bool oncePerUserCommand = true); // only run private command after user has hit <enter>
 
    // Give private command opportunity to capture terminal; returns true if it does (or already did).


### PR DESCRIPTION
- Fixes #2267
- Many variables here, so possible some combination of complex dynamic prompts and a slower machine could still result in a duplicate prompt after environment capture command finishes; the ultimate end-user fix is to turn off saving and restoring environment variables, but this change should fix it for many users
- See also #1454 for an earlier example of this issue