### PR TITLE
avoid attempt to add same line widget twice

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/LineWidgetManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/LineWidgetManager.java
@@ -22,7 +22,14 @@ public class LineWidgetManager extends JavaScriptObject
    protected LineWidgetManager() {}
    
    public native final void addLineWidget(LineWidget widget) /*-{
+      
+      // avoid duplicating a pre-existing line widget
+      var widgets = this.session.lineWidgets || {};
+      if (widgets[widget.row] === widget)
+         return;
+         
       this.addLineWidget(widget);
+      
    }-*/;
    
    public native final void removeLineWidget(LineWidget widget) /*-{


### PR DESCRIPTION
On some occasions, RStudio will attempt to add the same line widget twice in quick succession. This is not handled well by Ace, and can place the editor into an infinite Javascript loop when Ace attempts to re-render line widgets in the document.

For pinned line widgets, there are two places where we add line widgets:

https://github.com/rstudio/rstudio/blob/dcc58c299d097ca419068723d9f67e3f56dacf50/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/PinnedLineWidget.java#L137

https://github.com/rstudio/rstudio/blob/dcc58c299d097ca419068723d9f67e3f56dacf50/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/PinnedLineWidget.java#L217

If the Ace render were to finish immediately after our call to `syncEndAnchor()`, we could end up adding the same line widget to the document twice at the same location, thereby triggering this bug.

Closes #6226.