### PR TITLE
Add Edge to supported browser list

### DIFF
--- a/src/gwt/www/unsupported_browser.htm
+++ b/src/gwt/www/unsupported_browser.htm
@@ -35,6 +35,7 @@ p {
 <li><a href="https://www.apple.com/safari/">Safari 12.1</a></li>
 <li><a href="https://www.google.com/chrome/">Google Chrome 71</a></li>
 <li><a href="https://www.microsoft.com/en-us/download/internet-explorer.aspx">Internet Explorer 11</a></li>
+<li><a href="https://www.microsoft.com/en-us/edge/">Microsoft Edge 79</a></li>
 
 </ul>
 


### PR DESCRIPTION
This change adds Edge to the baked-in list of supported browsers. Edge uses Chromium (Chrome's browser engine) and also pretends to be Chrome in its user-agent string, so RStudio thinks it's a compatible version of Chrome. Which -- thankfully -- it is, for all intents and purposes.

Here's Edge's UA string on MacOS:

    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.116 Safari/537.36 Edg/80.0.361.57

(Favorite part: deliberate misspelling of `Edge` as `Edg`, probably to avoid UA detection of the old rendering engine)

Closes https://github.com/rstudio/rstudio/issues/6146.
