### PR TITLE
change toolbar and console output shortcuts on Windows and Linux

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -871,10 +871,12 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
-         <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+J"/>
+         <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Alt+Shift+B"/>
-         <shortcut refid="focusMainToolbar" value="Ctrl+Alt+Y"/>
+         <shortcut refid="focusMainToolbar" value="Ctrl+Alt+Y" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="focusMainToolbar" value="Alt+Shift+Y" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <!-- 
       Shortcuts in this group won't be shown in the quick reference card. 

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -73,13 +73,18 @@ Reference on default Ace shortcuts: https://github.com/ajaxorg/ace/wiki/Default-
     </tr>
     <tr>
       <td>Focus Console Output</td>
-      <td>Ctrl+Alt+J</td>
-      <td>⌃⌥J</td>
+      <td>Alt+Shift+2</td>
+      <td>⌃⌥2</td>
     </tr>
     <tr>
       <td>Toggle Tab Key Always Moves Focus</td>
       <td>Ctrl+Alt+Shift+T</td>
       <td>⌃⌥⇧T</td>
+    </tr>
+    <tr>
+      <td>Focus Main Toolbar</td>
+      <td>Alt+Shift+Y</td>
+      <td>⌃⌥Y</td>
     </tr>
     </tbody>
   </table>


### PR DESCRIPTION
- to reduce clashes with application shortcuts on Windows (Ctrl+Alt+?), change focus console output and focus main toolbar shortcuts to Alt+Shift+?
- also changed focus console output on Mac to use Ctrl+Alt+2 for better symmetry with Ctrl+2 (focus console); also avoids Ctrl+Alt+J which is commonly used to start JAWS on Windows
- added focus main toolbar to static keyboard help