### PR TITLE
stop using aria-modal property on modal dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -25,11 +25,6 @@ import org.rstudio.core.client.theme.res.ThemeStyles;
  */
 public class A11y
 {
-   public static void setARIADialogModal(Element element)
-   {
-      element.setAttribute("aria-modal", "true");
-   }
-
    /**
     * Flag an image that does not convey content, is decorative, or is
     * redundant (purpose already conveyed in text).

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -1,7 +1,7 @@
 /*
  * ModalDialogBase.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -84,7 +84,6 @@ public abstract class ModalDialogBase extends DialogBox
       // a11y
       role_ = role;
       role_.set(getElement());
-      A11y.setARIADialogModal(getElement());
 
       // main panel used to host UI
       mainPanel_ = new VerticalPanel();


### PR DESCRIPTION
- this property causes problems with certain screen reader / browser combinations including Safari / VoiceOver that can prevent the dialog from behing fully announced
- was seeing this happen consistently with Yes/No dialogs, and removing this fixed the problem
- article that discusses this: https://developer.paciellogroup.com/blog/2018/06/the-current-state-of-modal-dialog-accessibility/