### PR TITLE
Fix assorted visual consistency issues with export plot dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlot.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlot.css
@@ -13,17 +13,17 @@
 
 .fileNameTextBox {
    margin-top: -5px;
-   width: 165px;
+   width: 250px;
 }
 
 .directoryButton {
   margin-left: -2px;
 }
 
-.directoryLabel {
+.directoryTextBox {
    margin-top: -2px;
    width: 250px;
-   cursor: default;
+   background: #f3f4f4;
 }
 
 .imageOptionLabel {
@@ -125,6 +125,10 @@
 .savePdfDirectoryTextBox, .savePdfFileNameTextBox {
    margin-left: 10px;
    width: 280px;
+}
+
+.savePdfDirectoryTextBox {
+   background: #f3f4f4;
 }
 
 .savePdfViewAfterCheckbox {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/ExportPlotResources.java
@@ -29,7 +29,7 @@ public interface ExportPlotResources extends ClientBundle
       String fileNameLabel();
       String fileNameTextBox();
       String directoryButton();
-      String directoryLabel();
+      String directoryTextBox();
       
       String imagePreview();
       String imageOptionLabel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageTargetEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/SavePlotAsImageTargetEditor.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.exportplot;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.CanFocus;
@@ -32,7 +33,6 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.TextBox;
 
@@ -77,7 +77,7 @@ public class SavePlotAsImageTargetEditor extends Composite implements CanFocus
             fileDialogs_.chooseFolder(
                "Choose Directory",
                fileSystemContext_,
-               FileSystemItem.createDir(directoryLabel_.getTitle().trim()),
+               FileSystemItem.createDir(directoryTextBox_.getText().trim()),
                new ProgressOperationWithInput<FileSystemItem>() {
 
                  public void execute(FileSystemItem input,
@@ -98,10 +98,13 @@ public class SavePlotAsImageTargetEditor extends Composite implements CanFocus
          }
       });
       
-      directoryLabel_ = new Label();
+      directoryTextBox_ = new TextBox();
+      directoryTextBox_.setReadOnly(true);
+      Roles.getTextboxRole().setAriaLabelProperty(directoryTextBox_.getElement(), "Selected Directory");
+
       setDirectory(context_.getDirectory());
-      directoryLabel_.setStylePrimaryName(styles.directoryLabel());
-      grid.setWidget(1, 1, directoryLabel_);
+      directoryTextBox_.setStylePrimaryName(styles.directoryTextBox());
+      grid.setWidget(1, 1, directoryTextBox_);
       
       fileNameTextBox_ = new TextBox();
       fileNameTextBox_.setText(context.getUniqueFileStem());
@@ -148,17 +151,14 @@ public class SavePlotAsImageTargetEditor extends Composite implements CanFocus
         
       // set label
       String dirLabel = ExportPlotUtils.shortDirectoryName(directory, 250);
-      directoryLabel_.setText(dirLabel);
-      
-      // set tooltip
-      directoryLabel_.setTitle(directory.getPath());
+      directoryTextBox_.setText(dirLabel);
    }
    
    
    private ListBox imageFormatListBox_;
    private TextBox fileNameTextBox_;
    private FileSystemItem directory_;
-   private Label directoryLabel_;
+   private TextBox directoryTextBox_;
   
    
    private final SavePlotAsImageContext context_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -241,8 +241,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
       
       // view after size
       viewAfterSaveCheckBox_ = new CheckBox("View plot after saving");
-      viewAfterSaveCheckBox_.setStylePrimaryName(
-                                       styles.savePdfViewAfterCheckbox());
+      viewAfterSaveCheckBox_.addStyleName(styles.savePdfViewAfterCheckbox());
       viewAfterSaveCheckBox_.setValue(options_.getViewAfterSave());
       grid.setWidget(6, 1, viewAfterSaveCheckBox_);
       


### PR DESCRIPTION
- grey background for selected directory read-only textbox in "Save Plot as PDF" dialog (matching other similar controls)
- fix layout of "View plot after saving" checkbox in "Save Plot as PDF" dialog
- use read-only text for selected directory instead of label in "Save Plot as Image" dialog, matching behavior of "Save Plot as PDF" dialog

## Before
<img width="426" alt="2019-12-27_22-57-16" src="https://user-images.githubusercontent.com/10569626/71540582-7aca3600-2901-11ea-92ba-f40644ac1847.png">

## After
<img width="427" alt="2019-12-27_23-03-33" src="https://user-images.githubusercontent.com/10569626/71540586-86b5f800-2901-11ea-9a6f-0f9a8df79638.png">

## Before
<img width="571" alt="2019-12-27_23-06-10" src="https://user-images.githubusercontent.com/10569626/71540591-903f6000-2901-11ea-8474-4f57189abd2b.png">

## After
<img width="580" alt="2019-12-27_23-27-11" src="https://user-images.githubusercontent.com/10569626/71540593-96354100-2901-11ea-80e8-7334d10ddef6.png">

