### PR TITLE
tweak tutorial pane styles

### DIFF
--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -260,7 +260,7 @@ void handleTutorialHomeRequest(const http::Request& request,
          if (tutorial.description.empty())
          {
             ss << "<div class=\"rstudio-tutorials-description rstudio-tutorials-description-empty\">"
-               << "[No description available.]"
+               << "<p>[No description available.]</p>"
                << "</div>";
          }
          else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
@@ -93,17 +93,17 @@
 }
 
 .rstudio-tutorials-run-container {
-   float: right;
+   white-space: nowrap;
 }
 
 .rstudio-tutorials-label-container {
-   overflow: auto;
+   display: flex;
    width: 100%;
    padding: 4px;
 }
 
 .rstudio-tutorials-label {
-   float: left;
+   flex: 1;
    font-size: 16pt;
    font-weight: bold;
 }
@@ -216,4 +216,8 @@
 
 .rstudio-themes-dark-menus .rstudio-tutorials-install-learnr-link:link {
    color: rgb(118, 171, 221);
+}
+
+.rstudio-themes-dark-menus .rstudio-tutorials-description-empty {
+   color: rgb(172, 172, 172);
 }


### PR DESCRIPTION
- Wrap `[No description available]` text in `<p>` tag so that it gets correct margins
- Use flexbox to improve wrapping behavior at smaller widths

Before:

<img width="217" alt="Screen Shot 2020-02-24 at 6 36 41 PM" src="https://user-images.githubusercontent.com/1976582/75210006-bda75f00-5734-11ea-8f81-7d07be00aa01.png">

<img width="264" alt="Screen Shot 2020-02-24 at 6 39 44 PM" src="https://user-images.githubusercontent.com/1976582/75210102-0d862600-5735-11ea-91b2-1e739a14d216.png">

After:

<img width="267" alt="Screen Shot 2020-02-24 at 6 36 23 PM" src="https://user-images.githubusercontent.com/1976582/75210020-cbf57b00-5734-11ea-85b3-0d0cd804dfe4.png">

<img width="260" alt="Screen Shot 2020-02-24 at 6 37 24 PM" src="https://user-images.githubusercontent.com/1976582/75210025-cf890200-5734-11ea-900d-b588474af619.png">

