### PR TITLE
simplify screen reader toggle shortcut

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -871,6 +871,7 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
+         <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -63,8 +63,8 @@ Reference on default Ace shortcuts: https://github.com/ajaxorg/ace/wiki/Default-
     <tbody>
     <tr>
       <td>Toggle Screen Reader Support</td>
-      <td>Ctrl+Alt+Shift+/</td>
-      <td>⌃⌥⇧/</td>
+      <td>Alt+Shift+/</td>
+      <td>⌥⇧/</td>
     </tr>
     <tr>
       <td>Speak Text Editor Location</td>


### PR DESCRIPTION
Command that enables/disabled screen reader support had a 4-finger shortcut (Ctrl+Alt+Shift+/). Any shortcut requiring 4 fingers is unpleasant, but especially one that is so integral to bootstrapping the use of a screen reader in RStudio.

Changed to Alt+Shift+/ (but also left in the other mapping since it's been published on the blog). Will go back and update the blog to just reference the shorter one once a preview contains it.