### PR TITLE
Persist Program ID in Syslog

### DIFF
--- a/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/SyslogDestination.hpp
@@ -26,6 +26,8 @@
 
 #include <shared_core/ILogDestination.hpp>
 
+#include <shared_core/PImpl.hpp>
+
 namespace rstudio {
 namespace core {
 namespace system {
@@ -74,6 +76,10 @@ public:
     * @param in_message     The message to write to syslog.
     */
    void writeLog(log::LogLevel in_logLevel, const std::string& in_message) override;
+
+private:
+   // The private implementation of SyslogDestination
+   PRIVATE_IMPL(m_impl);
 };
 
 } // namespace system

--- a/src/cpp/shared_core/system/SyslogDestination.cpp
+++ b/src/cpp/shared_core/system/SyslogDestination.cpp
@@ -61,11 +61,30 @@ int logLevelToLogPriority(log::LogLevel in_logLevel)
 
 } // anonymous namespace
 
+struct SyslogDestination::Impl
+{
+   /**
+    * @brief Constructor.
+    *
+    * param in_programId        The ID of the program for which system logs should be written.
+    */
+   explicit Impl(const std::string& in_programId) :
+      ProgramId(in_programId)
+   {
+   }
+
+   /** The program ID. It must be persisted. */
+   std::string ProgramId;
+};
+
+PRIVATE_IMPL_DELETER_IMPL(SyslogDestination);
+
 SyslogDestination::SyslogDestination(log::LogLevel in_logLevel, const std::string& in_programId) :
-   ILogDestination(in_logLevel)
+   ILogDestination(in_logLevel),
+   m_impl(new Impl(in_programId))
 {
    // Open the system log. Don't set a mask because filtering is done at a higher level.
-   ::openlog(in_programId.c_str(), LOG_CONS | LOG_PID, LOG_USER);
+   ::openlog(m_impl->ProgramId.c_str(), LOG_CONS | LOG_PID, LOG_USER);
 }
 
 SyslogDestination::~SyslogDestination()


### PR DESCRIPTION
When the program ID passed to the SyslogDestination constructor had a lifetime which was shorter than the lifetime of the SyslogDestination itself, log messages would be written to syslog with nonsensical program IDs. This PR ensures that the program ID string will exist as long as the SyslogDestination exists.