### PR TITLE
cleanup static HTML for accessibility, valid HTML

### DIFF
--- a/src/cpp/desktop/html/connect.html
+++ b/src/cpp/desktop/html/connect.html
@@ -29,7 +29,7 @@
                 margin-right: auto;
                 background-color: #2268BC;
                 color: white;
-                border: 0px;
+                border: 0;
                 border-radius: 3px;
                 font-size: 12pt;
                 cursor: pointer;
@@ -40,7 +40,8 @@
     <body>
         <div style="float: right; width: 144px; height: 112px; position: relative; margin-left: 20px;">
             <!-- R logo -->
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="144" height="112" viewBox="0 0 724 561" style="position: absolute; top: 0px; left: 0px;">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="144" height="112" viewBox="0 0 724 561" style="position: absolute; top: 0; left: 0;">
+              <title>R Logo</title>
               <defs>
                 <linearGradient id="gradientFill-1" x1="0" x2="1" y1="0" y2="1" gradientUnits="objectBoundingBox" spreadMethod="pad">
                   <stop offset="0" stop-color="rgb(203,206,208)" stop-opacity="1"/>
@@ -55,7 +56,8 @@
               <path d="M550.000,377.000 C550.000,377.000 571.822,383.585 584.500,390.000 C588.899,392.226 596.510,396.668 602.000,402.500 C607.378,408.212 610.000,414.000 610.000,414.000 L696.000,559.000 L557.000,559.062 L492.000,437.000 C492.000,437.000 478.690,414.131 470.500,407.500 C463.668,401.969 460.755,400.000 454.000,400.000 C449.298,400.000 420.974,400.000 420.974,400.000 L421.000,558.974 L298.000,559.026 L298.000,152.938 L545.000,152.938 C545.000,152.938 657.500,154.967 657.500,262.000 C657.500,369.033 550.000,377.000 550.000,377.000 ZM496.500,241.024 L422.037,240.976 L422.000,310.026 L496.500,310.002 C496.500,310.002 531.000,309.895 531.000,274.877 C531.000,239.155 496.500,241.024 496.500,241.024 Z" fill="url(#gradientFill-2)" fill-rule="evenodd"/>
             </svg>
             <!-- Warning icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" style="position: absolute; bottom: 0px; left: 0px;">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" style="position: absolute; bottom: 0; left: 0;">
+                <title>Warning</title>
                 <path d="M12 5.177l8.631 15.823h-17.262l8.631-15.823zm0-4.177l-12 22h24l-12-22zm-1 9h2v6h-2v-6zm1 9.75c-.689 0-1.25-.56-1.25-1.25s.561-1.25 1.25-1.25 1.25.56 1.25 1.25-.561 1.25-1.25 1.25z"/>
             </svg>
         </div>
@@ -71,7 +73,7 @@
             Please try the following:
         </p>
         <ul>
-            <li>If you've customized R session creation by creating an R profile (e.g. located at <tt>~/.Rprofile</tt>), consider temporarily removing it.</li>
+            <li>If you've customized R session creation by creating an R profile (e.g. located at <samp>~/.Rprofile</samp>), consider temporarily removing it.</li>
             <li>If you are using a firewall or antivirus software which guards access to local network ports, add an exclusion for the RStudio and rsession executables.</li>
             <li>Run RGui, R.app, or R in a terminal to ensure that R itself starts up correctly.</li>
         </ul>

--- a/src/cpp/desktop/html/error.html
+++ b/src/cpp/desktop/html/error.html
@@ -51,7 +51,8 @@
     <body>
         <div style="float: right; width: 144px; height: 112px; position: relative; margin-left: 20px;">
             <!-- R logo -->
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="144" height="112" viewBox="0 0 724 561" style="position: absolute; top: 0px; left: 0px;">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="144" height="112" viewBox="0 0 724 561" style="position: absolute; top: 0; left: 0;">
+              <title>R Logo</title>
               <defs>
                 <linearGradient id="gradientFill-1" x1="0" x2="1" y1="0" y2="1" gradientUnits="objectBoundingBox" spreadMethod="pad">
                   <stop offset="0" stop-color="rgb(203,206,208)" stop-opacity="1"/>
@@ -66,7 +67,8 @@
               <path d="M550.000,377.000 C550.000,377.000 571.822,383.585 584.500,390.000 C588.899,392.226 596.510,396.668 602.000,402.500 C607.378,408.212 610.000,414.000 610.000,414.000 L696.000,559.000 L557.000,559.062 L492.000,437.000 C492.000,437.000 478.690,414.131 470.500,407.500 C463.668,401.969 460.755,400.000 454.000,400.000 C449.298,400.000 420.974,400.000 420.974,400.000 L421.000,558.974 L298.000,559.026 L298.000,152.938 L545.000,152.938 C545.000,152.938 657.500,154.967 657.500,262.000 C657.500,369.033 550.000,377.000 550.000,377.000 ZM496.500,241.024 L422.037,240.976 L422.000,310.026 L496.500,310.002 C496.500,310.002 531.000,309.895 531.000,274.877 C531.000,239.155 496.500,241.024 496.500,241.024 Z" fill="url(#gradientFill-2)" fill-rule="evenodd"/>
             </svg>
             <!-- Warning icon -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" style="position: absolute; bottom: 0px; left: 0px;">
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="50" height="50" viewBox="0 0 24 24" style="position: absolute; bottom: 0; left: 0;">
+                <title>Warning</title>
                 <path d="M12 5.177l8.631 15.823h-17.262l8.631-15.823zm0-4.177l-12 22h24l-12-22zm-1 9h2v6h-2v-6zm1 9.75c-.689 0-1.25-.56-1.25-1.25s.561-1.25 1.25-1.25 1.25.56 1.25 1.25-.561 1.25-1.25 1.25z"/>
             </svg>
         </div>
@@ -95,7 +97,7 @@
             <li>Investigate any errors above.</li> 
             <li>Make sure that R starts up correctly outside RStudio (using RGui, R.app, or R in a terminal).</li>
             <li>Fully uninstall all versions of R from your machine, and reinstall the version you wish to use with RStudio.</li>
-            <li>Remove startup customizations such as an <tt>.Rprofile</tt> file, if present.</li>
+            <li>Remove startup customizations such as an <samp>.Rprofile</samp> file, if present.</li>
         </ul>
         <p>
           Further troubleshooting help can be found on our website:

--- a/src/gwt/www/404.htm
+++ b/src/gwt/www/404.htm
@@ -5,7 +5,7 @@
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title>RStudio Server</title>
-   <script type="text/javascript">
+   <script>
       function getBaseUri()
       {
          var index = window.location.href.lastIndexOf("#!request_uri#");
@@ -28,9 +28,9 @@
       document.getElementsByTagName("head")[0].appendChild(cssLink);
       document.getElementsByTagName("head")[0].appendChild(iconLink);
    </script>
-   <style type="text/css">
+   <style>
       #banner {
-         margin-bottom: 0px;
+         margin-bottom: 0;
       }
       p {
          margin: 20px 20px 10px 20px;
@@ -43,7 +43,7 @@
    <div id="view" class="container">
 
    <div class="header-box">
-       <img class="logo-image" id="logo" src="/images/rstudio-logo.png" />
+       <img class="logo-image" alt id="logo" src="/images/rstudio-logo.png" />
        <h2>RStudio Server</h2>
    </div>
      
@@ -53,13 +53,10 @@
 
    </div>
 
-</body>
-
-<script type="text/javascript">
-   
+<script>
    document.getElementById("logo").src = getBaseUri() + "/images/rstudio-logo.png";
-
 </script>
 
+</body>
 </html>
 

--- a/src/gwt/www/error.htm
+++ b/src/gwt/www/error.htm
@@ -5,7 +5,7 @@
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1">
    <title>RStudio Server</title>
-   <script type="text/javascript">
+   <script>
       function getBaseUri()
       {
          var index = window.location.href.lastIndexOf("#!request_uri#");
@@ -28,9 +28,9 @@
       document.getElementsByTagName("head")[0].appendChild(cssLink);
       document.getElementsByTagName("head")[0].appendChild(iconLink);
    </script>
-   <style type="text/css">
+   <style>
       #banner {
-         margin-bottom: 0px;
+         margin-bottom: 0;
       }
       p {
          margin: 20px 20px 10px 20px;
@@ -44,7 +44,7 @@
    <form method="post" id="signOutForm" action="auth-sign-out">
      <input type="hidden" name="csrf-token" id="csrf-token"/>
      <div class="header-box">
-       <img class="logo-image" id="logo" src="/images/rstudio-logo.png" />
+       <img alt class="logo-image" id="logo" src="/images/rstudio-logo.png" />
        <span class="username">
         #!username#
         <input type="image" alt="Sign Out" id="signOut" src="/images/signOut.png" />
@@ -56,15 +56,15 @@
    <p>RStudio encountered an error and the request could not be processed:</p>
 
    <ul>
-      <b>#error_description#</b>
+      <li><b>#error_description#</b></li>
    </ul>
    <ul>
-      <b>#error_message#</b>
+      <li><b>#error_message#</b></li>
    </ul>
 
    <p>Please contact your system administrator for assistance, or click <a id="url" href="#" onClick="history.back();">here</a> to go back.</p>
 
-   <script type="text/javascript">
+   <script>
    
       document.getElementById("signOutForm").action = getBaseUri() + "/auth-sign-out";
       document.getElementById("signOut").src = getBaseUri() + "/images/signOut.png";

--- a/src/gwt/www/expired.htm
+++ b/src/gwt/www/expired.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 #
 # expired.htm
@@ -15,11 +16,11 @@
 <html lang="en">
 
 <head>
-
+<meta charset="utf-8">
 <title>RStudio Server Expired</title>
 <link rel="shortcut icon" href="images/favicon.ico" />
 
-<style type="text/css">
+<style>
 
 body {
   background-color: #fff;
@@ -44,6 +45,7 @@ body, td {
   padding: 8px;
   -moz-border-radius: 10px;
   -webkit-border-radius: 10px;
+  margin: 0 auto;
 }
 #image {
   margin-right: 30px;
@@ -61,7 +63,7 @@ body, td {
 }
 
 #detail {
-  color: #aaa;
+  color: #555;
   margin-top: 8px;
   margin-right: 10px;
 }
@@ -69,12 +71,12 @@ body, td {
 </style>
 
 </head>
+<body>
+<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio" alt="RStudio"/></a></h3>
 
-<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio"/></a></h3>
-
-<table id="border" align="center">
+<table id="border">
   <tr>
-    <td><img id="image" src="images/expired.png"/></td>
+    <td><img alt id="image" src="images/expired.png"/></td>
     <td>
       <h2 id="caption">RStudio Server License Expired</h2>
       <div id="detail">This version of RStudio Server has expired. Please <a href="http://www.rstudio.com">contact us</a> to obtain an up to date license.</div>

--- a/src/gwt/www/offline.htm
+++ b/src/gwt/www/offline.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 #
 # offline.htm
@@ -15,11 +16,11 @@
 <html lang="en">
 
 <head>
-
+<meta charset="utf-8">
 <title>RStudio Offline</title>
 <link rel="shortcut icon" href="images/favicon.ico" />
 
-<style type="text/css">
+<style>
 
 body {
   background-color: #fff;
@@ -44,6 +45,7 @@ body, td {
   padding: 8px;
   -moz-border-radius: 10px;
   -webkit-border-radius: 10px;
+  margin: 0 auto;
 }
 #image {
   margin-right: -18px;
@@ -68,7 +70,7 @@ body, td {
 
 </style>
 
-<script type="text/javascript">
+<script>
    function getBaseUri()
    {
       var index = window.location.href.lastIndexOf("#!request_uri#");
@@ -90,11 +92,11 @@ body, td {
 
 <body>
 
-<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" id="bannerImage" width="78" height="24" title="RStudio"/></a></h3>
+<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" id="bannerImage" width="78" height="24" title="RStudio" alt="RStudio"/></a></h3>
 
-<table id="border" align="center">
+<table id="border">
   <tr>
-    <td><img id="image" src="images/offline.png"/></td>
+    <td><img alt id="image" src="images/offline.png"/></td>
     <td>
       <h2 id="caption">RStudio Temporarily Offline</h2>
       <div id="detail">RStudio is temporarily offline due to system maintenance. We apologize for the inconvenience, please try again in a few minutes.</div>
@@ -102,13 +104,13 @@ body, td {
   </tr>
 </table>
 
-</body>
+<script>
 
-<script type="text/javascript">
-   
-   document.getElementById("bannerImage").src = getBaseUri() + "/images/rstudio.png";
-   document.getElementById("image").src = getBaseUri() + "/images/offline.png";
+  document.getElementById("bannerImage").src = getBaseUri() + "/images/rstudio.png";
+  document.getElementById("image").src = getBaseUri() + "/images/offline.png";
 
 </script>
+
+</body>
 
 </html>

--- a/src/gwt/www/progress.htm
+++ b/src/gwt/www/progress.htm
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <!--
 #
 # progress.htm
@@ -16,6 +17,7 @@
 <html lang="en">
 
 <head>
+<meta charset="utf-8">
 <title>RStudio</title>
 
 <link rel="stylesheet" href="rstudio.css" type="text/css"/>
@@ -25,7 +27,7 @@
 <body>
 
 <div style="text-align: center; margin-top: 30px;">
-<img src="images/progress_large.gif"/> <span style="position: relative; top: -10px; margin-left: 5px;"> #message# </span>
+<img alt src="images/progress_large.gif"/> <span style="position: relative; top: -10px; margin-left: 5px;"> #message# </span>
 </div>
 
 </body>

--- a/src/gwt/www/projectnotfound.htm
+++ b/src/gwt/www/projectnotfound.htm
@@ -1,15 +1,17 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
+<meta charset="utf-8">
 <title>RStudio: Project Not Found</title>
 
 <link rel="stylesheet" href="rstudio.css" type="text/css"/>
 <link rel="shortcut icon" href="images/favicon.ico" />
 
-<style type="text/css">
+<style>
 
 #banner {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 p {
@@ -21,7 +23,7 @@ p {
 
 <body>
 
-<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio"/></a></h3>
+<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio" alt="RStudio"/></a></h3>
 
 <p>RStudio could not open the requested project for one of the following 
     reasons:</p>

--- a/src/gwt/www/unsupported_browser.htm
+++ b/src/gwt/www/unsupported_browser.htm
@@ -1,15 +1,17 @@
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
+<meta charset="utf-8">
 <title>RStudio: Browser Not Supported</title>
 
 <link rel="stylesheet" href="rstudio.css" type="text/css"/>
 <link rel="shortcut icon" href="images/favicon.ico" />
 
-<style type="text/css">
+<style>
 
 #banner {
-  margin-bottom: 0px;
+  margin-bottom: 0;
 }
 
 p {
@@ -21,7 +23,7 @@ p {
 
 <body>
 
-<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio"/></a></h3>
+<h3 id="banner"><a href="http://www.rstudio.com"><img src="images/rstudio.png" width="78" height="24" title="RStudio" alt="RStudio"/></a></h3>
 
 <p>Your web browser is not supported by RStudio.</p> 
 


### PR DESCRIPTION
- remove unnecessary type="text/javascript"
- remove unnecessary type="text/css"
- ensure trailing script is inside body, not after it
- add missing alt to images
- mark cosmetic svg images with aria-hidden=true, also gave them titles though that's redundant in these cases, but for future copy/pasting...
- remove css units on 0 dimensions (0 vs 0px)
- replace obsolete `tt` element with `samp` element
- add missing DOCTYPE html
- add missing charset="utf-8"
- fix color contrast on text
- replace obsolete align="center" with css