### PR TITLE
move announcements preferences to separate pref pane tab

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -452,4 +452,8 @@ public class ElementIds
 
    // ProgressDialog
    public final static String PROGRESS_TITLE_LABEL = "progress_title_label";
+
+   // AccessibilityPreferencesPane
+   public final static String A11Y_GENERAL_PREFS = "a11y_general_prefs";
+   public final static String A11Y_ANNOUNCEMENTS_PREFS = "a11y_announcements_prefs";
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -62,18 +62,18 @@ public class AriaLiveService
       pUserPrefs_ = pUserPrefs;
 
       announcements_ = new HashMap<>();
-      announcements_.put(CONSOLE_CLEARED, "Announce console cleared");
-      announcements_.put(CONSOLE_LOG, "Announce console output (requires restart)");
-      announcements_.put(FILTERED_LIST, "Announce filtered result count");
-      announcements_.put(GIT_MESSAGE_LENGTH, "Announce commit message length");
-      announcements_.put(INFO_BAR, "Announce info bars");
-      announcements_.put(PROGRESS_COMPLETION, "Announce task completion");
-      announcements_.put(PROGRESS_LOG, "Announce task progress details");
-      announcements_.put(SCREEN_READER_NOT_ENABLED, "Announce screen reader not enabled");
-      announcements_.put(SESSION_STATE, "Announce changes in session state");
-      announcements_.put(TAB_KEY_MODE, "Announce tab key focus mode change");
-      announcements_.put(TOOLBAR_VISIBILITY, "Announce toolbar visibility change");
-      announcements_.put(WARNING_BAR, "Announce warning bars");
+      announcements_.put(CONSOLE_CLEARED, "Console cleared");
+      announcements_.put(CONSOLE_LOG, "Console output (requires restart)");
+      announcements_.put(FILTERED_LIST, "Filtered result count");
+      announcements_.put(GIT_MESSAGE_LENGTH, "Commit message length");
+      announcements_.put(INFO_BAR, "Info bars");
+      announcements_.put(PROGRESS_COMPLETION, "Task completion");
+      announcements_.put(PROGRESS_LOG, "Task progress details");
+      announcements_.put(SCREEN_READER_NOT_ENABLED, "Screen reader not enabled");
+      announcements_.put(SESSION_STATE, "Changes in session state");
+      announcements_.put(TAB_KEY_MODE, "Tab key focus mode change");
+      announcements_.put(TOOLBAR_VISIBILITY, "Toolbar visibility change");
+      announcements_.put(WARNING_BAR, "Warning bars");
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -23,10 +23,13 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.CheckBoxList;
 import org.rstudio.core.client.widget.NumericValueWidget;
 import org.rstudio.studio.client.application.AriaLiveService;
@@ -45,33 +48,43 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       res_ = res;
       ariaLive_ = ariaLive;
 
-      add(headerLabel("Assistive Tools"));
+      VerticalTabPanel generalPanel = new VerticalTabPanel(ElementIds.A11Y_GENERAL_PREFS);
+      VerticalTabPanel announcementsPanel = new VerticalTabPanel(ElementIds.A11Y_ANNOUNCEMENTS_PREFS);
+
+      generalPanel.add(headerLabel("Assistive Tools"));
       chkScreenReaderEnabled_ = new CheckBox("Screen reader support (requires restart)");
-      add(chkScreenReaderEnabled_);
+      generalPanel.add(chkScreenReaderEnabled_);
 
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
             1, 9999, prefs.typingStatusDelayMs());
-      add(indent(typingStatusDelay_));
+      generalPanel.add(indent(typingStatusDelay_));
 
-      Label announcementsLabel = headerLabel("Announcements");
+      Label displayLabel = headerLabel("Other");
+      generalPanel.add(displayLabel);
+      displayLabel.getElement().getStyle().setMarginTop(8, Style.Unit.PX);
+      generalPanel.add(checkboxPref("Reduce user interface animations", prefs.reducedMotion()));
+      chkTabMovesFocus_ = new CheckBox("Tab key always moves focus");
+      generalPanel.add(chkTabMovesFocus_);
+
+      Label announcementsLabel = headerLabel("Enable / Disable Announcements");
       announcements_ = new CheckBoxList(announcementsLabel);
-      add(announcementsLabel);
+      announcementsPanel.add(announcementsLabel);
       announcementsLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
-      add(announcements_);
+      announcementsPanel.add(announcements_);
       DomUtils.ensureHasId(announcementsLabel.getElement());
       Roles.getListboxRole().setAriaLabelledbyProperty(announcements_.getElement(),
             Id.of(announcementsLabel.getElement()));
-      announcements_.setHeight("150px");
-      announcements_.setWidth("300px");
+      announcements_.setHeight("380px");
+      announcements_.setWidth("390px");
       announcements_.getElement().getStyle().setMarginBottom(15, Unit.PX);
       announcements_.getElement().getStyle().setMarginLeft(3, Unit.PX);
-      
-      Label displayLabel = headerLabel("Other");
-      add(displayLabel);
-      displayLabel.getElement().getStyle().setMarginTop(8, Style.Unit.PX);
-      add(checkboxPref("Reduce user interface animations", prefs.reducedMotion()));
-      chkTabMovesFocus_ = new CheckBox("Tab key always moves focus");
-      add(chkTabMovesFocus_);
+
+      DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Accessibility");
+      tabPanel.setSize("435px", "498px");
+      tabPanel.add(generalPanel, "General", generalPanel.getBasePanelId());
+      tabPanel.add(announcementsPanel, "Announcements", announcementsPanel.getBasePanelId());
+      tabPanel.selectTab(0);
+      add(tabPanel);
    }
 
    @Override


### PR DESCRIPTION
Frees up more space for future preferences, and easier screen-reader/keyboard navigation.

## Before
<img width="592" alt="2020-01-27_10-00-27" src="https://user-images.githubusercontent.com/10569626/73200574-e7e10f00-40eb-11ea-8e36-79fce2ea4275.png">

## After
<img width="592" alt="2020-01-27_09-56-25" src="https://user-images.githubusercontent.com/10569626/73200608-faf3df00-40eb-11ea-83b8-c28eb6b7fb39.png">

<img width="592" alt="2020-01-27_09-56-44" src="https://user-images.githubusercontent.com/10569626/73200619-00512980-40ec-11ea-8178-a07f9cd5efde.png">
