### PR TITLE
Add support for json::readObject with sets

### DIFF
--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -2044,6 +2044,102 @@ Error readObject(const Object& in_object, const std::string& in_name, std::vecto
 }
 
 /**
+ * @brief Reads an array member from an object.
+ *
+ * @tparam T            The type of values of the array member.
+ *
+ * @param in_object     The object from which the member should be read.
+ * @param in_name       The name of the member to read.
+ * @param out_values    The set of unique values of the array member, if no error occurs.
+ *
+ * @return Success if the member could be found and its values are of type T; Error otherwise.
+ */
+template <typename T>
+Error readObject(const Object& in_object, const std::string& in_name, std::set<T>& out_values)
+{
+   Object::Iterator itr = in_object.find(in_name);
+   if ((itr == in_object.end()) || (*itr).getValue().isNull())
+      return jsonReadError(
+         JsonReadError::MISSING_MEMBER,
+         "Member " + in_name + " does not exist in the specified JSON object.",
+         ERROR_LOCATION);
+
+   if (!(*itr).getValue().isArray())
+      return jsonReadError(JsonReadError::INVALID_TYPE,
+                           "Member " + in_name + " is not an array.",
+                           ERROR_LOCATION);
+
+   Array array = (*itr).getValue().getArray();
+   for (size_t i = 0, n = array.getSize(); i < n; ++i)
+   {
+      const Value& value = array[i];
+      if (!isType<T>(value))
+      {
+         std::ostringstream msgStream;
+         msgStream << "Element " << i << " of member " + in_name << " is of type " <<  value.getType() <<
+                   " which is not compatible with the requested type " << typeid(T).name() << ".";
+         return jsonReadError(
+            JsonReadError::INVALID_TYPE,
+            msgStream.str(),
+            ERROR_LOCATION);
+      }
+
+      out_values.insert(value.getValue<T>());
+   }
+
+   return Success();
+}
+
+/**
+ * @brief Reads an optional array member from an object.
+ *
+ * @tparam T            The type of values of the array member.
+ *
+ * @param in_object     The object from which the member should be read.
+ * @param in_name       The name of the member to read.
+ * @param out_values    The values of the array member, if no error occurs.
+ *
+ * @return Success if the values of the member are of type T; Error otherwise.
+ */
+template <typename T>
+Error readObject(const Object& in_object, const std::string& in_name, boost::optional<std::vector<T> >& out_values)
+{
+   out_values = boost::none;
+   std::vector<T> values;
+   Error error = readObject(in_object, in_name, values);
+   if (error && !isMissingMemberError(error))
+      return error;
+
+   out_values = values;
+   return Success();
+}
+
+/**
+ * @brief Reads an optional array member from an object.
+ *
+ * @tparam T            The type of values of the array member.
+ *
+ * @param in_object     The object from which the member should be read.
+ * @param in_name       The name of the member to read.
+ * @param out_values    The set of unique values of the array member, if no error occurs.
+ *
+ * @return Success if the values of the member are of type T; Error otherwise.
+ */
+template <typename T>
+Error readObject(const Object& in_object, const std::string& in_name, boost::optional<std::set<T> >& out_values)
+{
+   out_values = boost::none;
+
+   std::set<T> values;
+   Error error = readObject(in_object, in_name, values);
+   if (error && !isMissingMemberError(error))
+      return error;
+
+   out_values = values;
+   return Success();
+}
+
+/**
  * @brief Reads multiple members from an object.
  *
  * @tparam T            The type of the first member to read.
@@ -2092,20 +2188,101 @@ Error readObject(const Object& in_object, const std::string& in_name, boost::opt
 /**
  * @brief Reads multiple members from an object.
  *
- * @tparam T            The type of the values of the first array member to read.
+ * @tparam T            The type of the values of the array member to read.
  * @tparam Args         The template parameter pack for the remaining members.
  *
  * @param in_object     The object from which to read the members.
  * @param in_name       The name of the first member to be read.
- * @param out_values    The values of the first array member to be read, if no error occurs.
+ * @param out_values    The values of the array member to be read, if no error occurs.
  * @param io_args       The parameter pack of the remaining members to be read.
  *
- * @return Success if all the members exist and have valid types; Error otherwise.
+ * @return Success if the array member exists and all its elements have valid types, and if all other members exist and
+ *         have valid types; Error otherwise.
  */
 template <typename T, typename... Args>
 Error readObject(const Object& in_object, const std::string& in_name, std::vector<T>& out_values, Args&... io_args)
 {
    Error error = readObject(in_object, in_name, out_values);
+   if (error)
+      return error;
+
+   return readObject(in_object, io_args...);
+}
+
+/**
+ * @brief Reads multiple members from an object.
+ *
+ * @tparam T            The type of the values of the array member to read.
+ * @tparam Args         The template parameter pack for the remaining members.
+ *
+ * @param in_object     The object from which to read the members.
+ * @param in_name       The name of the first member to be read.
+ * @param out_values    The set of unique values of the array member to be read, if no error occurs.
+ * @param io_args       The parameter pack of the remaining members to be read.
+ *
+ * @return Success if the array member exists and all its elements have valid types, and if all other members exist and
+ *         have valid types; Error otherwise.
+ */
+template <typename T, typename... Args>
+Error readObject(const Object& in_object, const std::string& in_name, std::set<T>& out_values, Args&... io_args)
+{
+   Error error = readObject(in_object, in_name, out_values);
+   if (error)
+      return error;
+
+   return readObject(in_object, io_args...);
+}
+
+/**
+ * @brief Reads multiple members from an object.
+ *
+ * @tparam T            The type of the values of the array member to read.
+ * @tparam Args         The template parameter pack for the remaining members.
+ *
+ * @param in_object     The object from which to read the members.
+ * @param in_name       The name of the first member to be read.
+ * @param out_values    The values of the array member to be read, if no error occurs.
+ * @param io_args       The parameter pack of the remaining members to be read.
+ *
+ * @return Success if the all the elements of the array member have valid types, and if all other members exist and
+ *         have valid types; Error otherwise.
+ */
+template <typename T, typename... Args>
+Error readObject(
+   const Object& in_object,
+   const std::string& in_name,
+   boost::optional<std::vector<T> >& out_value,
+   Args&... io_args)
+{
+   Error error = readObject(in_object, in_name, out_value);
+   if (error)
+      return error;
+
+   return readObject(in_object, io_args...);
+}
+
+/**
+ * @brief Reads multiple members from an object.
+ *
+ * @tparam T            The type of the values of the array member to read.
+ * @tparam Args         The template parameter pack for the remaining members.
+ *
+ * @param in_object     The object from which to read the members.
+ * @param in_name       The name of the first member to be read.
+ * @param out_values    The set of unique values of the array member to be read, if no error occurs.
+ * @param io_args       The parameter pack of the remaining members to be read.
+ *
+ * @return Success if the all the elements of the array member have valid types, and if all other members exist and
+ *         have valid types; Error otherwise.
+ */
+template <typename T, typename... Args>
+Error readObject(
+   const Object& in_object,
+   const std::string& in_name,
+   boost::optional<std::set<T> >& out_value,
+   Args&... io_args)
+{
+   Error error = readObject(in_object, in_name, out_value);
    if (error)
       return error;
 


### PR DESCRIPTION
Supports calling json::readObject with sets, as well as optional vectors and optional sets.