### PR TITLE
Use an empty source template if none found

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -842,6 +842,13 @@ Error processSourceTemplate(const std::string& name,
       }
    }
 
+   if (!templatePath.exists())
+   {
+      // We didn't find a user, system, or built-in template, so use an empty one.
+      *pContents = "";
+      return Success();
+   }
+
    // read file with template filter
    return core::readStringFromFile(templatePath,
                                    filter,


### PR DESCRIPTION
This change fixes a problem that occurs when creating a new source document *could* use a template, but no template is installed. We currently show an error in this case; the correct behavior is to just create an empty document.

Fixes https://github.com/rstudio/rstudio/issues/6351.