### PR TITLE
prevent JavaScript exception when tabbing through ConsoleProgressDialogs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -1,7 +1,7 @@
 /*
  * ShellWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -593,7 +593,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
                   return;
                break;
             case KeyCodes.KEY_TAB:
-               if (prefs_.tabKeyMoveFocus().getValue())
+               if (prefs_ == null || prefs_.tabKeyMoveFocus().getValue())
                   return;
          }
          input_.setFocus(true);


### PR DESCRIPTION
While doing basic accessibility check of ConsoleProgress dialogs (seen in cases such as switching branches in the Git pane, example below), noticed JavaScript exceptions when I tabbed through the dialog.

- prefs_ is passed in as null in ConsoleProgressDialog constructor super()
- the check for tabKeyMovesFocus wasn't checking for this, thus throwing an exception
- if it is null, we assume we want to allow tabbing to escape the AceEditor instead of inserting tabs

<img width="635" alt="screenshot of progress dialog shown when switching git branches in RStudio" src="https://user-images.githubusercontent.com/10569626/72632588-6f1fcd00-390b-11ea-8146-882571ef0658.png">
