### PR TITLE
provide alt-text for images in Environment pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.ui.xml
@@ -12,7 +12,7 @@
         <g:ResizeLayoutPanel styleName="{environmentStyle.fillHeight}">
             <g:ScrollPanel styleName="{environmentStyle.fillHeight}">
                 <g:HTMLPanel>
-                  <g:Image resource="{executionArrow}" styleName="{style.executionArrow}"></g:Image>
+                  <g:Image altText="Current" resource="{executionArrow}" styleName="{style.executionArrow}"></g:Image>
                   <g:HTMLPanel styleName="{style.frameList} {style.framePanel}" ui:field="callFramePanel"></g:HTMLPanel>
                 </g:HTMLPanel>
             </g:ScrollPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -1,7 +1,7 @@
 /*
  * EnvironmentObjectList.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -185,6 +185,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
             {
                String imageUri = "";
                String imageStyle = style_.expandIcon();
+               String imageAlt = "";
                if (object.canExpand())
                {
                   imageStyle = imageStyle + " " + ThemeStyles.INSTANCE.handCursor();
@@ -196,17 +197,19 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
                             new ImageResource2x(EnvironmentResources.INSTANCE.expandIcon2x());
 
                   imageUri = expandImage.getSafeUri().asString();
+                  imageAlt = object.expanded ? "Collapse Object" : "Expand Object";
                }
                else if (object.hasTraceInfo())
                {
                   imageUri = new ImageResource2x(EnvironmentResources.INSTANCE
                         .tracedFunction2x()).getSafeUri().asString();
                   imageStyle += (" " + style_.unclickableIcon());
+                  imageAlt = "Has Trace";
                }
                if (imageUri.length() > 0)
                {
                   return "<input type=\"image\" src=\"" + imageUri + "\" " +
-                         "class=\"" + imageStyle + "\" />";                        
+                         "class=\"" + imageStyle + "\" alt=\"" + imageAlt + "\" />";
                }
                return "";
             }


### PR DESCRIPTION
- image for expandable object, traced object, and current frame of callstack didn't have labels

<img width="644" alt="Environment pane showing an expandable object and an object with tracing" src="https://user-images.githubusercontent.com/10569626/72304423-5a9ab680-3625-11ea-9b09-79ab237e5ad5.png">

<img width="645" alt="Traceback pane in the Environment pane" src="https://user-images.githubusercontent.com/10569626/72304433-5f5f6a80-3625-11ea-853b-1a83c9a6a4eb.png">


