### PR TITLE
add user prefs to disable individual aria-live announcements

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -313,6 +313,7 @@ namespace prefs {
 #define kTerminalInitialDirectoryCurrent "current"
 #define kTerminalInitialDirectoryHome "home"
 #define kFullProjectPathInWindowTitle "full_project_path_in_window_title"
+#define kDisabledAriaLiveAnnouncements "disabled_aria_live_announcements"
 
 class UserPrefValues: public Preferences
 {
@@ -1379,6 +1380,12 @@ public:
     */
    bool fullProjectPathInWindowTitle();
    core::Error setFullProjectPathInWindowTitle(bool val);
+
+   /**
+    * List of aria-live announcements to disable.
+    */
+   core::json::Array disabledAriaLiveAnnouncements();
+   core::Error setDisabledAriaLiveAnnouncements(core::json::Array val);
 
 };
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2324,6 +2324,19 @@ core::Error UserPrefValues::setFullProjectPathInWindowTitle(bool val)
    return writePref("full_project_path_in_window_title", val);
 }
 
+/**
+ * List of aria-live announcements to disable.
+ */
+core::json::Array UserPrefValues::disabledAriaLiveAnnouncements()
+{
+   return readPref<core::json::Array>("disabled_aria_live_announcements");
+}
+
+core::Error UserPrefValues::setDisabledAriaLiveAnnouncements(core::json::Array val)
+{
+   return writePref("disabled_aria_live_announcements", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2504,6 +2517,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAutoSaveOnBlur,
       kTerminalInitialDirectory,
       kFullProjectPathInWindowTitle,
+      kDisabledAriaLiveAnnouncements,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1004,6 +1004,12 @@
             "type": "boolean",
             "default": false,
             "description": "Whether to show the full path to project in desktop window title."
+        },
+        "disabled_aria_live_announcements": {
+            "type": "array",
+            "default": [],
+            "description": "List of aria-live announcements to disable."
         }
     }
 }
+

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckBoxList.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckBoxList.css
@@ -1,0 +1,11 @@
+.checkBoxList
+{
+   background-color: #ffffff;
+   border: 1px solid #999999;
+   padding: 7px;
+   margin-top: 5px;
+   margin-bottom: 10px;
+   margin-right: 30px;
+   overflow: hidden;
+}
+

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckBoxList.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckBoxList.java
@@ -1,0 +1,94 @@
+/*
+ * CheckBoxList.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.shared.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.CssResource;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.dom.DomUtils;
+
+/**
+ * A set of checkboxes in a scrolling region. Each checkbox has its own tab index, so this
+ * isn't a list (accessibility-wise), just a bunch of checkboxes in a group.
+ */
+public class CheckBoxList extends Composite
+{
+   public CheckBoxList(Element labelElement)
+   {
+      resources_ = GWT.create(CheckBoxList.Resources.class);
+      style_ = resources_.listStyle();
+      style_.ensureInjected();
+
+      ScrollPanel scrollPanel = new ScrollPanel();
+      scrollPanel.addStyleName(style_.checkBoxList());
+      DomUtils.ensureHasId(labelElement);
+      panel_ = new VerticalPanel();
+      Roles.getGroupRole().set(panel_.getElement());
+      Roles.getGroupRole().setAriaLabelledbyProperty(panel_.getElement(), Id.of(labelElement));
+      scrollPanel.setWidget(panel_);
+      initWidget(scrollPanel);
+   }
+
+   public CheckBoxList(Widget labelWidget)
+   {
+      this(labelWidget.getElement());
+   }
+
+   public void addItem(CheckBox checkBox)
+   {
+      panel_.add(checkBox);
+   }
+
+   public int getItemCount()
+   {
+      return panel_.getWidgetCount();
+   }
+
+   public CheckBox getItemAtIdx(int i)
+   {
+      if (i >= 0 && i < getItemCount())
+         return (CheckBox)panel_.getWidget(i);
+      return null;
+   }
+
+   public void clearItems()
+   {
+      panel_.clear();
+   }
+
+   public interface ListStyle extends CssResource
+   {
+      String checkBoxList();
+   }
+
+   public interface Resources extends ClientBundle
+   {
+      @Source("CheckBoxList.css")
+      ListStyle listStyle();
+   }
+
+   private final VerticalPanel panel_;
+
+   private Resources resources_;
+   private ListStyle style_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -14,39 +14,105 @@
  */
 package org.rstudio.studio.client.application;
 
+import com.google.gwt.core.client.JsArrayString;
+import com.google.inject.Provider;
 import com.google.inject.Singleton;
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.Map;
 
 @Singleton
 public class AriaLiveService
 {
+   // Unique identifiers for aria-live announcements. Use the same text for the 
+   // value as the constant name to ensure uniqueness. Add here and in the constructor below to
+   // associate description for preferences UI.
+   public static final String CONSOLE_CLEARED = "console_cleared";
+   public static final String CONSOLE_LOG = "console_log";
+   public static final String FILTERED_LIST = "filtered_list";
+   public static final String GIT_MESSAGE_LENGTH = "git_message_length";
+   public static final String PROGRESS_COMPLETION = "progress_completion";
+   public static final String PROGRESS_LOG = "progress_log";
+   public static final String TAB_KEY_MODE = "tab_key_mode";
+   public static final String TOOLBAR_VISIBILITY = "toolbar_visibility";
+   
+   // Announcement requested by a user, not controlled by a preference since it is on-demand.
+   // Do not include in the announcements_ map.
+   public static final String ON_DEMAND = "on_demand";
+
    @Inject
-   public AriaLiveService(EventBus eventBus)
+   public AriaLiveService(EventBus eventBus, Provider<UserPrefs> pUserPrefs)
    {
       eventBus_ = eventBus;
+      pUserPrefs_ = pUserPrefs;
+
+      announcements_ = new HashMap<>();
+      announcements_.put(CONSOLE_CLEARED, "Announce console cleared");
+      announcements_.put(CONSOLE_LOG, "Announce console output (requires restart)");
+      announcements_.put(FILTERED_LIST, "Announce filtered result count");
+      announcements_.put(GIT_MESSAGE_LENGTH, "Announce commit message length");
+      announcements_.put(PROGRESS_COMPLETION, "Announce task completion");
+      announcements_.put(PROGRESS_LOG, "Announce task progress details");
+      announcements_.put(TAB_KEY_MODE, "Announce tab key focus mode change");
+      announcements_.put(TOOLBAR_VISIBILITY, "Announce toolbar visibility change");
    }
 
    /**
     * Report a message to screen reader after a debounce delay
+    * @param announcementId unique identifier of this announcement
     * @param message string to announce
     */
-   public void reportStatusDebounced(String message)
+   public void reportStatusDebounced(String announcementId, String message)
    {
-      eventBus_.fireEvent(new AriaLiveStatusEvent(message, false));
+      reportStatus(announcementId, message, false);
    }
 
    /**
     * Report a message to screen reader.
+    * @param announcementId unique identifier of this announcement
     * @param message string to announce
     */
-   public void reportStatus(String message)
+   public void reportStatus(String announcementId, String message)
    {
-      eventBus_.fireEvent(new AriaLiveStatusEvent(message, true));
+      reportStatus(announcementId, message, true);
    }
+
+   public Map<String, String> getAnnouncements()
+   {
+      return announcements_;
+   }
+
+   public boolean isDisabled(String announcementId)
+   {
+      JsArrayString disabledItems = pUserPrefs_.get().disabledAriaLiveAnnouncements().getValue();
+      for (int i = 0; i < disabledItems.length(); i++)
+      {
+         if (StringUtil.equals(announcementId, disabledItems.get(i)))
+            return true;
+      }
+      return false;
+   }
+
+   private void reportStatus(String announcementId, String message, boolean immediate)
+   {
+      if (!announcements_.containsKey(announcementId))
+         Debug.logWarning("Unregistered live announcement: " + announcementId);
+
+      if (isDisabled(announcementId))
+         return;
+
+      eventBus_.fireEvent(new AriaLiveStatusEvent(message, immediate));
+   }
+
+   private final Map<String, String> announcements_;
 
    // injected
    private final EventBus eventBus_;
+   private final Provider<UserPrefs> pUserPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -84,8 +84,8 @@ public class ApplicationWindow extends Composite
       updateWorkbenchTopBottom();
       applicationPanel_.forceLayout();  
       if (announce && showToolbar != currentVisibility)
-         ariaLive_.reportStatus(showToolbar ? "Main toolbar visible" :
-                                              "Main toolbar hidden");
+         ariaLive_.reportStatus(AriaLiveService.TOOLBAR_VISIBILITY,
+               showToolbar ? "Main toolbar visible" : "Main toolbar hidden");
    }
    
    @Override
@@ -99,7 +99,8 @@ public class ApplicationWindow extends Composite
    {
       if (!isToolbarShowing())
       {
-         ariaLive_.reportStatus("Toolbar hidden, unable to focus.");
+         ariaLive_.reportStatus(AriaLiveService.TOOLBAR_VISIBILITY,
+               "Toolbar hidden, unable to focus.");
          return;
       }
       applicationHeader_.focusToolbar();

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.htmlpreview.ui;
 import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.widget.ProgressDialog;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.common.compile.CompileOutputBuffer;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -91,7 +92,8 @@ public class HTMLPreviewProgressDialog extends ProgressDialog
    @Override
    protected void announceCompletion(String message)
    {
-      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(message);
+      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(
+            AriaLiveService.PROGRESS_COMPLETION, message);
    }
 
    private CompileOutputBuffer output_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -289,7 +289,7 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       });
       dataProvider_.setList(data);
-      ariaLive_.reportStatusDebounced(
+      ariaLive_.reportStatusDebounced(AriaLiveService.FILTERED_LIST,
             "Found " + data.size() + " addins matching " + StringUtil.spacedString(query));
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationQuit;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -58,6 +59,7 @@ public class UserPrefs extends UserPrefsComputed
                     Commands commands,
                     Binder binder,
                     GlobalDisplay display,
+                    AriaLiveService ariaLive,
                     ApplicationQuit quit)
    {
       super(session.getSessionInfo(),
@@ -72,6 +74,7 @@ public class UserPrefs extends UserPrefsComputed
       display_ = display;
       commands_ = commands;
       reloadAfterInit_ = false;
+      ariaLive_ = ariaLive;
       quit_ = quit;
       
       binder.bind(commands_, this);
@@ -329,13 +332,16 @@ public class UserPrefs extends UserPrefsComputed
    @Handler
    void onToggleTabKeyMovesFocus()
    {
-      RStudioGinjector.INSTANCE.getUserPrefs().tabKeyMoveFocus().setGlobalValue(
-            !RStudioGinjector.INSTANCE.getUserPrefs().tabKeyMoveFocus().getValue());
+      boolean newMode = !RStudioGinjector.INSTANCE.getUserPrefs().tabKeyMoveFocus().getValue();
+      RStudioGinjector.INSTANCE.getUserPrefs().tabKeyMoveFocus().setGlobalValue(newMode);
       writeUserPrefs(succeeded ->
       {
          if (succeeded)
          {
             syncToggleTabKeyMovesFocusState();
+            ariaLive_.reportStatus(AriaLiveService.TAB_KEY_MODE,
+                  newMode ? "Tab key always moves focus on" : "Tab key always moves focus off");
+            
          }
          else
          {
@@ -359,6 +365,7 @@ public class UserPrefs extends UserPrefsComputed
    private final GlobalDisplay display_;
    private final Commands commands_;
    private final EventBus eventBus_;
+   private final AriaLiveService ariaLive_;
    private final ApplicationQuit quit_;
 
    private boolean reloadAfterInit_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1657,6 +1657,14 @@ public class UserPrefsAccessor extends Prefs
       return bool("full_project_path_in_window_title", false);
    }
 
+   /**
+    * List of aria-live announcements to disable.
+    */
+   public PrefValue<JsArrayString> disabledAriaLiveAnnouncements()
+   {
+      return object("disabled_aria_live_announcements", JsArrayUtil.createStringArray());
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -2013,6 +2021,8 @@ public class UserPrefsAccessor extends Prefs
          terminalInitialDirectory().setValue(layer, source.getString("terminal_initial_directory"));
       if (source.hasKey("full_project_path_in_window_title"))
          fullProjectPathInWindowTitle().setValue(layer, source.getBool("full_project_path_in_window_title"));
+      if (source.hasKey("disabled_aria_live_announcements"))
+         disabledAriaLiveAnnouncements().setValue(layer, source.getObject("disabled_aria_live_announcements"));
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -251,7 +251,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       // clear output
       view_.clearOutput();
       
-      ariaLive_.reportStatus("Console cleared");
+      ariaLive_.reportStatus(AriaLiveService.CONSOLE_CLEARED, "Console cleared");
       
       // notify server
       server_.resetConsoleActions(new VoidServerRequestCallback());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -1,7 +1,7 @@
 /*
  * ShellPane.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,11 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell;
 
+import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.shell.ShellWidget;
@@ -28,7 +30,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 public class ShellPane extends ShellWidget implements Shell.Display
 {
    @Inject
-   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events)
+   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events, AriaLiveService ariaLive)
    {
       super(editor, uiPrefs, events);
 
@@ -38,6 +40,9 @@ public class ShellPane extends ShellWidget implements Shell.Display
       // Setting file type to R changes the wrap mode to false. We want it to
       // be true so that the console input can wrap.
       editor.setUseWrapMode(true);
+
+      if (!ariaLive.isDisabled(AriaLiveService.CONSOLE_LOG))
+         Roles.getLogRole().set(getOutputWidget().getElement());
 
       uiPrefs.syntaxColorConsole().bind(new CommandWithArg<Boolean>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -4209,7 +4209,7 @@ public class Source implements InsertSourceHandler,
       {
          announcement = activeEditor_.getCurrentStatus();
       }
-      ariaLive_.reportStatus(announcement);
+      ariaLive_.reportStatus(AriaLiveService.ON_DEMAND, announcement);
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsolePromptEvent;
@@ -204,7 +205,8 @@ public class ConsoleProgressDialog extends ProgressDialog
    @Override
    protected void announceCompletion(String message)
    {
-      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(message);
+      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(
+            AriaLiveService.PROGRESS_COMPLETION, message);
    }
 
    public void writeOutput(String output)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
@@ -15,6 +15,8 @@
 package org.rstudio.studio.client.workbench.views.vcs.common;
 
 import com.google.gwt.aria.client.Roles;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.common.shell.ShellDisplay;
 import org.rstudio.studio.client.common.shell.ShellWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
@@ -26,7 +28,8 @@ public class ConsoleProgressWidget extends ShellWidget implements ShellDisplay
       super(new AceEditor(), null, null);
       getEditor().setInsertMatching(false);
       getEditor().setTextInputAriaLabel("Progress details");
-      Roles.getLogRole().set(getOutputWidget().getElement());
+      if (!RStudioGinjector.INSTANCE.getAriaLiveService().isDisabled(AriaLiveService.PROGRESS_LOG))
+         Roles.getLogRole().set(getOutputWidget().getElement());
    }
    
    private AceEditor getEditor()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -711,7 +711,7 @@ public class GitReviewPanel extends ResizeComposite implements Display
       }
 
       // Debounce an update to the accessible character count
-      ariaLive_.reportStatusDebounced(liveRegionMessage);
+      ariaLive_.reportStatusDebounced(AriaLiveService.GIT_MESSAGE_LENGTH, liveRegionMessage);
    }
 
    @UiField(provided = true)


### PR DESCRIPTION
Motivation: a new user may want more verbose behavior, but as experience is gained many announcements can become annoying, so providing a way to toggle them off.

- also added new announcement for console output (via role="log") and toggling the Tab Key Always Moves Focus setting
- put the checkboxes in a scrolling region so it remains usable via keyboard as the list grows
- although the checkboxes are in a labelled group ("Announcements") most screen readers only announce when focus goes to first checkbox, so included "Announce" in label of each checkbox for better understandability

<img width="592" alt="screenshot of Accessibility Options showing new checkboxes for announcements" src="https://user-images.githubusercontent.com/10569626/72854611-b094dd00-3c69-11ea-99b9-ddc5d110efc8.png">
