### PR TITLE
annotate minimized quadrant as a region and as a tabpanel

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedModuleTabLayoutPanel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.theme;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.event.logical.shared.HasSelectionHandlers;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
@@ -33,6 +34,7 @@ public class MinimizedModuleTabLayoutPanel
    public MinimizedModuleTabLayoutPanel(String accessibleName)
    {
       super(null, accessibleName, new HorizontalPanel());
+      accessibleName_ = accessibleName;
       addStyleName(ThemeResources.INSTANCE.themeStyles().moduleTabPanel());
       addStyleName(ThemeResources.INSTANCE.themeStyles().minimized());
    }
@@ -41,6 +43,8 @@ public class MinimizedModuleTabLayoutPanel
    {
       HorizontalPanel horiz = (HorizontalPanel) getExtraWidget();
       horiz.clear();
+      Roles.getTablistRole().set(horiz.getElement());
+      Roles.getTablistRole().setAriaLabelProperty(horiz.getElement(), accessibleName_ + " minimized");
 
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       for (int i = 0; i < tabNames.length; i++)
@@ -68,4 +72,6 @@ public class MinimizedModuleTabLayoutPanel
    {
       return addHandler(handler, SelectionEvent.getType());
    }
+   
+   private final String accessibleName_;
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.core.client.theme;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
@@ -56,6 +57,9 @@ public class MinimizedWindowFrame
       layout_ = new ClickDockLayoutPanel(Style.Unit.PX);
       layout_.setStylePrimaryName(themeStyles.minimizedWindow());
       layout_.addStyleName(themeStyles.rstheme_minimizedWindowObject());
+
+      Roles.getRegionRole().set(layout_.getElement());
+      Roles.getRegionRole().setAriaLabelProperty(layout_.getElement(), accessibleName + " minimized");
 
       int leftPadding = title != null ? 8 : 4;
       layout_.addWest(createDiv(themeStyles.left()), leftPadding);


### PR DESCRIPTION
- this provides some visibility to screen readers about what's happening when a quadrant has been minimized, and surfaces the minimized quadrant as a region (e.g. "TabSet1 minimized region")

<img width="677" alt="Example of a minimized quadrant showing TabSet1 minimized" src="https://user-images.githubusercontent.com/10569626/72394175-22a97700-36ea-11ea-9603-46ce10a8fc0b.png">
