### PR TITLE
install tutorial dependencies before run

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2373,3 +2373,29 @@
    return(paste(truncated, marker))
    
 })
+
+.rs.addFunction("formatListForDialog", function(list, sep = ", ", max = 50L)
+{
+   # count index entries until we get too long
+   nc <- 0L
+   ns <- nchar(sep)
+   for (index in seq_along(list)) {
+      nc <- nc + ns + nchar(list[[index]])
+      if (nc > max)
+         break
+   }
+   
+   # collect items
+   n <- length(list)
+   items <- list
+   
+   # subset the list if we overflowed (index didn't reach end)
+   # avoid printing 'and 1 other'; no need to subset in that case
+   if (index < n - 1L)
+      items <- c(list[1:index], paste("and", n - index, "others"))
+   
+   # paste and truncate once more for safety
+   text <- paste(items, collapse = sep)
+   .rs.truncate(text, n = max * 2L)
+   
+})

--- a/src/cpp/session/modules/SessionTutorial.R
+++ b/src/cpp/session/modules/SessionTutorial.R
@@ -127,6 +127,9 @@
    if (.rs.tutorial.openExistingTutorial(name, package))
       return()
    
+   # install any required package dependencies before running tutorial
+   .rs.tutorial.installPackageDependencies(name, package)
+   
    # prepare the call to learnr to run the tutorial
    shiny_args$launch.browser <- quote(rstudioapi:::tutorialLaunchBrowser)
    
@@ -220,3 +223,57 @@
       description = .rs.scalar(desc)
    )
 })
+
+.rs.addFunction("tutorial.installPackageDependencies", function(name, package)
+{
+   pkgs <- character()
+
+   # form path to tutorial folder   
+   path <- system.file("tutorials", name, package = package)
+   if (!file.exists(path))
+      return(character())
+   
+   # find dependencies
+   deps <- renv::dependencies(path, quiet = TRUE)
+   pkgs <- sort(unique(deps$Package))
+   
+   # screen out some potentially invalid package names
+   pkgs <- grep("^[a-zA-Z0-9._]+$", pkgs, value = TRUE)
+   
+   # find packages which are not installed
+   installed <- vapply(pkgs, function(pkg) {
+      location <- find.package(pkg, quiet = TRUE)
+      length(location) > 0
+   }, FUN.VALUE = logical(1))
+   
+   missing <- pkgs[!installed]
+   if (length(missing) == 0)
+      return(character())
+   
+   # ask user to install these packages
+   title <- "Install Required Packages"
+   message <- paste(
+      "The following tutorial package dependencies are missing and will be installed:\n",
+      paste("-", .rs.formatListForDialog(missing)),
+      "\nWould you like to proceed?",
+      sep = "\n"
+   )
+   
+   ok <- .rs.api.showQuestion(title, message)
+   if (!ok) {
+      fmt <- "cannot run tutorial '%s'; required dependencies not installed"
+      msg <- sprintf(fmt, name)
+      stop(msg, call. = FALSE)
+   }
+ 
+   # write out call to console for user
+   call <- substitute(
+      install.packages(missing),
+      list(missing = missing)
+   )
+   
+   writeLines(paste(getOption("prompt"), format(call), sep = ""))
+   install.packages(missing)
+   
+})
+


### PR DESCRIPTION
This PR installs any required R packages before running the tutorial.

UI example:

![Screen Shot 2020-02-11 at 4 06 29 PM](https://user-images.githubusercontent.com/1976582/74291057-8ffbf800-4ce8-11ea-9e89-53ddd6f75ce0.png)

Packages are installed with a regular `install.packages()`, which implies hooks on `install.packages()` (e.g. from `renv`) are used as appropriate. Installation happens in the main R session as we need to block the process from proceeding until all packages have been installed.

Closes https://github.com/rstudio/rstudio/issues/6206.