### PR TITLE
Wrap around editor tabs by default

### DIFF
--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -800,7 +800,7 @@
         },
         "wrap_tab_navigation": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "description": "Whether to wrap around when going to the previous or next editor tab."
         },
         "global_theme": {


### PR DESCRIPTION
At rstudio::conf 2020, two people individually asked me if we would add a feature that would make the Previous/Next source tab gestures wrap around instead of stopping at the end. This is also a common request here on Github (e.g. https://github.com/rstudio/rstudio/issues/5539).

Of course, we already have this feature, and have for years, but you need to turn it on via an option, and even though that option is on the first page of Global Options it's difficult for people to find. 

This change turns it on by default since empirically most people appear to consider it the most useful behavior. 