### PR TITLE
avoid passing user input to printf format strings

### DIFF
--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -63,7 +63,7 @@ void reportDeferredDeserializationError(const Error& error)
 
    // report to user
    std::string errMsg = r::endUserErrorMessage(error);
-   REprintf((errMsg + "\n").c_str());
+   REprintf("%s\n", errMsg.c_str());
 }
 
 std::string createAliasedPath(const FilePath& filePath)
@@ -149,12 +149,14 @@ void deferredRestoreNewSession()
             << "'" << aliasedPath << "'" << std::endl
             << "Reason: " << errMessage << std::endl;
          std::string message = ss.str();
-         ::REprintf(message.c_str());
+         
+         ::REprintf("%s\n", message.c_str());
          LOG_ERROR_MESSAGE(message);
       }
       else
       {
-         Rprintf(("[Workspace loaded from " + aliasedPath + "]\n\n").c_str());
+         const char* fmt = "[Workspace loaded from %s]\n\n";
+         Rprintf(fmt, aliasedPath.c_str());
       }
    }
 
@@ -274,7 +276,7 @@ Error initialize()
 
       // show any error messages
       if (!errorMessages.empty())
-         REprintf(errorMessages.c_str());
+         REprintf("%s\n", errorMessages.c_str());
 
       // note we were resumed
       wasResumed = true;
@@ -287,7 +289,7 @@ Error initialize()
       
       // show any error messages
       if (!errorMessages.empty())
-         REprintf(errorMessages.c_str());
+         REprintf("%s\n", errorMessages.c_str());
 
       // note we were resumed
       wasResumed = true;
@@ -406,7 +408,7 @@ void reportHistoryAccessError(const std::string& context,
    // notify the user
    std::string path = createAliasedPath(historyFilePath);
    std::string errmsg = context + " " + path + ": " + summary;
-   REprintf(("Error attempting to " + errmsg + "\n").c_str());
+   REprintf("Error attempting to %s\n", errmsg.c_str());
 }
    
 namespace utils {

--- a/src/cpp/r/session/RQuit.cpp
+++ b/src/cpp/r/session/RQuit.cpp
@@ -98,14 +98,15 @@ void quit(bool saveWorkspace, int status)
    bool didQuit = win32Quit(save, 0, true, &quitErr);
    if (!didQuit)
    {
-      REprintf((quitErr + "\n").c_str());
+      REprintf("%s\n", quitErr.c_str());
       LOG_ERROR_MESSAGE(quitErr);
    }
  #else
    Error error = r::exec::RFunction("base:::q", save, status, true).call();
    if (error)
    {
-      REprintf((r::endUserErrorMessage(error) + "\n").c_str());
+      std::string message = r::endUserErrorMessage(error);
+      REprintf("%s\n", message.c_str());
       LOG_ERROR(error);
    }
  #endif

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -79,8 +79,8 @@ void reportRestoreError(const std::string& context,
    core::log::logError(restoreError, location);
    
    // notify end-user
-   std::string report = message + ": " + error.getMessage() + "\n";
-   REprintf(report.c_str());
+   std::string report = message + ": " + error.getMessage();
+   REprintf("%s\n", report.c_str());
 }   
    
 Error saveGlobalEnvironmentToFile(const FilePath& environmentFile)

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -403,7 +403,7 @@ void setClientMetrics(const RClientMetrics& metrics)
    {
       // report to user
       std::string errMsg = r::endUserErrorMessage(error);
-      REprintf("%s\n", errMsg);
+      REprintf("%s\n", errMsg.c_str());
 
       // restore previous values (but don't fire plotsChanged b/c
       // the reset doesn't result in a change in graphics state)

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -403,7 +403,7 @@ void setClientMetrics(const RClientMetrics& metrics)
    {
       // report to user
       std::string errMsg = r::endUserErrorMessage(error);
-      REprintf((errMsg + "\n").c_str());
+      REprintf("%s\n", errMsg);
 
       // restore previous values (but don't fire plotsChanged b/c
       // the reset doesn't result in a change in graphics state)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -254,7 +254,7 @@ void reportError(const std::string& action,
    if (reportFunction)
       reportFunction(report.c_str());
    else
-      REprintf(report.c_str());
+      REprintf("%s", report.c_str());
 }
 
 struct ErrorRecorder

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -175,7 +175,7 @@ bool consoleInputHook(const std::string& prompt,
    {
       if (!s_callbacks.handleUnsavedChanges())
       {
-         REprintf("User cancelled quit operation\n");
+         REprintf("%s\n", "User cancelled quit operation");
          return false;
       }
 
@@ -186,7 +186,7 @@ bool consoleInputHook(const std::string& prompt,
       std::string quitErr;
       bool didQuit = win32Quit(input, &quitErr);
       if (!didQuit)
-         REprintf((quitErr + "\n").c_str());
+         REprintf("%s\n", quitErr.c_str());
 
       // always return false (since we take over the command fully)
       return false;

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -427,7 +427,7 @@ void resyncDisplayList()
       {
          std::string errMsg;
          if (r::isCodeExecutionError(error, &errMsg))
-            Rprintf(errMsg.c_str());
+            Rprintf("%s\n", errMsg.c_str());
          else
             LOG_ERROR(error);
       }

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -205,8 +205,8 @@ RestorePreviousGraphicsDeviceScope::~RestorePreviousGraphicsDeviceScope()
 void reportError(const core::Error& error)
 {
    std::string endUserMessage = r::endUserErrorMessage(error);
-   std::string errmsg = ("Graphics error: " + endUserMessage + "\n");
-   REprintf(errmsg.c_str());
+   std::string errmsg = "Graphics error: " + endUserMessage;
+   REprintf("%s\n", errmsg.c_str());
 }
 
 void logAndReportError(const Error& error, const ErrorLocation& location)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -719,7 +719,7 @@ void notifyIfRVersionChanged()
    {
       const char* fmt =
             "R version change [%1% -> %2%] detected when restoring session; "
-            "search path not restored\n";
+            "search path not restored";
       
       boost::format formatter(fmt);
       formatter
@@ -727,7 +727,7 @@ void notifyIfRVersionChanged()
             % std::string(info.activeRVersion);
       
       std::string msg = formatter.str();
-      ::REprintf(msg.c_str());
+      ::REprintf("%s\n", msg.c_str());
    }
 }
 


### PR DESCRIPTION
This should fix some family of crashes; e.g.

https://sentry.io/organizations/rstudio/issues/1549458141/?project=1379214&referrer=slack

In many places, we were calling `Rprintf()` and `REprintf()` with the message provided directly to the function. This is dangerous, since user-defined input might contain arbitrary text -- including strings which might be interpreted for formatting!

The fix here is to always use an explicit format string, and then pass in user-defined input as an argument to the printf routine.