### PR TITLE
associate labels with listbox controls in New RMarkdown dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -197,6 +197,10 @@ public class ElementIds
    public static String getNewRmdTitle() { return getElementId(NEW_RMD_TITLE); }
    public final static String NEW_RMD_AUTHOR = "new_rmd_author";
    public static String getNewRmdAuthor() { return getElementId(NEW_RMD_AUTHOR); }
+   public final static String NEW_RMD_TEMPLATE_LABEL = "new_rmd_template_label";
+   public static String getNewRmdTemplateLabel() { return getElementId(NEW_RMD_TEMPLATE_LABEL); }
+   public final static String NEW_RMD_TEMPLATE = "new_rmd_template";
+   public static String getNewRmdTemplate() { return getElementId(NEW_RMD_TEMPLATE); }
 
    // RmdTemplateChooser
    public final static String RMD_TEMPLATE_CHOOSER_NAME = "rmd_template_chooser_name";

--- a/src/gwt/src/org/rstudio/core/client/widget/CaptionWithHelp.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CaptionWithHelp.java
@@ -14,7 +14,9 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -74,14 +76,31 @@ public class CaptionWithHelp extends Composite
    }
 
    /**
-    * Associate caption with a widget for a11y
+    * Associate caption label with a widget for a11y. Per HTML standards, this only
+    * works if the widget has role of <button>, <input>, <meter>, <output>, <progress>,
+    * <select>, or <textarea>.
     * @param widget
     */
    public void setFor(Widget widget)
    {
       captionLabel_.setFor(widget);
    }
+
+   /**
+    * Give the label an elementId, so it can be referenced by a control not suitable for
+    * labelling with setFor().
+    * @param elementId
+    */
+   public void setLabelId(String elementId)
+   {
+      ElementIds.assignElementId(captionLabel_, elementId);
+   }
    
+   public Element getLabelElement()
+   {
+      return captionLabel_.getElement();
+   }
+
    public void setRStudioLinkName(String linkName)
    {
       rstudioLinkName_ = linkName;

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
@@ -56,7 +56,8 @@ import com.google.gwt.user.client.ui.Widget;
 public class WidgetListBox<T extends Widget> 
    extends FocusPanel 
    implements HasChangeHandlers,
-              HasSelectionCommitHandlers<T>
+              HasSelectionCommitHandlers<T>,
+              CanSetControlId
 {
    private class ClickableHTMLPanel extends HTMLPanel
       implements HasClickHandlers
@@ -301,7 +302,13 @@ public class WidgetListBox<T extends Widget>
       emptyTextLabel_.setText(text);
       updateEmptyText();
    }
-   
+
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+
    private void updateEmptyText()
    {
       if (emptyTextBox_.getParent() == this && items_.size() > 0)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.rmarkdown.ui;
 
 import java.util.ArrayList;
 
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.widget.CaptionWithHelp;
@@ -71,7 +73,8 @@ public class RmdTemplateChooser extends Composite
                   item.getTemplate().getCreateDir() == "true");
          }
       });
-      captionWithHelp_.setFor(listTemplates_);
+      Roles.getListboxRole().setAriaLabelledbyProperty(listTemplates_.getElement(),
+         Id.of(captionWithHelp_.getLabelElement()));
    }
    
    public void populateTemplates()

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateChooser.ui.xml
@@ -60,10 +60,10 @@
      }
    </ui:style>
    <g:HTMLPanel>
-   <rs:CaptionWithHelp ui:field="captionWithHelp_" styleName="{style.help}"></rs:CaptionWithHelp>
+   <rs:CaptionWithHelp ui:field="captionWithHelp_" styleName="{style.help}" labelId="{ElementIds.getNewRmdTemplateLabel}"/>
    <rs:SimplePanelWithProgress ui:field="progressPanel_" 
                                styleName="{style.templateListArea}">
-      <rs:WidgetListBox width="100%" height="100%" ui:field="listTemplates_"></rs:WidgetListBox>
+      <rs:WidgetListBox width="100%" height="100%" ui:field="listTemplates_" elementId="{ElementIds.getNewRmdTemplate}"/>
    </rs:SimplePanelWithProgress>
    <g:HTMLPanel styleName="{style.templateListArea} {style.noTemplates}" 
                 visible="false" ui:field="noTemplatesFound_">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -200,13 +200,13 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       style.ensureInjected();
       txtAuthor_.setText(author);
       txtTitle_.setText("Untitled");
+      Roles.getListboxRole().setAriaLabelProperty(listTemplates_.getElement(), "Templates");
       listTemplates_.addChangeHandler(new ChangeHandler()
       {
          @Override
          public void onChange(ChangeEvent event)
          {
             updateOptions(getSelectedTemplate());
-            txtTitle_.setFocus(true);
          }
       });
 


### PR DESCRIPTION
The listbox on the left (which should probably be marked-up as a tab control instead of a listbox, but not going to mess with that now) didn't have a label, so added one via `aria-label`.

The templates listbox was associated with a label via `for=` on the label, but that pattern isn't supported for listboxes, so have to give the label itself an element ID, and reference it from the listbox via aria-labelledby.

Also, when switching via the listbox on the left, focus was being placed back in the area on the right, making it very painful to switch via keyboard, so stop doing that.

<img width="532" alt="2020-01-01_21-13-14" src="https://user-images.githubusercontent.com/10569626/71652755-92783480-2cdc-11ea-8b20-f258392c46de.png">
