### PR TITLE
Exception in Find in Files dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -126,8 +126,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       }-*/;
 
       public native final void clearResultsCount() /*-{
-         if (this.resultsCount != null)
-            this.resultsCount = 0;
+         this.resultsCount = 0;
       }-*/;
 
       public native final void updateErrorCount(int count) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -125,7 +125,8 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       }-*/;
 
       public native final void clearResultsCount() /*-{
-         this.resultsCount = 0;
+         if (this.resultsCount != null)
+            this.resultsCount = 0;
       }-*/;
 
       public native final void updateErrorCount(int count) /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -463,7 +463,6 @@ public class FindOutputPresenter extends BasePresenter
       view_.ensureVisible(false);
 
       currentFindHandle_ = state.getHandle();
-      dialogState_.clearResultsCount();
       view_.clearMatches();
       view_.addMatches(state.getResults().toArrayList());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -248,7 +248,8 @@ public class FindOutputPresenter extends BasePresenter
                                       {
                                          view_.clearMatches();
                                          currentFindHandle_ = handle;
-                                         dialogState_.clearResultsCount();
+                                         if (dialogState_ != null)
+                                            dialogState_.clearResultsCount();
                                       }
                                    });
          }


### PR DESCRIPTION
Fixes #6085 

This PR fixes an issue where the find result count was being cleared on initialization of the Find In Files dialog, causing this information to be lost from the state when a new rsession started. 
It also prevents any calls to clear the result count from causing an exception when the result count is null.