### PR TITLE
Add equality and inequality operators to User

### DIFF
--- a/src/cpp/shared_core/include/shared_core/system/User.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/User.hpp
@@ -132,6 +132,24 @@ public:
    static Error getUserFromIdentifier(UidType in_userId, User& out_user);
 
    /**
+    * @brief Equality operator.
+    *
+    * @param in_other      The user to compare with this user.
+    *
+    * @return True if this user and in_other have the same user ID; false otherwise.
+    */
+   bool operator==(const User& in_other) const;
+
+   /**
+    * @brief Inequality operator.
+    *
+    * @param in_other      The user to compare with this user.
+    *
+    * @return False if this user and in_other have the same user ID; true otherwise.
+    */
+   bool operator!=(const User& in_other) const;
+
+   /**
     * @brief Checks whether the user represented by this object exists.
     *
     * If this is an empty user, or is a user object which represents all users, this method will return false as it does

--- a/src/cpp/shared_core/include/shared_core/system/User.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/User.hpp
@@ -106,7 +106,7 @@ public:
     *
     * @param in_other   The user to move into this User.
     */
-   User(User&& in_other) noexcept;
+   User(User&& in_other) noexcept = default;
 
    /**
     * @brief Gets the current user.
@@ -154,7 +154,7 @@ public:
     *
     * @return This user.
     */
-   User& operator=(User&& in_other) noexcept;
+   User& operator=(User&& in_other) noexcept = default;
 
    /**
     * @brief Equality operator.

--- a/src/cpp/shared_core/include/shared_core/system/User.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/User.hpp
@@ -102,6 +102,13 @@ public:
    User(const User& in_other);
 
    /**
+    * @brief Move constructor.
+    *
+    * @param in_other   The user to move into this User.
+    */
+   User(User&& in_other) noexcept;
+
+   /**
     * @brief Gets the current user.
     *
     * @param out_currentUser    The user this process is currently executing on behalf of. This object will be the empty
@@ -130,6 +137,24 @@ public:
     * @return Success if the user could be retrieved; Error otherwise.
     */
    static Error getUserFromIdentifier(UidType in_userId, User& out_user);
+
+   /**
+    * @brief Overloaded assignment operator.
+    *
+    * @param in_other   The user to copy to this one.
+    *
+    * @return This user.
+    */
+   User& operator=(const User& in_other);
+
+   /**
+    * @brief Overloaded move operator.
+    *
+    * @param in_other   The user to move to this one.
+    *
+    * @return This user.
+    */
+   User& operator=(User&& in_other) noexcept;
 
    /**
     * @brief Equality operator.
@@ -207,15 +232,6 @@ public:
     * @return The name of this user ("*" for all users).
     */
    const std::string& getUsername() const;
-
-   /**
-    * @brief Overloaded assignment operator.
-    *
-    * @param in_other   The user to copy to this one.
-    *
-    * @return This user.
-    */
-   User& operator=(const User& in_other);
 
 private:
    // The private implementation of User.

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -110,6 +110,11 @@ User::User(const User& in_other) :
 {
 }
 
+User::User(User&& in_other) noexcept :
+   m_impl(std::move(in_other.m_impl))
+{
+}
+
 Error User::getCurrentUser(User& out_currentUser)
 {
    return getUserFromIdentifier(::geteuid(), out_currentUser);
@@ -159,6 +164,22 @@ FilePath User::getUserHomePath(const std::string& in_envOverride)
 
    // otherwise use standard unix HOME
    return FilePath(getEnvVariable("HOME"));
+}
+
+User& User::operator=(const User& in_other)
+{
+   m_impl->Name = in_other.m_impl->Name;
+   m_impl->UserId = in_other.m_impl->UserId;
+   m_impl->GroupId = in_other.m_impl->GroupId;
+   m_impl->HomeDirectory = in_other.m_impl->HomeDirectory;
+   m_impl->Shell = in_other.m_impl->Shell;
+   return *this;
+}
+
+User& User::operator=(User &&in_other) noexcept
+{
+   m_impl.reset();
+   m_impl.swap(in_other.m_impl);
 }
 
 bool User::operator==(const User& in_other) const
@@ -217,16 +238,6 @@ const std::string& User::getUsername() const
 const std::string& User::getShell() const
 {
    return m_impl->Shell;
-}
-
-User& User::operator=(const User& in_other)
-{
-   m_impl->Name = in_other.m_impl->Name;
-   m_impl->UserId = in_other.m_impl->UserId;
-   m_impl->GroupId = in_other.m_impl->GroupId;
-   m_impl->HomeDirectory = in_other.m_impl->HomeDirectory;
-   m_impl->Shell = in_other.m_impl->Shell;
-   return *this;
 }
 
 } // namespace system

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -110,11 +110,6 @@ User::User(const User& in_other) :
 {
 }
 
-User::User(User&& in_other) noexcept :
-   m_impl(std::move(in_other.m_impl))
-{
-}
-
 Error User::getCurrentUser(User& out_currentUser)
 {
    return getUserFromIdentifier(::geteuid(), out_currentUser);
@@ -186,12 +181,6 @@ User& User::operator=(const User& in_other)
    *m_impl = *in_other.m_impl;
 
    return *this;
-}
-
-User& User::operator=(User &&in_other) noexcept
-{
-   m_impl.reset();
-   m_impl.swap(in_other.m_impl);
 }
 
 bool User::operator==(const User& in_other) const

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -168,11 +168,23 @@ FilePath User::getUserHomePath(const std::string& in_envOverride)
 
 User& User::operator=(const User& in_other)
 {
-   m_impl->Name = in_other.m_impl->Name;
-   m_impl->UserId = in_other.m_impl->UserId;
-   m_impl->GroupId = in_other.m_impl->GroupId;
-   m_impl->HomeDirectory = in_other.m_impl->HomeDirectory;
-   m_impl->Shell = in_other.m_impl->Shell;
+   if (this == &in_other)
+      return *this;
+
+   if ((m_impl == nullptr) && (in_other.m_impl == nullptr))
+      return *this;
+
+   if (in_other.m_impl == nullptr)
+   {
+      m_impl.reset();
+      return *this;
+   }
+
+   if (m_impl == nullptr)
+      m_impl.reset(new Impl());
+
+   *m_impl = *in_other.m_impl;
+
    return *this;
 }
 

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -184,6 +184,14 @@ User& User::operator=(User &&in_other) noexcept
 
 bool User::operator==(const User& in_other) const
 {
+   // If one or the other is empty but not both, these objects aren't equal.
+   if (isEmpty() != in_other.isEmpty())
+      return false;
+
+   // Otherwise they're both empty or they're both not, so just return true if this user is empty.
+   if (isEmpty())
+      return true;
+
    // If one or the other is all users but not both, these aren't the same user.
    if (isAllUsers() != in_other.isAllUsers())
       return false;

--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -161,6 +161,24 @@ FilePath User::getUserHomePath(const std::string& in_envOverride)
    return FilePath(getEnvVariable("HOME"));
 }
 
+bool User::operator==(const User& in_other) const
+{
+   // If one or the other is all users but not both, these aren't the same user.
+   if (isAllUsers() != in_other.isAllUsers())
+      return false;
+
+   // Otherwise they're both all users or they're both not, so just return true if this user is all users.
+   if (isAllUsers())
+      return true;
+
+   return getUserId() == in_other.getUserId();
+}
+
+bool User::operator!=(const User &in_other) const
+{
+   return !(*this == in_other);
+}
+
 bool User::exists() const
 {
    return !isEmpty() && !isAllUsers();


### PR DESCRIPTION
Also need this for the Launcher Plugin SDK.

Two users are the same if they have the same user ID. Also implements move constructor and operator for User.