### PR TITLE
label assorted images missed on previous passes and annotate ProgressDialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -448,4 +448,7 @@ public class ElementIds
    public final static String FRAME_MAX_BTN = "frame_max_btn";
    public final static String MIN_FRAME_MIN_BTN = "min_frame_min_btn";
    public final static String MIN_FRAME_MAX_BTN = "min_frame_max_btn";
+
+   // ProgressDialog
+   public final static String PROGRESS_TITLE_LABEL = "progress_title_label";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
@@ -15,6 +15,8 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.aria.client.DialogRole;
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
@@ -32,10 +34,14 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.ui.*;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomMetrics;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 
 public abstract class ProgressDialog extends ModalDialogBase
 {
@@ -74,6 +80,8 @@ public abstract class ProgressDialog extends ModalDialogBase
       super(role);
       addStyleName(resources_.styles().progressDialog());
 
+      operationStarted_ = false;
+
       setText(title);
 
       display_ = createDisplayWidget(param);
@@ -88,6 +96,10 @@ public abstract class ProgressDialog extends ModalDialogBase
       stopButton_ = new ThemedButton("Stop");
       centralWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
 
+      ElementIds.assignElementId(label_, ElementIds.PROGRESS_TITLE_LABEL);
+      Roles.getProgressbarRole().set(progressAnim_.getElement());
+      Roles.getProgressbarRole().setAriaLabelledbyProperty(progressAnim_.getElement(),
+            Id.of(label_.getElement()));
       setLabel(title);
    } 
    
@@ -151,15 +163,25 @@ public abstract class ProgressDialog extends ModalDialogBase
       Size labelSize = DomMetrics.measureHTML(text);
       labelCell_.getStyle().setWidth(labelSize.width + 10, Unit.PX);
       label_.setText(text);
+      labelText_ = text;
    }
    
    protected void showProgress()
    {
+      operationStarted_ = true;
       progressAnim_.getElement().getStyle().setDisplay(Style.Display.INITIAL);
    }
    
    protected void hideProgress()
    {
+      if (operationStarted_)
+      {
+         operationStarted_ = false;
+         RStudioGinjector.INSTANCE.getEventBus().fireEvent(
+               new AriaLiveStatusEvent(
+                     StringUtil.isNullOrEmpty(labelText_) ? 
+                           "Operation completed" : labelText_ + " completed", true));
+      }
       progressAnim_.getElement().getStyle().setDisplay(Style.Display.NONE);
    }
 
@@ -183,7 +205,8 @@ public abstract class ProgressDialog extends ModalDialogBase
    @UiField(provided = true)
    ThemedButton stopButton_;
    private Widget centralWidget_;
-   
+   private boolean operationStarted_;
+   private String labelText_;
 
    private static final Resources resources_ = GWT.<Resources>create(Resources.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
@@ -1,5 +1,6 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
+   xmlns:rw='urn:import:org.rstudio.core.client.widget'
    xmlns:g="urn:import:com.google.gwt.user.client.ui">
    <ui:style>
    @eval proportionalFont org.rstudio.core.client.theme.ThemeFonts.getProportionalFont();
@@ -69,21 +70,21 @@
    <g:HTMLPanel styleName="{style.consoleErrorBox} ace_console_error">
      <g:HTMLPanel styleName="{style.consoleErrorCommands}">
         <g:HTMLPanel>
-           <g:Image resource="{traceback}"
+           <rw:DecorativeImage resource="{traceback}"
                   ui:field="showTracebackImage"
                   width="9"
                   height="9"
-                  styleName="{style.errorCommandImage}"></g:Image>
+                  styleName="{style.errorCommandImage}"/>
            <g:Anchor styleName="{style.errorCommandText}" ui:field="showTracebackText">
               Show Traceback
            </g:Anchor>
         </g:HTMLPanel>
         <g:HTMLPanel>
-           <g:Image resource="{rerun}"
+           <rw:DecorativeImage resource="{rerun}"
                     ui:field="rerunImage"
                     width="9"
                     height="9"
-                    styleName="{style.errorCommandImage}"></g:Image>
+                    styleName="{style.errorCommandImage}"/>
            <g:Anchor styleName="{style.errorCommandText}" ui:field="rerunText">
               Rerun with Debug
            </g:Anchor>

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -773,7 +773,12 @@ public class ShellWidget extends Composite implements ShellDisplay,
    {
       scrollPanel_.onContentSizeChanged();
    }
-   
+
+   public Widget getOutputWidget()
+   {
+      return output_.getWidget();
+   }
+
    private boolean cleared_ = false;
    private final ConsoleOutputWriter output_;
    private final PreWidget pendingInput_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionPreInstallOdbcHost.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionPreInstallOdbcHost.ui.xml
@@ -54,7 +54,8 @@
    <g:HTMLPanel stylePrimaryName="{style.panel}">
       <g:HTMLPanel ui:field="warningPanel_" styleName="{style.warning}">
         <g:Image resource='{res.warningSmall2x}'
-                 styleName='{style.warningIcon}'/>
+                 styleName='{style.warningIcon}'
+                 altText="Warning"/>
         <g:HTMLPanel ui:field="warningLabel_" styleName="{style.label}" />
       </g:HTMLPanel>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkConditionBar.ui.xml
@@ -40,12 +40,12 @@
 <g:HTMLPanel styleName="{style.host}">
   <g:VerticalPanel styleName="{style.panel}" ui:field="panel_">
      <g:HorizontalPanel visible="false" ui:field="messageBar_">
-       <g:Image styleName="{style.icon}" resource="{res.infoSmall2x}"></g:Image>
+       <g:Image altText="Info" styleName="{style.icon}" resource="{res.infoSmall2x}"></g:Image>
        <g:VerticalPanel styleName="{style.contents}" ui:field="messages_">
        </g:VerticalPanel>
      </g:HorizontalPanel>
      <g:HorizontalPanel visible="false" ui:field="warningBar_">
-       <g:Image styleName="{style.icon}" resource="{res.warningSmall2x}"></g:Image>
+       <g:Image altText="Warning" styleName="{style.icon}" resource="{res.warningSmall2x}"></g:Image>
        <g:VerticalPanel styleName="{style.contents}" ui:field="warnings_">
        </g:VerticalPanel>
      </g:HorizontalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPreview.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkHtmlPreview.ui.xml
@@ -18,7 +18,7 @@
 }
 </ui:style>
 <g:HTMLPanel styleName="{style.wrapper}">
-   <g:Image styleName="{style.icon}" resource="{res.htmlWidgetIcon2x}">
+   <g:Image altText="HTML Widget" styleName="{style.icon}" resource="{res.htmlWidgetIcon2x}">
 </g:Image>
 </g:HTMLPanel>
-</ui:UiBinder> 
+</ui:UiBinder>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/NotebookProgressWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/NotebookProgressWidget.ui.xml
@@ -45,7 +45,7 @@
                     width="150px">
        </g:HTMLPanel>
        <g:Image styleName="{style.interrupt}" resource="{res.interruptChunk2x}" 
-                ui:field="interruptButton_">
+                ui:field="interruptButton_" altText="Interrupt">
        </g:Image>
      </g:HorizontalPanel>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleProgressWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.common;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.studio.client.common.shell.ShellDisplay;
 import org.rstudio.studio.client.common.shell.ShellWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
@@ -24,6 +25,8 @@ public class ConsoleProgressWidget extends ShellWidget implements ShellDisplay
    {
       super(new AceEditor(), null, null);
       getEditor().setInsertMatching(false);
+      getEditor().setTextInputAriaLabel("Progress details");
+      Roles.getLogRole().set(getOutputWidget().getElement());
    }
    
    private AceEditor getEditor()


### PR DESCRIPTION
- many of these are images pretending to be buttons, so would require work in the future to implement keyboard support, but at least having names makes them usable via screen reader
- for ProgressDialog and ConsoleProgressWidget, annotate the progressbar as a progressbar, make the log region a log, and announce when the task is completed