### PR TITLE
Break out the token specificity in FileType for spellcheck

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
@@ -21,6 +21,7 @@ import com.google.gwt.resources.client.ImageResource;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
 
 public class CppFileType extends TextFileType
 {
@@ -77,7 +78,22 @@ public class CppFileType extends TextFileType
             
       return result;
    }
-    
+
+   @Override
+   public TokenPredicate getSpellCheckTokenPredicate()
+   {
+      return (token, row, column) ->
+      {
+         if (reNospellType_.match(token.getType(), 0) != null) {
+            return false;
+         }
+
+         return reCommentType_.match(token.getType(), 0) != null &&
+            reKeywordType_.match(token.getType(), 0) == null &&
+            reIdentifierType_.match(token.getType(), 0) == null;
+      };
+   }
+
    private final boolean isCpp_;
    private final boolean canSource_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RFileType.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
 
 import java.util.HashSet;
 
@@ -64,5 +65,20 @@ public class RFileType extends TextFileType
       result.add(commands.debugBreakpoint());
       result.add(commands.insertRoxygenSkeleton());
       return result;
+   }
+
+   @Override
+   public TokenPredicate getSpellCheckTokenPredicate()
+   {
+      return (token, row, column) ->
+      {
+         if (reNospellType_.match(token.getType(), 0) != null) {
+            return false;
+         }
+
+         return reCommentType_.match(token.getType(), 0) != null &&
+            reKeywordType_.match(token.getType(), 0) == null &&
+            reIdentifierType_.match(token.getType(), 0) == null;
+      };
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -475,8 +475,9 @@ public class TextFileType extends EditableFileType
       };
    }
 
-   // special token predicate for only getting commented words
-   public TokenPredicate getCommentsTokenPredicate()
+   // default to only returning comments and text, override in subclasses
+   // for more or less specificity
+   public TokenPredicate getSpellCheckTokenPredicate()
    {
       return (token, row, column) ->
       {
@@ -484,9 +485,10 @@ public class TextFileType extends EditableFileType
             return false;
          }
 
-         return reCommentType_.match(token.getType(), 0) != null &&
-            reKeywordType_.match(token.getType(), 0) == null &&
-            reIdentifierType_.match(token.getType(), 0) == null;
+         return (reCommentType_.match(token.getType(), 0) != null ||
+                 reTextType_.match(token.getType(), 0) != null) &&
+                 reKeywordType_.match(token.getType(), 0) == null &&
+                 reIdentifierType_.match(token.getType(), 0) == null;
       };
    }
 
@@ -537,11 +539,11 @@ public class TextFileType extends EditableFileType
    private final boolean canPreviewFromR_;
    private final String defaultExtension_;
 
-   private static Pattern reTextType_ = Pattern.create("\\btext\\b");
-   private static Pattern reStringType_ = Pattern.create("\\bstring\\b");
-   private static Pattern reHeaderType_ = Pattern.create("\\bheading\\b");
-   private static Pattern reNospellType_ = Pattern.create("\\bnospell\\b");
-   private static Pattern reCommentType_ = Pattern.create("\\bcomment\\b");
-   private static Pattern reKeywordType_ = Pattern.create("\\bkeyword\\b");
-   private static Pattern reIdentifierType_ = Pattern.create("\\bidentifier\\b");
+   protected static Pattern reTextType_ = Pattern.create("\\btext\\b");
+   protected static Pattern reStringType_ = Pattern.create("\\bstring\\b");
+   protected static Pattern reHeaderType_ = Pattern.create("\\bheading\\b");
+   protected static Pattern reNospellType_ = Pattern.create("\\bnospell\\b");
+   protected static Pattern reCommentType_ = Pattern.create("\\bcomment\\b");
+   protected static Pattern reKeywordType_ = Pattern.create("\\bkeyword\\b");
+   protected static Pattern reIdentifierType_ = Pattern.create("\\bidentifier\\b");
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
@@ -15,6 +15,7 @@ artefacts
 asan
 aspirationally
 async
+atomicity
 autotool
 az
 backports
@@ -277,6 +278,7 @@ renviron
 repl
 repo
 reprex
+reproducibility
 restructing
 retryable
 revdep
@@ -296,9 +298,10 @@ roxygen
 rprofile
 rprojroot
 rray's
+rsconnect
 rstd
 rstudio
-rstudio's
+rstudioapi
 rstudio’s
 rticles
 rtools
@@ -344,6 +347,8 @@ sw
 symlink
 symlinks
 sys
+temp
+tempfile
 templated
 templating
 testthat
@@ -353,6 +358,7 @@ tibble
 tibbles
 tidyverse
 tierney
+tmp
 toc
 todo
 tokenizer

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
@@ -72,7 +72,9 @@ public class TextEditingTargetSpelling implements TypoSpellChecker.Context
    public JsArray<LintItem> getLint()
    {
       TextFileType fileType = docDisplay_.getFileType();
-      TokenPredicate tokenPredicate = fileType.isR() ? fileType.getCommentsTokenPredicate() : fileType.getTokenPredicate();
+
+      // only spell check comments in code files
+      TokenPredicate tokenPredicate = fileType.getSpellCheckTokenPredicate();
 
       // only get tokens for the visible screen
       Iterable<Range> wordSource = docDisplay_.getWords(
@@ -214,7 +216,7 @@ public class TextEditingTargetSpelling implements TypoSpellChecker.Context
          // Get the word under the cursor
          Position pos = docDisplay_.getCursorPosition();
          TextFileType fileType = docDisplay_.getFileType();
-         TokenPredicate tokenPredicate = fileType.isR() ? fileType.getCommentsTokenPredicate() : fileType.getTokenPredicate();
+         TokenPredicate tokenPredicate = fileType.getSpellCheckTokenPredicate();
          Position endOfLine = Position.create(pos.getRow()+1, 0);
          Iterable<Range> wordSource = docDisplay_.getWords(
             tokenPredicate,


### PR DESCRIPTION
Previously we were spellchecking String types by default which caused myriad issues particularly in Rmd files. As part of removing that I refactored the token predicate function as well to make more sense.

Fixes #5009
Fixes #5242
Fixes #5393 