### PR TITLE
Fix basic accessibility issues with RSConnect / RPubs dialogs / wizards

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -125,7 +125,6 @@ public class ElementIds
    public final static String PUBLISH_ITEM = "publish_item";
    public final static String PUBLISH_RECONNECT = "publish_reconnect";
    public final static String PUBLISH_SHOW_DEPLOYMENTS = "show_deployments";
-   public final static String RSC_SERVER_URL = "rsc_server_url";
    public final static String SHELL_WIDGET = "shell_widget";
    public final static String SOURCE_TEXT_EDITOR = "source_text_editor";
    public final static String XTERM_WIDGET = "xterm_widget";
@@ -380,4 +379,13 @@ public class ElementIds
    // JobQuitControls
    public final static String JOB_QUIT_LISTBOX = "job_quit_listbox";
    public static String getJobQuitListbox() { return getElementId(JOB_QUIT_LISTBOX); }
+   
+   // RSConnect
+   public final static String RSC_SERVER_URL = "rsc_server_url";
+   public static String getRscServerUrl() { return getElementId(RSC_SERVER_URL); }
+   public final static String RSC_ACCOUNT_LIST_LABEL = "rsc_account_list_label";
+   public static String getRscAccountListLabel() { return getElementId(RSC_ACCOUNT_LIST_LABEL); }
+   public final static String RSC_ACCOUNT_LIST = "rsc_account_list";
+   public static String getRscAccountList() { return getElementId(RSC_ACCOUNT_LIST); }
+   public final static String RSC_FILES_LIST_LABEL = "rsc_files_list_label";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormLabel.java
@@ -25,7 +25,7 @@ import org.rstudio.core.client.StringUtil;
  * A label associated with a form control. Use in UiBinder-created labels where 
  * the association must be set manually after UI is generated.
  */
-public class FormLabel extends Label
+public class FormLabel extends Label implements CanSetControlId
 {
    public static String NoForId = null;
 
@@ -180,5 +180,11 @@ public class FormLabel extends Label
    public void setAriaHidden(boolean hidden)
    {
       Roles.getTextboxRole().setAriaHiddenState(getElement(), hidden);
+   }
+
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithCue.java
@@ -19,6 +19,7 @@ import com.google.gwt.user.client.ui.TextBox;
 import org.rstudio.core.client.dom.DomUtils;
 
 public class TextBoxWithCue extends TextBox
+                            implements CanSetControlId
 {
    public TextBoxWithCue() 
    {
@@ -51,6 +52,12 @@ public class TextBoxWithCue extends TextBox
    {
       cueText_ = cueText;
       DomUtils.setPlaceholder(this, cueText);
+   }
+   
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
    }
 
    private String cueText_;

--- a/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rpubs/ui/RPubsUploadDialog.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressImage;
@@ -40,7 +41,6 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.HasVerticalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -91,7 +91,7 @@ public class RPubsUploadDialog extends ModalDialogBase
   
       HorizontalPanel headerPanel = new HorizontalPanel();
       headerPanel.addStyleName(styles.headerPanel());
-      headerPanel.add(new Image(new ImageResource2x(RESOURCES.publishLarge2x())));
+      headerPanel.add(new DecorativeImage(new ImageResource2x(RESOURCES.publishLarge2x())));
       
       Label headerLabel = new Label("Publish to RPubs");
       headerLabel.addStyleName(styles.headerLabel());
@@ -117,6 +117,7 @@ public class RPubsUploadDialog extends ModalDialogBase
       Label descLabel = new Label(msg);
       descLabel.addStyleName(styles.descLabel());
       verticalPanel.add(descLabel);
+      setARIADescribedBy(descLabel.getElement());
 
       HTML warningLabel =  new HTML(
         "<strong>IMPORTANT: All documents published to RPubs are " +

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountList.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountList.java
@@ -17,6 +17,10 @@ package org.rstudio.studio.client.rsconnect.ui;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Element;
+import org.rstudio.core.client.widget.CanSetControlId;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.WidgetListBox;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -30,7 +34,7 @@ import com.google.gwt.event.dom.client.ChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Composite;
 
-public class RSConnectAccountList extends Composite
+public class RSConnectAccountList extends Composite implements CanSetControlId
 {
    public RSConnectAccountList(RSConnectServerOperations server, 
          GlobalDisplay display,
@@ -167,4 +171,15 @@ public class RSConnectAccountList extends Composite
    
    private ArrayList<RSConnectAccount> accounts_ = new ArrayList<>();
    private Operation onRefreshCompleted_ = null;
+
+   @Override
+   public void setElementId(String id)
+   {
+      accountList_.getElement().setId(id);
+   }
+   
+   public void setLabelledBy(Element describedBy)
+   {
+      Roles.getListboxRole().setAriaLabelledbyProperty(accountList_.getElement(), Id.of(describedBy));
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -16,8 +16,11 @@ package org.rstudio.studio.client.rsconnect.ui;
 
 import java.util.ArrayList;
 
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -175,7 +178,12 @@ public class RSConnectDeploy extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       style_ = RESOURCES.style();
       nameLabel_.setFor(appName_.getTextBox());
-      
+      accountList_.setLabelledBy(accountListLabel_.getElement());
+      ElementIds.assignElementId(fileListLabel_, ElementIds.RSC_FILES_LIST_LABEL);
+      Roles.getListboxRole().set(fileListPanel_.getElement());
+      Roles.getListboxRole().setAriaLabelledbyProperty(fileListPanel_.getElement(),
+         Id.of(fileListLabel_.getElement()));
+
       if (asWizard)
       {
          deployIllustration_.setVisible(false);
@@ -210,18 +218,12 @@ public class RSConnectDeploy extends Composite
          addAccountAnchor_.setVisible(false);
       }
       
-      createNewAnchor_.addClickHandler(new ClickHandler()
+      createNewAnchor_.setClickHandler(() ->
       {
-         @Override
-         public void onClick(ClickEvent event)
-         {
-            event.preventDefault();
-            event.stopPropagation();
-            display_.showMessage(GlobalDisplay.MSG_INFO, 
-                  "Create New Content", 
-                  "To publish this content to a new location, click the Publish drop-down menu " +
-                  "and choose Other Destination.");
-         }
+         display_.showMessage(GlobalDisplay.MSG_INFO, 
+               "Create New Content", 
+               "To publish this content to a new location, click the Publish drop-down menu " +
+               "and choose Other Destination.");
       });
 
       checkUncheckAllButton_.getElement().getStyle().setMarginLeft(0, Unit.PX);
@@ -1287,7 +1289,7 @@ public class RSConnectDeploy extends Composite
    }
 
    @UiField HyperlinkLabel addAccountAnchor_;
-   @UiField Anchor createNewAnchor_;
+   @UiField HyperlinkLabel createNewAnchor_;
    @UiField Anchor urlAnchor_;
    @UiField HTMLPanel appDetailsPanel_;
    @UiField HTMLPanel appInfoPanel_;
@@ -1298,6 +1300,7 @@ public class RSConnectDeploy extends Composite
    @UiField HTMLPanel accountEntryPanel_;
    @UiField Image deployIllustration_;
    @UiField Image descriptionImage_;
+   @UiField InlineLabel fileListLabel_;
    @UiField InlineLabel deployLabel_;
    @UiField Label appErrorMessage_;
    @UiField Label appExistingName_;
@@ -1312,6 +1315,7 @@ public class RSConnectDeploy extends Composite
    @UiField VerticalPanel descriptionPanel_;
    @UiField HorizontalPanel publishFromPanel_;
    @UiField RSConnectAccountEntry accountEntry_;
+   @UiField FormLabel accountListLabel_;
    
    // provided fields
    @UiField(provided=true) RSConnectAccountList accountList_;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -6,14 +6,15 @@
     <ui:with field="res" type="org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.DeployResources" />
     <ui:with field="coreRes" type="org.rstudio.core.client.resources.CoreResources" />
     <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources" />
+    <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
     <g:HTMLPanel ui:field="rootPanel_">
-    <g:Image ui:field="deployIllustration_"></g:Image>
+    <rw:DecorativeImage ui:field="deployIllustration_"/>
     <rw:LayoutGrid><rw:row>
     <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:VerticalPanel ui:field="filePanel_">
            <g:HTMLPanel>
-             <g:InlineLabel text="Publish Files From:"></g:InlineLabel>
+             <g:InlineLabel text="Publish Files From:" ui:field="fileListLabel_"/>
              <g:InlineLabel styleName="{res.style.deployLabel}" 
                             ui:field="deployLabel_">
              </g:InlineLabel>
@@ -34,7 +35,7 @@
                           visible="false">
             <g:Label text="Publish: "></g:Label>
             <g:HTMLPanel styleName="{res.style.fileList} {res.style.descriptionPanel}">
-               <g:Image ui:field="descriptionImage_"></g:Image>
+               <rw:DecorativeImage ui:field="descriptionImage_"/>
             </g:HTMLPanel>
             <rw:ThemedButton ui:field="previewButton_"
                              text="Preview...">
@@ -45,14 +46,14 @@
      <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%" ui:field="publishFromPanel_">
-            <g:Label styleName="{res.style.firstControlLabel}" 
-                     text="Publish From Account:">
-            </g:Label>
+            <rw:FormLabel styleName="{res.style.firstControlLabel}" 
+                     text="Publish From Account:" elementId="{ElementIds.getRscAccountListLabel}"
+                     ui:field="accountListLabel_"/>
             <rw:HyperlinkLabel styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}"
                        ui:field="addAccountAnchor_" text="Add New Account"/>
          </g:HorizontalPanel>
          <rsc:RSConnectAccountList styleName="{res.style.accountList}" 
-                                   ui:field="accountList_">
+                                   ui:field="accountList_" elementId="{ElementIds.getRscAccountList}">
          </rsc:RSConnectAccountList>
          <g:Label styleName="{res.style.firstControlLabel}" 
                   text="Publish To Account:"
@@ -75,9 +76,8 @@
                                styleName="{res.style.controlLabel}">
                <g:Label text="Update:">
                </g:Label>
-               <g:Anchor styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
-                          ui:field="createNewAnchor_" text="Create New">
-               </g:Anchor>
+               <rw:HyperlinkLabel stylePrimaryName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
+                          ui:field="createNewAnchor_" text="Create New"/>
             </g:HorizontalPanel>
             <g:HTMLPanel ui:field="appDetailsPanel_" 
                          styleName="{res.style.appDetailsPanel}" 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.java
@@ -1,7 +1,7 @@
 /*
  * RSConnectLocalAccount.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.rsconnect.ui;
 
-import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.TextBoxWithCue;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.HelpLink;
@@ -42,7 +41,6 @@ public class RSConnectLocalAccount extends Composite
       
       // apply the default server if one is registered
       Session session = RStudioGinjector.INSTANCE.getSession();
-      ElementIds.assignElementId(serverUrl_.getElement(), ElementIds.RSC_SERVER_URL);
       if (session != null && session.getSessionInfo() != null)
       {
          serverUrl_.setText(session.getSessionInfo().getDefaultRSConnectServer());

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
@@ -3,6 +3,7 @@
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:rsw="urn:import:org.rstudio.core.client.widget"
     xmlns:rsc="urn:import:org.rstudio.studio.client.common">
+    <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
     <ui:style>
     .explanatoryText
     {
@@ -30,12 +31,13 @@
     </ui:style>
     <g:HTMLPanel>
       <g:VerticalPanel>
-         <g:Label text="Enter the public URL of the RStudio Connect server:">
-         </g:Label>
+         <rsw:FormLabel for="{ElementIds.getRscServerUrl}"
+                        text="Enter the public URL of the RStudio Connect server:"/>
          <rsw:TextBoxWithCue styleName="{style.textControl}"
                              cueText="servername.com:3939"
                              width="250px"
-                             ui:field="serverUrl_"></rsw:TextBoxWithCue>
+                             elementId="{ElementIds.getRscServerUrl}" 
+                             ui:field="serverUrl_"/>
          <g:Label styleName="{style.spaced} {style.explanatoryText}"
                   text="Contact your RStudio Connect server administrator if you need its URL.">
          </g:Label>


### PR DESCRIPTION
Associate labels with custom listbox controls, mark images as cosmetic, and make the "Create New" hyperlink keyboard accessible.

The list of files in the left column of RSConnect publishing (when publishing all files in a directory) is not keyboard / screen-reader accessible, I opened #5951 to track that.

UI examples:

<img width="427" alt="2020-01-01_21-48-54" src="https://user-images.githubusercontent.com/10569626/71686106-1b2fb880-2d4f-11ea-9b88-9ce66790a99e.png">

<img width="422" alt="2020-01-02_09-28-52" src="https://user-images.githubusercontent.com/10569626/71686113-1ff46c80-2d4f-11ea-8151-3b473312357a.png">

<img width="586" alt="2020-01-02_09-34-58" src="https://user-images.githubusercontent.com/10569626/71686122-27b41100-2d4f-11ea-9541-dc374782da5d.png">

<img width="585" alt="2020-01-02_09-59-24" src="https://user-images.githubusercontent.com/10569626/71686127-2aaf0180-2d4f-11ea-98fe-139ee0ad2dd5.png">

<img width="590" alt="2020-01-02_10-38-41" src="https://user-images.githubusercontent.com/10569626/71686141-300c4c00-2d4f-11ea-8b9d-87e1cdb2724a.png">
