### PR TITLE
Only use user pref for default working dir if defined

### DIFF
--- a/src/cpp/session/SessionDirs.cpp
+++ b/src/cpp/session/SessionDirs.cpp
@@ -29,14 +29,21 @@ namespace dirs {
 
 FilePath getDefaultWorkingDirectory()
 {
-   // calculate using user settings
-   FilePath defaultWorkingDir = module_context::resolveAliasedPath(
-         prefs::userPrefs().initialWorkingDirectory());
+   // see if the user has defined a default working directory in preferences
+   FilePath defaultWorkingDir;
+   std::string initialWorkingDir = prefs::userPrefs().initialWorkingDirectory();
+   if (!initialWorkingDir.empty())
+   {
+      // the user has defined a default; resolve the path
+      defaultWorkingDir = module_context::resolveAliasedPath(initialWorkingDir);
+   }
+
+   // see if there's a working directory defined in the R session options (set by
+   // session-default-working-dir)
    FilePath sessionDefaultWorkingDir = FilePath(session::options().defaultWorkingDir());
 
-   // return it if it exists, otherwise use the
-   // session specified value if it exists
-   // otherwise, use the default user home path
+   // return the first of these directories that is defined and exists, or the user home directory
+   // in the case that neither exists
    if (defaultWorkingDir.exists() && defaultWorkingDir.isDirectory())
       return defaultWorkingDir;
    else if (sessionDefaultWorkingDir.exists() && sessionDefaultWorkingDir.isDirectory())


### PR DESCRIPTION
This change fixes an issue in which the `session-default-working-dir` setting was always ignored in `rsession.conf`. 

The problem was that we were trying to respect the new user preference for this value, but doing so by immediately resolving the path set in the preference. Because `resolveAliasedPath` resolves to the home folder when given an empty string (behavior we should probably consider changing), the user preference was treated as though it were set to the home directory even though it was actually unset. 

Fixes https://github.com/rstudio/rstudio-pro/issues/1556.