### PR TITLE
fix issues with modal dialogs and screen readers

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -456,4 +456,7 @@ public class ElementIds
    // AccessibilityPreferencesPane
    public final static String A11Y_GENERAL_PREFS = "a11y_general_prefs";
    public final static String A11Y_ANNOUNCEMENTS_PREFS = "a11y_announcements_prefs";
+   
+   // SatelliteWindow
+   public final static String SATELLITE_PANEL = "satellite_panel";
 }

--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -132,4 +132,18 @@ public class A11y
       // of setting it to false
       el.removeAttribute("aria-expanded");
    }
+
+   public static void setInert(Element el, boolean inert)
+   {
+      if (inert)
+      {
+         setARIAHidden(el);
+         el.setAttribute("inert", "");
+      }
+      else
+      {
+         setARIAVisible(el);
+         el.removeAttribute("inert");
+      }
+   }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
@@ -1,7 +1,7 @@
 /*
  * ModalDialogTracker.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,8 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.PopupPanel;
+import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
@@ -30,13 +32,13 @@ public class ModalDialogTracker
       dialogStack_.add(panel);
       if (Desktop.hasDesktopFrame())
          DesktopMenuCallback.setMainMenuEnabled(false);
-      updateInert();
+      updateInert(true);
    }
 
    public static boolean isTopMost(PopupPanel panel)
    {
       return !dialogStack_.isEmpty() &&
-             dialogStack_.get(dialogStack_.size()-1) == panel;
+             dialogStack_.get(dialogStack_.size() - 1) == panel;
    }
 
    public static void onHide(PopupPanel panel)
@@ -44,9 +46,9 @@ public class ModalDialogTracker
       dialogStack_.removeIf(panel::equals);
       if (Desktop.hasDesktopFrame() && numModalsShowing() == 0)
          DesktopMenuCallback.setMainMenuEnabled(true);
-      updateInert();
+      updateInert(false);
    }
-   
+
    public static int numModalsShowing()
    {
       return dialogStack_.size();
@@ -73,23 +75,46 @@ public class ModalDialogTracker
       return false;
    }
 
-   private static void updateInert()
+   private static void updateInert(boolean addedPopup)
+   {
+      assert(numModalsShowing() >= 0);
+
+      if (numModalsShowing() == 0)
+         setInertMainWindow(false); // closed last popup, reenable main window
+      else if (numModalsShowing() == 1 && addedPopup)
+         setInertMainWindow(true); // added first popup, disable main window
+      else if (addedPopup)
+         A11y.setInert(getSecondTopMostElement(), true); // disable previous topmost
+      else
+         A11y.setInert(getTopMostElement(), false); // enable newly exposed topmost
+   }
+
+   private static Element getTopMostElement()
+   {
+      if (dialogStack_.isEmpty())
+         return null;
+      return dialogStack_.get(dialogStack_.size() - 1).getElement();
+   }
+
+   private static Element getSecondTopMostElement()
+   {
+      if (dialogStack_.size() < 2)
+         return null;
+      return dialogStack_.get(dialogStack_.size() - 2).getElement();
+   }
+
+   private static void setInertMainWindow(boolean inert)
    {
       Element ideWrapper = DOM.getElementById("rstudio_container");
       Element ideFrame = DOM.getElementById("rstudio");
-      if (ideWrapper == null || ideFrame == null)
-         return;
-      
-      if (numModalsShowing() == 0)
-      {
-         ideWrapper.removeAttribute("inert");
-         ideFrame.removeAttribute("inert");
-      }
-      else if (numModalsShowing() == 1)
-      {
-         ideWrapper.setAttribute("inert", "");
-         ideFrame.setAttribute("inert", "");
-      }
+      Element satWrapper = DOM.getElementById(ElementIds.getElementId(ElementIds.SATELLITE_PANEL));
+
+      if (ideWrapper != null)
+         A11y.setInert(ideWrapper, inert);
+      if (ideFrame != null)
+         A11y.setInert(ideFrame, inert);
+      if (satWrapper != null)
+         A11y.setInert(satWrapper, inert);
    }
 
    private static final ArrayList<PopupPanel> dialogStack_ = new ArrayList<>();

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteWindow.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.common.satellite;
 
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.widget.AriaLiveStatusWidget;
@@ -65,7 +66,8 @@ public abstract class SatelliteWindow extends Composite
 
       // create application panel
       mainPanel_ = new LayoutPanel();
-      
+      ElementIds.assignElementId(mainPanel_.getElement(), ElementIds.SATELLITE_PANEL);
+
       // Register an event handler for themes so it will be triggered after a
       // UIPrefsChangedEvent updates the theme. Do this after SessionInit (if we
       // do it beforehand we'll trigger the event before the SessionInfo object


### PR DESCRIPTION
- When modal dialog is shown, make the main window hidden to screen readers via aria-hidden (the inert polyfill we use doesn't do this automatically; other polyfills do, but don't want to switch at this stage)
- Also support making satellite windows inert by giving root panel an ID to use for searching
- When modal dialogs are stacked and unstacked, make covered dialog inert otherwise it is reachable via tab key (from outside browser) and screen readers
- Fixes #6075