### PR TITLE
revamp RStudio diagnostics script

### DIFF
--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -1,7 +1,7 @@
 #
 # Diagnostics.R
 #
-# Copyright (C) 2009-19 by RStudio, PBC
+# Copyright (C) 2009-20 by RStudio, PBC
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -13,101 +13,217 @@
 #
 #
 
-# capture output into a file (note this path is in module_context::sourceDiagnostics
-# so changes to the path should be synchronized there)
+# Init ----
+
 library(utils)
-dir.create("~/rstudio-diagnostics", showWarnings=FALSE)
-diagnosticsFile <- suppressWarnings(normalizePath("~/rstudio-diagnostics/diagnostics-report.txt"))
+diagnosticsDefault <- path.expand("~/rstudio-diagnostics/diagnostics-report.txt")
+diagnosticsFile <- Sys.getenv("RSTUDIO_DIAGNOSTICS_REPORT", unset = diagnosticsDefault)
+dir.create(dirname(diagnosticsFile), recursive = TRUE, showWarnings = FALSE)
 
-capture.output({
+# Utility functions ----
 
-  cat("RStudio Diagnostics Report\n",
-      "-----------------------------------------------------------------------------\n",
-      "Generated ", date(), "\n\n",
-      "WARNING: This report may contain sensitive security information and/or\n",
-      "personally identifiable information. Please audit the below and redact any\n",
-      "sensitive information before submitting your diagnostics report, then remove\n",
-      "this notice.\n\n", sep = "")
+redact_regex <- function() {
+  
+  words <- c(
+    "API", "AUTH", "GITHUB", "HOST", "HOST", "KEY", "LOGNAME",
+    "PASSWORD", "PAT", "SECRET", "TOKEN", "USERNAME"
+  )
+  
+  fmt <- "\\b%s\\b"
+  sprintf("(?:%s)", paste(sprintf(fmt, words), collapse = "|"))
+  
+}
 
+header <- function(fmt, ...) {
+  label <- sprintf(fmt, ...)
+  separator <- paste(rep.int("-", 50L), collapse = "")
+  writeLines(c(label, separator))
+}
+
+newlines <- function(n = 2L) {
+  writeLines(character(n))
+}
+
+dump <- function(object) {
+  formatted <- if (!is.null(names(object))) {
+    paste(format(names(object)), format(object), sep = " : ")
+  } else {
+    format(object)
+  }
+  writeLines(formatted)
+}
+
+dumpfile <- function(path) {
+  
+  if (!file.exists(path)) {
+    writeLines("(File does not exist)")
+    return(invisible())
+  }
+  
+  contents <- readLines(path, warn = FALSE)
+  if (length(contents) == 0L) {
+    writeLines("(File exists but is empty)")
+    return(invisible())
+  }
+  
+  if (all(grepl("^\\s*$", contents, perl = TRUE))) {
+    writeLines("(File exists but is empty / blank)")
+    return(invisible())
+  }
+  
+  regex <- sprintf("%s\\s*=", redact_regex())
+  matches <- grep(regex, gsub("_", " ", contents))
+  for (i in matches) {
+    line <- contents[[i]]
+    redacted <- paste(substring(line, 1, regexpr("=", line, fixed = TRUE)), "*** redacted ***")
+    contents[[i]] <- redacted
+  }
+  
+  writeLines(contents)
+  
+}
+
+# Main script ----
+
+capture.output(file = diagnosticsFile, {
+
+  report <- "
+RStudio Diagnostics Report
+==========================
+
+WARNING: This report may contain sensitive security information and / or
+personally identifiable information. Please audit the below and redact any
+sensitive information before submitting your diagnostics report.
+"
+
+  writeLines(report)
+  writeLines(paste("Generated:", date()))
+  writeLines("")
+  
   # version
   versionFile <- "../VERSION"
   if (file.exists(versionFile)) {
-    print(readLines(versionFile))
-    cat("\n")
+    header("RStudio Version")
+    dumpfile(versionFile)
+    newlines()
   }
   
-  # basic info
-  print(as.list(Sys.which(c("R", 
-                            "pdflatex",
-                            "bibtex",
-                            "gcc",
-                            "git", 
-                            "svn"))))
+  header("Session Information")
   print(sessionInfo())
-  cat("\nSysInfo:\n")
-  print(Sys.info())
-  cat("\nR Version:\n")
-  print(version)
-
-  envVars <- Sys.getenv()
+  newlines()
   
-  # create a list of words that are likely to appear in environment variables
-  # that we shouldn't capture in a diagnostics report
-  redactWords <- c(
-     "API",
-     "AUTH",
-     "GITHUB",
-     "HOST",
-     "HOST",
-     "KEY",
-     "LOGNAME",
-     "PASSWORD",
-     "PAT",
-     "SECRET",
-     "TOKEN",
-     "USERNAME"
+  header("System Information")
+  dump(Sys.info())
+  newlines()
+  
+  header("Platform Information")
+  dump(.Platform)
+  newlines()
+  
+  header("R Version")
+  dump(R.Version())
+  newlines()
+  
+  # log environment variables, redacting any banned words (e.g. those that might
+  # expose API tokens or other secrets). match it on the list of environment
+  # variable names with _ converted to a space (so that e.g. GITHUB_PAT becomes
+  # GITHUB PAT and matches the banned word PAT)
+  envVars <- Sys.getenv()
+  matches <- grepl(
+    redact_regex(),
+    gsub("_", " ", names(envVars), fixed = TRUE),
+    ignore.case = TRUE
   )
   
-  # form each into a regex that matches the word exactly
-  redactRegexes <- vapply(redactWords, function(word) { 
-     paste0("\\b(?:", word, ")\\b")
-  }, "")
-  
-  # collapse all of the regexes into a mega-regex that matches any banned word,
-  # then match it on the list of environment variable names with _ converted to
-  # a space (so that e.g. GITHUB_PAT becomes GITHUB PAT and matches the banned
-  # word PAT)
-  matches <- grepl(paste0(redactRegexes, collapse = "|"), 
-                   gsub("_", " ", names(envVars), fixed = TRUE), 
-                   ignore.case = TRUE)
   envVars[matches] <- "*** redacted ***"
-
-  print(as.list(envVars))
-  print(search())
+  
+  header("Environment Variables")
+  dump(as.list(envVars))
+  newlines()
+  
+  header("Loaded Packages")
+  packages <- loadedNamespaces()
+  paths <- find.package(packages)
+  names(paths) <- packages
+  dump(sort(paths))
+  newlines()
+  
+  header("R Home")
+  dump(R.home())
+  newlines()
+  
+  header("R Search Path")
+  dump(search())
+  newlines()
+  
+  # dump .Rprofiles
+  r_base_profile <- file.path(R.home(), "library/base/R/Rprofile")
+  header("R System Profile: %s", r_base_profile)
+  dumpfile(r_base_profile)
+  newlines()
+  
+  r_site_profile <- Sys.getenv("R_PROFILE", unset = file.path(R.home("etc"), "Rprofile.site"))
+  header("R Site Profile: %s", r_site_profile)
+  dumpfile(r_site_profile)
+  newlines()
+  
+  r_user_profile <- Sys.getenv("R_PROFILE_USER", unset = path.expand("~/.Rprofile"))
+  header("R User Profile: %s", r_user_profile)
+  dumpfile(r_user_profile)
+  newlines()
+  
+  # dump .Renvirons
+  r_site_environ <- Sys.getenv("R_ENVIRON", unset = file.path(R.home("etc"), "Renviron.site"))
+  header("R Site Environ: %s", r_site_environ)
+  dumpfile(r_site_environ)
+  newlines()
+  
+  r_user_environ <- Sys.getenv("R_ENVIRON_USER", unset = path.expand("~/.Renviron"))
+  header("R User Environ: %s", r_user_environ)
+  dumpfile(r_user_environ)
+  newlines()
+  
+  header("R Temporary Directory")
+  dump(tempdir())
+  newlines()
+  
+  header("Files in R Temporary Directory")
+  dump(list.files(tempdir()))
+  newlines()
   
   # locate diagnostics binary and run it
-  sysName <- Sys.info()[['sysname']]
-  ext <- ifelse(identical(sysName, "Windows"), ".exe", "")
-  
-  # first look for debug version
-  cppDiag <- paste("../../../qtcreator-build/diagnostics/diagnostics",
-                ext, sep="")
-  if (!file.exists(cppDiag)) {
-    if (identical(sysName, "Darwin"))
-      cppDiag <- "../../MacOS/diagnostics"
+  binaryPath <- local({
+    
+    # detect dev configurations
+    postback <- Sys.getenv("RS_RPOSTBACK_PATH", unset = NA)
+    if (!is.na(postback)) {
+      devpath <- file.path(dirname(postback), "../../diagnostics/diagnostics")
+      if (file.exists(devpath))
+        return(devpath)
+    }
+    
+    # detect release configurations
+    sysname <- Sys.info()[["sysname"]]
+    if (identical(sysname, "Darwin"))
+      "../../MacOS/diagnostics"
+    else if (identical(sysname, "Windows"))
+      "../bin/diagnostics.exe"
     else
-      cppDiag <- paste("../bin/diagnostics", ext, sep="")
+      "../bin/diagnostics"
+    
+  })
+    
+  if (file.exists(binaryPath)) {
+    binaryPath <- normalizePath(binaryPath)
+    diagnostics <- system(binaryPath, intern = TRUE)
+    writeLines(diagnostics)
   }
   
-  if (file.exists(cppDiag)) {
-    diag <- system(cppDiag, intern=TRUE)
-    cat(diag, sep="\n")
-  }
-  
-  
-}, file=diagnosticsFile)
+})
 
-cat("Diagnostics report written to:", diagnosticsFile, "\n\n",
-    "Please audit the report and remove any sensitive information before submitting.\n", sep = "")
+footer <- c(
+  paste("Diagnotics report written to:", diagnosticsFile),
+  "Please audit the report and remove any sensitive information before sharing this report with RStudio."
+)
 
-
+writeLines(footer)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2211,11 +2211,14 @@ core::system::ProcessSupervisor& processSupervisor()
 
 FilePath sourceDiagnostics()
 {
-   r::exec::RFunction sourceFx("source");
-   sourceFx.addParam(string_utils::utf8ToSystem(
-      options().coreRSourcePath().completeChildPath("Diagnostics.R").getAbsolutePath()));
-   sourceFx.addParam("chdir", true);
-   Error error = sourceFx.call();
+   FilePath diagnosticsPath =
+         options().coreRSourcePath().completeChildPath("Diagnostics.R");
+   
+   Error error = r::exec::RFunction("source")
+         .addParam(string_utils::utf8ToSystem(diagnosticsPath.getAbsolutePath()))
+         .addParam("chdir", true)
+         .call();
+   
    if (error)
    {
       LOG_ERROR(error);
@@ -2225,8 +2228,10 @@ FilePath sourceDiagnostics()
    {
       // note this path is also in Diagnostics.R so changes to the path
       // need to be synchronized there
-      return module_context::resolveAliasedPath(
-                        "~/rstudio-diagnostics/diagnostics-report.txt");
+      std::string reportPath = core::system::getenv("RSTUDIO_DIAGNOSTICS_REPORT");
+      if (reportPath.empty())
+         reportPath = "~/rstudio-diagnostics/diagnostics-report.txt";
+      return module_context::resolveAliasedPath(reportPath);
    }
 }
    


### PR DESCRIPTION
This PR revamps the diagnostics script used by RStudio, and now also writes:

- The library paths,
- Loaded packages (and from where they were loaded),
- Installed packages,
- Any site / user profiles / environs,
- The R session temporary directory path + contents,
- A bit more extra information about the system / platform (as reported by R).

Would be nice to take this for v1.3 so we have some extra debugging tools at our disposal with the release, but understand if we should instead target for v1.4.