### PR TITLE
provide "Install learnr" link in Tutorial pane

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1716,3 +1716,12 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       .rs.scalar(FALSE)
    })
 })
+
+.rs.addJsonRpcHandler("is_package_installed", function(package, version)
+{
+   installed <- if (is.null(version))
+      .rs.isPackageInstalled(package)
+   else
+      .rs.isPackageVersionInstalled(package, version)
+   .rs.scalar(installed)
+})

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -204,12 +204,9 @@ void handleTutorialHomeRequest(const http::Request& request,
          // Button for 'click here' action (styled like a link; behaves like button)
          std::stringstream clickHere;
          clickHere << "<a"
-                   << " aria-role=\"button\""
-                   << " aria-label=\"Install learnr\""
                    << " class=\"rstudio-tutorials-install-learnr-link\""
-                   << " href=\"#\""
+                   << " href=\"javascript:void(0)\""
                    << " onclick=\"window.parent.tutorialInstallLearnr(); return false;\""
-                   << " onkeydown=\"window.parent.tutorialKeydown(event)\">"
                    << "click here"
                    << "</a>";
          

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -207,7 +207,7 @@ void handleTutorialHomeRequest(const http::Request& request,
                    << " aria-label\"Install learnr\""
                    << " class=\"rstudio-tutorials-install-learnr-link\""
                    << " href=\"javascript:void(0)\""
-                   << " onclick=\"window.parent.tutorialInstallLearnr(); return false;\""
+                   << " onclick=\"window.parent.tutorialInstallLearnr(); return false;\">"
                    << "click here"
                    << "</a>";
          

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -197,15 +197,31 @@ void handleTutorialHomeRequest(const http::Request& request,
    
    if (tutorialIndex().empty())
    {
-      ss << "<p>No tutorials are currently available.</p>";
+      ss << "<div class=\"rstudio-tutorials-section\">";
+      
       if (!module_context::isPackageInstalled("learnr"))
       {
-         ss << "<p>Please install the learnr package to enable tutorials for RStudio.</p>";
+         // Button for 'click here' action (styled like a link; behaves like button)
+         std::stringstream clickHere;
+         clickHere << "<a"
+                   << " aria-role=\"button\""
+                   << " aria-label=\"Install learnr\""
+                   << " class=\"rstudio-tutorials-install-learnr-link\""
+                   << " href=\"#\""
+                   << " onclick=\"window.parent.tutorialInstallLearnr(); return false;\""
+                   << " onkeydown=\"window.parent.tutorialKeydown(event)\">"
+                   << "click here"
+                   << "</a>";
+         
+         ss << "<p>The <code>learnr</code> package is required to run tutorials for RStudio.</p>"
+            << "<p>Please " << clickHere.str() << " to install the <code>learnr</code> package.</p>";
       }
       else
       {
-         ss << "<p>Please wait while RStudio finishes indexing...</p>";
+         ss << "<p>Please wait while RStudio finishes indexing available tutorials...</p>";
       }
+      
+      ss << "</div>";
    }
    
    for (auto entry : tutorialIndex())

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -204,6 +204,7 @@ void handleTutorialHomeRequest(const http::Request& request,
          // Button for 'click here' action (styled like a link; behaves like button)
          std::stringstream clickHere;
          clickHere << "<a"
+                   << " aria-label\"Install learnr\""
                    << " class=\"rstudio-tutorials-install-learnr-link\""
                    << " href=\"javascript:void(0)\""
                    << " onclick=\"window.parent.tutorialInstallLearnr(); return false;\""

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -201,7 +201,6 @@ void handleTutorialHomeRequest(const http::Request& request,
       
       if (!module_context::isPackageInstalled("learnr"))
       {
-         // Button for 'click here' action (styled like a link; behaves like button)
          std::stringstream clickHere;
          clickHere << "<a"
                    << " aria-label\"Install learnr\""

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -110,6 +110,11 @@
             "location": "cran",
             "source": false
         },
+        "learnr": {
+            "version": "0.10.1",
+            "location": "cran",
+            "source": false
+        },
         "magrittr": {
             "version": "1.5",
             "location": "cran",
@@ -519,6 +524,12 @@
             "packages": [
                 "DBI",
                 "RSQLite"
+            ]
+        },
+        "tutorial": {
+            "description": "RStudio Tutorials",
+            "packages": [
+                "learnr"
             ]
         }
     }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1274,6 +1274,17 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, IS_PACKAGE_LOADED, params, requestCallback);
    }
    
+   public void isPackageInstalled(String packageName,
+                                  String version,
+                                  ServerRequestCallback<Boolean> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(packageName));
+      params.set(1, (version == null) ? JSONNull.getInstance() : new JSONString(version));
+      sendRequest(RPC_SCOPE, IS_PACKAGE_INSTALLED, params, requestCallback);
+   }
+   
+   
    public void availablePackages(
          String repository,
          ServerRequestCallback<JsArrayString> requestCallback)
@@ -6213,6 +6224,7 @@ public class RemoteServer implements Server
    private static final String GET_PACKAGE_NEWS_URL = "get_package_news_url";
    private static final String GET_PACKAGE_INSTALL_CONTEXT = "get_package_install_context";
    private static final String IS_PACKAGE_LOADED = "is_package_loaded";
+   private static final String IS_PACKAGE_INSTALLED = "is_package_installed";
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";
    private static final String GET_CRAN_MIRRORS = "get_cran_mirrors";
    private static final String GET_CRAN_ACTIVES = "get_cran_actives";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
@@ -37,6 +37,10 @@ public interface PackagesServerOperations extends PackratServerOperations
    void isPackageLoaded(String packageName, String libName,
                         ServerRequestCallback<Boolean> requestCallback);
    
+   void isPackageInstalled(String packageName,
+                           String version,
+                           ServerRequestCallback<Boolean> requestCallback);
+   
    void checkForPackageUpdates(
             ServerRequestCallback<JsArray<PackageUpdate>> requestCallback);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
@@ -29,6 +29,7 @@
 @external rstudio-tutorials-sublabel;
 @external rstudio-tutorials-footer;
 @external rstudio-tutorials-footer-text;
+@external rstudio-tutorials-install-learnr-link;
 
 /* Scrollbars */
 
@@ -211,4 +212,8 @@
 
 .rstudio-themes-dark-menus .rstudio-tutorials-sublabel {
    color: rgb(172, 172, 172);
+}
+
+.rstudio-themes-dark-menus .rstudio-tutorials-install-learnr-link:link {
+   color: rgb(118, 171, 221);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -31,7 +31,7 @@ import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.model.SessionInfo;
+import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsolePromptHandler;
@@ -66,7 +66,7 @@ public class TutorialPane
    protected TutorialPane(GlobalDisplay globalDisplay,
                           EventBus events,
                           Commands commands,
-                          SessionInfo sessionInfo,
+                          Session session,
                           PackagesServerOperations server)
    {
       super("Tutorial");
@@ -74,7 +74,7 @@ public class TutorialPane
       globalDisplay_ = globalDisplay;
       events_        = events;
       commands_      = commands;
-      sessionInfo_   = sessionInfo;
+      session_       = session;
       server_        = server;
       
       indicator_ = globalDisplay_.getProgressIndicator("Error Loading Tutorial");
@@ -189,10 +189,12 @@ public class TutorialPane
    {
       commands_.tutorialStop().setVisible(false);
       commands_.tutorialStop().setEnabled(false);
+      
       String url = GWT.getHostPageBaseURL() +
             "tutorial/run" +
             "?package=" + tutorial.getPackageName() +
             "&name=" + tutorial.getTutorialName();
+      
       navigate(url, false);
    }
    
@@ -360,7 +362,7 @@ public class TutorialPane
                {
                   handler_.removeHandler();
                   
-                  String version = sessionInfo_.getPackageDependencies().getPackage("learnr").getVersion();
+                  String version = session_.getSessionInfo().getPackageDependencies().getPackage("learnr").getVersion();
                   server_.isPackageInstalled("learnr", version, new ServerRequestCallback<Boolean>()
                   {
                      @Override
@@ -426,7 +428,7 @@ public class TutorialPane
    private final GlobalDisplay globalDisplay_;
    private final EventBus events_;
    private final Commands commands_;
-   private final SessionInfo sessionInfo_;
+   private final Session session_;
    private final PackagesServerOperations server_;
 
    private static final Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -345,26 +345,6 @@ public class TutorialPane
          self.@org.rstudio.studio.client.workbench.views.tutorial.TutorialPane::installLearnr()();
       });
       
-      $wnd.tutorialKeydown = $entry(function(event) {
-         
-         var code = event.code;
-         var button = event.which || event.keyCode;
-         
-         var handled =
-            code === "Space" ||
-            code === "Enter" ||
-            button === 13 ||
-            button === 32;
-            
-         if (handled) {
-            self.@org.rstudio.studio.client.workbench.views.tutorial.TutorialPane::installLearnr()();
-            return false;
-         }
-         
-         return true;
-         
-      });
-      
    }-*/;
    
    // Resources ---- 


### PR DESCRIPTION
This PR provides a small, clickable link / button for installing `learnr` from the main landing page when we detect it is not yet installed.

![Screen Shot 2020-02-20 at 12 10 38 PM](https://user-images.githubusercontent.com/1976582/74974438-19db4d80-53da-11ea-99ce-85091063953e.png)

This makes it easy for users to immediately get started with the Tutorial pane. After clicking the button, `learnr` will be installed, and then the Tutorial pane will automatically refresh and show the newly-installed tutorials.

@gtritchie, let me know if this is an acceptable implementation of a "link that behaves like a button". I took a different approach than what's done in HyperlinkLabel. The element itself is an anchor element, but has its ARIA role set as a button and has the requisite handlers for Space + Enter so that it responds like a normal button would. (Re-using the anchor element just means we get consistent styling with other anchors; e.g. the "active" state and so on)