### PR TITLE
Improve screen reader accessibility of "All Keyboard Shortcuts" page

### DIFF
--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -2,854 +2,934 @@
 <html lang="en">
 
 <head>
+  <title>RStudio: Keyboard Shortcuts</title>
+  <link rel="stylesheet" href="../rstudio.css" type="text/css"/>
 
-<title>RStudio: Keyboard Shortcuts</title>
-
-<link rel="stylesheet" href="../rstudio.css" type="text/css"/>
-
-<style type="text/css">
-#banner {
-  margin-bottom: 0;
-}
-.shortcuts th {
-  text-align: left;
-  padding-right: 20px;
-}
-.shortcuts, .shortcuts td {
-  font-size: 10pt;
-  padding-right: 20px;
-}
-</style>
-
+  <style>
+    #banner {
+      margin-bottom: 0;
+    }
+    .shortcuts th[scope=col] {
+      text-align: left;
+      width: 360px;
+    }
+    .shortcuts th[scope=col]+th[scope=col] {
+      width: 320px;
+    }
+    .shortcuts, .shortcuts td {
+      font-size: 10pt;
+      padding-right: 20px;
+    }
+    .shortcuts td, .shortcuts th {
+      padding-bottom: 0.5em;
+    }
+  </style>
 </head>
+<!--
+For Mac, no plus sign between keys, and use following characters:
+  Left        &#8592;
+  Up          &#8593;
+  Right       &#8594;
+  Down        &#8595;
+  Enter       &#8617;
+  PgUp        &#8670;
+  PgDn        &#8671;
+  Tab         &#8677;
+  Shift       &#8679;
+  Ctrl        &#8963;
+  Meta/Cmd    &#8984;
+  Alt/Option  &#8997;
+  Delete      &#8998;
+  Backspace   &#9003;
+  Esc         &#9099;
 
+-->
 <body>
-
-<header role="banner" id="banner"><img src="../images/rstudio.png" alt="RStudio logo"/></header>
+<header id="banner"><img src="../images/rstudio.png" alt/></header>
 <main><div style="margin-left: 20px; margin-right: 20px">
-
-<h1>Keyboard Shortcuts</h1>
-
-<style type='text/css'> 
-  .shortcuts td, .shortcuts th {
-    padding-left: 1.6em;
-    padding-bottom: 0.5em; }
-</style> 
-<table class='shortcuts'>
-  <tr><td colspan="3"><h2>Console</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Move cursor to Console</td>
-    <td>Ctrl+2</td>
-    <td>Ctrl+2</td>
-  </tr>
-  <tr>
-    <td>Clear console</td>
-    <td>Ctrl+L</td>
-    <td>Ctrl+L</td>
-  </tr>
-  <tr>
-    <td>Move cursor to beginning of line</td>
-    <td>Home</td>
-    <td>Command+Left</td>
-  </tr>
-  <tr>
-    <td>Move cursor to end of line</td>
-    <td>End</td>
-    <td>Command+Right</td>
-  </tr>
-  <tr>
-    <td>Navigate command history</td>
-    <td>Up/Down</td>
-    <td>Up/Down</td>
-  </tr>
-  <tr>
-    <td>Popup command history</td>
-    <td>Ctrl+Up</td>
-    <td>Command+Up</td>
-  </tr>
-  <tr>
-    <td>Interrupt currently executing command</td>
-    <td>Esc</td>
-    <td>Esc</td>
-  </tr>
-  <tr>
-    <td>Change working directory</td>
-    <td>Ctrl+Shift+H</td>
-    <td>Ctrl+Shift+H</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Source</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-   <tr>
-    <td>Goto File/Function</td>
-    <td>Ctrl+.</td>
-    <td>Ctrl+.</td>
-  </tr>
-  <tr>
-    <td>Move cursor to Source Editor</td>
-    <td>Ctrl+1</td>
-    <td>Ctrl+1</td>
-  </tr>
-  <tr>
-    <td>New document (except on Chrome/Windows)</td>
-    <td>Ctrl+Shift+N</td>
-    <td>Command+Shift+N</td>
-  </tr>
-  <tr>
-    <td>New document (Chrome only)</td>
-    <td>Ctrl+Alt+Shift+N</td>
-    <td>Command+Shift+Alt+N</td>
-  </tr>
-  <tr>
-    <td>Open document</td>
-    <td>Ctrl+O</td>
-    <td>Command+O</td>
-  </tr>
-  <tr>
-    <td>Save active document</td>
-    <td>Ctrl+S</td>
-    <td>Command+S</td>
-  </tr>
-  <tr>
-    <td>Close active document (except on Chrome)</td>
-    <td>Ctrl+W</td>
-    <td>Command+W</td>
-  </tr>
-  <tr>
-    <td>Close active document (Chrome only)</td>
-    <td>Ctrl+Alt+W</td>
-    <td>Command+Option+W</td>
-  </tr>
-  <tr>
-     <td>Close all open documents</td>
-     <td>Ctrl+Shift+W</td>
-     <td>Command+Shift+W</td>
-   </tr>
-  <tr>
-    <td>Preview HTML (Markdown and HTML)</td>
-    <td>Ctrl+Shift+K</td>
-    <td>Command+Shift+K</td>
-  </tr>
-  <tr>
-    <td>Knit Document (knitr)</td>
-    <td>Ctrl+Shift+K</td>
-    <td>Command+Shift+K</td>
-  </tr>
-  <tr>
-    <td>Compile Notebook</td>
-    <td>Ctrl+Shift+K</td>
-    <td>Command+Shift+K</td>
-  </tr>
-  <tr>
-    <td>Compile PDF (TeX and Sweave)</td>
-    <td>Ctrl+Shift+K</td>
-    <td>Command+Shift+K</td>
-  </tr>
-  <tr>
-    <td>Insert chunk (Sweave and Knitr)</td>
-    <td>Ctrl+Alt+I</td>
-    <td>Command+Option+I</td>
-  </tr>
-  <tr>
-    <td>Insert code section</td>
-    <td>Ctrl+Shift+R</td>
-    <td>Command+Shift+R</td>
-  </tr>
-  <tr>
-    <td>Run current line/selection</td>
-    <td>Ctrl+Enter</td>
-    <td>Command+Enter</td>
-  </tr>
-  <tr>
-    <td>Run current line/selection (retain cursor position)</td>
-    <td>Alt+Enter</td>
-    <td>Option+Enter</td>
-  </tr>
-  <tr>
-    <td>Re-run previous region</td>
-    <td>Ctrl+Shift+P</td>
-    <td>Command+Shift+P</td>
-  </tr>
-  <tr>
-    <td>Run current document</td>
-    <td>Ctrl+Alt+R</td>
-    <td>Command+Option+R</td>
-  </tr>
-  <tr>
-    <td>Run from document beginning to current line</td>
-    <td>Ctrl+Alt+B</td>
-    <td>Command+Option+B</td>
-  </tr>
-  <tr>
-    <td>Run from current line to document end</td>
-    <td>Ctrl+Alt+E</td>
-    <td>Command+Option+E</td>
-  </tr>
-  <tr>
-    <td>Run the current function definition</td>
-    <td>Ctrl+Alt+F</td>
-    <td>Command+Option+F</td>
-  </tr>
-  <tr>
-    <td>Run the current code section</td>
-    <td>Ctrl+Alt+T</td>
-    <td>Command+Option+T</td>
-  </tr>
-  <tr>
-    <td>Run previous Sweave/Rmd code</td>
-    <td>Ctrl+Alt+P</td>
-    <td>Command+Option+P</td>
-  </tr>
-  <tr>
-    <td>Run the current Sweave/Rmd chunk</td>
-    <td>Ctrl+Alt+C</td>
-    <td>Command+Option+C</td>
-  </tr>
-  <tr>
-    <td>Run the next Sweave/Rmd chunk</td>
-    <td>Ctrl+Alt+N</td>
-    <td>Command+Option+N</td>
-  </tr>
-  <tr>
-    <td>Source a file</td>
-    <td>Ctrl+Shift+O</td>
-    <td>Command+Shift+O</td>
-  </tr>
-  <tr>
-    <td>Source the current document</td>
-    <td>Ctrl+Shift+S</td>
-    <td>Command+Shift+S</td>
-  </tr>
-  <tr>
-    <td>Source the current document (with echo)</td>
-    <td>Ctrl+Shift+Enter</td>
-    <td>Command+Shift+Enter</td>
-  </tr>
-  <tr>
-     <td>Fold Selected</td>
-     <td>Alt+L</td>
-     <td>Cmd+Option+L</td>
-   </tr>
-  <tr>
-     <td>Unfold Selected</td>
-     <td>Shift+Alt+L</td>
-     <td>Cmd+Shift+Option+L</td>
-   </tr>
-  <tr>
-     <td>Fold All</td>
-     <td>Alt+O</td>
-     <td>Cmd+Option+O</td>
-   </tr>
-  <tr>
-     <td>Unfold All</td>
-     <td>Shift+Alt+O</td>
-     <td>Cmd+Shift+Option+O</td>
-   </tr>
-  <tr>
-     <td>Go to line</td>
-     <td>Shift+Alt+G</td>
-     <td>Cmd+Shift+Option+G</td>
-   </tr>
-  <tr>
-    <td>Jump to</td>
-    <td>Shift+Alt+J</td>
-    <td>Cmd+Shift+Option+J</td>
-  </tr>
-  <tr>
-    <td>Switch to tab</td>
-    <td>Ctrl+Shift+.</td>
-    <td>Ctrl+Shift+.</td>
-  </tr>
-  <tr>
-    <td>Previous tab</td>
-    <td>Ctrl+F11</td>
-    <td>Ctrl+F11</td>
-  </tr>
-  <tr>
-    <td>Next tab</td>
-    <td>Ctrl+F12</td>
-    <td>Ctrl+F12</td>
-  </tr>
-  <tr>
-    <td>First tab</td>
-    <td>Ctrl+Shift+F11</td>
-    <td>Ctrl+Shift+F11</td>
-  </tr>
-  <tr>
-    <td>Last tab</td>
-    <td>Ctrl+Shift+F12</td>
-    <td>Ctrl+Shift+F12</td>
-  </tr>
-  <tr>
-     <td>Navigate back</td>
-     <td>Ctrl+F9</td>
-     <td>Cmd+F9</td>
-  </tr>
-  <tr>
-     <td>Navigate forward</td>
-     <td>Ctrl+F10</td>
-     <td>Cmd+F10</td>
-  </tr>
-  <tr>
-    <td>Extract function from selection</td>
-    <td>Ctrl+Alt+X</td>
-    <td>Command+Option+X</td>
-  </tr>
-  <tr>
-    <td>Extract variable from selection</td>
-    <td>Ctrl+Alt+V</td>
-    <td>Command+Option+V</td>
-  </tr>
-  <tr>
-     <td>Reindent lines</td>
-     <td>Ctrl+I</td>
-     <td>Command+I</td>
-   </tr>
-  <tr>
-    <td>Comment/uncomment current line/selection</td>
-    <td>Ctrl+Shift+C</td>
-    <td>Command+Shift+C</td>
-  </tr>
-  <tr>
-     <td>Reflow Comment</td>
-     <td>Ctrl+Shift+/</td>
-     <td>Command+Shift+/</td>
-   </tr>
-  <tr>
-    <td>Reformat Selection</td>
-    <td>Ctrl+Shift+A</td>
-    <td>Command+Shift+A</td>
-  </tr>
-  <tr>
-    <td>Show Diagnostics</td>
-    <td>Ctrl+Shift+Alt+P</td>
-    <td>Command+Shift+Alt+P</td>
-  </tr>
-  <tr>
-    <td>Transpose Letters</td>
-    <td></td>
-    <td>Ctrl+T</td>
-  </tr>
-  <tr>
-    <td>Move Lines Up/Down</td>
-    <td>Alt+Up/Down</td>
-    <td>Option+Up/Down</td>
-  </tr>
-  <tr>
-    <td>Copy Lines Up/Down</td>
-    <td>Shift+Alt+Up/Down</td>
-    <td>Command+Option+Up/Down</td>
-  </tr>
-  <tr>
-    <td>Jump to Matching Brace/Paren</td>
-    <td>Ctrl+P</td>
-    <td>Ctrl+P</td>
-  </tr>
-  <tr>
-    <td>Expand to Matching Brace/Paren</td>
-    <td>Ctrl+Shift+E</td>
-    <td>Ctrl+Shift+E</td>
-  </tr>
-  <tr>
-    <td>Select to Matching Brace/Paren</td>
-    <td>Ctrl+Shift+Alt+E</td>
-    <td>Ctrl+Shift+Alt+E</td>
-  </tr>
-  <tr>
-    <td>Add Cursor Above Current Cursor</td>
-    <td>Ctrl+Alt+Up</td>
-    <td>Ctrl+Alt+Up</td>
-  </tr>
-  <tr>
-    <td>Add Cursor Below Current Cursor</td>
-    <td>Ctrl+Alt+Down</td>
-    <td>Ctrl+Alt+Down</td>
-  </tr>
-  <tr>
-    <td>Move Active Cursor Up</td>
-    <td>Ctrl+Alt+Shift+Up</td>
-    <td>Ctrl+Alt+Shift+Up</td>
-  </tr>
-  <tr>
-    <td>Move Active Cursor Down</td>
-    <td>Ctrl+Alt+Shift+Down</td>
-    <td>Ctrl+Alt+Shift+Down</td>
-  </tr>
-  <tr>
-    <td>Find and Replace</td>
-    <td>Ctrl+F</td>
-    <td>Command+F</td>
-  </tr>
-  <tr>
-    <td>Find Next</td>
-    <td>Win: F3, Linux: Ctrl+G</td>
-    <td>Command+G</td>
-  </tr>
-  <tr>
-    <td>Find Previous</td>
-    <td>Win: Shift+F3, Linux: Ctrl+Shift+G</td>
-    <td>Command+Shift+G</td>
-  </tr>
-  <tr>
-    <td>Use Selection for Find</td>
-    <td>Ctrl+F3</td>
-    <td>Command+E</td>
-  </tr>
-  <tr>
-    <td>Replace and Find</td>
-    <td>Ctrl+Shift+J</td>
-    <td>Command+Shift+J</td>
-  </tr>
-  <tr>
-    <td>Find in Files</td>
-    <td>Ctrl+Shift+F</td>
-    <td>Command+Shift+F</td>
-  </tr>
-  <tr>
-    <td>Check Spelling</td>
-    <td>F7</td>
-    <td>F7</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Editing (Console and Source)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Undo</td>
-    <td>Ctrl+Z</td>
-    <td>Command+Z</td>
-  </tr>
-  <tr>
-    <td>Redo</td>
-    <td>Ctrl+Shift+Z</td>
-    <td>Command+Shift+Z</td>
-  </tr>
-  <tr>
-    <td>Cut</td>
-    <td>Ctrl+X</td>
-    <td>Command+X</td>
-  </tr>
-  <tr>
-    <td>Copy</td>
-    <td>Ctrl+C</td>
-    <td>Command+C</td>
-  </tr>
-  <tr>
-    <td>Paste</td>
-    <td>Ctrl+V</td>
-    <td>Command+V</td>
-  </tr>
-  <tr>
-    <td>Select All</td>
-    <td>Ctrl+A</td>
-    <td>Command+A</td>
-  </tr>
-  <tr>
-    <td>Jump to Word</td>
-    <td>Ctrl+Left/Right</td>
-    <td>Option+Left/Right</td>
-  </tr>
-  <tr>
-    <td>Jump to Start/End</td>
-    <td>Ctrl+Home/End or Ctrl+Up/Down</td>
-    <td>Command+Home/End or Command+Up/Down</td>
-  </tr>
-  <tr>
-    <td>Delete Line</td>
-    <td>Ctrl+D</td>
-    <td>Command+D</td>
-  </tr>
-  <tr>
-    <td>Select</td>
-    <td>Shift+[Arrow]</td>
-    <td>Shift+[Arrow]</td>
-  </tr>
-  <tr>
-    <td>Select Word</td>
-    <td>Ctrl+Shift+Left/Right</td>
-    <td>Option+Shift+Left/Right</td>
-  </tr>
-  <tr>
-    <td>Select to Line Start</td>
-    <td>Alt+Shift+Left</td>
-    <td>Command+Shift+Left</td>
-  </tr>
-  <tr>
-    <td>Select to Line End</td>
-    <td>Alt+Shift+Right</td>
-    <td>Command+Shift+Right</td>
-  </tr>
-  <tr>
-    <td>Select Page Up/Down</td>
-    <td>Shift+PageUp/PageDown</td>
-    <td>Shift+PageUp/Down</td>
-  </tr>
-  <tr>
-    <td>Select to Start/End</td>
-    <td>Ctrl+Shift+Home/End or Shift+Alt+Up/Down</td>
-    <td>Command+Shift+Up/Down</td>
-  </tr>
-  <tr>
-    <td>Delete Word Left</td>
-    <td>Ctrl+Backspace</td>
-    <td>Option+Backspace or Ctrl+Option+Backspace</td>
-  </tr>
-  <tr>
-    <td>Delete Word Right</td>
-    <td></td>
-    <td>Option+Delete</td>
-  </tr>
-  <tr>
-    <td>Delete to Line End</td>
-    <td></td>
-    <td>Ctrl+K</td>
-  </tr>
-  <tr>
-    <td>Delete to Line Start</td>
-    <td></td>
-    <td>Option+Backspace</td>
-  </tr>
-  <tr>
-    <td>Indent</td>
-    <td>Tab (at beginning of line)</td>
-    <td>Tab (at beginning of line)</td>
-  </tr>
-  <tr>
-    <td>Outdent</td>
-    <td>Shift+Tab</td>
-    <td>Shift+Tab</td>
-  </tr>
-  <tr>
-    <td>Yank line up to cursor</td>
-    <td>Ctrl+U</td>
-    <td>Ctrl+U</td>
-  </tr>
-  <tr>
-    <td>Yank line after cursor</td>
-    <td>Ctrl+K</td>
-    <td>Ctrl+K</td>
-  </tr>
-  <tr>
-    <td>Insert currently yanked text</td>
-    <td>Ctrl+Y</td>
-    <td>Ctrl+Y</td>
-  </tr>
-  <tr>
-    <td>Insert assignment operator</td>
-    <td>Alt+-</td>
-    <td>Option+-</td>
-  </tr>
-  <tr>
-    <td>Insert pipe operator</td>
-    <td>Ctrl+Shift+M</td>
-    <td>Cmd+Shift+M</td>
-  </tr>
-  <tr>
-    <td>Show help for function at cursor</td>
-    <td>F1</td>
-    <td>F1</td>
-  </tr>
-  <tr>
-    <td>Show source code for function at cursor</td>
-    <td>F2</td>
-    <td>F2</td>
-  </tr>
-  <tr>
-    <td>Find usages for symbol at cursor (C++)</td>
-    <td>Ctrl+Alt+U</td>
-    <td>Cmd+Option+U</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Completions (Console and Source)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Attempt completion</td>
-    <td>Tab or Ctrl+Space</td>
-    <td>Tab or Command+Space</td>
-  </tr>
-  <tr>
-    <td>Navigate candidates</td>
-    <td>Up/Down</td>
-    <td>Up/Down</td>
-  </tr>
-  <tr>
-    <td>Accept selected candidate</td>
-    <td>Enter, Tab, or Right</td>
-    <td>Enter, Tab, or Right</td>
-  </tr>
-  <tr>
-    <td>Dismiss completion popup</td>
-    <td>Esc</td>
-    <td>Esc</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Views</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Move focus to Source Editor</td>
-    <td>Ctrl+1</td>
-    <td>Ctrl+1</td>
-  </tr>
-  <tr>
-    <td>Move focus to Console</td>
-    <td>Ctrl+2</td>
-    <td>Ctrl+2</td>
-  </tr>
-  <tr>
-    <td>Move focus to Help</td>
-    <td>Ctrl+3</td>
-    <td>Ctrl+3</td>
-  </tr>
-  <tr>
-    <td>Show History</td>
-    <td>Ctrl+4</td>
-    <td>Ctrl+4</td>
-  </tr>
-  <tr>
-    <td>Show Files</td>
-    <td>Ctrl+5</td>
-    <td>Ctrl+5</td>
-  </tr>
-  <tr>
-    <td>Show Plots</td>
-    <td>Ctrl+6</td>
-    <td>Ctrl+6</td>
-  </tr>
-  <tr>
-    <td>Show Packages</td>
-    <td>Ctrl+7</td>
-    <td>Ctrl+7</td>
-  </tr>
-  <tr>
-    <td>Show Environment</td>
-    <td>Ctrl+8</td>
-    <td>Ctrl+8</td>
-  </tr>
-  <tr>
-    <td>Show Git/SVN</td>
-    <td>Ctrl+9</td>
-    <td>Ctrl+9</td>
-  </tr>
-  <tr>
-    <td>Show Build</td>
-    <td>Ctrl+0</td>
-    <td>Ctrl+0</td>
-  </tr>
-  <tr>
-    <td>Sync Editor &amp; PDF Preview</td>
-    <td>Ctrl+F8</td>
-    <td>Cmd+F8</td>
-  </tr>
-  <tr>
-    <td>Show Keyboard Shortcut Reference</td>
-    <td>Alt+Shift+K</td>
-    <td>Option+Shift+K</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  
-  <tr><td colspan="3"><h2>Build</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Install and Restart</td>
-    <td>Ctrl+Shift+B</td>
-    <td>Cmd+Shift+B</td>
-  </tr>
-  <tr>
-    <td>Load All (devtools)</td>
-    <td>Ctrl+Shift+L</td>
-    <td>Cmd+Shift+L</td>
-  </tr>
-  <tr>
-    <td>Test Package (Desktop)</td>
-    <td>Ctrl+Shift+T</td>
-    <td>Cmd+Shift+T</td>
-  </tr>
-  <tr>
-    <td>Test Package (Web)</td>
-    <td>Ctrl+Alt+F7</td>
-    <td>Cmd+Alt+F7</td>
-  </tr>
-  <tr>
-    <td>Check Package</td>
-    <td>Ctrl+Shift+E</td>
-    <td>Cmd+Shift+E</td>
-  </tr>
-  <tr>
-    <td>Document Package</td>
-    <td>Ctrl+Shift+D</td>
-    <td>Cmd+Shift+D</td>
-  </tr>
-  <tr><td><br/></td></tr>
-
-  <tr><td colspan="3"><h2>Debug</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-   <td>Toggle Breakpoint</td>
-   <td>Shift+F9</td>
-   <td>Shift+F9</td>
-  </tr>   
-  <tr>
-   <td>Execute Next Line</td>
-   <td>F10</td>
-   <td>F10</td>
-  </tr> 
-  <tr>
-   <td>Step Into Function</td>
-   <td>Shift+F4</td>
-   <td>Shift+F4</td>
-  </tr> 
-  <tr>
-   <td>Finish Function/Loop</td>
-   <td>Shift+F6</td>
-   <td>Shift+F6</td>
-  </tr>     
-  <tr>
-   <td>Continue</td>
-   <td>Shift+F5</td>
-   <td>Shift+F5</td>
-  </tr>   
-  <tr>
-   <td>Stop Debugging</td>
-   <td>Shift+F8</td>
-   <td>Shift+F8</td>
-  </tr>   
-  <tr><td><br/></td></tr>
-
-  <tr><td colspan="3"><h2>Plots</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Previous plot</td>
-    <td>Ctrl+Alt+F11</td>
-    <td>Command+Option+F11</td>
-  </tr>
-  <tr>
-    <td>Next plot</td>
-    <td>Ctrl+Alt+F12</td>
-    <td>Command+Option+F12</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Git/SVN</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Diff active source document</td>
-    <td>Ctrl+Alt+D</td>
-    <td>Ctrl+Option+D</td>
-  </tr>
-  <tr>
-    <td>Commit changes</td>
-    <td>Ctrl+Alt+M</td>
-    <td>Ctrl+Option+M</td>
-  </tr>
-  <tr>
-    <td>Scroll diff view</td>
-    <td>Ctrl+Up/Down</td>
-    <td>Ctrl+Up/Down</td>
-  </tr>
-  <tr>
-    <td>Stage/Unstage (Git)</td>
-    <td>Spacebar</td>
-    <td>Spacebar</td>
-  </tr>
-  <tr>
-    <td>Stage/Unstage and move to next (Git)</td>
-    <td>Enter</td>
-    <td>Enter</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Session</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>Quit Session (desktop only)</td>
-    <td>Ctrl+Q</td>
-    <td>Command+Q</td>
-  </tr>
-  <tr>
-    <td>Restart R Session</td>
-    <td>Ctrl+Shift+F10</td>
-    <td>Command+Shift+F10</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Terminal</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>New Terminal</td>
-    <td>Shift+Alt+T</td>
-    <td>Shift+Option+T</td>
-  </tr>
-  <tr>
-    <td>Rename Current Terminal</td>
-    <td>Shift+Alt+R</td>
-    <td>Shift+Option+R</td>
-  </tr>
-  <tr>
-    <td>Clear Current Terminal</td>
-    <td>Ctrl+Shift+L</td>
-    <td>Ctrl+Shift+L</td>
-  </tr>
-  <tr>
-    <td>Move Focus to Terminal</td>
-    <td>Ctrl+Shift+T</td>
-    <td>Ctrl+Shift+T</td>
-  </tr>
-  <tr>
-    <td>Previous Terminal</td>
-    <td>Shift+Alt+F11</td>
-    <td>Shift+Option+F11</td>
-  </tr>
-  <tr>
-    <td>Next Terminal</td>
-    <td>Shift+Alt+F12</td>
-    <td>Shift+Option+F12</td>
-  </tr>
-  <tr><td><br/></td></tr>
-  <tr><td colspan="3"><h2>Main Menu (Server)</h2></td></tr><tr><th>Description</th><th>Windows &amp; Linux</th><th>Mac</th></tr>
-  <tr>
-    <td>File Menu</td>
-    <td>Ctrl+Alt+F</td>
-    <td>Ctrl+Option+F</td>
-  </tr>
-  <tr>
-    <td>Edit Menu</td>
-    <td>Ctrl+Alt+I</td>
-    <td>Ctrl+Option+I</td>
-  </tr>
-  <tr>
-    <td>Code Menu</td>
-    <td>Ctrl+Alt+C</td>
-    <td>Ctrl+Option+C</td>
-  </tr>
-  <tr>
-    <td>View Menu</td>
-    <td>Ctrl+Alt+V</td>
-    <td>Ctrl+Option+V</td>
-  </tr>
-  <tr>
-    <td>Plots Menu</td>
-    <td>Ctrl+Alt+P</td>
-    <td>Ctrl+Option+P</td>
-  </tr>
-  <tr>
-    <td>Session Menu</td>
-    <td>Ctrl+Alt+S</td>
-    <td>Ctrl+Option+S</td>
-  </tr>
-  <tr>
-    <td>Build Menu</td>
-    <td>Ctrl+Alt+B</td>
-    <td>Ctrl+Option+B</td>
-  </tr>
-  <tr>
-    <td>Debug Menu</td>
-    <td>Ctrl+Alt+U</td>
-    <td>Ctrl+Option+U</td>
-  </tr>
-  <tr>
-    <td>Profile Menu</td>
-    <td>Ctrl+Alt+O</td>
-    <td>Ctrl+Option+O</td>
-  </tr>
-  <tr>
-    <td>Tools Menu</td>
-    <td>Ctrl+Alt+T</td>
-    <td>Ctrl+Option+T</td>
-  </tr>
-  <tr>
-    <td>Help Menu</td>
-    <td>Ctrl+Alt+H</td>
-    <td>Ctrl+Option+H</td>
-  </tr>
-  <tr><td><br/></td></tr>
-</table>
-</div></main>
-   
+  <h1>Keyboard Shortcuts</h1>
+  <h2 id="console">Console</h2>
+  <table aria-labelledby="console" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Move cursor to Console</td>
+      <td>Ctrl+2</td>
+      <td>&#8963;2</td>
+    </tr>
+    <tr>
+      <td>Clear console</td>
+      <td>Ctrl+L</td>
+      <td>&#8963;L</td>
+    </tr>
+    <tr>
+      <td>Move cursor to beginning of line</td>
+      <td>Home</td>
+      <td>&#8984;&#8592;</td>
+    </tr>
+    <tr>
+      <td>Move cursor to end of line</td>
+      <td>End</td>
+      <td>&#8984;&#8594;</td>
+    </tr>
+    <tr>
+      <td>Navigate command history</td>
+      <td>Up/Down</td>
+      <td>&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Popup command history</td>
+      <td>Ctrl+Up</td>
+      <td>&#8984;&#8593;</td>
+    </tr>
+    <tr>
+      <td>Interrupt currently executing command</td>
+      <td>Esc</td>
+      <td>&#9099;</td>
+    </tr>
+    <tr>
+      <td>Change working directory</td>
+      <td>Ctrl+Shift+H</td>
+      <td>&#8963;&#8679;H</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="source">Source</h2>
+  <table aria-labelledby="source" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Goto File/Function</td>
+      <td>Ctrl+.</td>
+      <td>&#8963;.</td>
+    </tr>
+    <tr>
+      <td>Move cursor to Source Editor</td>
+      <td>Ctrl+1</td>
+      <td>&#8963;1</td>
+    </tr>
+    <tr>
+      <td>New document (except on Chrome/Windows)</td>
+      <td>Ctrl+Shift+N</td>
+      <td>&#8984;&#8679;N</td>
+    </tr>
+    <tr>
+      <td>New document (Chrome only)</td>
+      <td>Ctrl+Alt+Shift+N</td>
+      <td>&#8984;&#8679;&#8997;N</td>
+    </tr>
+    <tr>
+      <td>Open document</td>
+      <td>Ctrl+O</td>
+      <td>&#8984;O</td>
+    </tr>
+    <tr>
+      <td>Save active document</td>
+      <td>Ctrl+S</td>
+      <td>&#8984;S</td>
+    </tr>
+    <tr>
+      <td>Close active document (except on Chrome)</td>
+      <td>Ctrl+W</td>
+      <td>&#8984;W</td>
+    </tr>
+    <tr>
+      <td>Close active document (Chrome only)</td>
+      <td>Ctrl+Alt+W</td>
+      <td>&#8984;&#8997;W</td>
+    </tr>
+    <tr>
+      <td>Close all open documents</td>
+      <td>Ctrl+Shift+W</td>
+      <td>&#8984;&#8679;W</td>
+    </tr>
+    <tr>
+      <td>Preview HTML (Markdown and HTML)</td>
+      <td>Ctrl+Shift+K</td>
+      <td>&#8984;&#8679;K</td>
+    </tr>
+    <tr>
+      <td>Knit Document (knitr)</td>
+      <td>Ctrl+Shift+K</td>
+      <td>&#8984;&#8679;K</td>
+    </tr>
+    <tr>
+      <td>Compile Notebook</td>
+      <td>Ctrl+Shift+K</td>
+      <td>&#8984;&#8679;K</td>
+    </tr>
+    <tr>
+      <td>Compile PDF (TeX and Sweave)</td>
+      <td>Ctrl+Shift+K</td>
+      <td>&#8984;&#8679;K</td>
+    </tr>
+    <tr>
+      <td>Insert chunk (Sweave and Knitr)</td>
+      <td>Ctrl+Alt+I</td>
+      <td>&#8984;&#8997;I</td>
+    </tr>
+    <tr>
+      <td>Insert code section</td>
+      <td>Ctrl+Shift+R</td>
+      <td>&#8984;&#8679;R</td>
+    </tr>
+    <tr>
+      <td>Run current line/selection</td>
+      <td>Ctrl+Enter</td>
+      <td>&#8984;&#8617;</td>
+    </tr>
+    <tr>
+      <td>Run current line/selection (retain cursor position)</td>
+      <td>Alt+Enter</td>
+      <td>&#8997;&#8617;</td>
+    </tr>
+    <tr>
+      <td>Re-run previous region</td>
+      <td>Ctrl+Shift+P</td>
+      <td>&#8984;&#8679;P</td>
+    </tr>
+    <tr>
+      <td>Run current document</td>
+      <td>Ctrl+Alt+R</td>
+      <td>&#8984;&#8997;R</td>
+    </tr>
+    <tr>
+      <td>Run from document beginning to current line</td>
+      <td>Ctrl+Alt+B</td>
+      <td>&#8984;&#8997;B</td>
+    </tr>
+    <tr>
+      <td>Run from current line to document end</td>
+      <td>Ctrl+Alt+E</td>
+      <td>&#8984;&#8997;E</td>
+    </tr>
+    <tr>
+      <td>Run the current function definition</td>
+      <td>Ctrl+Alt+F</td>
+      <td>&#8984;&#8997;F</td>
+    </tr>
+    <tr>
+      <td>Run the current code section</td>
+      <td>Ctrl+Alt+T</td>
+      <td>&#8984;&#8997;T</td>
+    </tr>
+    <tr>
+      <td>Run previous Sweave/Rmd code</td>
+      <td>Ctrl+Alt+P</td>
+      <td>&#8984;&#8997;P</td>
+    </tr>
+    <tr>
+      <td>Run the current Sweave/Rmd chunk</td>
+      <td>Ctrl+Alt+C</td>
+      <td>&#8984;&#8997;C</td>
+    </tr>
+    <tr>
+      <td>Run the next Sweave/Rmd chunk</td>
+      <td>Ctrl+Alt+N</td>
+      <td>&#8984;&#8997;N</td>
+    </tr>
+    <tr>
+      <td>Source a file</td>
+      <td>Ctrl+Shift+O</td>
+      <td>&#8984;&#8679;O</td>
+    </tr>
+    <tr>
+      <td>Source the current document</td>
+      <td>Ctrl+Shift+S</td>
+      <td>&#8984;&#8679;S</td>
+    </tr>
+    <tr>
+      <td>Source the current document (with echo)</td>
+      <td>Ctrl+Shift+Enter</td>
+      <td>&#8984;&#8679;&#8617;</td>
+    </tr>
+    <tr>
+      <td>Fold Selected</td>
+      <td>Alt+L</td>
+      <td>&#8984;&#8997;L</td>
+    </tr>
+    <tr>
+      <td>Unfold Selected</td>
+      <td>Shift+Alt+L</td>
+      <td>&#8984;&#8679;&#8997;L</td>
+    </tr>
+    <tr>
+      <td>Fold All</td>
+      <td>Alt+O</td>
+      <td>&#8984;&#8997;O</td>
+    </tr>
+    <tr>
+      <td>Unfold All</td>
+      <td>Shift+Alt+O</td>
+      <td>&#8984;&#8679;&#8997;O</td>
+    </tr>
+    <tr>
+      <td>Go to line</td>
+      <td>Shift+Alt+G</td>
+      <td>&#8984;&#8679;&#8997;G</td>
+    </tr>
+    <tr>
+      <td>Jump to</td>
+      <td>Shift+Alt+J</td>
+      <td>&#8984;&#8679;&#8997;J</td>
+    </tr>
+    <tr>
+      <td>Switch to tab</td>
+      <td>Ctrl+Shift+.</td>
+      <td>&#8963;&#8679;.</td>
+    </tr>
+    <tr>
+      <td>Previous tab</td>
+      <td>Ctrl+F11</td>
+      <td>&#8963;F11</td>
+    </tr>
+    <tr>
+      <td>Next tab</td>
+      <td>Ctrl+F12</td>
+      <td>&#8963;F12</td>
+    </tr>
+    <tr>
+      <td>First tab</td>
+      <td>Ctrl+Shift+F11</td>
+      <td>&#8963;&#8679;F11</td>
+    </tr>
+    <tr>
+      <td>Last tab</td>
+      <td>Ctrl+Shift+F12</td>
+      <td>&#8963;&#8679;F12</td>
+    </tr>
+    <tr>
+      <td>Navigate back</td>
+      <td>Ctrl+F9</td>
+      <td>&#8984;F9</td>
+    </tr>
+    <tr>
+      <td>Navigate forward</td>
+      <td>Ctrl+F10</td>
+      <td>&#8984;F10</td>
+    </tr>
+    <tr>
+      <td>Extract function from selection</td>
+      <td>Ctrl+Alt+X</td>
+      <td>&#8984;&#8997;X</td>
+    </tr>
+    <tr>
+      <td>Extract variable from selection</td>
+      <td>Ctrl+Alt+V</td>
+      <td>&#8984;&#8997;V</td>
+    </tr>
+    <tr>
+      <td>Reindent lines</td>
+      <td>Ctrl+I</td>
+      <td>&#8984;I</td>
+    </tr>
+    <tr>
+      <td>Comment/uncomment current line/selection</td>
+      <td>Ctrl+Shift+C</td>
+      <td>&#8984;&#8679;C</td>
+    </tr>
+    <tr>
+      <td>Reflow Comment</td>
+      <td>Ctrl+Shift+/</td>
+      <td>&#8984;&#8679;/</td>
+    </tr>
+    <tr>
+      <td>Reformat Selection</td>
+      <td>Ctrl+Shift+A</td>
+      <td>&#8984;&#8679;A</td>
+    </tr>
+    <tr>
+      <td>Show Diagnostics</td>
+      <td>Ctrl+Shift+Alt+P</td>
+      <td>&#8984;&#8679;&#8997;P</td>
+    </tr>
+    <tr>
+      <td>Transpose Letters</td>
+      <td>No shortcut</td>
+      <td>&#8963;T</td>
+    </tr>
+    <tr>
+      <td>Move Lines Up/Down</td>
+      <td>Alt+Up/Down</td>
+      <td>&#8997;&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Copy Lines Up/Down</td>
+      <td>Shift+Alt+Up/Down</td>
+      <td>&#8984;&#8997;&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Jump to Matching Brace/Paren</td>
+      <td>Ctrl+P</td>
+      <td>&#8963;P</td>
+    </tr>
+    <tr>
+      <td>Expand to Matching Brace/Paren</td>
+      <td>Ctrl+Shift+E</td>
+      <td>&#8963;&#8679;E</td>
+    </tr>
+    <tr>
+      <td>Select to Matching Brace/Paren</td>
+      <td>Ctrl+Shift+Alt+E</td>
+      <td>&#8963;&#8679;&#8997;E</td>
+    </tr>
+    <tr>
+      <td>Add Cursor Above Current Cursor</td>
+      <td>Ctrl+Alt+Up</td>
+      <td>&#8963;&#8997;&#8593;</td>
+    </tr>
+    <tr>
+      <td>Add Cursor Below Current Cursor</td>
+      <td>Ctrl+Alt+Down</td>
+      <td>&#8963;&#8997;&#8595;</td>
+    </tr>
+    <tr>
+      <td>Move Active Cursor Up</td>
+      <td>Ctrl+Alt+Shift+Up</td>
+      <td>+&#8997;&#8679;&#8593;</td>
+    </tr>
+    <tr>
+      <td>Move Active Cursor Down</td>
+      <td>Ctrl+Alt+Shift+Down</td>
+      <td>&#8963;&#8997;&#8679;&#8595;</td>
+    </tr>
+    <tr>
+      <td>Find and Replace</td>
+      <td>Ctrl+F</td>
+      <td>&#8984;F</td>
+    </tr>
+    <tr>
+      <td>Find Next</td>
+      <td>Win: F3, Linux: Ctrl+G</td>
+      <td>&#8984;G</td>
+    </tr>
+    <tr>
+      <td>Find Previous</td>
+      <td>Win: Shift+F3, Linux: Ctrl+Shift+G</td>
+      <td>&#8984;&#8679;G</td>
+    </tr>
+    <tr>
+      <td>Use Selection for Find</td>
+      <td>Ctrl+F3</td>
+      <td>&#8984;E</td>
+    </tr>
+    <tr>
+      <td>Replace and Find</td>
+      <td>Ctrl+Shift+J</td>
+      <td>&#8984;&#8679;J</td>
+    </tr>
+    <tr>
+      <td>Find in Files</td>
+      <td>Ctrl+Shift+F</td>
+      <td>&#8984;&#8679;F</td>
+    </tr>
+    <tr>
+      <td>Check Spelling</td>
+      <td>F7</td>
+      <td>F7</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="editing">Editing (Console and Source)</h2>
+  <table aria-labelledby="editing" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Undo</td>
+      <td>Ctrl+Z</td>
+      <td>&#8984;Z</td>
+    </tr>
+    <tr>
+      <td>Redo</td>
+      <td>Ctrl+Shift+Z</td>
+      <td>&#8984;&#8679;Z</td>
+    </tr>
+    <tr>
+      <td>Cut</td>
+      <td>Ctrl+X</td>
+      <td>&#8984;X</td>
+    </tr>
+    <tr>
+      <td>Copy</td>
+      <td>Ctrl+C</td>
+      <td>&#8984;C</td>
+    </tr>
+    <tr>
+      <td>Paste</td>
+      <td>Ctrl+V</td>
+      <td>&#8984;V</td>
+    </tr>
+    <tr>
+      <td>Select All</td>
+      <td>Ctrl+A</td>
+      <td>&#8984;A</td>
+    </tr>
+    <tr>
+      <td>Jump to Word</td>
+      <td>Ctrl+Left/Right</td>
+      <td>&#8997;&#8592; or &#8594;</td>
+    </tr>
+    <tr>
+      <td>Jump to Start/End</td>
+      <td>Ctrl+Home/End or Ctrl+Up/Down</td>
+      <td>&#8984;&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Delete Line</td>
+      <td>Ctrl+D</td>
+      <td>&#8984;D</td>
+    </tr>
+    <tr>
+      <td>Select</td>
+      <td>Shift+[Arrow]</td>
+      <td>&#8679;[Arrow]</td>
+    </tr>
+    <tr>
+      <td>Select Word</td>
+      <td>Ctrl+Shift+Left/Right</td>
+      <td>&#8997;&#8679;&#8592; or &#8594;</td>
+    </tr>
+    <tr>
+      <td>Select to Line Start</td>
+      <td>Alt+Shift+Left</td>
+      <td>&#8984;&#8679;&#8592;</td>
+    </tr>
+    <tr>
+      <td>Select to Line End</td>
+      <td>Alt+Shift+Right</td>
+      <td>&#8984;&#8679;&#8594;</td>
+    </tr>
+    <tr>
+      <td>Select Page Up/Down</td>
+      <td>Shift+PageUp/PageDown</td>
+      <td>&#8679;&#8670; or &#8671;</td>
+    </tr>
+    <tr>
+      <td>Select to Start/End</td>
+      <td>Ctrl+Shift+Home/End or Shift+Alt+Up/Down</td>
+      <td>&#8984;&#8679;&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Delete Word Left</td>
+      <td>Ctrl+Backspace</td>
+      <td>&#8997;&#9003; or &#8963;&#8997;&#9003;</td>
+    </tr>
+    <tr>
+      <td>Delete Word Right</td>
+      <td>No shortcut</td>
+      <td>&#8997;&#8998;</td>
+    </tr>
+    <tr>
+      <td>Delete to Line End</td>
+      <td>No shortcut</td>
+      <td>&#8963;K</td>
+    </tr>
+    <tr>
+      <td>Delete to Line Start</td>
+      <td>No shortcut</td>
+      <td>&#8997;&#9003;</td>
+    </tr>
+    <tr>
+      <td>Indent</td>
+      <td>Tab (at beginning of line)</td>
+      <td>&#8677; (at beginning of line)</td>
+    </tr>
+    <tr>
+      <td>Outdent</td>
+      <td>Shift+Tab</td>
+      <td>&#8679;&#8677;</td>
+    </tr>
+    <tr>
+      <td>Yank line up to cursor</td>
+      <td>Ctrl+U</td>
+      <td>&#8963;U</td>
+    </tr>
+    <tr>
+      <td>Yank line after cursor</td>
+      <td>Ctrl+K</td>
+      <td>&#8963;K</td>
+    </tr>
+    <tr>
+      <td>Insert currently yanked text</td>
+      <td>Ctrl+Y</td>
+      <td>&#8963;Y</td>
+    </tr>
+    <tr>
+      <td>Insert assignment operator</td>
+      <td>Alt+-</td>
+      <td>&#8997;-</td>
+    </tr>
+    <tr>
+      <td>Insert pipe operator</td>
+      <td>Ctrl+Shift+M</td>
+      <td>&#8984;&#8679;M</td>
+    </tr>
+    <tr>
+      <td>Show help for function at cursor</td>
+      <td>F1</td>
+      <td>F1</td>
+    </tr>
+    <tr>
+      <td>Show source code for function at cursor</td>
+      <td>F2</td>
+      <td>F2</td>
+    </tr>
+    <tr>
+      <td>Find usages for symbol at cursor (C++)</td>
+      <td>Ctrl+Alt+U</td>
+      <td>&#8984;&#8997;U</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="completions">Completions (Console and Source)</h2>
+  <table aria-labelledby="completions" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Attempt completion</td>
+      <td>Tab or Ctrl+Space</td>
+      <td>&#8677; or &#8984;Space</td>
+    </tr>
+    <tr>
+      <td>Navigate candidates</td>
+      <td>Up/Down</td>
+      <td>&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Accept selected candidate</td>
+      <td>Enter, Tab, or Right</td>
+      <td>&#8617;, &#8677;, or &#8594;</td>
+    </tr>
+    <tr>
+      <td>Dismiss completion popup</td>
+      <td>Esc</td>
+      <td>&#9099;</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="views">Views</h2>
+  <table aria-labelledby="views" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Move focus to Source Editor</td>
+      <td>Ctrl+1</td>
+      <td>&#8963;1</td>
+    </tr>
+    <tr>
+      <td>Move focus to Console</td>
+      <td>Ctrl+2</td>
+      <td>&#8963;2</td>
+    </tr>
+    <tr>
+      <td>Move focus to Help</td>
+      <td>Ctrl+3</td>
+      <td>&#8963;3</td>
+    </tr>
+    <tr>
+      <td>Show History</td>
+      <td>Ctrl+4</td>
+      <td>&#8963;4</td>
+    </tr>
+    <tr>
+      <td>Show Files</td>
+      <td>Ctrl+5</td>
+      <td>&#8963;5</td>
+    </tr>
+    <tr>
+      <td>Show Plots</td>
+      <td>Ctrl+6</td>
+      <td>&#8963;6</td>
+    </tr>
+    <tr>
+      <td>Show Packages</td>
+      <td>Ctrl+7</td>
+      <td>&#8963;7</td>
+    </tr>
+    <tr>
+      <td>Show Environment</td>
+      <td>Ctrl+8</td>
+      <td>&#8963;8</td>
+    </tr>
+    <tr>
+      <td>Show Git/SVN</td>
+      <td>Ctrl+9</td>
+      <td>&#8963;9</td>
+    </tr>
+    <tr>
+      <td>Show Build</td>
+      <td>Ctrl+0</td>
+      <td>&#8963;0</td>
+    </tr>
+    <tr>
+      <td>Sync Editor &amp; PDF Preview</td>
+      <td>Ctrl+F8</td>
+      <td>&#8984;F8</td>
+    </tr>
+    <tr>
+      <td>Show Keyboard Shortcut Reference</td>
+      <td>Alt+Shift+K</td>
+      <td>&#8997;&#8679;K</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="build">Build</h2>
+  <table aria-labelledby="build" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Install and Restart</td>
+      <td>Ctrl+Shift+B</td>
+      <td>&#8984;&#8679;B</td>
+    </tr>
+    <tr>
+      <td>Load All (devtools)</td>
+      <td>Ctrl+Shift+L</td>
+      <td>&#8984;&#8679;L</td>
+    </tr>
+    <tr>
+      <td>Test Package (Desktop)</td>
+      <td>Ctrl+Shift+T</td>
+      <td>&#8984;&#8679;T</td>
+    </tr>
+    <tr>
+      <td>Test Package (Web)</td>
+      <td>Ctrl+Alt+F7</td>
+      <td>&#8984;&#8997;F7</td>
+    </tr>
+    <tr>
+      <td>Check Package</td>
+      <td>Ctrl+Shift+E</td>
+      <td>&#8984;&#8679;E</td>
+    </tr>
+    <tr>
+      <td>Document Package</td>
+      <td>Ctrl+Shift+D</td>
+      <td>&#8984;&#8679;D</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="debug">Debug</h2>
+  <table aria-labelledby="debug" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Toggle Breakpoint</td>
+      <td>Shift+F9</td>
+      <td>&#8679;F9</td>
+    </tr>
+    <tr>
+      <td>Execute Next Line</td>
+      <td>F10</td>
+      <td>F10</td>
+    </tr>
+    <tr>
+      <td>Step Into Function</td>
+      <td>Shift+F4</td>
+      <td>&#8679;F4</td>
+    </tr>
+    <tr>
+      <td>Finish Function/Loop</td>
+      <td>Shift+F6</td>
+      <td>&#8679;F6</td>
+    </tr>
+    <tr>
+      <td>Continue</td>
+      <td>Shift+F5</td>
+      <td>&#8679;F5</td>
+    </tr>
+    <tr>
+      <td>Stop Debugging</td>
+      <td>Shift+F8</td>
+      <td>&#8679;F8</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="plots">Plots</h2>
+  <table aria-labelledby="plots" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Previous plot</td>
+      <td>Ctrl+Alt+F11</td>
+      <td>&#8984;&#8997;F11</td>
+    </tr>
+    <tr>
+      <td>Next plot</td>
+      <td>Ctrl+Alt+F12</td>
+      <td>&#8984;&#8997;F12</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="git">Git/SVN</h2>
+  <table aria-labelledby="git" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Diff active source document</td>
+      <td>Ctrl+Alt+D</td>
+      <td>&#8963;&#8997;D</td>
+    </tr>
+    <tr>
+      <td>Commit changes</td>
+      <td>Ctrl+Alt+M</td>
+      <td>&#8963;&#8997;M</td>
+    </tr>
+    <tr>
+      <td>Scroll diff view</td>
+      <td>Ctrl+Up/Down</td>
+      <td>&#8963;&#8593; or &#8595;</td>
+    </tr>
+    <tr>
+      <td>Stage/Unstage (Git)</td>
+      <td>Spacebar</td>
+      <td>Spacebar</td>
+    </tr>
+    <tr>
+      <td>Stage/Unstage and move to next (Git)</td>
+      <td>Enter</td>
+      <td>&#8617;</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="session">Session</h2>
+  <table aria-labelledby="session" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Quit Session (desktop only)</td>
+      <td>Ctrl+Q</td>
+      <td>&#8984;Q</td>
+    </tr>
+    <tr>
+      <td>Restart R Session</td>
+      <td>Ctrl+Shift+F10</td>
+      <td>&#8984;&#8679;F10</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="terminal">Terminal</h2>
+  <table aria-labelledby="terminal" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>New Terminal</td>
+      <td>Shift+Alt+T</td>
+      <td>&#8679;&#8997;T</td>
+    </tr>
+    <tr>
+      <td>Rename Current Terminal</td>
+      <td>Shift+Alt+R</td>
+      <td>&#8679;&#8997;R</td>
+    </tr>
+    <tr>
+      <td>Clear Current Terminal</td>
+      <td>Ctrl+Shift+L</td>
+      <td>&#8963;&#8679;L</td>
+    </tr>
+    <tr>
+      <td>Move Focus to Terminal</td>
+      <td>Ctrl+Shift+T</td>
+      <td>&#8963;&#8679;T</td>
+    </tr>
+    <tr>
+      <td>Previous Terminal</td>
+      <td>Shift+Alt+F11</td>
+      <td>&#8679;&#8997;F11</td>
+    </tr>
+    <tr>
+      <td>Next Terminal</td>
+      <td>Shift+Alt+F12</td>
+      <td>&#8679;&#8997;F12</td>
+    </tr>
+    </tbody>
+  </table>
+  <h2 id="mainmenu">Main Menu (Server)</h2>
+  <table aria-labelledby="mainmenu" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>File Menu</td>
+      <td>Ctrl+Alt+F</td>
+      <td>&#8963;&#8997;F</td>
+    </tr>
+    <tr>
+      <td>Edit Menu</td>
+      <td>Ctrl+Alt+I</td>
+      <td>&#8963;&#8997;I</td>
+    </tr>
+    <tr>
+      <td>Code Menu</td>
+      <td>Ctrl+Alt+C</td>
+      <td>&#8963;&#8997;C</td>
+    </tr>
+    <tr>
+      <td>View Menu</td>
+      <td>Ctrl+Alt+V</td>
+      <td>&#8963;&#8997;V</td>
+    </tr>
+    <tr>
+      <td>Plots Menu</td>
+      <td>Ctrl+Alt+P</td>
+      <td>&#8963;&#8997;P</td>
+    </tr>
+    <tr>
+      <td>Session Menu</td>
+      <td>Ctrl+Alt+S</td>
+      <td>&#8963;&#8997;S</td>
+    </tr>
+    <tr>
+      <td>Build Menu</td>
+      <td>Ctrl+Alt+B</td>
+      <td>&#8963;&#8997;B</td>
+    </tr>
+    <tr>
+      <td>Debug Menu</td>
+      <td>Ctrl+Alt+U</td>
+      <td>&#8963;&#8997;U</td>
+    </tr>
+    <tr>
+      <td>Profile Menu</td>
+      <td>Ctrl+Alt+O</td>
+      <td>&#8963;&#8997;O</td>
+    </tr>
+    <tr>
+      <td>Tools Menu</td>
+      <td>Ctrl+Alt+T</td>
+      <td>&#8963;&#8997;T</td>
+    </tr>
+    <tr>
+      <td>Help Menu</td>
+      <td>Ctrl+Alt+H</td>
+      <td>&#8963;&#8997;H</td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+</main>
 </body>
 </html>


### PR DESCRIPTION
This static, manually edited page (see #6117) is not very accessible to screen readers. Plan is to expose this page to screen reader users via #6118. Mostly mechanical and lots of search and replace. Still need to check for changes to shortcuts in 1.3, will do that separately.

Sorry, didn't notice editor had reindented the HTML until I had done all the work. Makes very difficult to review, but I have tested the resulting page with all browsers we care about, validated the HTML (strictly compliant), and re-ran accessibility tests (100% passing).

Details:

- use separate tables (with headings) for each section, instead of one table with headings inside the table
- allows screen readers to see individually named tables
- properly associate headings with columns so screen readers can announce
- switch Mac shortcuts to use Mac Unicode characters (these are supported by VoiceOver on Mac, and we use them on our automatically generated shortcuts overlay)

<img width="756" alt="screenshot of first page of keyboards shortcut page" src="https://user-images.githubusercontent.com/10569626/73422891-46221380-42df-11ea-9ed4-d33160ea816c.png">
