### PR TITLE
Supply correct name of libxkbcommon-11 on SuSE

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -62,7 +62,12 @@ elseif(RSTUDIO_DESKTOP)
   set(RPM_POSTRM postrm-desktop.sh.in)
 
   # rpm dependencies
-  set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11, ")
+  if(EXISTS "/etc/SuSE-release")
+     # SuSE based systems name this dependency with a -0 suffix
+     set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11-0, ")
+  else()
+     set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11, ")
+  endif()
 
   # deb dependencies
   set(RSTUDIO_DEBIAN_DEPENDS "libedit2, libssl1.0.0 | libssl1.0.2 | libssl1.1, libclang-dev, libxkbcommon-x11-0, ")

--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -1,3 +1,17 @@
+#
+# CMakeLists.txt
+#
+# Copyright (C) 2009-20 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
 
 # configure cpack install location 
 set(CPACK_SET_DESTDIR "ON")
@@ -62,7 +76,8 @@ elseif(RSTUDIO_DESKTOP)
   set(RPM_POSTRM postrm-desktop.sh.in)
 
   # rpm dependencies
-  if(EXISTS "/etc/SuSE-release")
+  string(FIND "${RSTUDIO_PACKAGE_OS}" "SUSE" SUSE_POS)
+  if(SUSE_POS GREATER 0)
      # SuSE based systems name this dependency with a -0 suffix
      set(RSTUDIO_RPM_DEPENDS "libxkbcommon-x11-0, ")
   else()


### PR DESCRIPTION
On SuSE based systems, the package that supplies `libxkbcommon-11` (needed by Qt on desktop Linux releases) is named `libxkbcommon-11-0`. RStudio will run if this dependency is installed, but it has the wrong package name in `Requires`, so it will complain about an unmet dependency even if the binaries are where they need to be. 

See https://forums.opensuse.org/showthread.php/538588-Naming-of-packages-libxkbcommon-x11 for details.

Fixes https://github.com/rstudio/rstudio/issues/5554. 