### PR TITLE
Fix global replace on Windows

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -525,7 +525,12 @@ private:
              !tempReplaceFile_.getAbsolutePath().empty() &&
              outputStream_->good())
          {
-            Error error = FilePath(currentFile_).testWritePermissions();
+             Error error;
+             // For Windows we ignore this additional safety check
+             // it will always fail because we have inputStream_ reading the file
+#ifndef _WIN32
+            error = FilePath(currentFile_).testWritePermissions();
+#endif
             if (error)
             {
                json::Array replaceMatchOn, replaceMatchOff;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -530,7 +530,6 @@ private:
              // it will always fail because we have inputStream_ reading the file
 #ifndef _WIN32
             error = FilePath(currentFile_).testWritePermissions();
-#endif
             if (error)
             {
                json::Array replaceMatchOn, replaceMatchOff;
@@ -538,6 +537,7 @@ private:
                   &replaceMatchOff, &fileSuccess_);
                return error;
             }
+#endif
             std::string line;
             while (std::getline(*inputStream_, line))
             {
@@ -549,7 +549,13 @@ private:
             outputStream_.reset();
             error = tempReplaceFile_.move(FilePath(currentFile_));
             currentFile_.clear();
-            return error;
+            if (error)
+            {
+               json::Array replaceMatchOn, replaceMatchOff;
+               addReplaceErrorMessage(error.asString(), pErrorMessage, &replaceMatchOn,
+                  &replaceMatchOff, &fileSuccess_);
+               return error;
+            }
          }
       }
       return Success();


### PR DESCRIPTION
This PR fixes two bugs that caused global replace to not work on Windows and a bug that prevented the correct error message from being displayed when this happened. 
I updated the call to `completeFileReplace` to include an `errorMessage` set so it not only returns the system error, but also the errors we are using to send to the backend to be displayed in the Find in Files tab. With this the Windows error was properly displayed. The second issue is that the `testWritePermissions` function always failed on Windows after we opened `inputStream_` (even though it's only used for reading) - to prevent this from happening I only call this function for the second time on non-Windows systems.