### PR TITLE
support F13 - F24 for custom keyboard shortcuts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,6 +103,7 @@
 * New `rstudio --version` command to return the version of RStudio Desktop (#3922)
 * Scan R Markdown YAML header for R packages required to render document (#4779)
 * Change shortcuts for Next/Previous terminal to avoid clash with common Windows shortcuts (#4892)
+* Support use of F13 - F24 for custom keyboard shortcuts (full Mac keyboard has F13-F19, for example)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
@@ -1,7 +1,7 @@
 /*
  * KeyboardHelper.java
  *
- * Copyright (C) 2009-15 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -151,8 +151,8 @@ public class KeyboardHelper
       
       map[111] = "/";
       
-      // Function keys
-      for (var i = 112; i <= 123; i++)
+      // Function keys (full Mac keyboard supports up to F19, some keyboard go up to F24)
+      for (var i = 112; i <= 135; i++)
          map[i] = "F" + (i - 111);
       
       map[144] = "NumLock";

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutsEmitter.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -271,6 +271,30 @@ public class ShortcutsEmitter
          return "122";
       if (val.equalsIgnoreCase("F12"))
          return "123";
+      if (val.equalsIgnoreCase("F13"))
+         return "124";
+      if (val.equalsIgnoreCase("F14"))
+         return "125";
+      if (val.equalsIgnoreCase("F15"))
+         return "126";
+      if (val.equalsIgnoreCase("F16"))
+         return "127";
+      if (val.equalsIgnoreCase("F17"))
+         return "128";
+      if (val.equalsIgnoreCase("F18"))
+         return "129";
+      if (val.equalsIgnoreCase("F19"))
+         return "130";
+      if (val.equalsIgnoreCase("F20"))
+         return "131";
+      if (val.equalsIgnoreCase("F21"))
+         return "132";
+      if (val.equalsIgnoreCase("F22"))
+         return "133";
+      if (val.equalsIgnoreCase("F23"))
+         return "134";
+      if (val.equalsIgnoreCase("F24"))
+         return "135";
       if (val.equals("`"))
          return "192";
       if (val.equals("."))


### PR DESCRIPTION
- Tested with my full Mac keyboard which includes F13 to F19
- Also works with Windows/Linux if you have a keyboard with these keys
- Helpful when using screen readers, where unused keyboard shortcuts are hard to come by

Here's a full Mac keyboard:
<img width="1282" alt="full-size Apple Mac keyboard showing where F13 - F19 are located" src="https://user-images.githubusercontent.com/10569626/72298908-44382f00-3614-11ea-91b3-9c8c60c3b792.png">

- Keys up to F24 are defined, hard to find these days, but they do exist, so why not:

![older IBM keyboard with full F1 through F24 keys](https://user-images.githubusercontent.com/10569626/72298666-9298fe00-3613-11ea-8e01-a359e3b5cf0a.jpg)
