### PR TITLE
use main menu shortcuts more in line with Google Docs on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -846,17 +846,27 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="nextTerminal" value="Shift+Alt+F12"/>
       </shortcutgroup>
       <shortcutgroup name="Main Menu (Server)">
-         <shortcut refid="showFileMenu" value="Ctrl+Alt+F"/>
-         <shortcut refid="showEditMenu" value="Ctrl+Alt+I"/>
-         <shortcut refid="showCodeMenu" value="Ctrl+Alt+C"/>
-         <shortcut refid="showViewMenu" value="Ctrl+Alt+V"/>
-         <shortcut refid="showPlotsMenu" value="Ctrl+Alt+P"/>
+         <shortcut refid="showFileMenu" value="Ctrl+Alt+F" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showFileMenu" value="Alt+Shift+F" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showEditMenu" value="Ctrl+Alt+I" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showEditMenu" value="Alt+Shift+E" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showCodeMenu" value="Ctrl+Alt+C" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showCodeMenu" value="Alt+Shift+C" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showViewMenu" value="Ctrl+Alt+V" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showViewMenu" value="Alt+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showPlotsMenu" value="Ctrl+Alt+P" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showPlotsMenu" value="Alt+Shift+P" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showSessionMenu" value="Ctrl+Alt+Shift+S"/>
-         <shortcut refid="showBuildMenu" value="Ctrl+Alt+B"/>
-         <shortcut refid="showDebugMenu" value="Ctrl+Alt+U"/>
-         <shortcut refid="showProfileMenu" value="Ctrl+Alt+O"/>
-         <shortcut refid="showToolsMenu" value="Ctrl+Alt+L"/>
-         <shortcut refid="showHelpMenu" value="Ctrl+Alt+H"/>
+         <shortcut refid="showBuildMenu" value="Ctrl+Alt+B" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showBuildMenu" value="Alt+Shift+B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showDebugMenu" value="Ctrl+Alt+U" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showDebugMenu" value="Alt+Shift+U" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showProfileMenu" value="Ctrl+Alt+O" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showProfileMenu" value="Alt+Shift+I" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showToolsMenu" value="Ctrl+Alt+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showToolsMenu" value="Alt+Shift+S" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showHelpMenu" value="Ctrl+Alt+H" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showHelpMenu" value="Alt+Shift+H" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -1101,27 +1101,27 @@ Reference on default Ace shortcuts: https://github.com/ajaxorg/ace/wiki/Default-
     <tbody>
     <tr>
       <td>File Menu</td>
-      <td>Ctrl+Alt+F</td>
+      <td>Alt+Shift+F</td>
       <td>⌃⌥F</td>
     </tr>
     <tr>
       <td>Edit Menu</td>
-      <td>Ctrl+Alt+I</td>
+      <td>Alt+Shift+E</td>
       <td>⌃⌥I</td>
     </tr>
     <tr>
       <td>Code Menu</td>
-      <td>Ctrl+Alt+C</td>
+      <td>Alt+Shift+C</td>
       <td>⌃⌥C</td>
     </tr>
     <tr>
       <td>View Menu</td>
-      <td>Ctrl+Alt+V</td>
+      <td>Alt+Shift+V</td>
       <td>⌃⌥V</td>
     </tr>
     <tr>
       <td>Plots Menu</td>
-      <td>Ctrl+Alt+P</td>
+      <td>Alt+Shift+P</td>
       <td>⌃⌥P</td>
     </tr>
     <tr>
@@ -1131,27 +1131,27 @@ Reference on default Ace shortcuts: https://github.com/ajaxorg/ace/wiki/Default-
     </tr>
     <tr>
       <td>Build Menu</td>
-      <td>Ctrl+Alt+B</td>
+      <td>Alt+Shift+B</td>
       <td>⌃⌥B</td>
     </tr>
     <tr>
       <td>Debug Menu</td>
-      <td>Ctrl+Alt+U</td>
+      <td>Alt+Shift+U</td>
       <td>⌃⌥U</td>
     </tr>
     <tr>
       <td>Profile Menu</td>
-      <td>Ctrl+Alt+O</td>
+      <td>Alt+Shift+I</td>
       <td>⌃⌥O</td>
     </tr>
     <tr>
       <td>Tools Menu</td>
-      <td>Ctrl+Alt+L</td>
+      <td>Alt+Shift+S</td>
       <td>⌃⌥L</td>
     </tr>
     <tr>
       <td>Help Menu</td>
-      <td>Ctrl+Alt+H</td>
+      <td>Alt+Shift+H</td>
       <td>⌃⌥H</td>
     </tr>
     </tbody>


### PR DESCRIPTION
- I was using the same shortcuts on all platforms, based on what Google Docs uses on Mac
- These were less appropriate on Windows due to increased likelihood of clashes, so switched to be Alt+Shift based instead of Ctrl+Alt based (i.e. same as Google Docs main menu shortcuts)
- Fixes #6353