### PR TITLE
make global VCS commands rebindable

### DIFF
--- a/src/gwt/.gitignore
+++ b/src/gwt/.gitignore
@@ -1,6 +1,7 @@
 bin/
 extras/
 gen/
+log/
 sdk/
 war/
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2279,14 +2279,12 @@ well as menu structures (for main menu and popup menus).
         buttonLabel="Diff"
         menuLabel="Diff"
         desc="Diff selected file(s)"
-        rebindable="false"
         context="vcs"/>
         
    <cmd id="vcsCommit"
         buttonLabel="Commit"
         menuLabel="_Commit..."
         desc="Commit pending changes"
-        rebindable="false"
         context="vcs"
         windowMode="review_changes"/>
 
@@ -2307,7 +2305,6 @@ well as menu structures (for main menu and popup menus).
         
    <cmd id="vcsRefresh"
         desc="Refresh listing"
-        rebindable="false"
         context="vcs"/>
         
    <cmd id="vcsRefreshNoError"
@@ -2330,21 +2327,18 @@ well as menu structures (for main menu and popup menus).
    <cmd id="vcsPull"
         menuLabel="_Pull Branches"
         buttonLabel="Pull"
-        rebindable="false"
         context="vcs"
         windowMode="review_changes"/>
         
    <cmd id="vcsPullRebase"
         menuLabel="_Pull with Rebase"
         buttonLabel="Pull with Rebase"
-        rebindable="false"
         context="vcs"
         windowMode="review_changes"/>
         
    <cmd id="vcsPush"
         menuLabel="P_ush Branch"
         buttonLabel="Push"
-        rebindable="false"
         context="vcs"
         windowMode="review_changes"/>
         


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6501.

Candidate for backport to v1.3, as we are stuck with a Qt issue that makes it impossible for us to differentiate between <kbd>Ctrl + Alt + M</kbd> and <kbd>AltGr + M</kbd>.

Fortunately, removing or renaming the binding is a way out.