### PR TITLE
emit aria-live alert at startup if screen reader support not enabled (Server only)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusReporter.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AriaLiveStatusReporter.java
@@ -1,7 +1,7 @@
 /*
  * AriaLiveStatusReporter.java
  *
- * Copyright (C) 2019 by RStudio, Inc.
+ * Copyright (C) 2020 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,7 +14,9 @@
  */
 package org.rstudio.core.client.widget;
 
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+
 public interface AriaLiveStatusReporter
 {
-   void reportStatus(String message, int delayMs);
+   void reportStatus(String message, int delayMs, Severity severity);
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -52,6 +52,7 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.NativeWindow;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.Timers;
 
@@ -824,9 +825,9 @@ public abstract class ModalDialogBase extends DialogBox
    }
 
    @Override
-   public void reportStatus(String status, int delayMs)
+   public void reportStatus(String status, int delayMs, Severity severity)
    {
-      ariaLiveStatusWidget_.reportStatus(status, delayMs);
+      ariaLiveStatusWidget_.reportStatus(status, delayMs, severity);
    }
 
    private static Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
@@ -19,6 +19,7 @@ import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.PopupPanel;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 
 import java.util.ArrayList;
 
@@ -56,15 +57,16 @@ public class ModalDialogTracker
     * 
     * @param message message to announce
     * @param delayMs delay before announcing
+    * @param severity polite or assertive announcement
     * @return true if message was dispatched, false if no popups support status messages
     */
-   public static boolean dispatchAriaLiveStatus(String message, int delayMs)
+   public static boolean dispatchAriaLiveStatus(String message, int delayMs, Severity severity)
    {
       for (int i = dialogStack_.size() - 1; i >= 0; i--)
       {
          if (dialogStack_.get(i) instanceof AriaLiveStatusReporter)
          {
-            ((AriaLiveStatusReporter) dialogStack_.get(i)).reportStatus(message, delayMs);
+            ((AriaLiveStatusReporter) dialogStack_.get(i)).reportStatus(message, delayMs, severity);
             return true;
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -53,6 +53,7 @@ import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationQuit.QuitContext;
 import org.rstudio.studio.client.application.events.*;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.model.InvalidSessionInfo;
 import org.rstudio.studio.client.application.model.ProductEditionInfo;
 import org.rstudio.studio.client.application.model.ProductInfo;
@@ -351,9 +352,10 @@ public class Application implements ApplicationEventHandlers
    @Override
    public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
-      int delayMs = event.getImmediate() ? 0 : userPrefs_.get().typingStatusDelayMs().getValue();
-      if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs))
-         view_.reportStatus(event.getMessage(), userPrefs_.get().typingStatusDelayMs().getValue());
+      int delayMs = (event.getTiming() == Timing.IMMEDIATE) ?
+            0 : userPrefs_.get().typingStatusDelayMs().getValue();
+      if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs, event.getSeverity()))
+         view_.reportStatus(event.getMessage(), delayMs, event.getSeverity());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationView.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.application;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.widget.AriaLiveStatusReporter;
 import org.rstudio.core.client.widget.Operation;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 
 public interface ApplicationView extends AriaLiveStatusReporter
 {       
@@ -46,10 +47,9 @@ public interface ApplicationView extends AriaLiveStatusReporter
    // error messages
    void showSessionAbendWarning();
    
-   // informative status message for screen reader users,
-   // announced at next graceful opportunity after given delay
+   // status or alert message for screen reader users,
    @Override
-   void reportStatus(String message, int delayMs);
+   void reportStatus(String message, int delayMs, Severity severity);
 
    // progress
    void showSerializationProgress(String message, 

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -20,6 +20,8 @@ import com.google.inject.Singleton;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
@@ -40,6 +42,7 @@ public class AriaLiveService
    public static final String INFO_BAR = "info_bar";
    public static final String PROGRESS_COMPLETION = "progress_completion";
    public static final String PROGRESS_LOG = "progress_log";
+   public static final String SCREEN_READER_NOT_ENABLED = "screen_reader_not_enabled";
    public static final String SESSION_STATE = "session_state";
    public static final String TAB_KEY_MODE = "tab_key_mode";
    public static final String TOOLBAR_VISIBILITY = "toolbar_visibility";
@@ -48,6 +51,9 @@ public class AriaLiveService
    // Announcement requested by a user, not controlled by a preference since it is on-demand.
    // Do not include in the announcements_ map.
    public static final String ON_DEMAND = "on_demand";
+
+   // Milliseconds to wait before making an announcement at session load
+   public static final int STARTUP_ANNOUNCEMENT_DELAY = 3000;
 
    @Inject
    public AriaLiveService(EventBus eventBus, Provider<UserPrefs> pUserPrefs)
@@ -63,6 +69,7 @@ public class AriaLiveService
       announcements_.put(INFO_BAR, "Announce info bars");
       announcements_.put(PROGRESS_COMPLETION, "Announce task completion");
       announcements_.put(PROGRESS_LOG, "Announce task progress details");
+      announcements_.put(SCREEN_READER_NOT_ENABLED, "Announce screen reader not enabled");
       announcements_.put(SESSION_STATE, "Announce changes in session state");
       announcements_.put(TAB_KEY_MODE, "Announce tab key focus mode change");
       announcements_.put(TOOLBAR_VISIBILITY, "Announce toolbar visibility change");
@@ -70,23 +77,24 @@ public class AriaLiveService
    }
 
    /**
-    * Report a message to screen reader after a debounce delay
-    * @param announcementId unique identifier of this announcement
+    * Update live region so screen reader will announce.
+    * @param announcementId unique identifier of this alert
     * @param message string to announce
+    * @param timing IMMEDIATE or DEBOUNCED
+    * @param severity STATUS (polite) or ALERT (assertive, use sparingly)
     */
-   public void reportStatusDebounced(String announcementId, String message)
+   public void announce(String announcementId,
+                        String message,
+                        Timing timing,
+                        Severity severity)
    {
-      reportStatus(announcementId, message, false);
-   }
+      if (!announcements_.containsKey(announcementId))
+         Debug.logWarning("Unregistered live announcement: " + announcementId);
 
-   /**
-    * Report a message to screen reader.
-    * @param announcementId unique identifier of this announcement
-    * @param message string to announce
-    */
-   public void reportStatus(String announcementId, String message)
-   {
-      reportStatus(announcementId, message, true);
+      if (isDisabled(announcementId))
+         return;
+
+      eventBus_.fireEvent(new AriaLiveStatusEvent(message, timing, severity));
    }
 
    public Map<String, String> getAnnouncements()
@@ -105,16 +113,6 @@ public class AriaLiveService
       return false;
    }
 
-   private void reportStatus(String announcementId, String message, boolean immediate)
-   {
-      if (!announcements_.containsKey(announcementId))
-         Debug.logWarning("Unregistered live announcement: " + announcementId);
-
-      if (isDisabled(announcementId))
-         return;
-
-      eventBus_.fireEvent(new AriaLiveStatusEvent(message, immediate));
-   }
 
    private final Map<String, String> announcements_;
 

--- a/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/AriaLiveStatusEvent.java
@@ -19,15 +19,28 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
 {
+   public enum Timing
+   {
+      IMMEDIATE,
+      DEBOUNCE // wait for UserPrefs::typingStatusDelayMs before updating
+   }
+
+   public enum Severity
+   {
+      STATUS, // polite announcements, won't interrupt other speech
+      ALERT // assertive announcements, may interrupt other speech
+   }
+
    public interface Handler extends EventHandler
    {
       void onAriaLiveStatus(AriaLiveStatusEvent event);
    }
 
-   public AriaLiveStatusEvent(String message, boolean immediate)
+   public AriaLiveStatusEvent(String message, Timing timing, Severity severity)
    {
       message_ = message;
-      immediate_ = immediate;
+      timing_ = timing;
+      severity_ = severity;
    }
 
    public String getMessage()
@@ -35,9 +48,14 @@ public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
       return message_;
    }
    
-   public boolean getImmediate()
+   public Timing getTiming()
    {
-      return immediate_;
+      return timing_;
+   }
+
+   public Severity getSeverity()
+   {
+      return severity_;
    }
 
    @Override
@@ -53,7 +71,8 @@ public class AriaLiveStatusEvent extends GwtEvent<AriaLiveStatusEvent.Handler>
    }
 
    private final String message_;
-   private final boolean immediate_;
+   private final Timing timing_;
+   private final Severity severity_;
 
    public static final Type<AriaLiveStatusEvent.Handler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/ApplicationWindow.java
@@ -29,6 +29,8 @@ import org.rstudio.core.client.widget.AriaLiveStatusWidget;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.ApplicationView;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.ui.appended.ApplicationEndedPopupPanel;
 import org.rstudio.studio.client.application.ui.serializationprogress.ApplicationSerializationProgress;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -84,8 +86,9 @@ public class ApplicationWindow extends Composite
       updateWorkbenchTopBottom();
       applicationPanel_.forceLayout();  
       if (announce && showToolbar != currentVisibility)
-         ariaLive_.reportStatus(AriaLiveService.TOOLBAR_VISIBILITY,
-               showToolbar ? "Main toolbar visible" : "Main toolbar hidden");
+         ariaLive_.announce(AriaLiveService.TOOLBAR_VISIBILITY,
+               showToolbar ? "Main toolbar visible" : "Main toolbar hidden",
+               Timing.IMMEDIATE, Severity.STATUS);
    }
    
    @Override
@@ -99,8 +102,9 @@ public class ApplicationWindow extends Composite
    {
       if (!isToolbarShowing())
       {
-         ariaLive_.reportStatus(AriaLiveService.TOOLBAR_VISIBILITY,
-               "Toolbar hidden, unable to focus.");
+         ariaLive_.announce(AriaLiveService.TOOLBAR_VISIBILITY,
+               "Toolbar hidden, unable to focus.",
+               Timing.IMMEDIATE, Severity.STATUS);
          return;
       }
       applicationHeader_.focusToolbar();
@@ -280,9 +284,9 @@ public class ApplicationWindow extends Composite
    }
    
    @Override
-   public void reportStatus(String message, int delayMs)
+   public void reportStatus(String message, int delayMs, Severity severity)
    {
-      ariaLiveStatusWidget_.reportStatus(message, delayMs);
+      ariaLiveStatusWidget_.reportStatus(message, delayMs, severity);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.core.client.widget.ModalDialogTracker;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.ChangeFontSizeEvent;
 import org.rstudio.studio.client.application.events.ChangeFontSizeHandler;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -144,9 +145,10 @@ public abstract class SatelliteWindow extends Composite
    @Override
    public void onAriaLiveStatus(AriaLiveStatusEvent event)
    {
-      int delayMs = event.getImmediate() ? 0 : RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue();
-      if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs))
-         ariaLiveStatusWidget_.reportStatus(event.getMessage(), delayMs);
+      int delayMs = (event.getTiming() == Timing.IMMEDIATE) ?
+            0 : RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue();
+      if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs, event.getSeverity()))
+         ariaLiveStatusWidget_.reportStatus(event.getMessage(), delayMs, event.getSeverity());
    }
 
    abstract protected void onInitialize(LayoutPanel mainPanel, 

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/ui/HTMLPreviewProgressDialog.java
@@ -19,6 +19,8 @@ import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.widget.ProgressDialog;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.common.compile.CompileOutputBuffer;
 
 import com.google.gwt.dom.client.Style.Unit;
@@ -92,8 +94,8 @@ public class HTMLPreviewProgressDialog extends ProgressDialog
    @Override
    protected void announceCompletion(String message)
    {
-      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(
-            AriaLiveService.PROGRESS_COMPLETION, message);
+      RStudioGinjector.INSTANCE.getAriaLiveService().announce(
+            AriaLiveService.PROGRESS_COMPLETION, message, Timing.IMMEDIATE, Severity.STATUS);
    }
 
    private CompileOutputBuffer output_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -53,6 +53,8 @@ import org.rstudio.core.client.widget.RStudioDataGrid;
 import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddin;
@@ -289,8 +291,9 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       });
       dataProvider_.setList(data);
-      ariaLive_.reportStatusDebounced(AriaLiveService.FILTERED_LIST,
-            "Found " + data.size() + " addins matching " + StringUtil.spacedString(query));
+      ariaLive_.announce(AriaLiveService.FILTERED_LIST,
+            "Found " + data.size() + " addins matching " + StringUtil.spacedString(query),
+            Timing.DEBOUNCE, Severity.STATUS);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -835,6 +835,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+Alt+," if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isSafariOrFirefox()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
+         <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Shift+/"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Shift+B"/>
       </shortcutgroup>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -35,6 +35,8 @@ import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.CommandLineHistory;
 import org.rstudio.studio.client.common.debugging.ErrorManager;
@@ -251,8 +253,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       // clear output
       view_.clearOutput();
       
-      ariaLive_.reportStatus(AriaLiveService.CONSOLE_CLEARED, "Console cleared");
-      
+      ariaLive_.announce(AriaLiveService.CONSOLE_CLEARED, "Console cleared",
+            Timing.IMMEDIATE, Severity.STATUS);
+
       // notify server
       server_.resetConsoleActions(new VoidServerRequestCallback());
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -67,6 +67,8 @@ import org.rstudio.studio.client.application.ApplicationAction;
 import org.rstudio.studio.client.application.ApplicationUtils;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FileDialogs;
@@ -4209,7 +4211,7 @@ public class Source implements InsertSourceHandler,
       {
          announcement = activeEditor_.getCurrentStatus();
       }
-      ariaLive_.reportStatus(AriaLiveService.ON_DEMAND, announcement);
+      ariaLive_.announce(AriaLiveService.ON_DEMAND, announcement, Timing.IMMEDIATE, Severity.STATUS);
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -28,6 +28,8 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.console.ConsoleOutputEvent;
 import org.rstudio.studio.client.common.console.ConsolePromptEvent;
@@ -205,8 +207,8 @@ public class ConsoleProgressDialog extends ProgressDialog
    @Override
    protected void announceCompletion(String message)
    {
-      RStudioGinjector.INSTANCE.getAriaLiveService().reportStatus(
-            AriaLiveService.PROGRESS_COMPLETION, message);
+      RStudioGinjector.INSTANCE.getAriaLiveService().announce(
+            AriaLiveService.PROGRESS_COMPLETION, message, Timing.IMMEDIATE, Severity.STATUS);
    }
 
    public void writeOutput(String output)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -49,6 +49,8 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.*;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.vcs.GitServerOperations.PatchMode;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
@@ -711,7 +713,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
       }
 
       // Debounce an update to the accessible character count
-      ariaLive_.reportStatusDebounced(AriaLiveService.GIT_MESSAGE_LENGTH, liveRegionMessage);
+      ariaLive_.announce(AriaLiveService.GIT_MESSAGE_LENGTH, liveRegionMessage,
+            Timing.DEBOUNCE, Severity.STATUS);
    }
 
    @UiField(provided = true)


### PR DESCRIPTION
A user running RStudio Server via screen reader won't know that there is an option to enable full screen reader support, nor how to get to it.

Added a keyboard shortcut to the command <kbd>Ctrl+Shift+/</kbd>, and issue an alert announcement at startup if the setting is off including description of the shortcut. Most things work in RStudio Server even if the setting is off, but over time more behaviors may be gated by this so want to have it enabled for screen reader users.

Also fixed an issue where immediate announcements in main window were being delayed using the debounce delay.

Rest is plumbing to support differentiating between status announcements (polite) and alerts (assertive). The latter should be very rare, not many alerts that are only relevant to screen reader users.