### PR TITLE
Scan R Markdown YAML header for dependencies

### DIFF
--- a/src/cpp/tests/testthat/test-pkg-deps.R
+++ b/src/cpp/tests/testthat/test-pkg-deps.R
@@ -1,0 +1,94 @@
+#
+# test-pkg-deps.R
+#
+# Copyright (C) 2020 by RStudio, Inc.
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("package dependencies")
+
+test_that("package dependencies are discovered in R scripts", {
+   contents <- paste(
+      "library(ggplot2)",
+      "require(dplyr)",
+      "",
+      "# Digest something",
+      "digest::digest(something)", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".R")
+   expect_equal(sort(packages), sort(c("ggplot2", "dplyr", "digest")))
+})
+
+test_that("package dependencies are discovered in R Markdown documents", {
+   contents <- paste(
+      "# This is a markdown header",
+      "",
+      "And here's a paragraph. Now, how about a code chunk?",
+      "",
+      "```{r}",
+      "require(caret)",
+      "",
+      "# Knit something",
+      "knitr::knit(something)", 
+      "```",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".Rmd")
+   expect_equal(sort(packages), sort(c("caret", "knitr")))
+})
+
+
+test_that("package dependencies are discovered in R Markdown YAML headers", {
+
+   # simple YAML header naming a package
+   contents <- paste(
+      "---",
+      "title: Test Doc 1",
+      "output: flexdashboard::flex_dashboard",
+      "---",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".Rmd")
+   expect_equal(packages, "flexdashboard")
+
+   # more complicated YAML header in which package name is used as a key
+   contents <- paste(
+      "---",
+      "title: Test Doc 2",
+      "output:",
+      "  flexdashboard::flex_dashboard:",
+      "    orientation: columns",
+      "---",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".Rmd")
+   expect_equal(packages, "flexdashboard")
+
+   # runtime: shiny requires the shiny package
+   contents <- paste(
+      "---",
+      "title: Test Doc 3",
+      "output: flexdashboard::flex_dashboard",
+      "runtime: shiny",
+      "---",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".Rmd")
+   expect_equal(sort(packages), sort(c("flexdashboard", "shiny")))
+
+   # parameterized R Markdown also requires the shiny package (for parameter prompts/deployment)
+   contents <- paste(
+      "---",
+      "title: Test Doc 4",
+      "output: html_document",
+      "params:",
+      "  data: \"hawaii\"",
+      "---",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".Rmd")
+   expect_equal(packages, "shiny")
+})
+


### PR DESCRIPTION
This change extends the package dependency scanner for R Markdown documents so that it looks in the YAML header in addition to the R code in the body of the document.

![image](https://user-images.githubusercontent.com/470418/71935535-e27f4d00-315b-11ea-8c22-b76af5c4b069.png)

It currently understands three types of dependencies:

- A dependency on an output format supplied by an R package, given as `pkg::output_format`
- An explicit dependency on the `shiny` package via `runtime: shiny` or similar
- An implicit dependency on the `shiny` package via parameterization

Also adds unit tests for this feature. 

Closes https://github.com/rstudio/rstudio/issues/4779. 