### PR TITLE
Make openssl verification work on windows by importing windows cert store certificates

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -81,11 +81,16 @@ public:
             {
                if (::X509_STORE_add_cert(store, cert) != 1)
                {
+                  char* subjectName = X509_NAME_oneline(X509_get_subject_name(cert), nullptr, 0);
+                  std::string subjectNameStr(subjectName);
+                  OPENSSL_free(subjectName);
+
                   boost::system::error_code ec = rstudio_boost::system::error_code(
                               static_cast<int>(::ERR_get_error()),
                               boost::asio::error::get_ssl_category());
                   Error error(ec, ERROR_LOCATION);
-                  error.addProperty("Description", "Could not add Windows certificate to OpenSSL cert store");
+                  error.addProperty("Description", "Could not add Windows certificate to OpenSSL cert store: " + subjectNameStr);
+
                   LOG_ERROR(error);
                }
             }

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -34,7 +34,7 @@
 
 namespace rstudio {
 namespace core {
-namespace http {  
+namespace http {
 
 class TcpIpAsyncClientSsl
    : public AsyncClient<boost::asio::ssl::stream<boost::asio::ip::tcp::socket> >
@@ -192,8 +192,7 @@ private:
          LPCSTR stores[] = {"ROOT", "CA"};
          for (const LPCSTR& store : stores)
          {
-             HCERTSTORE hStore = nullptr;
-             hStore = CertOpenSystemStore(NULL, store);
+             HCERTSTORE hStore = CertOpenSystemStore(NULL, store);
              if (!hStore)
              {
                 LOG_ERROR_MESSAGE("Could not open certificate store");
@@ -205,16 +204,12 @@ private:
              {
                 // convert the certificate returned from the Windows store into a
                 // format that OpenSSL can understand
-                X509* x509 = nullptr;
-                x509 = d2i_X509(nullptr,
-                                const_cast<const unsigned char**>(
-                                   reinterpret_cast<const unsigned char* const*>(&pContext->pbCertEncoded)),
-                                pContext->cbCertEncoded);
+                const BYTE* certPtr = pContext->pbCertEncoded;
+                X509* x509 = d2i_X509(nullptr, &certPtr, pContext->cbCertEncoded);
                 if (x509)
                    certificates.push_back(x509);
              }
 
-             CertFreeCertificateContext(pContext);
              CertCloseStore(hStore, 0);
          }
       }
@@ -242,7 +237,7 @@ private:
    std::string certificateAuthority_;
    boost::posix_time::time_duration connectionTimeout_;
 };
-   
+
 
 } // namespace http
 } // namespace core

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -221,7 +221,7 @@ private:
 
    static const WindowsCertificateStore& getCertificateStore()
    {
-       // Myers singleton - guarantees this is thread safe
+       // Meyer's singleton - guarantees this is thread safe
        // and will be initialized exactly once by the first caller
        static WindowsCertificateStore instance;
        return instance;

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -25,6 +25,13 @@
 #include <core/http/AsyncClient.hpp>
 #include <core/http/TcpIpAsyncConnector.hpp>
 
+#ifdef _WIN32
+#include <windows.h>
+#include <wincrypt.h>
+#include <cryptuiapi.h>
+#include <openssl/x509.h>
+#endif
+
 namespace rstudio {
 namespace core {
 namespace http {  
@@ -62,6 +69,28 @@ public:
             if (ec)
                LOG_ERROR(Error(ec, ERROR_LOCATION));
          }
+
+      #ifdef _WIN32
+         // on Windows, OpenSSL does not support loading certificates from the Windows certificate store
+         // because of this, each time we need to verify certificates, we initialize
+         // all certificates individually with OpenSSL
+         const WindowsCertificateStore& certStore = getCertificateStore();
+         for (const auto& cert : certStore.certificates)
+         {
+            if (X509_STORE* store = SSL_CTX_get_cert_store(sslContext_.native_handle()))
+            {
+               if (::X509_STORE_add_cert(store, cert) != 1)
+               {
+                  boost::system::error_code ec = rstudio_boost::system::error_code(
+                              static_cast<int>(::ERR_get_error()),
+                              boost::asio::error::get_ssl_category());
+                  Error error(ec, ERROR_LOCATION);
+                  error.addProperty("Description", "Could not add Windows certificate to OpenSSL cert store");
+                  LOG_ERROR(error);
+               }
+            }
+         }
+      #endif
       }
       else
       {
@@ -153,6 +182,56 @@ private:
    {
       return util::isSslShutdownError(ec);
    }
+
+#ifdef _WIN32
+   struct WindowsCertificateStore
+   {
+      WindowsCertificateStore()
+      {
+         // load certificates from important stores
+         LPCSTR stores[] = {"ROOT", "CA"};
+         for (const LPCSTR& store : stores)
+         {
+             HCERTSTORE hStore = nullptr;
+             hStore = CertOpenSystemStore(NULL, store);
+             if (!hStore)
+             {
+                LOG_ERROR_MESSAGE("Could not open certificate store");
+                return;
+             }
+
+             PCCERT_CONTEXT pContext = nullptr;
+             while (pContext = CertEnumCertificatesInStore(hStore, pContext))
+             {
+                // convert the certificate returned from the Windows store into a
+                // format that OpenSSL can understand
+                X509* x509 = nullptr;
+                x509 = d2i_X509(nullptr,
+                                const_cast<const unsigned char**>(
+                                   reinterpret_cast<const unsigned char* const*>(&pContext->pbCertEncoded)),
+                                pContext->cbCertEncoded);
+                if (x509)
+                   certificates.push_back(x509);
+             }
+
+             CertFreeCertificateContext(pContext);
+             CertCloseStore(hStore, 0);
+         }
+      }
+
+      // certificate pointers - these are intentionally leaked
+      // as they need to be available for the entire run of the program
+      std::vector<X509*> certificates;
+   };
+
+   static const WindowsCertificateStore& getCertificateStore()
+   {
+       // Myers singleton - guarantees this is thread safe
+       // and will be initialized exactly once by the first caller
+       static WindowsCertificateStore instance;
+       return instance;
+   }
+#endif
 
 private:
    boost::asio::ssl::context sslContext_;


### PR DESCRIPTION
OpenSSL does not support the use of the Windows certificate store out-of-the-box, so some additional programming is needed to get this working.

Fixes https://github.com/rstudio/rstudio-pro/issues/1522