### PR TITLE
Enable the job's progress bar to be clicked to open the job output

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.java
@@ -141,12 +141,9 @@ public class JobItem extends Composite implements JobItemView
       {
          if (DomUtils.isDescendant(
                Element.as(evt.getNativeEvent().getEventTarget()),
-               running_.getElement()) ||
-             DomUtils.isDescendant(
-               Element.as(evt.getNativeEvent().getEventTarget()),
                    stop_.getElement()))
          {
-            // ignore clicks occurring inside the progress area, or the stop button
+            // ignore clicks occurring inside the stop button
             return;
          }
          eventBus_.fireEvent(new JobSelectionEvent(job.id, job.type, true, !prefs.reducedMotion()));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobItem.ui.xml
@@ -146,7 +146,7 @@
     
     .progress
     {
-        cursor: default;
+        cursor: pointer;
     }
     
     </ui:style>


### PR DESCRIPTION
Fixes #5739 

When you hover over a job's progress bar it will now display the pointer cursor to indicate it can be selected - selection will open the job's output.