### PR TITLE
add links to accessibility support article in options and menu

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -518,6 +518,7 @@ well as menu structures (for main menu and popup menus).
                </menu>
             <separator/>
             <cmd refid="showAccessibilityOptions"/>
+            <cmd refid="showAccessibilityHelp"/>
          </menu>
          <separator/>
          <cmd refid="helpUsingRStudio"/>
@@ -3622,6 +3623,10 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="showAccessibilityOptions"
         menuLabel="Accessibility _Options..."
+        windowMode="main"/>
+
+   <cmd id="showAccessibilityHelp"
+        menuLabel="Accessibility _Help..."
         windowMode="main"/>
 
    <cmd id="toggleTabKeyMovesFocus"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -647,6 +647,7 @@ public abstract class
    public abstract AppCommand focusMainToolbar();
    public abstract AppCommand speakEditorLocation();
    public abstract AppCommand focusConsoleOutputEnd();
+   public abstract AppCommand showAccessibilityHelp();
 
    // Internal
    public abstract AppCommand showDomElements();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -34,6 +34,7 @@ import org.rstudio.core.client.widget.CheckBoxList;
 import org.rstudio.core.client.widget.NumericValueWidget;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
 import java.util.Map;
@@ -71,6 +72,11 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       generalPanel.add(checkboxPref("Reduce user interface animations", prefs.reducedMotion()));
       chkTabMovesFocus_ = new CheckBox("Tab key always moves focus");
       generalPanel.add(chkTabMovesFocus_);
+
+      HelpLink helpLink = new HelpLink("RStudio accessibility help", "rstudio_a11y", false);
+      nudgeRight(helpLink);
+      helpLink.addStyleName(res_.styles().newSection());
+      generalPanel.add(helpLink);
 
       Label announcementsLabel = headerLabel("Enable / Disable Announcements");
       announcements_ = new CheckBoxList(announcementsLabel);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/Help.java
@@ -306,6 +306,11 @@ public class Help extends BasePresenter implements ShowHelpHandler
       events_.fireEvent(new ShowHelpEvent("help/doc/markdown_help.html"));
    }
 
+   void onShowAccessibilityHelp()
+   {
+      globalDisplay_.openRStudioLink("rstudio_a11y", false);
+   }
+
    void onProfileHelp()
    {
       globalDisplay_.openRStudioLink("profiling_help", false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpTab.java
@@ -56,6 +56,7 @@ public class HelpTab extends DelayLoadWorkbenchTab<Help>
       @Handler public abstract void onOpenRoxygenQuickReference();
       @Handler public abstract void onBrowseCheatSheets();
       @Handler public abstract void onProfileHelp();
+      @Handler public abstract void onShowAccessibilityHelp();
       
       public abstract void bringToFront();
    }


### PR DESCRIPTION
- Fixes #6013
- Article is a stub at the moment but will be written in next few days

<img width="592" alt="screenshot showing new accessibility help link in accessibility preferences" src="https://user-images.githubusercontent.com/10569626/75498862-34cf3400-597d-11ea-959a-e341d57087d3.png">

<img width="521" alt="screenshot showing new accessibility help menu item in help / accessibility menu" src="https://user-images.githubusercontent.com/10569626/75498875-3b5dab80-597d-11ea-95ac-8f325666225e.png">
