### PR TITLE
associate label with text area in ShowPublicKeyDialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -362,4 +362,8 @@ public class ElementIds
    public final static String SVN_RESOLVE_MINE_ALL_DESC = "svn_resolve_mine_all_desc";
    public final static String SVN_RESOLVE_THEIRS_ALL = "svn_resolve_theirs_all";
    public final static String SVN_RESOLVE_THEIRS_ALL_DESC = "svn_resolve_theirs_all_desc";
+
+   // ShowPublicKeyDialog
+   public final static String PUBLIC_KEY_TEXT = "public_key_text";
+   public final static String PUBLIC_KEY_LABEL = "public_key_label";
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
@@ -240,9 +240,8 @@ public class CreateKeyDialog extends ModalDialog<CreateKeyOptions>
    }
    
    @Override
-   protected void onLoad()
+   protected void focusInitialControl()
    {
-      super.onLoad();
       FocusHelper.setFocusDeferred(txtPassphrase_);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ShowPublicKeyDialog.java
@@ -14,8 +14,10 @@
  */
 package org.rstudio.studio.client.common.vcs;
 
+import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.command.KeyCombination;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomUtils;
@@ -25,8 +27,6 @@ import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ThemedButton;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.ui.HTML;
@@ -37,7 +37,6 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class ShowPublicKeyDialog extends ModalDialogBase
 {
- 
    public ShowPublicKeyDialog(String caption, String publicKey)
    {
       super(Roles.getDialogRole());
@@ -47,13 +46,8 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       
       setButtonAlignment(HasHorizontalAlignment.ALIGN_CENTER);
       
-      ThemedButton closeButton = new ThemedButton("Close",
-                                                  new ClickHandler() {
-         public void onClick(ClickEvent event) {
-            closeDialog();
-         }
-      });
-      addOkButton(closeButton); 
+      ThemedButton closeButton = new ThemedButton("Close", event -> closeDialog());
+      addOkButton(closeButton);
    }
    
    @Override
@@ -68,7 +62,9 @@ public class ShowPublicKeyDialog extends ModalDialogBase
                             " to copy the key to the clipboard");
       label.addStyleName(RES.styles().viewPublicKeyLabel());
       panel.add(label);
-      
+      ElementIds.assignElementId(label, ElementIds.PUBLIC_KEY_LABEL);
+      setARIADescribedBy(label.getElement());
+
       textArea_ = new TextArea();
       textArea_.setReadOnly(true);
       textArea_.setText(publicKey_);
@@ -76,7 +72,9 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       textArea_.setSize("400px", "250px");
       DomUtils.disableSpellcheck(textArea_);
       FontSizer.applyNormalFontSize(textArea_.getElement());
-      
+      ElementIds.assignElementId(textArea_, ElementIds.PUBLIC_KEY_TEXT);
+      Roles.getTextboxRole().setAriaLabelledbyProperty(textArea_.getElement(),
+         Id.of(label.getElement()));
       panel.add(textArea_);
       
       return panel;
@@ -88,9 +86,14 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       super.onLoad();
      
       textArea_.selectAll();
+   }
+
+   @Override
+   protected void focusInitialControl()
+   {
       FocusHelper.setFocusDeferred(textArea_);
    }
-   
+
    static interface Styles extends CssResource
    {
       String viewPublicKeyContent();
@@ -103,7 +106,7 @@ public class ShowPublicKeyDialog extends ModalDialogBase
       Styles styles();
    }
    
-   static Resources RES = (Resources)GWT.create(Resources.class) ;
+   static Resources RES = GWT.create(Resources.class);
    public static void ensureStylesInjected()
    {
       RES.styles().ensureInjected();


### PR DESCRIPTION
- give the overall dialog a description, and provide a label for the text area
- other minor source style cleanup

<img width="428" alt="2019-12-26_21-32-27" src="https://user-images.githubusercontent.com/10569626/71502966-f35cc400-2827-11ea-89ae-0252c491dde3.png">
