### PR TITLE
fixes around handling of Shiny interrupts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputPresenter.java
@@ -123,12 +123,6 @@ public class RmdOutputPresenter implements
    }
    
    @Override
-   public String getWindowName()
-   {
-      return view_.getName();
-   }
-
-   @Override
    public void onShinyDisconnect()
    {
       WindowEx.get().close();

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationPresenter.java
@@ -47,7 +47,6 @@ public class ShinyApplicationPresenter implements
       String getDocumentTitle();
       String getUrl();
       String getAbsoluteUrl();
-      String getName();
       void showApp(ShinyApplicationParams params, LoadHandler handler);
       void reloadApp();
    }
@@ -96,12 +95,6 @@ public class ShinyApplicationPresenter implements
       {
          reload();
       }
-   }
-   
-   @Override
-   public String getWindowName()
-   {
-      return view_.getName();
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
@@ -22,7 +22,6 @@ public class ShinyDisconnectNotifier
    public interface ShinyDisconnectSource
    {
       public String getShinyUrl();
-      public String getWindowName();
       public void onShinyDisconnect();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
@@ -80,7 +80,6 @@ public class ShinyDisconnectNotifier
       // check to see whether we should handle this message
       boolean ok =
             StringUtil.equals(data, "disconnected") &&
-            StringUtil.equals(name, source_.getWindowName()) &&
             source_.getShinyUrl().startsWith(origin);
       
       if (!ok)

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
@@ -77,25 +77,25 @@ public class ShinyDisconnectNotifier
    
    private void onMessage(String data, String origin, String name)
    {
-      // check to see whether we should handle this message
-      boolean ok =
-            StringUtil.equals(data, "disconnected") &&
-            source_.getShinyUrl().startsWith(origin);
-      
-      if (!ok)
+      // check to see if this is a 'disconnected' message
+      if (!StringUtil.equals(data, "disconnected"))
          return;
       
-      if (StringUtil.equals(source_.getShinyUrl(), suppressUrl_))
+      // check to see if the message originated from the same origin
+      String url = source_.getShinyUrl();
+      if (!url.startsWith(origin))
+         return;
+      
+      // if we were suppressing disconnect notifications from this URL,
+      // consume this disconnection and resume
+      if (StringUtil.equals(url, suppressUrl_))
       {
-         // we were suppressing disconnect notifications from this URL;
-         // consume this disconnection and resume
          unsuppress();
-      }
-      else
-      {
-         source_.onShinyDisconnect();
+         return;
       }
       
+      // respond to Shiny disconnect
+      source_.onShinyDisconnect();
    }
 
    private final ShinyDisconnectSource source_;

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyDisconnectNotifier.java
@@ -65,9 +65,9 @@ public class ShinyDisconnectNotifier
             return;
          
          self.@org.rstudio.studio.client.shiny.ShinyDisconnectNotifier::onMessage(*)(
-            e.data,
-            e.origin,
-            e.target.name
+            event.data,
+            event.origin,
+            event.target.name
          );
          
       });

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyApplicationPanel.java
@@ -119,12 +119,6 @@ public class ShinyApplicationPanel extends SatelliteFramePanel<RStudioFrame>
    }
    
    @Override
-   public String getName()
-   {
-      return getFrame().getWindow().getName();
-   }
-   
-   @Override
    protected RStudioFrame createFrame(String url)
    {
       return new RStudioFrame("Shiny Application", url);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -224,12 +224,6 @@ public class TutorialPane
       return frame_.getElement().getAttribute("src");
    }
    
-   @Override
-   public String getName()
-   {
-      return frame_.getWindowName();
-   }
-   
    private void runTutorial(String tutorialName,
                             String packageName)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
@@ -64,7 +64,6 @@ public class TutorialPresenter
       
       String getUrl();
       String getRawSrcUrl();
-      String getName();
       
       void launchTutorial(Tutorial tutorial);
       
@@ -307,12 +306,6 @@ public class TutorialPresenter
       return display_.getUrl();
    }
    
-   @Override
-   public String getWindowName()
-   {
-      return display_.getName();
-   }
-
    @Override
    public void onShinyDisconnect()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -226,12 +226,6 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    }
    
    @Override
-   public String getName()
-   {
-      return frame_.getWindow().getName();
-   }
-   
-   @Override
    public void popout()
    {
       if (rmdPreviewParams_ != null && 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPresenter.java
@@ -92,7 +92,6 @@ public class ViewerPresenter extends BasePresenter
       HandlerRegistration addLoadHandler(LoadHandler handler);
       String getUrl();
       String getTitle();
-      String getName();
       void popout();
       void refresh();
       Size getViewerFrameSize();
@@ -271,12 +270,6 @@ public class ViewerPresenter extends BasePresenter
       return display_.getUrl();
    }
    
-   @Override
-   public String getWindowName()
-   {
-      return display_.getName();
-   }
-
    @Override
    public void onShinyDisconnect()
    {


### PR DESCRIPTION
It looks like this was broken by some of the work I was doing on tutorials. Quick summary of changes:

- Fix typos in refactoring of Shiny disconnect message handler
- Avoid using window methods as they're likely to fail due to CORS restrictions
- Avoid checking window name when handling event (checking URL is sufficient)