### PR TITLE
add Zsh as a supported terminal on Mac, Linux, and Server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@
 * Custom terminal shell option for Windows desktop (previously only on Mac, Linux, and server)
 * Change shortcuts for Next/Previous terminal to avoid clash with common Windows shortcuts (#4892)
 * Add 'Close All Terminals' command to Terminal menu (#3564)
+* Zsh option in terminal for Mac and Linux desktop, and RStudio Server (#5587)
 
 ### Diagnostics and Recovery
 

--- a/src/cpp/core/terminal/PrivateCommand.cpp
+++ b/src/cpp/core/terminal/PrivateCommand.cpp
@@ -1,7 +1,7 @@
 /*
  * PrivateCommand.cpp
  *
- * Copyright (C) 2009-18 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -44,6 +44,10 @@ const std::string kEol = "\r\n";
  * Command is prefixed with a space, to take advantage of
  * HISTCONTROL=ignorespace (or ignoreboth) as a way to prevent command from
  * showing up in shell history.
+ * 
+ * In Zsh, we rely on the shell having the HIST_IGNORE_SPACE option set, which we
+ * do via -g when we start Zsh. There is no attempt to detect if this setting has
+ * been overridden.
  */
 
 PrivateCommand::PrivateCommand(const std::string& command,

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -597,7 +597,7 @@
             "win-ps", "win-git-bash", "win-wsl-bash", "ps-core", "custom")
    }      
    if (!validShellType)
-      stop("'shellType' must be NULL, or one of 'default', 'win-cmd', 'win-ps', 'win-git-bash', 'win-wsl-bash', 'ps-core', or 'custom'.") 
+      stop("'shellType' must be NULL, or one of 'default', 'win-cmd', 'win-ps', 'win-git-bash', 'win-wsl-bash', 'ps-core', 'bash', 'zsh', or 'custom'.") 
 
    .Call("rs_terminalCreate", caption, show, shellType)
 })

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleProcess.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -65,6 +65,11 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    // don't add commands starting with a space to shell history
    if (procInfo.getTrackEnv())
    {
+      // HISTCONTROL is Bash-specific. In Zsh we rely on the shell having the 
+      // HIST_IGNORE_SPACE option set, which we do via -g when we start Zsh. In the
+      // future we could make environment-capture smarter and not set this variable
+      // for shells that don't use it, but for now keeping it to avoid having to 
+      // rework PrivateCommand class.
       core::system::setenv(&shellEnv, "HISTCONTROL", "ignoreboth");
    }
 #else

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionTerminalShell.hpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -46,8 +46,9 @@ struct TerminalShell
       CustomShell  = 8, // User-specified shell command
       NoShell      = 9, // Non-interactive job with no shell
       PSCore      = 10, // PowerShell Core (v6)
+      PosixZsh    = 11, // Posix: Zsh
 
-      Max          = PSCore
+      Max          = PosixZsh
    };
 
    TerminalShell() = default;

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -64,6 +64,7 @@ namespace prefs {
 #define kPosixTerminalShell "posix_terminal_shell"
 #define kPosixTerminalShellDefault "default"
 #define kPosixTerminalShellBash "bash"
+#define kPosixTerminalShellZsh "zsh"
 #define kPosixTerminalShellCustom "custom"
 #define kPosixTerminalShellNone "none"
 #define kCustomShellCommand "custom_shell_command"

--- a/src/cpp/session/modules/SessionTerminalShellTests.cpp
+++ b/src/cpp/session/modules/SessionTerminalShellTests.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionTerminalShellTests.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -106,7 +106,7 @@ test_context("session terminal shell tests")
 
 
 #else // Posix
-   test_that("One shell (bash) on Posix")
+   test_that("Bash on Posix")
    {
       AvailableTerminalShells shells;
       TerminalShell shell;

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -107,7 +107,7 @@
         },
         "posix_terminal_shell": {
             "type": "string",
-            "enum": ["default", "bash", "custom", "none"],
+            "enum": ["default", "bash", "zsh", "custom", "none"],
             "default": "default", 
             "description": "The terminal shell to use on POSIX operating systems (MacOS and Linux)."
         },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -201,6 +201,7 @@ public class UserPrefsAccessor extends Prefs
 
    public final static String POSIX_TERMINAL_SHELL_DEFAULT = "default";
    public final static String POSIX_TERMINAL_SHELL_BASH = "bash";
+   public final static String POSIX_TERMINAL_SHELL_ZSH = "zsh";
    public final static String POSIX_TERMINAL_SHELL_CUSTOM = "custom";
    public final static String POSIX_TERMINAL_SHELL_NONE = "none";
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalShellInfo.java
@@ -1,7 +1,7 @@
 /*
  * TerminalShellInfo.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -52,6 +52,8 @@ public class TerminalShellInfo extends JavaScriptObject
          return "Custom";
       case UserPrefs.POSIX_TERMINAL_SHELL_NONE:
          return "User command";
+      case UserPrefs.POSIX_TERMINAL_SHELL_ZSH:
+         return "Zsh";
       default:
          return "Unknown";
       }


### PR DESCRIPTION
- new Zsh option in terminal shell dropdown, but only if zsh found in /etc/shells
- fixes core of #5587 (but decided not to select zsh by default even on Catalina; maybe in a future release)
- one quirk of Zsh, it doesn't use the HISTCONTROL setting we rely on in bash to keep "hidden" commands used to capture environment variables from showing up in history, it uses a shell option, which we set via -g; we don't try to detect if this has been unset so if a user has a configuration that unsets this they will see weird commands in history unless they turn off Capture Environment Variables