### PR TITLE
Allow to use system wide installations of pandoc, mathjax and Qt

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -62,6 +62,11 @@ if (NOT RSTUDIO_UNIT_TESTS_DISABLED)
   add_definitions(-DRSTUDIO_UNIT_TESTS_ENABLED)
 endif()
 
+# unless explicitly enabled, don't search system paths
+if (NOT RSTUDIO_SEARCH_SYSTEM_PATHS_FOR_DEPENDENCIES)
+  set(RSTUDIO_SEARCH_SYSTEM_PATHS_FOR_DEPENDENCIES false)
+endif()
+
 # platform specific default for targets
 if(NOT RSTUDIO_TARGET)
    set(RSTUDIO_TARGET "Development")

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -94,6 +94,13 @@ else()
    endif()
 endif()
 
+if(NOT QT_QMAKE_EXECUTABLE AND RSTUDIO_SEARCH_SYSTEM_PATHS_FOR_DEPENDENCIES)
+   find_program(QT_QMAKE_EXECUTABLE
+      NAMES "qmake"
+      PATHS "/usr/lib64/qt5/bin/" "/usr/lib/qt5/bin")
+   message(STATUS ${QT_QMAKE_EXECUTABLE})
+endif()
+
 if(QT_QMAKE_EXECUTABLE)
    message(STATUS "Found Qt: ${QT_QMAKE_EXECUTABLE}")
 else()

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -22,11 +22,33 @@ add_subdirectory(workers)
 if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/dictionaries")
   message(FATAL_ERROR "Dictionaries not found (re-run install-dependencies script to install)")
 endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-27")
+
+set(MATHJAX_SEARCH_PATHS "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-27")
+set(PANDOC_SEARCH_PATHS "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc/")
+if(RSTUDIO_SEARCH_SYSTEM_PATHS_FOR_DEPENDENCIES)
+   list(APPEND MATHJAX_SEARCH_PATHS /usr/share/javascript/mathjax/)
+   list(APPEND PANDOC_SEARCH_PATHS /usr/bin/)
+endif()
+
+find_file(MATHJAX_JS_LOCATION
+   NAMES MathJax.js
+   PATHS ${MATHJAX_SEARCH_PATHS})
+if("${MATHJAX_JS_LOCATION}" STREQUAL "MATHJAX_JS_LOCATION-NOTFOUND")
   message(FATAL_ERROR "Mathjax 2.7 not found (re-run install-dependencies script to install)")
 endif()
-if(NOT EXISTS "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc")
-  message(FATAL_ERROR "pandoc not found (re-run install-dependencies script to install)")
+get_filename_component(MATHJAX_PATH ${MATHJAX_JS_LOCATION} DIRECTORY)
+
+find_program(PANDOC_BIN_LOCATION
+   NAMES pandoc
+   PATHS ${PANDOC_SEARCH_PATHS})
+find_program(PANDOC_CITEPROC_BIN_LOCATION
+   NAMES pandoc-citeproc
+   PATHS ${PANDOC_SEARCH_PATHS})
+if(
+      "${PANDOC_BIN_LOCATION}" STREQUAL "PANDOC_BIN_LOCATION-NOTFOUND"
+      OR
+      "${PANDOC_CITEPROC_BIN_LOCATION}" STREQUAL "PANDOC_CITEPROC_BIN_LOCATION-NOTFOUND")
+   message(FATAL_ERROR "pandoc not found (re-run install-dependencies script to install)")
 endif()
 
 # verify embedded packages are available
@@ -500,7 +522,7 @@ if (NOT RSTUDIO_SESSION_WIN32)
            DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/resources")
 
    # install mathjax for local html preview
-   install(DIRECTORY "${RSTUDIO_DEPENDENCIES_DIR}/common/mathjax-27"
+   install(DIRECTORY "${MATHJAX_PATH}"
            DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/resources")
 
    # icons for database connections
@@ -520,6 +542,7 @@ if (NOT RSTUDIO_SESSION_WIN32)
 
    set(PANDOC_BIN "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc/${PANDOC_VERSION}")
    file(GLOB PANDOC_FILES "${PANDOC_BIN}/pandoc*")
+   set(PANDOC_FILES ${PANDOC_CITEPROC_BIN_LOCATION} ${PANDOC_BIN_LOCATION})
    install(FILES ${PANDOC_FILES}
            PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
            DESTINATION  ${RSTUDIO_INSTALL_BIN}/pandoc)


### PR DESCRIPTION
We are currently working on bringing RStudio into openSUSE Tumbleweed's main repositories and had to unbundle the qt, mathjax & pandoc dependencies for that. I am submitting the resulting patches, as other distributions could find them useful and they shouldn't interfere with the default behavior of RStudio's build.

The patches essentially just extend the possible search paths for the dependencies from `/opt/RStudio-QtSDK/` and `${RSTUDIO_DEPENDENCIES_DIR}` to system wide installation paths (`/var/lib/qt5/`, `/var/lib64/qt5/`, `/usr/bin/` and `/usr/share/javascript/mathjax`).

If you prefer, I can wrap these with a bunch of
``` CMake
if(${I_KNOW_THAT_UNBUNDLED_DEPS_ARE_UNSUPORTED})
   # insert system-wide installations paths here
endif()
```
so that the system wide installations cannot be used by accident.