### PR TITLE
fixes for UBSAN warnings + potential crashes

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -127,6 +127,7 @@ public:
       running_(false),
       replace_(false),
       preview_(false),
+      gitFlag_(false),
       pReplaceProgress_(nullptr)
    {
    }

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -211,7 +211,8 @@ std::string embeddedWebFonts()
 
       // base64 encoder
       FilePath fontPath = session::options().rResourcesPath().completePath(fonts);
-      filteredStream.push(html_utils::CssUrlFilter(fontPath));
+      auto cssFilter = html_utils::CssUrlFilter(fontPath);
+      filteredStream.push(cssFilter);
 
       // target stream
       std::ostringstream os;
@@ -781,10 +782,13 @@ bool createStandalonePresentation(const FilePath& targetFile,
       return false;
    }
 
+   // collect filters
+   std::vector<boost::iostreams::regex_filter> filters;
+   
    // create image filter
    FilePath dirPath = presentation::state::directory();
-   std::vector<boost::iostreams::regex_filter> filters;
-   filters.push_back(html_utils::Base64ImageFilter(dirPath));
+   auto imageFilter = html_utils::Base64ImageFilter(dirPath);
+   filters.push_back(imageFilter);
 
    // render presentation
    return renderPresentation(vars, filters, *pOfs, pErrorResponse);

--- a/src/tools/clang-ubsan-build
+++ b/src/tools/clang-ubsan-build
@@ -1,18 +1,24 @@
 #!/usr/bin/env bash
 
-: ${ASANFLAGS="-fsanitize=address,undefined -fsanitize-recover=address,undefined -fno-omit-frame-pointer -fno-sanitize=float-divide-by-zero"}
-: ${LDFLAGS=""}
+read -r -d '' ASANFLAGS <<- EOF
+-fsanitize=address,undefined
+-fsanitize-recover=address,undefined
+-fno-sanitize=vptr,float-divide-by-zero
+-fno-omit-frame-pointer
+EOF
+ASANFLAGS="$(echo "${ASANFLAGS}" | tr '\n' ' ')"
+
 : ${BUILD_DIR="clang-ubsan-build"}
 : ${MAKEFLAGS="-j$(getconf _NPROCESSORS_ONLN)"}
 : ${R_HOME="$(R RHOME)"}
 
 mkdir -p "${BUILD_DIR}"
 cd "${BUILD_DIR}"
-cmake ../cpp                                    \
-    -DLIBR_HOME="${R_HOME}"                     \
-    -DCMAKE_BUILD_TYPE="Debug"                  \
-    -DCMAKE_C_FLAGS="${ASANFLAGS} ${LDFLAGS}"   \
-    -DCMAKE_CXX_FLAGS="${ASANFLAGS} ${LDFLAGS}" \
+cmake ../cpp                         \
+    -DLIBR_HOME="${R_HOME}"          \
+    -DCMAKE_BUILD_TYPE="Debug"       \
+    -DCMAKE_C_FLAGS="${ASANFLAGS}"   \
+    -DCMAKE_CXX_FLAGS="${ASANFLAGS}" \
     "$@"
 cd ..
 


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6391.

Also updates the `clang` UBSAN script (used to generate sanitizer builds of RStudio locally on macOS)