### PR TITLE
Fix issues with find in files and colons

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1504,7 +1504,7 @@ boost::regex getGrepOutputRegex(bool isGitGrep)
 {
    boost::regex regex;
    if (isGitGrep)
-      regex = boost::regex("^((?:[a-zA-Z]:)?[^:]+)\x1B\\[\\d+?m:\x1B\\[m(\\d+).*:\x1B\\[m(.*)");
+      regex = boost::regex("^((?:[a-zA-Z]:)?[^:]+)\x1B\\[\\d+?m:\x1B\\[m(\\d+)\x1B\\[36m:\x1B\\[m(.*)");
    else
       regex = boost::regex("^((?:[a-zA-Z]:)?[^:]+):(\\d+):(.*)");
    return regex;

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -190,6 +190,19 @@ TEST_CASE("SessionFind")
       CHECK(match[3].str().compare(kGitGrepPattern) == 0);
    }
 
+   SECTION("Git grep with colon get file, line number, and contents")
+   {
+      boost::regex regex = getGrepOutputRegex(/*isGitGrep*/ true);
+      std::string contents(
+         "file.test\033[36m:\033[m9\033[36m:\033[m  - \033[1;31mr:\033[m devel");
+
+      boost::smatch match;
+      CHECK(regex_utils::match(contents, match, regex));
+      CHECK(match[1].str().compare("file.test") == 0);
+      CHECK(match[2].str().compare("9") == 0);
+      CHECK(match[3].str().compare("  - \033[1;31mr:\033[m devel") == 0);
+   }
+
    SECTION("Git grep get color encoding regex")
    {
       boost::regex regex = getColorEncodingRegex(/*isGitGrep*/ true);


### PR DESCRIPTION
Fixes #6240 

Previously the regex used to parse `git grep` results for Find in Files included a wildcard to handle a pattern that included a colon. When the resulting line contained a colon, the regex was unable to properly parse the line and would crash RStudio. This PR makes this regex more specific so it can process lines with colons and adds a unit test for this process. It has been tested with a variety of Find in Files searches. 