### PR TITLE
ensure menu buttons have correct expanded state after menu closes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -125,4 +125,11 @@ public class A11y
    {
       el.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
    }
+   
+   public static void setARIANotExpanded(Element el)
+   {
+      // aria best-practices recommends not including aria-expanded property at all instead 
+      // of setting it to false
+      el.removeAttribute("aria-expanded");
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -26,6 +26,7 @@ import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasVerticalAlignment.VerticalAlignmentConstant;
 
 import org.rstudio.core.client.SeparatorManager;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -117,8 +118,7 @@ public class Toolbar extends Composite
       private void addMenuHandlers()
       {
          Roles.getButtonRole().setAriaHaspopupProperty(getElement(), true);
-         Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
-         menuShowing_ = false;
+         setMenuShowing(false);
 
          addMouseDownHandler(event ->
          {
@@ -131,8 +131,7 @@ public class Toolbar extends Composite
             removeStyleName(styles_.toolbarButtonPushed());
             Scheduler.get().scheduleDeferred(() ->
             {
-               menuShowing_ = false;
-               Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+               setMenuShowing(false);
                setFocus(true);
             });
          });
@@ -155,19 +154,28 @@ public class Toolbar extends Composite
          {
             removeStyleName(styles_.toolbarButtonPushed());
             menuSource_.getMenu().hide();
-            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+            setMenuShowing(false);
             setFocus(true);
          }
          else
          {
             menuSource_.getMenu().showRelativeTo(label_);
             menuSource_.getMenu().getElement().getStyle().setPaddingTop(3, Unit.PX);
-            menuShowing_ = true;
+            setMenuShowing(true);
             menuSource_.getMenu().focus();
-            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
          }
       }
-      
+
+      private void setMenuShowing(boolean showing)
+      {
+         if (showing)
+            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
+         else
+            A11y.setARIANotExpanded(getElement());
+
+         menuShowing_ = showing;
+      }
+
       private boolean menuShowing_;
       private final MenuSource menuSource_;
       private final Widget label_;

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarMenuButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarMenuButton.java
@@ -1,7 +1,7 @@
 /*
  * ToolbarMenuButton.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -21,6 +21,7 @@ import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.ImageResourceProvider;
 import org.rstudio.core.client.command.SimpleImageResourceProvider;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -86,11 +87,22 @@ public class ToolbarMenuButton extends ToolbarButton
       addStyleName(styles_.toolbarButtonMenu());
    }
 
+   private void setMenuShowing(boolean showing)
+   {
+      if (showing)
+         Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
+      else
+         A11y.setARIANotExpanded(getElement());
+         
+      menuShowing_ = showing;
+   }
+
    private void addMenuHandlers(final ToolbarPopupMenu popupMenu,
                                 final boolean rightAlignMenu)
    {
       Roles.getButtonRole().setAriaHaspopupProperty(getElement(), true);
-      
+      setMenuShowing(false);
+
       menu_ = popupMenu;
       rightAlignMenu_ = rightAlignMenu;
 
@@ -113,7 +125,7 @@ public class ToolbarMenuButton extends ToolbarButton
       popupMenu.addCloseHandler(popupPanelCloseEvent ->
       {
          removeStyleName(styles_.toolbarButtonPushed());
-         Scheduler.get().scheduleDeferred(() -> menuShowing_ = false);
+         Scheduler.get().scheduleDeferred(() -> setMenuShowing(false));
       });
       addKeyPressHandler(event ->
       {
@@ -138,7 +150,7 @@ public class ToolbarMenuButton extends ToolbarButton
          {
             removeStyleName(styles_.toolbarButtonPushed());
             menu.hide();
-            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.FALSE);
+            setMenuShowing(false);
             setFocus(true);
          }
          else
@@ -165,9 +177,8 @@ public class ToolbarMenuButton extends ToolbarButton
             {
                menu.showRelativeTo(ToolbarMenuButton.this);
             }
-            menuShowing_ = true;
+            setMenuShowing(true);
             menu_.focus();
-            Roles.getMenuRole().setAriaExpandedState(getElement(), ExpandedValue.TRUE);
          }
       });
    }


### PR DESCRIPTION
- Fixes #6106
- Also follow best-practice from Aria guidelines and remove aria-expanded altogether when the menu is closed, instead of setting it to false (otherwise screen readers may read some additional and not-helpful information when buttons get focus)
- Some duplicate code due to two similar implementation of toolbar menu buttons; consolidating this is a future chore