### PR TITLE
Intentionally Leak Logger Object

### DIFF
--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -175,8 +175,10 @@ public:
 
 Logger& logger()
 {
-   static Logger logger;
-   return logger;
+   // Intentionally leak the logger object to avoid some crashes because we don't (can't currently) always wait for all
+   // the background threads of a process, and destruction isn't necessary.
+   static Logger* logger = new Logger();
+   return *logger;
 }
 
 void Logger::writeMessageToDestinations(


### PR DESCRIPTION
We are seeing some crashes during static object deconstruction that seem to be caused by attempts to write logs after the log object has been deconstructed. This PR attempts to address those crashes by intentionally leaking the logger object. This means log destinations will not be able to rely on their destructors to flush their streams. Existing log destinations already flush (if necessary) after each message is logged.

Fixes #6282. There are other reports in sentry, but I can't seem to find associated git issues.