### PR TITLE
Reload packages pane state after installing dependencies

### DIFF
--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "SessionDependencies.hpp"
+#include "SessionPackages.hpp"
 
 #include <boost/bind.hpp>
 #include <boost/algorithm/string/join.hpp>
@@ -447,7 +448,11 @@ Error installDependencies(const json::JsonRpcRequest& request,
       installJob.setProcOptions(async_r::R_PROCESS_VANILLA);
 
    std::string jobId;
-   error = jobs::startScriptJob(installJob, &jobId);
+   error = jobs::startScriptJob(installJob, [&]()
+   {
+      // When job is finished, update the packages state
+      packages::enquePackageStateChanged();
+   }, &jobId);
 
    // Return handle to script job
    pResponse->setResult(jobId);

--- a/src/cpp/session/modules/jobs/AsyncRJobManager.cpp
+++ b/src/cpp/session/modules/jobs/AsyncRJobManager.cpp
@@ -121,7 +121,7 @@ Error registerAsyncRJob(boost::shared_ptr<AsyncRJob> job,
    job->registerJob();
 
    // remove the job from the registry when it's done
-   job->addOnComplete([&]() 
+   job->addOnComplete([=]() 
    { 
       // remove the job from the list of those running
       s_jobs.erase(std::remove(s_jobs.begin(), s_jobs.end(), job), s_jobs.end());

--- a/src/cpp/session/modules/jobs/AsyncRJobManager.cpp
+++ b/src/cpp/session/modules/jobs/AsyncRJobManager.cpp
@@ -1,7 +1,7 @@
 /*
  * AsyncRJobManager.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -85,7 +85,11 @@ void AsyncRJob::onCompleted(int exitStatus)
       }
    }
    
-   onComplete_();
+   // run all finalizers
+   for (const auto& onComplete: onComplete_)
+   {
+      onComplete();
+   }
 }
 
 std::string AsyncRJob::id()
@@ -105,9 +109,9 @@ void AsyncRJob::cancel()
    }
 }
 
-void AsyncRJob::setOnComplete(boost::function<void()> onComplete)
+void AsyncRJob::addOnComplete(boost::function<void()> onComplete)
 {
-   onComplete_ = onComplete;
+   onComplete_.push_back(onComplete);
 }
 
 Error registerAsyncRJob(boost::shared_ptr<AsyncRJob> job,
@@ -117,7 +121,7 @@ Error registerAsyncRJob(boost::shared_ptr<AsyncRJob> job,
    job->registerJob();
 
    // remove the job from the registry when it's done
-   job->setOnComplete([&]() 
+   job->addOnComplete([&]() 
    { 
       // remove the job from the list of those running
       s_jobs.erase(std::remove(s_jobs.begin(), s_jobs.end(), job), s_jobs.end());

--- a/src/cpp/session/modules/jobs/AsyncRJobManager.hpp
+++ b/src/cpp/session/modules/jobs/AsyncRJobManager.hpp
@@ -1,7 +1,7 @@
 /*
  * AsyncRJobManager.hpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -18,6 +18,8 @@
 
 #include <session/jobs/Job.hpp>
 #include <session/SessionAsyncRProcess.hpp>
+
+#include <vector>
 
 namespace rstudio {
 namespace core {
@@ -48,8 +50,8 @@ public:
    // Register the job (create the underlying job)
    void registerJob();
 
-   // Set a callback for the job's exit
-   void setOnComplete(boost::function<void()> onComplete);
+   // Add a callback for the job's exit
+   void addOnComplete(boost::function<void()> onComplete);
 
    // Override default AsyncRProcess methods
    virtual void onStdout(const std::string& output);
@@ -66,7 +68,8 @@ protected:
    // The underlying job
    boost::shared_ptr<Job> job_;
 
-   boost::function<void()> onComplete_;
+   // Methods to call on completion
+   std::vector<boost::function<void()> > onComplete_;
    std::string name_;
 };
 

--- a/src/cpp/session/modules/jobs/ScriptJob.hpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.hpp
@@ -96,6 +96,10 @@ private:
 core::Error startScriptJob(const ScriptLaunchSpec& spec, 
       std::string *pId);
 
+core::Error startScriptJob(const ScriptLaunchSpec& spec, 
+      boost::function<void()> onComplete,
+      std::string *pId);
+
 core::Error stopScriptJob(const std::string& id);
 
 } // namespace jobs


### PR DESCRIPTION
This change causes the Packages pane to reload its state after we're done installing dependencies in a background job, so that the newly installed packages can be clearly shown.

Fixes https://github.com/rstudio/rstudio/issues/6274.