### PR TITLE
Fixes a crash when constructing FilePath with null char*

### DIFF
--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -90,6 +90,27 @@ TEST_CASE("file paths")
    }
 }
 
+TEST_CASE("Null char* construction")
+{
+   SECTION("Null char*")
+   {
+      char* nullPtr = NULL;
+
+      FilePath aPath(nullPtr);
+      CHECK(aPath.isEmpty());
+   }
+
+#ifdef _WIN32
+   SECTION("Null wchar_t*")
+   {
+      wchar_t* nullPtr = NULL;
+
+      FilePath aPath(nullPtr);
+      CHECK(aPath.isEmpty());
+   }
+#endif
+}
+
 } // end namespace tests
 } // end namespace core
 } // end namespace rstudio

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -319,15 +319,29 @@ FilePath::FilePath() :
 {
 }
 
+FilePath::FilePath(const char* in_absolutePath)
+{
+   if (nullptr == in_absolutePath)
+      m_impl.reset(new Impl());
+   else
+      m_impl.reset(new Impl(in_absolutePath));
+}
+
 FilePath::FilePath(const std::string& in_absolutePath) :
    m_impl(new Impl(fromString(std::string(in_absolutePath.c_str())))) // thwart ref-count
 {
 }
 
 #ifdef _WIN32
-FilePath::FilePath(const std::wstring& absolutePath)
-   : m_impl(new Impl(absolutePath)) // thwart ref-count
+FilePath::FilePath(const std::wstring& absolutePath) :
+   m_impl(new Impl(toString(std::wstring(absolutePath.c_str())))) // thwart ref-count
 {
+}
+
+FilePath::FilePath(const wchar_t* absolutePath)
+{
+   if (nullptr == absolutePath)
+      m_impl.reset(new FilePath())
 }
 #endif
 

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -334,14 +334,16 @@ FilePath::FilePath(const std::string& in_absolutePath) :
 
 #ifdef _WIN32
 FilePath::FilePath(const std::wstring& absolutePath) :
-   m_impl(new Impl(toString(std::wstring(absolutePath.c_str())))) // thwart ref-count
+   m_impl(new Impl(absolutePath)) // thwart ref-count
 {
 }
 
 FilePath::FilePath(const wchar_t* absolutePath)
 {
    if (nullptr == absolutePath)
-      m_impl.reset(new FilePath())
+      m_impl.reset(new Impl());
+   else
+      m_impl.reset(new Impl(absolutePath));
 }
 #endif
 

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -82,10 +82,17 @@ public:
     *
     * @param in_absolutePath    The string representation of the path.
     */
+   explicit FilePath(const char* in_absolutePath);
+   /**
+    * @brief Constructor.
+    *
+    * @param in_absolutePath    The string representation of the path.
+    */
    explicit FilePath(const std::string& in_absolutePath);
 
 #if _WIN32
    explicit FilePath(const std::wstring& in_absolutePath);
+   explicit FilePath(const wchar_t* absolutePath);
 #endif
 
    /**


### PR DESCRIPTION
Kevin pointed out that a crash can happen if a `NULL` `char *` is passed to the `FilePath` constructor because it tries to coerce the `char *` to `string. This PR resolves that issue by adding `FilePath` constructors for `const char*` and `const wchar_t*` that explicitly handle null pointers. Unfortunately, we weren't able to find the Sentry record that brought this to Kevin's attention.