### PR TITLE
mark tabset quadrants as named regions

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.theme;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Float;
 import com.google.gwt.dom.client.Style.Unit;
@@ -70,6 +71,8 @@ public class WindowFrame extends Composite
       minimizeButton_.setClickHandler(() -> minimize());
 
       frame_ = new LayoutPanel();
+      Roles.getRegionRole().set(frame_.getElement());
+      Roles.getRegionRole().setAriaLabelProperty(frame_.getElement(), name);
       frame_.setStylePrimaryName(styles.windowframe());
       frame_.addStyleName(styles.windowFrameObject());
 


### PR DESCRIPTION
- provides another way to get to the 4 quadrants of the UI via screen-reader navigation

For example in VoiceOver rotor:

![VoiceOver rotor showing RStudio landmarks](https://user-images.githubusercontent.com/10569626/72306057-b451af80-362a-11ea-807d-4a7820e0b8ee.jpg)
