### PR TITLE
use different keyboard shortcut for Global Options on Safari/Firefox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -1,7 +1,7 @@
 /*
  * BrowseCap.java
  *
- * Copyright (C) 2009-17 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -147,6 +147,11 @@ public class BrowseCap
    public static boolean isFirefox()
    {
       return isUserAgent("firefox");
+   }
+   
+   public static boolean isSafariOrFirefox()
+   {
+      return isSafari() || isFirefox();
    }
    
    public static boolean isChromeFrame()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -831,7 +831,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="viewerSaveAllAndRefresh" value="Cmd+Shift+F5"/>
          <shortcut refid="helpKeyboardShortcuts" value="Alt+Shift+K"/>
          <shortcut refid="toggleFullScreen" value="Ctrl+Meta+F" if="org.rstudio.core.client.BrowseCap.isMacintoshDesktop()"/>
-         <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showOptions" value="Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; !org.rstudio.core.client.BrowseCap.isSafariOrFirefox()"/>
+         <shortcut refid="showOptions" value="Meta+Alt+," if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isSafariOrFirefox()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>


### PR DESCRIPTION
- on macOS, Safari and Firefox show their own preferences when Cmd+comma is pressed so make the shortcut Cmd+Option+comma when running on those browsers
- Cmd+comma works as desired on Chrome and Edge on Mac, so leave as-is for users who were already using it on Chrome

Fixes #6015 
