### PR TITLE
Check env var for RStudio Server Pro user identity

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -825,8 +825,8 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 })
 
 # return system username 
-.rs.addApiFunction("systemUser", function() {
-   .Call("rs_systemUser", PACKAGE = "(embedding)")
+.rs.addApiFunction("systemUsername", function() {
+   .Call("rs_systemUsername", PACKAGE = "(embedding)")
 })
 
 # Tutorial ----


### PR DESCRIPTION
This small change fixes two small issues with the nascent user identity APIs:

1. It corrects the method name for system username to `systemUsername` (which is what rstudioapi calls)
2. It checks the environment variable `RSTUDIO_USER_IDENTITY_DISPLAY` for user identity on RStudio Server Pro (see https://github.com/rstudio/rstudio-pro/pull/1431)