### PR TITLE
display full SHA in git history

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1370,7 +1370,7 @@ public:
             {
                if (!currentCommit.parent.empty())
                   currentCommit.parent.push_back(' ');
-               currentCommit.parent.append(value, 0, 8);
+               currentCommit.parent.append(value);
             }
             else if (key == "gpgsig")
             {
@@ -2321,7 +2321,7 @@ Error vcsHistory(const json::JsonRpcRequest& request,
         it != commits.end();
         it++)
    {
-      ids.push_back(json::Value(it->id.substr(0, 8)));
+      ids.push_back(json::Value(it->id));
       authors.push_back(json::Value(string_utils::filterControlChars(it->author)));
       parents.push_back(json::Value(string_utils::filterControlChars(it->parent)));
       subjects.push_back(json::Value(string_utils::filterControlChars(it->subject)));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitListTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitListTable.java
@@ -227,7 +227,7 @@ public class CommitListTable extends MultiSelectCellTable<CommitInfo>
          @Override
          public String getValue(CommitInfo object)
          {
-            return object.getId();
+            return object.getId().substring(0, 8);
          }
       };
       addColumn(idCol, idColName);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/DiffFrame.java
@@ -93,7 +93,7 @@ public class DiffFrame extends Composite
          
          viewFileHyperlink_.setClickHandler(viewFileClickHandler);
          viewFileHyperlink_.setAlwaysUnderline(false);
-         viewFileHyperlink_.setText("View file @ " + commitId);
+         viewFileHyperlink_.setText("View file @ " + commitId.substring(0, 8));
          viewFileHyperlink_.addStyleName(RES.styles().viewFileHyperlink());
       }
       


### PR DESCRIPTION
Git SHAs were being truncated session-side, which is undesirable in locations where we might want to display the full hash. Avoid truncating on the session side and instead truncate client-side if appropriate.

Closes #6155.