### PR TITLE
accessibility labels for images used in Git history UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
@@ -1,7 +1,7 @@
 /*
  * DiffFrame.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -25,6 +25,7 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.theme.res.ThemeResources;
+import org.rstudio.core.client.widget.DecorativeImage;
 import org.rstudio.core.client.widget.HyperlinkLabel;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
@@ -111,7 +112,7 @@ public class DiffFrame extends Composite
    @UiField
    Image fileIcon_;
    @UiField
-   Image separatorImage_;
+   DecorativeImage separatorImage_;
    @UiField
    HyperlinkLabel viewFileHyperlink_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.ui.xml
@@ -23,7 +23,7 @@
          <g:layer right='0px' width='175px'>
             <g:SimplePanel>
                <g:HorizontalPanel styleName="{res.styles.viewFilePanel}">
-                  <g:Image ui:field="separatorImage_"/>
+                  <rsw:DecorativeImage ui:field="separatorImage_"/>
                   <rsw:HyperlinkLabel ui:field="viewFileHyperlink_"/>
                </g:HorizontalPanel>
             </g:SimplePanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/graph/GraphLine.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/graph/GraphLine.java
@@ -1,7 +1,7 @@
 /*
  * GraphLine.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -28,6 +28,7 @@ public class GraphLine
       columns_ = new GraphColumn[vals.length];
       for (int i = 0; i < columns_.length; i++)
          columns_[i] = new GraphColumn(vals[i]);
+      altText_ = "";
    }
 
    public GraphColumn[] getColumns()
@@ -53,6 +54,7 @@ public class GraphLine
    {
       draw(s_canvas, theme);
       return SafeHtmlUtil.createOpenTag("img",
+                                        "alt", altText_,
                                         "class", theme.getImgClassName(),
                                         "src", s_canvas.toDataUrl());
    }
@@ -108,6 +110,7 @@ public class GraphLine
             if (c.nexus)
             {
                nexusColumn = i;
+               altText_ = "commit depth " + nexusColumn;
                ctx.setFillStyle(theme.getColorForId(c.id));
             }
 
@@ -151,6 +154,7 @@ public class GraphLine
    }
 
    private GraphColumn[] columns_;
+   private String altText_;
 
    // Use a static canvas to avoid the overhead of continually recreating them
    private static final Canvas s_canvas = Canvas.createIfSupported();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.java
@@ -1,7 +1,7 @@
 /*
  * SVNReviewPanel.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -42,6 +42,7 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.WidgetHandlerRegistration;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.LeftRightToggleButton;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -265,6 +266,7 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       discardAllButton_ = diffToolbar_.addLeftWidget(new ToolbarButton(
             "Discard All", ToolbarButton.NoTitle,  new ImageResource2x(RES.discard2x())));
 
+      lblContext_.setFor(contextLines_);
       listBoxAdapter_ = new ListBoxAdapter(contextLines_);
 
       new WidgetHandlerRegistration(this)
@@ -464,6 +466,8 @@ public class SVNReviewPanel extends ResizeComposite implements Display
    ChangelistTable changelist_;
    @UiField(provided = true)
    LineTableView lines_;
+   @UiField
+   FormLabel lblContext_;
    @UiField
    ListBox contextLines_;
    @UiField(provided = true)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.ui.xml
@@ -24,7 +24,7 @@
             <g:north size="28">
                <g:FlowPanel styleName="{res.styles.toolbarWrapper} {res.styles.diffToolbarWrapper}">
                   <g:FlowPanel styleName="{res.styles.diffViewOptions}">
-                     <g:Label text="Context" styleName="{res.styles.contextLabel}"/>
+                     <rs_widget:FormLabel ui:field="lblContext_" display="inline" text="Context" styleName="{res.styles.contextLabel}"/>
                      <g:ListBox ui:field="contextLines_" visibleItemCount="1" selectedIndex="0">
                         <g:item value="5">5 line</g:item>
                         <g:item value="10">10 line</g:item>


### PR DESCRIPTION
- dynamically generated branch graphic, announce depth of the commit (0-based)
- separator, mark as decorative
- in SVN UI, associate "Context" label with its dropdown control

<img width="266" alt="screenshot showing the dynamically generated branch graphic" src="https://user-images.githubusercontent.com/10569626/72486864-04627a80-37c1-11ea-8667-96294d063a14.png">
