### PR TITLE
annotate console output element for easier screen-reader access

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ConsoleOutputWriter;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -72,7 +73,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
                                                       RequiresResize,
                                                       ConsoleError.Observer
 {
-   public ShellWidget(AceEditor editor, UserPrefs prefs, EventBus events, AriaLiveService ariaLive)
+   public ShellWidget(AceEditor editor,
+                      UserPrefs prefs,
+                      EventBus events,
+                      AriaLiveService ariaLive,
+                      String outputLabel)
    {
       styles_ = ConsoleResources.INSTANCE.consoleStyles();
       events_ = events;
@@ -186,6 +191,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
       verticalPanel_ = new VerticalPanel();
       verticalPanel_.setStylePrimaryName(styles_.console());
       FontSizer.applyNormalFontSize(verticalPanel_);
+      if (!StringUtil.isNullOrEmpty(outputLabel))
+      {
+         Roles.getRegionRole().set(output_.getElement());
+         Roles.getRegionRole().setAriaLabelProperty(output_.getElement(), outputLabel);
+      }
       verticalPanel_.add(output_.getWidget());
       verticalPanel_.add(pendingInput_);
       verticalPanel_.add(inputLine_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellPane.java
@@ -31,7 +31,7 @@ public class ShellPane extends ShellWidget implements Shell.Display
    @Inject
    public ShellPane(final AceEditor editor, UserPrefs uiPrefs, EventBus events, AriaLiveService ariaLive)
    {
-      super(editor, uiPrefs, events, ariaLive);
+      super(editor, uiPrefs, events, ariaLive, "Console Output");
 
       editor.setDisableOverwrite(true);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressWidget.java
@@ -25,7 +25,7 @@ public class ConsoleProgressWidget extends ShellWidget implements ShellDisplay
 {
    public ConsoleProgressWidget()
    {
-      super(new AceEditor(), null, null, null);
+      super(new AceEditor(), null, null, null, null);
       getEditor().setInsertMatching(false);
       getEditor().setTextInputAriaLabel("Progress details");
       if (!RStudioGinjector.INSTANCE.getAriaLiveService().isDisabled(AriaLiveService.PROGRESS_LOG))


### PR DESCRIPTION
- The console output element shows up as a region landmark named "Console Output"
- Fixes #6292