### PR TITLE
Blacklist for Typo.js unsupported dictionaries

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -183,11 +183,12 @@ public class TypoSpellChecker
 
       // subscribe to spelling prefs changes (invalidateAll on changes)
       ValueChangeHandler<Boolean> prefChangedHandler = (event) -> context_.invalidateAllWords();
+      ValueChangeHandler<Boolean> realtimeChangedHandler = (event) -> loadDictionary();
       ValueChangeHandler<String> dictChangedHandler = (event) -> loadDictionary();
-      userPrefs_.realTimeSpellchecking().addValueChangeHandler(prefChangedHandler);
       userPrefs_.ignoreUppercaseWords().addValueChangeHandler(prefChangedHandler);
       userPrefs_.ignoreWordsWithNumbers().addValueChangeHandler(prefChangedHandler);
       userPrefs_.spellingDictionaryLanguage().addValueChangeHandler(dictChangedHandler);
+      userPrefs_.realTimeSpellchecking().addValueChangeHandler(realtimeChangedHandler);
 
       // subscribe to user dictionary changes
       context_.releaseOnDismiss(userDictionary_.addListChangedHandler((ListChangedEvent event) ->
@@ -335,18 +336,28 @@ public class TypoSpellChecker
 
    private void loadDictionary()
    {
-      // don't load the same dictionary again
       final String language = userPrefs_.spellingDictionaryLanguage().getValue();
-      if (typoLoaded_ && loadedDict_ == language)
+
+      if (!userPrefs_.realTimeSpellchecking().getValue() || typoLoaded_ && loadedDict_.equals(language))
          return;
-      
+
+      // See canRealtimeSpellcheckDict comment, temporary stop gap
+      // Disable real time spellchecking if this dictionary is incompatible
+      // with Typo.js. Final invariant check to ensure that we never try to
+      // load a blacklisted dictionary.
+      if (!canRealtimeSpellcheckDict(language))
+      {
+         userPrefs_.realTimeSpellchecking().setGlobalValue(false);
+         return;
+      }
+
       // check for an active request
       if (activeRequest_ != null && activeRequest_.isAlive())
       {
          // if we're already requesting this language's dictionary, bail
          if (StringUtil.equals(activeRequest_.getLanguage(), language))
             return;
-         
+
          // otherwise, cancel that request and start a new one
          activeRequest_.cancel();
          activeRequest_ = null;
@@ -396,6 +407,26 @@ public class TypoSpellChecker
       }
 
       return true;
+   }
+
+   /*
+      Stop gap function to prevent loading dictionaries that Typo.js has
+      severe issues with. This is being tracked to be fixed in issue #6041 as
+      soon as possible so this can then be removed.
+    */
+   private static String[] realtimeDictBlacklist = {"cs_CZ", "de_DE_neu", "lt_LT", "pt_BR"};
+   public static boolean canRealtimeSpellcheckDict(String dict)
+   {
+      boolean exists = false;
+      for (int i = 0; i < realtimeDictBlacklist.length; i++)
+      {
+         if (realtimeDictBlacklist[i].equals(dict))
+         {
+            exists = true;
+            break;
+         }
+      }
+      return !exists;
    }
 
    public static boolean isLoaded() { return typoLoaded_; }

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -342,14 +342,11 @@ public class TypoSpellChecker
          return;
 
       // See canRealtimeSpellcheckDict comment, temporary stop gap
-      // Disable real time spellchecking if this dictionary is incompatible
+      // Return early if this dictionary is incompatible
       // with Typo.js. Final invariant check to ensure that we never try to
       // load a blacklisted dictionary.
       if (!canRealtimeSpellcheckDict(language))
-      {
-         userPrefs_.realTimeSpellchecking().setGlobalValue(false);
          return;
-      }
 
       // check for an active request
       if (activeRequest_ != null && activeRequest_.isAlive())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -63,7 +63,7 @@ public class SpellingPreferencesPane extends PreferencesPane
 
       boolean canRealtime = TypoSpellChecker.canRealtimeSpellcheckDict(prefs.spellingDictionaryLanguage().getValue());
       realtimeSpellcheckingCheckbox_ = checkboxPref("Use real time spellchecking", prefs.realTimeSpellchecking());
-      realtimeSpellcheckingCheckbox_.getElement().getStyle().setColor(canRealtime ? "black" : "darkgrey");
+      realtimeSpellcheckingCheckbox_.getElement().getStyle().setOpacity(canRealtime ? 1.0 : 0.6);
       add(realtimeSpellcheckingCheckbox_);
 
       blacklistWarning_ = new Label("Real time spellchecking currently unavailable for this dictionary");
@@ -77,7 +77,7 @@ public class SpellingPreferencesPane extends PreferencesPane
          blacklistWarning_.setVisible(!canRealtimeCheck);
          realtimeSpellcheckingCheckbox_.setValue(realtimeSpellcheckingCheckbox_.getValue() && canRealtimeCheck);
          realtimeSpellcheckingCheckbox_.setEnabled(canRealtimeCheck);
-         realtimeSpellcheckingCheckbox_.getElement().getStyle().setColor(canRealtimeCheck ? "black" : "darkgrey");
+         realtimeSpellcheckingCheckbox_.getElement().getStyle().setOpacity(canRealtimeCheck ? 1.0 : 0.6);
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -17,6 +17,8 @@ package org.rstudio.studio.client.workbench.prefs.views;
 
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.CommandWithArg;
@@ -26,6 +28,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.spelling.SpellingService;
+import org.rstudio.studio.client.common.spelling.TypoSpellChecker;
 import org.rstudio.studio.client.common.spelling.ui.SpellingCustomDictionariesWidget;
 import org.rstudio.studio.client.common.spelling.ui.SpellingLanguageSelectWidget;
 import org.rstudio.studio.client.server.ServerError;
@@ -54,12 +57,28 @@ public class SpellingPreferencesPane extends PreferencesPane
       spaced(customDictsWidget_);
       nudgeRight(customDictsWidget_);
       add(customDictsWidget_);
-            
+
       add(checkboxPref("Ignore words in UPPERCASE", prefs.ignoreUppercaseWords()));
-      
       add(checkboxPref("Ignore words with numbers", prefs.ignoreWordsWithNumbers()));
 
-      add(checkboxPref("Use real time spellchecking", prefs.realTimeSpellchecking()));
+      boolean canRealtime = TypoSpellChecker.canRealtimeSpellcheckDict(prefs.spellingDictionaryLanguage().getValue());
+      realtimeSpellcheckingCheckbox_ = checkboxPref("Use real time spellchecking", prefs.realTimeSpellchecking());
+      realtimeSpellcheckingCheckbox_.getElement().getStyle().setColor(canRealtime ? "black" : "darkgrey");
+      add(realtimeSpellcheckingCheckbox_);
+
+      blacklistWarning_ = new Label("Real time spellchecking currently unavailable for this dictionary");
+      blacklistWarning_.getElement().getStyle().setColor("red");
+      blacklistWarning_.setVisible(!canRealtime);
+
+      add(blacklistWarning_);
+
+      languageWidget_.addChangeHandler((event) -> {
+         boolean canRealtimeCheck = TypoSpellChecker.canRealtimeSpellcheckDict(languageWidget_.getSelectedLanguage());
+         blacklistWarning_.setVisible(!canRealtimeCheck);
+         realtimeSpellcheckingCheckbox_.setValue(realtimeSpellcheckingCheckbox_.getValue() && canRealtimeCheck);
+         realtimeSpellcheckingCheckbox_.setEnabled(canRealtimeCheck);
+         realtimeSpellcheckingCheckbox_.getElement().getStyle().setColor(canRealtimeCheck ? "black" : "darkgrey");
+      });
    }
 
    
@@ -161,4 +180,6 @@ public class SpellingPreferencesPane extends PreferencesPane
    private final SpellingService spellingService_;
    private final SpellingLanguageSelectWidget languageWidget_;
    private final SpellingCustomDictionariesWidget customDictsWidget_;
+   private final Label blacklistWarning_;
+   private final CheckBox realtimeSpellcheckingCheckbox_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
@@ -222,8 +222,9 @@ public class TextEditingTargetSpelling implements TypoSpellChecker.Context
    {
       docDisplay_.addContextMenuHandler((event) ->
       {
+         // If real time checking is off or
          // If we have a selection, just return as the user likely wants to cut/copy/paste
-         if (docDisplay_.hasSelection())
+         if (!prefs_.realTimeSpellchecking().getValue() || docDisplay_.hasSelection())
             return;
 
          // Get the word under the cursor

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
@@ -71,6 +71,20 @@ public class TextEditingTargetSpelling implements TypoSpellChecker.Context
 
    public JsArray<LintItem> getLint()
    {
+      JsArray<LintItem> lint = JsArray.createArray().cast();
+
+      /*
+         There are certain dictionaries blacklisted from realtime spellchecking, it's
+         possible due to external preference funny business to get into a state where
+         this function was incorrectly called. Detect that state, clean it up, and return.
+       */
+      final String language = prefs_.spellingDictionaryLanguage().getValue();
+      if (!TypoSpellChecker.canRealtimeSpellcheckDict(language))
+      {
+         prefs_.realTimeSpellchecking().setGlobalValue(false);
+         return lint;
+      }
+
       TextFileType fileType = docDisplay_.getFileType();
 
       // only spell check comments in code files
@@ -84,7 +98,6 @@ public class TextEditingTargetSpelling implements TypoSpellChecker.Context
          Position.create(docDisplay_.getLastVisibleRow(), docDisplay_.getLength(docDisplay_.getLastVisibleRow())));
 
       final ArrayList<Range> wordRanges = new ArrayList<>();
-      JsArray<LintItem> lint = JsArray.createArray().cast();
       ArrayList<String> prefetchWords = new ArrayList<>();
 
       for (Range r : wordSource)


### PR DESCRIPTION
Reported in issue #6041 there are some dictionaries that Typo.js has severe issues loading. In fact, due to the size of these dictionaries in memory for most tested spellchecking libraries (6GB for Lithuanian in a tested Python package), some serious problem solving will have to go into this issue at some point.

The discussed stopgap to implement was to add a blacklist for the known incompatible dictionaries and not allow them to be loaded for real time spellchecking. Due to how preferences are saved and handled there was a fair amount of funny business making sure that [hopefully] all weird edge cases would be caught to prevent the user from getting into a bad state.

On the plus side I found and fixed a bug with turning real time spellchecking off and then on again.

![spellcheck_unavailable](https://user-images.githubusercontent.com/136863/73324570-5ff92300-4219-11ea-8937-d89db4b41be7.png)
