### PR TITLE
When screen reader support enabled, reduce UI animations

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -305,6 +305,12 @@ public class UserPrefs extends UserPrefsComputed
          RStudioGinjector.INSTANCE.getUserPrefs().enableScreenReader().setGlobalValue(enabled);
 
       screenReaderEnabled_ = enabled;
+
+      // When screen-reader is enabled, reduce UI animations as they serve no purpose 
+      // other than to potentially confuse the screen reader; turn animations back
+      // on when screen-reader support is disabled as that is the normal default and most
+      // users will never touch it.
+      RStudioGinjector.INSTANCE.getUserPrefs().reducedMotion().setGlobalValue(enabled);
    }
 
    @Handler


### PR DESCRIPTION
The UI animations are not useful or necessary to a screen-reader user and may confuse screen reader software, so enable the "reduce motion" setting automatically when screen-reader is enabled, and turn it off when screen reader is disabled.

Potentially annoying to a user who frequently switches between screen-reader on / off and prefers no animations in both cases; they will have to manually turn animations back off after disabling screen reader. But fancier handling of this (expected to be) very rare case specially seems like overkill.