### PR TITLE
change keyboard shortcuts for next/prev terminal to use Shift instead of Ctrl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,6 +102,7 @@
 * Option to only show project name instead of full path in desktop window title (#1817)
 * New `rstudio --version` command to return the version of RStudio Desktop (#3922)
 * Scan R Markdown YAML header for R packages required to render document (#4779)
+* Change shortcuts for Next/Previous terminal to avoid clash with common Windows shortcuts (#4892)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -835,8 +835,8 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Terminal">
          <shortcut refid="newTerminal" value="Alt+Shift+R"/>
-         <shortcut refid="previousTerminal" value="Ctrl+Alt+F11"/>
-         <shortcut refid="nextTerminal" value="Ctrl+Alt+F12"/>
+         <shortcut refid="previousTerminal" value="Shift+Alt+F11"/>
+         <shortcut refid="nextTerminal" value="Shift+Alt+F12"/>
       </shortcutgroup>
 
       <shortcutgroup name="Main Menu (Server)">


### PR DESCRIPTION
Fixes #4892

- avoids a clash with commonly used shortcuts on Windows
- issue reported it on Dell XPS, I was also seeing the same problem on my Lenovo IdeaPad
- tested the next shortcuts on those, macOS Desktop, and Server on Mac and Windows in Chrome