### PR TITLE
remove document outline from tab sequence when hidden

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -267,6 +267,11 @@ public class DocumentOutlineWidget extends Composite
          A11y.setARIAHidden(getElement());
    }
 
+   public void setTabIndex(int index)
+   {
+      tree_.setTabIndex(index);
+   }
+
    private void initHandlers()
    {
       handlers_.add(target_.getDocDisplay().addScopeTreeReadyHandler(new ScopeTreeReadyEvent.Handler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -595,6 +595,7 @@ public class TextEditingTargetWidget
    {
       toggleDocOutlineButton_.setLatched(latched);
       docOutlineWidget_.setAriaVisible(latched);
+      docOutlineWidget_.setTabIndex(latched ? 0 : -1);
    }
    
    private ToolbarButton createLatexFormatButton()


### PR DESCRIPTION
Editor's document outline uses a Tree control, which contains an element with tabindex=0. If document outline is not visible, set that to -1 so normal tabbing doesn't give it focus while hidden.