### PR TITLE
fix resetting of ANSI console color 255 (foreground or background)

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -1,7 +1,7 @@
 /*
  * AnsiEscapeCode.java
  *
- * Copyright (C) 2009-18 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -598,7 +598,7 @@ public class AnsiCode
     
    private void resetForeground()
    {
-      for (int i = 0; i < 255; i++)
+      for (int i = 0; i < 256; i++)
       {
          clazzes_.remove(Color.clazzForColorIndex(i, false /*background*/));
       }
@@ -607,7 +607,7 @@ public class AnsiCode
 
    private void resetBackground()
    {
-      for (int i = 0; i < 255; i++)
+      for (int i = 0; i < 256; i++)
       {
          clazzes_.remove(Color.clazzForColorIndex(i, true /*background*/));
       }

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1049,4 +1049,34 @@ public class VirtualConsoleTests extends GWTTestCase
       String newText = vc.getNewText();
       Assert.assertEquals(newText, text);
    }
+
+   public void testBackground255Carryover6092()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = 
+            setForegroundIndex(232) + setBackgroundIndex(255) + "one" +
+            setCsiCode(AnsiCode.RESET_BACKGROUND) + setCsiCode(AnsiCode.RESET_FOREGROUND) + " two";
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermColor232 xtermBgColor255\">one</span><span> two</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("one two", vc.toString());
+   }
+
+   public void testForeground255Carryover6092()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput =
+            setForegroundIndex(255) + setBackgroundIndex(232) + "one" +
+                  setCsiCode(AnsiCode.RESET_BACKGROUND) + setCsiCode(AnsiCode.RESET_FOREGROUND) + " two";
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermColor255 xtermBgColor232\">one</span><span> two</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("one two", vc.toString());
+   }
 }


### PR DESCRIPTION
Fixes #6092 

The ANSI reset was ignored for color 255 (foreground or background) due to range-check bug.