### PR TITLE
new command for putting focus on the last chunk of console output

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -88,6 +88,7 @@ public class ConsoleOutputWriter
       if (virtualConsole_ == null)
       {
          SpanElement trailing = Document.get().createSpanElement();
+         trailing.setTabIndex(-1);
          outEl.appendChild(trailing);
          virtualConsole_ = vcFactory_.create(trailing);
       }
@@ -152,6 +153,15 @@ public class ConsoleOutputWriter
          return "";
       else
          return virtualConsole_.getNewText();
+   }
+
+   public void focusEnd()
+   {
+      Node lastChild = output_.getElement().getLastChild();
+      if (lastChild == null)
+         return;
+      Element last = lastChild.cast();
+      last.focus();
    }
 
    private int maxLines_ = -1;

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.common.shell;
 
+import org.rstudio.core.client.ConsoleOutputWriter;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.studio.client.workbench.model.ConsoleAction;
@@ -36,6 +37,7 @@ public interface ShellDisplay extends ShellOutputWriter,
    void consolePrompt(String prompt, boolean showInput);
    void ensureInputVisible();
    InputEditorDisplay getInputEditorDisplay();
+   ConsoleOutputWriter getConsoleOutputWriter();
    void clearOutput();
    String processCommandEntry();
    int getCharacterWidth();

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -191,12 +191,17 @@ public class ShellWidget extends Composite implements ShellDisplay,
       verticalPanel_ = new VerticalPanel();
       verticalPanel_.setStylePrimaryName(styles_.console());
       FontSizer.applyNormalFontSize(verticalPanel_);
-      if (!StringUtil.isNullOrEmpty(outputLabel))
+      if (StringUtil.isNullOrEmpty(outputLabel))
+         verticalPanel_.add(output_.getWidget());
+      else
       {
-         Roles.getRegionRole().set(output_.getElement());
-         Roles.getRegionRole().setAriaLabelProperty(output_.getElement(), outputLabel);
+         HTML wrapper = new HTML();
+         Roles.getRegionRole().set(wrapper.getElement());
+         Roles.getRegionRole().setAriaLabelProperty(wrapper.getElement(), outputLabel);
+         Roles.getDocumentRole().set(output_.getElement());
+         wrapper.getElement().appendChild(output_.getElement());
+         verticalPanel_.add(wrapper);
       }
-      verticalPanel_.add(output_.getWidget());
       verticalPanel_.add(pendingInput_);
       verticalPanel_.add(inputLine_);
       verticalPanel_.setWidth("100%");
@@ -715,6 +720,12 @@ public class ShellWidget extends Composite implements ShellDisplay,
    public InputEditorDisplay getInputEditorDisplay()
    {
       return input_;
+   }
+
+   @Override
+   public ConsoleOutputWriter getConsoleOutputWriter()
+   {
+      return output_;
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -507,12 +507,15 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <menu label="Acc_essibility">
             <cmd refid="toggleScreenReaderSupport"/>
-            <cmd refid="toggleTabKeyMovesFocus"/>
             <separator/>
-            <menu label="_Speak">
+            <menu label="S_peak">
                <cmd refid="speakEditorLocation"/>
             </menu>
-            <cmd refid="focusMainToolbar"/>
+            <menu label="_Focus">
+               <cmd refid="focusConsoleOutputEnd"/>
+               <cmd refid="focusMainToolbar"/>
+               <cmd refid="toggleTabKeyMovesFocus"/>
+               </menu>
             <separator/>
             <cmd refid="showAccessibilityOptions"/>
          </menu>
@@ -857,6 +860,7 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
+         <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+J"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Alt+Shift+B"/>
          <shortcut refid="focusMainToolbar" value="Ctrl+Alt+Y"/>
@@ -3627,6 +3631,10 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="focusMainToolbar"
         menuLabel="Focus _Main Toolbar"
+        windowMode="main"/>
+
+   <cmd id="focusConsoleOutputEnd"
+        menuLabel="_Focus Console Output"
         windowMode="main"/>
 
    <cmd id="signOut"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -646,7 +646,8 @@ public abstract class
    public abstract AppCommand showAccessibilityOptions();
    public abstract AppCommand focusMainToolbar();
    public abstract AppCommand speakEditorLocation();
-   
+   public abstract AppCommand focusConsoleOutputEnd();
+
    // Internal
    public abstract AppCommand showDomElements();
    public abstract AppCommand showShortcutCommand();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -272,6 +272,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    }
 
+   @Handler
+   void onFocusConsoleOutputEnd()
+   {
+      view_.getConsoleOutputWriter().focusEnd();
+   }
+
    public void addKeyDownPreviewHandler(KeyDownPreviewHandler handler)
    {
       keyDownPreviewHandlers_.add(handler);

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -67,19 +67,19 @@ Reference on default Ace shortcuts: https://github.com/ajaxorg/ace/wiki/Default-
       <td>⌃⌥⇧/</td>
     </tr>
     <tr>
-      <td>Toggle Tab Key Always Moves Focus</td>
-      <td>Ctrl+Alt+Shift+T</td>
-      <td>⌃⌥⇧T</td>
-    </tr>
-    <tr>
       <td>Speak Text Editor Location</td>
       <td>Ctrl+Alt+Shift+B</td>
       <td>⌃⌥⇧B</td>
     </tr>
     <tr>
-      <td>Focus Main Toolbar</td>
-      <td>Ctrl+Alt+Y</td>
-      <td>⌃⌥Y</td>
+      <td>Focus Console Output</td>
+      <td>Ctrl+Alt+J</td>
+      <td>⌃⌥J</td>
+    </tr>
+    <tr>
+      <td>Toggle Tab Key Always Moves Focus</td>
+      <td>Ctrl+Alt+Shift+T</td>
+      <td>⌃⌥⇧T</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
- Intended for screen-reader users as a way to quickly get screen-reader onto the console output
- Goes to the last chunk of output, which is usually the last entered command all its output (if console has been reloaded e.g. by closing and reopening the browser then all previous output is in a single chunk)
- Group focus-related accessibility commands into a Help / Accessibility / Focus submenu; there will be more commands here in the future (e.g. 1.4)
- marks the console output region as having document role which hints to screen readers that they could use browse mode instead of focus mode