### PR TITLE
Associate labels and controls in Rmd Options dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdChoiceOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdChoiceOption.java
@@ -1,7 +1,7 @@
 /*
  * RmdChoiceOption.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -28,7 +28,6 @@ public class RmdChoiceOption extends RmdNullableOption
       defaultValue_ = option.getDefaultValue();
 
       HTMLPanel panel = new HTMLPanel("");
-      panel.add(getOptionLabelWidget());
       choices_ = new ListBox();
       
       JsArrayString choiceList = option.getChoiceList();
@@ -42,6 +41,7 @@ public class RmdChoiceOption extends RmdNullableOption
          }
       }
       choices_.setSelectedIndex(selectedIdx);
+      panel.add(getOptionLabelWidget(choices_.getElement()));
       panel.add(choices_);
 
       updateNull();

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdFileOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdFileOption.java
@@ -1,7 +1,7 @@
 /*
  * RmdFileOption.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,13 +29,13 @@ public class RmdFileOption extends RmdNullableOption
       defaultValue_ = option.getDefaultValue();
 
       HTMLPanel panel = new HTMLPanel("");
-      panel.add(getOptionLabelWidget());
-      
+
       fileChooser_ = new FileChooserTextBox("", "", false, null, null);
       if (initialValue != "null")
          fileChooser_.setText(initialValue);
       fileChooser_.getElement().getStyle().setMarginLeft(20, Unit.PX);
       fileChooser_.getElement().getStyle().setMarginTop(3, Unit.PX);
+      panel.add(getOptionLabelWidget(fileChooser_.getTextBox().getElement()));
       panel.add(fileChooser_);
 
       updateNull();

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdFloatOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdFloatOption.java
@@ -1,7 +1,7 @@
 /*
  * RmdNumberOption.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -28,7 +28,6 @@ public class RmdFloatOption extends RmdNullableOption
       super(option, initialValue);
       HTMLPanel panel = new HTMLPanel("");
       defaultValue_ = Float.parseFloat(option.getDefaultValue());
-      panel.add(getOptionLabelWidget());
       txtValue_ = new NumericTextBox();
       if (initialValue.equals("null"))
          txtValue_.setValue(option.getDefaultValue());
@@ -36,6 +35,7 @@ public class RmdFloatOption extends RmdNullableOption
          txtValue_.setValue(initialValue);
       txtValue_.setWidth("40px");
       txtValue_.getElement().getStyle().setMarginLeft(5, Unit.PX);
+      panel.add(getOptionLabelWidget(txtValue_.getElement()));
       panel.add(txtValue_);
 
       updateNull();

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdNullableOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdNullableOption.java
@@ -1,7 +1,7 @@
 /*
  * RmdNullableOption.java
  *
- * Copyright (C) 2009-14 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,12 +14,13 @@
  */
 package org.rstudio.studio.client.rmarkdown.ui;
 
+import com.google.gwt.dom.client.Element;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.studio.client.rmarkdown.model.RmdTemplateFormatOption;
 
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.InlineLabel;
 import com.google.gwt.user.client.ui.Widget;
 
 public abstract class RmdNullableOption extends RmdBaseOption
@@ -40,6 +41,10 @@ public abstract class RmdNullableOption extends RmdBaseOption
             }
          });
       }
+      else
+      {
+         notNullableLabel_ = new FormLabel(true, getOption().getUiName() + ": ", FormLabel.NoForId);
+      }
    }
 
    public abstract void updateNull();
@@ -48,14 +53,29 @@ public abstract class RmdNullableOption extends RmdBaseOption
    {
       return nonNullCheck_ != null && !nonNullCheck_.getValue();
    }
-   
-   protected Widget getOptionLabelWidget()
+
+   /**
+    * Associates label with an element and returns it
+    * @param ele element referred to by the label
+    * @return label
+    */
+   protected Widget getOptionLabelWidget(Element ele)
    {
       if (nonNullCheck_ != null)
+      {
+         // visible "label" is the checkbox, apply it's text as the aria-label on the
+         // control associated with the checkbox
+         ele.setAttribute("aria-label", nonNullCheck_.getText());
          return nonNullCheck_;
+      }
       else
-         return new InlineLabel(getOption().getUiName() + ": ");
+      {
+         // visible label is the label for this control
+         notNullableLabel_.setFor(ele);
+         return notNullableLabel_;
+      }
    }
-   
+
    private CheckBox nonNullCheck_;
+   private FormLabel notNullableLabel_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdStringOption.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdStringOption.java
@@ -30,7 +30,6 @@ public class RmdStringOption extends RmdNullableOption
       defaultValue_ = option.getDefaultValue();
 
       HTMLPanel panel = new HTMLPanel("");
-      panel.add(getOptionLabelWidget());
       txtValue_ = new TextBox();
       if (initialValue != "null")
          txtValue_.setValue(initialValue);
@@ -38,6 +37,7 @@ public class RmdStringOption extends RmdNullableOption
       txtValue_.getElement().getStyle().setMarginLeft(20, Unit.PX);
       txtValue_.getElement().getStyle().setMarginTop(3, Unit.PX);
       txtValue_.setWidth("75%");
+      panel.add(getOptionLabelWidget(txtValue_.getElement()));
       panel.add(txtValue_);
 
       updateNull();


### PR DESCRIPTION
- in addition to the standard case of using a label and associating with its control via "for", have to also deal with "nullable" controls, which consist of a checkbox with a label, followed by a control; visually the label applies to both the checkbox and the subsequent control, so mimic this for screen readers by using aria-label with the checkbox's label text

Typical example (this dialog is dynamically generated in many different configurations):

<img width="472" alt="2019-12-28_19-17-43" src="https://user-images.githubusercontent.com/10569626/71552443-6db94f80-29b2-11ea-870e-91f99a6d4cb8.png">
