### PR TITLE
Update Find in Files Package option

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1276,6 +1276,11 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    if (grepOptions.gitFlag())
    {
       cmd = shell_utils::ShellCommand("git");
+      cmd << "-c" << "grep.lineNumber=true";
+      cmd << "-c" << "grep.column=false";
+      cmd << "-c" << "grep.patternType=default";
+      cmd << "-c" << "grep.extendedRegexp=false";
+      cmd << "-c" << "grep.fullName=false";
       cmd << "-C";
       cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
       cmd <<  "grep";

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1276,6 +1276,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    if (grepOptions.gitFlag())
    {
       cmd = shell_utils::ShellCommand("git");
+      // -c is used to override potential user-defined git parameters
       cmd << "-c" << "grep.lineNumber=true";
       cmd << "-c" << "grep.column=false";
       cmd << "-c" << "grep.patternType=default";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -154,7 +154,8 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       AllFiles,
       CommonRSourceFiles,
       RScripts,
-      Package,
+      PackageSource,
+      PackageTests,
       CustomFilter
    }
 
@@ -252,15 +253,25 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       if (!packageStatus_)
       {
          ((Element) listPresetFilePatterns_.getElement().getChild(
-               Include.Package.ordinal()))
+               Include.PackageSource.ordinal()))
             .setAttribute("disabled", "disabled");
+         ((Element) listPresetFilePatterns_.getElement().getChild(
+               Include.PackageTests.ordinal()))
+            .setAttribute("disabled", "disabled");
+
          if (listPresetFilePatterns_.getSelectedIndex() ==
-             Include.Package.ordinal())
+             Include.PackageSource.ordinal() ||
+             listPresetFilePatterns_.getSelectedIndex() ==
+             Include.PackageTests.ordinal())
             listPresetFilePatterns_.setSelectedIndex(Include.AllFiles.ordinal());
       }
       else
+      {
          ((Element) listPresetFilePatterns_.getElement().getChild(
-            Include.Package.ordinal())).removeAttribute("disabled");
+            Include.PackageSource.ordinal())).removeAttribute("disabled");
+         ((Element) listPresetFilePatterns_.getElement().getChild(
+            Include.PackageTests.ordinal())).removeAttribute("disabled");
+      }
    }
 
    private void manageExcludeFilePattern()
@@ -423,7 +434,8 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
          listPresetFilePatterns_.setSelectedIndex(index);
       else
          listPresetFilePatterns_.setSelectedIndex(Include.CustomFilter.ordinal());
-      if (index == Include.Package.ordinal())
+      if (index == Include.PackageSource.ordinal() ||
+          index == Include.PackageTests.ordinal())
          packageStatus_ = true;
       txtFilePattern_.setText(includeFilePatterns);
       manageFilePattern();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -47,7 +47,7 @@
             <g:item value="">All Files</g:item>
             <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp">Common R source files (R, C/C++, Rnw, Rmd, Rhtml)</g:item>
             <g:item value="*.r, *.R">R Scripts</g:item>
-            <g:item value="packageSource">Package Source (R/ , src/)</g:item>
+            <g:item value="packageSource">Package Sources (R/ , src/)</g:item>
             <g:item value="packageTests">Package Tests (tests/)</g:item>
             <g:item value="custom">Custom Filter</g:item>
          </rw:FormListBox>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -45,9 +45,10 @@
          <rw:FormListBox ui:field="listPresetFilePatterns_"
                     styleName="{style.presetFilePatterns}">
             <g:item value="">All Files</g:item>
-            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.rhtml, *.Rhtml, *.rd, *.Rd, *.h, *.hpp, *.c, *.cpp">Common R source files (R, C/C++, Rnw, Rmd, Rhtml, Rd)</g:item>
+            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp">Common R source files (R, C/C++, Rnw, Rmd, Rhtml)</g:item>
             <g:item value="*.r, *.R">R Scripts</g:item>
-            <g:item value="package">Package Source (R/ , src/, tests/)</g:item>
+            <g:item value="packageSource">Package Source (R/ , src/)</g:item>
+            <g:item value="packageTests">Package Tests (tests/)</g:item>
             <g:item value="custom">Custom Filter</g:item>
          </rw:FormListBox>
          <div ui:field="divCustomFilter_">


### PR DESCRIPTION
After some user testing, we determined it makes more sense to separate the `Search in: Package Source` option into two options: `Package Source (/R, /src)` and `Package Tests (/tests)`.

![image](https://user-images.githubusercontent.com/5323711/74788436-92b99880-5266-11ea-9eb1-4cb462d5da38.png)

This PR also updates the `git grep` command to override any global git configurations the user may have set up on their computer. This could've led to rstudio mis-parsing output received from the command. 
It also removes `.Rd` from the `Search in: R Common Source Files` option based on feedback that the majority of users have these files autogenerated. 