### PR TITLE
make min/max/restore quadrant controls fully accessible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -442,4 +442,10 @@ public class ElementIds
    public final static String RSC_ACCOUNT_LIST = "rsc_account_list";
    public static String getRscAccountList() { return getElementId(RSC_ACCOUNT_LIST); }
    public final static String RSC_FILES_LIST_LABEL = "rsc_files_list_label";
+   
+   // WindowFrameButton (combined with unique suffix for each quadrant
+   public final static String FRAME_MIN_BTN = "frame_min_btn";
+   public final static String FRAME_MAX_BTN = "frame_max_btn";
+   public final static String MIN_FRAME_MIN_BTN = "min_frame_min_btn";
+   public final static String MIN_FRAME_MAX_BTN = "min_frame_max_btn";
 }

--- a/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
@@ -1,7 +1,7 @@
 /*
  * LogicalWindow.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -104,16 +104,8 @@ public class LogicalWindow implements HasWindowStateChangeHandlers,
 
    public void transitionToState(WindowState newState)
    {
-      if (newState == MAXIMIZE)
-         normal_.addStyleDependentName("maximized");
-      else
-         normal_.removeStyleDependentName("maximized");
-
-      if (newState == EXCLUSIVE)
-         normal_.addStyleDependentName("exclusive");
-      else
-         normal_.removeStyleDependentName("exclusive");
-
+      normal_.setMaximizedDependentState(newState);
+      normal_.setExclusiveDependentState(newState);
       state_ = newState;
 
       if (getActiveWidget() == normal_)

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
@@ -1,7 +1,7 @@
 /*
  * MinimizedModuleTabLayoutPanel.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -30,9 +30,9 @@ public class MinimizedModuleTabLayoutPanel
       extends MinimizedWindowFrame
    implements HasSelectionHandlers<Integer>
 {
-   public MinimizedModuleTabLayoutPanel()
+   public MinimizedModuleTabLayoutPanel(String accessibleName)
    {
-      super(null, new HorizontalPanel());
+      super(null, accessibleName, new HorizontalPanel());
       addStyleName(ThemeResources.INSTANCE.themeStyles().moduleTabPanel());
       addStyleName(ThemeResources.INSTANCE.themeStyles().minimized());
    }

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
@@ -1,7 +1,7 @@
 /*
  * MinimizedWindowFrame.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.events.HasWindowStateChangeHandlers;
 import org.rstudio.core.client.events.WindowStateChangeEvent;
 import org.rstudio.core.client.events.WindowStateChangeHandler;
@@ -43,12 +44,12 @@ public class MinimizedWindowFrame
       }
    }
 
-   public MinimizedWindowFrame(String title)
+   public MinimizedWindowFrame(String title, String accessibleName)
    {
-      this(title, null);
+      this(title, accessibleName, null);
    }
 
-   public MinimizedWindowFrame(String title, Widget extraWidget)
+   public MinimizedWindowFrame(String title, String accessibleName, Widget extraWidget)
    {
       ThemeStyles themeStyles = ThemeResources.INSTANCE.themeStyles();
 
@@ -87,29 +88,21 @@ public class MinimizedWindowFrame
          inner.setCellWidth(extraWidget, "100%");
       }
 
-      HTML minimize = createDiv(themeStyles.minimize() + " " +
-                                ThemeStyles.INSTANCE.handCursor());
-      minimize.addClickHandler(new ClickHandler()
+      WindowFrameButton minimize = new WindowFrameButton(accessibleName, WindowState.NORMAL);
+      minimize.setElementId(ElementIds.MIN_FRAME_MIN_BTN + "_" + ElementIds.idSafeString(accessibleName));
+      minimize.setStylePrimaryName(themeStyles.minimize());
+      minimize.setClickHandler(() ->
       {
-         public void onClick(ClickEvent event)
-         {
-            event.preventDefault();
-            event.stopPropagation();
-            fireEvent(new WindowStateChangeEvent(WindowState.MINIMIZE));
-         }
+         fireEvent(new WindowStateChangeEvent(WindowState.MINIMIZE));
       });
       inner.add(minimize);
 
-      HTML maximize = createDiv(themeStyles.maximize() + " " + 
-                                themeStyles.handCursor());
-      maximize.addClickHandler(new ClickHandler()
+      WindowFrameButton maximize = new WindowFrameButton(accessibleName, WindowState.MAXIMIZE);
+      maximize.setElementId(ElementIds.MIN_FRAME_MAX_BTN + "_" + ElementIds.idSafeString(accessibleName));
+      maximize.setStylePrimaryName(themeStyles.maximize());
+      maximize.setClickHandler(() ->
       {
-         public void onClick(ClickEvent event)
-         {
-            event.preventDefault();
-            event.stopPropagation();
-            fireEvent(new WindowStateChangeEvent(WindowState.MAXIMIZE));
-         }
+         fireEvent(new WindowStateChangeEvent(WindowState.MAXIMIZE));
       });
       inner.add(maximize);
 

--- a/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
@@ -1,7 +1,7 @@
 /*
  * PrimaryWindowFrame.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -45,6 +45,7 @@ public class PrimaryWindowFrame extends WindowFrame
    public PrimaryWindowFrame(String title,
                              Widget mainWidget)
    {
+      super(title);
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
 
       panel_ = new ClickFlowPanel();

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -1,7 +1,7 @@
 /*
  * WindowFrame.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,14 +17,13 @@ package org.rstudio.core.client.theme;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Float;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 
 import java.util.HashMap;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.RequiresVisibilityChanged;
 import org.rstudio.core.client.layout.WindowState;
@@ -42,13 +41,13 @@ public class WindowFrame extends Composite
               EnsureVisibleHandler,
               EnsureHeightHandler
 {  
-   public WindowFrame(Widget mainWidget)
+   public WindowFrame(Widget mainWidget, String name)
    {
-      this();
+      this(name);
       setMainWidget(mainWidget);
    }
    
-   public WindowFrame()
+   public WindowFrame(String name)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -60,27 +59,15 @@ public class WindowFrame extends Composite
       borderPositioner_ = new SimplePanel();
       borderPositioner_.add(border_);
 
-      HTML maximize = new HTML();
-      maximize.setStylePrimaryName(styles.maximize());
-      maximize.addStyleName(ThemeStyles.INSTANCE.handCursor());
-      maximize.addClickHandler(new ClickHandler()
-      {
-         public void onClick(ClickEvent event)
-         {
-            maximize();
-         }
-      });
+      maximizeButton_ = new WindowFrameButton(name, WindowState.MAXIMIZE);
+      maximizeButton_.setElementId(ElementIds.FRAME_MAX_BTN + "_" + ElementIds.idSafeString(name));
+      maximizeButton_.setStylePrimaryName(styles.maximize());
+      maximizeButton_.setClickHandler(() -> maximize());
 
-      HTML minimize = new HTML();
-      minimize.setStylePrimaryName(styles.minimize());
-      minimize.addStyleName(ThemeStyles.INSTANCE.handCursor());
-      minimize.addClickHandler(new ClickHandler()
-      {
-         public void onClick(ClickEvent event)
-         {
-            minimize();
-         }
-      });
+      minimizeButton_ = new WindowFrameButton(name, WindowState.MINIMIZE);
+      minimizeButton_.setElementId(ElementIds.FRAME_MIN_BTN + "_" + ElementIds.idSafeString(name));
+      minimizeButton_.setStylePrimaryName(styles.minimize());
+      minimizeButton_.setClickHandler(() -> minimize());
 
       frame_ = new LayoutPanel();
       frame_.setStylePrimaryName(styles.windowframe());
@@ -92,22 +79,22 @@ public class WindowFrame extends Composite
       frame_.setWidgetLeftRight(borderPositioner_, 0, Style.Unit.PX,
                                                    0, Style.Unit.PX);
 
-      frame_.add(maximize);
-      frame_.setWidgetTopHeight(maximize,
+      frame_.add(minimizeButton_);
+      frame_.setWidgetTopHeight(minimizeButton_,
+            ShadowBorder.TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
+            14, Style.Unit.PX);
+      frame_.setWidgetRightWidth(minimizeButton_,
+            ShadowBorder.RIGHT_SHADOW_WIDTH + 25, Style.Unit.PX,
+            14, Style.Unit.PX);
+
+      frame_.add(maximizeButton_);
+      frame_.setWidgetTopHeight(maximizeButton_,
                                 ShadowBorder.TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
                                 14, Style.Unit.PX);
-      frame_.setWidgetRightWidth(maximize,
+      frame_.setWidgetRightWidth(maximizeButton_,
                                  ShadowBorder.RIGHT_SHADOW_WIDTH + 7, Style.Unit.PX,
                                  14, Style.Unit.PX);
 
-      frame_.add(minimize);
-      frame_.setWidgetTopHeight(minimize,
-                                ShadowBorder.TOP_SHADOW_WIDTH + 4, Style.Unit.PX,
-                                14, Style.Unit.PX);
-      frame_.setWidgetRightWidth(minimize,
-                                 ShadowBorder.RIGHT_SHADOW_WIDTH + 25, Style.Unit.PX,
-                                 14, Style.Unit.PX);
-      
       buttonsArea_ = new FlowPanel();
       frame_.add(buttonsArea_);
       
@@ -372,9 +359,33 @@ public class WindowFrame extends Composite
       return fill_;
    }
 
+   public void setMaximizedDependentState(WindowState state)
+   {
+      if (state == WindowState.MAXIMIZE)
+      {
+         addStyleDependentName("maximized");
+      }
+      else
+      {
+         removeStyleDependentName("maximized");
+      }
+      maximizeButton_.setMaximized(state == WindowState.MAXIMIZE);
+   }
+
+   public void setExclusiveDependentState(WindowState state)
+   {
+      if (state == WindowState.EXCLUSIVE)
+         addStyleDependentName("exclusive");
+      else
+         removeStyleDependentName("exclusive");
+      maximizeButton_.setExclusive(state == WindowState.EXCLUSIVE);
+   }
+
    private final LayoutPanel frame_;
    private final ShadowBorder border_;
    private final SimplePanel borderPositioner_;
+   private final WindowFrameButton maximizeButton_;
+   private final WindowFrameButton minimizeButton_;
    private Widget main_;
    private Widget header_;
    private Widget fill_;

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
@@ -1,0 +1,162 @@
+/*
+ * WindowFrameButton.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.theme;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.FocusWidget;
+import com.google.gwt.user.client.ui.HTML;
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.HandlerRegistrations;
+import org.rstudio.core.client.layout.WindowState;
+import org.rstudio.core.client.theme.res.ThemeStyles;
+import org.rstudio.core.client.widget.CanSetControlId;
+
+/**
+ * Minimize/maximize/restore buttons in logical windows (the 4 quadrants)
+ */
+public class WindowFrameButton extends FocusWidget
+                               implements CanSetControlId
+{
+   public WindowFrameButton(String name, WindowState state)
+   {
+      super(new HTML().getElement());
+
+      name_ = name;
+      defaultState_ = state;
+      maximized_ = false;
+      exclusive_ = false;
+      Roles.getButtonRole().set(getElement());
+      updateLabel();
+      getElement().setTabIndex(0);
+      addStyleName(ThemeStyles.INSTANCE.handCursor());
+   }
+
+   public void setExclusive(boolean exclusive)
+   {
+      exclusive_ = exclusive;
+      updateLabel();
+   }
+
+   public void setMaximized(boolean maximized)
+   {
+      maximized_ = maximized;
+      updateLabel();
+   }
+
+   /**
+    * update accessibility label based on button's default state (max, min) and current
+    * state of its window (normal, maximized, or exclusive)
+    */
+   private  void updateLabel()
+   {
+      WindowState computedState = defaultState_;
+      if (maximized_ || exclusive_)
+         computedState = WindowState.NORMAL; // "restore"
+      Roles.getButtonRole().setAriaLabelProperty(getElement(), stateString(computedState) + " " + name_);
+   }
+
+   public void setClickHandler(Command clickHandler)
+   {
+      clickHandler_ = clickHandler;
+      registerClickHandler();
+   }
+
+   @Override
+   public HandlerRegistration addClickHandler(ClickHandler handler)
+   {
+      Debug.logWarning("WindowFrameButton: for keyboard support use setClickHandler instead of addClickHandler");
+      return super.addClickHandler(handler);
+   }
+
+   private void registerClickHandler()
+   {
+      if (isAttached() && clickHandler_ != null)
+      {
+         releaseOnUnload_.add(super.addClickHandler(event -> click()));
+
+         releaseOnUnload_.add(addKeyPressHandler(event ->
+         {
+            char charCode = event.getCharCode();
+            if (charCode == KeyCodes.KEY_ENTER || charCode == KeyCodes.KEY_SPACE)
+            {
+               event.preventDefault();
+               event.stopPropagation();
+               click();
+            }
+         }));
+      }
+   }
+
+   private void click()
+   {
+      if (clickHandler_ == null)
+         return;
+      clickHandler_.execute();
+   }
+
+   @Override
+   protected void onLoad()
+   {
+      registerClickHandler();
+   }
+
+   @Override
+   protected void onUnload()
+   {
+      releaseOnUnload_.removeHandler();
+   }
+
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
+   }
+
+   private String stateString(WindowState state)
+   {
+      switch (state)
+      {
+      case MINIMIZE:
+         return "Minimize";
+
+      case MAXIMIZE:
+         return "Maximize";
+
+      case NORMAL:
+      default:
+         return "Restore";
+
+      case HIDE:
+         return "Hide";
+
+      case EXCLUSIVE:
+         return "Exclusive";
+      }
+   }
+   
+   private final String name_;
+   private final WindowState defaultState_;
+
+   // modifiers for accessible label based on overall state of logical window
+   private boolean maximized_;
+   private boolean exclusive_;
+
+   private Command clickHandler_ ;
+   private final HandlerRegistrations releaseOnUnload_ = new HandlerRegistrations();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1,7 +1,7 @@
 /*
  * PaneManager.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1007,7 +1007,8 @@ public class PaneManager
 
    private LogicalWindow createConsole()
    {
-      PrimaryWindowFrame frame = new PrimaryWindowFrame("Console", null);
+      String frameName = "Console";
+      PrimaryWindowFrame frame = new PrimaryWindowFrame(frameName, null);
       
       ToolbarButton goToWorkingDirButton =
             commands_.goToWorkingDir().createToolbarButton();
@@ -1015,7 +1016,7 @@ public class PaneManager
             ThemeResources.INSTANCE.themeStyles().windowFrameToolbarButton());
       
       LogicalWindow logicalWindow =
-            new LogicalWindow(frame, new MinimizedWindowFrame("Console"));
+            new LogicalWindow(frame, new MinimizedWindowFrame(frameName, frameName));
 
       consoleTabPanel_ = new ConsoleTabPanel(
             frame,
@@ -1042,20 +1043,21 @@ public class PaneManager
 
    private LogicalWindow createSource()
    {
-      WindowFrame sourceFrame = new WindowFrame();
+      String frameName = "Source";
+      WindowFrame sourceFrame = new WindowFrame(frameName);
       sourceFrame.setFillWidget(source_.asWidget());
       source_.forceLoad();
       return sourceLogicalWindow_ = new LogicalWindow(
             sourceFrame,
-            new MinimizedWindowFrame("Source"));
+            new MinimizedWindowFrame(frameName, frameName));
    }
 
    private
          Triad<LogicalWindow, WorkbenchTabPanel, MinimizedModuleTabLayoutPanel>
          createTabSet(String persisterName, ArrayList<Tab> tabs)
    {
-      final WindowFrame frame = new WindowFrame();
-      final MinimizedModuleTabLayoutPanel minimized = new MinimizedModuleTabLayoutPanel();
+      final WindowFrame frame = new WindowFrame(persisterName);
+      final MinimizedModuleTabLayoutPanel minimized = new MinimizedModuleTabLayoutPanel(persisterName);
       final LogicalWindow logicalWindow = new LogicalWindow(frame, minimized);
 
       final WorkbenchTabPanel tabPanel = new WorkbenchTabPanel(frame, logicalWindow, persisterName);


### PR DESCRIPTION
- the controls to the right of tabs for minimizing, maximizing, and restoring each quadrant can now be operated by screen reader and/or keyboard (in addition to mouse, of course), and report distinctive names indicating both which quadrant they are in, and their current state (min/max/restore)
- also gave each a unique, stable elementId

Visual reminder of the controls (none of this is change by this PR, just FYI). Note the different appearance for Console and Source quadrants when minimized (they hide all tabs and just show the name "Console" or "Source"), whereas the other two quadrants ("TabSet1" and "TabSet2") continue showing just the tabs when minimized.

## Minimized pane ("restore", "maximize")
<img width="58" alt="screenshot of minimized pane size controls" src="https://user-images.githubusercontent.com/10569626/72180046-2613ca00-339b-11ea-8719-3d48cb92b052.png">

### Maximized or exclusive (full-screen) pane ("minimize", "restore")
<img width="52" alt="screenshot of maximized pane size controls" src="https://user-images.githubusercontent.com/10569626/72180049-28762400-339b-11ea-8f32-cbe662062a86.png">

### Normal pane ("minimize", "maximize")
<img width="56" alt="screenshot of normal pane config size controls" src="https://user-images.githubusercontent.com/10569626/72180057-2b711480-339b-11ea-8a4c-1ac3b2f9a139.png">

### Minimized Console
<img width="340" alt="screenshot of minimized console pane's full titlebar" src="https://user-images.githubusercontent.com/10569626/72180446-0c26b700-339c-11ea-8cf1-2366593809c2.png">

### Minimized TabSet1
<img width="456" alt="screenshot of minimized TabSet1 pane's full titlebar" src="https://user-images.githubusercontent.com/10569626/72180480-2496d180-339c-11ea-84b6-4f121ce3fa70.png">
