### PR TITLE
Tolerate invalid user prefs data, with a warning

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopWebPage.cpp
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -397,10 +397,12 @@ bool WebPage::acceptNavigationRequest(const QUrl &url,
    if (url.toString() == QStringLiteral("chrome://gpu/"))
       return true;
 
+   if (url.scheme() == QStringLiteral("data"))
+      return true;
+
    if (url.scheme() != QStringLiteral("http") &&
        url.scheme() != QStringLiteral("https") &&
-       url.scheme() != QStringLiteral("mailto") &&
-       url.scheme() != QStringLiteral("data"))
+       url.scheme() != QStringLiteral("mailto"))
    {
       qDebug() << url.toString();
       return false;
@@ -408,8 +410,7 @@ bool WebPage::acceptNavigationRequest(const QUrl &url,
    
    // determine if this is a local request (handle internally only if local)
    std::string host = url.host().toStdString();
-   bool isLocal = host == "localhost" || host == "127.0.0.1" || host == "::1" ||
-                  url.scheme() == QStringLiteral("data");
+   bool isLocal = host == "localhost" || host == "127.0.0.1" || host == "::1";
    
    // accept Chrome Developer Tools navigation attempts
 #ifndef NDEBUG

--- a/src/cpp/session/modules/SessionUserPrefs.cpp
+++ b/src/cpp/session/modules/SessionUserPrefs.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserPrefs.cpp
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -258,6 +258,10 @@ SEXP rs_allPrefs()
    std::vector<std::string> keys = userPrefs().allKeys();
    std::vector<std::string> sources;
    std::vector<std::string> values;
+
+   // Sort preference keys alphabetically for convenience
+   std::sort(keys.begin(), keys.end());
+
    for (const auto key: keys) 
    {
       std::string layer;


### PR DESCRIPTION
This change fixes a problem wherein corrupting the user prefs file causes RStudio to fail to boot. As far as we can tell this can't happen in normal use, but since the prefs now advertise as at least marginally hand-editable we need to be more tolerant to errors.

The problem is that in some failure modes for loading prefs from a file, we wind up with a prefs cache and in others we don't. The fix is to ensure that as a postcondition of loading prefs from a file we always end up with a prefs cache (even if it's a empty as a result of the prefs file failing to load for some reason such as parse errors).

Also includes a drive-by fix for #6027, and another issue I discovered in which the startup diagnostics added in #5509 do not show up in release builds, the fix for which is to always allow `data://` URLs to load. 

Fixes #6023
Fixes #6027