### PR TITLE
Fix accessibility issues in Shiny Document Warning dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarning.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarning.java
@@ -1,7 +1,7 @@
 /*
  * ShinyDocumentWarning.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,8 +15,11 @@
 package org.rstudio.studio.client.rmarkdown.ui;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Widget;
 
 public class ShinyDocumentWarning extends Composite
@@ -33,4 +36,11 @@ public class ShinyDocumentWarning extends Composite
    {
       initWidget(uiBinder.createAndBindUi(this));
    }
+
+   public Element getMessageElement()
+   {
+      return dialogMessage_.getElement();
+   }
+
+   @UiField HTML dialogMessage_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarning.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarning.ui.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   xmlns:rw='urn:import:org.rstudio.core.client.widget'
    xmlns:rs="urn:import:org.rstudio.studio.client.common">
    <ui:with field="projRes" type="org.rstudio.studio.client.projects.ui.newproject.NewProjectResources" />
    <ui:style>
@@ -15,8 +16,8 @@
      }
    </ui:style>
    <g:HTMLPanel>
-   <g:Image styleName="{style.shinyLogo}" resource="{projRes.shinyAppIcon2x}"></g:Image>
-   <g:HTML styleName="{style.warning}">
+   <rw:DecorativeImage styleName="{style.shinyLogo}" resource="{projRes.shinyAppIcon2x}"></rw:DecorativeImage>
+   <g:HTML ui:field="dialogMessage_" styleName="{style.warning}">
      This R Markdown document contains Shiny content, but was rendered to 
      a static file. Shiny content in the document may not appear, and will not
      be interactive.<br/>

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarningDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/ShinyDocumentWarningDialog.java
@@ -41,6 +41,14 @@ public class ShinyDocumentWarningDialog extends ModalDialogBase
       addLeftButton(new ThemedButton("No", 
             returnResult(onSelected, RENDER_SHINY_NO)),
             ElementIds.DIALOG_NO_BUTTON);
+
+      setARIADescribedBy(warning_.getMessageElement());
+   }
+
+   @Override
+   protected void focusInitialControl()
+   {
+      focusOkButton();
    }
 
    @Override


### PR DESCRIPTION
- mark image as decorative
- read the message when dialog is shown
- set initial focus on the Ok ("Yes, Once") button

<img width="403" alt="2019-12-27_17-33-04" src="https://user-images.githubusercontent.com/10569626/71537531-44c18d80-28d2-11ea-8e08-be1d9ab4a3fc.png">
