### PR TITLE
Fixes a bug where some Error constructors are ambiguous.

### DIFF
--- a/src/cpp/session/modules/SessionConfigFile.cpp
+++ b/src/cpp/session/modules/SessionConfigFile.cpp
@@ -55,11 +55,11 @@ Error configError(ConfigErrorCode code, const Error& cause, const ErrorLocation&
       case ConfigErrorCode::SUCCESS:
          return Success();
       case ConfigErrorCode::READ_ERROR:
-         return Error(static_cast<int>(code), errorName, "Error while reading config file.", cause, location);
+         return Error(errorName, static_cast<int>(code), "Error while reading config file.", cause, location);
       case ConfigErrorCode::WRITE_ERROR:
-         return Error(static_cast<int>(code), errorName, "Error while writing config file.", cause, location);
+         return Error(errorName, static_cast<int>(code), "Error while writing config file.", cause, location);
       default:
-         return Error(static_cast<int>(code), errorName, "Unknown config error.", cause, location);
+         return Error(errorName, static_cast<int>(code), "Unknown config error.", cause, location);
    }
 }
 

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -42,6 +42,22 @@ namespace session {
 namespace modules {
 namespace find {
 
+namespace errc {
+
+enum errc_t
+{
+   Success = 0,
+   RegexError = 1
+};
+
+const std::string& findCategory()
+{
+   static const std::string findCategory = "find_error";
+   return findCategory;
+}
+
+}
+
 namespace {
 
 // This must be the same as MAX_COUNT in FindOutputPane.java
@@ -1430,7 +1446,14 @@ core::Error Replacer::completeReplace(const boost::regex& searchRegex,
    }
    catch (const boost::regex_error& e)
    {
-      return core::Error(e.position(), e.what(), ERROR_LOCATION);
+      core::Error error(
+         errc::findCategory(),
+         errc::RegexError,
+         "A regex error occurred during replace operation: " + std::string(e.what()),
+         ERROR_LOCATION);
+
+      error.addProperty("position", e.position());
+      return error;
    }
 
    temp.insert(0, pLine->substr(0, matchOn));
@@ -1461,7 +1484,14 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
    }
    catch (const boost::regex_error& e)
    {
-      return core::Error(e.position(), e.what(), ERROR_LOCATION);
+      core::Error error(
+         errc::findCategory(),
+         errc::RegexError,
+         "A regex error occurred during replace operation: " + std::string(e.what()),
+         ERROR_LOCATION);
+
+      error.addProperty("position", e.position());
+      return error;
    }
 }
 
@@ -1479,7 +1509,14 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
    }
    catch (const boost::regex_error& e)
    {
-      return core::Error(e.position(), e.what(), ERROR_LOCATION);
+      core::Error error(
+         errc::findCategory(),
+         errc::RegexError,
+         "A regex error occurred during replace operation: " + std::string(e.what()),
+         ERROR_LOCATION);
+
+      error.addProperty("position", e.position());
+      return error;
    }
 }
 

--- a/src/cpp/session/prefs/PrefLayer.cpp
+++ b/src/cpp/session/prefs/PrefLayer.cpp
@@ -41,15 +41,15 @@ Error prefsError(PrefErrorCode code, const Error& cause, const ErrorLocation& lo
          return Success();
       case PrefErrorCode::LOAD_ERROR:
          return Error(
-            static_cast<int>(PrefErrorCode::LOAD_ERROR),
             "pref_error",
+            static_cast<int>(PrefErrorCode::LOAD_ERROR),
             "Error occurred while loading preferences.",
             cause,
             location);
       case PrefErrorCode::WRITE_ERROR:
          return Error(
-            static_cast<int>(PrefErrorCode::WRITE_ERROR),
             "pref_error",
+            static_cast<int>(PrefErrorCode::WRITE_ERROR),
             "Error occurred while writing preferences.",
             cause,
             location);
@@ -57,8 +57,8 @@ Error prefsError(PrefErrorCode code, const Error& cause, const ErrorLocation& lo
       {
          assert(false);
          return Error(
-            static_cast<int>(PrefErrorCode::UNKNOWN_ERROR),
             "pref_error",
+            static_cast<int>(PrefErrorCode::UNKNOWN_ERROR),
             "Unknown preferences error.",
             cause,
             location);
@@ -177,8 +177,8 @@ Error PrefLayer::loadPrefsFromFile(const core::FilePath& prefsFile,
    {
       // We parsed but got a non-object JSON value (this is exceedingly unlikely)
       error = Error(
-         static_cast<int>(PrefErrorCode::LOAD_ERROR),
          "pref_error",
+         static_cast<int>(PrefErrorCode::LOAD_ERROR),
          "Invalid value while parsing preferences: " + val.write(),
          ERROR_LOCATION);
    }

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -214,24 +214,24 @@ Error::Error(
 {
 }
 
-Error::Error(int in_code, std::string in_name, const ErrorLocation& in_location) :
+Error::Error(std::string in_name, int in_code, const ErrorLocation& in_location) :
    m_impl(new Impl(in_code, std::move(in_name), in_location))
 {
 }
 
-Error::Error(int in_code, std::string in_name, const Error& in_cause, const ErrorLocation& in_location) :
+Error::Error(std::string in_name, int in_code, const Error& in_cause, const ErrorLocation& in_location) :
    m_impl(new Impl(in_code, std::move(in_name), in_cause, in_location))
 {
 }
 
-Error::Error(int in_code, std::string in_name, std::string in_message, const ErrorLocation& in_location) :
+Error::Error(std::string in_name,int in_code,  std::string in_message, const ErrorLocation& in_location) :
    m_impl(new Impl(in_code, std::move(in_name), std::move(in_message), in_location))
 {
 }
 
 Error::Error(
-   int in_code,
    std::string in_name,
+   int in_code,
    std::string in_message,
    const Error& in_cause,
    const ErrorLocation& in_location) :
@@ -461,8 +461,8 @@ Error systemError(int in_value,
 Error unknownError(const std::string& in_message, const ErrorLocation&  in_location)
 {
    return Error(
-      1,
       "UnknownError",
+      1,
       in_message,
       in_location);
 }
@@ -470,8 +470,8 @@ Error unknownError(const std::string& in_message, const ErrorLocation&  in_locat
 Error unknownError(const std::string& in_message, const Error& in_cause, const ErrorLocation& in_location)
 {
    return Error(
-      1,
       "UnknownError",
+      1,
       in_message,
       in_cause,
       in_location);

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -224,7 +224,7 @@ Error::Error(std::string in_name, int in_code, const Error& in_cause, const Erro
 {
 }
 
-Error::Error(std::string in_name,int in_code,  std::string in_message, const ErrorLocation& in_location) :
+Error::Error(std::string in_name, int in_code, std::string in_message, const ErrorLocation& in_location) :
    m_impl(new Impl(in_code, std::move(in_name), std::move(in_message), in_location))
 {
 }

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -210,7 +210,31 @@ Error::Error(
    std::string in_message,
    const Error& in_cause,
    const ErrorLocation& in_location) :
-      m_impl(new Impl(in_ec.value(), in_ec.category().name(), std::move(in_message), in_cause, in_location))
+   m_impl(new Impl(in_ec.value(), in_ec.category().name(), std::move(in_message), in_cause, in_location))
+{
+}
+
+Error::Error(const boost::system::error_condition& in_ec, const ErrorLocation& in_location) :
+   m_impl(new Impl(in_ec.value(), in_ec.category().name(), in_ec.message(), in_location))
+{
+}
+
+Error::Error(const boost::system::error_condition& in_ec, const Error& in_cause, const ErrorLocation& in_location) :
+   m_impl(new Impl(in_ec.value(), in_ec.category().name(), in_ec.message(), in_cause, in_location))
+{
+}
+
+Error::Error(const boost::system::error_condition& in_ec, std::string in_message, const ErrorLocation& in_location) :
+   m_impl(new Impl(in_ec.value(), in_ec.category().name(), std::move(in_message), in_location))
+{
+}
+
+Error::Error(
+   const boost::system::error_condition& in_ec,
+   std::string in_message,
+   const Error& in_cause,
+   const ErrorLocation& in_location) :
+   m_impl(new Impl(in_ec.value(), in_ec.category().name(), std::move(in_message), in_cause, in_location))
 {
 }
 
@@ -235,7 +259,7 @@ Error::Error(
    std::string in_message,
    const Error& in_cause,
    const ErrorLocation& in_location) :
-      m_impl(new Impl(in_code, std::move(in_name), std::move(in_message), in_cause, in_location))
+   m_impl(new Impl(in_code, std::move(in_name), std::move(in_message), in_cause, in_location))
 {
 }
 
@@ -372,12 +396,12 @@ const std::string& Error::getName() const
 {
    return impl().Name;
 }
-   
+
 const ErrorProperties& Error::getProperties() const
 {
    return impl().Properties;
 }
-   
+
 std::string Error::getProperty(const std::string& in_name) const
 {
    for (const auto & it : getProperties())
@@ -385,7 +409,7 @@ std::string Error::getProperty(const std::string& in_name) const
       if (it.first == in_name)
          return it.second;
    }
-   
+
    return std::string();
 }
 

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -156,7 +156,7 @@ private:
    // The private implementation of ErrorLocation.
    PRIVATE_IMPL(m_impl);
 };
- 
+
 /**
  * @brief Convenience typedef for error properties.
  */
@@ -221,6 +221,47 @@ public:
     * @param in_location        The location of the error.
     */
    Error(const boost::system::error_code& in_ec,
+         std::string in_message,
+         const Error& in_cause,
+         const ErrorLocation& in_location);
+
+   /**
+    * @brief Constructor.
+    *
+    * @param in_ec              The boost error condition to convert from.
+    * @param in_location        The location of the error.
+    */
+   Error(const boost::system::error_condition& in_ec, const ErrorLocation& in_location);
+
+   /**
+    * @brief Constructor.
+    *
+    * @param in_ec              The boost error condition to convert from.
+    * @param in_cause           The error which caused this error.
+    * @param in_location        The location of the error.
+    */
+   Error(const boost::system::error_condition& in_ec, const Error& in_cause, const ErrorLocation& in_location);
+
+   /**
+    * @brief Constructor.
+    *
+    * @param in_ec              The boost error condition to convert from.
+    * @param in_message         The detailed error message. (e.g. "The JobNetworkRequest is not supported by this
+    *                           plugin.")
+    * @param in_location        The location of the error.
+    */
+   Error(const boost::system::error_condition& in_ec, std::string in_message, const ErrorLocation& in_location);
+
+   /**
+    * @brief Constructor.
+    *
+    * @param in_ec              The boost error condition to convert from.
+    * @param in_message         The detailed error message. (e.g. "The JobNetworkRequest is not supported by this
+    *                           plugin.")
+    * @param in_cause           The error which caused this error.
+    * @param in_location        The location of the error.
+    */
+   Error(const boost::system::error_condition& in_ec,
          std::string in_message,
          const Error& in_cause,
          const ErrorLocation& in_location);

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -228,46 +228,46 @@ public:
    /**
     * @brief Constructor.
     *
-    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_name            A contextual or categorical name for the error. (e.g. "RequestNotSupported")
+    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_location        The location of the error.
     */
-   Error(int in_code, std::string in_name, const ErrorLocation& in_location);
+   Error(std::string in_name, int in_code, const ErrorLocation& in_location);
 
    /**
     * @brief Constructor.
     *
-    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_name            A contextual or categorical name for the error. (e.g. "RequestNotSupported")
+    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_cause           The error which caused this error.
     * @param in_location        The location of the error.
     */
-   Error(int in_code, std::string in_name, const Error& in_cause, const ErrorLocation& in_location);
+   Error(std::string in_name, int in_code, const Error& in_cause, const ErrorLocation& in_location);
 
 
    /**
     * @brief Constructor.
     *
-    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_name            A contextual or categorical name for the error. (e.g. "RequestNotSupported")
+    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_message         The detailed error message. (e.g. "The JobNetworkRequest is not supported by this
     *                           plugin.")
     * @param in_location        The location of the error.
     */
-   Error(int in_code, std::string in_name, std::string in_message, const ErrorLocation& in_location);
+   Error(std::string in_name, int in_code, std::string in_message, const ErrorLocation& in_location);
 
    /**
     * @brief Constructor.
     *
-    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_name            A contextual or categorical name for the error. (e.g. "RequestNotSupported")
+    * @param in_code            The non-zero error code. Note that an error code of zero indicates success. (e.g. 1)
     * @param in_message         The detailed error message. (e.g. "The JobNetworkRequest is not supported by this
     *                           plugin.")
     * @param in_cause           The error which caused this error.
     * @param in_location        The location of the error.
     */
-   Error(int in_code,
-         std::string in_name,
+   Error(std::string in_name,
+         int in_code,
          std::string in_message,
          const Error& in_cause,
          const ErrorLocation& in_location);


### PR DESCRIPTION
JJ reported this bug earlier this week. Because `boost::system::error_code`s can be implicitly converted to `int`, sometimes `Error(int code, std::string name, ErrorLocation location)` was being invoked instead of `Error(boost::system::error_code, std::string message, ErrorLocation location)`, resulting in the name (category) of the error being set to the intended message. This PR resolves that issue by swapping the name and code parameters. It also revealed the need for `Error(boost::system::error_condition)` constructors.

There's also a minor change to SessionFind errors. 