### PR TITLE
fix reference to 'studio' from 'core' in ProgressDialog abstract class

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.java
@@ -40,8 +40,6 @@ import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.dom.DomMetrics;
-import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 
 public abstract class ProgressDialog extends ModalDialogBase
 {
@@ -177,10 +175,8 @@ public abstract class ProgressDialog extends ModalDialogBase
       if (operationStarted_)
       {
          operationStarted_ = false;
-         RStudioGinjector.INSTANCE.getEventBus().fireEvent(
-               new AriaLiveStatusEvent(
-                     StringUtil.isNullOrEmpty(labelText_) ? 
-                           "Operation completed" : labelText_ + " completed", true));
+         announceCompletion(StringUtil.isNullOrEmpty(labelText_) ?
+            "Operation completed" : labelText_ + " completed");
       }
       progressAnim_.getElement().getStyle().setDisplay(Style.Display.NONE);
    }
@@ -189,7 +185,12 @@ public abstract class ProgressDialog extends ModalDialogBase
    {
       return false;
    }
-   
+
+   /**
+    * Invoked when action has completed with a message suitable for announcement via
+    * screen readers
+    */
+   protected abstract void announceCompletion(String message);
    
    private HandlerRegistrations registrations_ = new HandlerRegistrations();
   
@@ -208,5 +209,5 @@ public abstract class ProgressDialog extends ModalDialogBase
    private boolean operationStarted_;
    private String labelText_;
 
-   private static final Resources resources_ = GWT.<Resources>create(Resources.class);
+   private static final Resources resources_ = GWT.create(Resources.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
@@ -1,7 +1,7 @@
 /*
  * HTMLPreviewProgressDialog.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,8 @@ package org.rstudio.studio.client.htmlpreview.ui;
 
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.widget.ProgressDialog;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.common.compile.CompileOutputBuffer;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -85,7 +87,13 @@ public class HTMLPreviewProgressDialog extends ProgressDialog
       output_ = new CompileOutputBuffer();
       panel.setWidget(output_);
       return panel;
-   } 
+   }
 
-   private CompileOutputBuffer output_;  
+   @Override
+   protected void announceCompletion(String message)
+   {
+      RStudioGinjector.INSTANCE.getEventBus().fireEvent(new AriaLiveStatusEvent(message, true));
+   }
+
+   private CompileOutputBuffer output_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleProgressDialog.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -26,6 +26,8 @@ import com.google.gwt.user.client.ui.*;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.*;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsolePromptEvent;
@@ -199,7 +201,13 @@ public class ConsoleProgressDialog extends ProgressDialog
          return false;
       }
    }
-   
+
+   @Override
+   protected void announceCompletion(String message)
+   {
+      RStudioGinjector.INSTANCE.getEventBus().fireEvent(new AriaLiveStatusEvent(message, true));
+   }
+
    public void writeOutput(String output)
    {
       maybeShowOnOutput(output);


### PR DESCRIPTION
- The ProgressDialog abstract class, in `core`, was referencing code in non-core in order to perform aria-live announcements
- Fixed by making that an abstract method that concrete subclasses of ProgressDialog must implement
- Will make some planned future work a bit tidier as well as avoid adding yet-another circular reference between core and studio