### PR TITLE
check for null pointers in shadowDevOff

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -469,12 +469,12 @@ Error system(const std::string& command, std::string* pOutput)
 
 void error(const std::string& message)   
 {
-   Rf_error(message.c_str());
+   Rf_error("%s", message.c_str());
 }
 
 void errorCall(SEXP call, const std::string& message)
 {
-   Rf_errorcall(call, message.c_str());
+   Rf_errorcall(call, "%s", message.c_str());
 }
    
 std::string getErrorMessage()

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -457,7 +457,9 @@ SEXP rs_createGD()
          {
             std::string msg = error.getSummary();
             r::isCodeExecutionError(error, &msg);
-            Rf_warning(("Error creating graphics device: " + msg).c_str());
+            
+            std::string rMsg = "Error creating graphics device: " + msg;
+            Rf_warning("%s\n", rMsg.c_str());
          }
       }
       else


### PR DESCRIPTION
Potential fix for https://sentry.io/organizations/rstudio/issues/1551321276/?project=1379214&referrer=slack.

Also fixes some more cases where we were passing arbitrary messages to R format strings.