### PR TITLE
Spellcheck custom preferences fixes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -380,6 +380,9 @@ public class TypoSpellChecker
       if (r.getEnd().getColumn() - r.getStart().getColumn() > 250)
          return false;
 
+      if (isWordIgnored(word))
+         return false;
+
       // Don't spellcheck yaml
       Scope s = ((AceEditor)dd).getScopeAtPosition(r.getStart());
       if (s != null && s.isYaml())

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/ui/SpellingCustomDictionariesWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/ui/SpellingCustomDictionariesWidget.java
@@ -85,6 +85,7 @@ public class SpellingCustomDictionariesWidget extends Composite
       globalDisplay_= globalDisplay;
       fileDialogs_ = fileDialogs;
       fileSystemContext_ = fileSystemContext;
+      customDictsModified_ = false;
    }
    
    public void setDictionaries(JsArrayString dictionaries)
@@ -125,6 +126,8 @@ public class SpellingCustomDictionariesWidget extends Composite
                   spellingService_.addCustomDictionary(
                                                   input.getPath(),
                                                   customDictRequestCallback_);
+
+                  customDictsModified_ = true;
                }
                
             }); 
@@ -155,6 +158,8 @@ public class SpellingCustomDictionariesWidget extends Composite
                         spellingService_.removeCustomDictionary(
                                                   dictionary,
                                                   customDictRequestCallback_);
+
+                        customDictsModified_ = true;
                      }
                   },
                   false);
@@ -187,14 +192,20 @@ public class SpellingCustomDictionariesWidget extends Composite
       button.fillWidth();
       return button;
    }
-   
+
+   public boolean getCustomDictsModified()
+   {
+      return customDictsModified_;
+   }
+
    private final ListBox listBox_;
    private SpellingService spellingService_;
    private ProgressIndicator progressIndicator_;
    private GlobalDisplay globalDisplay_;
    private FileDialogs fileDialogs_;
    private RemoteFileSystemContext fileSystemContext_;
-   
+   private boolean customDictsModified_;
+
    static interface Styles extends CssResource
    {
       String helpButton();
@@ -213,4 +224,5 @@ public class SpellingCustomDictionariesWidget extends Composite
    {
       RES.styles().ensureInjected();
    }
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -150,7 +150,7 @@ public class SpellingPreferencesPane extends PreferencesPane
                                        languageWidget_.getSelectedLanguage());
       
       RestartRequirement restart = super.onApply(rPrefs);
-      restart.setDesktopRestartRequired(customDictsWidget_.getCustomDictsModified());
+      restart.setDesktopRestartRequired(restart.getDesktopRestartRequired() || customDictsWidget_.getCustomDictsModified());
       return restart;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -138,7 +138,7 @@ public class SpellingPreferencesPane extends PreferencesPane
       
       languageWidget_.setSelectedLanguage(
                         uiPrefs_.spellingDictionaryLanguage().getValue());
-      
+
       customDictsWidget_.setDictionaries(context.getCustomDictionaries());
       customDictsWidget_.setProgressIndicator(getProgressIndicator());
    }
@@ -149,7 +149,9 @@ public class SpellingPreferencesPane extends PreferencesPane
       uiPrefs_.spellingDictionaryLanguage().setGlobalValue(
                                        languageWidget_.getSelectedLanguage());
       
-      return super.onApply(rPrefs);
+      RestartRequirement restart = super.onApply(rPrefs);
+      restart.setDesktopRestartRequired(customDictsWidget_.getCustomDictsModified());
+      return restart;
    }
 
    


### PR DESCRIPTION
Fixes #6045 
The list of custom dictionaries comes from the server and is set in the context. It's not dynamically updated after adding/removing a dictionary so force a restart when doing this. This is actually ok because it perfectly dovetails into the next issue (which requires a restart anyway).

Fixes #6047 
We were not using custom dictionaries. I was very confident that I had this working at some point but looking at the code it's possible it never actually worked and I was only testing that I preserved the functionality of the old spellcheck while implementing the new feature. Was a little worried when I caught this but implementing it turned out to be easier than I expected due to the nice loading infrastructure that Kevin helped with (and I jerry rigged a touch here).

Unfortunately, we take a pretty noticeable initial loading performance hit once you add more than one extra custom dict but it's to be expected. I think our system could use a little refurbish as there's no way to use _only_ a custom dictionary. I'm also not offering suggestions from the custom dicts and only doing boolean checks against them at the moment to avoid some serious clutter and traffic on a suggestion prompt.

Half Fixes #6074 
I implemented the CAPITALS portion. I believe the numbers portion actually isn't a regression but is just quirky with our tokenizer. We count numbers as word boundaries so, for all intents and purposes, there is actually no such thing as a word with numbers in our spellchecker and never has been on the client side. The numbers setting is kind of a weird one to me anyway and I wouldn't mind removing it. I propose closing #6074 and make a new issue regarding that setting.