### PR TITLE
Avoid stealing focus when closing tabs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -237,7 +237,16 @@ public class DocTabLayoutPanel
    @Override
    public void selectTab(int index)
    {
-      super.selectTab(index);
+      // select the tab, but don't fire events (we need to fire our own)
+      super.selectTab(index, false);
+      
+      // determine whether focus is currently inside the container
+      boolean focused = DomUtils.contains(getElement(), DomUtils.getActiveElement());
+     
+      // fire our own selection event
+      fireEvent(new DocTabSelectionEvent(index, focused));
+      
+      // ensure the newly selected tab is visible
       ensureSelectedTabIsVisible(!RStudioGinjector.INSTANCE.getUserPrefs().reducedMotion().getValue());
    }
 

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabSelectionEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabSelectionEvent.java
@@ -1,0 +1,33 @@
+/*
+ * DocTabSelectionEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.theme;
+
+import com.google.gwt.event.logical.shared.SelectionEvent;
+
+public class DocTabSelectionEvent extends SelectionEvent<Integer>
+{
+   public DocTabSelectionEvent(int tab, boolean focus)
+   {
+      super(tab);
+      focus_ = focus;
+   }
+   
+   public boolean getFocus()
+   {
+      return focus_;
+   }
+   
+   private final boolean focus_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -57,6 +57,7 @@ import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.theme.DocTabSelectionEvent;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -3744,7 +3745,18 @@ public class Source implements InsertSourceHandler,
             {
                public void execute()
                {
-                  if (activeEditor_ != null)
+                  // presume that we will give focus to the tab
+                  boolean focus = true;
+                  
+                  if (event instanceof DocTabSelectionEvent)
+                  {
+                     // however, if this event was generated from a doc tab
+                     // selection that did not have focus, don't steal focus
+                     DocTabSelectionEvent tabEvent = (DocTabSelectionEvent) event;
+                     focus = tabEvent.getFocus();
+                  }
+
+                  if (focus && activeEditor_ != null)
                      activeEditor_.focus();
                }
             });


### PR DESCRIPTION
This change fixes an annoying issue with focus while debugging, which is that the cursor jumps into the Source pane a lot more than most people expect. 

The reason this occurs is somewhat involved (see #6039 for details). The short version is that we open tabs to view source code while stepping through instructions, then automatically close those tabs when we are done stepping. The problem is that closing a tab always causes us to open _and then immediately focus_ the adjacent tab -- regardless of where focus was before. 

The fix is to use a custom selection event that carries information about whether we had focus when the tab was closed, and to only restore focus if we had it in the first place. 

Fixes https://github.com/rstudio/rstudio/issues/6039.