### PR TITLE
Allow same origin for Tutorial pane sandbox

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -244,7 +244,7 @@ public class TutorialPane
       }
       else
       {
-         frame_.getElement().setAttribute("sandbox", "allow-scripts");
+         frame_.getElement().setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms allow-popups");
       }
      
       frame_.setUrl(url);


### PR DESCRIPTION
This change fixes an issue in which the Tutorial pane didn't load or work correctly on non-local instances of RStudio server. 

The problem was that the Tutorial pane loads non-local URLs with a very restrictive sandbox that keeps them from using the origin of the hosting page, with the result that CORS denied all the AJAX requests originating on the page. The fix is to give them the `allow-same-origin` privilege (along with a couple other that tutorials are likely to need down the road). 

Fixes #6362.