### PR TITLE
add user prefs to control warning bar, info bar, and session state announcements

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -1,7 +1,7 @@
 /*
  * InfoBar.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,7 +29,6 @@ import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -40,6 +39,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.model.Session;
 
@@ -74,10 +74,13 @@ public class InfoBar extends Composite
       initWidget(binder.createAndBindUi(this));
 
       A11y.setARIAHidden(label_);
-      if (mode == ERROR)
-         Roles.getAlertRole().set(live_.getElement());
-      else
-         Roles.getStatusRole().set(live_.getElement());
+      if (!RStudioGinjector.INSTANCE.getAriaLiveService().isDisabled(AriaLiveService.INFO_BAR))
+      {
+         if (mode == ERROR)
+            Roles.getAlertRole().set(live_.getElement());
+         else
+            Roles.getStatusRole().set(live_.getElement());
+      }
       dismiss_.addStyleName(ThemeResources.INSTANCE.themeStyles().handCursor());
       
       if (dismissHandler != null)
@@ -195,7 +198,7 @@ public class InfoBar extends Composite
    @UiField(provided = true)
    protected HorizontalPanel labelRight_;
    @UiField
-   Image dismiss_;
+   ImageButton dismiss_;
 
    interface MyBinder extends UiBinder<Widget, InfoBar>{}
    private static MyBinder binder = GWT.create(MyBinder.class);

--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.ui.xml
@@ -6,7 +6,7 @@
 
 
    <ui:style>
-      @external rstudio-themes-flat, rstudio-themes-dark-grey;
+      @external rstudio-themes-flat, rstudio-themes-dark-grey, gwt-Image;
       @eval THEME_DARKGREY_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyBackground;
       @eval THEME_DARKGREY_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyBorder;
 
@@ -35,6 +35,12 @@
       .dismiss {
          margin-top: 4px;
          margin-right: 4px;
+         right: 0;
+         width: 9px;
+         height: 9px;
+      }
+      .dismiss .gwt-Image {
+         float: left;
          width: 9px;
          height: 9px;
       }
@@ -60,10 +66,10 @@
          </g:HorizontalPanel>
       </g:center>
       <g:east size="13">
-          <g:Image ui:field="dismiss_"
+          <f:ImageButton ui:field="dismiss_"
                    resource="{themeRes.closeTab2x}"
-                   styleName="{style.dismiss}"
-                   title="Dismiss"/>
+                   addStyleNames="{style.dismiss}"
+                   title="Dismiss infobar"/>
       </g:east>
    </g:DockLayoutPanel>
    </g:FlowPanel>

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -37,10 +37,13 @@ public class AriaLiveService
    public static final String CONSOLE_LOG = "console_log";
    public static final String FILTERED_LIST = "filtered_list";
    public static final String GIT_MESSAGE_LENGTH = "git_message_length";
+   public static final String INFO_BAR = "info_bar";
    public static final String PROGRESS_COMPLETION = "progress_completion";
    public static final String PROGRESS_LOG = "progress_log";
+   public static final String SESSION_STATE = "session_state";
    public static final String TAB_KEY_MODE = "tab_key_mode";
    public static final String TOOLBAR_VISIBILITY = "toolbar_visibility";
+   public static final String WARNING_BAR = "warning_bar";
    
    // Announcement requested by a user, not controlled by a preference since it is on-demand.
    // Do not include in the announcements_ map.
@@ -57,10 +60,13 @@ public class AriaLiveService
       announcements_.put(CONSOLE_LOG, "Announce console output (requires restart)");
       announcements_.put(FILTERED_LIST, "Announce filtered result count");
       announcements_.put(GIT_MESSAGE_LENGTH, "Announce commit message length");
+      announcements_.put(INFO_BAR, "Announce info bars");
       announcements_.put(PROGRESS_COMPLETION, "Announce task completion");
       announcements_.put(PROGRESS_LOG, "Announce task progress details");
+      announcements_.put(SESSION_STATE, "Announce changes in session state");
       announcements_.put(TAB_KEY_MODE, "Announce tab key focus mode change");
       announcements_.put(TOOLBAR_VISIBILITY, "Announce toolbar visibility change");
+      announcements_.put(WARNING_BAR, "Announce warning bars");
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -296,7 +296,8 @@ public class ApplicationWindow extends Composite
       
       // create and show progress
       activeSerializationProgress_ = 
-                    new ApplicationSerializationProgress(msg, modal, delayMs);
+                    new ApplicationSerializationProgress(msg, modal, delayMs,
+                          !ariaLive_.isDisabled(AriaLiveService.SESSION_STATE));
       
       // implement timeout for *this* serialization progress instance if 
       // requested (check to ensure the same instance because another 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -37,6 +37,8 @@ import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.widget.ImageButton;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
 
 public class WarningBar extends Composite
@@ -82,7 +84,8 @@ public class WarningBar extends Composite
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
       A11y.setARIAHidden(label_);
-      Roles.getAlertRole().set(live_);
+      if (!RStudioGinjector.INSTANCE.getAriaLiveService().isDisabled(AriaLiveService.WARNING_BAR))
+         Roles.getAlertRole().set(live_);
    }
 
    public void setText(String value)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgress.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgress.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationSerializationProgress.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -31,7 +31,8 @@ public class ApplicationSerializationProgress extends PopupPanel
 {
    public ApplicationSerializationProgress(String message, 
                                            boolean modal, 
-                                           int delayMs)
+                                           int delayMs,
+                                           boolean announce)
    {
       super(false, modal);
       addStyleName(RESOURCES.styles().panel());
@@ -43,7 +44,7 @@ public class ApplicationSerializationProgress extends PopupPanel
       }
 
       ApplicationSerializationProgressLabel label =
-            new ApplicationSerializationProgressLabel();
+            new ApplicationSerializationProgressLabel(announce);
       label.setText(message);
 
       // set widget

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/serializationprogress/ApplicationSerializationProgressLabel.java
@@ -1,7 +1,7 @@
 /*
  * ApplicationSerializationProgressLabel.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,10 +29,11 @@ public class ApplicationSerializationProgressLabel extends Composite
    {}
    private static MyBinder binder = GWT.create(MyBinder.class);
 
-   public ApplicationSerializationProgressLabel()
+   public ApplicationSerializationProgressLabel(boolean announce)
    {
       initWidget(binder.createAndBindUi(this));
-      Roles.getStatusRole().set(label_.getElement());
+      if (announce)
+         Roles.getStatusRole().set(label_.getElement());
    }
 
    public void setText(String text)


### PR DESCRIPTION
- some existing announcements I forgot about when I added the preferences
- also made InfoBar close "button" into a real button (had previously done the same for WarningBar)
- InfoBars are used in editor (e.g. if file is read-only and you try to save), in Git Pane if you need to push/pull, and so forth
- WarningBar appears at bottom of main window, e.g. for license warnings
- Session State announcements are those toasts at top of window, such as "Backup up R session" when it suspends