### PR TITLE
disable indented soft wrap

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -4030,6 +4030,11 @@ public class AceEditor implements DocDisplay,
    {
       widget_.getEditor().setScrollSpeed(speed);
    }
+   
+   public final void setIndentedSoftWrap(boolean softWrap)
+   {
+      widget_.getEditor().setIndentedSoftWrap(softWrap);
+   }
 
    private void fireLineWidgetsChanged()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -111,6 +111,7 @@ public class AceEditorWidget extends Composite
       editor_.setHighlightActiveLine(false);
       editor_.setHighlightGutterLine(false);
       editor_.setFixedWidthGutter(true);
+      editor_.setIndentedSoftWrap(false);
       editor_.delegateEventsTo(AceEditorWidget.this);
       editor_.onChange(new CommandWithArg<AceDocumentChangeEventNative>()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -651,6 +651,10 @@ public class AceEditorNative extends JavaScriptObject
    public final native void setScrollSpeed(double speed) /*-{
       this.setOption("scrollSpeed", speed);
    }-*/;
+   
+   public final native void setIndentedSoftWrap(boolean softWrap) /*-{
+      this.setOption("indentedSoftWrap", softWrap);
+   }-*/;
 
    public final native void setTabMovesFocus(boolean movesFocus) /*-{
       if (movesFocus) {
@@ -661,6 +665,7 @@ public class AceEditorNative extends JavaScriptObject
          this.commands.bindKey("Shift+Tab", "outdent");
       }
    }-*/;
+   
 
    private static final native void initialize()
    /*-{


### PR DESCRIPTION
Spotted by @hadley. In RStudio v1.3, indented lines that are soft-wrapped are also indented; this behavior is undesired by default as it becomes less clear what indents are "real" and what are "not".

Before:

<img width="409" alt="Screen Shot 2020-03-06 at 1 54 55 PM" src="https://user-images.githubusercontent.com/1976582/76125651-1e932a80-5fb2-11ea-9979-536c2fdc56ca.png">

After:

<img width="411" alt="Screen Shot 2020-03-06 at 1 55 08 PM" src="https://user-images.githubusercontent.com/1976582/76125670-25ba3880-5fb2-11ea-8640-073186cb8ce8.png">

Realize this is coming in pretty late for v1.3 but since this is just toggling an already-there Ace option to revert behavior it should be safe.