### PR TITLE
Install Qt via shell script in Linux Docker containers

### DIFF
--- a/dependencies/common/install-qt.sh
+++ b/dependencies/common/install-qt.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#############################################################################
+##
+## Copyright (C) 2019 Richard Weickelt.
+## Contact: https://www.qt.io/licensing/
+##
+## This file is part of Qbs.
+##
+## $QT_BEGIN_LICENSE:LGPL$
+## Commercial License Usage
+## Licensees holding valid commercial Qt licenses may use this file in
+## accordance with the commercial license agreement provided with the
+## Software or, alternatively, in accordance with the terms contained in
+## a written agreement between you and The Qt Company. For licensing terms
+## and conditions see https://www.qt.io/terms-conditions. For further
+## information use the contact form at https://www.qt.io/contact-us.
+##
+## GNU Lesser General Public License Usage
+## Alternatively, this file may be used under the terms of the GNU Lesser
+## General Public License version 3 as published by the Free Software
+## Foundation and appearing in the file LICENSE.LGPL3 included in the
+## packaging of this file. Please review the following information to
+## ensure the GNU Lesser General Public License version 3 requirements
+## will be met: https://www.gnu.org/licenses/lgpl-3.0.html.
+##
+## GNU General Public License Usage
+## Alternatively, this file may be used under the terms of the GNU
+## General Public License version 2.0 or (at your option) the GNU General
+## Public license version 3 or any later version approved by the KDE Free
+## Qt Foundation. The licenses are as published by the Free Software
+## Foundation and appearing in the file LICENSE.GPL2 and LICENSE.GPL3
+## included in the packaging of this file. Please review the following
+## information to ensure the GNU General Public License requirements will
+## be met: https://www.gnu.org/licenses/gpl-2.0.html and
+## https://www.gnu.org/licenses/gpl-3.0.html.
+##
+## $QT_END_LICENSE$
+##
+#############################################################################
+set -eu
+
+function help() {
+    cat <<EOF
+usage: install-qt [options] [components]
+
+Examples
+  ./install-qt.sh --version 5.13.1 qtbase
+  ./install-qt.sh --version 5.14.0 --target android --toolchain any qtbase qtscript
+
+Positional arguments
+  components
+        SDK components to be installed. All possible components
+        can be found in the online repository at https://download.qt.io,
+        for instance: qtbase, qtdeclarative, qtscript, qttools, icu, ...
+
+        In addition to Qt packages, qtcreator is also accepted.
+
+        The actual availability of packages may differ depending on
+        target and toolchain.
+
+Options
+  --directory <directory>
+        Root directory where to install the components.
+        Maps to C:/Qt on Windows, /opt/Qt on Linux, /usr/local/Qt on Mac
+        by default.
+
+  --host <host-os>
+        The host operating system. Can be one of linux_x64, mac_x64,
+        windows_x86. Auto-detected by default.
+
+  --target <target-platform>
+        The desired target platform. Can be one of desktop, android, ios.
+        The default value is desktop.
+
+  --toolchain <toolchain-type>
+        The toolchain that has been used to build the binaries.
+        Possible values depend on --host and --target, respectively:
+
+            linux_x64
+                android
+                    any, android_armv7, android_arm64_v8a
+                desktop
+                    gcc_64 (default)
+
+            mac_x64
+                android
+                    any, android_armv7, android_arm64_v8a
+                desktop
+                    clang_64 (default),
+                ios
+                    ios
+
+            windows_x86
+                android
+                    any, android_armv7, android_arm64_v8a
+                desktop
+                    win64_mingw73, win64_msvc2017_64 (default)
+
+  --version <version>
+        The desired Qt version. Currently supported are all versions
+        above 5.9.0.
+
+EOF
+}
+
+TARGET_PLATFORM=desktop
+COMPONENTS=
+VERSION=
+
+case "$OSTYPE" in
+    *linux*)
+        HOST_OS=linux_x64
+        INSTALL_DIR=/opt/Qt
+        TOOLCHAIN=gcc_64
+        ;;
+    *darwin*)
+        HOST_OS=mac_x64
+        INSTALL_DIR=/usr/local/Qt
+        TOOLCHAIN=clang_64
+        ;;
+    msys)
+        HOST_OS=windows_x86
+        INSTALL_DIR=/c/Qt
+        TOOLCHAIN=win64_msvc2015_64
+        ;;
+    *)
+        HOST_OS=
+        INSTALL_DIR=
+        ;;
+esac
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --directory|-d)
+            INSTALL_DIR="$2"
+            shift
+            ;;
+        --host)
+            HOST_OS="$2"
+            shift
+            ;;
+        --target)
+            TARGET_PLATFORM="$2"
+            shift
+            ;;
+        --toolchain)
+            TOOLCHAIN=$(echo $2 | tr '[A-Z]' '[a-z]')
+            shift
+            ;;
+        --version)
+            VERSION="$2"
+            shift
+            ;;
+        --help|-h)
+            help
+            exit 0
+            ;;
+        *)
+            COMPONENTS="${COMPONENTS} $1"
+            ;;
+    esac
+    shift
+done
+
+if [ -z "${HOST_OS}" ]; then
+    echo "No --host specified or auto-detection failed." >&2
+    exit 1
+fi
+
+if [ -z "${INSTALL_DIR}" ]; then
+    echo "No --directory specified or auto-detection failed." >&2
+    exit 1
+fi
+
+if [ -z "${VERSION}" ]; then
+    echo "No --version specified." >&2
+    exit 1
+fi
+
+if [ -z "${COMPONENTS}" ]; then
+    echo "No components specified." >&2
+    exit 1
+fi
+
+case "$TARGET_PLATFORM" in
+    android)
+        ;;
+    ios)
+        ;;
+    desktop)
+        ;;
+    *)
+        echo "Error: TARGET_PLATFORM=${TARGET_PLATFORM} is not valid." >&2
+        exit 1
+        ;;
+esac
+
+DOWNLOAD_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'install-qt'`
+
+#
+# The repository structure is a mess. Try different URL variants
+#
+function compute_url(){
+    local COMPONENT=$1
+    local CURL="curl -s -L"
+    local BASE_URL="http://download.qt.io/online/qtsdkrepository/${HOST_OS}/${TARGET_PLATFORM}"
+
+    if [[ "${COMPONENT}" =~ "qtcreator" ]]; then
+
+        REMOTE_BASE="tools_qtcreator/qt.tools.qtcreator"
+        REMOTE_PATH="$(${CURL} ${BASE_URL}/${REMOTE_BASE}/ | grep -o -E "${VERSION}[0-9\-]*${COMPONENT}\.7z" | tail -1)"
+
+        if [ ! -z "${REMOTE_PATH}" ]; then
+            echo "${BASE_URL}/${REMOTE_BASE}/${REMOTE_PATH}"
+            return 0
+        fi
+
+    else
+        REMOTE_BASES=(
+            # New repository format (>=5.9.6)
+            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${TOOLCHAIN}"
+            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
+            # Multi-abi Android since 5.14
+            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${TARGET_PLATFORM}"
+            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${COMPONENT}.${TARGET_PLATFORM}"
+            # Older repository format (<5.9.0)
+            "qt5_${VERSION//./}/qt.${VERSION//./}.${TOOLCHAIN}"
+            "qt5_${VERSION//./}/qt.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
+        )
+
+        for REMOTE_BASE in ${REMOTE_BASES[*]}; do
+            REMOTE_PATH="$(${CURL} ${BASE_URL}/${REMOTE_BASE}/ | grep -o -E "[[:alnum:]_.\-]*7z" | grep "${COMPONENT}" | tail -1)"
+            if [ ! -z "${REMOTE_PATH}" ]; then
+                echo "${BASE_URL}/${REMOTE_BASE}/${REMOTE_PATH}"
+                return 0
+            fi
+        done
+    fi
+
+    echo "Could not determine a remote URL for ${COMPONENT} with version ${VERSION}">&2
+    exit 1
+}
+
+mkdir -p ${INSTALL_DIR}
+
+for COMPONENT in ${COMPONENTS}; do
+
+    URL="$(compute_url ${COMPONENT})"
+echo URL=${URL}
+    echo "Downloading ${COMPONENT}..." >&2
+    curl --progress-bar -L -o ${DOWNLOAD_DIR}/package.7z ${URL} >&2
+    7z x -y -o${INSTALL_DIR} ${DOWNLOAD_DIR}/package.7z >/dev/null 2>&1
+    rm -f ${DOWNLOAD_DIR}/package.7z
+
+    #
+    # conf file is needed for qmake
+    #
+    if [ "${COMPONENT}" == "qtbase" ]; then
+        if [[ "${TOOLCHAIN}" =~ "win64_mingw" ]]; then
+            SUBDIR="${TOOLCHAIN/win64_/}_64"
+        elif [[ "${TOOLCHAIN}" =~ "win32_mingw" ]]; then
+            SUBDIR="${TOOLCHAIN/win32_/}_32"
+        elif [[ "${TOOLCHAIN}" =~ "win64_msvc" ]]; then
+            SUBDIR="${TOOLCHAIN/win64_/}"
+        elif [[ "${TOOLCHAIN}" =~ "win32_msvc" ]]; then
+            SUBDIR="${TOOLCHAIN/win32_/}"
+        elif [[ "${TOOLCHAIN}" =~ "any" ]] && [[ "${TARGET_PLATFORM}" == "android" ]]; then
+            SUBDIR="android"
+        else
+            SUBDIR="${TOOLCHAIN}"
+        fi
+
+        CONF_FILE="${INSTALL_DIR}/${VERSION}/${SUBDIR}/bin/qt.conf"
+        echo "[Paths]" > ${CONF_FILE}
+        echo "Prefix = .." >> ${CONF_FILE}
+
+        # Adjust the license to be able to run qmake
+        # sed with -i requires intermediate file on Mac OS
+        PRI_FILE="${INSTALL_DIR}/${VERSION}/${SUBDIR}/mkspecs/qconfig.pri"
+        sed -i.bak 's/Enterprise/OpenSource/g' "${PRI_FILE}"
+        sed -i.bak 's/licheck.*//g' "${PRI_FILE}"
+        rm "${PRI_FILE}.bak"
+
+        # Print the directory so that the caller can
+        # adjust the PATH variable.
+        echo $(dirname "${CONF_FILE}")
+    elif [[ "${COMPONENT}" =~ "qtcreator" ]]; then
+        echo "${INSTALL_DIR}/Tools/QtCreator/bin"
+    fi
+
+done
+

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -17,9 +17,16 @@
 
 # Install minimal Qt bits needed to build via command-line (e.g. Docker).
 # For developer environments, better to install using Qt's online installer.
-DEST=/opt/RStudio-QtSDK
-mkdir -p ${DEST}
-./install-qt.sh --version 5.12.6 --directory ${DEST}/Qt5.12.6 \
+
+if [ -z "$QT_VERSION" ]; then
+    QT_VERSION=5.12.6
+fi
+if [ -z "$QT_SDK_DIR" ]; then
+   QT_SDK_DIR=/opt/RStudio-QtSDK
+fi
+
+mkdir -p ${QT_SDK_DIR}
+./install-qt.sh --version $QT_VERSION --directory ${QT_SDK_DIR}/$QT_VERSION \
     qtbase \
     qtwebengine \
     qtwebchannel \

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -31,5 +31,8 @@ mkdir -p ${DEST}
     qtsvg \
     qtxmlpatterns \
     qttools \
-    icu
+    icu \
+    qttranslations \
+    qtwayland \
+    qtwebsockets \
 

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -26,7 +26,7 @@ if [ -z "$QT_SDK_DIR" ]; then
 fi
 
 mkdir -p ${QT_SDK_DIR}
-./install-qt.sh --version $QT_VERSION --directory ${QT_SDK_DIR}/$QT_VERSION \
+./install-qt.sh --version $QT_VERSION --directory ${QT_SDK_DIR}/Qt$QT_VERSION \
     qtbase \
     qtwebengine \
     qtwebchannel \

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+#
+# install-qt-linux
+#
+# Copyright (C) 2009-20 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+# Install minimal Qt bits needed to build via command-line (e.g. Docker).
+# For developer environments, better to install using Qt's online installer.
+DEST=/opt/RStudio-QtSDK
+mkdir -p ${DEST}
+./install-qt.sh --version 5.12.6 --directory ${DEST}/Qt5.12.6 \
+    qtbase \
+    qtwebengine \
+    qtwebchannel \
+    qtquick \
+    qtquickcontrols2 \
+    qtdeclarative \
+    qtsensors \
+    qtlocation \
+    qtsvg \
+    qtxmlpatterns \
+    qttools \
+    icu
+

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -45,6 +45,7 @@ RUN apt-get update && \
     libxslt1-dev \
     lsof \
     openjdk-8-jdk \
+    p7zip-full \
     pkg-config \
     python \
     r-base \
@@ -86,11 +87,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -30,6 +30,8 @@ RUN yum install -y \
     make \
     mariadb-libs \
     openssl-devel \
+    p7zip \
+    p7zip-plugins \
     pam-devel \
     pango-devel \
     patchelf \
@@ -84,11 +86,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-common"
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # remove any previous users with conflicting IDs
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.centos8-x86_64
+++ b/docker/jenkins/Dockerfile.centos8-x86_64
@@ -32,6 +32,8 @@ RUN yum install -y \
     make \
     mesa-libGL-devel \
     openssl-devel \
+    p7zip \
+    p7zip-plugins \
     pam-devel \
     pango-devel \
     patchelf \
@@ -71,11 +73,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # get libuser header files (libuser-devel not currently available on centos8)
 RUN wget https://pagure.io/libuser/archive/libuser-0.62/libuser-libuser-0.62.tar.gz

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -32,6 +32,7 @@ RUN apt-get update -y && apt-get install -y \
     procps \
     uuid-dev \
     make \
+    p7zip-full \
     libssl1.0-dev \
     libpango-1.0-0 \
     r-base \
@@ -76,11 +77,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -27,6 +27,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     lsof \
     make \
     openssl-devel \
+    p7zip-full \
     pam-devel \
     pango-devel \
     python \
@@ -67,11 +68,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # install GnuPG 1.4 from source (needed for release signing)
 RUN cd /tmp && \

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -27,7 +27,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     lsof \
     make \
     openssl-devel \
-    p7zip-full \
+    p7zip \
     pam-devel \
     pango-devel \
     python \

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -43,6 +43,7 @@ RUN apt-get update && \
     libxslt1-dev \
     lsof \
     openjdk-8-jdk \
+    p7zip-full \
     pkg-config \
     python \
     r-base \
@@ -91,11 +92,9 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 
 # install Qt SDK
-COPY dependencies/linux/install-qt-sdk /tmp/
-RUN mkdir -p /opt/RStudio-QtSDK && \
-    export QT_SDK_DIR=/opt/RStudio-QtSDK/Qt5.12.6 && \
-    export QT_QPA_PLATFORM=minimal && \
-    /tmp/install-qt-sdk
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999


### PR DESCRIPTION
This is due to Qt's recent change to require entering Qt account credentials in the online and offline installers, breaking our ability to rebuild docker images for the build machines.

Uses `install-qt-sh` script as-is from Qt: https://code.qt.io/cgit/qbs/qbs.git/tree/scripts/install-qt.sh which can install minimal SDK bits needed for building, without going through the installer (and also avoids need to install Qt Creator, documentation, etc.). Much faster.

This script is driven by `install-qt-linux` script which selects which version of Qt, which components, and where to extract them. The extraction is done via 7z so needed to ensure that was installed in the images.

Our Windows build is still ok; it downloads and extracts an archive (making the installer-scripting robust had previously eluded me). Same with opensuse, which does the same for older Qt 5.10.1.

I did not fix the Mac vagrant build yet, nor the developer bootstrappers (they will still work if you first install Qt yourself before running them).

I tested by building (via local docker) desktop for Ubuntu 16 and 18, CentOS7, and OpenSUSE 15.1, and installed them in VMs to ensure they ran correctly.