### PR TITLE
Match realtime and not realtime token predicates, allow missing aff files

### DIFF
--- a/src/cpp/session/modules/SessionSpelling.cpp
+++ b/src/cpp/session/modules/SessionSpelling.cpp
@@ -178,6 +178,11 @@ void handleDictionaryRequest(const http::Request& request, http::Response* pResp
    {
       pResponse->setCacheableFile(options().hunspellDictionariesPath().completePath(splat[1]), request);
    }
+   else if (boost::algorithm::ends_with(splat[1], "aff"))
+   {
+      // the aff file is optional, especially for custom dictionaries
+      pResponse->setCacheableBody("", request);
+   }
    else
    {
       pResponse->setNotFoundError(request);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -168,7 +168,7 @@ public class CheckSpelling
          showProgress();
 
          Iterable<Range> wordSource = docDisplay_.getWords(
-               docDisplay_.getFileType().getTokenPredicate(),
+               docDisplay_.getFileType().getSpellCheckTokenPredicate(),
                docDisplay_.getFileType().getCharPredicate(),
                currentPos_,
                wrapped_ ? initialCursorPos_.getPosition() : null);


### PR DESCRIPTION
Fixes #5242  - I had missed updating the token for non-realtime spellchecking. This works now.

Hopefully Fixes #6047 
I cannot reproduce what @rich-rstudio is seeing but this will help reduce errors for custom dictionaries. I suspect something else is going on in rich's environment still but this is worth a shot.