### PR TITLE
use aria-pressed to make LatchingToolbarButton a toggle button

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/LatchingToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LatchingToolbarButton.java
@@ -1,7 +1,7 @@
 /*
  * LatchingToolbarButton.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,20 +14,30 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.PressedValue;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
 
+/**
+ * A button that toggles between pressed and unpressed. If the text is changed to indicate
+ * which state the button is in, then "textIndicatesState" must be true; otherwise aria-pressed
+ * property will be used so screen readers know what state the button is in.
+ */
 public class LatchingToolbarButton extends ToolbarButton
 {
-
    public LatchingToolbarButton(String text, 
                                 String title,
+                                boolean textIndicatesState,
                                 ImageResource leftImage,
                                 ClickHandler clickHandler)
    {
       super(text, title, leftImage, clickHandler);
+      textIndicatesState_ = textIndicatesState;
+      if (!textIndicatesState_)
+         Roles.getButtonRole().setAriaPressedState(getElement(), PressedValue.FALSE);
       getElement().addClassName(ThemeStyles.INSTANCE.toolbarButtonLatchable());
    }
    
@@ -39,10 +49,19 @@ public class LatchingToolbarButton extends ToolbarButton
       latched_ = latched;
       
       if (latched_)
+      {
+         if (!textIndicatesState_)
+            Roles.getButtonRole().setAriaPressedState(getElement(), PressedValue.TRUE);
          getElement().addClassName(ThemeStyles.INSTANCE.toolbarButtonLatched());
+      }
       else
+      {
+         if (!textIndicatesState_)
+            Roles.getButtonRole().setAriaPressedState(getElement(), PressedValue.FALSE);
          getElement().removeClassName(ThemeStyles.INSTANCE.toolbarButtonLatched());
+      }
    }
    
    private boolean latched_ = false;
+   private boolean textIndicatesState_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -1,7 +1,7 @@
 /*
  * DataTable.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -52,6 +52,7 @@ public class DataTable
       filterButton_ = new LatchingToolbarButton(
               "Filter",
               ToolbarButton.NoTitle,
+              false, /* textIndicatesState */
               new ImageResource2x(DataViewerResources.INSTANCE.filterIcon2x()),
               new ClickHandler() {
                  public void onClick(ClickEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -506,6 +506,7 @@ public class TextEditingTargetWidget
       toggleDocOutlineButton_ = new LatchingToolbarButton(
             ToolbarButton.NoText,
             ToolbarButton.NoTitle,
+            true, /* textIndicatesState */
             new ImageResource2x(StandardIcons.INSTANCE.outline2x()),
             event -> {
                final double initialSize = editorPanel_.getWidgetSize(docOutlineWidget_);


### PR DESCRIPTION
- in one use of this control (for showing/hiding document outline), the accessibility text is changed to indicate the state of the button; in that situation it is NOT appropriate to use aria-pressed as the text is sufficient to tell screen readers what is going on
- in the other use, the Filter button in the data viewer, the text does not change, so aria-pressed is required to indicate that this is a toggle button and to indicate what state it is currently in

## Toggle Button example
<img width="581" alt="Filter toggle button shown in the RStudio data viewer" src="https://user-images.githubusercontent.com/10569626/72234386-a2680200-3581-11ea-8e34-ef13d55d084a.png">
