### PR TITLE
Use random column name for relabeling in data viewer

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -251,12 +251,13 @@
       # "x" is a function argument and therefore a promise whose value won't
       # be bound via substitute() below. we use a random-looking name so we 
       # can spot it later when relabeling columns.
-      ioHe4iej <- x
+      `__RSTUDIO_VIEWER_COLUMN__` <- x
 
       # perform the actual coercion in the global environment; this is 
       # necessary because we want to honor as.data.frame overrides of packages
       # which are loaded after tools:rstudio in the search path
-      frame <- eval(substitute(as.data.frame(ioHe4iej, optional = TRUE)), 
+      frame <- eval(substitute(as.data.frame(`__RSTUDIO_VIEWER_COLUMN__`, 
+                                             optional = TRUE)), 
                     envir = globalenv())
     },
     error = function(e)
@@ -266,7 +267,7 @@
     # as.data.frame uses the name of its argument to label unlabeled columns,
     # so label these back to the original name
     if (!is.null(frame) && !is.null(names(frame)))
-      names(frame)[names(frame) == "ioHe4iej"] <- name
+      names(frame)[names(frame) == "__RSTUDIO_VIEWER_COLUMN__"] <- name
     x <- frame 
   }
 

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -1,7 +1,7 @@
 #
 # SessionDataViewer.R
 #
-# Copyright (C) 2009-18 by RStudio, PBC
+# Copyright (C) 2009-20 by RStudio, PBC
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -249,13 +249,14 @@
     {
       # create a temporary frame to hold the value; this is necessary because
       # "x" is a function argument and therefore a promise whose value won't
-      # be bound via substitute() below
-      coerced <- x
+      # be bound via substitute() below. we use a random-looking name so we 
+      # can spot it later when relabeling columns.
+      ioHe4iej <- x
 
       # perform the actual coercion in the global environment; this is 
       # necessary because we want to honor as.data.frame overrides of packages
       # which are loaded after tools:rstudio in the search path
-      frame <- eval(substitute(as.data.frame(coerced, optional = TRUE)), 
+      frame <- eval(substitute(as.data.frame(ioHe4iej, optional = TRUE)), 
                     envir = globalenv())
     },
     error = function(e)
@@ -265,7 +266,7 @@
     # as.data.frame uses the name of its argument to label unlabeled columns,
     # so label these back to the original name
     if (!is.null(frame) && !is.null(names(frame)))
-      names(frame)[names(frame) == "x"] <- name
+      names(frame)[names(frame) == "ioHe4iej"] <- name
     x <- frame 
   }
 


### PR DESCRIPTION
This change fixes an issue in which columns named `x` were sometimes incorrectly relabeled (when the column was part of an object that was not a data frame but had to be coerced to one for viewing). 

The faulting code is supposed to restore incorrectly labeled columns but has not worked correctly for some time; in commit https://github.com/rstudio/rstudio/commit/a58944bf2ddd0a190d6ad1e3237c79e333c46299 we gave the name `coerced` to the object instead of `x`, but continued to look for `x` when relabeling. 

The fix is to (a) use a random name for the object we coerce, and (b) fix the column relabeling so it finds the random object name (which is now vanishingly unlikely to appear as a real column name). 

Fixes https://github.com/rstudio/rstudio/issues/3304.