### PR TITLE
include screen reader state in menu text to workaround Qt bug

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -1,7 +1,7 @@
 /*
  * UserPrefs.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -80,6 +80,7 @@ public class UserPrefs extends UserPrefsComputed
       eventBus.addHandler(DeferredInitCompletedEvent.TYPE, this);
       Scheduler.get().scheduleDeferred(() ->
       {
+         origScreenReaderLabel_ = commands_.toggleScreenReaderSupport().getMenuLabel(false);
          loadScreenReaderEnabledSetting();
          syncToggleTabKeyMovesFocusState();
       });
@@ -231,6 +232,14 @@ public class UserPrefs extends UserPrefsComputed
       server_.viewPreferences(new VoidServerRequestCallback());
    }
 
+   private void setScreenReaderMenuState(boolean checked)
+   {
+      commands_.toggleScreenReaderSupport().setChecked(checked);
+      commands_.toggleScreenReaderSupport().setMenuLabel(checked ?
+            origScreenReaderLabel_ + " (enabled)" :
+            origScreenReaderLabel_ + " (disabled)");
+   }
+
    /**
     * Screen-reader enabled setting is stored differently on desktop vs server.
     * On desktop is must be available earlier in startup so the RStudio.app/exe native
@@ -243,7 +252,7 @@ public class UserPrefs extends UserPrefsComputed
       if (screenReaderEnabled_ != null)
          return;
 
-      Command onCompleted = () -> commands_.toggleScreenReaderSupport().setChecked(screenReaderEnabled_);
+      Command onCompleted = () -> setScreenReaderMenuState(screenReaderEnabled_);
 
       if (Desktop.hasDesktopFrame())
          Desktop.getFrame().getEnableAccessibility(enabled ->
@@ -301,7 +310,7 @@ public class UserPrefs extends UserPrefsComputed
                });
             },
             () -> {
-               commands_.toggleScreenReaderSupport().setChecked(getScreenReaderEnabled());
+               setScreenReaderMenuState(getScreenReaderEnabled());
             },
             false);
    }
@@ -354,4 +363,5 @@ public class UserPrefs extends UserPrefsComputed
 
    private boolean reloadAfterInit_;
    private Boolean screenReaderEnabled_ = null;
+   private String origScreenReaderLabel_;
 }


### PR DESCRIPTION
Workaround for Qt issue described here: #5833 

- on Windows desktop, Qt has a bug preventing screen readers from knowing if a menu item has a checkbox so a blind user can't tell current state of the "Help / Accessibility / Screen Reader Support" menu item
- this is particularly bad because the other way to see this state is in the accessibility preferences pane (via a regular checkbox), but this isn't accessible until screen reader support is on
- append (enabled) or (disabled) to the menu item to provide an additional indication of state
- not making Windows-desktop specific, doesn't do any harm to have this extra information in all cases
- not implementing a generic fix for all checkable menu items, will consider on a case-by-case basis

![Screen shot of RStudio on Windows showing Help / About / Accessibility menu with this fix](https://user-images.githubusercontent.com/10569626/72101543-cd302d00-32d9-11ea-87ef-11fc27470934.png)
