### PR TITLE
Fix up libssl paths when building on macOS Catalina/libssl 1.1+

### DIFF
--- a/src/cpp/diagnostics/CMakeLists.txt
+++ b/src/cpp/diagnostics/CMakeLists.txt
@@ -64,11 +64,24 @@ endif()
 
 # if doing a package build on MacOS, reroute the OpenSSL libraries to our bundled copies
 if(APPLE AND RSTUDIO_PACKAGE_BUILD)
+
    find_package(OpenSSL REQUIRED QUIET)
    foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-      get_filename_component(LIB_DIR ${lib} PATH)
-      execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+      # get the real path to the library (with all symlinks resolved) and filename
+      get_filename_component(LIB_PATH "${lib}" REALPATH)
+      get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
+      # this command does the following:
+      # 1. runs otool -L to find the path at which the OpenSSL library is
+      #    linked into the executable (this path is unfortunately not canonical
+      #    and includes layers of both resolved and unresolved symlinks)
+      # 2. extracts the path from the output using grep and awk
+      # 3. runs install_name_tool and tells it to replace the path with one that
+      #    points to a bundled copy of the same file
       add_custom_command (TARGET diagnostics POST_BUILD
-         COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/diagnostics)
+         COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/diagnostics | grep ${LIB_FILE} | awk '{ print $$1 }'` @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/diagnostics)
    endforeach()
+
 endif()
+
+
+

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -631,10 +631,18 @@ if(APPLE)
    if (RSTUDIO_PACKAGE_BUILD)
       find_package(OpenSSL REQUIRED QUIET)
       foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-         get_filename_component(LIB_DIR ${lib} PATH)
-         execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+         # get the real path to the library (with all symlinks resolved) and filename
+         get_filename_component(LIB_PATH "${lib}" REALPATH)
+         get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
+         # this command does the following:
+         # 1. runs otool -L to find the path at which the OpenSSL library is
+         #    linked into the executable (this path is unfortunately not canonical
+         #    and includes layers of both resolved and unresolved symlinks)
+         # 2. extracts the path from the output using grep and awk
+         # 3. runs install_name_tool and tells it to replace the path with one that
+         #    points to a bundled copy of the same file
          add_custom_command (TARGET rsession POST_BUILD
-            COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
+            COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rsession | grep ${LIB_FILE} | awk '{ print $$1 }'` @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
       endforeach()
    endif()
 

--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -69,12 +69,22 @@ endif()
 
 # if doing a package build on MacOS, reroute the OpenSSL libraries to our bundled copies
 if(APPLE AND RSTUDIO_PACKAGE_BUILD)
+
    find_package(OpenSSL REQUIRED QUIET)
    foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-      get_filename_component(LIB_DIR ${lib} PATH)
-      execute_process(COMMAND readlink ${lib} OUTPUT_VARIABLE LIB_FILE OUTPUT_STRIP_TRAILING_WHITESPACE)
+      # get the real path to the library (with all symlinks resolved) and filename
+      get_filename_component(LIB_PATH "${lib}" REALPATH)
+      get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
+      # this command does the following:
+      # 1. runs otool -L to find the path at which the OpenSSL library is
+      #    linked into the executable (this path is unfortunately not canonical
+      #    and includes layers of both resolved and unresolved symlinks)
+      # 2. extracts the path from the output using grep and awk
+      # 3. runs install_name_tool and tells it to replace the path with one that
+      #    points to a bundled copy of the same file
       add_custom_command (TARGET rpostback POST_BUILD
-         COMMAND install_name_tool -change ${LIB_DIR}/${LIB_FILE} @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rpostback)
+         COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rpostback | grep ${LIB_FILE} | awk '{ print $$1 }'` @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rpostback)
    endforeach()
+
 endif()
 


### PR DESCRIPTION
This change fixes a boot failure when RStudio is built on a macOS Catalina machine with homebrew OpenSSL 1.1, and then installed on a machine which doesn't have that library.

The general approach we take to this problem is to bundle OpenSSL with RStudio, and to rewrite the library paths of the compiled binaries so they point to the bundled copies (`@executable_path/...`) instead of the homebrew copies in `/usr/local/opt`. 

This isn't working any more with the latest homebrew OpenSSL 1.1 because of path canonicalization issues. The library path that is ultimately compiled into the binary is partially versioned but includes some symlinks. 

The fix is not pleasant. There is no deterministic way to determine the library path that will be compiled into the binary (as far as I can tell), so we need to interrogate the binary itself (using `otool`). We can then be confident we've got the correct path for rewriting.

Fixes https://github.com/rstudio/rstudio/issues/6398.