### PR TITLE
Console output screen-reader announcement implementation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -70,12 +70,14 @@ public class ConsoleOutputWriter
     * @param className Text style
     * @param isError Is this an error message?
     * @param ignoreLineCount Output without checking buffer length?
+    * @param ariaLiveAnnounce Include in arialive output announcement
     * @return was this output below the maximum buffer line count?
     */
    public boolean outputToConsole(String text,
                                   String className,
                                   boolean isError,
-                                  boolean ignoreLineCount)
+                                  boolean ignoreLineCount,
+                                  boolean ariaLiveAnnounce)
    {
       if (text.indexOf('\f') >= 0)
          clearConsoleOutput();
@@ -91,7 +93,7 @@ public class ConsoleOutputWriter
       }
 
       int oldLineCount = DomUtils.countLines(virtualConsole_.getParent(), true);
-      virtualConsole_.submit(text, className, isError);
+      virtualConsole_.submit(text, className, isError, ariaLiveAnnounce);
       int newLineCount = DomUtils.countLines(virtualConsole_.getParent(), true);
       lines_ += newLineCount - oldLineCount;
 

--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleOutputWriter.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -143,7 +143,15 @@ public class ConsoleOutputWriter
    {
       return lines_;
    }
-   
+
+   public String getNewText()
+   {
+      if (virtualConsole_ == null)
+         return "";
+      else
+         return virtualConsole_.getNewText();
+   }
+
    private int maxLines_ = -1;
    private int lines_ = 0;
    private final PreWidget output_;

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -420,7 +420,7 @@ public class VirtualConsole
 
    public void submit(String data, String clazz)
    {
-      submit(data, clazz, false/*forceNewRange*/);
+      submit(data, clazz, false/*forceNewRange*/, false/*ariaLiveAnnounce*/);
    }
 
    /**
@@ -428,9 +428,10 @@ public class VirtualConsole
     * @param data text to output
     * @param clazz text style
     * @param forceNewRange force any output from this call to be in a new
+    * @param ariaLiveAnnounce include in aria-live output announcement
     * output range (span) even if style matches previous output
     */
-   public void submit(String data, String clazz, boolean forceNewRange)
+   public void submit(String data, String clazz, boolean forceNewRange, boolean ariaLiveAnnounce)
    {
       // Only capture new elements when dealing with error output, which
       // is only place that sets forceNewRange to true. This is just an 
@@ -439,7 +440,7 @@ public class VirtualConsole
       captureNewElements_ = forceNewRange;
       newElements_.clear();
 
-      newText_ = prefs_.screenReaderEnabled() ? new StringBuilder() : null;
+      newText_ = ariaLiveAnnounce && prefs_.screenReaderEnabled() ? new StringBuilder() : null;
 
       // If previous submit ended with an incomplete ANSI code, add new data
       // to the previous (unwritten) data so we can try again to recognize
@@ -609,7 +610,7 @@ public class VirtualConsole
    // for use in reporting output to screen readers.
    public String getNewText()
    {
-      return newText_ == null ? null : newText_.toString();
+      return newText_ == null ? "" : newText_.toString();
    }
 
    private class ClassRange

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.common.shell;
 import com.google.gwt.aria.client.LiveValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Text;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
 
@@ -37,10 +36,36 @@ public class AriaLiveShellWidget extends Widget
    
    public void announce(String text)
    {
-      // TODO (gary) line counting
-      Text textNode = Document.get().createTextNode(text);
-      getElement().appendChild(textNode);
-      lineCount_++;
+      if (lineCount_ > LINE_REPORTING_LIMIT)
+         return;
+
+      StringBuilder line = new StringBuilder();
+      for (int i = 0; i < text.length(); i++)
+      {
+         char ch = text.charAt(i);
+         if (ch == '\n')
+         {
+            line.append(ch);
+            lineCount_++;
+            append(line.toString());
+            line.setLength(0);
+            
+            if (lineCount_ == LINE_REPORTING_LIMIT)
+            {
+               append("Too much output to announce in console.");
+               lineCount_++;
+               return;
+            }
+         }
+         else
+         {
+            line.append(ch);
+         }
+      }
+      if (line.length() > 0)
+      {
+         append(line.toString());
+      }
    }
 
    public void clearLiveRegion()
@@ -48,6 +73,11 @@ public class AriaLiveShellWidget extends Widget
       getElement().setInnerText("");
       lineCount_ = 0;
    }
-   
+
+   private void append(String text)
+   {
+      getElement().appendChild(Document.get().createTextNode(text));
+   }
+
    private int lineCount_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
@@ -1,0 +1,53 @@
+/*
+ * AriaLiveShellWidget.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.shell;
+
+import com.google.gwt.aria.client.LiveValue;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Text;
+import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.a11y.A11y;
+
+/**
+ * Visibly-hidden live region used to report recent console output to a screen reader.
+ */
+public class AriaLiveShellWidget extends Widget
+{
+   private static final int LINE_REPORTING_LIMIT = 25;
+   public AriaLiveShellWidget()
+   {
+      lineCount_ = 0;
+      setElement(Document.get().createDivElement());
+      A11y.setVisuallyHidden(getElement());
+      Roles.getStatusRole().setAriaLiveProperty(getElement(), LiveValue.ASSERTIVE);
+   }
+   
+   public void announce(String text)
+   {
+      // TODO (gary) line counting
+      Text textNode = Document.get().createTextNode(text);
+      getElement().appendChild(textNode);
+      lineCount_++;
+   }
+
+   public void clearLiveRegion()
+   {
+      getElement().setInnerText("");
+      lineCount_ = 0;
+   }
+   
+   private int lineCount_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -1,7 +1,7 @@
 /*
  * ShellDisplay.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -55,4 +55,7 @@ public interface ShellDisplay extends ShellOutputWriter,
    HandlerRegistration addCapturingKeyUpHandler(KeyUpHandler handler);
    
    Widget getShellWidget();
+   
+   void enableLiveReporting();
+   void clearLiveRegion();
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -267,7 +267,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public void consoleWriteError(final String error)
    {
       clearPendingInput();
-      output(error, getErrorClass(), true /*isError*/, false /*ignoreLineCount*/);
+      output(error, getErrorClass(), true /*isError*/, false /*ignoreLineCount*/, true /*announce*/);
 
       // Pick up the elements emitted to the console by this call. If we get 
       // extended information for this error, we'll need to swap out the simple 
@@ -331,7 +331,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public void consoleWriteOutput(final String output)
    {
       clearPendingInput();
-      output(output, styles_.output(), false /*isError*/, false /*ignoreLineCount*/);
+      output(output, styles_.output(), false /*isError*/, false /*ignoreLineCount*/, true /*announce*/);
    }
 
    @Override
@@ -345,7 +345,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
 
       clearPendingInput();
       output(input, styles_.command() + KEYWORD_CLASS_NAME, false /*isError*/, 
-            false /*ignoreLineCount*/);
+            false /*ignoreLineCount*/, false /*announce*/);
    }
    
    private void clearPendingInput()
@@ -358,7 +358,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public void consoleWritePrompt(final String prompt)
    {
       output(prompt, styles_.prompt() + KEYWORD_CLASS_NAME, false /*isError*/,
-            false /*ignoreLineCount*/);
+            false /*ignoreLineCount*/, false /*announce*/);
       clearErrors_ = true;
    }
 
@@ -408,15 +408,18 @@ public class ShellWidget extends Composite implements ShellDisplay,
     * @param className Text style
     * @param isError Is this an error message?
     * @param ignoreLineCount Output without checking buffer length?
+    * @param ariaLiveAnnounce Include in arialive output announcement
     * @return was this output below the maximum buffer line count?
     */
    private boolean output(String text,
                           String className,
                           boolean isError,
-                          boolean ignoreLineCount)
+                          boolean ignoreLineCount,
+                          boolean ariaLiveAnnounce)
    {
       boolean canContinue = output_.outputToConsole(text, className, 
-                                                    isError, ignoreLineCount);
+                                                    isError, ignoreLineCount,
+                                                    ariaLiveAnnounce);
 
       // if we're currently scrolled to the bottom, nudge the timer so that we
       // will keep up with output
@@ -496,25 +499,29 @@ public class ShellWidget extends Composite implements ShellDisplay,
                      canContinue = output(action.getData() + "\n",
                                           styles_.command() + " " + KEYWORD_CLASS_NAME,
                                           false /*isError*/, 
-                                          true /*ignoreLineCount*/);
+                                          true /*ignoreLineCount*/,
+                                          false /*announce*/);
                      break;
                   case ConsoleAction.OUTPUT:
                      canContinue = output(action.getData(),
                                           styles_.output(),
                                           false /*isError*/,
-                                          true /*ignoreLineCount*/);
+                                          true /*ignoreLineCount*/,
+                                          false /*announce*/);
                      break;
                   case ConsoleAction.ERROR:
                      canContinue = output(action.getData(),
                                           getErrorClass(),
                                           true /*isError*/,
-                                          true /*ignoreLineCount*/);
+                                          true /*ignoreLineCount*/,
+                                          false /*announce*/);
                      break;
                   case ConsoleAction.PROMPT:
                      canContinue = output(action.getData(),
                                           styles_.prompt() + " " + KEYWORD_CLASS_NAME,
                                           false /*isError*/,
-                                          true /*ignoreLineCount*/);
+                                          true /*ignoreLineCount*/,
+                                          false /*announce*/);
                      break;
                }
                if (!canContinue)
@@ -674,6 +681,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public void clearOutput()
    {
       output_.clearConsoleOutput();
+      clearLiveRegion();
       cleared_ = true;
    }
    
@@ -806,10 +814,18 @@ public class ShellWidget extends Composite implements ShellDisplay,
       return output_.getWidget();
    }
 
+   @Override
    public void enableLiveReporting()
    {
       liveRegion_ = new AriaLiveShellWidget();
       verticalPanel_.add(liveRegion_);
+   }
+
+   @Override
+   public void clearLiveRegion()
+   {
+      if (liveRegion_ != null)
+         liveRegion_.clearLiveRegion();
    }
 
    private boolean cleared_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -181,7 +181,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       inputLine_.setCellWidth(input_.asWidget(), "100%");
       inputLine_.setWidth("100%");
 
-      VerticalPanel verticalPanel_ = new VerticalPanel();
+      verticalPanel_ = new VerticalPanel();
       verticalPanel_.setStylePrimaryName(styles_.console());
       FontSizer.applyNormalFontSize(verticalPanel_);
       verticalPanel_.add(output_.getWidget());
@@ -423,6 +423,9 @@ public class ShellWidget extends Composite implements ShellDisplay,
       if (scrollPanel_.isScrolledToBottom())
          resizeCommand_.nudge();
       
+      if (liveRegion_ != null)
+         liveRegion_.announce(output_.getNewText());
+
       return canContinue;
    }
 
@@ -803,10 +806,17 @@ public class ShellWidget extends Composite implements ShellDisplay,
       return output_.getWidget();
    }
 
+   public void enableLiveReporting()
+   {
+      liveRegion_ = new AriaLiveShellWidget();
+      verticalPanel_.add(liveRegion_);
+   }
+
    private boolean cleared_ = false;
    private final ConsoleOutputWriter output_;
    private final PreWidget pendingInput_;
    private final HTML prompt_;
+   private AriaLiveShellWidget liveRegion_ = null;
    protected final AceEditor input_;
    private final DockPanel inputLine_;
    protected final ClickableScrollPanel scrollPanel_;
@@ -815,7 +825,8 @@ public class ShellWidget extends Composite implements ShellDisplay,
    private boolean suppressPendingInput_;
    private final EventBus events_;
    private final UserPrefs prefs_;
-   
+   private VerticalPanel verticalPanel_;
+
    // A list of errors that have occurred between console prompts. 
    private final Map<String, List<Element>> errorNodes_ = new TreeMap<>();
    private boolean clearErrors_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/ScreenReaderStateReadyEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/ScreenReaderStateReadyEvent.java
@@ -1,0 +1,49 @@
+/*
+ * ScreenReaderStateReadyEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.prefs.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Loading the Screen reader availability flag happens in a deferred fashion (due to it
+ * requiring an async call on desktop IDE). This event is fired when that state has been
+ * loaded and is ready to be queried via UserPrefs.getScreenReaderEnabled()
+ */
+public class ScreenReaderStateReadyEvent extends GwtEvent<ScreenReaderStateReadyEvent.Handler>
+{
+   public static final Type<ScreenReaderStateReadyEvent.Handler> TYPE = new Type<>();
+
+   public ScreenReaderStateReadyEvent()
+   {
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onScreenReaderStateReady(ScreenReaderStateReadyEvent e);
+   }
+
+   @Override
+   public Type<ScreenReaderStateReadyEvent.Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onScreenReaderStateReady(this);
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.prefs.events.ScreenReaderStateReadyEvent;
 import org.rstudio.studio.client.workbench.prefs.events.UserPrefsChangedEvent;
 import org.rstudio.studio.client.workbench.prefs.events.UserPrefsChangedHandler;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -258,7 +259,11 @@ public class UserPrefs extends UserPrefsComputed
       if (screenReaderEnabled_ != null)
          return;
 
-      Command onCompleted = () -> setScreenReaderMenuState(screenReaderEnabled_);
+      Command onCompleted = () ->
+      {
+         setScreenReaderMenuState(screenReaderEnabled_);
+         eventBus_.fireEvent(new ScreenReaderStateReadyEvent());
+      };
 
       if (Desktop.hasDesktopFrame())
          Desktop.getFrame().getEnableAccessibility(enabled ->

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -99,7 +99,6 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       void onBeforeUnselected();
       void onBeforeSelected();
       void onSelected();
-      void enableLiveReporting();
    }
    
    @Inject
@@ -285,6 +284,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    
    public void onConsoleInput(final ConsoleInputEvent event)
    {
+      view_.clearLiveRegion();
       server_.consoleInput(event.getInput(), 
                            event.getConsole(),
                            new ServerRequestCallback<Void>() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -55,6 +55,7 @@ import org.rstudio.studio.client.workbench.model.ConsoleAction;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.model.helper.StringStateValue;
+import org.rstudio.studio.client.workbench.prefs.events.ScreenReaderStateReadyEvent;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.views.console.events.*;
@@ -86,7 +87,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                               SendToConsoleHandler,
                               DebugModeChangedEvent.Handler,
                               RunCommandWithDebugEvent.Handler,
-                              UnhandledErrorEvent.Handler
+                              UnhandledErrorEvent.Handler,
+                              ScreenReaderStateReadyEvent.Handler
 {
    static interface Binder extends CommandBinder<Commands, Shell>
    {
@@ -97,6 +99,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       void onBeforeUnselected();
       void onBeforeSelected();
       void onSelected();
+      void enableLiveReporting();
    }
    
    @Inject
@@ -131,7 +134,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       
       editorProvider.setConsoleEditor(input_);
       
-      
+      eventBus_.addHandler(ScreenReaderStateReadyEvent.TYPE, this);
+     
       prefs_.surroundSelection().bind(new CommandWithArg<String>()
       {
          @Override
@@ -776,6 +780,13 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    public void onSelected()
    {
       view_.onSelected();
+   }
+   
+   @Override
+   public void onScreenReaderStateReady(ScreenReaderStateReadyEvent e)
+   {
+      if (prefs_.getScreenReaderEnabled() && !ariaLive_.isDisabled(AriaLiveService.CONSOLE_LOG))
+         view_.enableLiveReporting();
    }
 
    private final ConsoleServerOperations server_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -14,13 +14,11 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell;
 
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.shell.ShellWidget;
@@ -30,7 +28,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 public class ShellPane extends ShellWidget implements Shell.Display
 {
    @Inject
-   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events, AriaLiveService ariaLive)
+   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events)
    {
       super(editor, uiPrefs, events);
 
@@ -40,9 +38,6 @@ public class ShellPane extends ShellWidget implements Shell.Display
       // Setting file type to R changes the wrap mode to false. We want it to
       // be true so that the console input can wrap.
       editor.setUseWrapMode(true);
-
-      if (!ariaLive.isDisabled(AriaLiveService.CONSOLE_LOG))
-         Roles.getLogRole().set(getOutputWidget().getElement());
 
       uiPrefs.syntaxColorConsole().bind(new CommandWithArg<Boolean>()
       {

--- a/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
+++ b/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
@@ -1,7 +1,7 @@
 /*
  * ConsoleOutputWriterTests.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,6 @@ package org.rstudio.core.client;
 
 import java.util.List;
 
-import org.rstudio.core.client.ConsoleOutputWriter;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
@@ -64,8 +63,15 @@ public class ConsoleOutputWriterTests extends GWTTestCase
          return ansiMode_;
       }
       
+      @Override
+      public boolean screenReaderEnabled()
+      {
+         return screenReaderEnabled_;
+      }
+      
       public int truncateLines_ = 1000;
       public String ansiMode_ = UserPrefs.ANSI_CONSOLE_MODE_ON;
+      public boolean screenReaderEnabled_ = false;
    }
    
    private class VCFactory implements VirtualConsoleFactory

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1,7 +1,7 @@
 /*
  * VirtualConsoleTests.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,8 +50,15 @@ public class VirtualConsoleTests extends GWTTestCase
          return ansiMode_;
       }
       
+      @Override
+      public boolean screenReaderEnabled()
+      {
+         return screenReaderEnabled_;
+      }
+      
       public int truncateLines_ = 1000;
       public String ansiMode_ = UserPrefs.ANSI_CONSOLE_MODE_ON;
+      public boolean screenReaderEnabled_ = false;
    }
    
    private static String consolify(String text)
@@ -1012,4 +1019,24 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals(expected, ele.getInnerHTML());
       Assert.assertEquals("cc 33 ", vc.toString());
    }
- }
+
+   public void testScreenReaderOffNoTextNotCaptured()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+      vc.submit("Hello World", "someclass");
+      Assert.assertNull(vc.getNewText());
+   }
+
+   public void testScreenReaderOnTextCaptured()
+   {
+      PreElement ele = Document.get().createPreElement();
+      FakePrefs prefs = new FakePrefs();
+      prefs.screenReaderEnabled_ = true;
+      VirtualConsole vc = new VirtualConsole(ele, prefs);
+      String text = "Hello World\nHow are you?";
+      vc.submit(text, "someclass");
+      String newText = vc.getNewText();
+      Assert.assertEquals(newText, text);
+   }
+}


### PR DESCRIPTION
Goal is to have screen-reader announce new output as it appears in the RStudio Console.

Previous attempt to simply mark the entire console as role="log" did not work as hoped, especially on Chrome where it would re-announce the entire console with each new line of output.

This new approach uses similar pattern to xterm.js. Text output to the console (minus all formatting) is added to a separate aria-live region. This region tracks  number of lines output, and cuts it off at 25 lines (currently a constant, may make into a user-preference) at which point it announces "Too much output to announce in console" and stops updating the live region. Screen-reader users can still navigate the entire output via screen-reader commands, it just won't be announced automatically.

The live-region and line-count is cleared whenever a new command is executed, or when the console is cleared. Could also consider using yet-another-timer to auto-clear the hidden area after some amount of non-activity, etc., but will evaluate need for such "finicky" options after more testing.

This new behavior only happens if screen-reader support is enabled (same is true for terminal/xterm). There is also an option to disable this announcement separately.

Fixes #6084 
