### PR TITLE
optionally announce echoed prompt and command in console

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -37,6 +37,7 @@ public class AriaLiveService
    // associate description for preferences UI.
    public static final String CONSOLE_CLEARED = "console_cleared";
    public static final String CONSOLE_LOG = "console_log";
+   public static final String CONSOLE_COMMAND = "console_command";
    public static final String FILTERED_LIST = "filtered_list";
    public static final String GIT_MESSAGE_LENGTH = "git_message_length";
    public static final String INACCESSIBLE_FEATURE = "inaccessible_feature";
@@ -65,6 +66,7 @@ public class AriaLiveService
       announcements_ = new HashMap<>();
       announcements_.put(CONSOLE_CLEARED, "Console cleared");
       announcements_.put(CONSOLE_LOG, "Console output (requires restart)");
+      announcements_.put(CONSOLE_COMMAND, "Console command (requires restart)");
       announcements_.put(FILTERED_LIST, "Filtered result count");
       announcements_.put(GIT_MESSAGE_LENGTH, "Commit message length");
       announcements_.put(INACCESSIBLE_FEATURE, "Inaccessible feature warning");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -162,6 +162,7 @@ public class AccessibilityPreferencesPane extends PreferencesPane
    private boolean applyAnnouncementList(UserPrefs prefs)
    {
       boolean origConsoleLog = ariaLive_.isDisabled(AriaLiveService.CONSOLE_LOG);
+      boolean origConsoleCommand = ariaLive_.isDisabled(AriaLiveService.CONSOLE_COMMAND);
       boolean restartNeeded = false;
 
       JsArrayString settings = prefs.disabledAriaLiveAnnouncements().getValue();
@@ -174,6 +175,11 @@ public class AccessibilityPreferencesPane extends PreferencesPane
          
          if (StringUtil.equals(chk.getFormValue(), AriaLiveService.CONSOLE_LOG) &&
                origConsoleLog == chk.getValue())
+         {
+            restartNeeded = true;
+         }
+         else if (StringUtil.equals(chk.getFormValue(), AriaLiveService.CONSOLE_COMMAND) &&
+               origConsoleCommand == chk.getValue())
          {
             restartNeeded = true;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -785,8 +785,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    @Override
    public void onScreenReaderStateReady(ScreenReaderStateReadyEvent e)
    {
-      if (prefs_.getScreenReaderEnabled() && !ariaLive_.isDisabled(AriaLiveService.CONSOLE_LOG))
+      if (prefs_.getScreenReaderEnabled() &&
+            (!ariaLive_.isDisabled(AriaLiveService.CONSOLE_LOG) ||
+             !ariaLive_.isDisabled(AriaLiveService.CONSOLE_COMMAND)))
+      {
          view_.enableLiveReporting();
+      }
    }
 
    private final ConsoleServerOperations server_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -19,6 +19,7 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.ui.*;
 import com.google.inject.Inject;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.shell.ShellWidget;
@@ -28,9 +29,9 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 public class ShellPane extends ShellWidget implements Shell.Display
 {
    @Inject
-   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events)
+   public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events, AriaLiveService ariaLive)
    {
-      super(editor, uiPrefs, events);
+      super(editor, uiPrefs, events, ariaLive);
 
       editor.setDisableOverwrite(true);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
@@ -25,7 +25,7 @@ public class ConsoleProgressWidget extends ShellWidget implements ShellDisplay
 {
    public ConsoleProgressWidget()
    {
-      super(new AceEditor(), null, null);
+      super(new AceEditor(), null, null, null);
       getEditor().setInsertMatching(false);
       getEditor().setTextInputAriaLabel("Progress details");
       if (!RStudioGinjector.INSTANCE.getAriaLiveService().isDisabled(AriaLiveService.PROGRESS_LOG))


### PR DESCRIPTION
Wasn't announcing the echoed prompt/command. For example, this:

> cat("Hello")
Hello

was being announced as "Hello".

Now it is announced as "> cat("Hello")  Hello", with an option to go back to the previous behavior (not announce the prompt/command). I can imagine some users preferring one model over the other.