### PR TITLE
fix color of job status in dark mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobProgress.ui.xml
@@ -10,12 +10,7 @@
       overflow: hidden;
       word-wrap: nowrap;
    }
-   
-   .status
-   {
-      color: #717171;
-   }
-   
+
    .host
    {
       width: 100%;


### PR DESCRIPTION
- Use the normal text color instead of a hardcoded color
- Fixes #6144 (just the main issue, didn't address the mentioned inefficient space usage in the status bar; that can be opened as a separate issue if desired)

<img width="446" alt="screenshot of jobs pane in dark theme" src="https://user-images.githubusercontent.com/10569626/73717274-279c8d80-46ce-11ea-9833-d0a54cbcd417.png">

<img width="446" alt="screenshot of jobs pane in light theme" src="https://user-images.githubusercontent.com/10569626/73717278-2b301480-46ce-11ea-9ba8-a5cd0cc6327b.png">
