### PR TITLE
keyboard and screenreader support for dropdown in slides and help panes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -1,7 +1,7 @@
 /*
  * ThemeStyles.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -70,6 +70,7 @@ public interface ThemeStyles extends CssResource
    String webHeaderBarCommandsProjectMenu();
    String toolbarButton();
    String noLabel();
+   String popupButton();
    String toolbarButtonPushed();
    String emptyProjectMenu();
    String menuSubheader();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1318,6 +1318,10 @@ body.windows .toolbar {
    overflow: hidden;
 }
 
+.toolbarButton.popupButton {
+   margin: 0;
+}
+
 .toolbarButton:focus {
    outline: none;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -1,7 +1,7 @@
 /*
  * Toolbar.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,14 +14,14 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.ExpandedValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasVerticalAlignment.VerticalAlignmentConstant;
 
@@ -75,6 +75,102 @@ public class Toolbar extends Composite
       {
          item.setVisible(visible);
       }
+   }
+
+   /**
+    * This is only used in a couple places, and should someday be replaced with standard
+    * ToolbarMenuButton; for now didn't want to have to rework the code using it to
+    * conform to the different model so duplicated some logic from ToolbarMenuButton to support
+    * screen readers and keyboard-use.
+    */
+   private class ToolbarPopupButton extends FocusWidget
+   {
+      public ToolbarPopupButton(final MenuLabel menuLabel, MenuSource menuSource)
+      {
+         menuSource_ = menuSource;
+
+         setElement(Document.get().createPushButtonElement());
+         getElement().setClassName(styles_.toolbarButton());
+         getElement().addClassName(styles_.toolbarButtonMenu());
+         getElement().addClassName(styles_.popupButton());
+
+         HorizontalPanel container = new HorizontalPanel();
+         container.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
+         getElement().appendChild(container.getElement());
+
+         label_ = menuLabel.asWidget();
+         label_.setStylePrimaryName("rstudio-StrongLabel");
+         label_.getElement().getStyle().setOverflow(Overflow.HIDDEN);
+         container.add(label_);
+
+         Image image = new DecorativeImage(new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()));
+         image.getElement().getStyle().setMarginLeft(5, Unit.PX);
+         image.getElement().getStyle().setMarginRight(8, Unit.PX);
+         image.getElement().getStyle().setMarginBottom(2, Unit.PX);
+         image.addStyleName("rstudio-themes-inverts");
+         image.addStyleName(styles_.toolbarButtonRightImage());
+         container.add(image);
+
+         addMenuHandlers();
+      }
+
+      private void addMenuHandlers()
+      {
+         Roles.getButtonRole().setAriaHaspopupProperty(getElement(), true);
+         Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+         menuShowing_ = false;
+
+         addMouseDownHandler(event ->
+         {
+            event.preventDefault();
+            event.stopPropagation();
+            menuClick();
+         });
+         menuSource_.getMenu().addCloseHandler(popupPanelCloseEvent ->
+         {
+            removeStyleName(styles_.toolbarButtonPushed());
+            Scheduler.get().scheduleDeferred(() ->
+            {
+               menuShowing_ = false;
+               Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+               setFocus(true);
+            });
+         });
+         addKeyPressHandler(event ->
+         {
+            char charCode = event.getCharCode();
+            if (charCode == KeyCodes.KEY_ENTER || charCode == KeyCodes.KEY_SPACE)
+            {
+               event.preventDefault();
+               event.stopPropagation();
+               menuClick();
+            }
+         });
+      }
+
+      private void menuClick()
+      {
+         addStyleName(styles_.toolbarButtonPushed());
+         if (menuShowing_)
+         {
+            removeStyleName(styles_.toolbarButtonPushed());
+            menuSource_.getMenu().hide();
+            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+            setFocus(true);
+         }
+         else
+         {
+            menuSource_.getMenu().showRelativeTo(label_);
+            menuSource_.getMenu().getElement().getStyle().setPaddingTop(3, Unit.PX);
+            menuShowing_ = true;
+            menuSource_.getMenu().focus();
+            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
+         }
+      }
+      
+      private boolean menuShowing_;
+      private final MenuSource menuSource_;
+      private final Widget label_;
    }
 
    public Toolbar(Widget[] leftWidgets, Widget[] rightWidgets, String label)
@@ -335,42 +431,19 @@ public class Toolbar extends Composite
          final MenuSource menuSource,
          boolean left)
    {
-      final Widget label = menuLabel.asWidget();
-      label.setStylePrimaryName("rstudio-StrongLabel") ;
-      label.getElement().getStyle().setCursor(Style.Cursor.DEFAULT);
-      label.getElement().getStyle().setOverflow(Overflow.HIDDEN);
+      ToolbarPopupButton button = new ToolbarPopupButton(menuLabel, menuSource);
+
       if (left)
-         addLeftWidget(label);
+         addLeftWidget(button);
       else
-         addRightWidget(label);
-      Image image = new Image(new ImageResource2x(ThemeResources.INSTANCE.menuDownArrow2x()));
-      image.getElement().getStyle().setMarginLeft(5, Unit.PX);
-      image.getElement().getStyle().setMarginRight(8, Unit.PX);
-      image.getElement().getStyle().setMarginBottom(2, Unit.PX);
-      image.addStyleName("rstudio-themes-inverts");
-      if (left)
-         addLeftWidget(image);
-      else
-         addRightWidget(image);
-      
-      final ClickHandler clickHandler = new ClickHandler()
-      {
-         public void onClick(ClickEvent event)
-         {
-            ToolbarPopupMenu menu = menuSource.getMenu();
-            menu.showRelativeTo(label);
-            menu.getElement().getStyle().setPaddingTop(3, Style.Unit.PX);
-         }
-      };
-      menuLabel.addClickHandler(clickHandler);
-      image.addClickHandler(clickHandler);
-      
-      return image;
+         addRightWidget(button);
+
+      return button;
    }
 
-   private HorizontalPanel horizontalPanel_ ;
-   private HorizontalPanel leftToolbarPanel_ ;
-   private HorizontalPanel rightToolbarPanel_ ;
+   private HorizontalPanel horizontalPanel_;
+   private HorizontalPanel leftToolbarPanel_;
+   private HorizontalPanel rightToolbarPanel_;
    private HTMLPanel toolbarWrapper_;
    protected final ThemeStyles styles_ = ThemeResources.INSTANCE.themeStyles();
    private boolean separatorsInvalidated_ = false;


### PR DESCRIPTION
Dropdown toolbar button control used just in these two places. Prior to this didn't support keyboard or screen-reader use; now it does.

<img width="306" alt="screenshot of help pane with arrow pointing at dropdown" src="https://user-images.githubusercontent.com/10569626/73237475-9b78ec00-414a-11ea-9f05-5095ac89d4b5.png">
<img width="653" alt="screenshot of presentation pane with arrow pointing at dropdown" src="https://user-images.githubusercontent.com/10569626/73237477-9e73dc80-414a-11ea-82f1-44705b33bf3f.png">
