### PR TITLE
don't bind cut / copy / paste commands on desktop

### DIFF
--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -168,6 +168,13 @@ void WebView::keyPressEvent(QKeyEvent* pEvent)
       return;
    }
 #endif
+ 
+   // allow Ctrl+Shift+V to act as a 'paste with indent' action
+   if (pEvent->key() == Qt::Key_V && pEvent->modifiers() == Qt::CTRL + Qt::SHIFT)
+   {
+      triggerPageAction(QWebEnginePage::PasteAndMatchStyle);
+      return;
+   }
    
    // use default behavior otherwise
    QWebEngineView::keyPressEvent(pEvent);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -583,17 +583,6 @@ well as menu structures (for main menu and popup menus).
       <!-- Use spaces for key sequences, e.g. 'Ctrl+X Ctrl+F' -->
       <!-- Separate shortcuts with '|', e.g. 'Ctrl+X Ctrl+F|Cmd+O' -->
       <shortcutgroup name="Source Editor">
-
-         <shortcut refid="cutDummy"             value="Ctrl+X"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; !org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut refid="copyDummy"            value="Ctrl+C"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; !org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="pasteDummy"           value="Ctrl+V"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; !org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="pasteWithIndentDummy" value="Ctrl+Shift+V" if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; !org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-
-         <shortcut refid="cutDummy"             value="Meta+X"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; org.rstudio.core.client.BrowseCap.isMacintosh()" />
-         <shortcut refid="copyDummy"            value="Meta+C"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="pasteDummy"           value="Meta+V"       if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="pasteWithIndentDummy" value="Meta+Shift+V" if="org.rstudio.studio.client.application.Desktop.isDesktop() &amp;&amp; org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-
          <shortcut refid="insertChunk" value="Cmd+Alt+I"/>
          <shortcut refid="insertSection" value="Cmd+Shift+R" disableModes="sublime"/>
          <shortcut refid="insertSection" value="Ctrl+Shift+R" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>


### PR DESCRIPTION
As these commands will interfere with attempts to cut / copy / paste in things that happen outside of the GWT context (e.g. in desktop-generated dialogs).

Closes #5894, #5936.