### PR TITLE
Fix inability to change default R version

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
@@ -1,7 +1,7 @@
 /*
  * RVersionSelectWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,11 +17,13 @@ package org.rstudio.studio.client.application.ui;
 
 import java.util.ArrayList;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.HelpButton;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.studio.client.application.model.RVersionSpec;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 
 public class RVersionSelectWidget extends SelectWidget
 {
@@ -104,12 +106,12 @@ public class RVersionSelectWidget extends SelectWidget
    {
       if (str != null)
       {
-         String[] values = str.split(SEP);
-         if (values.length == 3)
+         JsArrayString values = StringUtil.split(str, SEP);
+         if (values.length() == 3)
          {
-            String version = values[0];
-            String rHomeDir = values[1];
-            String label = values[2];
+            String version = values.get(0);
+            String rHomeDir = values.get(1);
+            String label = values.get(2);
             if (version.length() > 0 && rHomeDir.length() > 0)
                return RVersionSpec.create(version, rHomeDir, label);
          }


### PR DESCRIPTION
This fixes an issue in which you can't change the default version of R from Global Options (in RStudio Pro). 

The problem is subtle. It turns out that GWT implements its own `String.split` method, which doesn't have the same semantics as JavaScript's; in particular, `foo,bar,` splits to two elements instead of three. 

The fix is to use JavaScript's native string splitting method. 

Introduced by https://github.com/rstudio/rstudio/commit/489ded0ebf093ecc025cc28a4e7d3fd4f4b7b901; fixes https://github.com/rstudio/rstudio-pro/issues/1470. 

