### PR TITLE
add keyboard shortcuts for next/previous help page, and for searching R Help

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,7 @@
 * Change shortcuts for Next/Previous terminal to avoid clash with common Windows shortcuts (#4892)
 * Support use of F13 - F24 for custom keyboard shortcuts (full Mac keyboard has F13-F19, for example)
 * Add ability to resize panes using keyboard arrow keys via View / Panes / Adjust Splitter
+* Keyboard shortcuts for searching R help in Help pane, and next/previous help page (#5149)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -498,6 +498,8 @@ well as menu structures (for main menu and popup menus).
 
       <menu label="_Help">
          <cmd refid="helpHome"/>
+         <cmd refid="helpSearch"/>
+         <separator/>
          <cmd refid="showAboutDialog"/>
          <cmd refid="showLicenseDialog"/>
          <cmd refid="checkForUpdates"/>
@@ -838,6 +840,9 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Shift+/"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Shift+B"/>
+         <shortcut refid="helpSearch" value="Ctrl+Alt+F1"/>
+         <shortcut refid="helpBack" value="Shift+Alt+F2"/>
+         <shortcut refid="helpForward" value="Shift+Alt+F3"/>
       </shortcutgroup>
       <shortcutgroup name="Console">
          <shortcut refid="consoleClear" value="Ctrl+L" disableModes="emacs"/>
@@ -2854,21 +2859,23 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="helpBack"
         buttonLabel=""
-        desc="Previous topic"
-        rebindable="false"/>
-        
+        desc="Previous topic"/>
+
    <cmd id="helpForward"
         buttonLabel=""
-        desc="Next topic"
-        rebindable="false"/>
-        
+        desc="Next topic"/>
+
    <cmd id="helpHome"
         label="Show R Help"
         menuLabel="R _Help"
         buttonLabel=""
         desc="Show R Help"
         windowMode="main"/>
-        
+
+   <cmd id="helpSearch"
+        menuLabel="Search R Hel_p"
+        windowMode="main"/>
+
    <cmd id="printHelp"
         buttonLabel=""
         desc="Print topic"
@@ -3065,7 +3072,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="showLicenseDialog"
         label="Manage License..."
-        menuLabel="Manage License"
+        menuLabel="Ma_nage License..."
         rebindable="false"
         windowMode="main"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -1,7 +1,7 @@
 /*
  * Commands.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -438,6 +438,7 @@ public abstract class
    public abstract AppCommand helpBack();
    public abstract AppCommand helpForward();
    public abstract AppCommand helpHome();
+   public abstract AppCommand helpSearch();
    public abstract AppCommand printHelp();
    public abstract AppCommand clearHelpHistory();
    public abstract AppCommand helpPopout();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
@@ -1,7 +1,7 @@
 /*
  * Help.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -57,6 +57,7 @@ public class Help extends BasePresenter implements ShowHelpHandler
       void popout();
       void refresh();
       void focus();
+      void focusSearchHelp();
       
       LinkMenu getHistory();
 
@@ -166,11 +167,12 @@ public class Help extends BasePresenter implements ShowHelpHandler
       
    }
 
-   // Home handled by Shim for activation from main menu context
+   // Commands handled by Shim for activation from main menu context
    public void onHelpHome() { bringToFront(); home(); }
-   
-   @Handler public void onHelpBack() { view_.back(); }
-   @Handler public void onHelpForward() { view_.forward(); }
+   public void onHelpSearch() { bringToFront(); view_.focusSearchHelp(); }
+   public void onHelpBack() { bringToFront(); view_.back(); }
+   public void onHelpForward() { bringToFront(); view_.forward(); }
+
    @Handler public void onPrintHelp() { view_.print(); }
    @Handler public void onHelpPopout() { view_.popout(); }
    @Handler public void onRefreshHelp() { view_.refresh(); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -59,8 +59,10 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.FindTextBox;
+import org.rstudio.core.client.widget.FocusHelper;
 import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.RStudioThemedFrame;
+import org.rstudio.core.client.widget.SearchDisplay;
 import org.rstudio.core.client.widget.SecondaryToolbar;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.Toolbar;
@@ -402,8 +404,9 @@ public class HelpPane extends WorkbenchPane
          toolbar.addLeftSeparator();
       }
       toolbar.addLeftWidget(commands_.helpPopout().createToolbarButton());
-        
-      toolbar.addRightWidget(searchProvider_.get().getSearchWidget());
+
+      searchWidget_ = searchProvider_.get().getSearchWidget();
+      toolbar.addRightWidget((Widget)searchWidget_);
 
       toolbar.addRightSeparator();
 
@@ -633,6 +636,7 @@ public class HelpPane extends WorkbenchPane
       return isFindSupported() && !BrowseCap.isFirefox();
    }
 
+   @Override
    public String getUrl()
    {
       String url = null;
@@ -650,11 +654,20 @@ public class HelpPane extends WorkbenchPane
       return url;
    }
    
+   @Override
    public String getDocTitle()
    {
       return getIFrameEx().getContentDocument().getTitle();
    }
 
+   @Override
+   public void focusSearchHelp()
+   {
+      if (searchWidget_ != null)
+         FocusHelper.setFocusDeferred(searchWidget_);
+   }
+
+   @Override
    public void showHelp(String url)
    {
       ensureWidget();
@@ -719,6 +732,7 @@ public class HelpPane extends WorkbenchPane
       }
    }
    
+   @Override
    public void refresh()
    {
       String url = getUrl();
@@ -731,6 +745,7 @@ public class HelpPane extends WorkbenchPane
       return getIFrameEx() != null ? getIFrameEx().getContentWindow() : null;
    }
    
+   @Override
    public void back()
    {
       VirtualHistory.Data back = navStack_.back();
@@ -738,6 +753,7 @@ public class HelpPane extends WorkbenchPane
          setLocation(back.getUrl(), back.getScrollPosition());
    }
 
+   @Override
    public void forward()
    {
       VirtualHistory.Data fwd = navStack_.forward();
@@ -745,12 +761,14 @@ public class HelpPane extends WorkbenchPane
          setLocation(fwd.getUrl(), fwd.getScrollPosition());
    }
 
+   @Override
    public void print()
    {
       getContentWindow().focus();
       getContentWindow().print();
    }
    
+   @Override
    public void popout()
    {
       String href = getContentWindow().getLocationHref();
@@ -767,17 +785,20 @@ public class HelpPane extends WorkbenchPane
          contentWindow.focus();
    }
    
+   @Override
    public HandlerRegistration addHelpNavigateHandler(HelpNavigateHandler handler)
    {
       return addHandler(handler, HelpNavigateEvent.TYPE);
    }
    
  
+   @Override
    public LinkMenu getHistory()
    {
       return history_;
    }
 
+   @Override
    public boolean navigated()
    {
       return navigated_;
@@ -864,4 +885,5 @@ public class HelpPane extends WorkbenchPane
    private Timer scrollTimer_;
    private boolean selected_;
    private static int popoutCount_ = 0;
+   private SearchDisplay searchWidget_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
@@ -1,7 +1,7 @@
 /*
  * HelpTab.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -37,6 +37,9 @@ public class HelpTab extends DelayLoadWorkbenchTab<Help>
                                                 ActivateHelpHandler
    {
       @Handler public abstract void onHelpHome();
+      @Handler public abstract void onHelpSearch();
+      @Handler public abstract void onHelpBack();
+      @Handler public abstract void onHelpForward();
       @Handler public abstract void onDebugHelp();
       @Handler public abstract void onMarkdownHelp();
       @Handler public abstract void onOpenRStudioIDECheatSheet();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearch.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearch.java
@@ -1,7 +1,7 @@
 /*
  * HelpSearch.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,7 +18,6 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
-import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.events.SelectionCommitEvent;
@@ -64,9 +63,9 @@ public class HelpSearch
       });
    }
 
-   public Widget getSearchWidget()
+   public SearchDisplay getSearchWidget()
    {
-      return (Widget) display_.getSearchDisplay();
+      return display_.getSearchDisplay();
    }
    
    private void fireShowHelpEvent(String topic)


### PR DESCRIPTION
- Fixes #5149
- Added "Search R Help" command to Help menu; shows Help pane if not visible and puts focus in the search field; shortcut is Ctrl+Alt+F1 (editable as "Help Search" command)
- Shortcut for previous help page now Alt+Shift+F2 (editable as "Help Back" command)
- Shortcut for next help page now Alt+Shift+F3 (editable as "Help Forward" command)
- Using next/prev shortcuts while Help pane is not visible will make it visible
- Added missing menu accelerator and trailing "..." to Manage License command (Desktop Pro)

<img width="240" alt="screenshot of RStudio Server help menu showing new command" src="https://user-images.githubusercontent.com/10569626/73316130-ed6f4f80-41e6-11ea-9f3a-3ca6415dc254.png">
