### PR TITLE
use dependency manager for tutorial dependencies

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -745,6 +745,21 @@ public class DependencyManager implements InstallShinyEvent.Handler,
       );
    }
    
+   public void withTutorialDependencies(final Command command)
+   {
+      withDependencies(
+            "Starting tutorial",
+            "Starting a tutorial",
+            getFeatureDescription("tutorial"),
+            getFeatureDependencies("tutorial"),
+            true,
+            (Boolean succeeded) ->
+            {
+               if (succeeded)
+                  command.execute();
+            });
+   }
+   
    private ArrayList<Dependency> connectionPackageDependencies(
               String packageName,
               String packageVersion)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.GlobalDisplay.NewWindowOptions;
+import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -67,6 +68,7 @@ public class TutorialPane
                           EventBus events,
                           Commands commands,
                           Session session,
+                          DependencyManager dependencies,
                           PackagesServerOperations server)
    {
       super("Tutorial");
@@ -75,6 +77,7 @@ public class TutorialPane
       events_        = events;
       commands_      = commands;
       session_       = session;
+      dependencies_  = dependencies;
       server_        = server;
       
       indicator_ = globalDisplay_.getProgressIndicator("Error Loading Tutorial");
@@ -226,8 +229,11 @@ public class TutorialPane
    private void runTutorial(String tutorialName,
                             String packageName)
    {
-      Tutorial tutorial = new Tutorial(tutorialName, packageName);
-      launchTutorial(tutorial);
+      dependencies_.withTutorialDependencies(() ->
+      {
+         Tutorial tutorial = new Tutorial(tutorialName, packageName);
+         launchTutorial(tutorial);
+      });
    }
    
    private void navigate(String url, boolean replaceUrl)
@@ -422,6 +428,7 @@ public class TutorialPane
    private final EventBus events_;
    private final Commands commands_;
    private final Session session_;
+   private final DependencyManager dependencies_;
    private final PackagesServerOperations server_;
 
    private static final Resources RES = GWT.create(Resources.class);


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6418.

This was missed because we normally install tutorial dependencies here:

https://github.com/rstudio/rstudio/blob/d539bdbca79261d237f5350fd392ab416e95bb51/src/cpp/session/modules/SessionTutorial.R#L226-L280

However, this code path does not check package versions (and that's something to be addressed separately; I need to confirm whether there's an official mechanism for a `learnr` tutorial to declare that it requires a specific set of packages).

