### PR TITLE
Provide aria-label for toolbar buttons whose labels are hidden

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -251,6 +251,20 @@ public class ToolbarButton extends FocusWidget
       leftImageWidget_.setResource(imageResource);
    }
 
+   public void setText(boolean visible, String text)
+   {
+      if (visible)
+      {
+         setText(text);
+         Roles.getButtonRole().setAriaLabelProperty(getElement(), "");
+      }
+      else
+      {
+         setText("");
+         Roles.getButtonRole().setAriaLabelProperty(getElement(), text);
+      }
+   }
+
    public void setText(String label)
    {
       if (!StringUtil.isNullOrEmpty(label))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -75,7 +75,6 @@ import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionUtils;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
-import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.edit.ui.EditDialog;
 import org.rstudio.studio.client.workbench.views.source.DocumentOutlineWidget;
 import org.rstudio.studio.client.workbench.views.source.PanelWithToolbars;
@@ -847,11 +846,11 @@ public class TextEditingTargetWidget
       if (width == 0)
          return;
       
-      texToolbarButton_.setText(width < 520 ? "" : "Format");
-      runButton_.setText(((width < 480) || isShinyFile()) ? "" : "Run");
-      compilePdfButton_.setText(width < 450 ? "" : "Compile PDF");
-      previewHTMLButton_.setText(width < 450 ? "" : previewCommandText_);
-      knitDocumentButton_.setText(width < 450 ? "" : knitCommandText_);
+      texToolbarButton_.setText(width >= 520, "Format");
+      runButton_.setText(((width >= 480) && !isShinyFile()), "Run");
+      compilePdfButton_.setText(width >= 450, "Compile PDF");
+      previewHTMLButton_.setText(width >= 450, previewCommandText_);
+      knitDocumentButton_.setText(width >= 450, knitCommandText_);
       
       if (editor_.getFileType().isRd() || editor_.getFileType().isJS() || 
           editor_.getFileType().isSql() || editor_.getFileType().canPreviewFromR())
@@ -864,7 +863,7 @@ public class TextEditingTargetWidget
          srcOnSaveLabel_.setText(width < 450 ? "Source" : "Source on Save");
       }
 
-      sourceButton_.setText(width < 400 ? "" : sourceCommandText_);
+      sourceButton_.setText(width >= 400, sourceCommandText_);
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -218,12 +218,12 @@ public class GitPane extends WorkbenchPane implements Display
       int width = getOffsetWidth();
       if (width == 0)
          return;
-      
-      pullButton_.setText(width > 600 ? "Pull" : "");
-      pushButton_.setText(width > 600 ? "Push" : "");
-      historyButton_.setText(width > 680 ? "History" : "");
-      moreButton_.setText(width > 680 ? "More" : "");
-      createBranchToolbarButton_.setText(width > 730 ? "New Branch" : "");
+
+      pullButton_.setText(width > 600, "Pull");
+      pushButton_.setText(width > 600, "Push");
+      historyButton_.setText(width > 680, "History");
+      moreButton_.setText(width > 680, "More");
+      createBranchToolbarButton_.setText(width > 730, "New Branch");
    }
 
    @Override


### PR DESCRIPTION
- Git pane and Text pane set labels to empty string on some toolbar buttons depending on width of the pane; this resulted in no accessible text for these buttons making them unusable via screen reader
- Provide a helper that either sets the label normally, or sets it to blank but puts the text into an aria-label

Example (git pane):

<img width="738" alt="2019-12-29_21-43-44" src="https://user-images.githubusercontent.com/10569626/71570007-d0c8e600-2a87-11ea-8827-79e8ac89a969.png">
<img width="429" alt="2019-12-29_21-43-03" src="https://user-images.githubusercontent.com/10569626/71570012-d3c3d680-2a87-11ea-90b5-3bf1df86d421.png">
