### PR TITLE
add aria-label to textarea in ShinyApps.Io connection dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/FormTextArea.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormTextArea.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.TextArea;
 
 public class FormTextArea extends TextArea
@@ -23,5 +24,10 @@ public class FormTextArea extends TextArea
    public void setElementId(String id)
    {
       getElement().setId(id);
+   }
+   
+   public void setAriaLabel(String label)
+   {
+      Roles.getTextboxRole().setAriaLabelProperty(getElement(), label);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
@@ -1,6 +1,7 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   xmlns:rw="urn:import:org.rstudio.core.client.widget">
    <ui:style type="org.rstudio.studio.client.rsconnect.ui.RSConnectCloudAccount.ConnectStyle">
     @eval fixedFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
    
@@ -29,9 +30,9 @@
        <p>Click <b>Show</b> on the token you want to use, then <b>Show
           Secret</b> and <b>Copy to Clipboard.</b> Paste the result here:</p>
      </g:HTML>
-     <g:TextArea styleName="{style.accountInfo} {style.spaced}"
-                 ui:field="accountInfo" visibleLines="5">
-     </g:TextArea>
+     <rw:FormTextArea styleName="{style.accountInfo} {style.spaced}"
+                 ui:field="accountInfo" visibleLines="5" ariaLabel="ShinyApps Token and Secret">
+     </rw:FormTextArea>
      <g:HTML>
         <small>
         Need a ShinyApps.io account? 


### PR DESCRIPTION
Labelled text area with "ShinyApps Token and Secret" which will be read as description of this text area by screen readers (and avoid an accessibility violation from automated tests).

<img width="535" alt="2020-01-02_17-48-42" src="https://user-images.githubusercontent.com/10569626/71704528-cb251600-2d8f-11ea-9f23-164e0b06aedc.png">
