### PR TITLE
allow configuring graphics device type, antialias

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1093,3 +1093,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       options(HTTPUserAgent = newAgent)
    }
 })
+
+.rs.addFunction("hasCapability", function(what)
+{
+   cap <- capabilities(what)
+   length(cap) && cap
+})

--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -1,7 +1,7 @@
 /*
  * RGraphics.hpp
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/r/include/r/session/RGraphicsConstants.h
+++ b/src/cpp/r/include/r/session/RGraphicsConstants.h
@@ -1,0 +1,23 @@
+/*
+ * RGraphicsConstants.hpp
+ *
+ * Copyright (C) 2009-20 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_GRAPHICS_CONSTANTS_HPP
+#define R_SESSION_GRAPHICS_CONSTANTS_HPP
+
+#define kGraphicsOptionBackend   "RStudioGD.backend"
+#define kGraphicsOptionAntialias "RStudioGD.antialias"
+
+#endif // R_SESSION_GRAPHICS_CONSTANTS_HPP
+

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -162,6 +162,13 @@ std::string extraBitmapParams()
       type = "default";
 #endif
    
+#ifndef _WIN32
+   // silently ignore 'windows' on non-Windows platforms
+   // (assume this would arise if one copied UI prefs across different machines)
+   if (type == "windows")
+      type = "default";
+#endif
+   
    if (type != "default")
       params.push_back("type = \"" + type + "\"");
    

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -185,7 +185,7 @@ std::string extraBitmapParams()
 
 #ifdef _WIN32
    // fix up antialias for windows backend
-   if (backend == "windows" && antialias == "subpixel")
+   if ((backend == "windows" || backend == "default") && antialias == "subpixel")
       antialias = "cleartype";
 #endif
 

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -183,6 +183,12 @@ std::string extraBitmapParams()
             "default",
             false);
 
+#ifdef _WIN32
+   // fix up antialias for windows backend
+   if (backend == "windows" && antialias == "subpixel")
+      antialias = "cleartype";
+#endif
+
    if (antialias != "default")
       params.push_back("antialias = \"" + antialias + "\"");
    

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * RGraphicsUtils.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,9 +17,10 @@
 
 #include <boost/format.hpp>
 
+#include <shared_core/Error.hpp>
+
 #include <core/Algorithm.hpp>
 #include <core/Log.hpp>
-#include <shared_core/Error.hpp>
 
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
@@ -29,6 +30,8 @@
 #define R_USE_PROTOTYPES 1
 #include <R_ext/GraphicsEngine.h>
 #include <R_ext/GraphicsDevice.h>
+
+#include <r/session/RGraphicsConstants.h>
 
 #include <r/RErrorCategory.hpp>
 
@@ -153,26 +156,33 @@ std::string extraBitmapParams()
 {
    std::vector<std::string> params;
    
-   std::string type = r::options::getOption<std::string>("RStudioGD.type", "default", false);
+   std::string backend = r::options::getOption<std::string>(
+            kGraphicsOptionBackend,
+            "default",
+            false);
    
 #ifndef __APPLE__
    // silently ignore 'quartz' on non-macOS platforms
    // (assume this would arise if one copied UI prefs across different machines)
-   if (type == "quartz")
-      type = "default";
+   if (backend == "quartz")
+      backend = "default";
 #endif
    
 #ifndef _WIN32
    // silently ignore 'windows' on non-Windows platforms
    // (assume this would arise if one copied UI prefs across different machines)
-   if (type == "windows")
-      type = "default";
+   if (backend == "windows")
+      backend = "default";
 #endif
    
-   if (type != "default")
-      params.push_back("type = \"" + type + "\"");
+   if (backend != "default")
+      params.push_back("type = \"" + backend + "\"");
    
-   std::string antialias = r::options::getOption<std::string>("RStudioGD.antialias", "default", false);
+   std::string antialias = r::options::getOption<std::string>(
+            kGraphicsOptionAntialias,
+            "default",
+            false);
+
    if (antialias != "default")
       params.push_back("antialias = \"" + antialias + "\"");
    

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -118,6 +118,7 @@ set (SESSION_SOURCE_FILES
    modules/SessionFilesQuotas.cpp
    modules/SessionFind.cpp
    modules/SessionGit.cpp
+   modules/SessionGraphics.cpp
    modules/SessionHelp.cpp
    modules/SessionHelpHome.cpp
    modules/SessionHistory.cpp

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -28,6 +28,7 @@
 #include "modules/SessionRAddins.hpp"
 #include "modules/SessionErrors.hpp"
 #include "modules/SessionFind.hpp"
+#include "modules/SessionGraphics.hpp"
 #include "modules/SessionHTMLPreview.hpp"
 #include "modules/SessionLists.hpp"
 #include "modules/clang/SessionClang.hpp"
@@ -379,6 +380,8 @@ void handleClientInit(const boost::function<void()>& initFunction,
       sessionInfo["has_pkg_src"] = false;
       sessionInfo["has_pkg_vig"] = false;
    }
+   
+   sessionInfo["graphics_backends"] = modules::graphics::supportedBackends();
 
    sessionInfo["presentation_state"] = modules::presentation::presentationStateAsJson();
    sessionInfo["presentation_commands"] = options.allowPresentationCommands();

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -134,6 +134,7 @@
 #include "modules/SessionErrors.hpp"
 #include "modules/SessionFiles.hpp"
 #include "modules/SessionFind.hpp"
+#include "modules/SessionGraphics.hpp"
 #include "modules/SessionDependencies.hpp"
 #include "modules/SessionDependencyList.hpp"
 #include "modules/SessionDirty.hpp"
@@ -578,6 +579,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::terminal::initialize)
       (modules::config_file::initialize)
       (modules::tutorial::initialize)
+      (modules::graphics::initialize)
 
       // workers
       (workers::web_request::initialize)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -322,6 +322,17 @@ namespace prefs {
 #define kScreenreaderConsoleAnnounceLimit "screenreader_console_announce_limit"
 #define kFileMonitorIgnoredComponents "file_monitor_ignored_components"
 #define kInstallPkgDepsIndividually "install_pkg_deps_individually"
+#define kGraphicsBackend "graphics_backend"
+#define kGraphicsBackendDefault "default"
+#define kGraphicsBackendCairo "cairo"
+#define kGraphicsBackendCairoPng "cairo-png"
+#define kGraphicsBackendQuartz "quartz"
+#define kGraphicsBackendWindows "windows"
+#define kGraphicsAntialiasing "graphics_antialiasing"
+#define kGraphicsAntialiasingDefault "default"
+#define kGraphicsAntialiasingNone "none"
+#define kGraphicsAntialiasingGray "gray"
+#define kGraphicsAntialiasingSubpixel "subpixel"
 
 class UserPrefValues: public Preferences
 {
@@ -1436,6 +1447,18 @@ public:
     */
    bool installPkgDepsIndividually();
    core::Error setInstallPkgDepsIndividually(bool val);
+
+   /**
+    * R graphics backend.
+    */
+   std::string graphicsBackend();
+   core::Error setGraphicsBackend(std::string val);
+
+   /**
+    * Type of anti-aliasing to be used for generated R plots.
+    */
+   std::string graphicsAntialiasing();
+   core::Error setGraphicsAntialiasing(std::string val);
 
 };
 

--- a/src/cpp/session/modules/SessionGraphics.R
+++ b/src/cpp/session/modules/SessionGraphics.R
@@ -1,0 +1,29 @@
+#
+# SessionGraphics.R
+#
+# Copyright (C) 2009-20 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("graphics.supportedBackends", function()
+{
+   c(
+      if (Sys.info()[["sysname"]] == "Windows")
+         "windows",
+      
+      if (.rs.hasCapability("aqua"))
+         "quartz",
+      
+      if (.rs.hasCapability("cairo"))
+         c("cairo", "cairo-png")
+   )
+   
+})

--- a/src/cpp/session/modules/SessionGraphics.cpp
+++ b/src/cpp/session/modules/SessionGraphics.cpp
@@ -35,7 +35,7 @@ namespace graphics {
 
 namespace {
 
-void onPreferencesSaved()
+void syncWithPrefs()
 {
    r::options::setOption(
             kGraphicsOptionBackend,
@@ -44,6 +44,11 @@ void onPreferencesSaved()
    r::options::setOption(
             kGraphicsOptionAntialias,
             prefs::userPrefs().graphicsAntialiasing());
+}
+
+void onPreferencesSaved()
+{
+   syncWithPrefs();
 }
 
 } // end anonymous namespace
@@ -75,6 +80,8 @@ core::Error initialize()
    using namespace module_context;
    
    events().onPreferencesSaved.connect(onPreferencesSaved);
+   
+   syncWithPrefs();
    
    using boost::bind;
    ExecBlock initBlock;

--- a/src/cpp/session/modules/SessionGraphics.cpp
+++ b/src/cpp/session/modules/SessionGraphics.cpp
@@ -1,0 +1,88 @@
+/*
+ * SessionGraphics.cpp
+ *
+ * Copyright (C) 2009-20 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionGraphics.hpp"
+
+#include <boost/bind.hpp>
+
+#include <r/RExec.hpp>
+#include <r/RJson.hpp>
+#include <r/ROptions.hpp>
+
+#include <session/prefs/UserPrefs.hpp>
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace graphics {
+
+namespace {
+
+void onPreferencesSaved()
+{
+   r::options::setOption(
+            "RStudioGD.backend",
+            prefs::userPrefs().graphicsBackend());
+   
+   r::options::setOption(
+            "RStudioGD.antialias",
+            prefs::userPrefs().graphicsAntialiasing());
+}
+
+} // end anonymous namespace
+
+core::json::Array supportedBackends()
+{
+   r::sexp::Protect protect;
+   SEXP backends;
+   Error error = r::exec::RFunction(".rs.graphics.supportedBackends").call(&backends, &protect);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return json::Array();
+   }
+   
+   core::json::Array backendsJson;
+   error = r::json::jsonValueFromVector(backends, &backendsJson);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return json::Array();
+   }
+   
+   return backendsJson;
+}
+
+core::Error initialize()
+{
+   using namespace module_context;
+   
+   events().onPreferencesSaved.connect(onPreferencesSaved);
+   
+   using boost::bind;
+   ExecBlock initBlock;
+   initBlock.addFunctions()
+         (bind(sourceModuleRFile, "SessionGraphics.R"));
+
+   return initBlock.execute();
+}
+
+} // namespace graphics
+} // namespace modules
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/modules/SessionGraphics.cpp
+++ b/src/cpp/session/modules/SessionGraphics.cpp
@@ -21,6 +21,8 @@
 #include <r/RJson.hpp>
 #include <r/ROptions.hpp>
 
+#include <r/session/RGraphicsConstants.h>
+
 #include <session/prefs/UserPrefs.hpp>
 #include <session/SessionModuleContext.hpp>
 
@@ -36,11 +38,11 @@ namespace {
 void onPreferencesSaved()
 {
    r::options::setOption(
-            "RStudioGD.backend",
+            kGraphicsOptionBackend,
             prefs::userPrefs().graphicsBackend());
    
    r::options::setOption(
-            "RStudioGD.antialias",
+            kGraphicsOptionAntialias,
             prefs::userPrefs().graphicsAntialiasing());
 }
 

--- a/src/cpp/session/modules/SessionGraphics.hpp
+++ b/src/cpp/session/modules/SessionGraphics.hpp
@@ -1,0 +1,38 @@
+/*
+ * SessionGraphics.hpp
+ *
+ * Copyright (C) 2009-20 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_GRAPHICS_HPP
+#define SESSION_GRAPHICS_HPP
+
+#include <shared_core/json/Json.hpp>
+#include <shared_core/Error.hpp>
+
+#include <core/Exec.hpp>
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace graphics {
+
+core::json::Array supportedBackends();
+
+core::Error initialize();
+
+} // namespace graphics
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_GRAPHICS_HPP

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2428,6 +2428,32 @@ core::Error UserPrefValues::setInstallPkgDepsIndividually(bool val)
    return writePref("install_pkg_deps_individually", val);
 }
 
+/**
+ * R graphics backend.
+ */
+std::string UserPrefValues::graphicsBackend()
+{
+   return readPref<std::string>("graphics_backend");
+}
+
+core::Error UserPrefValues::setGraphicsBackend(std::string val)
+{
+   return writePref("graphics_backend", val);
+}
+
+/**
+ * Type of anti-aliasing to be used for generated R plots.
+ */
+std::string UserPrefValues::graphicsAntialiasing()
+{
+   return readPref<std::string>("graphics_antialiasing");
+}
+
+core::Error UserPrefValues::setGraphicsAntialiasing(std::string val)
+{
+   return writePref("graphics_antialiasing", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -2616,6 +2642,8 @@ std::vector<std::string> UserPrefValues::allKeys()
       kScreenreaderConsoleAnnounceLimit,
       kFileMonitorIgnoredComponents,
       kInstallPkgDepsIndividually,
+      kGraphicsBackend,
+      kGraphicsAntialiasing,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1050,6 +1050,18 @@
             "type": "boolean",
             "default": true,
             "description": "Whether to install R package dependencies one at a time."
+        },
+        "graphics_backend": {
+            "type": "string",
+            "enum": ["default", "cairo", "cairo-png", "quartz", "windows"],
+            "default": "default",
+            "description": "R graphics backend."
+        },
+        "graphics_antialiasing": {
+            "type": "string",
+            "enum": ["default", "none", "gray", "subpixel"],
+            "default": "default",
+            "description": "Type of anti-aliasing to be used for generated R plots."
         }
     }
 }

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -157,6 +157,7 @@ public class ElementIds
    public final static String EDIT_DIAGNOSTICS_PREFS = "editing_diagnostics_prefs";
 
    public final static String GENERAL_BASIC_PREFS = "general_basic_prefs";
+   public final static String GENERAL_GRAPHICS_PREFS = "general_graphics_prefs";
    public final static String GENERAL_ADVANCED_PREFS = "general_advanced_prefs";
    
    public final static String RMARKDOWN_BASIC_PREFS = "rmarkdown_basic_prefs";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -634,4 +634,9 @@ public class SessionInfo extends JavaScriptObject
    public final native String getProjectId() /*-{
       return this.project_id;
    }-*/;
+   
+   public final native JsArrayString getGraphicsBackends()
+   /*-{
+     return this.graphics_backends;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1722,6 +1722,33 @@ public class UserPrefsAccessor extends Prefs
       return bool("install_pkg_deps_individually", true);
    }
 
+   /**
+    * R graphics backend.
+    */
+   public PrefValue<String> graphicsBackend()
+   {
+      return string("graphics_backend", "default");
+   }
+
+   public final static String GRAPHICS_BACKEND_DEFAULT = "default";
+   public final static String GRAPHICS_BACKEND_CAIRO = "cairo";
+   public final static String GRAPHICS_BACKEND_CAIRO_PNG = "cairo-png";
+   public final static String GRAPHICS_BACKEND_QUARTZ = "quartz";
+   public final static String GRAPHICS_BACKEND_WINDOWS = "windows";
+
+   /**
+    * Type of anti-aliasing to be used for generated R plots.
+    */
+   public PrefValue<String> graphicsAntialiasing()
+   {
+      return string("graphics_antialiasing", "default");
+   }
+
+   public final static String GRAPHICS_ANTIALIASING_DEFAULT = "default";
+   public final static String GRAPHICS_ANTIALIASING_NONE = "none";
+   public final static String GRAPHICS_ANTIALIASING_GRAY = "gray";
+   public final static String GRAPHICS_ANTIALIASING_SUBPIXEL = "subpixel";
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -2094,6 +2121,10 @@ public class UserPrefsAccessor extends Prefs
          fileMonitorIgnoredComponents().setValue(layer, source.getObject("file_monitor_ignored_components"));
       if (source.hasKey("install_pkg_deps_individually"))
          installPkgDepsIndividually().setValue(layer, source.getBool("install_pkg_deps_individually"));
+      if (source.hasKey("graphics_backend"))
+         graphicsBackend().setValue(layer, source.getString("graphics_backend"));
+      if (source.hasKey("graphics_antialiasing"))
+         graphicsAntialiasing().setValue(layer, source.getString("graphics_antialiasing"));
    }
    
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -23,7 +23,9 @@ import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.JsArray;
+import org.rstudio.core.client.JsArrayUtil;
 
 
 /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -16,6 +16,10 @@ package org.rstudio.studio.client.workbench.prefs.views;
 
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
@@ -40,6 +44,7 @@ import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.resources.client.ImageResource;
@@ -195,6 +200,31 @@ public class GeneralPreferencesPane extends PreferencesPane
          enableCrashReporting_.setEnabled(session.getSessionInfo().getCrashHandlerSettingsModifiable());
          basic.add(enableCrashReporting_);
       }
+      
+      VerticalTabPanel graphics = new VerticalTabPanel(ElementIds.GENERAL_GRAPHICS_PREFS);
+      
+      graphics.add(headerLabel("Graphics Device"));
+      graphics.add(graphicsBackend_ = graphicsBackendWidget());
+      
+      graphicsAntialias_ = new SelectWidget(
+            "Antialiasing:",
+            new String[] {
+                  "(Default)",
+                  "None",
+                  "Gray",
+                  "Subpixel"
+            },
+            new String[] {
+                  UserPrefs.GRAPHICS_ANTIALIASING_DEFAULT,
+                  UserPrefs.GRAPHICS_ANTIALIASING_NONE,
+                  UserPrefs.GRAPHICS_ANTIALIASING_GRAY,
+                  UserPrefs.GRAPHICS_ANTIALIASING_SUBPIXEL
+            },
+            false,
+            true,
+            false);
+      
+      graphics.add(graphicsAntialias_);
 
       VerticalTabPanel advanced = new VerticalTabPanel(ElementIds.GENERAL_ADVANCED_PREFS);
 
@@ -353,6 +383,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("General");
       tabPanel.setSize("435px", "498px");
       tabPanel.add(basic, "Basic", basic.getBasePanelId());
+      tabPanel.add(graphics, "Graphics", graphics.getBasePanelId());
       tabPanel.add(advanced, "Advanced", advanced.getBasePanelId());
       tabPanel.selectTab(0);
       add(tabPanel);
@@ -424,6 +455,10 @@ public class GeneralPreferencesPane extends PreferencesPane
       // projects prefs
       restoreLastProject_.setEnabled(true);
       restoreLastProject_.setValue(prefs.restoreLastProject().getValue());
+      
+      // graphics prefs
+      graphicsBackend_.setValue(prefs.graphicsBackend().getValue());
+      graphicsAntialias_.setValue(prefs.graphicsAntialiasing().getValue());
    }
    
 
@@ -500,6 +535,8 @@ public class GeneralPreferencesPane extends PreferencesPane
       prefs.alwaysSaveHistory().setGlobalValue(alwaysSaveHistory_.getValue());
       prefs.removeHistoryDuplicates().setGlobalValue(removeHistoryDuplicates_.getValue());
       prefs.restoreLastProject().setGlobalValue(restoreLastProject_.getValue());
+      prefs.graphicsBackend().setGlobalValue(graphicsBackend_.getValue());
+      prefs.graphicsAntialiasing().setGlobalValue(graphicsAntialias_.getValue());
       
       // Pro specific
       if (showServerHomePage_ != null && showServerHomePage_.isEnabled())
@@ -537,6 +574,30 @@ public class GeneralPreferencesPane extends PreferencesPane
       else
          return false;
    }
+   
+   private SelectWidget graphicsBackendWidget()
+   {
+      Map<String, String> valuesToLabelsMap = new HashMap<String, String>();
+      valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_DEFAULT, " (Default)");
+      valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_QUARTZ,    "Quartz");
+      valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_WINDOWS,   "Windows");
+      valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_CAIRO,     "Cairo");
+      valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_CAIRO_PNG, "Cairo PNG");
+      
+      JsArrayString supportedBackends =
+            session_.getSessionInfo().getGraphicsBackends();
+      
+      String[] values = new String[supportedBackends.length() + 1];
+      values[0] = "default";
+      for (int i = 0; i < supportedBackends.length(); i++)
+         values[i + 1] = supportedBackends.get(i);
+      
+      String[] labels = new String[supportedBackends.length() + 1];
+      for (int i = 0; i < labels.length; i++)
+         labels[i] = valuesToLabelsMap.get(values[i]);
+      
+      return new SelectWidget("Backend:", labels, values, false, true, false);
+   }
 
    private static final String ENGINE_AUTO        = "auto";
    private static final String ENGINE_DESKTOP     = "desktop";
@@ -559,6 +620,10 @@ public class GeneralPreferencesPane extends PreferencesPane
    private CheckBox useGpuDriverBugWorkarounds_ = null;
    private SelectWidget renderingEngineWidget_ = null;
    private String renderingEngine_ = null;
+   
+   private SelectWidget graphicsBackend_;
+   private SelectWidget graphicsAntialias_;
+   
    private SelectWidget showServerHomePage_;
    private SelectWidget saveWorkspace_;
    private TextBoxWithButton rVersion_;


### PR DESCRIPTION
This PR makes it possible to configure some parameters of the graphics device created by RStudio. In particular:

1. The backend (ie: Quartz vs. Windows vs. Cairo);
2. Whether anti-aliasing is used for the generated plots.

This will primarily be useful on Windows, where users have often wished they could use Cairo as opposed to the default Windows graphics backend.

Closes https://github.com/rstudio/rstudio/issues/2142.