### PR TITLE
enable use of Toggle tri-state checkboxes via keyboard and screen reader

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/ChunkOptionsPopupPanel.java
@@ -202,8 +202,10 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       });
       
       int row = includeChunkNameUI ? 1 : 0;
-      nameAndOutputGrid.setWidget(row, 0, new Label("Output:"));
+      FormLabel outputLabel = new FormLabel("Output:");
+      nameAndOutputGrid.setWidget(row, 0, outputLabel);
       nameAndOutputGrid.setWidget(row, 1, outputComboBox_);
+      outputLabel.setFor(outputComboBox_);
       
       panel_.add(nameAndOutputGrid);
       
@@ -255,13 +257,13 @@ public abstract class ChunkOptionsPopupPanel extends MiniPopupPanel
       figureDimensionsPanel_.getElement().getStyle().setMarginTop(5, Unit.PX);
       
       figWidthBox_ = makeInputBox("fig.width", false);
-      Label widthLabel = new Label("Width (inches):");
+      FormLabel widthLabel = new FormLabel("Width (inches):", figWidthBox_);
       widthLabel.getElement().getStyle().setMarginLeft(20, Unit.PX);
       figureDimensionsPanel_.setWidget(0, 0, widthLabel);
       figureDimensionsPanel_.setWidget(0, 1, figWidthBox_);
       
       figHeightBox_ = makeInputBox("fig.height", false);
-      Label heightLabel = new Label("Height (inches):");
+      FormLabel heightLabel = new FormLabel("Height (inches):", figHeightBox_);
       heightLabel.getElement().getStyle().setMarginLeft(20, Unit.PX);
       figureDimensionsPanel_.setWidget(1, 0, heightLabel);
       figureDimensionsPanel_.setWidget(1, 1, figHeightBox_);


### PR DESCRIPTION
- also associate labels/controls in the ChunkOptionsPopupPanel

<img width="297" alt="chunk options popup showing tri-state checkboxes" src="https://user-images.githubusercontent.com/10569626/72655791-bfb71a80-394b-11ea-9344-fc575baafa3c.png">
