### PR TITLE
tutorial pane bugfixes

### DIFF
--- a/src/cpp/session/modules/SessionTutorial.R
+++ b/src/cpp/session/modules/SessionTutorial.R
@@ -29,34 +29,27 @@
 
 .rs.addJsonRpcHandler("tutorial_stop", function(url)
 {
-   # search for tutorial bound to this url
-   keys <- ls(envir = .rs.tutorial.registry)
-   for (key in keys)
-   {
-      tutorial <- .rs.tutorial.registry[[key]]
-      
-      match <-
-         identical(url, tutorial[["shiny_url"]]) ||
-         identical(url, tutorial[["browser_url"]])
-      
-      if (match)
-      {
-         # found the tutorial; stop it and return
-         .rs.tutorial.stopTutorial(
-            name    = tutorial[["name"]],
-            package = tutorial[["package"]]
-         )
-         
-         return(TRUE)
-      }
-   }
+   tutorial <- .rs.tutorial.registryFind(url)
+   if (is.null(tutorial))
+      return(FALSE)
    
-   # failed to find tutorial; log a warning
-   fmt <- "no tutorial associated with url '%s'"
-   warning(sprintf(fmt, url))
+   .rs.tutorial.stopTutorial(
+      name    = tutorial[["name"]],
+      package = tutorial[["package"]]
+   )
+   
+   TRUE
+   
 })
 
-
+.rs.addJsonRpcHandler("tutorial_metadata", function(url)
+{
+   tutorial <- .rs.tutorial.registryFind(url)
+   if (is.null(tutorial))
+      return(list())
+   
+   .rs.scalarListFromList(as.list(tutorial))
+})
 
 # Methods ----
 
@@ -85,6 +78,25 @@
 {
    key <- .rs.tutorial.registryKey(name, package)
    .rs.tutorial.registry[[key]]
+})
+
+.rs.addFunction("tutorial.registryFind", function(url)
+{
+   keys <- ls(envir = .rs.tutorial.registry)
+   for (key in keys)
+   {
+      tutorial <- .rs.tutorial.registry[[key]]
+      
+      match <-
+         identical(url, tutorial[["shiny_url"]]) ||
+         identical(url, tutorial[["browser_url"]])
+      
+      if (match)
+         return(tutorial)
+   }
+   
+   NULL
+   
 })
 
 # TODO: local jobs are stopped when the session is suspended, and so running

--- a/src/cpp/session/modules/SessionTutorial.R
+++ b/src/cpp/session/modules/SessionTutorial.R
@@ -1,7 +1,7 @@
 #
 # SessionTutorial.R
 #
-# Copyright (C) 2009-19 by RStudio, PBC
+# Copyright (C) 2009-20 by RStudio, PBC
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -22,12 +22,38 @@
 # JSON RPC ----
 .rs.addJsonRpcHandler("tutorial_started", function(name, package, url)
 {
-   .rs.tutorial.setRunningTutorialUrl(name, package, url)
+   # tag the associated tutorial with the browser url
+   tutorial <- .rs.tutorial.registryGet(name, package)
+   tutorial[["browser_url"]] <- url
 })
 
-.rs.addJsonRpcHandler("tutorial_stop", function(name, package)
+.rs.addJsonRpcHandler("tutorial_stop", function(url)
 {
-   .rs.tutorial.stopTutorial(name, package)
+   # search for tutorial bound to this url
+   keys <- ls(envir = .rs.tutorial.registry)
+   for (key in keys)
+   {
+      tutorial <- .rs.tutorial.registry[[key]]
+      
+      match <-
+         identical(url, tutorial[["shiny_url"]]) ||
+         identical(url, tutorial[["browser_url"]])
+      
+      if (match)
+      {
+         # found the tutorial; stop it and return
+         .rs.tutorial.stopTutorial(
+            name    = tutorial[["name"]],
+            package = tutorial[["package"]]
+         )
+         
+         return(TRUE)
+      }
+   }
+   
+   # failed to find tutorial; log a warning
+   fmt <- "no tutorial associated with url '%s'"
+   warning(sprintf(fmt, url))
 })
 
 
@@ -39,24 +65,26 @@
    paste(package, name, sep = "::")
 })
 
+.rs.addFunction("tutorial.registryCreate", function(name, package)
+{
+   # NOTE: we use an R environment here just so we can get reference semantics
+   # (makes mutation of existing tutorial objects more straight-forward, which
+   # is necessary as we'll need to tag tutorial objects with extra meta-data
+   # after creation)
+   tutorial <- as.environment(list(name = name, package = package))
+   
+   # store in registry
+   key <- .rs.tutorial.registryKey(name, package)
+   .rs.tutorial.registry[[key]] <- tutorial
+   
+   # return tutorial object
+   tutorial
+})
+
 .rs.addFunction("tutorial.registryGet", function(name, package)
 {
    key <- .rs.tutorial.registryKey(name, package)
    .rs.tutorial.registry[[key]]
-})
-
-.rs.addFunction("tutorial.registrySet", function(name, package, tutorial)
-{
-   key <- .rs.tutorial.registryKey(name, package)
-   tutorial$package <- package
-   tutorial$name <- name
-   .rs.tutorial.registry[[key]] <- tutorial
-})
-
-.rs.addFunction("tutorial.registryClear", function(name, package)
-{
-   key <- .rs.tutorial.registryKey(name, package)
-   .rs.tutorial.registry[[key]] <- NULL
 })
 
 # TODO: local jobs are stopped when the session is suspended, and so running
@@ -72,52 +100,40 @@
 
 .rs.addFunction("tutorial.launchBrowser", function(url)
 {
+   # get the pending tutorial
    tutorial <- .rs.getVar("tutorial.pendingTutorial")
    .rs.clearVar("tutorial.pendingTutorial")
    
+   # tag that tutorial with the shiny url
+   tutorial[["shiny_url"]] <- url
+   
+   # open tutorial in pane
    meta <- .rs.scalarListFromList(tutorial)
    .rs.invokeShinyTutorialViewer(url, meta)
 })
 
-.rs.addFunction("tutorial.getRunningTutorial", function(name, package)
-{
-   .rs.tutorial.registryGet(name, package)
-})
-
-.rs.addFunction("tutorial.setRunningTutorial", function(name, package, job)
-{
-   tutorial <- list(name = name, package = package, job = job)
-   .rs.tutorial.registrySet(name, package, tutorial)
-})
-
-.rs.addFunction("tutorial.setRunningTutorialUrl", function(name, package, url)
-{
-   tutorial <- .rs.tutorial.registryGet(name, package)
-   tutorial$url <- url
-   .rs.tutorial.registrySet(name, package, tutorial)
-})
-
-.rs.addFunction("tutorial.clearRunningTutorial", function(name, package)
-{
-   .rs.tutorial.registryClear(name, package)
-})
-
 .rs.addFunction("tutorial.openExistingTutorial", function(name, package)
 {
-   tutorial <- .rs.tutorial.getRunningTutorial(name, package)
+   # find tutorial in registry
+   tutorial <- .rs.tutorial.registryGet(name, package)
    if (is.null(tutorial))
       return(FALSE)
 
-   url <- tutorial$url
+   # get underlying shiny url
+   url <- tutorial[["shiny_url"]]
    if (is.null(url))
       return(FALSE)   
    
-   job <- tutorial$job
+   # check for an associated active job
+   job <- tutorial[["job"]]
    running <- .rs.tryCatch(.Call("rs_isJobRunning", job, PACKAGE = "(embedding)"))
    if (!identical(running, TRUE))
       return(FALSE)
    
-   .rs.tutorial.enqueueClientEvent("navigate", list(url = url))
+   # open tutorial in pane
+   meta <- .rs.scalarListFromList(tutorial)
+   .rs.invokeShinyTutorialViewer(url, meta)
+   
    TRUE
 })
 
@@ -161,11 +177,14 @@
       encoding = "UTF-8"
    )
    
-   # set and return job id for caller
-   .rs.tutorial.setRunningTutorial(name, package, job)
+   # register a tutorial object
+   tutorial <- .rs.tutorial.registryCreate(name, package)
    
-   pendingTutorial <- list(name = name, package = package, job = job)
-   .rs.setVar("tutorial.pendingTutorial", pendingTutorial)
+   # add job id
+   tutorial[["job"]] <- job
+   
+   # set as pending
+   .rs.setVar("tutorial.pendingTutorial", tutorial)
    
    invisible(job)
    
@@ -173,9 +192,15 @@
 
 .rs.addFunction("tutorial.stopTutorial", function(name, package)
 {
-   tutorial <- .rs.tutorial.getRunningTutorial(name, package)
-   .rs.api.stopJob(tutorial$job)
-   .rs.tutorial.clearRunningTutorial(name, package)
+   # find tutorial in registry
+   tutorial <- .rs.tutorial.registryGet(name, package)
+   
+   # stop its associated job
+   .rs.api.stopJob(tutorial[["job"]])
+   
+   # remove from registry
+   key <- .rs.tutorial.registryKey(name, package)
+   .rs.tutorial.registry[[key]] <- NULL
 })
 
 .rs.addFunction("tutorial.enqueueClientEvent", function(type, data = list())

--- a/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
@@ -396,6 +396,20 @@ public class DefaultGlobalDisplay extends GlobalDisplay
    }
    
    @Override
+   public void bringWindowToFront(String name)
+   {
+      if (Desktop.isDesktop())
+         Desktop.getFrame().activateMinimalWindow(name);
+      else
+         bringWindowToFrontImpl(name);
+   }
+   
+   private static final native void bringWindowToFrontImpl(String name)
+   /*-{
+      $wnd.open("", name);
+   }-*/;
+   
+   @Override
    public void openRStudioLink(String linkName, boolean includeVersionInfo)
    {
       // build url

--- a/src/gwt/src/org/rstudio/studio/client/common/GlobalDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/GlobalDisplay.java
@@ -92,6 +92,16 @@ public abstract class GlobalDisplay extends MessageDisplay
       {
          return showDesktopToolbar_;
       }
+      
+      public void setAppendClientId(boolean append)
+      {
+         appendClientId_ = append;
+      }
+      
+      public boolean appendClientId()
+      {
+         return appendClientId_;
+      }
 
       private Point position_ = null;
       private String name_ = "_blank";
@@ -99,6 +109,7 @@ public abstract class GlobalDisplay extends MessageDisplay
       private OperationWithInput<WindowEx> callback_;
       private boolean allowExternalNavigation_ = false;
       private boolean showDesktopToolbar_ = true;
+      private boolean appendClientId_ = false;
    }
    
    public abstract void openWindow(String url);
@@ -134,6 +145,8 @@ public abstract class GlobalDisplay extends MessageDisplay
                                    NewWindowOptions options);
 
    public abstract void openEmailComposeWindow(String to, String subject);
+   
+   public abstract void bringWindowToFront(String name);
    
    public abstract void showHtmlFile(String path);
    

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebWindowOpener.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebWindowOpener.java
@@ -147,12 +147,13 @@ public class WebWindowOpener implements WindowOpener
       if (name == null)
          name = "_blank";
 
-      if (!name.equals("_blank")
+      if (options.appendClientId()
+          && !name.equals("_blank")
           && !name.equals("_top")
           && !name.equals("_parent")
           && !name.equals("_self"))
       {
-         name += "_" + clientId;
+         name += "_" + CLIENT_ID;
       }
 
       // Need to make the URL absolute because IE resolves relative URLs
@@ -213,6 +214,6 @@ public class WebWindowOpener implements WindowOpener
       return window;
    }-*/;
 
-   private static final String clientId = (int)(Math.random() * 10000) + "";
+   public static final String CLIENT_ID = (int)(Math.random() * 10000) + "";
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4231,13 +4231,11 @@ public class RemoteServer implements Server
    }
    
    @Override
-   public void tutorialStop(String tutorialName,
-                            String tutorialPackage,
+   public void tutorialStop(String tutorialUrl,
                             ServerRequestCallback<Void> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
-            .add(tutorialName)
-            .add(tutorialPackage)
+            .add(tutorialUrl)
             .get();
       
       sendRequest(RPC_SCOPE, TUTORIAL_STOP, params, requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4242,6 +4242,18 @@ public class RemoteServer implements Server
    }
    
    @Override
+   public void tutorialMetadata(String tutorialUrl,
+                                ServerRequestCallback<JsObject> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(tutorialUrl)
+            .get();
+      
+      sendRequest(RPC_SCOPE, TUTORIAL_METADATA, params, requestCallback);
+   }
+   
+   
+   @Override
    public void getSlideNavigationForFile(
                      String filePath,
                      ServerRequestCallback<SlideNavigation> requestCallback)
@@ -6406,6 +6418,7 @@ public class RemoteServer implements Server
    
    private static final String TUTORIAL_STARTED = "tutorial_started";
    private static final String TUTORIAL_STOP = "tutorial_stop";
+   private static final String TUTORIAL_METADATA = "tutorial_metadata";
    
    private static final String GET_SLIDE_NAVIGATION_FOR_FILE = "get_slide_navigation_for_file";
    private static final String GET_SLIDE_NAVIGATION_FOR_CODE = "get_slide_navigation_for_code";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -171,11 +171,19 @@ public class TutorialPane
       int width = Math.max(800, frame_.getElement().getClientWidth());
       int height = Math.max(800, frame_.getElement().getClientHeight());
       
+      String windowName = "rstudio-tutorial-" + StringUtil.makeRandomId(16);
+      
       NewWindowOptions options = new NewWindowOptions();
-      options.setName("rstudio-tutorial-" + StringUtil.makeRandomId(16));
+      options.setAppendClientId(false);
+      options.setName(windowName);
       options.setCallback((WindowEx window) ->
       {
-         initExternalWindowJsCallbacks(window, tutorialUrl, tutorialName, tutorialPackage);
+         initExternalWindowJsCallbacks(
+               window,
+               tutorialUrl,
+               tutorialName,
+               tutorialPackage,
+               windowName);
       });
       
       globalDisplay_.openWebMinimalWindow(
@@ -450,7 +458,8 @@ public class TutorialPane
    private final native void initExternalWindowJsCallbacks(WindowEx window,
                                                            String tutorialUrl,
                                                            String tutorialName,
-                                                           String tutorialPackage)
+                                                           String tutorialPackage,
+                                                           String windowName)
    /*-{
       
       // register this window
@@ -458,7 +467,8 @@ public class TutorialPane
       $wnd.tutorialWindows[tutorialUrl] = {
          "package": tutorialPackage,
          "name": tutorialName,
-         "window": window
+         "window": window,
+         "windowName": windowName
       };
       
       // start polling for window closure
@@ -505,8 +515,8 @@ public class TutorialPane
          
          if (match)
          {
-            var window = entry["window"];
-            $wnd.open("", window.name);
+            var windowName = entry["windowName"];
+            this.@org.rstudio.studio.client.workbench.views.tutorial.TutorialPane::focusExistingTutorialWindowImpl(*)(windowName);
             return true;
          }
       }
@@ -514,6 +524,11 @@ public class TutorialPane
       return false;
       
    }-*/;
+   
+   private void focusExistingTutorialWindowImpl(String name)
+   {
+      globalDisplay_.bringWindowToFront(name);
+   }
    
    // Resources ---- 
    public interface Resources extends ClientBundle

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -511,7 +511,7 @@ public class TutorialPane
          
          var match =
             entry["name"] === tutorialName &&
-            entry["package"] == tutorialPackage;
+            entry["package"] === tutorialPackage;
          
          if (match)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
@@ -223,11 +223,11 @@ public class TutorialPresenter
       }
       else if (StringUtil.equals(state, ShinyApplicationParams.STATE_STOPPING))
       {
-         Debug.logToRConsole("Tutorial: stopping");
+         // handled separately
       }
       else if (StringUtil.equals(state, ShinyApplicationParams.STATE_STOPPED))
       {
-         Debug.logToRConsole("Tutorial: stopped");
+         // handled separately
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPresenter.java
@@ -16,7 +16,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.container.SafeMap;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -63,7 +63,6 @@ public class TutorialPresenter
       void home();
       
       String getUrl();
-      String getRawSrcUrl();
       
       void launchTutorial(Tutorial tutorial);
       
@@ -127,7 +126,6 @@ public class TutorialPresenter
       commands_ = commands;
       server_ = server;
       
-      paramsMap_ = new SafeMap<>();
       disconnectNotifier_ = new ShinyDisconnectNotifier(this);
       
       events_.addHandler(TutorialCommandEvent.TYPE, this);
@@ -161,6 +159,14 @@ public class TutorialPresenter
          JsObject data = event.getData().cast();
          String url = data.getString("url");
          display_.openTutorial(url);
+      }
+      
+      // Stop a running tutorial.
+      else if (StringUtil.equals(type, TutorialCommandEvent.TYPE_STOP))
+      {
+         JsObject data = event.getData().cast();
+         String url = data.getString("url");
+         tutorialStop(url);
       }
       
       // Tutorial indexing completed; if we're viewing the list of available
@@ -198,26 +204,22 @@ public class TutorialPresenter
       if (StringUtil.equals(state, ShinyApplicationParams.STATE_STARTED))
       {
          display_.bringToFront();
-         if (Desktop.hasDesktopFrame())
-         {
-            String url = event.getParams().getUrl();
-            Desktop.getFrame().setTutorialUrl(url);
-         }
          
          ShinyApplicationParams params = event.getParams();
          String tutorialName = params.getMeta().getString("name");
-         String packageName  = params.getMeta().getString("package");
-         String url = params.getUrl();
+         String tutorialPackage = params.getMeta().getString("package");
+         String tutorialUrl = DomUtils.makeAbsoluteUrl(params.getUrl());
          
-         paramsMap_.put(url, params);
+         if (Desktop.hasDesktopFrame())
+            Desktop.getFrame().setTutorialUrl(tutorialUrl);
          
          server_.tutorialStarted(
                tutorialName,
-               packageName,
-               url,
+               tutorialPackage,
+               tutorialUrl,
                new VoidServerRequestCallback());
          
-         display_.openTutorial(url);
+         display_.openTutorial(tutorialUrl);
       }
       else if (StringUtil.equals(state, ShinyApplicationParams.STATE_STOPPING))
       {
@@ -243,31 +245,8 @@ public class TutorialPresenter
    @Handler
    void onTutorialStop()
    {
-      // NOTE: 'getUrl()' will automatically prepend the scheme + authority
-      // to the 'raw' src attribute set on an iframe; in our case, we require
-      // the 'raw' src URL for our mapping so grab that instead
-      String url = display_.getRawSrcUrl();
-      ShinyApplicationParams params = paramsMap_.get(url);
-      assert params != null :
-         "no known tutorial associated with URL '" + url + "'";
-            
-      server_.tutorialStop(
-            params.getMeta().getString("name"),
-            params.getMeta().getString("package"),
-            new ServerRequestCallback<Void>()
-            {
-               @Override
-               public void onResponseReceived(Void response)
-               {
-                  onTutorialStopped();
-               }
-
-               @Override
-               public void onError(ServerError error)
-               {
-                  Debug.logError(error);
-               }
-            });
+      String url = DomUtils.makeAbsoluteUrl(display_.getUrl());
+      tutorialStop(url);
    }
    
    @Handler
@@ -322,15 +301,29 @@ public class TutorialPresenter
       commands_.tutorialPopout().setEnabled(isShiny);
    }
    
-   
+   private void tutorialStop(String url)
+   {
+      server_.tutorialStop(url, new ServerRequestCallback<Void>()
+      {
+         @Override
+         public void onResponseReceived(Void response)
+         {
+            onTutorialStopped();
+         }
+
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
+   }
    
    private final Display display_;
    private final EventBus events_;
    private final Commands commands_;
    private final TutorialServerOperations server_;
    private final ShinyDisconnectNotifier disconnectNotifier_;
-   
-   private final SafeMap<String, ShinyApplicationParams> paramsMap_;
    
    public static final String VIEWER_TYPE_TUTORIAL = "tutorial";
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
@@ -24,4 +24,9 @@ public interface TutorialServerOperations
    
    void tutorialStop(String tutorialUrl,
                      ServerRequestCallback<Void> requestCallback);
+   
+   void isPackageInstalled(String packageName,
+                           String version,
+                           ServerRequestCallback<Boolean> requestCallback);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
@@ -13,6 +13,7 @@
 package org.rstudio.studio.client.workbench.views.tutorial;
 
 import org.rstudio.studio.client.server.Void;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 
 public interface TutorialServerOperations
@@ -24,6 +25,9 @@ public interface TutorialServerOperations
    
    void tutorialStop(String tutorialUrl,
                      ServerRequestCallback<Void> requestCallback);
+   
+   void tutorialMetadata(String tutorialUrl,
+                         ServerRequestCallback<JsObject> requestCallback);
    
    void isPackageInstalled(String packageName,
                            String version,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialServerOperations.java
@@ -22,7 +22,6 @@ public interface TutorialServerOperations
                         String tutorialUrl,
                         ServerRequestCallback<Void> requestCallback);
    
-   void tutorialStop(String tutorialName,
-                     String tutorialPackage,
+   void tutorialStop(String tutorialUrl,
                      ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialUtil.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialUtil.java
@@ -16,11 +16,16 @@ import com.google.gwt.core.client.GWT;
 
 public class TutorialUtil
 {
+   // NOTE: Shiny URLs are either accessed through a proxied path
+   // (using the 'p/' or 'p6/' path component as appropriate),
+   // or directly from a separate authority (which may be a different
+   // port on the same host)
    public static boolean isShinyUrl(String url)
    {
+      String host = GWT.getHostPageBaseURL();
       return
-            url.startsWith(GWT.getHostPageBaseURL() + "p/") ||
-            url.startsWith(GWT.getHostPageBaseURL() + "p6/") ||
-            !url.startsWith(GWT.getHostPageBaseURL());
+            url.startsWith(host + "p/") ||
+            url.startsWith(host + "p6/") ||
+            !url.startsWith(host);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/events/TutorialCommandEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/events/TutorialCommandEvent.java
@@ -63,8 +63,6 @@ public class TutorialCommandEvent extends CrossWindowEvent<TutorialCommandEvent.
    private final String type_;
    private final JavaScriptObject data_;
    
-   public static final String TYPE_STOP = "stop";
-   
    // Boilerplate ----
    
    public interface Handler extends EventHandler
@@ -87,6 +85,7 @@ public class TutorialCommandEvent extends CrossWindowEvent<TutorialCommandEvent.
    public static final Type<Handler> TYPE = new Type<Handler>();
    
    public static final String TYPE_STARTED = "started";
+   public static final String TYPE_STOP = "stop";
    public static final String TYPE_NAVIGATE = "navigate";
    public static final String TYPE_INDEXING_COMPLETED = "indexing_completed";
    public static final String TYPE_LAUNCH_DEFAULT_TUTORIAL = "launch_default_tutorial";


### PR DESCRIPTION
This PR fixes a number of issues with the Tutorial pane.

- Tutorials can now be stopped after a browser refresh, regardless of whether RStudio Server is proxying URLs or not. This is accomplished by tagging running tutorials with both the underlying Shiny URL, as well as the proxied URL. This also allows us to avoid maintaining any extra state client-side -- as long as we have the tutorial URL, we can find the underlying running tutorial.

- Popped-out tutorials now have their underlying tutorial stopped when the associated window is closed.

- If a user pops out a tutorial, leaves that window open, and later tries to restart that tutorial, we will bring that popped-out window to the front rather than attempt to launch a second instance of that tutorial.