### PR TITLE
Prevent duplicate element IDs when multiple source files are open

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -121,8 +121,6 @@ public class TextEditingTargetWidget
       plumberViewerMenu_ = RStudioGinjector.INSTANCE.getPlumberViewerTypePopupMenu();
       handlerManager_ = new HandlerManager(this);
       
-      ElementIds.assignElementId(sourceOnSave_, ElementIds.CB_SOURCE_ON_SAVE);
-
       findReplace_ = new TextEditingTargetFindReplace(
          new TextEditingTargetFindReplace.Container()
          {  
@@ -1484,6 +1482,7 @@ public class TextEditingTargetWidget
 
       ElementIds.assignElementId(sourceButton_, ElementIds.TEXT_SOURCE_BUTTON);
       ElementIds.assignElementId(sourceMenuButton_, ElementIds.TEXT_SOURCE_BUTTON_DROPDOWN);
+      ElementIds.assignElementId(sourceOnSave_, ElementIds.CB_SOURCE_ON_SAVE);
    }
 
    private final TextEditingTarget target_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -549,10 +549,6 @@ public class TextEditingTargetWidget
             });
       
       toggleDocOutlineButton_.addStyleName("rstudio-themes-inverts");
-      
-      ElementIds.assignElementId(
-            toggleDocOutlineButton_,
-            ElementIds.TOGGLE_DOC_OUTLINE_BUTTON);
 
       // Time-out setting the latch just to ensure the document outline
       // has actually been appropriately rendered.
@@ -1483,6 +1479,7 @@ public class TextEditingTargetWidget
       ElementIds.assignElementId(sourceButton_, ElementIds.TEXT_SOURCE_BUTTON);
       ElementIds.assignElementId(sourceMenuButton_, ElementIds.TEXT_SOURCE_BUTTON_DROPDOWN);
       ElementIds.assignElementId(sourceOnSave_, ElementIds.CB_SOURCE_ON_SAVE);
+      ElementIds.assignElementId(toggleDocOutlineButton_, ElementIds.TOGGLE_DOC_OUTLINE_BUTTON);
    }
 
    private final TextEditingTarget target_;


### PR DESCRIPTION
- when starting IDE with multiple documents already loaded in editor, those editors are created before they are attached to the DOM, so it is necessary to assign element IDs in onAttach so they can be de-dup'd
- including Kevin as FYI reviewer since he added this ID recently