### PR TITLE
Use R_NoSave over R_Slave for R 4.0+

### DIFF
--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -15,6 +15,18 @@
 
 project (R)
 
+# find the version of R in play
+find_package(LibR REQUIRED)
+execute_process(
+    COMMAND "${LIBR_EXECUTABLE}" "--vanilla" "--slave" "-e" "cat(as.character(getRversion()))"
+    OUTPUT_VARIABLE LIBR_VERSION)
+
+# parse and save the R version to a variable
+string(REPLACE "." ";" R_VERSION_LIST "${LIBR_VERSION}")
+list(GET R_VERSION_LIST 0 R_VERSION_MAJOR)
+list(GET R_VERSION_LIST 1 R_VERSION_MINOR)
+list(GET R_VERSION_LIST 2 R_VERSION_PATCH)
+
 # include files
 file(GLOB_RECURSE R_HEADER_FILES "*.h*")
 

--- a/src/cpp/r/config.h.in
+++ b/src/cpp/r/config.h.in
@@ -1,7 +1,7 @@
 /*
  * config.h.in
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -15,5 +15,11 @@
 
 
 #cmakedefine PANGO_CAIRO_FOUND
+
+// Important: These variables represent the version of R found during
+// compile/link time, NOT the version of R present at runtime.
+#define R_VERSION_MAJOR ${R_VERSION_MAJOR}
+#define R_VERSION_MINOR ${R_VERSION_MINOR}
+#define R_VERSION_PATCH ${R_VERSION_PATCH}
 
 

--- a/src/cpp/r/session/REmbeddedPosix.cpp
+++ b/src/cpp/r/session/REmbeddedPosix.cpp
@@ -1,7 +1,7 @@
 /*
  * REmbeddedPosix.cpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -37,6 +37,8 @@ extern "C" void (*ptr_R_ProcessEvents)(void);
 #define QCF_SET_FRONT  2  /* set application mode to front */
 extern "C"  typedef void (*ptr_QuartzCocoa_SetupEventLoop)(int, unsigned long);
 #endif
+
+#include "config.h"
 
 extern int R_running_as_main_program;  // from unix/system.c
 
@@ -103,14 +105,20 @@ void runEmbeddedR(const core::FilePath& /*rHome*/,    // ignored on posix
    //
    structRstart rp;
    Rstart Rp = &rp;
-   R_DefParams(Rp) ;
-   Rp->R_Slave = FALSE ;
+   R_DefParams(Rp);
+#if R_VERSION_MAJOR > 3
+   // R 4.0 and above use --no-echo to suppress output
+   Rp->R_NoEcho = FALSE;
+#else
+   // R 3.x and below use --slave
+   Rp->R_Slave = FALSE;
+#endif
    Rp->R_Quiet = quiet ? TRUE : FALSE;
-   Rp->R_Interactive = TRUE ;
-   Rp->SaveAction = defaultSaveAction ;
+   Rp->R_Interactive = TRUE;
+   Rp->SaveAction = defaultSaveAction;
    Rp->RestoreAction = SA_NORESTORE; // handled within initialize()
    Rp->LoadInitFile = loadInitFile ? TRUE : FALSE;
-   R_SetParams(Rp) ;
+   R_SetParams(Rp);
 
    // redirect console
    R_Interactive = TRUE; // should have also been set by call to Rf_initialize_R


### PR DESCRIPTION
This is the minimal change required to get RStudio building against R 4.0+. In R 4.0, the field `R_Slave` was removed from `structRstart` and replaced with `R_NoEcho`. 

https://github.com/wch/r-source/commit/f1ff49e74593341c74c20de9517f31a22c8bcb04#diff-178cb445c6da1cdb9d55c898b6118256R70

Since RStudio references this field, and we would like to be able to build against both R 4.0 and R 3.x (largely for ease of development and testing), we need to refer to the field by the appropriate name.

The irony of using `--slave` to determine whether we need to use `R_Slave` or `R_NoEcho` is not lost. R 4.0 (currently) only soft-deprecates `--slave`, whereas `R_Slave` has been simply removed.

Related to https://github.com/rstudio/rstudio/issues/5923. We will need to make another (significantly more invasive) change when R fully removes `--slave`. 