### PR TITLE
fix regression in update packages dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageActionConfirmationDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageActionConfirmationDialog.java
@@ -1,7 +1,7 @@
 /*
  * PackageActionConfirmationDialog.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -105,7 +105,7 @@ public abstract class PackageActionConfirmationDialog<T extends JavaScriptObject
       actionsTable_ = new CellTable<>(
             15,
             GWT.<PackagesCellTableResources> create(PackagesCellTableResources.class));
-      actionsTable_.setKeyboardSelectionPolicy(KeyboardSelectionPolicy.ENABLED);
+      actionsTable_.setKeyboardSelectionPolicy(KeyboardSelectionPolicy.DISABLED);
       actionsTable_.setSelectionModel(new NoSelectionModel<>());
       actionsTable_.setWidth("100%", true);
       


### PR DESCRIPTION
Fixes #6375

Regression introduced by accessibility work (early summer 2019); I enabled keyboard-selection in this dialog's cell table, but that alone wasn't sufficient to make this dialog fully keyboard usable, and caused a nasty regression when using via mouse, so reverting. Didn't see any other instances where I used this pattern. Regression was introduced in 8bf99466.