### PR TITLE
Fix tutorial home page on Server Pro

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
@@ -341,6 +341,6 @@ public class TutorialPresenter
    
    public static final String VIEWER_TYPE_TUTORIAL = "tutorial";
    
-   public static final String URLS_HOME = "/tutorial/home";
+   public static final String URLS_HOME = "./tutorial/home";
    
 }


### PR DESCRIPTION
The tutorial URL currently is presumed to be at the root of the host, which is only true when running dev mode or open source without a proxy. This change makes the URL relative so that it also works for Server Pro or open source behind a non-root URL.

Fixes https://github.com/rstudio/rstudio-pro/issues/1401