### PR TITLE
announce when Console is cleared via aria-live

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1012,12 +1012,6 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromXLS().remove();
       }
 
-      // remove commands that only make sense if screen reader is enabled
-      if (!userPrefs_.get().enableScreenReader().getValue())
-      {
-         commands_.speakEditorLocation().remove();
-      }
-
       // If no project, ensure we show the product-edition title; if there is a project
       // open this was already done
       if (!Desktop.isDesktop() &&

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -1,7 +1,7 @@
 /*
  * Shell.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -34,6 +34,7 @@ import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.CommandLineHistory;
 import org.rstudio.studio.client.common.debugging.ErrorManager;
@@ -247,6 +248,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    {
       // clear output
       view_.clearOutput();
+      
+      eventBus_.fireEvent(new AriaLiveStatusEvent("Console cleared", true));
       
       // notify server
       server_.resetConsoleActions(new VoidServerRequestCallback());


### PR DESCRIPTION
- don't bother trying to hide "speak" accessibility commands based on state of screen reader enabled flag; the technique I was using to hide them is Server specific (desktop uses a different flag, which requires an async call to the desktop executable to read and isn't worth the complexity)