### PR TITLE
fix assorted accessibility issues in build output toolbars, connections UI

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressSpinner.java
@@ -1,7 +1,7 @@
 /*
  * ProgressSpinner.java
  *
- * Copyright (C) 2009-16 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.HTMLPanel;
 
@@ -69,6 +70,9 @@ public class ProgressSpinner extends Composite
       // initialize canvas
       canvas_.setCoordinateSpaceWidth(COORD_SIZE);
       canvas_.setCoordinateSpaceHeight(COORD_SIZE);
+
+      Roles.getImgRole().set(canvas_.getElement());
+      Roles.getImgRole().setAriaLabelProperty(canvas_.getElement(), "Busy");
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -1,7 +1,7 @@
 /*
  * DesktopApplicationHeader.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.application.ui.impl;
 
 import java.util.ArrayList;
 
-import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppMenuBar;
@@ -244,7 +243,6 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          usernameLabel.setTitle(userIdentity);
          userIdentity = userIdentity.split("@")[0];
          usernameLabel.setText(userIdentity);
-         Roles.getPresentationRole().setAriaLabelProperty(usernameLabel.getElement(), "Username");
 
          addRightCommand(usernameLabel);
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -425,7 +425,6 @@ public class WebApplicationHeader extends Composite
          usernameLabel.setTitle(userIdentity);
          userIdentity = userIdentity.split("@")[0];
          usernameLabel.setText(userIdentity);
-         Roles.getPresentationRole().setAriaLabelProperty(usernameLabel.getElement(), "Username");
          headerBarCommandsPanel_.add(usernameLabel);
          
          overlayUserCommandsPanel_ = new HorizontalPanel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionCodePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionCodePanel.java
@@ -1,7 +1,7 @@
 /*
  * ConnectionCodePanel.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,11 +17,13 @@
 package org.rstudio.studio.client.workbench.views.connections.ui;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.views.connections.model.ConnectionOptions;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditorWidget.TabKeyMode;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.EditSession;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedHandler;
@@ -105,6 +107,14 @@ public class ConnectionCodePanel extends Composite implements RequiresResize
             connectPanel, HasHorizontalAlignment.ALIGN_RIGHT);
       if (connectViaUI)
          container_.add(codeHeaderPanel);
+      else
+      {
+         // accessibility requires a label for the editor, so put the one we're not using 
+         // into our container
+         codeHeaderPanel.remove(codeLabel_);
+         container_.add(codeLabel_);
+         codeLabel_.setStyleName(ThemeStyles.INSTANCE.visuallyHidden());
+      }
      
       initWidget(container_);
    }
@@ -150,7 +160,8 @@ public class ConnectionCodePanel extends Composite implements RequiresResize
       
       // create new code viewer
       codeViewer_ = new AceEditorWidget(false);
-      codeLabel_.setFor(codeViewer_);
+      codeViewer_.setTabKeyMode(TabKeyMode.AlwaysMoveFocus);
+      codeLabel_.setFor(codeViewer_.getTextInputElement());
       codeViewer_.addStyleName(RES.styles().codeViewer());
       codeViewer_.getEditor().getSession().setEditorMode(
             EditorLanguage.LANG_R.getParserName(), false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionExplorer.java
@@ -1,7 +1,7 @@
 /*
  * ConnectionExplorer.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -54,7 +54,7 @@ public class ConnectionExplorer extends Composite implements RequiresResize
       disconnectedUI_.add(codePanel_);
       Label label = new Label("(Not connected)");
       Style labelStyle = label.getElement().getStyle();
-      labelStyle.setColor("#888");
+      labelStyle.setColor("#767676");
       labelStyle.setMarginTop(25, Unit.PX);
       labelStyle.setTextAlign(TextAlign.CENTER);
       disconnectedUI_.add(label);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/common/CompileOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/common/CompileOutputPane.java
@@ -1,7 +1,7 @@
 /*
  * CompileOutputPane.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -58,7 +58,7 @@ public class CompileOutputPane extends WorkbenchPane
    @Override
    protected Toolbar createMainToolbar()
    {
-      Toolbar toolbar = new Toolbar("Compile Output Tab");
+      Toolbar toolbar = new Toolbar(getTitle() + " Tab");
       
       fileLabel_ = new ToolbarFileLabel(toolbar, 200);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1,7 +1,7 @@
 /*
  * AceEditorWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -981,6 +981,11 @@ public class AceEditorWidget extends Composite
    public void setElementId(String id)
    {
       editor_.setElementId(id);
+   }
+
+   public Element getTextInputElement()
+   {
+      return editor_.getTextInputElement();
    }
 
    // This class binds an ace annotation (used for the gutter) with an

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -1,7 +1,7 @@
 /*
  * AceEditorNative.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -201,7 +201,7 @@ public class AceEditorNative extends JavaScriptObject
       };
    }
 
-   private native Element getTextInputElement() /*-{
+   public final native Element getTextInputElement() /*-{
       return this.textInput.getElement();
    }-*/;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
@@ -1,7 +1,7 @@
 /*
  * ChangelistTable.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -209,7 +209,7 @@ public abstract class ChangelistTable extends Composite
    }
    
 
-   public void showInfoBar(String message)
+   public void showInfoBar(String message, boolean animate)
    {
       if (infoBar_ == null)
       {
@@ -223,7 +223,7 @@ public abstract class ChangelistTable extends Composite
                                     infoBar_.getHeight(), Unit.PX,
                                     0, Unit.PX);
          infoBar_.setText(message);
-         layout_.animate(250);
+         layout_.animate(animate ? 250 : 0);
       }
       else
       {
@@ -231,13 +231,13 @@ public abstract class ChangelistTable extends Composite
       }
    }
 
-   public void hideInfoBar()
+   public void hideInfoBar(boolean animate)
    {
       if (infoBar_ != null)
       {
          layout_.remove(infoBar_);
          layout_.setWidgetTopBottom(scrollPanel_, 0, Unit.PX, 0, Unit.PX);
-         layout_.animate(250);
+         layout_.animate(animate ? 250 : 0);
          infoBar_ = null;
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
@@ -1,7 +1,7 @@
 /*
  * GitChangelistTablePresenter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import org.rstudio.studio.client.common.vcs.GitServerOperations;
 import org.rstudio.studio.client.common.vcs.RemoteBranchInfo;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.StageUnstageEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.StageUnstageHandler;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.VcsRefreshEvent;
@@ -33,11 +34,13 @@ public class GitChangelistTablePresenter
    @Inject
    public GitChangelistTablePresenter(GitServerOperations server,
                                       GitChangelistTable view,
-                                      GitState gitState)
+                                      GitState gitState,
+                                      UserPrefs prefs)
    {
       server_ = server;
       view_ = view;
       gitState_ = gitState;
+      prefs_ = prefs;
 
       view_.addStageUnstageHandler(new StageUnstageHandler()
       {
@@ -76,11 +79,11 @@ public class GitChangelistTablePresenter
                   remote.getCommitsBehind() + " commit" +
                   (remote.getCommitsBehind() > 1 ? "s" : "") + ".";
                
-               view_.showInfoBar(message);
+               view_.showInfoBar(message, !prefs.reducedMotion().getValue());
             }
             else
             {
-               view_.hideInfoBar();
+               view_.hideInfoBar(!prefs_.reducedMotion().getValue());
             } 
          }
       });
@@ -99,4 +102,5 @@ public class GitChangelistTablePresenter
    private final GitServerOperations server_;
    private final GitChangelistTable view_;
    private final GitState gitState_;
+   private final UserPrefs prefs_;
 }


### PR DESCRIPTION
- connection code editor not labeled in pane instance, and incorrectly labeled in dialog instance
- tab traps in connection code editor in connection dialog and pane
- contrast too low on "(Not connected)" message in pane
- animation when showing/hiding git infobar wasn't obeying reduced motion setting
- toolbar class used in CompilePDFOutput, RenderRmdOutput, RSConnectDeployOutput, and TestsOutput panes had the same name in all of them ("Compile Output Tab", now it has a name representative of the tab
- using aria-label on the username in toolbar was not valid and not useful in screen readers
- progress spinner canvas control used in "busy" tabs now read as "Busy", so a tab will read "R Markdown Busy Tab" (for example) in screen reader when spinner is showing

<img width="528" alt="Screenshot of R Markdown tab showing toolbar and progress spinner regions" src="https://user-images.githubusercontent.com/10569626/72039195-efce3180-3258-11ea-8fb7-acb6091eb2ac.png">


<img width="834" alt="Screenshot of Connections tab showing code editor" src="https://user-images.githubusercontent.com/10569626/72039327-78e56880-3259-11ea-9e08-f550827aa14b.png">


<img width="532" alt="Screenshot of new connection dialog showing code editor" src="https://user-images.githubusercontent.com/10569626/72039329-7be05900-3259-11ea-9738-39bc1f287de7.png">
