### PR TITLE
Fix excessive CPU usage in pathological R session closure

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionModuleContext.cpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1842,7 +1842,7 @@ SEXP rs_isRScriptInPackageBuildTarget(SEXP filePathSEXP)
    return r::sexp::create(isRScriptInPackageBuildTarget(filePath), &protect);
 }
 
-bool fileListingFilter(const core::FileInfo& fileInfo)
+bool fileListingFilter(const core::FileInfo& fileInfo, bool hideObjectFiles)
 {
    // check extension for special file types which are always visible
    core::FilePath filePath(fileInfo.absolutePath());
@@ -1875,7 +1875,7 @@ bool fileListingFilter(const core::FileInfo& fileInfo)
    {
       return true;
    }
-   else if (prefs::userPrefs().hideObjectFiles() &&
+   else if (hideObjectFiles &&
             (ext == ".o" || ext == ".so" || ext == ".dll") &&
             filePath.getParent().getFilename() == "src")
    {

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -1,8 +1,8 @@
 /*
  * SessionModuleContext.hpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
-
+ * Copyright (C) 2009-20 by RStudio, Inc.
+ *
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -433,7 +433,7 @@ bool isDirectoryMonitored(const core::FilePath& directory);
 bool isRScriptInPackageBuildTarget(const core::FilePath& filePath);
 
 // convenience method for filtering out file listing and changes
-bool fileListingFilter(const core::FileInfo& fileInfo);
+bool fileListingFilter(const core::FileInfo& fileInfo, bool hideObjectFiles);
 
 // enque file changed events
 void enqueFileChangedEvent(const core::system::FileChangeEvent& event);

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -479,7 +479,8 @@ void ProjectContext::onDeferredInit(bool newSession)
    core::system::file_monitor::registerMonitor(
                                          directory(),
                                          true,
-                                         module_context::fileListingFilter,
+                                         boost::bind(module_context::fileListingFilter,
+                                            _1, prefs::userPrefs().hideObjectFiles()),
                                          cb);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/ExistingDirectoryPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/ExistingDirectoryPage.java
@@ -1,7 +1,7 @@
 /*
  * ExistingDirectoryPage.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.projects.ui.newproject;
 
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
 import org.rstudio.core.client.widget.MessageDialog;
@@ -77,6 +79,18 @@ public class ExistingDirectoryPage extends NewProjectWizardPage
                "Error", 
                "You must specify an existing working directory to " +
                "create the new project within.");
+         
+         return false;
+      }
+      else if (StringUtil.equals(
+            FileSystemItem.createFile(input.getProjectFile()).getParentPathString(),
+            "~"))
+      {
+         globalDisplay_.showMessage(
+               MessageDialog.WARNING,
+               "Error", 
+               "Your home directory cannot be treated as an RStudio Project; " +
+               "select a different directory.");
          
          return false;
       }


### PR DESCRIPTION
This change fixes an issue in which R sessions can hang around eating CPU for unreasonably long after they should have been terminated. 

The problem is that when the R session is bound to a giant, unindexed directory (which occurs if you e.g. try to create a project from your home directory), the file indexing threads can keep running for a long time. These threads try to retrieve preferences related to object file hiding, which results in exceptions once the main thread is unwound and the preferences don't exist any more. These exceptions then trigger expensive exception handling and logging code which further slows the termination process. 

The fix is to pass the pref values in using functional value binding (once) instead of hitting the pref for every single file test, which is more performant anyway. 

Of course, there are a lot of other pathologies that occur when you try to open ~ as a project (see #5855), so I've also added a sanity check to prevent that.

![image](https://user-images.githubusercontent.com/470418/71755502-bd2ece00-2e3f-11ea-88c4-46a1c7354522.png)

Fixes #5855.  
Closes #1552.