### PR TITLE
Be more resilient to YAML load errors in dependency scan

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2119,13 +2119,20 @@
 
    # for R Markdown docs, scan the YAML header (requires the YAML package, a dependency of
    # rmarkdown)
-   if (requireNamespace("yaml", quietly = TRUE))
+   if (identical(extension, ".Rmd") && requireNamespace("yaml", quietly = TRUE))
    {
       # split document into sections based on the YAML header delimter
       sections <- unlist(strsplit(contents, "---", fixed = TRUE))
       if (length(sections) > 2)
       {
-         front <- yaml::read_yaml(text = sections[[2]])
+         front <- NULL
+
+         tryCatch({
+            front <- yaml::read_yaml(text = sections[[2]])
+         }, error = function(e) {
+            # ignore errors when reading YAML; it's very possible that the document's YAML will not
+            # be correct at all times (e.g. during editing) 
+         })
 
          # start with an empty output
          output <- NULL

--- a/src/cpp/tests/testthat/test-pkg-deps.R
+++ b/src/cpp/tests/testthat/test-pkg-deps.R
@@ -92,3 +92,20 @@ test_that("package dependencies are discovered in R Markdown YAML headers", {
    expect_equal(packages, "shiny")
 })
 
+test_that("R scripts do not get treated like R Markdown docs", {
+   # ensures that the --- YAML delimiters don't cause us to try to parse YAML inside R scripts
+   contents <- paste(
+      "require(ggplot2)",
+      "require(yaml)",
+      "",
+      "# ---",
+      "# This is a comment header: a long one, too.",
+      "x <- 1",
+      "y <- 2",
+      "# ---",
+      "",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".R")
+   expect_equal(sort(packages), sort(c("ggplot2", "yaml")))
+})
+


### PR DESCRIPTION
There have been a few reports of the following error with 1.3:

```
Error in yaml.load(string, error.label = error.label, ...) : 
  Scanner error: while scanning a simple key at line 2, column 1 could not find expected ':' at line 8, column 1
```

It is fairly clear that this is a regression caused by https://github.com/rstudio/rstudio/pull/5973. The problem is mostly that we look for a YAML header in all kinds of files to see if it has any interesting dependencies. This is normally harmless, but if an R script contains something that _looks_ like a pair of YAML demarcators, an attempt will be made to parse everything inside them as YAML, with predictable results.

The fix is to only do this kind of scan in R Markdown files, and to swallow any errors we do find (as they are both harmless and not actionable). 