### PR TITLE
share web profile across different pages

### DIFF
--- a/src/cpp/desktop/DesktopWebProfile.cpp
+++ b/src/cpp/desktop/DesktopWebProfile.cpp
@@ -69,6 +69,14 @@ private:
 WebProfile::WebProfile(const QUrl& baseUrl, QObject* parent)
    : QWebEngineProfile(QString::fromUtf8("rstudio-desktop"), parent)
 {
+   // force an in-memory cache of web resources
+   // otherwise, multiple windows / pages attempting to access
+   // or mutate the disk cache at the same time can cause
+   // data corruption to occur
+   //
+   // https://github.com/rstudio/rstudio/issues/6201
+   setHttpCacheType(QWebEngineProfile::MemoryHttpCache);
+   
    sharedSecret_ = core::system::getenv("RS_SHARED_SECRET");
    setBaseUrl(baseUrl);
 }


### PR DESCRIPTION
Candidate fix for https://github.com/rstudio/rstudio/issues/6201.

Note: merely sharing the web profile across different pages (RStudio windows) was surprisingly not sufficient; I was still able to reproduce cache load failures when opening multiple satellite windows at the same time. It looks like forcing HTTP resources to be cached in-memory helps avoid this issue, at least as far as I can see in testing.