### PR TITLE
implement options dialog for renv

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -314,6 +314,9 @@ namespace prefs {
 #define kTerminalInitialDirectoryHome "home"
 #define kFullProjectPathInWindowTitle "full_project_path_in_window_title"
 #define kDisabledAriaLiveAnnouncements "disabled_aria_live_announcements"
+#define kRenvSandboxEnabled "renv_sandbox_enabled"
+#define kRenvShimsEnabled "renv_shims_enabled"
+#define kRenvUpdatesCheck "renv_updates_check"
 
 class UserPrefValues: public Preferences
 {
@@ -1386,6 +1389,24 @@ public:
     */
    core::json::Array disabledAriaLiveAnnouncements();
    core::Error setDisabledAriaLiveAnnouncements(core::json::Array val);
+
+   /**
+    * Enable sandboxing of system library in renv projects
+    */
+   bool renvSandboxEnabled();
+   core::Error setRenvSandboxEnabled(bool val);
+
+   /**
+    * Enable renv shims in renv projects
+    */
+   bool renvShimsEnabled();
+   core::Error setRenvShimsEnabled(bool val);
+
+   /**
+    * Automatically check for package updates in renv projects
+    */
+   bool renvUpdatesCheck();
+   core::Error setRenvUpdatesCheck(bool val);
 
 };
 

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -121,8 +121,8 @@
    df
 })
 
-.rs.addFunction("renv.listPackages", function(project) {
-   
+.rs.addFunction("renv.listPackages", function(project)
+{
    # get list of packages
    installedPackages <- .rs.listInstalledPackages()
    
@@ -135,16 +135,23 @@
    names(lockfilePackages) <- c("name", "packrat.version", "packrat.source")
 
    # note which packages are in project library
-   installedPackages[["in.project.library"]] <-
-      installedPackages$library_absolute == renv:::renv_paths_library(project = project)
-
+   lib <- path.expand(installedPackages$library_absolute)
+   projlib <- path.expand(renv:::renv_paths_library(project = project))
+   
+   lib <- gsub("\\", "/", lib, fixed = TRUE)
+   projlib <- gsub("\\", "/", projlib, fixed = TRUE)
+   
+   installedPackages[["in.project.library"]] <- lib == projlib
+   
    # merge together
-   merge.data.frame(
+   merged <- merge.data.frame(
       x = installedPackages,
       y = lockfilePackages,
       by = "name",
       all.x = TRUE,
       all.y = TRUE
    )
+   
+   merged
    
 })

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -70,6 +70,7 @@
             renv::settings[[setting]](project = project)
       })
       
+      # add only settings understood by RStudio to the context object
       context$settings$snapshot.type      <- .rs.scalar(context$settings$snapshot.type)
       context$settings$use.cache          <- .rs.scalar(context$settings$use.cache)
       context$settings$vcs.ignore.library <- .rs.scalar(context$settings$vcs.ignore.library)
@@ -90,9 +91,11 @@
    
    if (active)
    {
+      # project options that are understood by RStudio
       options[["projectUseCache"]]         <- context$settings$use.cache
       options[["projectVcsIgnoreLibrary"]] <- context$settings$vcs.ignore.library
       
+      # user settings understood by RStudio
       options[["userSandboxEnabled"]] <- renv:::renv_config("sandbox.enabled", default = TRUE)
       options[["userShimsEnabled"]]   <- renv:::renv_config("shims.enabled", default = TRUE)
       options[["userUpdatesCheck"]]   <- renv:::renv_config("updates.check", default = TRUE)
@@ -121,7 +124,8 @@
    # check for changes
    old <- .rs.renvCache[["modifiedTimes"]]
    
-   # have things changed?
+   # if neither the lockfile nor the library has been mutated,
+   # then there is nothing to do
    if (identical(old, new))
       return()
    
@@ -147,6 +151,11 @@
       
       object$Package <- record$Package %||% "(unknown)"
       object$Version <- record$Version %||% "(unknown)"
+      
+      # for packages from a known R package repository (e.g. CRAN),
+      # we prefer displaying the repository name as opposed to just
+      # plain "Repository". other sources (e.g. GitHub) are okay
+      # to display as-is and will not have a Repository field
       object$Source <-
          record$Repository %||%
          record$Source %||%

--- a/src/cpp/session/modules/SessionRenv.R
+++ b/src/cpp/session/modules/SessionRenv.R
@@ -114,11 +114,29 @@
 {
    lockpath <- file.path(project, "renv.lock")
    lockfile <- renv:::renv_lockfile_read(lockpath)
-   packages <- renv:::renv_records(lockfile)
-   filtered <- lapply(packages, `[`, c("Package", "Version", "Source"))
+   records <- renv:::renv_records(lockfile)
+   
+   `%||%` <- function(x, y) if (is.null(x)) y else x
+   
+   filtered <- lapply(records, function(record) {
+      
+      object <- list()
+      
+      object$Package <- record$Package %||% "(unknown)"
+      object$Version <- record$Version %||% "(unknown)"
+      object$Source <-
+         record$Repository %||%
+         record$Source %||%
+         "(unknown)"
+      
+      object
+         
+   })
+   
    df <- .rs.rbindList(filtered)
    rownames(df) <- NULL
    df
+   
 })
 
 .rs.addFunction("renv.listPackages", function(project)

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -122,8 +122,6 @@ Error initialize()
    // initialize renv options from prefs
    if (projects::projectContext().hasProject())
    {
-      std::cerr << "Hello, world!" << std::endl;
-      
       r::exec::RFunction options("base:::options");
       options.addParam("renv.config.sandbox.enabled", prefs::userPrefs().renvSandboxEnabled());
       options.addParam("renv.config.shims.enabled", prefs::userPrefs().renvShimsEnabled());

--- a/src/cpp/session/modules/SessionRenv.cpp
+++ b/src/cpp/session/modules/SessionRenv.cpp
@@ -22,6 +22,7 @@
 #include <r/RJson.hpp>
 
 #include <session/SessionModuleContext.hpp>
+#include <session/prefs/UserPrefs.hpp>
 #include <session/projects/SessionProjects.hpp>
 
 
@@ -117,6 +118,21 @@ Error initialize()
    // initialize renv after session init (need to make sure
    // all other RStudio startup code runs first)
    events().onConsolePrompt.connect(onConsolePrompt);
+   
+   // initialize renv options from prefs
+   if (projects::projectContext().hasProject())
+   {
+      std::cerr << "Hello, world!" << std::endl;
+      
+      r::exec::RFunction options("base:::options");
+      options.addParam("renv.config.sandbox.enabled", prefs::userPrefs().renvSandboxEnabled());
+      options.addParam("renv.config.shims.enabled", prefs::userPrefs().renvShimsEnabled());
+      options.addParam("renv.config.updates.check", prefs::userPrefs().renvUpdatesCheck());
+
+      Error error = options.call();
+      if (error)
+         LOG_ERROR(error);
+   }
 
    using boost::bind;
    ExecBlock initBlock;

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2337,6 +2337,45 @@ core::Error UserPrefValues::setDisabledAriaLiveAnnouncements(core::json::Array v
    return writePref("disabled_aria_live_announcements", val);
 }
 
+/**
+ * Enable sandboxing of system library in renv projects
+ */
+bool UserPrefValues::renvSandboxEnabled()
+{
+   return readPref<bool>("renv_sandbox_enabled");
+}
+
+core::Error UserPrefValues::setRenvSandboxEnabled(bool val)
+{
+   return writePref("renv_sandbox_enabled", val);
+}
+
+/**
+ * Enable renv shims in renv projects
+ */
+bool UserPrefValues::renvShimsEnabled()
+{
+   return readPref<bool>("renv_shims_enabled");
+}
+
+core::Error UserPrefValues::setRenvShimsEnabled(bool val)
+{
+   return writePref("renv_shims_enabled", val);
+}
+
+/**
+ * Automatically check for package updates in renv projects
+ */
+bool UserPrefValues::renvUpdatesCheck()
+{
+   return readPref<bool>("renv_updates_check");
+}
+
+core::Error UserPrefValues::setRenvUpdatesCheck(bool val)
+{
+   return writePref("renv_updates_check", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2518,6 +2557,9 @@ std::vector<std::string> UserPrefValues::allKeys()
       kTerminalInitialDirectory,
       kFullProjectPathInWindowTitle,
       kDisabledAriaLiveAnnouncements,
+      kRenvSandboxEnabled,
+      kRenvShimsEnabled,
+      kRenvUpdatesCheck,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1009,6 +1009,21 @@
             "type": "array",
             "default": [],
             "description": "List of aria-live announcements to disable."
+        },
+        "renv_sandbox_enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable sandboxing of system library in renv projects"
+        },
+        "renv_shims_enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable renv shims in renv projects"
+        },
+        "renv_updates_check": {
+            "type": "boolean",
+            "default": false,
+            "description": "Automatically check for package updates in renv projects"
         }
     }
 }

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
@@ -24,12 +24,14 @@ import org.rstudio.core.client.widget.ProgressIndicator;
 
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Display;
+import com.google.gwt.dom.client.Style.FontStyle;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -153,6 +155,23 @@ public abstract class PreferencesDialogPaneBase<T> extends VerticalPanel
       helpStyle.setMarginLeft(6, Unit.PX);
       panel.add(helpButton);
       return panel;
+   }
+   
+   protected Label header(String text)
+   {
+      Label label = new Label(text);
+      label.addStyleName(res_.styles().headerLabel());
+      nudgeRight(label);
+      return label;
+   }
+   
+   protected Label info(String text)
+   {
+      Label label = new Label(text);
+      label.getElement().getStyle().setFontStyle(FontStyle.ITALIC);
+      nudgeRight(label);
+      spaced(label);
+      return label;
    }
    
    protected void forceClosed(Command onClosed)

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectRenvOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectRenvOptions.java
@@ -29,4 +29,13 @@ public class RProjectRenvOptions
    }
    
    public boolean useRenv;
+   
+   // Project settings
+   public boolean projectUseCache;
+   public boolean projectVcsIgnoreLibrary;
+   
+   // User configuration
+   public boolean userSandboxEnabled;
+   public boolean userShimsEnabled;
+   public boolean userUpdatesCheck;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -162,11 +162,12 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
       EventBus events = pEventBus_.get();
       
       // renv is off and staying off -- nothing to do
-      if (!renvOptions_.useRenv && !newOptions.useRenv)
-         return;
+      if (!newOptions.useRenv && !renvOptions_.useRenv)
+      {
+      }
       
       // turning renv off -- just call deactivate
-      if (renvOptions_.useRenv && !newOptions.useRenv)
+      else if (!newOptions.useRenv && renvOptions_.useRenv)
       {
          String action = "renv::deactivate()";
          events.fireEvent(new SendToConsoleEvent(action, true, true));
@@ -174,35 +175,42 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
       }
       
       // turning renv on -- just call activate
-      if (newOptions.useRenv != renvOptions_.useRenv)
+      //
+      // TODO: we need to apply project options here, but we need to call
+      // renv::activate() first to activate the project ... and that will
+      // force the R session to restart. is there a way for us to cleanly
+      // orchestrate this chain of events?
+      else if (newOptions.useRenv && !renvOptions_.useRenv)
       {
          String action = "renv::activate()";
          events.fireEvent(new SendToConsoleEvent(action, true, true));
          return;
       }
-      
-      // update project settings, etc
-      List<String> commands = new ArrayList<>();
-      
-      if (renvOptions_.projectUseCache != newOptions.projectUseCache)
-         commands.add(setting("use.cache", newOptions.projectUseCache));
-      
-      if (renvOptions_.projectVcsIgnoreLibrary != newOptions.projectVcsIgnoreLibrary)
-         commands.add(setting("vcs.ignore.library", newOptions.projectVcsIgnoreLibrary));
-      
-      if (renvOptions_.userSandboxEnabled != newOptions.userSandboxEnabled)
-         commands.add(config("sandbox.enabled", newOptions.userSandboxEnabled));
-      
-      if (renvOptions_.userShimsEnabled != newOptions.userShimsEnabled)
-         commands.add(config("shims.enabled", newOptions.userShimsEnabled));
-      
-      if (renvOptions_.userUpdatesCheck != newOptions.userUpdatesCheck)
-         commands.add(config("updates.check", newOptions.userUpdatesCheck));
-      
-      if (!commands.isEmpty())
+      else
       {
-         String command = StringUtil.join(commands, "\n");
-         events.fireEvent(new SendToConsoleEvent(command, true, true));
+         // update project settings, etc
+         List<String> commands = new ArrayList<>();
+
+         if (renvOptions_.projectUseCache != newOptions.projectUseCache)
+            commands.add(setting("use.cache", newOptions.projectUseCache));
+
+         if (renvOptions_.projectVcsIgnoreLibrary != newOptions.projectVcsIgnoreLibrary)
+            commands.add(setting("vcs.ignore.library", newOptions.projectVcsIgnoreLibrary));
+
+         if (renvOptions_.userSandboxEnabled != newOptions.userSandboxEnabled)
+            commands.add(config("sandbox.enabled", newOptions.userSandboxEnabled));
+
+         if (renvOptions_.userShimsEnabled != newOptions.userShimsEnabled)
+            commands.add(config("shims.enabled", newOptions.userShimsEnabled));
+
+         if (renvOptions_.userUpdatesCheck != newOptions.userUpdatesCheck)
+            commands.add(config("updates.check", newOptions.userUpdatesCheck));
+
+         if (!commands.isEmpty())
+         {
+            String command = StringUtil.join(commands, "\n");
+            events.fireEvent(new SendToConsoleEvent(command, true, true));
+         }
       }
       
    }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectRenvPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectRenvPreferencesPane.java
@@ -55,7 +55,7 @@ public class ProjectRenvPreferencesPane extends ProjectPreferencesPane
    @Override
    public String getName()
    {
-      return "Environments";
+      return "renv";
    }
 
    @Override
@@ -63,7 +63,7 @@ public class ProjectRenvPreferencesPane extends ProjectPreferencesPane
    {
       String labelText =
             "RStudio uses the renv package to give your projects their " +
-            "own privately-managed package library, making your R code " +
+            "own project-local library of R packages, making your projects " +
             "more isolated, portable, and reproducible.";
             
       Label label = new Label(labelText);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1665,6 +1665,30 @@ public class UserPrefsAccessor extends Prefs
       return object("disabled_aria_live_announcements", JsArrayUtil.createStringArray());
    }
 
+   /**
+    * Enable sandboxing of system library in renv projects
+    */
+   public PrefValue<Boolean> renvSandboxEnabled()
+   {
+      return bool("renv_sandbox_enabled", true);
+   }
+
+   /**
+    * Enable renv shims in renv projects
+    */
+   public PrefValue<Boolean> renvShimsEnabled()
+   {
+      return bool("renv_shims_enabled", true);
+   }
+
+   /**
+    * Automatically check for package updates in renv projects
+    */
+   public PrefValue<Boolean> renvUpdatesCheck()
+   {
+      return bool("renv_updates_check", false);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -2023,6 +2047,12 @@ public class UserPrefsAccessor extends Prefs
          fullProjectPathInWindowTitle().setValue(layer, source.getBool("full_project_path_in_window_title"));
       if (source.hasKey("disabled_aria_live_announcements"))
          disabledAriaLiveAnnouncements().setValue(layer, source.getObject("disabled_aria_live_announcements"));
+      if (source.hasKey("renv_sandbox_enabled"))
+         renvSandboxEnabled().setValue(layer, source.getBool("renv_sandbox_enabled"));
+      if (source.hasKey("renv_shims_enabled"))
+         renvShimsEnabled().setValue(layer, source.getBool("renv_shims_enabled"));
+      if (source.hasKey("renv_updates_check"))
+         renvUpdatesCheck().setValue(layer, source.getBool("renv_updates_check"));
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/projects/RenvContext.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.projects;
 
+import org.rstudio.core.client.js.JsObject;
+
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 
@@ -22,4 +24,5 @@ public class RenvContext
 {
    public boolean installed;
    public boolean active;
+   public JsObject settings;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -656,7 +656,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
                  .libraryHeader());
            cell.title(library);
            cell.startH1().text(
-                 PackageLibraryUtils.getLibraryDescription(session_, library))
+                 PackageLibraryUtils.getLibraryDescription(pkg, session_))
                  .endH1();
            row.endTD();
            

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
@@ -29,9 +29,13 @@ public class PackageLibraryUtils
       System
    }
 
-   public static PackageLibraryType typeOfLibrary(Session session, 
-                                                  String library)
+   public static PackageLibraryType typeOfLibrary(PackageInfo info,
+                                                  Session session)
    {
+      // if we know it's in the project library, use that directly
+      if (info.isInProjectLibrary())
+         return PackageLibraryType.Project;
+      
       FileSystemItem projectDir = null;
       SessionInfo sessionInfo = session.getSessionInfo();
       if (sessionInfo != null)
@@ -43,6 +47,7 @@ public class PackageLibraryUtils
       // if there's an active project and this package is in its library or
       // the package has no recorded library (i.e. it's not installed), it
       // belongs in the project library
+      String library = info.getLibrary();
       if (StringUtil.isNullOrEmpty(library) ||
           (projectDir != null && library.startsWith(projectDir.getPath())))
       {
@@ -70,8 +75,8 @@ public class PackageLibraryUtils
       return "Library";
    }
    
-   public static String getLibraryDescription (Session session, String library)
+   public static String getLibraryDescription (PackageInfo info, Session session)
    {
-      return nameOfLibraryType(typeOfLibrary(session, library));
+      return nameOfLibraryType(typeOfLibrary(info, session));
    }
 }


### PR DESCRIPTION
This PR makes it possible to configure a subset of `renv`'s options and settings through the RStudio UI.

![Screen Shot 2020-02-07 at 10 29 53 AM](https://user-images.githubusercontent.com/1976582/74055395-cbb75a80-4994-11ea-80f5-e7b23ad1945d.png)

Some background: `renv` has its own notion of project settings (tied to a particular project), and user configuration (tied to a particular user). I'll discuss those both briefly so the PR is a bit easier to review.

## Project Settings

Project settings for `renv` are persisted as part of the project, in a file called `renv/settings.dcf`. These project settings are accessed and modified through the `renv::settings` helper API; e.g. the cache might be enabled with:

```
renv::settings$use.cache(TRUE)
```

Because these settings are persisted in the project and understood directly by `renv`, all RStudio needs to do when a user sets these options in the UI is emit the appropriate console commands to change those project settings. If curious, there is more documentation in `?renv::settings`.

## User Configuration

User configuration is more ad-hoc. It is done through R options -- for example:

```
options(renv.config.auto.snapshot = TRUE)
```

would instruct `renv` to automatically snapshot and update the lockfile after installing or removing a package. More documentation is available in `?renv::config`.

Currently, because `renv` does not maintain its own single source of truth as to where these user settings should be stored, I've instead opted to have these stored as project preferences. It's worth discussing if this is the correct decision.

This PR does not yet add support for Python within `renv`; that will be considered as part of a follow-up PR after we're sure we have the right framework for managing these.