### PR TITLE
suppress macOS Catalina warning about old system bash

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcess.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -54,6 +54,11 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 
    if (shellEnv.empty())
       core::system::environment(&shellEnv);
+
+#ifdef __APPLE__
+   // suppress macOS Catalina warning suggesting switching to zsh
+   core::system::setenv(&shellEnv, "BASH_SILENCE_DEPRECATION_WARNING", "1");
+#endif
 
    *pSelectedShellType = procInfo.getShellType();
 


### PR DESCRIPTION
MacOS Catalina users who still use the old bash bundled with macOS will no longer see the warning suggesting switching to zsh when they start a terminal.

- Fixes #6182