### PR TITLE
tweaks to keyboard shortcuts page

### DIFF
--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -53,6 +53,34 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
 <header id="banner"><img src="../images/rstudio.png" alt/></header>
 <main><div style="margin-left: 20px; margin-right: 20px">
   <h1>Keyboard Shortcuts</h1>
+  <h2 id="a11y">Accessibility</h2>
+  <table aria-labelledby="a11y" class="shortcuts">
+    <thead>
+    <tr><th scope="col">Description</th><th scope="col">Windows &amp; Linux</th><th scope="col">Mac</th></tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td>Toggle Screen Reader Support</td>
+      <td>Ctrl+Alt+Shift+/</td>
+      <td>⌃⌥⇧/</td>
+    </tr>
+    <tr>
+      <td>Toggle Tab Key Always Moves Focus</td>
+      <td>Ctrl+Alt+Shift+T</td>
+      <td>⌃⌥⇧T</td>
+    </tr>
+    <tr>
+      <td>Speak Text Editor Location</td>
+      <td>Ctrl+Alt+Shift+B</td>
+      <td>⌃⌥⇧B</td>
+    </tr>
+    <tr>
+      <td>Focus Main Toolbar</td>
+      <td>Ctrl+Alt+L</td>
+      <td>⌃⌥L</td>
+    </tr>
+    </tbody>
+  </table>
   <h2 id="console">Console</h2>
   <table aria-labelledby="console" class="shortcuts">
     <thead>
@@ -180,7 +208,7 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
     <tr>
       <td>Insert code section</td>
       <td>Ctrl+Shift+R</td>
-      <td>⇧⌘R</td>
+      <td>⇧⌘R or ⌃⇧R</td>
     </tr>
     <tr>
       <td>Run current line/selection</td>
@@ -340,7 +368,7 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
     <tr>
       <td>Reflow Comment</td>
       <td>Ctrl+Shift+/</td>
-      <td>⇧⌘/</td>
+      <td>⌃⇧/</td>
     </tr>
     <tr>
       <td>Reformat Selection</td>
@@ -348,9 +376,9 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
       <td>⇧⌘A</td>
     </tr>
     <tr>
-      <td>Show Diagnostics</td>
-      <td>Ctrl+Shift+Alt+P</td>
-      <td>⌥⇧⌘P</td>
+      <td>Show Diagnostics for Current Project</td>
+      <td>Ctrl+Shift+Alt+D</td>
+      <td>⌥⇧⌘D</td>
     </tr>
     <tr>
       <td>Transpose Letters</td>
@@ -436,6 +464,16 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
       <td>Check Spelling</td>
       <td>F7</td>
       <td>F7</td>
+    </tr>
+    <tr>
+      <td>Rename Symbol in Scope</td>
+      <td>Ctrl+Alt+Shift+M</td>
+      <td>⌥⇧⌘M</td>
+    </tr>
+    <tr>
+      <td>Insert Roxygen Skeleton</td>
+      <td>Ctrl+Shift+Alt+R</td>
+      <td>⌥⇧⌘R</td>
     </tr>
     </tbody>
   </table>
@@ -642,6 +680,11 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
       <td>⌃3</td>
     </tr>
     <tr>
+      <td>Move Focus to Terminal</td>
+      <td>Ctrl+Shift+T</td>
+      <td>⌃⇧T</td>
+    </tr>
+    <tr>
       <td>Show History</td>
       <td>Ctrl+4</td>
       <td>⌃4</td>
@@ -667,14 +710,24 @@ Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
       <td>⌃8</td>
     </tr>
     <tr>
-      <td>Show Git/SVN</td>
+      <td>Show Viewer</td>
       <td>Ctrl+9</td>
       <td>⌃9</td>
     </tr>
     <tr>
       <td>Show Build</td>
-      <td>Ctrl+0</td>
-      <td>⌃0</td>
+      <td>Ctrl+F2</td>
+      <td>⌃F2</td>
+    </tr>
+    <tr>
+      <td>Show Connections</td>
+      <td>Ctrl+F5</td>
+      <td>⌃F5</td>
+    </tr>
+    <tr>
+      <td>Show Find in Files</td>
+      <td>Ctrl+F6</td>
+      <td>⌃F6</td>
     </tr>
     <tr>
       <td>Sync Editor &amp; PDF Preview</td>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
   <title>RStudio: Keyboard Shortcuts</title>
   <link rel="stylesheet" href="../rstudio.css" type="text/css"/>
 
@@ -26,22 +27,26 @@
   </style>
 </head>
 <!--
-For Mac, no plus sign between keys, and use following characters:
-  Left        &#8592;
-  Up          &#8593;
-  Right       &#8594;
-  Down        &#8595;
-  Enter       &#8617;
-  PgUp        &#8670;
-  PgDn        &#8671;
-  Tab         &#8677;
-  Shift       &#8679;
-  Ctrl        &#8963;
-  Meta/Cmd    &#8984;
-  Alt/Option  &#8997;
-  Delete      &#8998;
-  Backspace   &#9003;
-  Esc         &#9099;
+For Mac, no plus sign between keys, and use following characters. Use actual UTF-8 characters,
+no need to use the &#xxxx; sequences shown here for reference. Be sure to use ⌃ for Ctrl, NOT a 
+caret character (^) or it will be misread by screen readers.
+
+Standard listing order for Mac modifiers is Ctrl Option Shift Command whatever.
+
+  ←    Left        &#8592;
+  ↑    Up          &#8593;
+  →    Right       &#8594;
+  ↓    Down        &#8595;
+  ⇞    PgUp        &#8670;
+  ⇟    PgDn        &#8671;
+  ⇥    Tab         &#8677;
+  ⇧    Shift       &#8679;
+  ⌃    Ctrl        &#8963;
+  ⌘    Meta/Cmd    &#8984;
+  ⌥    Alt/Option  &#8997;
+  ⌦    Delete      &#8998;
+  ⌫    Backspace   &#9003;
+  ⎋    Esc         &#9099;
 
 -->
 <body>
@@ -57,42 +62,42 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Move cursor to Console</td>
       <td>Ctrl+2</td>
-      <td>&#8963;2</td>
+      <td>⌃2</td>
     </tr>
     <tr>
       <td>Clear console</td>
       <td>Ctrl+L</td>
-      <td>&#8963;L</td>
+      <td>⌃L</td>
     </tr>
     <tr>
       <td>Move cursor to beginning of line</td>
       <td>Home</td>
-      <td>&#8984;&#8592;</td>
+      <td>⌘←</td>
     </tr>
     <tr>
       <td>Move cursor to end of line</td>
       <td>End</td>
-      <td>&#8984;&#8594;</td>
+      <td>⌘→</td>
     </tr>
     <tr>
       <td>Navigate command history</td>
       <td>Up/Down</td>
-      <td>&#8593; or &#8595;</td>
+      <td>↑ or ↓</td>
     </tr>
     <tr>
       <td>Popup command history</td>
       <td>Ctrl+Up</td>
-      <td>&#8984;&#8593;</td>
+      <td>⌘↑</td>
     </tr>
     <tr>
       <td>Interrupt currently executing command</td>
       <td>Esc</td>
-      <td>&#9099;</td>
+      <td>⎋</td>
     </tr>
     <tr>
       <td>Change working directory</td>
       <td>Ctrl+Shift+H</td>
-      <td>&#8963;&#8679;H</td>
+      <td>⌃⇧H</td>
     </tr>
     </tbody>
   </table>
@@ -104,328 +109,328 @@ For Mac, no plus sign between keys, and use following characters:
     <tbody>
     <tr>
       <td>Goto File/Function</td>
-      <td>Ctrl+.</td>
-      <td>&#8963;.</td>
+      <td>Ctrl+. [period]</td>
+      <td>⌃. [period]</td>
     </tr>
     <tr>
       <td>Move cursor to Source Editor</td>
       <td>Ctrl+1</td>
-      <td>&#8963;1</td>
+      <td>⌃1</td>
     </tr>
     <tr>
       <td>New document (except on Chrome/Windows)</td>
       <td>Ctrl+Shift+N</td>
-      <td>&#8984;&#8679;N</td>
+      <td>⇧⌘N</td>
     </tr>
     <tr>
       <td>New document (Chrome only)</td>
       <td>Ctrl+Alt+Shift+N</td>
-      <td>&#8984;&#8679;&#8997;N</td>
+      <td>⌥⇧⌘N</td>
     </tr>
     <tr>
       <td>Open document</td>
       <td>Ctrl+O</td>
-      <td>&#8984;O</td>
+      <td>⌘O</td>
     </tr>
     <tr>
       <td>Save active document</td>
       <td>Ctrl+S</td>
-      <td>&#8984;S</td>
+      <td>⌘S</td>
     </tr>
     <tr>
       <td>Close active document (except on Chrome)</td>
       <td>Ctrl+W</td>
-      <td>&#8984;W</td>
+      <td>⌘W</td>
     </tr>
     <tr>
       <td>Close active document (Chrome only)</td>
       <td>Ctrl+Alt+W</td>
-      <td>&#8984;&#8997;W</td>
+      <td>⌥⌘W</td>
     </tr>
     <tr>
       <td>Close all open documents</td>
       <td>Ctrl+Shift+W</td>
-      <td>&#8984;&#8679;W</td>
+      <td>⇧⌘W</td>
     </tr>
     <tr>
       <td>Preview HTML (Markdown and HTML)</td>
       <td>Ctrl+Shift+K</td>
-      <td>&#8984;&#8679;K</td>
+      <td>⇧⌘K</td>
     </tr>
     <tr>
       <td>Knit Document (knitr)</td>
       <td>Ctrl+Shift+K</td>
-      <td>&#8984;&#8679;K</td>
+      <td>⇧⌘K</td>
     </tr>
     <tr>
       <td>Compile Notebook</td>
       <td>Ctrl+Shift+K</td>
-      <td>&#8984;&#8679;K</td>
+      <td>⇧⌘K</td>
     </tr>
     <tr>
       <td>Compile PDF (TeX and Sweave)</td>
       <td>Ctrl+Shift+K</td>
-      <td>&#8984;&#8679;K</td>
+      <td>⇧⌘K</td>
     </tr>
     <tr>
       <td>Insert chunk (Sweave and Knitr)</td>
       <td>Ctrl+Alt+I</td>
-      <td>&#8984;&#8997;I</td>
+      <td>⌥⌘I</td>
     </tr>
     <tr>
       <td>Insert code section</td>
       <td>Ctrl+Shift+R</td>
-      <td>&#8984;&#8679;R</td>
+      <td>⇧⌘R</td>
     </tr>
     <tr>
       <td>Run current line/selection</td>
       <td>Ctrl+Enter</td>
-      <td>&#8984;&#8617;</td>
+      <td>⌘Return</td>
     </tr>
     <tr>
       <td>Run current line/selection (retain cursor position)</td>
       <td>Alt+Enter</td>
-      <td>&#8997;&#8617;</td>
+      <td>⌥Return</td>
     </tr>
     <tr>
       <td>Re-run previous region</td>
       <td>Ctrl+Shift+P</td>
-      <td>&#8984;&#8679;P</td>
+      <td>⇧⌘P</td>
     </tr>
     <tr>
       <td>Run current document</td>
       <td>Ctrl+Alt+R</td>
-      <td>&#8984;&#8997;R</td>
+      <td>⌥⌘R</td>
     </tr>
     <tr>
       <td>Run from document beginning to current line</td>
       <td>Ctrl+Alt+B</td>
-      <td>&#8984;&#8997;B</td>
+      <td>⌥⌘B</td>
     </tr>
     <tr>
       <td>Run from current line to document end</td>
       <td>Ctrl+Alt+E</td>
-      <td>&#8984;&#8997;E</td>
+      <td>⌥⌘E</td>
     </tr>
     <tr>
       <td>Run the current function definition</td>
       <td>Ctrl+Alt+F</td>
-      <td>&#8984;&#8997;F</td>
+      <td>⌥⌘F</td>
     </tr>
     <tr>
       <td>Run the current code section</td>
       <td>Ctrl+Alt+T</td>
-      <td>&#8984;&#8997;T</td>
+      <td>⌥⌘T</td>
     </tr>
     <tr>
       <td>Run previous Sweave/Rmd code</td>
       <td>Ctrl+Alt+P</td>
-      <td>&#8984;&#8997;P</td>
+      <td>⌥⌘P</td>
     </tr>
     <tr>
       <td>Run the current Sweave/Rmd chunk</td>
       <td>Ctrl+Alt+C</td>
-      <td>&#8984;&#8997;C</td>
+      <td>⌥⌘C</td>
     </tr>
     <tr>
       <td>Run the next Sweave/Rmd chunk</td>
       <td>Ctrl+Alt+N</td>
-      <td>&#8984;&#8997;N</td>
+      <td>⌥⌘N</td>
     </tr>
     <tr>
       <td>Source a file</td>
       <td>Ctrl+Shift+O</td>
-      <td>&#8984;&#8679;O</td>
+      <td>⇧⌘O</td>
     </tr>
     <tr>
       <td>Source the current document</td>
       <td>Ctrl+Shift+S</td>
-      <td>&#8984;&#8679;S</td>
+      <td>⇧⌘S</td>
     </tr>
     <tr>
       <td>Source the current document (with echo)</td>
       <td>Ctrl+Shift+Enter</td>
-      <td>&#8984;&#8679;&#8617;</td>
+      <td>⇧⌘Return</td>
     </tr>
     <tr>
       <td>Fold Selected</td>
       <td>Alt+L</td>
-      <td>&#8984;&#8997;L</td>
+      <td>⌥⌘L</td>
     </tr>
     <tr>
       <td>Unfold Selected</td>
       <td>Shift+Alt+L</td>
-      <td>&#8984;&#8679;&#8997;L</td>
+      <td>⌥⇧⌘L</td>
     </tr>
     <tr>
       <td>Fold All</td>
       <td>Alt+O</td>
-      <td>&#8984;&#8997;O</td>
+      <td>⌥⌘O</td>
     </tr>
     <tr>
       <td>Unfold All</td>
       <td>Shift+Alt+O</td>
-      <td>&#8984;&#8679;&#8997;O</td>
+      <td>⌥⇧⌘O</td>
     </tr>
     <tr>
       <td>Go to line</td>
       <td>Shift+Alt+G</td>
-      <td>&#8984;&#8679;&#8997;G</td>
+      <td>⌥⇧⌘G</td>
     </tr>
     <tr>
       <td>Jump to</td>
       <td>Shift+Alt+J</td>
-      <td>&#8984;&#8679;&#8997;J</td>
+      <td>⌥⇧⌘J</td>
     </tr>
     <tr>
       <td>Switch to tab</td>
-      <td>Ctrl+Shift+.</td>
-      <td>&#8963;&#8679;.</td>
+      <td>Ctrl+Shift+. [period]</td>
+      <td>⌃⇧. [period]</td>
     </tr>
     <tr>
       <td>Previous tab</td>
       <td>Ctrl+F11</td>
-      <td>&#8963;F11</td>
+      <td>⌃F11</td>
     </tr>
     <tr>
       <td>Next tab</td>
       <td>Ctrl+F12</td>
-      <td>&#8963;F12</td>
+      <td>⌃F12</td>
     </tr>
     <tr>
       <td>First tab</td>
       <td>Ctrl+Shift+F11</td>
-      <td>&#8963;&#8679;F11</td>
+      <td>⌃⇧F11</td>
     </tr>
     <tr>
       <td>Last tab</td>
       <td>Ctrl+Shift+F12</td>
-      <td>&#8963;&#8679;F12</td>
+      <td>⌃⇧F12</td>
     </tr>
     <tr>
       <td>Navigate back</td>
       <td>Ctrl+F9</td>
-      <td>&#8984;F9</td>
+      <td>⌘F9</td>
     </tr>
     <tr>
       <td>Navigate forward</td>
       <td>Ctrl+F10</td>
-      <td>&#8984;F10</td>
+      <td>⌘F10</td>
     </tr>
     <tr>
       <td>Extract function from selection</td>
       <td>Ctrl+Alt+X</td>
-      <td>&#8984;&#8997;X</td>
+      <td>⌥⌘X</td>
     </tr>
     <tr>
       <td>Extract variable from selection</td>
       <td>Ctrl+Alt+V</td>
-      <td>&#8984;&#8997;V</td>
+      <td>⌥⌘V</td>
     </tr>
     <tr>
       <td>Reindent lines</td>
       <td>Ctrl+I</td>
-      <td>&#8984;I</td>
+      <td>⌘I</td>
     </tr>
     <tr>
       <td>Comment/uncomment current line/selection</td>
       <td>Ctrl+Shift+C</td>
-      <td>&#8984;&#8679;C</td>
+      <td>⇧⌘C</td>
     </tr>
     <tr>
       <td>Reflow Comment</td>
       <td>Ctrl+Shift+/</td>
-      <td>&#8984;&#8679;/</td>
+      <td>⇧⌘/</td>
     </tr>
     <tr>
       <td>Reformat Selection</td>
       <td>Ctrl+Shift+A</td>
-      <td>&#8984;&#8679;A</td>
+      <td>⇧⌘A</td>
     </tr>
     <tr>
       <td>Show Diagnostics</td>
       <td>Ctrl+Shift+Alt+P</td>
-      <td>&#8984;&#8679;&#8997;P</td>
+      <td>⌥⇧⌘P</td>
     </tr>
     <tr>
       <td>Transpose Letters</td>
       <td>No shortcut</td>
-      <td>&#8963;T</td>
+      <td>⌃T</td>
     </tr>
     <tr>
       <td>Move Lines Up/Down</td>
       <td>Alt+Up/Down</td>
-      <td>&#8997;&#8593; or &#8595;</td>
+      <td>⌥↑ or ↓</td>
     </tr>
     <tr>
       <td>Copy Lines Up/Down</td>
       <td>Shift+Alt+Up/Down</td>
-      <td>&#8984;&#8997;&#8593; or &#8595;</td>
+      <td>⌥⌘↑ or ↓</td>
     </tr>
     <tr>
       <td>Jump to Matching Brace/Paren</td>
       <td>Ctrl+P</td>
-      <td>&#8963;P</td>
+      <td>⌃P</td>
     </tr>
     <tr>
       <td>Expand to Matching Brace/Paren</td>
       <td>Ctrl+Shift+E</td>
-      <td>&#8963;&#8679;E</td>
+      <td>⌃⇧E</td>
     </tr>
     <tr>
       <td>Select to Matching Brace/Paren</td>
       <td>Ctrl+Shift+Alt+E</td>
-      <td>&#8963;&#8679;&#8997;E</td>
+      <td>⌃⌥⇧E</td>
     </tr>
     <tr>
       <td>Add Cursor Above Current Cursor</td>
       <td>Ctrl+Alt+Up</td>
-      <td>&#8963;&#8997;&#8593;</td>
+      <td>⌃⌥↑</td>
     </tr>
     <tr>
       <td>Add Cursor Below Current Cursor</td>
       <td>Ctrl+Alt+Down</td>
-      <td>&#8963;&#8997;&#8595;</td>
+      <td>⌃⌥↓</td>
     </tr>
     <tr>
       <td>Move Active Cursor Up</td>
       <td>Ctrl+Alt+Shift+Up</td>
-      <td>+&#8997;&#8679;&#8593;</td>
+      <td>⌥⇧↑</td>
     </tr>
     <tr>
       <td>Move Active Cursor Down</td>
       <td>Ctrl+Alt+Shift+Down</td>
-      <td>&#8963;&#8997;&#8679;&#8595;</td>
+      <td>⌃⌥⇧↓</td>
     </tr>
     <tr>
       <td>Find and Replace</td>
       <td>Ctrl+F</td>
-      <td>&#8984;F</td>
+      <td>⌘F</td>
     </tr>
     <tr>
       <td>Find Next</td>
       <td>Win: F3, Linux: Ctrl+G</td>
-      <td>&#8984;G</td>
+      <td>⌘G</td>
     </tr>
     <tr>
       <td>Find Previous</td>
       <td>Win: Shift+F3, Linux: Ctrl+Shift+G</td>
-      <td>&#8984;&#8679;G</td>
+      <td>⇧⌘G</td>
     </tr>
     <tr>
       <td>Use Selection for Find</td>
       <td>Ctrl+F3</td>
-      <td>&#8984;E</td>
+      <td>⌘E</td>
     </tr>
     <tr>
       <td>Replace and Find</td>
       <td>Ctrl+Shift+J</td>
-      <td>&#8984;&#8679;J</td>
+      <td>⇧⌘J</td>
     </tr>
     <tr>
       <td>Find in Files</td>
       <td>Ctrl+Shift+F</td>
-      <td>&#8984;&#8679;F</td>
+      <td>⇧⌘F</td>
     </tr>
     <tr>
       <td>Check Spelling</td>
@@ -443,132 +448,132 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Undo</td>
       <td>Ctrl+Z</td>
-      <td>&#8984;Z</td>
+      <td>⌘Z</td>
     </tr>
     <tr>
       <td>Redo</td>
       <td>Ctrl+Shift+Z</td>
-      <td>&#8984;&#8679;Z</td>
+      <td>⇧⌘Z</td>
     </tr>
     <tr>
       <td>Cut</td>
       <td>Ctrl+X</td>
-      <td>&#8984;X</td>
+      <td>⌘X</td>
     </tr>
     <tr>
       <td>Copy</td>
       <td>Ctrl+C</td>
-      <td>&#8984;C</td>
+      <td>⌘C</td>
     </tr>
     <tr>
       <td>Paste</td>
       <td>Ctrl+V</td>
-      <td>&#8984;V</td>
+      <td>⌘V</td>
     </tr>
     <tr>
       <td>Select All</td>
       <td>Ctrl+A</td>
-      <td>&#8984;A</td>
+      <td>⌘A</td>
     </tr>
     <tr>
       <td>Jump to Word</td>
       <td>Ctrl+Left/Right</td>
-      <td>&#8997;&#8592; or &#8594;</td>
+      <td>⌥← or →</td>
     </tr>
     <tr>
       <td>Jump to Start/End</td>
       <td>Ctrl+Home/End or Ctrl+Up/Down</td>
-      <td>&#8984;&#8593; or &#8595;</td>
+      <td>⌘↑ or ↓</td>
     </tr>
     <tr>
       <td>Delete Line</td>
       <td>Ctrl+D</td>
-      <td>&#8984;D</td>
+      <td>⌘D</td>
     </tr>
     <tr>
       <td>Select</td>
       <td>Shift+[Arrow]</td>
-      <td>&#8679;[Arrow]</td>
+      <td>⇧[Arrow]</td>
     </tr>
     <tr>
       <td>Select Word</td>
       <td>Ctrl+Shift+Left/Right</td>
-      <td>&#8997;&#8679;&#8592; or &#8594;</td>
+      <td>⌥⇧← or →</td>
     </tr>
     <tr>
       <td>Select to Line Start</td>
       <td>Alt+Shift+Left</td>
-      <td>&#8984;&#8679;&#8592;</td>
+      <td>⇧⌘←</td>
     </tr>
     <tr>
       <td>Select to Line End</td>
       <td>Alt+Shift+Right</td>
-      <td>&#8984;&#8679;&#8594;</td>
+      <td>⇧⌘→</td>
     </tr>
     <tr>
       <td>Select Page Up/Down</td>
       <td>Shift+PageUp/PageDown</td>
-      <td>&#8679;&#8670; or &#8671;</td>
+      <td>⇧⇞ or ⇟</td>
     </tr>
     <tr>
       <td>Select to Start/End</td>
       <td>Ctrl+Shift+Home/End or Shift+Alt+Up/Down</td>
-      <td>&#8984;&#8679;&#8593; or &#8595;</td>
+      <td>⇧⌘↑ or ↓</td>
     </tr>
     <tr>
       <td>Delete Word Left</td>
       <td>Ctrl+Backspace</td>
-      <td>&#8997;&#9003; or &#8963;&#8997;&#9003;</td>
+      <td>⌥⌫ or ⌃⌥⌫</td>
     </tr>
     <tr>
       <td>Delete Word Right</td>
       <td>No shortcut</td>
-      <td>&#8997;&#8998;</td>
+      <td>⌥⌦</td>
     </tr>
     <tr>
       <td>Delete to Line End</td>
       <td>No shortcut</td>
-      <td>&#8963;K</td>
+      <td>⌃K</td>
     </tr>
     <tr>
       <td>Delete to Line Start</td>
       <td>No shortcut</td>
-      <td>&#8997;&#9003;</td>
+      <td>⌥⌫</td>
     </tr>
     <tr>
       <td>Indent</td>
       <td>Tab (at beginning of line)</td>
-      <td>&#8677; (at beginning of line)</td>
+      <td>⇥ (at beginning of line)</td>
     </tr>
     <tr>
       <td>Outdent</td>
       <td>Shift+Tab</td>
-      <td>&#8679;&#8677;</td>
+      <td>⇧⇥</td>
     </tr>
     <tr>
       <td>Yank line up to cursor</td>
       <td>Ctrl+U</td>
-      <td>&#8963;U</td>
+      <td>⌃U</td>
     </tr>
     <tr>
       <td>Yank line after cursor</td>
       <td>Ctrl+K</td>
-      <td>&#8963;K</td>
+      <td>⌃K</td>
     </tr>
     <tr>
       <td>Insert currently yanked text</td>
       <td>Ctrl+Y</td>
-      <td>&#8963;Y</td>
+      <td>⌃Y</td>
     </tr>
     <tr>
       <td>Insert assignment operator</td>
       <td>Alt+-</td>
-      <td>&#8997;-</td>
+      <td>⌥-</td>
     </tr>
     <tr>
       <td>Insert pipe operator</td>
       <td>Ctrl+Shift+M</td>
-      <td>&#8984;&#8679;M</td>
+      <td>⇧⌘M</td>
     </tr>
     <tr>
       <td>Show help for function at cursor</td>
@@ -583,7 +588,7 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Find usages for symbol at cursor (C++)</td>
       <td>Ctrl+Alt+U</td>
-      <td>&#8984;&#8997;U</td>
+      <td>⌥⌘U</td>
     </tr>
     </tbody>
   </table>
@@ -596,22 +601,22 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Attempt completion</td>
       <td>Tab or Ctrl+Space</td>
-      <td>&#8677; or &#8984;Space</td>
+      <td>⇥ or ⌘Space</td>
     </tr>
     <tr>
       <td>Navigate candidates</td>
       <td>Up/Down</td>
-      <td>&#8593; or &#8595;</td>
+      <td>↑ or ↓</td>
     </tr>
     <tr>
       <td>Accept selected candidate</td>
       <td>Enter, Tab, or Right</td>
-      <td>&#8617;, &#8677;, or &#8594;</td>
+      <td>Return, ⇥, or →</td>
     </tr>
     <tr>
       <td>Dismiss completion popup</td>
       <td>Esc</td>
-      <td>&#9099;</td>
+      <td>⎋</td>
     </tr>
     </tbody>
   </table>
@@ -624,62 +629,62 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Move focus to Source Editor</td>
       <td>Ctrl+1</td>
-      <td>&#8963;1</td>
+      <td>⌃1</td>
     </tr>
     <tr>
       <td>Move focus to Console</td>
       <td>Ctrl+2</td>
-      <td>&#8963;2</td>
+      <td>⌃2</td>
     </tr>
     <tr>
       <td>Move focus to Help</td>
       <td>Ctrl+3</td>
-      <td>&#8963;3</td>
+      <td>⌃3</td>
     </tr>
     <tr>
       <td>Show History</td>
       <td>Ctrl+4</td>
-      <td>&#8963;4</td>
+      <td>⌃4</td>
     </tr>
     <tr>
       <td>Show Files</td>
       <td>Ctrl+5</td>
-      <td>&#8963;5</td>
+      <td>⌃5</td>
     </tr>
     <tr>
       <td>Show Plots</td>
       <td>Ctrl+6</td>
-      <td>&#8963;6</td>
+      <td>⌃6</td>
     </tr>
     <tr>
       <td>Show Packages</td>
       <td>Ctrl+7</td>
-      <td>&#8963;7</td>
+      <td>⌃7</td>
     </tr>
     <tr>
       <td>Show Environment</td>
       <td>Ctrl+8</td>
-      <td>&#8963;8</td>
+      <td>⌃8</td>
     </tr>
     <tr>
       <td>Show Git/SVN</td>
       <td>Ctrl+9</td>
-      <td>&#8963;9</td>
+      <td>⌃9</td>
     </tr>
     <tr>
       <td>Show Build</td>
       <td>Ctrl+0</td>
-      <td>&#8963;0</td>
+      <td>⌃0</td>
     </tr>
     <tr>
       <td>Sync Editor &amp; PDF Preview</td>
       <td>Ctrl+F8</td>
-      <td>&#8984;F8</td>
+      <td>⌘F8</td>
     </tr>
     <tr>
       <td>Show Keyboard Shortcut Reference</td>
       <td>Alt+Shift+K</td>
-      <td>&#8997;&#8679;K</td>
+      <td>⌥⇧K</td>
     </tr>
     </tbody>
   </table>
@@ -692,32 +697,32 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Install and Restart</td>
       <td>Ctrl+Shift+B</td>
-      <td>&#8984;&#8679;B</td>
+      <td>⇧⌘B</td>
     </tr>
     <tr>
       <td>Load All (devtools)</td>
       <td>Ctrl+Shift+L</td>
-      <td>&#8984;&#8679;L</td>
+      <td>⇧⌘L</td>
     </tr>
     <tr>
       <td>Test Package (Desktop)</td>
       <td>Ctrl+Shift+T</td>
-      <td>&#8984;&#8679;T</td>
+      <td>⇧⌘T</td>
     </tr>
     <tr>
       <td>Test Package (Web)</td>
       <td>Ctrl+Alt+F7</td>
-      <td>&#8984;&#8997;F7</td>
+      <td>⌥⌘F7</td>
     </tr>
     <tr>
       <td>Check Package</td>
       <td>Ctrl+Shift+E</td>
-      <td>&#8984;&#8679;E</td>
+      <td>⇧⌘E</td>
     </tr>
     <tr>
       <td>Document Package</td>
       <td>Ctrl+Shift+D</td>
-      <td>&#8984;&#8679;D</td>
+      <td>⇧⌘D</td>
     </tr>
     </tbody>
   </table>
@@ -730,7 +735,7 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Toggle Breakpoint</td>
       <td>Shift+F9</td>
-      <td>&#8679;F9</td>
+      <td>⇧F9</td>
     </tr>
     <tr>
       <td>Execute Next Line</td>
@@ -740,22 +745,22 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Step Into Function</td>
       <td>Shift+F4</td>
-      <td>&#8679;F4</td>
+      <td>⇧F4</td>
     </tr>
     <tr>
       <td>Finish Function/Loop</td>
       <td>Shift+F6</td>
-      <td>&#8679;F6</td>
+      <td>⇧F6</td>
     </tr>
     <tr>
       <td>Continue</td>
       <td>Shift+F5</td>
-      <td>&#8679;F5</td>
+      <td>⇧F5</td>
     </tr>
     <tr>
       <td>Stop Debugging</td>
       <td>Shift+F8</td>
-      <td>&#8679;F8</td>
+      <td>⇧F8</td>
     </tr>
     </tbody>
   </table>
@@ -768,12 +773,12 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Previous plot</td>
       <td>Ctrl+Alt+F11</td>
-      <td>&#8984;&#8997;F11</td>
+      <td>⌥⌘F11</td>
     </tr>
     <tr>
       <td>Next plot</td>
       <td>Ctrl+Alt+F12</td>
-      <td>&#8984;&#8997;F12</td>
+      <td>⌥⌘F12</td>
     </tr>
     </tbody>
   </table>
@@ -786,17 +791,17 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Diff active source document</td>
       <td>Ctrl+Alt+D</td>
-      <td>&#8963;&#8997;D</td>
+      <td>⌃⌥D</td>
     </tr>
     <tr>
       <td>Commit changes</td>
       <td>Ctrl+Alt+M</td>
-      <td>&#8963;&#8997;M</td>
+      <td>⌃⌥M</td>
     </tr>
     <tr>
       <td>Scroll diff view</td>
       <td>Ctrl+Up/Down</td>
-      <td>&#8963;&#8593; or &#8595;</td>
+      <td>⌃↑ or ↓</td>
     </tr>
     <tr>
       <td>Stage/Unstage (Git)</td>
@@ -806,7 +811,7 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Stage/Unstage and move to next (Git)</td>
       <td>Enter</td>
-      <td>&#8617;</td>
+      <td>Return</td>
     </tr>
     </tbody>
   </table>
@@ -819,12 +824,12 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>Quit Session (desktop only)</td>
       <td>Ctrl+Q</td>
-      <td>&#8984;Q</td>
+      <td>⌘Q</td>
     </tr>
     <tr>
       <td>Restart R Session</td>
       <td>Ctrl+Shift+F10</td>
-      <td>&#8984;&#8679;F10</td>
+      <td>⇧⌘F10</td>
     </tr>
     </tbody>
   </table>
@@ -837,32 +842,32 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>New Terminal</td>
       <td>Shift+Alt+T</td>
-      <td>&#8679;&#8997;T</td>
+      <td>⌥⇧T</td>
     </tr>
     <tr>
       <td>Rename Current Terminal</td>
       <td>Shift+Alt+R</td>
-      <td>&#8679;&#8997;R</td>
+      <td>⌥⇧R</td>
     </tr>
     <tr>
       <td>Clear Current Terminal</td>
       <td>Ctrl+Shift+L</td>
-      <td>&#8963;&#8679;L</td>
+      <td>⌃⇧L</td>
     </tr>
     <tr>
       <td>Move Focus to Terminal</td>
       <td>Ctrl+Shift+T</td>
-      <td>&#8963;&#8679;T</td>
+      <td>⌃⇧T</td>
     </tr>
     <tr>
       <td>Previous Terminal</td>
       <td>Shift+Alt+F11</td>
-      <td>&#8679;&#8997;F11</td>
+      <td>⌥⇧F11</td>
     </tr>
     <tr>
       <td>Next Terminal</td>
       <td>Shift+Alt+F12</td>
-      <td>&#8679;&#8997;F12</td>
+      <td>⌥⇧F12</td>
     </tr>
     </tbody>
   </table>
@@ -875,57 +880,57 @@ For Mac, no plus sign between keys, and use following characters:
     <tr>
       <td>File Menu</td>
       <td>Ctrl+Alt+F</td>
-      <td>&#8963;&#8997;F</td>
+      <td>⌃⌥F</td>
     </tr>
     <tr>
       <td>Edit Menu</td>
       <td>Ctrl+Alt+I</td>
-      <td>&#8963;&#8997;I</td>
+      <td>⌃⌥I</td>
     </tr>
     <tr>
       <td>Code Menu</td>
       <td>Ctrl+Alt+C</td>
-      <td>&#8963;&#8997;C</td>
+      <td>⌃⌥C</td>
     </tr>
     <tr>
       <td>View Menu</td>
       <td>Ctrl+Alt+V</td>
-      <td>&#8963;&#8997;V</td>
+      <td>⌃⌥V</td>
     </tr>
     <tr>
       <td>Plots Menu</td>
       <td>Ctrl+Alt+P</td>
-      <td>&#8963;&#8997;P</td>
+      <td>⌃⌥P</td>
     </tr>
     <tr>
       <td>Session Menu</td>
       <td>Ctrl+Alt+S</td>
-      <td>&#8963;&#8997;S</td>
+      <td>⌃⌥S</td>
     </tr>
     <tr>
       <td>Build Menu</td>
       <td>Ctrl+Alt+B</td>
-      <td>&#8963;&#8997;B</td>
+      <td>⌃⌥B</td>
     </tr>
     <tr>
       <td>Debug Menu</td>
       <td>Ctrl+Alt+U</td>
-      <td>&#8963;&#8997;U</td>
+      <td>⌃⌥U</td>
     </tr>
     <tr>
       <td>Profile Menu</td>
       <td>Ctrl+Alt+O</td>
-      <td>&#8963;&#8997;O</td>
+      <td>⌃⌥O</td>
     </tr>
     <tr>
       <td>Tools Menu</td>
       <td>Ctrl+Alt+T</td>
-      <td>&#8963;&#8997;T</td>
+      <td>⌃⌥T</td>
     </tr>
     <tr>
       <td>Help Menu</td>
       <td>Ctrl+Alt+H</td>
-      <td>&#8963;&#8997;H</td>
+      <td>⌃⌥H</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Going to push this in without review as it's just WIP on static content, but for the record:

- Use actual Mac keyboard characters (instead of entities) in the htm (search and replace).
- Put Mac shortcuts in the standard order (Ctrl+Opt+Shift+Foo)
- Added accessibility shortcuts
- Added a few other shortcuts