### PR TITLE
Bug fix for 'Search these files' resetting to 'All Files'

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -254,7 +254,9 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
          ((Element) listPresetFilePatterns_.getElement().getChild(
                Include.Package.ordinal()))
             .setAttribute("disabled", "disabled");
-         listPresetFilePatterns_.setSelectedIndex(Include.AllFiles.ordinal());
+         if (listPresetFilePatterns_.getSelectedIndex() ==
+             Include.Package.ordinal())
+            listPresetFilePatterns_.setSelectedIndex(Include.AllFiles.ordinal());
       }
       else
          ((Element) listPresetFilePatterns_.getElement().getChild(


### PR DESCRIPTION
Fixes #6194 

`Search these files` was being set to `All Files` whenever the directory being searched was not a package directory. This PR fixes this issue so it only gets reset to `All Files` when the package option is selected and the directory is not a package directory.