### PR TITLE
Show accessible keyboard shortcut help when screenreader enabled

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutViewer.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutViewer.java
@@ -1,7 +1,7 @@
 /*
  * ShortcutViewer.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,9 +16,13 @@
 package org.rstudio.core.client.command;
 
 
+import com.google.inject.Provider;
 import org.rstudio.core.client.widget.ShortcutInfoPanel;
 import org.rstudio.core.client.widget.VimKeyInfoPanel;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
+import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
@@ -34,6 +38,7 @@ import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 @Singleton
 public class ShortcutViewer implements NativePreviewHandler
@@ -44,10 +49,13 @@ public class ShortcutViewer implements NativePreviewHandler
    public ShortcutViewer(
          Binder binder,
          Commands commands,
+         Provider<UserPrefs> pPrefs,
+         Provider<AriaLiveService> pAriaLive,
          GlobalDisplay globalDisplay)
    {
       binder.bind(commands, this);
-      
+      pPrefs_ = pPrefs;
+      pAriaLive_ = pAriaLive;
       globalDisplay_ = globalDisplay;
    }
    
@@ -59,17 +67,19 @@ public class ShortcutViewer implements NativePreviewHandler
       {
          return;
       }
-      showShortcutInfoPanel(new ShortcutInfoPanel(new Command()
+
+      Command showAllShortcutsPage = ()->
       {
-         @Override
-         public void execute()
-         {
-            if (Desktop.hasDesktopFrame())
-               Desktop.getFrame().showKeyboardShortcutHelp();
-            else 
-               openApplicationURL("docs/keyboard.htm");
-         }
-      }));
+         if (Desktop.hasDesktopFrame())
+            Desktop.getFrame().showKeyboardShortcutHelp();
+         else
+            openApplicationURL("docs/keyboard.htm");
+      };
+
+      if (pPrefs_.get().getScreenReaderEnabled())
+         showAllShortcutsPage.execute();
+      else
+         showShortcutInfoPanel(new ShortcutInfoPanel(showAllShortcutsPage));
    }
    
    public void showVimKeyboardShortcuts()
@@ -78,6 +88,13 @@ public class ShortcutViewer implements NativePreviewHandler
       if (shortcutInfo_ != null)
       {
          return;
+      }
+      if (pPrefs_.get().getScreenReaderEnabled())
+      {
+         pAriaLive_.get().announce(AriaLiveService.INACCESSIBLE_FEATURE,
+               "Vim keyboard shortcut help not screen reader accessible. Press any key to close.",
+               Timing.IMMEDIATE,
+               Severity.ALERT);
       }
       showShortcutInfoPanel(new VimKeyInfoPanel());
    }
@@ -135,5 +152,9 @@ public class ShortcutViewer implements NativePreviewHandler
    
    private ShortcutInfoPanel shortcutInfo_ = null;
    private HandlerRegistration preview_;
-   private GlobalDisplay globalDisplay_;
+
+   // injected
+   private final Provider<UserPrefs> pPrefs_;
+   private final Provider<AriaLiveService> pAriaLive_;
+   private final GlobalDisplay globalDisplay_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -39,6 +39,7 @@ public class AriaLiveService
    public static final String CONSOLE_LOG = "console_log";
    public static final String FILTERED_LIST = "filtered_list";
    public static final String GIT_MESSAGE_LENGTH = "git_message_length";
+   public static final String INACCESSIBLE_FEATURE = "inaccessible_feature";
    public static final String INFO_BAR = "info_bar";
    public static final String PROGRESS_COMPLETION = "progress_completion";
    public static final String PROGRESS_LOG = "progress_log";
@@ -66,6 +67,7 @@ public class AriaLiveService
       announcements_.put(CONSOLE_LOG, "Console output (requires restart)");
       announcements_.put(FILTERED_LIST, "Filtered result count");
       announcements_.put(GIT_MESSAGE_LENGTH, "Commit message length");
+      announcements_.put(INACCESSIBLE_FEATURE, "Inaccessible feature warning");
       announcements_.put(INFO_BAR, "Info bars");
       announcements_.put(PROGRESS_COMPLETION, "Task completion");
       announcements_.put(PROGRESS_LOG, "Task progress details");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -281,8 +281,9 @@ public class UserPrefs extends UserPrefsComputed
          {
             Timers.singleShot(AriaLiveService.STARTUP_ANNOUNCEMENT_DELAY, () ->
             {
+               String shortcut = commands_.toggleScreenReaderSupport().getShortcutRaw();
                ariaLive_.announce(AriaLiveService.SCREEN_READER_NOT_ENABLED,
-                     "Warning: screen reader mode not enabled. Turn on using shortcut Ctrl+Shift+Forward Slash.",
+                     "Warning: screen reader mode not enabled. Turn on using shortcut " + shortcut + ".",
                      Timing.IMMEDIATE, Severity.ALERT);
             });
          }


### PR DESCRIPTION
- Fixes #6118
- Also emit an announcement if user brings up the Vim help pane (:help in editor) warning it isn't screen reader accessible (see #6123)
- Noticed that keyboard shortcut read to help enable screen reader was hardcoded and already wrong (I changed it yesterday) so get the actual shortcut at runtime
- Not impossible to make the ShortcutViewer panel accessible, but not trivial, either; needs to do the things a modal dialog does (make rest of UI inert, provide a way to close with keyboard and mouse that isn't simply "click anywhere, type anything", then ensure the content of the panel is reasonably accessible)