### PR TITLE
Include count of unsaved files in unsaved files alert dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/unsaved/UnsavedChangesDialog.java
@@ -155,7 +155,9 @@ public class UnsavedChangesDialog extends ModalDialog<UnsavedChangesDialog.Resul
       // main widget
       VerticalPanel panel = new VerticalPanel();
       Label captionLabel = new Label(
-            "The following files have unsaved changes:");
+         targets_.size() == 1 ?
+            "The following file has unsaved changes:" :
+            "The following " + targets_.size() + " files have unsaved changes:");
       captionLabel.setStylePrimaryName(RESOURCES.styles().captionLabel());
       panel.add(captionLabel);
 


### PR DESCRIPTION
- Provides immediate info to screen reader user about how many files are involved

Before, always read "The following files have unsaved changes" for any number of files (including 1). Now:

<img width="425" alt="2019-12-26_20-40-50" src="https://user-images.githubusercontent.com/10569626/71501715-cd7ff100-2820-11ea-8cb7-714efd6be1a2.png">

<img width="425" alt="2019-12-26_20-42-30" src="https://user-images.githubusercontent.com/10569626/71501717-d07ae180-2820-11ea-800d-cf489cc7677e.png">
