### PR TITLE
fix for refresh when indexing complete; always run default tutorial on startup

### DIFF
--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -303,18 +303,16 @@ void onDeferredInit(bool newSession)
    if (!projectContext().hasProject())
       return;
    
-   if (!projectContext().isNewProject())
-      return;
-   
    std::string defaultTutorial = projectContext().config().defaultTutorial;
    if (defaultTutorial.empty())
       return;
    
-   std::vector<std::string> parts =
-         core::algorithm::split(defaultTutorial, "::");
-   
+   std::vector<std::string> parts = core::algorithm::split(defaultTutorial, "::");
    if (parts.size() != 2)
+   {
+      LOG_WARNING_MESSAGE("Unexpected DefaultTutorial field: " + defaultTutorial);
       return;
+   }
    
    json::Object data;
    data["package"] = parts[0];

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -193,7 +193,7 @@ public class TutorialPane
    @Override
    public void home()
    {
-      frame_.setUrl(TutorialPresenter.URLS_HOME);
+      frame_.setUrl("." + TutorialPresenter.URLS_HOME);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
@@ -341,6 +341,6 @@ public class TutorialPresenter
    
    public static final String VIEWER_TYPE_TUTORIAL = "tutorial";
    
-   public static final String URLS_HOME = "./tutorial/home";
+   public static final String URLS_HOME = "/tutorial/home";
    
 }


### PR DESCRIPTION
This PR fixes two issues:

1. The tutorial index was not being refreshed after indexing was completed; this is because of the path check here:

https://github.com/rstudio/rstudio/blob/9679854e04ab6b1358e4798250d535ef82b9f9e3/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java#L171

2. Always run the default tutorial on startup -- at least to make testing easier for now.