### PR TITLE
Update rsconnect dependency to 0.8.16

### DIFF
--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -221,7 +221,7 @@
             "source": false
         },
         "rsconnect": {
-            "version": "0.8.15",
+            "version": "0.8.16",
             "location": "cran",
             "source": false
         },


### PR DESCRIPTION
This change updates the version of the rsconnect package to the newest one on CRAN. 

Closes https://github.com/rstudio/rstudio/issues/5839. 