### PR TITLE
stop embedding rstudioapi

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -217,7 +217,7 @@ endif()
 file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
 
 # embedded packages
-set(RSTUDIO_EMBEDDED_PACKAGES rstudioapi CACHE INTERNAL "Embedded R Packages")
+# set(RSTUDIO_EMBEDDED_PACKAGES rstudioapi CACHE INTERNAL "Embedded R Packages")
 
 # include utilities
 include(RStudioCMakeUtils)

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -82,8 +82,6 @@ mv $PACKAGE_ARCHIVE $PACKAGE_ARCHIVE_SHA1
 # install rsconnect master rstudio
 # install renv master rstudio
 
-install rstudioapi master rstudio
-
 RHOME=$(Rscript -e 'Sys.getenv("R_HOME")')
 if [[ ! -w $RHOME ]]; then
   echo "$RHOME is not writable. Creating user R library directory."

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -13,8 +13,6 @@ REM call:install rsconnect master rstudio --no-build-vignettes
 REM call:install rmarkdown master rstudio --no-build-vignettes
 REM call:install renv master rstudio --no-build-vignettes
 
-call:install rstudioapi master rstudio --no-build-vignettes
-
 GOTO:EOF
 
 :install

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -231,7 +231,7 @@
             "source": false
         },
         "rstudioapi": {
-            "version": "0.10",
+            "version": "0.11",
             "location": "cran",
             "source": false
         },


### PR DESCRIPTION
rstudioapi 0.11 is now on CRAN; it is no longer necessary for us to embed rstudioapi.