### PR TITLE
Maintain file permissions while performing replace

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -489,6 +489,8 @@ private:
       }
    }
 
+// permissions getter/setter (only applicable to Unix platforms)
+#ifndef _WIN32
    Error setPermissions(const std::string& filePath, boost::filesystem::perms permissions)
    {
       boost::filesystem::path path(filePath);
@@ -524,6 +526,7 @@ private:
                   ERROR_LOCATION));
       }
    }
+#endif
 
    void adjustForPreview(std::string* contents, json::Array* pMatchOn, json::Array* pMatchOff)
    {
@@ -565,8 +568,8 @@ private:
              outputStream_->good())
          {
              Error error;
-             // For Windows we ignore this additional safety check
-             // it will always fail because we have inputStream_ reading the file
+// For Windows we ignore this additional safety check
+// it will always fail because we have inputStream_ reading the file
 #ifndef _WIN32
             error = FilePath(currentFile_).testWritePermissions();
             if (error)
@@ -587,10 +590,10 @@ private:
             inputStream_.reset();
             outputStream_.reset();
 
-            // Unneccesary on Windows because this only sets write permissions which we
-            // already know are correct if we are writing.
-            // For efficiency, this should not be combined with the above check as flushing
-            // outputStream could change the file permissions
+// Unneccesary on Windows because this only sets write permissions which we
+// already know are correct if we are writing.
+// For efficiency, this should not be combined with the above check as flushing
+// outputStream could change the file permissions
 #ifndef _WIN32
             error = setPermissions(tempReplaceFile_.getAbsolutePath(), filePermissions_);
 #endif

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -586,7 +586,14 @@ private:
             outputStream_->flush();
             inputStream_.reset();
             outputStream_.reset();
+
+            // Unneccesary on Windows because this only sets write permissions which we
+            // already know are correct if we are writing.
+            // For efficiency, this should not be combined with the above check as flushing
+            // outputStream could change the file permissions
+#ifndef _WIN32
             error = setPermissions(tempReplaceFile_.getAbsolutePath(), filePermissions_);
+#endif
             if (!error)
                error = tempReplaceFile_.move(FilePath(currentFile_));
             currentFile_.clear();
@@ -670,9 +677,12 @@ private:
       if (error)
          return error;
 
+      // boost only acknowledges write permissions on Windows which we already know exist
+#ifndef _WIN32
       error = getPermissions(file.getAbsolutePath(), &filePermissions_);
       if (error)
          return (error);
+#endif
 
       fileSuccess_ = true;
       inputLineNum_ = 0;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -592,8 +592,7 @@ private:
 
 // Unneccesary on Windows because this only sets write permissions which we
 // already know are correct if we are writing.
-// For efficiency, this should not be combined with the above check as flushing
-// outputStream could change the file permissions
+// This needs to happen after outputStream is flushed
 #ifndef _WIN32
             error = setPermissions(tempReplaceFile_.getAbsolutePath(), filePermissions_);
 #endif

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -515,7 +515,6 @@ private:
       {
          boost::filesystem::file_status fileStatus = status(path);
          *pPerms = fileStatus.permissions();
-         return Success();
       }
       catch (const boost::filesystem::filesystem_error& e)
       {
@@ -525,6 +524,7 @@ private:
                   "A permissions error occured during replace operation.",
                   ERROR_LOCATION));
       }
+      return Success();
    }
 #endif
 


### PR DESCRIPTION
Fixes #6048 

This PR fixes the global replace functionality so it no longer changes the file permissions where the replace takes place. Since we are using a temporary file to perform the replace, we save the permissions of the original file while initializing the replace, and set these permissions after overwriting the original file with the one containing the replace.