### PR TITLE
Render dataviewer cells with block elements

### DIFF
--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -3,7 +3,7 @@
 /*
  * dtviewer.js
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -279,7 +279,7 @@ var renderCellClass = function (data, type, row, meta, clazz) {
     title = data;
 
   // produce tag
-  return createTag('span', contents, {
+  return createTag('div', contents, {
     'class': classes,
     'title': title
   });


### PR DESCRIPTION
We currently render data viewer cells as inline elements (`<span>`). This prevents alignment from working correctly, so this change renders the cells using block elements instead.

Fixes https://github.com/rstudio/rstudio/issues/6314. 