### PR TITLE
check user preference when displaying tooltip

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/r/SignatureToolTipManager.java
@@ -391,6 +391,9 @@ public class SignatureToolTipManager
    
    public void resolveActiveFunctionAndDisplayToolTip()
    {
+      if (!userPrefs_.showFunctionSignatureTooltips().getGlobalValue())
+         return;
+      
       if (docDisplay_.isPopupVisible())
          return;
       


### PR DESCRIPTION
Closes #5405. We were checking the preference for explicitly-completed function names, but not implicitly-completed functions -- e.g. where you manually type `rnorm(` or similar.