### PR TITLE
label nav and main landmarks, give warningbar a role and make its close btn accessible

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationWindow.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.application.ui;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.Timer;
@@ -190,6 +191,8 @@ public class ApplicationWindow extends Composite
       if (warningBar_ == null)
       {
          warningBar_ = new WarningBar();
+         Roles.getContentinfoRole().set(warningBar_.getElement());
+         Roles.getContentinfoRole().setAriaLabelProperty(warningBar_.getElement(), "Warning bar");
          warningBar_.addCloseHandler(warningBarCloseEvent -> hideWarning());
          applicationPanel_.add(warningBar_);
          applicationPanel_.setWidgetBottomHeight(warningBar_,

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.css
@@ -1,3 +1,5 @@
+@external gwt-Image;
+
 .warning, .error {
    
 }
@@ -37,6 +39,13 @@
 }
 
 .dismiss {
+   right: 0;
+   width: 9px;
+   height: 9px;
+}
+
+.dismiss .gwt-Image {
+   float: left;
    margin-right: 2px;
    background-size: 9px 9px;
    width: 9px;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -1,7 +1,7 @@
 /*
  * WarningBar.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -35,8 +35,8 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.widget.ImageButton;
 import org.rstudio.studio.client.application.Desktop;
 
 public class WarningBar extends Composite
@@ -140,7 +140,7 @@ public class WarningBar extends Composite
    @UiField
    Button moreButton_;
    @UiField
-   Image dismiss_;
+   ImageButton dismiss_;
 
    private static final Styles styles_ =
          ((Resources) GWT.create(Resources.class)).styles();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.ui.xml
@@ -9,7 +9,7 @@
    <table class="{res.styles.warningBar}" role="presentation"
           cellpadding="0" cellspacing="0" border="0" width="100%">
       <tr>
-         <td class="{res.styles.left}"></td>
+         <td class="{res.styles.left}"/>
          <td class="{res.styles.center}" valign="top">
             <rw:DecorativeImage resource="{res.warningIconSmall2x}"
                      width="21"
@@ -20,14 +20,14 @@
             <g:Button ui:field="moreButton_"/>
          </td>
          <td class="{res.styles.center}" align="right">
-            <g:Image ui:field="dismiss_"
+            <rw:ImageButton ui:field="dismiss_"
                      resource="{themeRes.closeTab2x}"
                      width="9"
                      height="9"
-                     styleName="{res.styles.dismiss}"
-                     title="Dismiss"/>
+                     addStyleNames="{res.styles.dismiss}"
+                     description="Dismiss Warning Bar"/>
          </td>
-         <td class="{res.styles.right}"></td>
+         <td class="{res.styles.right}"/>
       </tr>
    </table>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -250,6 +250,7 @@ public class WebApplicationHeader extends Composite
          }
          HeaderPanel headerPanel = new HeaderPanel(headerBarPanel_, toolbar_);
          Roles.getNavigationRole().set(headerPanel.getElement());
+         Roles.getNavigationRole().setAriaLabelProperty(headerPanel.getElement(), "Main menu and toolbar");
          outerPanel_.add(headerPanel);
          preferredHeight_ = 65;
          showProjectMenu(false);
@@ -264,6 +265,7 @@ public class WebApplicationHeader extends Composite
          }
          MenubarPanel menubarPanel = new MenubarPanel(headerBarPanel_);
          Roles.getNavigationRole().set(menubarPanel.getElement());
+         Roles.getNavigationRole().setAriaLabelProperty(menubarPanel.getElement(), "Main menu");
          outerPanel_.add(menubarPanel);
          preferredHeight_ = 45;
          showProjectMenu(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -124,6 +124,7 @@ public class WorkbenchScreen extends Composite
       tabsPanel_.setSize("100%", "100%");
       tabsPanel_.addStyleDependentName("Workbench");
       Roles.getMainRole().set(tabsPanel_.getElement());
+      Roles.getMainRole().setAriaLabelProperty(tabsPanel_.getElement(), "Workbench");
 
       // Prevent doOnPaneSizesChanged() from being called more than once
       // every N milliseconds. Note that the act of sending the client metrics


### PR DESCRIPTION
Give main and nav landmarks labels so they are more useful in screen readers. Put the warning bar occasionally shown at bottom of the UI in a contentinfo landmark, and fix its close [x] button so it's a real button that can be used via keyboard, not just mouse.

Here's an example of landmarks exposed in the NVDA screen reader. The warning-bar wasn't visible, so it isn't showing here. This list allows screen-reader user to understand big-picture layout of the page, and navigate to those regions.

![Screen shot of NVDA elements dialog showing landmarks in RStudio](https://user-images.githubusercontent.com/10569626/72010663-22ead380-320d-11ea-8e08-617832b53a50.png)
