### PR TITLE
Update Find in Files CSS so disabled elements will be obvious is desktop mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -25,6 +25,10 @@
       .presetFilePatterns {
          width: 100%;
       }
+
+      .presetFilePatterns option:disabled {
+         color: #999;
+      }
    </ui:style>
 
    <g:HTMLPanel styleName="{style.panel}">


### PR DESCRIPTION
Fixes #6255 

When running RStudio Server, the browser takes care of making sure disabled elements appear disabled as well as being disabled. In Desktop mode, the disabled Find in Files include/exclude options looked the same as the enabled options. This PR adds CSS code to make disabled options obviously disabled.

![image](https://user-images.githubusercontent.com/5323711/74987228-8e6cb700-53ef-11ea-80b5-2a597a841d08.png)
 