### PR TITLE
option to show only project name instead of full path in desktop window title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -98,6 +98,7 @@
 * RStudio Server now uses 2048 bit RSA keys, for secure communication of encrypted credentials between server / session and client
 * Add support for running Shiny applications as background jobs (#5190)
 * Make maximum lines in R console configurable; was previously fixed at 1000 (#5919)
+* Option to only show project name instead of full path in desktop window title (#1817)
 
 ### Bugfixes
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -313,6 +313,7 @@ namespace prefs {
 #define kTerminalInitialDirectoryProject "project"
 #define kTerminalInitialDirectoryCurrent "current"
 #define kTerminalInitialDirectoryHome "home"
+#define kFullProjectPathInWindowTitle "full_project_path_in_window_title"
 
 class UserPrefValues: public Preferences
 {
@@ -1379,6 +1380,12 @@ public:
     */
    std::string terminalInitialDirectory();
    core::Error setTerminalInitialDirectory(std::string val);
+
+   /**
+    * Whether to show the full path to project in desktop window title.
+    */
+   bool fullProjectPathInWindowTitle();
+   core::Error setFullProjectPathInWindowTitle(bool val);
 
 };
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2324,6 +2324,19 @@ core::Error UserPrefValues::setTerminalInitialDirectory(std::string val)
    return writePref("terminal_initial_directory", val);
 }
 
+/**
+ * Whether to show the full path to project in desktop window title.
+ */
+bool UserPrefValues::fullProjectPathInWindowTitle()
+{
+   return readPref<bool>("full_project_path_in_window_title");
+}
+
+core::Error UserPrefValues::setFullProjectPathInWindowTitle(bool val)
+{
+   return writePref("full_project_path_in_window_title", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2504,6 +2517,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAutoSaveIdleMs,
       kAutoSaveOnBlur,
       kTerminalInitialDirectory,
+      kFullProjectPathInWindowTitle,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1004,6 +1004,11 @@
             "enum": ["project", "current", "home"],
             "default": "project",
             "description": "Initial directory for new terminals."
+        },
+        "full_project_path_in_window_title": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to show the full path to project in desktop window title."
         }
     }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
@@ -1,7 +1,7 @@
 /*
  * DesktopHooks.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -109,7 +109,12 @@ public class DesktopHooks
    String getActiveProjectDir()
    {
       if (workbenchContext_.getActiveProjectDir() != null)
-         return workbenchContext_.getActiveProjectDir().getPath();
+      {
+         if (pUIPrefs_.get().fullProjectPathInWindowTitle().getValue())
+            return workbenchContext_.getActiveProjectDir().getPath();
+         else
+            return workbenchContext_.getActiveProjectDir().getName();
+      }
       else
          return "";
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchContext.java
@@ -25,6 +25,7 @@ import org.rstudio.studio.client.workbench.events.BusyEvent;
 import org.rstudio.studio.client.workbench.events.BusyHandler;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedEvent;
 import org.rstudio.studio.client.workbench.views.console.events.WorkingDirChangedHandler;
 import org.rstudio.studio.client.workbench.views.vcs.git.model.GitState;
@@ -40,10 +41,11 @@ public class WorkbenchContext
 
    @Inject
    public WorkbenchContext(Session session, EventBus eventBus,
-         Provider<GitState> pGitState)
+         Provider<GitState> pGitState, Provider<UserPrefs> pUserPrefs)
    {
       session_ = session;
       pGitState_ = pGitState;
+      pUserPrefs_ = pUserPrefs;
       
       // track current working dir
       currentWorkingDir_ = FileSystemItem.home();
@@ -229,7 +231,11 @@ public class WorkbenchContext
       FileSystemItem projDir = getActiveProjectDir();
       if (projDir != null)
       {
-         String title = projDir.getPath();
+         String title;
+         if (pUserPrefs_.get().fullProjectPathInWindowTitle().getValue())
+            title = projDir.getPath();
+         else
+            title = projDir.getName();
          BranchesInfo branchInfo = pGitState_.get().getBranchInfo();
          if (branchInfo != null)
          {
@@ -256,6 +262,7 @@ public class WorkbenchContext
    private FileSystemItem activeProjectDir_ = null;
    private final Session session_; 
    private final Provider<GitState> pGitState_;
+   private final Provider<UserPrefs> pUserPrefs_;
    private RVersionsInfo rVersionsInfo_ = null;
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1657,6 +1657,14 @@ public class UserPrefsAccessor extends Prefs
    public final static String TERMINAL_INITIAL_DIRECTORY_CURRENT = "current";
    public final static String TERMINAL_INITIAL_DIRECTORY_HOME = "home";
 
+   /**
+    * Whether to show the full path to project in desktop window title.
+    */
+   public PrefValue<Boolean> fullProjectPathInWindowTitle()
+   {
+      return bool("full_project_path_in_window_title", false);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -2013,6 +2021,8 @@ public class UserPrefsAccessor extends Prefs
          autoSaveOnBlur().setValue(layer, source.getBool("auto_save_on_blur"));
       if (source.hasKey("terminal_initial_directory"))
          terminalInitialDirectory().setValue(layer, source.getString("terminal_initial_directory"));
+      if (source.hasKey("full_project_path_in_window_title"))
+         fullProjectPathInWindowTitle().setValue(layer, source.getBool("full_project_path_in_window_title"));
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -302,6 +302,9 @@ public class GeneralPreferencesPane extends PreferencesPane
                clipboardMonitoring_.setValue(monitoring);
             });
          }
+
+         fullPathInTitle_ = new CheckBox("Show full path to project in window title");
+         advanced.add(lessSpaced(fullPathInTitle_));
       }
       
       Label otherLabel = headerLabel("Other");
@@ -410,6 +413,9 @@ public class GeneralPreferencesPane extends PreferencesPane
                                    prefs.restoreProjectRVersion().getValue());
       }
 
+      if (fullPathInTitle_ != null)
+         fullPathInTitle_.setValue(prefs.fullProjectPathInWindowTitle().getValue());
+
       enableCrashReporting_.setValue(prefs.submitCrashReports().getValue());
      
       // projects prefs
@@ -444,6 +450,13 @@ public class GeneralPreferencesPane extends PreferencesPane
          Desktop.getFrame().setClipboardMonitoring(desktopMonitoring);
       }
       
+      if (fullPathInTitle_ != null &&
+         fullPathInTitle_.getValue() != prefs.fullProjectPathInWindowTitle().getValue())
+      {
+         restartRequirement.setDesktopRestartRequired(true);
+         prefs.fullProjectPathInWindowTitle().setGlobalValue(fullPathInTitle_.getValue());
+      }
+
       if (renderingEngineWidget_ != null &&
           !StringUtil.equals(renderingEngineWidget_.getValue(), renderingEngine_))
       {
@@ -536,6 +549,7 @@ public class GeneralPreferencesPane extends PreferencesPane
    private CheckBox reuseSessionsForProjectLinks_ = null;
    private SelectWidget helpFontSize_;
    private CheckBox clipboardMonitoring_ = null;
+   private CheckBox fullPathInTitle_ = null;
    private CheckBox useGpuBlacklist_ = null;
    private CheckBox useGpuDriverBugWorkarounds_ = null;
    private SelectWidget renderingEngineWidget_ = null;


### PR DESCRIPTION
Fixes #1817

Added desktop-only option to General / Advanced / OS Integration / "Show full path to project in window title". Off by default, which more closely matches behavior of RStudio Server

On Windows, and some Linux desktops, makes the taskbar labels more useful when working with projects, e.g.:
![Annotation 2019-12-30 172152](https://user-images.githubusercontent.com/10569626/71606866-6e282680-2b29-11ea-913e-7f571da9b3c5.png)

