### PR TITLE
allow user select in request log details

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogDetail.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogDetail.java
@@ -51,6 +51,7 @@ public class RequestLogDetail extends Composite
                    + tryPrettyJson(resp)
                    + "\n");
       html.getElement().getStyle().setProperty("whiteSpace", "pre-wrap");
+      html.getElement().getStyle().setProperty("userSelect", "text");
 
       panel.add(html);
 


### PR DESCRIPTION
Since we disallow user selection in the `<body>` by default, we need to explicitly add it here.