### PR TITLE
Remove DocDisplay debug highlighting from manual spellcheck

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -184,10 +184,6 @@ public class CheckSpelling
             wordRanges.add(r);
             words.add(docDisplay_.getTextForRange(r));
 
-            SourcePosition startPos = SourcePosition.create(r.getStart().getRow(), r.getStart().getColumn());
-            SourcePosition endPos = SourcePosition.create(r.getEnd().getRow(), r.getEnd().getColumn());
-            docDisplay_.highlightDebugLocation(startPos, endPos, true);
-
             // Check a maximum of N words at a time
             if (wordRanges.size() == 100)
                break;


### PR DESCRIPTION
Fixes #6298 

This was something I added to give the manual spellchecking a little extra visual clarity but it's currently unreliable and not necessary so I'm removing it.