### PR TITLE
fix broken "build" keyboard shortcut

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutInfoPanel.java
  *
- * Copyright (C) 2009-19 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -82,7 +82,7 @@ public class ShortcutInfoPanel extends Composite
       String[][] groupNames = { 
             new String[] { "Tabs", "Panes", "Files", "Main Menu (Server)" },
             new String[] { "Source Navigation", "Execute" },
-            new String[] { "Source Editor", "Debug" }, 
+            new String[] { "Source Editor", "Debug", "Accessibility" }, 
             new String[] { "Source Control", "Build", "Console", "Terminal", "Other" }
       };
       int pctWidth = 100 / groupNames.length;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -837,9 +837,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showOptions" value="Meta+Alt+," if="org.rstudio.core.client.BrowseCap.isMacintosh() &amp;&amp; org.rstudio.core.client.BrowseCap.isSafariOrFirefox()"/>
          <shortcut refid="projectOptions" value="Shift+Meta+," if="org.rstudio.core.client.BrowseCap.isMacintosh()"/> 
          <shortcut refid="goToHelp" value="Ctrl+C Ctrl+V" disableModes="default,vim,sublime"/>
-         <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Shift+/"/>
-         <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
-         <shortcut refid="speakEditorLocation" value="Ctrl+Shift+B"/>
          <shortcut refid="helpSearch" value="Ctrl+Alt+F1"/>
          <shortcut refid="helpBack" value="Shift+Alt+F2"/>
          <shortcut refid="helpForward" value="Shift+Alt+F3"/>
@@ -853,7 +850,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="previousTerminal" value="Shift+Alt+F11"/>
          <shortcut refid="nextTerminal" value="Shift+Alt+F12"/>
       </shortcutgroup>
-
       <shortcutgroup name="Main Menu (Server)">
          <shortcut refid="showFileMenu" value="Ctrl+Alt+F"/>
          <shortcut refid="showEditMenu" value="Ctrl+Alt+I"/>
@@ -866,9 +862,13 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showProfileMenu" value="Ctrl+Alt+O"/>
          <shortcut refid="showToolsMenu" value="Ctrl+Alt+T"/>
          <shortcut refid="showHelpMenu" value="Ctrl+Alt+H"/>
+      </shortcutgroup>
+      <shortcutgroup name="Accessibility">
+         <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
+         <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
+         <shortcut refid="speakEditorLocation" value="Ctrl+Alt+Shift+B"/>
          <shortcut refid="focusMainToolbar" value="Ctrl+Alt+L"/>
       </shortcutgroup>
-
       <!-- 
       Shortcuts in this group won't be shown in the quick reference card. 
        -->

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -782,13 +782,13 @@
   </tr>
   <tr>
     <td>Previous Terminal</td>
-    <td>Ctrl+Alt+F11</td>
-    <td>Ctrl+Option+F11</td>
+    <td>Shift+Alt+F11</td>
+    <td>Shift+Option+F11</td>
   </tr>
   <tr>
     <td>Next Terminal</td>
-    <td>Ctrl+Alt+F12</td>
-    <td>Ctrl+Option+F12</td>
+    <td>Shift+Alt+F12</td>
+    <td>Shift+Option+F12</td>
   </tr>
   <tr><td><br/></td></tr>
   <tr><td colspan="3"><h2>Main Menu (Server)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>


### PR DESCRIPTION
I broke this when I added <kbd>Ctrl+Shift+B</kbd> as shortcut for reading editor info via screen reader; I checked for that shortcut existing as <kbd>Ctrl+Shift+B</kbd> but I didn't look for <kbd>Cmd+Shift+B</kbd> (which ends up being the same thing on Windows).

Changed the accessibility shortcut to <kbd>Ctrl+Alt+Shift+B</kbd>. Also changed "toggleScreenReader" to <kbd>Ctrl+Alt+Shift+/</kbd> for consistency.

Added a group for accessibility shortcuts and put them on the shortcuts reference popup.

Noticed and fixed incorrect shortcuts for terminal next/prev in the static keyboard.htm page, and logged an issue #6117 to work on making that page be automatically generated (or at least update it manually) for 1.3.

Fixes #6115