### PR TITLE
Apply help panel font size selection to all text

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -293,7 +293,7 @@ public:
    void do_filter(const Characters& src, Characters& dest)
    {
       std::string cssValue(src.begin(), src.end());
-      cssValue.append("body {\n   font-size:");
+      cssValue.append("body, td {\n   font-size:");
       cssValue.append(safe_convert::numberToString(prefs::userPrefs().helpFontSizePoints()));
       cssValue.append("pt;\n}");
       std::copy(cssValue.begin(), cssValue.end(), std::back_inserter(dest));


### PR DESCRIPTION
Fixes #6425 
This PR fixes the issue where all text in the Help Pane was not being adjusted according to the selected size in the User Prefs.