### PR TITLE
Reduce disruptions caused by autosave

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -291,9 +291,17 @@ public class TextEditingTarget implements
          // (without this and when file monitoring is active we'd
          // end up immediately checking for external edits)
          externalEditCheckInterval_.reset(250);
+         boolean fileTypeChanged = true;
 
          if (newFileType_ != null)
+         {
+            // if we already had a file type, see if the underlying type has changed
+            if (fileType_ != null)
+            {
+               fileTypeChanged = !StringUtil.equals(newFileType_.getTypeId(), fileType_.getTypeId());
+            }
             fileType_ = newFileType_;
+         }
 
          if (file_ != null)
          {
@@ -314,7 +322,7 @@ public class TextEditingTarget implements
             dirtyState_.markClean();
          }
 
-         if (newFileType_ != null)
+         if (newFileType_ != null && fileTypeChanged)
          {
             // Make sure the icon gets updated, even if name hasn't changed
             name_.fireChangeEvent();
@@ -2879,6 +2887,10 @@ public class TextEditingTarget implements
    @Override
    public void adaptToExtendedFileType(String extendedType)
    {
+      // ignore if unchanged
+      if (StringUtil.equals(extendedType, extendedType_))
+         return;
+
       view_.adaptToExtendedFileType(extendedType);
       if (extendedType == SourceDocument.XT_RMARKDOWN)
          updateRmdFormatList();


### PR DESCRIPTION
This change fixes a couple of disruptions caused by autosave. These are in turn caused by the fact that we reload some parts of the editing system every time we save, because sometimes content changes in the file need to trigger different editor behavior. 

For example, if you paste a Shiny app.R file into an ordinary R script and save it, RStudio's editor adapts and gives you the Run App button.

Unfortunately this has some side effects, including losing some vim state and (more importantly) knocking down autocompletion popups. So this change causes us to be just a little more conservative about reloading those parts of the editing system. We now avoid refreshing them unless the incoming file type and/or extended type are different than the ones we already know about.

Fixes https://github.com/rstudio/rstudio/issues/6363
Fixes https://github.com/rstudio/rstudio/issues/6302