### PR TITLE
Check for write permissions before performing a global replace

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1222,6 +1222,12 @@ Error FilePath::openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_
    return Success();
 }
 
+Error FilePath::testWritePermissions() const
+{
+   std::shared_ptr<std::ostream> testStream;
+   return openForWrite(testStream, false);
+}
+
 Error FilePath::remove() const
 {
    try

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1222,12 +1222,6 @@ Error FilePath::openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_
    return Success();
 }
 
-Error FilePath::testWritePermissions() const
-{
-   std::shared_ptr<std::ostream> testStream;
-   return openForWrite(testStream, false);
-}
-
 Error FilePath::remove() const
 {
    try
@@ -1293,6 +1287,12 @@ void FilePath::setLastWriteTime(std::time_t in_time) const
       logError(m_impl->Path, e, ERROR_LOCATION);
       return;
    }
+}
+
+Error FilePath::testWritePermissions() const
+{
+   std::shared_ptr<std::ostream> testStream;
+   return openForWrite(testStream, false);
 }
 
 // PathScope Classes ===================================================================================================

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -573,6 +573,14 @@ public:
     */
    Error openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_truncate = true) const;
 
+   /*
+    * @brief Checks if a file can be written to by opening the file
+    * If write access is not absolutely necessary, use isFileWriteable from FileMode.hpp
+    *
+    * @return Success if file can be written to; system error otherwise
+    */
+   Error testWritePermissions() const;
+
    /**
     * @brief Removes this file or directory from the filesystem.
     *

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -612,6 +612,7 @@ public:
    /**
     * @brief Checks if a file can be written to by opening the file.
     *
+    * To be successful, the file must already exist on the system.
     * If write access is not absolutely necessary, use isFileWriteable from FileMode.hpp.
     *
     * @return Success if file can be written to; system error otherwise (e.g. EPERM, ENOENT, etc.)

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -573,14 +573,6 @@ public:
     */
    Error openForWrite(std::shared_ptr<std::ostream>& out_stream, bool in_truncate = true) const;
 
-   /*
-    * @brief Checks if a file can be written to by opening the file
-    * If write access is not absolutely necessary, use isFileWriteable from FileMode.hpp
-    *
-    * @return Success if file can be written to; system error otherwise
-    */
-   Error testWritePermissions() const;
-
    /**
     * @brief Removes this file or directory from the filesystem.
     *
@@ -616,6 +608,15 @@ public:
     * @param in_time    The time to which to set the last write time of this file. Default: now.
     */
    void setLastWriteTime(std::time_t in_time = ::time(nullptr)) const;
+
+   /**
+    * @brief Checks if a file can be written to by opening the file.
+    *
+    * If write access is not absolutely necessary, use isFileWriteable from FileMode.hpp.
+    *
+    * @return Success if file can be written to; system error otherwise (e.g. EPERM, ENOENT, etc.)
+    */
+   Error testWritePermissions() const;
 
 private:
    // The private implementation of FilePath.


### PR DESCRIPTION
Fixes #6048 

Global replace functionality works by copying the contents of the initial file to a temporary file while replacing every occurrence of the specified value - it then overrides the original file with the new file by performing a `move`. This caused the replace to work even when RStudio didn't have write permissions for that file. 
This PR tests if the original file can be written to before starting the replace process and immediately before performing the move. This will prevent the process from going forward with replace logic when it fails on the first check, and ensure the permissions were not changed by an outside process immediately before the `move`. 

This PR also fixes a, possibly impossible with the current UI, bug that was discovered while writing R unit tests where the `grep` command would have invalid syntax if a blank space was passed for the include or exclude tags.