### PR TITLE
simplify several accessibility-related shortcuts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -505,7 +505,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="showLicenseDialog"/>
          <cmd refid="checkForUpdates"/>
          <separator/>
-         <menu label="Acc_essibility">
+         <menu label="_Accessibility">
             <cmd refid="toggleScreenReaderSupport"/>
             <separator/>
             <menu label="S_peak">
@@ -874,13 +874,15 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+Shift+T"/>
-         <shortcut refid="speakEditorLocation" value="Ctrl+Alt+Shift+B"/>
+         <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleTabKeyMovesFocus" value="Alt+Shift+[" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="speakEditorLocation" value="Ctrl+Alt+1" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="speakEditorLocation" value="Alt+Shift+1" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusMainToolbar" value="Ctrl+Alt+Y" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusMainToolbar" value="Alt+Shift+Y" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <!-- 
-      Shortcuts in this group won't be shown in the quick reference card. 
+      Shortcuts in this group won't be shown in the quick reference card.
        -->
       <shortcutgroup name="Not Displayed">
          <shortcut refid="layoutZoomSource" value="Ctrl+Shift+1"/>
@@ -3081,7 +3083,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="showAboutDialog"
         label="About RStudio..."
-        menuLabel="_About RStudio"
+        menuLabel="A_bout RStudio"
         rebindable="false"
         windowMode="main"/>
 

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -70,8 +70,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Speak Text Editor Location</td>
-      <td>Ctrl+Alt+Shift+B</td>
-      <td>⌃⌥⇧B</td>
+      <td>Alt+Shift+1</td>
+      <td>⌃⌥1</td>
     </tr>
     <tr>
       <td>Focus Console Output</td>
@@ -80,8 +80,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Toggle Tab Key Always Moves Focus</td>
-      <td>Ctrl+Alt+Shift+T</td>
-      <td>⌃⌥⇧T</td>
+      <td>Ctrl+Alt+[</td>
+      <td>⌃⌥[</td>
     </tr>
     <tr>
       <td>Focus Main Toolbar</td>


### PR DESCRIPTION
Change the letter used to access the Accessibility submenu to "A" and the letter used for About to "B". Keyboard users will be more likely to use the Accessibility submenu than the About dialog, so having the most memorable key be used is ideal.

Based on user feedback, changing several accessibility keyboard shortcuts to be 3-finger instead of 4-finger:

- Toggle Tab Key Moves Focus is now Alt+Shift+[ on Windows and Linux, and Ctrl+Option+[ on Mac
- Speak Editor Location is  now Alt+Shift+1 on Windows and Linux, and Ctrl+Option+1 on Mac
- These are the last planned accessibility-related shortcut tweaks for 1.3 (barring discovery of conflicts)