### PR TITLE
fix regression with right-click pasting into console on RStudio Desktop

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -16,6 +16,7 @@ package org.rstudio.core.client;
 
 import java.util.List;
 
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.PreWidget;
 
@@ -30,10 +31,15 @@ import com.google.gwt.dom.client.SpanElement;
  */
 public class ConsoleOutputWriter
 {
-   public ConsoleOutputWriter(VirtualConsoleFactory vcFactory)
+   public ConsoleOutputWriter(VirtualConsoleFactory vcFactory, String a11yLabel)
    {
       vcFactory_ = vcFactory;
       output_ = new PreWidget();
+      if (!StringUtil.isNullOrEmpty(a11yLabel))
+      {
+         output_.getElement().setAttribute("aria-label", a11yLabel);
+         Roles.getDocumentRole().set(output_.getElement());
+      }
    }
    
    public PreWidget getWidget()

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ConsoleOutputWriter;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -86,7 +85,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       
       SelectInputClickHandler secondaryInputHandler = new SelectInputClickHandler();
 
-      output_ = new ConsoleOutputWriter(RStudioGinjector.INSTANCE.getVirtualConsoleFactory());
+      output_ = new ConsoleOutputWriter(RStudioGinjector.INSTANCE.getVirtualConsoleFactory(), outputLabel);
       output_.getWidget().setStylePrimaryName(styles_.output());
       output_.getWidget().addClickHandler(secondaryInputHandler);
       ElementIds.assignElementId(output_.getElement(), ElementIds.CONSOLE_OUTPUT);
@@ -191,17 +190,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       verticalPanel_ = new VerticalPanel();
       verticalPanel_.setStylePrimaryName(styles_.console());
       FontSizer.applyNormalFontSize(verticalPanel_);
-      if (StringUtil.isNullOrEmpty(outputLabel))
-         verticalPanel_.add(output_.getWidget());
-      else
-      {
-         HTML wrapper = new HTML();
-         Roles.getRegionRole().set(wrapper.getElement());
-         Roles.getRegionRole().setAriaLabelProperty(wrapper.getElement(), outputLabel);
-         Roles.getDocumentRole().set(output_.getElement());
-         wrapper.getElement().appendChild(output_.getElement());
-         verticalPanel_.add(wrapper);
-      }
+      verticalPanel_.add(output_.getWidget());
       verticalPanel_.add(pendingInput_);
       verticalPanel_.add(inputLine_);
       verticalPanel_.setWidth("100%");

--- a/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
+++ b/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
@@ -85,7 +85,7 @@ public class ConsoleOutputWriterTests extends GWTTestCase
    
    private ConsoleOutputWriter getCOW()
    {
-      return new ConsoleOutputWriter(new VCFactory());
+      return new ConsoleOutputWriter(new VCFactory(), null);
    }
 
    @Override


### PR DESCRIPTION
- Fixes #6413
- Was caused by #6341
- This change removes the extra div that was put around the console output `pre` element; that div was providing a named landmark around the console output and is what messed up this paste scenario
- The command for focusing the console output is still in place and makes a landmark around the console output largely redundant, so safer to remove that div rather than giving it a paste handler
- Moved the aria-label from the landmark down to the pre element
- This will require a small edit to the accessibility blog post since it mentions the console output landmark removed in this change