### PR TITLE
apply banner, nav, and main landmarks to IDE main window, remove application role

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1,6 +1,6 @@
 /* UserPrefValues.hpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -300,7 +300,6 @@ namespace prefs {
 #define kDataViewerMaxColumns "data_viewer_max_columns"
 #define kEnableScreenReader "enable_screen_reader"
 #define kTypingStatusDelayMs "typing_status_delay_ms"
-#define kAriaApplicationRole "aria_application_role"
 #define kReducedMotion "reduced_motion"
 #define kTabKeyMoveFocus "tab_key_move_focus"
 #define kAutoSaveOnIdle "auto_save_on_idle"
@@ -1338,12 +1337,6 @@ public:
     */
    int typingStatusDelayMs();
    core::Error setTypingStatusDelayMs(int val);
-
-   /**
-    * Whether to tell screen readers that the entire page is an application.
-    */
-   bool ariaApplicationRole();
-   core::Error setAriaApplicationRole(bool val);
 
    /**
     * Reduce use of animations in the user interface.

--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -1,6 +1,6 @@
 /* UserPrefValues.hpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1,6 +1,6 @@
 /* UserPrefValues.cpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -2234,19 +2234,6 @@ core::Error UserPrefValues::setTypingStatusDelayMs(int val)
 }
 
 /**
- * Whether to tell screen readers that the entire page is an application.
- */
-bool UserPrefValues::ariaApplicationRole()
-{
-   return readPref<bool>("aria_application_role");
-}
-
-core::Error UserPrefValues::setAriaApplicationRole(bool val)
-{
-   return writePref("aria_application_role", val);
-}
-
-/**
  * Reduce use of animations in the user interface.
  */
 bool UserPrefValues::reducedMotion()
@@ -2510,7 +2497,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDataViewerMaxColumns,
       kEnableScreenReader,
       kTypingStatusDelayMs,
-      kAriaApplicationRole,
       kReducedMotion,
       kTabKeyMoveFocus,
       kAutoSaveOnIdle,

--- a/src/cpp/session/prefs/UserStateValues.cpp
+++ b/src/cpp/session/prefs/UserStateValues.cpp
@@ -1,6 +1,6 @@
 /* UserPrefValues.cpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -968,11 +968,6 @@
             "default": 2000,
             "description": "Number of milliseconds to wait after last keystroke before updating live region."
         },
-        "aria_application_role": {
-            "type": "boolean",
-            "default": true,
-            "description": "Whether to tell screen readers that the entire page is an application."
-        },
         "reduced_motion": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/core/client/widget/BannerWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/BannerWidget.java
@@ -1,0 +1,31 @@
+/*
+ * BannerWidget.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * A widget with role=banner wrapping another widget
+ */
+public class BannerWidget extends SimplePanel
+{
+   public BannerWidget(Widget child)
+   {
+      setWidget(child);
+      Roles.getBannerRole().set(getElement());
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1,7 +1,7 @@
 /*
  * Application.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -172,9 +172,6 @@ public class Application implements ApplicationEventHandlers
 
       Widget w = view_.getWidget();
       rootPanel.add(w);
-
-      // wrapping in a role=main placates automated accessibility checks
-      rootPanel.getElement().setAttribute("role", "main");
 
       rootPanel.setWidgetTopBottom(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
       rootPanel.setWidgetLeftRight(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
@@ -1013,13 +1010,6 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromSAS().remove();
          commands_.importDatasetFromStata().remove();
          commands_.importDatasetFromXLS().remove();
-      }
-
-      if (userPrefs_.get().ariaApplicationRole().getValue())
-      {
-         // "application" role prioritizes application keyboard handling
-         // over screen-reader shortcuts
-         view_.getWidget().getElement().setAttribute("role", "application");
       }
 
       // If no project, ensure we show the product-edition title; if there is a project

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -1,7 +1,7 @@
 /*
  * WebApplicationHeader.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -52,6 +52,7 @@ import org.rstudio.core.client.command.impl.WebMenuCallback;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
+import org.rstudio.core.client.widget.BannerWidget;
 import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.core.client.widget.MessageDialogLabel;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -113,12 +114,12 @@ public class WebApplicationHeader extends Composite
       
       // large logo
       logoLarge_ = new Image(new ImageResource2x(ThemeResources.INSTANCE.rstudio2x()));
-      ((ImageElement)logoLarge_.getElement().cast()).setAlt("RStudio");
+      ((ImageElement)logoLarge_.getElement().cast()).setAlt("");
       logoLarge_.getElement().getStyle().setBorderWidth(0, Unit.PX);
       
       // small logo
       logoSmall_ = new Image(new ImageResource2x(ThemeResources.INSTANCE.rstudio_small2x()));
-      ((ImageElement)logoSmall_.getElement().cast()).setAlt("RStudio");
+      ((ImageElement)logoSmall_.getElement().cast()).setAlt("");
       logoSmall_.getElement().getStyle().setBorderWidth(0, Unit.PX);
 
       // link target for logo
@@ -245,9 +246,10 @@ public class WebApplicationHeader extends Composite
          {
             logoAnchor_.getElement().removeAllChildren();
             logoAnchor_.getElement().appendChild(logoLarge_.getElement());
-            outerPanel_.add(logoAnchor_);
+            outerPanel_.add(new BannerWidget(logoAnchor_));
          }
          HeaderPanel headerPanel = new HeaderPanel(headerBarPanel_, toolbar_);
+         Roles.getNavigationRole().set(headerPanel.getElement());
          outerPanel_.add(headerPanel);
          preferredHeight_ = 65;
          showProjectMenu(false);
@@ -258,9 +260,10 @@ public class WebApplicationHeader extends Composite
          {
             logoAnchor_.getElement().removeAllChildren();
             logoAnchor_.getElement().appendChild(logoSmall_.getElement());
-            outerPanel_.add(logoAnchor_);
+            outerPanel_.add(new BannerWidget(logoAnchor_));
          }
          MenubarPanel menubarPanel = new MenubarPanel(headerBarPanel_);
+         Roles.getNavigationRole().set(menubarPanel.getElement());
          outerPanel_.add(menubarPanel);
          preferredHeight_ = 45;
          showProjectMenu(true);

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/header/MenubarPanel.ui.xml
@@ -4,7 +4,7 @@
    <ui:with field='res' type='org.rstudio.studio.client.application.ui.impl.header.MenubarPanel.Resources'/>
 
    <g:HTMLPanel>
-      <table class="{res.styles.panel}" cellpadding='0' cellspacing='0' border='0'>
+      <table class="{res.styles.panel}" role='presentation' cellpadding='0' cellspacing='0' border='0'>
          <tr>
             <td class="{res.styles.left}"></td>
             <td class="{res.styles.center}" valign="middle">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1,6 +1,6 @@
 /* UserPrefsAccessor.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1594,14 +1594,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to tell screen readers that the entire page is an application.
-    */
-   public PrefValue<Boolean> ariaApplicationRole()
-   {
-      return bool("aria_application_role", true);
-   }
-
-   /**
     * Reduce use of animations in the user interface.
     */
    public PrefValue<Boolean> reducedMotion()
@@ -2007,8 +1999,6 @@ public class UserPrefsAccessor extends Prefs
          enableScreenReader().setValue(layer, source.getBool("enable_screen_reader"));
       if (source.hasKey("typing_status_delay_ms"))
          typingStatusDelayMs().setValue(layer, source.getInteger("typing_status_delay_ms"));
-      if (source.hasKey("aria_application_role"))
-         ariaApplicationRole().setValue(layer, source.getBool("aria_application_role"));
       if (source.hasKey("reduced_motion"))
          reducedMotion().setValue(layer, source.getBool("reduced_motion"));
       if (source.hasKey("tab_key_move_focus"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -1,6 +1,6 @@
 /* UserStateAccessor.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -1,7 +1,7 @@
 /*
  * AccessibilityPreferencesPane.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -36,10 +36,6 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       add(headerLabel("Assistive Tools"));
       chkScreenReaderEnabled_ = new CheckBox("Screen reader support (requires restart)");
       add(chkScreenReaderEnabled_);
-
-      initialAriaApplicationRole_ = prefs.ariaApplicationRole().getValue();
-      add(chkApplicationRole_ = checkboxPref("Entire page has application role (requires restart)",
-            prefs.ariaApplicationRole()));
 
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
             1, 9999, prefs.typingStatusDelayMs());
@@ -89,13 +85,6 @@ public class AccessibilityPreferencesPane extends PreferencesPane
             restartRequirement.setUiReloadRequired(true);
       }
 
-      boolean applicationRoleSetting = chkApplicationRole_.getValue();
-      if (applicationRoleSetting != initialAriaApplicationRole_)
-      {
-         initialAriaApplicationRole_ = applicationRoleSetting;
-         restartRequirement.setUiReloadRequired(true);
-      }
-
       prefs.tabKeyMoveFocus().setGlobalValue(chkTabMovesFocus_.getValue());
       prefs.syncToggleTabKeyMovesFocusState(chkTabMovesFocus_.getValue());
       return restartRequirement;
@@ -109,12 +98,10 @@ public class AccessibilityPreferencesPane extends PreferencesPane
 
    private final CheckBox chkScreenReaderEnabled_;
    private final NumericValueWidget typingStatusDelay_;
-   private final CheckBox chkApplicationRole_;
    private final CheckBox chkTabMovesFocus_;
 
    // initial values of prefs that can trigger reloads (to avoid unnecessary reloads)
    private boolean initialScreenReaderEnabled_;
-   private boolean initialAriaApplicationRole_;
 
    private final PreferencesDialogResources res_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -1,7 +1,7 @@
 /*
  * WorkbenchScreen.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
@@ -122,6 +123,7 @@ public class WorkbenchScreen extends Composite
       tabsPanel_ = paneManager_.getPanel();
       tabsPanel_.setSize("100%", "100%");
       tabsPanel_.addStyleDependentName("Workbench");
+      Roles.getMainRole().set(tabsPanel_.getElement());
 
       // Prevent doOnPaneSizesChanged() from being called more than once
       // every N milliseconds. Note that the act of sending the client metrics


### PR DESCRIPTION
- the application role preference setting was an experiment, after further discussions with accessibility experts, removing altogether
- don't put alt="RStudio" on the logo in upper-left of the IDE, it's a distraction when using screen readers
- give the logo the banner role; if it has a link (i.e. on server-pro) then it will show up as a landmark
- give the menu and toolbar areas the navigation role
- give the tab panel area the main role, instead of the entire page
- mark a layout table used only when the toolbar is hidden as role=presentation