### PR TITLE
speculative fix for writeToPNG errors

### DIFF
--- a/src/cpp/r/session/graphics/RGraphicsPlot.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlot.cpp
@@ -133,8 +133,9 @@ Error Plot::renderFromDisplay()
    std::string storageUuid = core::system::generateUuid();
    
    // generate snapshot and image files
-   Error error = graphicsDevice_.saveSnapshot(snapshotFilePath(storageUuid),
-                                              imageFilePath(storageUuid));
+   FilePath snapshotPath = snapshotFilePath(storageUuid);
+   FilePath imagePath = imageFilePath(storageUuid);
+   Error error = graphicsDevice_.saveSnapshot(snapshotPath, imagePath);
    if (error)
       return Error(errc::PlotRenderingError, error, ERROR_LOCATION);
    


### PR DESCRIPTION
On Windows, we seem to get occasional crahses when invoking `writeToPNG` that appear to be due to invalid or corrupt file paths:

https://sentry.io/organizations/rstudio/issues/1560024620/?project=1379214&referrer=slack

It's not clear to me why this could occur, but we also observed a similar issue with R Presentations, where crashes appeared to occur when FilePaths were used as rvalues:

https://github.com/rstudio/rstudio/pull/6392/commits/91e15dbc8bd074c79815d9cd4c147e035c5f373a

This fix does the same thing as above, hoisting the file paths into their own variables rather than passing them directly into `saveSnapshot()`.