### PR TITLE
Fix editor find / replace bar keyboard tab sequence

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -1,7 +1,7 @@
 /*
  * FindReplaceBar.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -126,25 +126,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       panel.add(optionsPanel);
       
       shelf.addLeftWidget(panel);
-      
-      // fixup tab indexes of controls
-      txtFind_.setTabIndex(100);
-      txtReplace_.setTabIndex(101);
-      chkInSelection_.setTabIndex(102);
-      chkCaseSensitive_.setTabIndex(103);
-      chkWholeWord_.setTabIndex(104);
-      chkRegEx_.setTabIndex(105);
-      chkWrapSearch_.setTabIndex(106);
-      
-      // remove SmallButton instances from tab order since (a) they aren't
-      // capable of showing a focused state; and (b) enter is already a
-      // keyboard shortcut for both find and replace
-      btnFindNext_.setTabIndex(-1);
-      btnFindPrev_.setTabIndex(-1);
-      btnSelectAll_.setTabIndex(-1);
-      btnReplace_.setTabIndex(-1);
-      btnReplaceAll_.setTabIndex(-1);
-     
+
       shelf.setRightVerticalAlignment(HasVerticalAlignment.ALIGN_TOP);
       shelf.addRightWidget(btnClose_ = new Button());
       btnClose_.setStyleName(RES.styles().closeButton());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -86,6 +86,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       txtReplace_.addStyleName(RES.styles().replaceTextBox());
       findReplacePanel.add(btnReplace_ = new SmallButton(cmds.replaceAndFind()));
       findReplacePanel.add(btnReplaceAll_ = new SmallButton("All"));
+      btnReplaceAll_.setTitle("Replace all occurrences");
       
       panel.add(findReplacePanel);
       


### PR DESCRIPTION
Fixes #6216 

- remove setting tab indexes > 0 on controls (this should never be done)
- don't set buttons to tab index -1; they are now able to show keyboard focus, not all of them have equivalent keyboard shortcuts, and those shortcuts are not discoverable to a keyboard/screen reader user without letting focus get to the buttons
 - add tooltip to replace-all button to disambiguate the generic "All" button label

<img width="587" alt="screenshot of Find and Replace bar in RStudio editor" src="https://user-images.githubusercontent.com/10569626/74384839-0101e500-4da7-11ea-8d78-a942fc4ec6fe.png">



