### PR TITLE
Make LeftRightToggleButton accessible using html buttons and aria-pressed

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.css
@@ -33,6 +33,17 @@
    width: auto;
 }
 
+.leftLeft button,
+.rightRight button {
+   background: none;
+   color: inherit;
+   border: none;
+   padding: 0;
+   font: inherit;
+   cursor: pointer;
+   outline: inherit;
+}
+
 @sprite .leftRight {
    gwt-image: 'leftToggleRightOff';
    width: value('leftToggleRightOff.getWidth', 'px');

--- a/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.java
@@ -1,7 +1,7 @@
 /*
  * LeftRightToggleButton.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-19 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.PressedValue;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.theme.res.ThemeResources;
 
 import com.google.gwt.core.client.GWT;
@@ -82,6 +84,9 @@ public class LeftRightToggleButton extends Widget
          addStyleName(styles.leftOn());
       else
          addStyleName(styles.rightOn());
+
+      Roles.getButtonRole().setAriaPressedState(left_, leftIsOn ? PressedValue.TRUE : PressedValue.FALSE);
+      Roles.getButtonRole().setAriaPressedState(right_, leftIsOn ? PressedValue.FALSE : PressedValue.TRUE);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/LeftRightToggleButton.ui.xml
@@ -6,10 +6,10 @@
 
    <table class="{res.styles.container}" cellpadding="0" cellspacing="0">
       <tr>
-         <td class="{res.styles.leftLeft}" ui:field="left_"/>
+         <td class="{res.styles.leftLeft}"><button ui:field="left_"/></td>
          <td class="{res.styles.leftRight}"/>
          <td class="{res.styles.rightLeft}"/>
-         <td class="{res.styles.rightRight}" ui:field="right_"/>
+         <td class="{res.styles.rightRight}"><button ui:field="right_"/></td>
       </tr>
    </table>
 


### PR DESCRIPTION
Fixes #5899 

## TL;DR 
Made keyboard and screen reader accessible by using actual `<button>` elements (thus obtaining keyboard and focus handling for free), and use the aria-pressed attribute to let screen readers know which button is pressed. Tested on IE11, FireFox, Chrome, Safari.

FYI to @melissa-barca  since we discussed this before the break.

## More
I originally thought I would make behave like a tab control, but that would require reworking the fundamental way this control is used. Every visible instance of this control is actually two separate concrete instances, one set to having left button pressed, one with right button pressed. Clicking on one hides that instance and shows the other. Making this a fully functioning tab control (especially the keyboard behavior) would be difficult. Fact it is hosted in a toolbar compounds the problems because the keyboard behavior of tab controls conflicts with those of toolbars.