### PR TITLE
change toggle screenreader shortcut on Mac to avoid clash with intl keyboards

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -871,7 +871,8 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
-         <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/"/>
+         <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+/" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -3633,8 +3634,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="toggleScreenReaderSupport"
         menuLabel="_Screen Reader Support"
         checkable="true"
-        windowMode="main"
-        rebindable="false"/>
+        windowMode="main"/>
 
    <cmd id="showAccessibilityOptions"
         menuLabel="Accessibility _Options..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -870,7 +870,6 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showHelpMenu" value="Alt+Shift+H" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>
       <shortcutgroup name="Accessibility">
-         <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+Shift+/"/>
          <shortcut refid="toggleScreenReaderSupport" value="Ctrl+Alt+/" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -66,7 +66,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Toggle Screen Reader Support</td>
       <td>Alt+Shift+/</td>
-      <td>⌥⇧/</td>
+      <td>⌃⌥/</td>
     </tr>
     <tr>
       <td>Speak Text Editor Location</td>


### PR DESCRIPTION
- Fixes #6447
- Shortcut now follows the same pattern as others in terms of Mac vs. Windows (not sure why I didn't do this the first time...)
- Also make the "Toggle Screen Reader Support" command's shortcut user-customizable
- Remove original shortcut (Ctrl+Alt+Shift+/) as it is no longer mentioned in blog post or keyboard reference