### PR TITLE
remove 'paste with indent' desktop-level binding

### DIFF
--- a/src/cpp/desktop/DesktopWebView.cpp
+++ b/src/cpp/desktop/DesktopWebView.cpp
@@ -169,13 +169,6 @@ void WebView::keyPressEvent(QKeyEvent* pEvent)
    }
 #endif
  
-   // allow Ctrl+Shift+V to act as a 'paste with indent' action
-   if (pEvent->key() == Qt::Key_V && pEvent->modifiers() == Qt::CTRL + Qt::SHIFT)
-   {
-      triggerPageAction(QWebEnginePage::PasteAndMatchStyle);
-      return;
-   }
-   
    // use default behavior otherwise
    QWebEngineView::keyPressEvent(pEvent);
    


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6395.

I had tried to implement support for Paste vs. Paste with Indent in a previous PR, but backed that out after running into trouble in having it work properly in different contexts. Unfortunately, this part was left in and caused the previously-referenced issue.