### PR TITLE
Add toggle for enabling/disabling directory view restrictions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,7 +34,7 @@
 * Add option `auth-cookies-force-secure` to always mark auth cookies as secure when SSL is terminated upstream (Pro #995)
 * Set HTTP header `X-Content-Type-Options` to discourage MIME type sniffing (Pro #1219)
 * Authentication cookies are now revoked after signout (Pro #606)
-* File-serving resource endpoints are now more restrictive; added new `directory-view-whitelist` option (Pro #607)
+* File-serving resource endpoints can now be made more restrictive; added new `restrict-directory-view` and `directory-view-whitelist` options (Pro #607)
 * RStudio Server now uses 2048 bit RSA keys, for secure communication of encrypted credentials between server / session and client
 
 ### iPad OS 13

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2388,6 +2388,10 @@ std::string sessionTempDirUrl(const std::string& sessionTempPath)
 
 bool isPathViewAllowed(const FilePath& filePath)
 {
+   // Check to see if restrictions are in place
+   if (!options().restrictDirectoryView())
+      return true;
+
    // No paths are restricted in desktop mode
    if (options().programMode() != kSessionProgramModeServer)
       return true;

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -255,9 +255,12 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
       (kUseSecureCookiesSessionOption,
        value<bool>(&useSecureCookies_)->default_value(false),
        "whether to mark cookies as secure")
+      ("restrict-directory-view",
+       value<bool>(&restrictDirectoryView_)->default_value(false),
+       "whether to restrict the directories that can be viewed in the IDE")
       ("directory-view-whitelist",
        value<std::string>(&directoryViewWhitelist_)->default_value(""),
-       "list of directories where files can be viewed, separated by :")
+       "list of directories exempt from directory view restrictions, separated by :")
       (kSessionEnvVarSaveBlacklist,
        value<std::string>(&envVarSaveBlacklist_)->default_value(""),
        "list of environment variables not saved on session suspend, separated by :");

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -614,6 +614,11 @@ public:
    {
       return useSecureCookies_;
    }
+
+   bool restrictDirectoryView() const
+   {
+      return restrictDirectoryView_;
+   }
    
    std::string directoryViewWhitelist() const
    {
@@ -699,6 +704,7 @@ private:
    bool packageOutputToPackageFolder_;
    std::string terminalPort_;
    bool useSecureCookies_;
+   bool restrictDirectoryView_;
    std::string directoryViewWhitelist_;
    std::string envVarSaveBlacklist_;
 


### PR DESCRIPTION
This feature was previously always on; it is now on only optionally (for hardening) -- see linked Pro issue for rationale. 

Fixes https://github.com/rstudio/rstudio-pro/issues/1455. 