### PR TITLE
Accessibility improvements to editor pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -1,7 +1,7 @@
 /*
  * A11y.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -100,6 +100,15 @@ public class A11y
    public static void setARIAHidden(Element el)
    {
       el.setAttribute("aria-hidden", "true");
+   }
+
+   /**
+    * Make an element visible to screen readers.
+    * @param el
+    */
+   public static void setARIAVisible(Element el)
+   {
+      el.removeAttribute("aria-hidden");
    }
 
    public static void setVisuallyHidden(Widget widget)

--- a/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusWidget.java
@@ -1,7 +1,7 @@
 /*
  * AriaLiveStatusWidget.java
  *
- * Copyright (C) 2019 by RStudio, Inc.
+ * Copyright (C) 2019-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -36,14 +36,15 @@ public class AriaLiveStatusWidget extends Widget
    {
       if (speakDelayMs < 0)
       {
-         if (updateReaderTimer_.isRunning())
-            updateReaderTimer_.cancel();
+         clearMessage();
          return;
       }
 
       resultsMessage_ = message;
       if (updateReaderTimer_.isRunning())
          updateReaderTimer_.cancel();
+      if (clearReaderTimer_.isRunning())
+         clearReaderTimer_.cancel();
       updateReaderTimer_.schedule(speakDelayMs);
    }
 
@@ -51,6 +52,8 @@ public class AriaLiveStatusWidget extends Widget
    {
       if (updateReaderTimer_.isRunning())
          updateReaderTimer_.cancel();
+      if (clearReaderTimer_.isRunning())
+         clearReaderTimer_.cancel();
       getElement().setInnerText("");
    }
 
@@ -63,7 +66,22 @@ public class AriaLiveStatusWidget extends Widget
       public void run()
       {
          getElement().setInnerText(resultsMessage_);
+         if (clearReaderTimer_.isRunning())
+            clearReaderTimer_.cancel();
+         clearReaderTimer_.schedule(4000);
       }
+   };
+
+   /**
+    * Timer for clearing the previous message if nothing new arrives
+    */
+   private Timer clearReaderTimer_ = new Timer()
+   {
+     @Override
+     public void run()
+     {
+        getElement().setInnerText("");
+     }
    };
 
    private String resultsMessage_;

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -351,7 +351,7 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
-      int delayMs = userPrefs_.get().typingStatusDelayMs().getValue();
+      int delayMs = event.getImmediate() ? 0 : userPrefs_.get().typingStatusDelayMs().getValue();
       if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs))
          view_.reportStatus(event.getMessage(), userPrefs_.get().typingStatusDelayMs().getValue());
    }
@@ -1010,6 +1010,12 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromSAS().remove();
          commands_.importDatasetFromStata().remove();
          commands_.importDatasetFromXLS().remove();
+      }
+
+      // remove commands that only make sense if screen reader is enabled
+      if (!userPrefs_.get().enableScreenReader().getValue())
+      {
+         commands_.speakEditorLocation().remove();
       }
 
       // If no project, ensure we show the product-edition title; if there is a project

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
@@ -1,7 +1,7 @@
 /*
  * AriaLiveStatusEvent.java
  *
- * Copyright (C) 2019 by RStudio, Inc.
+ * Copyright (C) 2019-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,12 +26,23 @@ public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
 
    public AriaLiveStatusEvent(String message)
    {
+      this(message, false);
+   }
+   
+   public AriaLiveStatusEvent(String message, boolean immediate)
+   {
       message_ = message;
+      immediate_ = immediate;
    }
 
    public String getMessage()
    {
       return message_;
+   }
+   
+   public boolean getImmediate()
+   {
+      return immediate_;
    }
 
    @Override
@@ -47,6 +58,7 @@ public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
    }
 
    private final String message_;
+   private final boolean immediate_;
 
    public static final Type<AriaLiveStatusEvent.Handler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -1,7 +1,7 @@
 /*
  * SatelliteWindow.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -144,7 +144,7 @@ public abstract class SatelliteWindow extends Composite
    @Override
    public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
-      int delayMs = RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue();
+      int delayMs = event.getImmediate() ? 0 : RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue();
       if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs))
          ariaLiveStatusWidget_.announce(event.getMessage(), delayMs);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -502,6 +502,9 @@ well as menu structures (for main menu and popup menus).
             <cmd refid="toggleScreenReaderSupport"/>
             <cmd refid="toggleTabKeyMovesFocus"/>
             <separator/>
+            <menu label="Speak">
+               <cmd refid="speakEditorLocation"/>
+            </menu>
             <cmd refid="focusMainToolbar"/>
             <separator/>
             <cmd refid="showAccessibilityOptions"/>
@@ -828,6 +831,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
+         <shortcut refid="speakEditorLocation" value="Ctrl+Shift+B"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
@@ -3620,5 +3624,9 @@ well as menu structures (for main menu and popup menus).
         buttonLabel=""
         menuLabel="Sign Ou_t"
         desc="Sign out from RStudio"
+        windowMode="main"/>
+
+   <cmd id="speakEditorLocation"
+        menuLabel="Speak Text Editor Location"
         windowMode="main"/>
 </commands>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -640,6 +640,7 @@ public abstract class
    public abstract AppCommand toggleTabKeyMovesFocus();
    public abstract AppCommand showAccessibilityOptions();
    public abstract AppCommand focusMainToolbar();
+   public abstract AppCommand speakEditorLocation();
    
    // Internal
    public abstract AppCommand showDomElements();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.css
@@ -30,7 +30,7 @@
    overflow: hidden;
    margin-top: 20px;
    font-style: italic;
-   color: rgb(128, 128, 128) !important;
+   color: rgb(117, 117, 117) !important;
 }
 
 .tree {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -1,7 +1,7 @@
 /*
  * DocumentOutlineWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,10 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.source;
 
+import com.google.gwt.aria.client.OrientationValue;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Counter;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -63,6 +66,9 @@ public class DocumentOutlineWidget extends Composite
       {
          panel_ = new FlowPanel();
          panel_.addStyleName(RES.styles().leftSeparator());
+         Roles.getSeparatorRole().set(panel_.getElement());
+         Roles.getSeparatorRole().setAriaOrientationProperty(panel_.getElement(),
+               OrientationValue.VERTICAL);
          initWidget(panel_);
       }
       
@@ -228,6 +234,7 @@ public class DocumentOutlineWidget extends Composite
       
       tree_ = new Tree();
       tree_.addStyleName(RES.styles().tree());
+      Roles.getTreeRole().setAriaLabelProperty(tree_.getElement(), "Document Outline");
       
       panel_ = new FlowPanel();
       panel_.addStyleName(RES.styles().panel());
@@ -252,6 +259,14 @@ public class DocumentOutlineWidget extends Composite
       updateStyles(emptyPlaceholder_, event.getStyle());
    }
    
+   public void setAriaVisible(boolean visible)
+   {
+      if (visible)
+         A11y.setARIAVisible(getElement());
+      else
+         A11y.setARIAHidden(getElement());
+   }
+
    private void initHandlers()
    {
       handlers_.add(target_.getDocDisplay().addScopeTreeReadyHandler(new ScopeTreeReadyEvent.Handler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1,7 +1,7 @@
 /*
  * Source.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -65,6 +65,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationAction;
 import org.rstudio.studio.client.application.ApplicationUtils;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FileDialogs;
@@ -4182,6 +4183,19 @@ public class Source implements InsertSourceHandler,
    public void onOpenPreviousFileOnFilesystem()
    {
       openAdjacentFile(false);
+   }
+   
+   @Handler
+   public void onSpeakEditorLocation()
+   {
+      String announcement;
+      if (view_.getTabCount() == 0)
+         announcement = "No documents open in editor";
+      else
+      {
+         announcement = "Nothing to see here";
+      }
+      events_.fireEvent(new AriaLiveStatusEvent(announcement, true));
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -4189,11 +4189,11 @@ public class Source implements InsertSourceHandler,
    public void onSpeakEditorLocation()
    {
       String announcement;
-      if (view_.getTabCount() == 0)
-         announcement = "No documents open in editor";
+      if (activeEditor_ == null)
+         announcement = "No document tabs open";
       else
       {
-         announcement = "Nothing to see here";
+         announcement = activeEditor_.getCurrentStatus();
       }
       events_.fireEvent(new AriaLiveStatusEvent(announcement, true));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceShim.java
@@ -1,7 +1,7 @@
 /*
  * SourceShim.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -155,7 +155,9 @@ public class SourceShim extends Composite
       public abstract void onOpenNextFileOnFilesystem();
       @Handler
       public abstract void onOpenPreviousFileOnFilesystem();
-      
+      @Handler
+      public abstract void onSpeakEditorLocation();
+
       // NOTE: These aren't really Source-level commands, but we
       // need them to be registered for both the whole application
       // as well as popped-out source windows.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * EditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -146,7 +146,13 @@ public interface EditingTarget extends IsWidget,
    long getLargeFileSize();
    
    String getDefaultNamePrefix();
-   
+
+   /**
+    * @return Summary of the pane's current state for screen readers (read out 
+    * loud by user request)
+    */
+   public String getCurrentStatus();
+
    public final static int DISMISS_TYPE_CLOSE = 0;
    public final static int DISMISS_TYPE_MOVE = 1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -752,7 +752,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    @Override
    public void endDebugHighlighting()
    {
-      docDisplay_.endDebugHighlighting();      
+      docDisplay_.endDebugHighlighting();
    } 
    
    @Override 
@@ -770,6 +770,12 @@ public class CodeBrowserEditingTarget implements EditingTarget
    public String getDefaultNamePrefix()
    {
       return null;
+   }
+
+   @Override
+   public String getCurrentStatus()
+   {
+      return "Code Browser displayed";
    }
 
    // Private methods --------------------------------------------------------

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * CodeBrowserEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -88,6 +88,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
       void findPrevious();
       void findFromSelection();
       void scrollToLeft();
+      void setAccessibleName(String name);
    }
 
    interface MyBinder extends CommandBinder<Commands, CodeBrowserEditingTarget>
@@ -201,6 +202,9 @@ public class CodeBrowserEditingTarget implements EditingTarget
       {
          docDisplay_.setCode("", false);
       }
+
+      name_.addValueChangeHandler(event -> view_.setAccessibleName(name_.getValue()));
+      name_.fireChangeEvent();
    }
    
    public void showFunction(SearchPathFunctionDefinition functionDef)
@@ -812,8 +816,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    private SourceDocument doc_;
  
    private final Value<Boolean> dirtyState_ = new Value<Boolean>(false);
-   private ArrayList<HandlerRegistration> releaseOnDismiss_ =
-         new ArrayList<HandlerRegistration>();
+   private ArrayList<HandlerRegistration> releaseOnDismiss_ = new ArrayList<>();
    private final SourceServerOperations server_;
    private final Commands commands_;
    private final EventBus events_;
@@ -823,7 +826,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    private Display view_;
    private HandlerRegistration commandReg_;
    private boolean shownWarningBar_ = false;
-   private final Value<String> name_ = new Value<String>("Source Viewer");  
+   private final Value<String> name_ = new Value<>("Source Viewer");
    private DocDisplay docDisplay_;
    private EditingTargetCodeExecution codeExecution_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * CodeBrowserEditingTargetWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.codebrowser;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -31,6 +32,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 import java.util.List;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -114,7 +116,8 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
                                      docDisplay_.asWidget(),
                                      null);
       panel_.setSize("100%", "100%");
-      
+      Roles.getTabpanelRole().set(panel_.getElement());
+      setAccessibleName(null);
       docDisplay_.setReadOnly(true);
       
       docDisplay_.addCommandClickHandler(new CommandClickEvent.Handler()
@@ -285,7 +288,15 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
          }
       }.schedule(100);
    }
-   
+
+   @Override
+   public void setAccessibleName(String name)
+   {
+      if (StringUtil.isNullOrEmpty(name))
+         name = "Untitled Source Viewer";
+      Roles.getTabpanelRole().setAriaLabelProperty(panel_.getElement(), name + " Source Viewer");
+   }
+
    private void showWarningImpl(final Command command)
    {
       if (warningBar_ == null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -211,6 +211,12 @@ public class DataEditingTarget extends UrlContentEditingTarget
       events_.fireEvent(new PopoutDocEvent(getId(), null));
    }
 
+   @Override
+   public String getCurrentStatus()
+   {
+      return "Data Browser displayed";
+   }
+
    protected String getCacheKey()
    {
       return getDataItem().getCacheKey();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * DataEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,10 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.data;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -62,12 +64,19 @@ public class DataEditingTarget extends UrlContentEditingTarget
    {
       progressPanel_ = new SimplePanelWithProgress();
       progressPanel_.setSize("100%", "100%");
+      Roles.getTabpanelRole().set(progressPanel_.getElement());
+      setAccessibleName(null);
       reloadDisplay();
       return new Display()
       {
          public void print()
          {
             ((Display)progressPanel_.getWidget()).print();
+         }
+
+         public void setAccessibleName(String accessibleName)
+         {
+            DataEditingTarget.this.setAccessibleName(accessibleName);
          }
 
          public Widget asWidget()
@@ -98,6 +107,14 @@ public class DataEditingTarget extends UrlContentEditingTarget
             doQueuedRefresh(false);
          }
       }
+   }
+
+   private void setAccessibleName(String accessibleName)
+   {
+      if (StringUtil.isNullOrEmpty(accessibleName))
+         accessibleName = "Untitled Data Browser";
+      Roles.getTabpanelRole().setAriaLabelProperty(progressPanel_.getElement(), accessibleName + 
+            " Data Browser");
    }
 
    @Override
@@ -151,7 +168,7 @@ public class DataEditingTarget extends UrlContentEditingTarget
    private void reloadDisplay()
    {
       view_ = new DataEditingTargetWidget(
-            "Data Editing Target",
+            "Data Browser",
             commands_,
             events_,
             getDataItem());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * DataEditingTargetWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -181,11 +181,18 @@ public class DataEditingTargetWidget extends Composite
       return frameEl.getContentWindow();
    }
 
+   @Override
    public void print()
    {
       getWindow().print();
    }
-   
+
+   @Override
+   public void setAccessibleName(String name)
+   {
+      // Accessible name is set on container of this widget
+   }
+
    public void setFilterUIVisible(boolean visible)
    {
       if (table_ != null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * ObjectExplorerEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,9 +14,11 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.explorer;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -52,12 +54,19 @@ public class ObjectExplorerEditingTarget
    {
       progressPanel_ = new SimplePanelWithProgress();
       progressPanel_.setSize("100%", "100%");
+      Roles.getTabpanelRole().set(progressPanel_.getElement());
+      setAccessibleName(null);
       reloadDisplay();
       return new Display()
       {
          public void print()
          {
             ((Display)progressPanel_.getWidget()).print();
+         }
+
+         public void setAccessibleName(String name)
+         {
+            ObjectExplorerEditingTarget.this.setAccessibleName(name);
          }
 
          public Widget asWidget()
@@ -157,7 +166,14 @@ public class ObjectExplorerEditingTarget
       view_.setSize("100%", "100%");
       progressPanel_.setWidget(view_);
    }
-   
+
+   private void setAccessibleName(String accessibleName)
+   {
+      if (StringUtil.isNullOrEmpty(accessibleName))
+         accessibleName = "Untitled Object Explorer";
+      Roles.getTabpanelRole().setAriaLabelProperty(progressPanel_.getElement(), accessibleName +
+            " Object Explorer");
+   }
 
    private SimplePanelWithProgress progressPanel_;
    private ObjectExplorerEditingTargetWidget view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -151,7 +151,13 @@ public class ObjectExplorerEditingTarget
       
       view_.refresh();
    }
-   
+
+   @Override
+   public String getCurrentStatus()
+   {
+      return "Object Explorer displayed";
+   }
+
    // Private methods ----
    
    private void reloadDisplay()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * ProfilerEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -650,7 +650,13 @@ public class ProfilerEditingTarget implements EditingTarget,
    {
       return "Profile";
    }
-   
+
+   @Override
+   public String getCurrentStatus()
+   {
+      return "Code Profile results displayed";
+   }
+
    private void savePropertiesWithPath(String path)
    {
       String name = FileSystemItem.getNameFromPath(path);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * ProfilerEditingTargetWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.profiler;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
@@ -39,7 +40,8 @@ public class ProfilerEditingTargetWidget extends Composite
    public ProfilerEditingTargetWidget(String title, Commands commands, PublishHtmlSource publishHtmlSource)
    {
       VerticalPanel panel = new VerticalPanel();
-
+      Roles.getTabpanelRole().set(panel.getElement());
+      Roles.getTabpanelRole().setAriaLabelProperty(panel.getElement(), title + " Profile View");
 
       PanelWithToolbars mainPanel = new PanelWithToolbars(
                                           createToolbar(commands, publishHtmlSource), 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * TextEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -256,6 +256,8 @@ public class TextEditingTarget implements
       void toggleDocumentOutline();
       
       void setNotebookUIVisible(boolean visible);
+
+      void setAccessibleName(String name);
    }
 
    private class SaveProgressIndicator implements ProgressIndicator
@@ -1402,6 +1404,7 @@ public class TextEditingTarget implements
          @Override
          public void onValueChange(ValueChangeEvent<String> event)
          {
+            view_.setAccessibleName(name_.getValue());
             FileSystemItem item = FileSystemItem.createFile(event.getValue());
             if (shouldEnforceHardTabs(item))
                docDisplay_.setUseSoftTabs(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5033,6 +5033,25 @@ public class TextEditingTarget implements
    {
       return null;
    }
+
+   @Override
+   public String getCurrentStatus()
+   {
+      Position pos = docDisplay_.getCursorPosition();
+      String scope = statusBar_.getScope().getValue();
+      if (StringUtil.isNullOrEmpty(scope))
+         scope = "None";
+      String name = getName().getValue();
+      if (StringUtil.isNullOrEmpty(name))
+         name = "No name";
+
+      StringBuilder status = new StringBuilder();
+      status.append("Row ").append(pos.getRow() + 1).append(" Column ").append(pos.getColumn() + 1);
+      status.append(" Scope ").append(scope);
+      status.append(" File type ").append(fileType_.getLabel());
+      status.append(" File name ").append(name);
+      return status.toString();
+   }
    
    private boolean isRChunk(Scope scope)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -189,7 +189,7 @@ public class TextEditingTargetWidget
                      clamped = 0;
                   
                   editorPanel_.setWidgetSize(docOutlineWidget_, clamped);
-                  toggleDocOutlineButton_.setLatched(clamped != 0);
+                  setDocOutlineLatchState(clamped != 0);
                   editor_.onResize();
                }
                
@@ -217,7 +217,7 @@ public class TextEditingTargetWidget
       adaptToFileType(fileType);
       
       editor.addFocusHandler(event ->
-            toggleDocOutlineButton_.setLatched(docOutlineWidget_.getOffsetWidth() > 0));
+            setDocOutlineLatchState(docOutlineWidget_.getOffsetWidth() > 0));
 
       editor_.setTextInputAriaLabel("Text editor");
 
@@ -245,7 +245,7 @@ public class TextEditingTargetWidget
          double widgetSize = target_.getPreferredOutlineWidgetSize();
          double size = Math.min(editorSize, widgetSize);
          editorPanel_.setWidgetSize(docOutlineWidget_, size);
-         toggleDocOutlineButton_.setLatched(true);
+         setDocOutlineLatchState(true);
       }
    }
    
@@ -525,7 +525,7 @@ public class TextEditingTargetWidget
                   title = title.replace("Hide ", "Show ");
                toggleDocOutlineButton_.setTitle(title);
 
-               toggleDocOutlineButton_.setLatched(destination != 0);
+               setDocOutlineLatchState(destination != 0);
 
                int duration = (userPrefs_.reducedMotion().getValue() ? 0 : 500);
                new Animation()
@@ -564,7 +564,7 @@ public class TextEditingTargetWidget
                   ? title.replace("Show ", "Hide ")
                   : title.replace("Hide ", "Show ");
             toggleDocOutlineButton_.setTitle(title);
-            toggleDocOutlineButton_.setLatched(docOutlineWidget_.getOffsetWidth() > 0);
+            setDocOutlineLatchState(docOutlineWidget_.getOffsetWidth() > 0);
          }
       }.schedule(100);
       
@@ -588,6 +588,12 @@ public class TextEditingTargetWidget
       toolbar.addRightWidget(showWhitespaceCharactersCheckbox_);
       
       return toolbar;
+   }
+   
+   private void setDocOutlineLatchState(boolean latched)
+   {
+      toggleDocOutlineButton_.setLatched(latched);
+      docOutlineWidget_.setAriaVisible(latched);
    }
    
    private ToolbarButton createLatexFormatButton()
@@ -775,7 +781,7 @@ public class TextEditingTargetWidget
       if (!fileType.canShowScopeTree())
       {
          editorPanel_.setWidgetSize(docOutlineWidget_, 0);
-         toggleDocOutlineButton_.setLatched(false);
+         setDocOutlineLatchState(false);
       }
       
       toolbar_.invalidateSeparators();
@@ -820,7 +826,7 @@ public class TextEditingTargetWidget
    public void setAccessibleName(String name)
    {
       if (StringUtil.isNullOrEmpty(name))
-         name = "Text editor";
+         name = "Untitled Text editor";
       Roles.getTabpanelRole().setAriaLabelProperty(panel_.getElement(), name);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * TextEditingTargetWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -212,6 +212,8 @@ public class TextEditingTargetWidget
             editorPanel_,
             statusBar_);
       
+      Roles.getTabpanelRole().set(panel_.getElement());
+      setAccessibleName(null);
       adaptToFileType(fileType);
       
       editor.addFocusHandler(event ->
@@ -812,6 +814,14 @@ public class TextEditingTargetWidget
    public void setNotebookUIVisible(boolean visible)
    {
       runSetupChunkOptionMenu_.setVisible(visible);
+   }
+
+   @Override
+   public void setAccessibleName(String name)
+   {
+      if (StringUtil.isNullOrEmpty(name))
+         name = "Text editor";
+      Roles.getTabpanelRole().setAriaLabelProperty(panel_.getElement(), name);
    }
 
    public HasValue<Boolean> getSourceOnSave()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -1,7 +1,7 @@
 /*
  * UrlContentEditingTarget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -62,6 +62,7 @@ public class UrlContentEditingTarget implements EditingTarget
    public interface Display extends IsWidget
    {
       void print();
+      void setAccessibleName(String name);
    }
 
    interface MyBinder extends CommandBinder<Commands, UrlContentEditingTarget>
@@ -97,8 +98,8 @@ public class UrlContentEditingTarget implements EditingTarget
 
    public HasValue<String> getName()
    {
-      String title = getContentTitle();
-      return new Value<String>(title);
+      name_.setValue(getContentTitle(), true);
+      return name_;
    }
    
    public String getTitle()
@@ -402,11 +403,13 @@ public class UrlContentEditingTarget implements EditingTarget
    {
       doc_ = document;
       view_ = createDisplay();
+      name_.addValueChangeHandler(event -> view_.setAccessibleName(name_.getValue()));
+      name_.setValue(getContentTitle(), true);
    }
 
    protected Display createDisplay()
    {
-      return new UrlContentEditingTargetWidget("Url Content Editing",
+      return new UrlContentEditingTargetWidget("URL Browser",
             commands_,
             getContentUrl());
    }
@@ -476,6 +479,7 @@ public class UrlContentEditingTarget implements EditingTarget
    private final EventBus events_;
    private Display view_;
    private HandlerRegistration commandReg_;
+   private Value<String> name_ = new Value<>(null);
 
    private static final MyBinder binder_ = GWT.create(MyBinder.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -465,6 +465,12 @@ public class UrlContentEditingTarget implements EditingTarget
       return null;
    }
 
+   @Override
+   public String getCurrentStatus()
+   {
+      return "URL Viewer displayed";
+   }
+
    private ContentItem getContentItem()
    {
       return (ContentItem)doc_.getProperties().cast();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTargetWidget.java
@@ -1,7 +1,7 @@
 /*
  * UrlContentEditingTargetWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,8 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.urlcontent;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.widget.RStudioThemedFrame;
 import org.rstudio.core.client.widget.Toolbar;
@@ -33,11 +35,10 @@ public class UrlContentEditingTargetWidget extends Composite
       frame_ = new RStudioThemedFrame(title, url, true, "allow-same-origin", null, null, false, true);
       frame_.setSize("100%", "100%");
 
-      PanelWithToolbars panel = new PanelWithToolbars(createToolbar(),
-                                                    frame_);
-
-      initWidget(panel);
-
+      panel_ = new PanelWithToolbars(createToolbar(), frame_);
+      Roles.getTabpanelRole().set(panel_.getElement());
+      setAccessibleName(null);
+      initWidget(panel_);
    }
 
    private Toolbar createToolbar()
@@ -57,6 +58,15 @@ public class UrlContentEditingTargetWidget extends Composite
       return this;
    }
 
+   @Override
+   public void setAccessibleName(String name)
+   {
+      if (StringUtil.isNullOrEmpty(name))
+         name = "Untitled URL Browser";
+      Roles.getTabpanelRole().setAriaLabelProperty(panel_.getElement(), name + " URL Browser");
+   }
+
    private final Commands commands_;
    private RStudioThemedFrame frame_;
+   private final PanelWithToolbars panel_;
 }


### PR DESCRIPTION
- when document outline is visually hidden also make it invisible to screen readers
- markup document outline splitter as a splitter
- give document outline a label for accessibility tools
- increase contrast of message shown when document outline is empty
- option to read aria-status messages with no delay
- clear prior aria-live status message after 4 seconds (this is to allow a repeated message to be read and so it doesn't show up again when navigating page with screen reader cursor)
- new command "Speak text editor location" (Ctrl+Shift+B) that reads out current row, col, scope, file type and filename via aria-live; command hidden if screen reader support disabled
- annotate the panels for each tab in editor pane with role=tabpanel and a label (had to be done for text editors, data browser, object browser, profile results, code browser, url viewer)
