### PR TITLE
Show AppCommand's Id when "nobody was listening"

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -168,7 +168,7 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       if (enableNoHandlerAssertions_)
       {
          assert handlers_.getHandlerCount(CommandEvent.TYPE) > 0 
-                  : "AppCommand executed but nobody was listening";
+                  : "AppCommand executed but nobody was listening: " + getId();
       }
       
       CommandEvent event = new CommandEvent(this);


### PR DESCRIPTION
- see these "AppCommand executed but nobody was listening" exceptions from time to time and often not sure what command I triggered to cause it; add the command's ID to the message

## Before
29 Dec 2019 04:50:58 [rserver] ERROR CLIENT EXCEPTION (rsession-gary): AppCommand executed but nobody was listening;

## After
29 Dec 2019 04:53:42 [rserver] ERROR CLIENT EXCEPTION (rsession-gary): AppCommand executed but nobody was listening: **showAboutDialog**;
