### PR TITLE
Replace more instances of String.CharAt with StringUtil.CharAt

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
@@ -249,8 +249,8 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
                   String repoUrl = repo.getURL();
                   if (repoUrl.length() > 0 &&
                       cranRepoUrl_.length() > 0) {
-                      char mainEnd = cranRepoUrl_.charAt(cranRepoUrl_.length() - 1);
-                      char repoEnd = repo.getURL().charAt(repoUrl.length() - 1);
+                      char mainEnd = StringUtil.charAt(cranRepoUrl_, cranRepoUrl_.length() - 1);
+                      char repoEnd = StringUtil.charAt(repo.getURL(), repoUrl.length() - 1);
                       if (mainEnd == '/' && repoEnd != '/')
                          repoUrl = repoUrl + "/";
                       else if (mainEnd != '/' && repoEnd == '/')

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
@@ -56,7 +56,7 @@ public final class DialogHtmlSanitizer implements HtmlSanitizer {
          String tag = null;
          boolean isValidTag = false;
          if (tagEnd > 0) {
-            if (segment.charAt(0) == '/') {
+            if (StringUtil.charAt(segment, 0) == '/') {
                tagStart = 1;
             }
             tag = segment.substring(tagStart, tagEnd).toLowerCase();

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
@@ -1,7 +1,7 @@
 /*
  * DialogHtmlSanitizer.java
  *
- * Copyright (C) 2009-16 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -1,7 +1,7 @@
 /*
  * CodeSearchOracle.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -82,7 +82,7 @@ public class CodeSearchOracle extends SuggestOracle
          // Less penalty if character follows special delim
          if (matchPos >= 1)
          {
-            char prevChar = suggestionLower.charAt(matchPos - 1);
+            char prevChar = StringUtil.charAt(suggestionLower, matchPos - 1);
             if (prevChar == '_' || prevChar == '-' ||
                   (!isFile && prevChar == '.'))
             {
@@ -91,7 +91,7 @@ public class CodeSearchOracle extends SuggestOracle
          }
          
          // Less penalty for case-sensitive matches
-         if (suggestion.charAt(matchPos) == query.charAt(j))
+         if (StringUtil.charAt(suggestion, matchPos) == query.charAt(j))
             penalty--;
          
          // More penalty for 'uninteresting' files

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -1,7 +1,7 @@
 /*
  * CompletionManagerBase.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -611,7 +611,7 @@ public abstract class CompletionManagerBase
       for (int i = 0; i < lookbackLimit; i++)
       {
          int index = cursorColumn - i - 1;
-         if (isBoundaryCharacter(currentLine.charAt(index)))
+         if (isBoundaryCharacter(StringUtil.charAt(currentLine, index)))
             return false;
       }
       
@@ -703,7 +703,7 @@ public abstract class CompletionManagerBase
          }
          
          String line = docDisplay_.getCurrentLine();
-         char ch = line.charAt(cursorColumn - 1);
+         char ch = StringUtil.charAt(line, cursorColumn - 1);
          if (isBoundaryCharacter(ch))
          {
             invalidatePendingRequests();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1,7 +1,7 @@
 /*
  * RCompletionManager.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -753,7 +753,7 @@ public class RCompletionManager implements CompletionManager
          // Immediately display completions after '$', '::', etc.
          if (input_.getCursorPosition().getColumn() > 0)
          {
-            char prevChar = docDisplay_.getCurrentLine().charAt(
+            char prevChar = StringUtil.charAt(docDisplay_.getCurrentLine(),
                   input_.getCursorPosition().getColumn() - 1);
             if (
                   (c == ':' && prevChar == ':') ||
@@ -1885,7 +1885,7 @@ public class RCompletionManager implements CompletionManager
             int startPos = selection_.getStart().getPosition();
             String currentLine = docDisplay_.getCurrentLine();
             while (startPos < currentLine.length() &&
-                  currentLine.charAt(startPos) == ' ')
+                  StringUtil.charAt(currentLine, startPos) == ' ')
                ++startPos;
             
             input_.setSelection(new InputEditorSelection(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1,7 +1,7 @@
 /*
  * AceEditor.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -1693,7 +1693,7 @@ public class AceEditor implements DocDisplay,
       if (column == line.length())
          return '\0';
 
-      return line.charAt(column);
+      return StringUtil.charAt(line, column);
    }
 
    public char getCharacterBeforeCursor()
@@ -1704,7 +1704,7 @@ public class AceEditor implements DocDisplay,
          return '\0';
 
       String line = getLine(cursorPos.getRow());
-      return line.charAt(column - 1);
+      return StringUtil.charAt(line, column - 1);
    }
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5246,7 +5246,7 @@ public class TextEditingTarget implements
       {
          String text = scopeHelper_.getSweaveChunkText(chunk);
          code.append(text);
-         if (text.length() > 0 && text.charAt(text.length()-1) != '\n')
+         if (text.length() > 0 && StringUtil.charAt(text, text.length()-1) != '\n')
             code.append('\n');
       }
       return code.toString();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedParser.java
@@ -1,7 +1,7 @@
 /*
  * UnifiedParser.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.vcs.common.diff;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.workbench.views.vcs.common.diff.Line.Type;
 
 import java.util.ArrayList;
@@ -118,12 +119,12 @@ public class UnifiedParser implements DiffParser
          int directive = ' ';
          for (int i = 0; i < columns; i++)
          {
-            mask[i] = diffLine.charAt(i) != ' ';
+            mask[i] = StringUtil.charAt(diffLine, i) != ' ';
             if (mask[i])
             {
                if (directive == ' ')
-                  directive = diffLine.charAt(i);
-               else if (directive != diffLine.charAt(i))
+                  directive = StringUtil.charAt(diffLine, i);
+               else if (directive != StringUtil.charAt(diffLine,i))
                   throw new DiffFormatException("Conflicting directives");
             }
          }
@@ -256,7 +257,7 @@ public class UnifiedParser implements DiffParser
 
    private boolean nextLineIsComment()
    {
-      return !isEOD() && data_.charAt(pos_) == '\\';
+      return !isEOD() && StringUtil.charAt(data_, pos_) == '\\';
    }
 
    private String peekLine()
@@ -285,7 +286,7 @@ public class UnifiedParser implements DiffParser
          i = data_.length();
          length = 0;
       }
-      else if (i > 0 && data_.charAt(i-1) == '\r')
+      else if (i > 0 && StringUtil.charAt(data_, i - 1) == '\r')
       {
          i--;
          length = 2;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitStatusRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitStatusRenderer.java
@@ -78,6 +78,9 @@ public class GitStatusRenderer implements SafeHtmlRenderer<String>
 
    private String descForStatus(String str)
    {
+      if (str.length() < 2)
+         return null;
+
       String indexDesc = descForStatus(str.charAt(0));
       String treeDesc = descForStatus(str.charAt(1));
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitStatusRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitStatusRenderer.java
@@ -1,7 +1,7 @@
 /*
  * GitStatusRenderer.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -79,7 +79,7 @@ public class GitStatusRenderer implements SafeHtmlRenderer<String>
    private String descForStatus(String str)
    {
       if (str.length() < 2)
-         return null;
+         return "";
 
       String indexDesc = descForStatus(str.charAt(0));
       String treeDesc = descForStatus(str.charAt(1));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNStatusRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNStatusRenderer.java
@@ -1,7 +1,7 @@
 /*
  * SVNStatusRenderer.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNStatusRenderer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNStatusRenderer.java
@@ -85,6 +85,9 @@ public class SVNStatusRenderer implements SafeHtmlRenderer<String>
 
    private String descForStatus(String str)
    {
+      if (str.isEmpty())
+         return "";
+
       char c = str.charAt(0);
       
       switch (c)


### PR DESCRIPTION
JavaScript exception related to charAt; don't know exact repro, taking opportunity to fix that call stack and defensively change a few other instances of charAt to use safer StringUtil.charAt.

For more context:

* fix exceptions caused by gwt 2.8.2 checking charAt bounds #4451
* more fixes for new behavior of String.charAt in GWT 2.8.2 #4489
* fix exception when typing Shift+Tab on whitespace-only editor line #5036
* javascript exceptions being thrown by charAt in cpp completion code #5052

Callstack:
```
15 Feb 2020 00:03:26 [rserver] ERROR CLIENT EXCEPTION (rsession-gary): Index: -1, Size: 226;
rstudio-0.js@10#639::Throwable.createError
rstudio-0.js@48#703::Throwable.initializeBackingError
rstudio-0.js@8#535::Throwable.Throwable
rstudio-0.js@18#808::Exception.Exception
rstudio-0.js@18#862::RuntimeException.RuntimeException
rstudio-0.js@25#3620::IndexOutOfBoundsException.IndexOutOfBoundsException
rstudio-0.js@34#5360::StringIndexOutOfBoundsException
rstudio-0.js@21#5794::checkCriticalStringElementIndex
rstudio-0.js@5#6025::checkStringElementIndex
rstudio-0.js@3#4059::charAt
rstudio-0.js@10#4633::charAt_I_C__devirtual$
rstudio-0.js@39#356896::CompletionManagerBase.canAutoPopup
rstudio-0.js@14#357339::CompletionManagerBase.previewKeyPress
rstudio-0.js@61#360873::MarkdownCompletionManager.previewKeyPress
rstudio-0.js@23#359555::DelegatingCompletionManager.previewKeyPress
rstudio-0.js@43#464919::AceKeyboardPreviewer$1.previewKeyPress
rstudio-0.js@24#464884::AceKeyboardPreviewer.onTextInput
rstudio-0.js@21#464852::<anonymous>
rstudio-0.js@28#16334::apply
rstudio-0.js@16#16393::entry0
rstudio-0.js@14#16372::handleKeyboard
http://localhost:9876/rstudio/7D3FB0FCC17B7BB289C4D681EC4DE752.cache.js@43#42254::callKeyboardHandlers
http://localhost:9876/rstudio/7D3FB0FCC17B7BB289C4D681EC4DE752.cache.js@14#42290::onTextInput
http://localhost:9876/rstudio/7D3FB0FCC17B7BB289C4D681EC4DE752.cache.js@36#49554::onTextInput
http://localhost:9876/rstudio/7D3FB0FCC17B7BB289C4D681EC4DE752.cache.js@22#40398::sendText
http://localhost:9876/rstudio/7D3FB0FCC17B7BB289C4D681EC4DE752.cache.js@24#40419::onInput
Client-ID: 3049a086-a908-4534-a87e-4dcaca02d7f7
User-Agent: Mozilla/5.0 (Macintosh  Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.106 Safari/537.36
```