### PR TITLE
re-initialize Ctrl + C handler after Python initialized

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -303,23 +303,6 @@ bool s_destroySession = false;
 // did we fail to coerce the charset to UTF-8
 bool s_printCharsetWarning = false;
 
-#ifdef _WIN32
-
-BOOL CALLBACK handleConsoleCtrl(DWORD type)
-{
-   switch (type)
-   {
-   case CTRL_C_EVENT:
-   case CTRL_BREAK_EVENT:
-      rstudio::r::exec::setInterruptsPending(true);
-      return true;
-   default:
-      return false;
-   }
-}
-
-#endif
-
 void handleINT(int)
 {
    rstudio::r::exec::setInterruptsPending(true);
@@ -382,13 +365,7 @@ Error registerSignalHandlers()
 
    ExecBlock registerBlock;
 
-#ifdef _WIN32
-   // accept Ctrl + C interrupts
-   ::SetConsoleCtrlHandler(nullptr, FALSE);
-
-   // register console control handler
-   ::SetConsoleCtrlHandler(handleConsoleCtrl, TRUE);
-#endif
+   module_context::initializeConsoleCtrlHandler();
    
    // SIGINT: set interrupt flag on R session
    registerBlock.addFunctions()

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -890,6 +890,40 @@ void onBackgroundProcessing(bool isIdle)
       executeScheduledCommands(&s_idleScheduledCommands);
 }
 
+#ifdef _WIN32
+
+namespace {
+
+BOOL CALLBACK consoleCtrlHandler(DWORD type)
+{
+   switch (type)
+   {
+   case CTRL_C_EVENT:
+   case CTRL_BREAK_EVENT:
+      rstudio::r::exec::setInterruptsPending(true);
+      return true;
+   default:
+      return false;
+   }
+}
+
+} // end anonymous namespace
+
+#endif
+
+void initializeConsoleCtrlHandler()
+{
+#ifdef _WIN32
+   // accept Ctrl + C interrupts
+   ::SetConsoleCtrlHandler(nullptr, FALSE);
+
+   // remove an old registration (if any)
+   ::SetConsoleCtrlHandler(consoleCtrlHandler, FALSE);
+
+   // register console control handler
+   ::SetConsoleCtrlHandler(consoleCtrlHandler, TRUE);
+#endif
+}
 
 Error registerIdleOnlyAsyncRpcMethod(
                              const std::string& name,

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -854,6 +854,8 @@ bool isPathViewAllowed(const core::FilePath& path);
 
 void onBackgroundProcessing(bool isIdle);
 
+void initializeConsoleCtrlHandler();
+
 } // namespace module_context
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -13,6 +13,10 @@
 #
 #
 
+options(reticulate.initialized = function() {
+   .Call("rs_reticulateInitialized", PACKAGE = "(embedding)")
+})
+
 .rs.setVar("python.moduleCache", new.env(parent = emptyenv()))
 
 .rs.addJsonRpcHandler("python_get_completions", function(line, ctx)


### PR DESCRIPTION
When Python is initialized, it injects its own console control handler:

https://github.com/python/cpython/blob/5807efd4c396d5718325e21f5a14e324a77ff77c/PC/launcher.c#L787-L789

https://github.com/python/cpython/blob/5807efd4c396d5718325e21f5a14e324a77ff77c/PC/launcher.c#L730-L734

On Windows, processes have a stack of console control handlers. When a console control event is generated (e.g. by `Ctrl + C`), Windows will execute each in turn until one returns `TRUE`. Because Python is initialized lazily, this handler goes on top of the stack, and then effectively swallows any console control event before we get to see it with our own handler.

The solution is to re-initialize RStudio's console control handler after Python has been initialized, effectively placing it back on top of the stack.

Closes https://github.com/rstudio/reticulate/issues/683.