### PR TITLE
user preference to control console output announcement limit

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -314,6 +314,7 @@ namespace prefs {
 #define kTerminalInitialDirectoryHome "home"
 #define kFullProjectPathInWindowTitle "full_project_path_in_window_title"
 #define kDisabledAriaLiveAnnouncements "disabled_aria_live_announcements"
+#define kScreenreaderConsoleAnnounceLimit "screenreader_console_announce_limit"
 
 class UserPrefValues: public Preferences
 {
@@ -1386,6 +1387,12 @@ public:
     */
    core::json::Array disabledAriaLiveAnnouncements();
    core::Error setDisabledAriaLiveAnnouncements(core::json::Array val);
+
+   /**
+    * Maximum number of lines of console output announced after a command.
+    */
+   int screenreaderConsoleAnnounceLimit();
+   core::Error setScreenreaderConsoleAnnounceLimit(int val);
 
 };
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2337,6 +2337,19 @@ core::Error UserPrefValues::setDisabledAriaLiveAnnouncements(core::json::Array v
    return writePref("disabled_aria_live_announcements", val);
 }
 
+/**
+ * Maximum number of lines of console output announced after a command.
+ */
+int UserPrefValues::screenreaderConsoleAnnounceLimit()
+{
+   return readPref<int>("screenreader_console_announce_limit");
+}
+
+core::Error UserPrefValues::setScreenreaderConsoleAnnounceLimit(int val)
+{
+   return writePref("screenreader_console_announce_limit", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2518,6 +2531,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kTerminalInitialDirectory,
       kFullProjectPathInWindowTitle,
       kDisabledAriaLiveAnnouncements,
+      kScreenreaderConsoleAnnounceLimit,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1009,6 +1009,11 @@
             "type": "array",
             "default": [],
             "description": "List of aria-live announcements to disable."
+        },
+        "screenreader_console_announce_limit": {
+            "type": "integer",
+            "default": 25,
+            "description": "Maximum number of lines of console output announced after a command."
         }
     }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericValueWidget.java
@@ -1,7 +1,7 @@
 /*
  * NumericValueWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -39,6 +39,7 @@ public class NumericValueWidget extends Composite
     */
    public NumericValueWidget(String label, Integer minValue, Integer maxValue)
    {
+      label_ = label;
       FlowPanel flowPanel = new FlowPanel();
 
       textBox_ = new NumericTextBox();
@@ -53,7 +54,7 @@ public class NumericValueWidget extends Composite
          textBox_.setMax(maxValue);
       textBox_.getElement().getStyle().setMarginLeft(0.6, Unit.EM);
 
-      flowPanel.add(new SpanLabel(label, textBox_, true));
+      flowPanel.add(new SpanLabel(label_, textBox_, true));
       flowPanel.add(textBox_);
 
       initWidget(flowPanel);
@@ -88,7 +89,7 @@ public class NumericValueWidget extends Composite
     * Make sure field is a valid integer in the range [min, max]. If min or max
     * are null, then 0 and infinity are assumed, respectively.
     */
-   public boolean validate(String fieldName)
+   public boolean validate()
    {
       String value = textBox_.getValue().trim();
       if (!value.matches("^\\d+$"))
@@ -97,7 +98,7 @@ public class NumericValueWidget extends Composite
          textBox_.getElement().focus();
          RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                "Error",
-               fieldName + " must be a valid number.",
+               label_ + " must be a valid number.",
                textBox_);
          return false;
       }
@@ -108,7 +109,7 @@ public class NumericValueWidget extends Composite
          {
             RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                   "Error",
-                  fieldName + " must be greater than or equal to " + minValue_ + ".",
+                  label_ + " must be greater than or equal to " + minValue_ + ".",
                   textBox_);
             return false;
          }
@@ -116,7 +117,7 @@ public class NumericValueWidget extends Composite
          {
             RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                   "Error",
-                  fieldName + " must be less than or equal to " + maxValue_ + ".",
+                  label_ + " must be less than or equal to " + maxValue_ + ".",
                   textBox_);
             return false;
          }
@@ -132,4 +133,5 @@ public class NumericValueWidget extends Composite
    private final NumericTextBox textBox_;
    private final Integer minValue_;
    private final Integer maxValue_;
+   private final String label_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/AriaLiveShellWidget.java
@@ -19,15 +19,16 @@ import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.a11y.A11y;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 /**
  * Visibly-hidden live region used to report recent console output to a screen reader.
  */
 public class AriaLiveShellWidget extends Widget
 {
-   private static final int LINE_REPORTING_LIMIT = 25;
-   public AriaLiveShellWidget()
+   public AriaLiveShellWidget(UserPrefs prefs)
    {
+      prefs_ = prefs;
       lineCount_ = 0;
       setElement(Document.get().createDivElement());
       A11y.setVisuallyHidden(getElement());
@@ -36,7 +37,7 @@ public class AriaLiveShellWidget extends Widget
    
    public void announce(String text)
    {
-      if (lineCount_ > LINE_REPORTING_LIMIT)
+      if (lineCount_ > prefs_.screenreaderConsoleAnnounceLimit().getValue())
          return;
 
       StringBuilder line = new StringBuilder();
@@ -50,9 +51,9 @@ public class AriaLiveShellWidget extends Widget
             append(line.toString());
             line.setLength(0);
             
-            if (lineCount_ == LINE_REPORTING_LIMIT)
+            if (lineCount_ == prefs_.screenreaderConsoleAnnounceLimit().getValue())
             {
-               append("Too much output to announce in console.");
+               append("Too much console output to announce.");
                lineCount_++;
                return;
             }
@@ -80,4 +81,5 @@ public class AriaLiveShellWidget extends Widget
    }
 
    private int lineCount_;
+   private final UserPrefs prefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -817,7 +817,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    @Override
    public void enableLiveReporting()
    {
-      liveRegion_ = new AriaLiveShellWidget();
+      liveRegion_ = new AriaLiveShellWidget(prefs_);
       verticalPanel_.add(liveRegion_);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
@@ -142,7 +142,7 @@ public class ProjectEditingPreferencesPane extends ProjectPreferencesPane
    @Override
    public boolean validate()
    {
-      return numSpacesForTab_.validate("Tab width"); 
+      return numSpacesForTab_.validate();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -379,6 +379,7 @@ public class UserPrefs extends UserPrefsComputed
    public static final int LAYER_PROJECT  = 4;
 
    public static final int MAX_TAB_WIDTH = 64;
+   public static final int MAX_SCREEN_READER_CONSOLE_OUTPUT = 999;
 
    private final Session session_;
    private final PrefsServerOperations server_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1665,6 +1665,14 @@ public class UserPrefsAccessor extends Prefs
       return object("disabled_aria_live_announcements", JsArrayUtil.createStringArray());
    }
 
+   /**
+    * Maximum number of lines of console output announced after a command.
+    */
+   public PrefValue<Integer> screenreaderConsoleAnnounceLimit()
+   {
+      return integer("screenreader_console_announce_limit", 25);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -2023,6 +2031,8 @@ public class UserPrefsAccessor extends Prefs
          fullProjectPathInWindowTitle().setValue(layer, source.getBool("full_project_path_in_window_title"));
       if (source.hasKey("disabled_aria_live_announcements"))
          disabledAriaLiveAnnouncements().setValue(layer, source.getObject("disabled_aria_live_announcements"));
+      if (source.hasKey("screenreader_console_announce_limit"))
+         screenreaderConsoleAnnounceLimit().setValue(layer, source.getInteger("screenreader_console_announce_limit"));
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -58,6 +58,8 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
             1, 9999, prefs.typingStatusDelayMs());
       generalPanel.add(indent(typingStatusDelay_));
+      generalPanel.add(indent(maxOutput_ = numericPref("Maximum number of console output lines to read",
+            0, UserPrefs.MAX_SCREEN_READER_CONSOLE_OUTPUT, prefs.screenreaderConsoleAnnounceLimit())));
 
       Label displayLabel = headerLabel("Other");
       generalPanel.add(displayLabel);
@@ -136,7 +138,8 @@ public class AccessibilityPreferencesPane extends PreferencesPane
    @Override
    public boolean validate()
    {
-      return (!chkScreenReaderEnabled_.getValue() || typingStatusDelay_.validate("Speak results after typing delay"));
+      return (!chkScreenReaderEnabled_.getValue() ||
+            (typingStatusDelay_.validate() && maxOutput_.validate()));
    }
 
    private void populateAnnouncementList()
@@ -182,6 +185,7 @@ public class AccessibilityPreferencesPane extends PreferencesPane
 
    private final CheckBox chkScreenReaderEnabled_;
    private final NumericValueWidget typingStatusDelay_;
+   private final NumericValueWidget maxOutput_;
    private final CheckBox chkTabMovesFocus_;
    private final CheckBoxList announcements_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -607,11 +607,11 @@ public class EditingPreferencesPane extends PreferencesPane
    @Override
    public boolean validate()
    {
-      return (!spacesForTab_.getValue() || tabWidth_.validate("Tab width")) && 
-             (!showMargin_.getValue() || marginCol_.validate("Margin column")) &&
-             alwaysCompleteChars_.validate("Characters entered") &&
-             alwaysCompleteDelayMs_.validate("Completion keyboard idle (ms)") &&
-             backgroundDiagnosticsDelayMs_.validate("Diagnostics keyboard idle (ms):");
+      return (!spacesForTab_.getValue() || tabWidth_.validate()) && 
+             (!showMargin_.getValue() || marginCol_.validate()) &&
+             alwaysCompleteChars_.validate() &&
+             alwaysCompleteDelayMs_.validate() &&
+             backgroundDiagnosticsDelayMs_.validate();
    }
 
    @Override


### PR DESCRIPTION
- Remove hardcoded limit of 25 lines and let user configure via Accessibility Preferences
- Tweaked NumericValueWidget to track its own label to use in validation messages instead of callers having to pass it in twice