### PR TITLE
put back option to set global application role (a11y)

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -301,6 +301,7 @@ namespace prefs {
 #define kDataViewerMaxColumns "data_viewer_max_columns"
 #define kEnableScreenReader "enable_screen_reader"
 #define kTypingStatusDelayMs "typing_status_delay_ms"
+#define kAriaApplicationRole "aria_application_role"
 #define kReducedMotion "reduced_motion"
 #define kTabKeyMoveFocus "tab_key_move_focus"
 #define kAutoSaveOnIdle "auto_save_on_idle"
@@ -1341,6 +1342,12 @@ public:
     */
    int typingStatusDelayMs();
    core::Error setTypingStatusDelayMs(int val);
+
+   /**
+    * Whether to tell screen readers that the entire page is an application.
+    */
+   bool ariaApplicationRole();
+   core::Error setAriaApplicationRole(bool val);
 
    /**
     * Reduce use of animations in the user interface.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2234,6 +2234,19 @@ core::Error UserPrefValues::setTypingStatusDelayMs(int val)
 }
 
 /**
+ * Whether to tell screen readers that the entire page is an application.
+ */
+bool UserPrefValues::ariaApplicationRole()
+{
+   return readPref<bool>("aria_application_role");
+}
+
+core::Error UserPrefValues::setAriaApplicationRole(bool val)
+{
+   return writePref("aria_application_role", val);
+}
+
+/**
  * Reduce use of animations in the user interface.
  */
 bool UserPrefValues::reducedMotion()
@@ -2536,6 +2549,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDataViewerMaxColumns,
       kEnableScreenReader,
       kTypingStatusDelayMs,
+      kAriaApplicationRole,
       kReducedMotion,
       kTabKeyMoveFocus,
       kAutoSaveOnIdle,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -968,6 +968,11 @@
             "default": 2000,
             "description": "Number of milliseconds to wait after last keystroke before updating live region."
         },
+        "aria_application_role": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to tell screen readers that the entire page is an application."
+        },
         "reduced_motion": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1014,6 +1014,20 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromXLS().remove();
       }
 
+      if (userPrefs_.get().ariaApplicationRole().getValue())
+      {
+         Element el = Document.get().getElementById("rstudio_container");
+         if (el == null)
+         {
+            // some satellite windows don't have "rstudio_container"
+            el = view_.getWidget().getElement();
+         }
+
+         // "application" role prioritizes application keyboard handling
+         // over screen-reader shortcuts
+         el.setAttribute("role", "application");
+      } 
+
       // If no project, ensure we show the product-edition title; if there is a project
       // open this was already done
       if (!Desktop.isDesktop() &&

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
@@ -1,7 +1,7 @@
 /*
  * SatelliteApplication.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -27,11 +27,13 @@ import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Provider;
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandHandler;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;
 import org.rstudio.studio.client.application.ui.RequestLogVisualization;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 public class SatelliteApplication
@@ -44,6 +46,7 @@ public class SatelliteApplication
       SatelliteApplicationView view,
       Satellite satellite,
       Provider<AceThemes> pAceThemes,
+      Provider<UserPrefs> pUserPrefs,
       ApplicationUncaughtExceptionHandler uncaughtExHandler,
       Commands commands)
    {
@@ -52,6 +55,7 @@ public class SatelliteApplication
          view,
          satellite,
          pAceThemes,
+         pUserPrefs,
          uncaughtExHandler,
          commands);
    }
@@ -61,6 +65,7 @@ public class SatelliteApplication
       SatelliteApplicationView view,
       Satellite satellite,
       Provider<AceThemes> pAceThemes,
+      Provider<UserPrefs> pUserPrefs,
       ApplicationUncaughtExceptionHandler uncaughtExHandler,
       Commands commands)
    {
@@ -68,6 +73,7 @@ public class SatelliteApplication
       view_ = view;
       satellite_ = satellite;
       pAceThemes_ = pAceThemes;
+      pUserPrefs_ = pUserPrefs;
       uncaughtExHandler_ = uncaughtExHandler;
       
       commands.showRequestLog().addHandler(new CommandHandler()
@@ -143,7 +149,14 @@ public class SatelliteApplication
       rootPanel.add(w);
       rootPanel.setWidgetTopBottom(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
       rootPanel.setWidgetLeftRight(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
-      
+
+      if (pUserPrefs_.get().ariaApplicationRole().getValue())
+      {
+         // "application" role prioritizes application keyboard handling
+         // over screen-reader shortcuts
+         view_.getWidget().getElement().setAttribute("role", "application");
+      }
+
       // show the view
       view_.show(satellite_.getParams());
       
@@ -161,5 +174,6 @@ public class SatelliteApplication
    private SatelliteApplicationView view_;
    private Satellite satellite_;
    private Provider<AceThemes> pAceThemes_;
+   private Provider<UserPrefs> pUserPrefs_;
    private ApplicationUncaughtExceptionHandler uncaughtExHandler_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
@@ -27,7 +27,6 @@ import com.google.gwt.user.client.ui.RootLayoutPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Provider;
 import org.rstudio.core.client.CommandWithArg;
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandHandler;
 import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler;

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewApplication.java
@@ -1,7 +1,7 @@
 /*
  * HTMLPreviewApplication.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.htmlpreview.ui.HTMLPreviewApplicationView;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -34,9 +35,10 @@ public class HTMLPreviewApplication extends SatelliteApplication
    public HTMLPreviewApplication(HTMLPreviewApplicationView view,
                                  Satellite satellite,
                                  Provider<AceThemes> pAceThemes,
+                                 Provider<UserPrefs> pUserPrefs,
                                  ApplicationUncaughtExceptionHandler exHandler,
                                  Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler, commands);
+      super(NAME, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/plumber/PlumberAPISatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/plumber/PlumberAPISatellite.java
@@ -1,7 +1,7 @@
 /*
  * PlumberAPISatellite.java
  *
- * Copyright (C) 2009-18 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.plumber.ui.PlumberAPIView;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -34,9 +35,10 @@ public class PlumberAPISatellite extends SatelliteApplication
    public PlumberAPISatellite(PlumberAPIView view,
                               Satellite satellite,
                               Provider<AceThemes> pAceThemes,
+                              Provider<UserPrefs> pUserPrefs,
                               ApplicationUncaughtExceptionHandler exHandler,
                               Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler, commands);
+      super(NAME, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutputSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutputSatellite.java
@@ -1,7 +1,7 @@
 /*
  * RmdOutputSatellite.java
  *
- * Copyright (C) 2009-14 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -34,9 +35,10 @@ public class RmdOutputSatellite extends SatelliteApplication
    public RmdOutputSatellite(RmdOutputView view,
                              Satellite satellite,
                              Provider<AceThemes> pAceThemes,
+                             Provider<UserPrefs> pUserPrefs,
                              ApplicationUncaughtExceptionHandler exHandler,
                              Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, exHandler, commands);
+      super(NAME, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationSatellite.java
@@ -1,7 +1,7 @@
 /*
  * ShinyApplicationSatellite.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.shiny.ui.ShinyApplicationView;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -49,10 +50,11 @@ public class ShinyApplicationSatellite extends SatelliteApplication
    public void initialize(ShinyApplicationView view,
                           Satellite satellite,
                           Provider<AceThemes> pAceThemes,
+                          Provider<UserPrefs> pUserPrefs,
                           ApplicationUncaughtExceptionHandler exHandler,
                           Commands commands)
    {
-      initialize(name_, view, satellite, pAceThemes, exHandler, commands);
+      initialize(name_, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
    
    private final String name_;

--- a/src/gwt/src/org/rstudio/studio/client/vcs/VCSApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/vcs/VCSApplication.java
@@ -1,7 +1,7 @@
 /*
  * VCSApplication.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -19,6 +19,7 @@ import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.common.vcs.AskPassManager;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -32,11 +33,12 @@ public class VCSApplication extends SatelliteApplication
    public VCSApplication(VCSApplicationView view,
                          Satellite satellite,
                          Provider<AceThemes> pAceThemes,
+                         Provider<UserPrefs> pUserPrefs,
                          ApplicationUncaughtExceptionHandler uncaughtExHandler,
                          AskPassManager askPassManager, // force gin to create
                          Commands commands)
    {
-      super(NAME, view, satellite, pAceThemes, uncaughtExHandler, commands);
+      super(NAME, view, satellite, pAceThemes, pUserPrefs, uncaughtExHandler, commands);
    }
 
    public final static String NAME = "review_changes";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1595,6 +1595,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to tell screen readers that the entire page is an application.
+    */
+   public PrefValue<Boolean> ariaApplicationRole()
+   {
+      return bool("aria_application_role", false);
+   }
+
+   /**
     * Reduce use of animations in the user interface.
     */
    public PrefValue<Boolean> reducedMotion()
@@ -2024,6 +2032,8 @@ public class UserPrefsAccessor extends Prefs
          enableScreenReader().setValue(layer, source.getBool("enable_screen_reader"));
       if (source.hasKey("typing_status_delay_ms"))
          typingStatusDelayMs().setValue(layer, source.getInteger("typing_status_delay_ms"));
+      if (source.hasKey("aria_application_role"))
+         ariaApplicationRole().setValue(layer, source.getBool("aria_application_role"));
       if (source.hasKey("reduced_motion"))
          reducedMotion().setValue(layer, source.getBool("reduced_motion"));
       if (source.hasKey("tab_key_move_focus"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -55,6 +55,10 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       chkScreenReaderEnabled_ = new CheckBox("Screen reader support (requires restart)");
       generalPanel.add(chkScreenReaderEnabled_);
 
+      initialAriaApplicationRole_ = prefs.ariaApplicationRole().getValue();
+      generalPanel.add(chkApplicationRole_ = checkboxPref(
+            "Entire page has application role (requires restart)", prefs.ariaApplicationRole())); 
+
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
             1, 9999, prefs.typingStatusDelayMs());
       generalPanel.add(indent(typingStatusDelay_));
@@ -126,6 +130,13 @@ public class AccessibilityPreferencesPane extends PreferencesPane
             restartRequirement.setUiReloadRequired(true);
       }
 
+      boolean applicationRoleSetting = chkApplicationRole_.getValue();
+      if (applicationRoleSetting != initialAriaApplicationRole_)
+      {
+         initialAriaApplicationRole_ = applicationRoleSetting;
+         restartRequirement.setUiReloadRequired(true);
+      }
+
       prefs.tabKeyMoveFocus().setGlobalValue(chkTabMovesFocus_.getValue());
       prefs.syncToggleTabKeyMovesFocusState(chkTabMovesFocus_.getValue());
 
@@ -192,11 +203,13 @@ public class AccessibilityPreferencesPane extends PreferencesPane
    private final CheckBox chkScreenReaderEnabled_;
    private final NumericValueWidget typingStatusDelay_;
    private final NumericValueWidget maxOutput_;
+   private final CheckBox chkApplicationRole_;
    private final CheckBox chkTabMovesFocus_;
    private final CheckBoxList announcements_;
 
    // initial values of prefs that can trigger reloads (to avoid unnecessary reloads)
    private boolean initialScreenReaderEnabled_;
+   private boolean initialAriaApplicationRole_;
 
    private final PreferencesDialogResources res_;
    private final AriaLiveService ariaLive_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceSatellite.java
@@ -1,7 +1,7 @@
 /*
  * SourceSatellite.java
  *
- * Copyright (C) 2009-15 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -41,10 +42,11 @@ public class SourceSatellite extends SatelliteApplication
    public void initialize(SourceSatelliteView view,
                           Satellite satellite,
                           Provider<AceThemes> pAceThemes,
+                          Provider<UserPrefs> pUserPrefs,
                           ApplicationUncaughtExceptionHandler exHandler,
                           Commands commands)
    {
-      initialize(name_, view, satellite, pAceThemes, exHandler, commands);
+      initialize(name_, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
    
    private final String name_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatellite.java
@@ -1,7 +1,7 @@
 /*
  * ChunkSatellite.java
  *
- * Copyright (C) 2009-16 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -20,6 +20,7 @@ import org.rstudio.studio.client.application.ApplicationUncaughtExceptionHandler
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteApplication;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 
 import com.google.inject.Inject;
@@ -39,10 +40,11 @@ public class ChunkSatellite extends SatelliteApplication
    public void initialize(ChunkSatelliteView view,
                           Satellite satellite,
                           Provider<AceThemes> pAceThemes,
+                          Provider<UserPrefs> pUserPrefs,
                           ApplicationUncaughtExceptionHandler exHandler,
                           Commands commands)
    {
-      initialize(name_, view, satellite, pAceThemes, exHandler, commands);
+      initialize(name_, view, satellite, pAceThemes, pUserPrefs, exHandler, commands);
    }
    
    private final String name_;


### PR DESCRIPTION
- I had removed this a while back, thinking it was unnecessary, but a screen-reader user who is helping test out 1.3 requested I put it back
- Changed default to false (off)
- When this role is assigned, there will be Axe violations due to some landmark roles being nested inside it
- Also assigned the role on satellite windows, which I had originally missed
- Overall purpose of this is to potentially change some default behavior of certain screen readers on Windows (whether they are in forms/focus mode or regular browsing mode)