### PR TITLE
Add parameter to EditingTarget.onActivated indicating whether it's being activated for user interaction

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -654,7 +654,7 @@ public class Source implements InsertSourceHandler,
 
             if (view_.getTabCount() > 0 && view_.getActiveTabIndex() >= 0)
             {
-               editors_.get(view_.getActiveTabIndex()).onInitiallyLoaded();        
+               editors_.get(view_.getActiveTabIndex()).onInitiallyLoaded();
             }
 
             // clear the history manager

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -642,6 +642,11 @@ public class Source implements InsertSourceHandler,
          @Override
          protected void onInit(Integer value)
          {
+            // set flag indicating that tab selections are actual "user-level"
+            // document activations (in contrast to onActivated which is fired
+            // for every new tab added during startup)
+            tabActivationsAreForUser_ = true;
+            
             if (value == null)
                return;
             if (value >= 0 && view_.getTabCount() > value)
@@ -649,7 +654,7 @@ public class Source implements InsertSourceHandler,
 
             if (view_.getTabCount() > 0 && view_.getActiveTabIndex() >= 0)
             {
-               editors_.get(view_.getActiveTabIndex()).onInitiallyLoaded();
+               editors_.get(view_.getActiveTabIndex()).onInitiallyLoaded();        
             }
 
             // clear the history manager
@@ -1945,7 +1950,7 @@ public class Source implements InsertSourceHandler,
             @Override
             public void onSuccess(EditingTarget target)
             {
-               activeEditor_ = target;
+               setActiveEditor(target);
                doActivateSource(afterActivation);
             }
             
@@ -3735,7 +3740,7 @@ public class Source implements InsertSourceHandler,
 
       if (event.getSelectedItem() >= 0)
       {
-         activeEditor_ = editors_.get(event.getSelectedItem());
+         setActiveEditor(editors_.get(event.getSelectedItem()));
          activeEditor_.onActivate();
          
          // let any listeners know this tab was activated
@@ -3778,6 +3783,13 @@ public class Source implements InsertSourceHandler,
       
       if (initialized_)
          manageCommands();
+   }
+   
+   private void setActiveEditor(EditingTarget target)
+   {
+      activeEditor_ = target;
+      if (tabActivationsAreForUser_)
+         activeEditor_.onActivatedForUser();
    }
 
    private void manageCommands()
@@ -5014,6 +5026,7 @@ public class Source implements InsertSourceHandler,
    private static final String KEY_ACTIVETAB = "activeTab";
    private boolean initialized_;
    private Timer debugSelectionTimer_ = null;
+   private boolean tabActivationsAreForUser_ = false;
    
    private final SourceWindowManager windowManager_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -3741,9 +3741,7 @@ public class Source implements InsertSourceHandler,
       if (event.getSelectedItem() >= 0)
       {
          activeEditor_ = editors_.get(event.getSelectedItem());
-         activeEditor_.onActivate();
-         if (tabActivationsAreForUser_)
-            activeEditor_.onActivatedForUser();
+         activeEditor_.onActivate(tabActivationsAreForUser_);
          
          // let any listeners know this tab was activated
          events_.fireEvent(new DocTabActivatedEvent(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1950,7 +1950,7 @@ public class Source implements InsertSourceHandler,
             @Override
             public void onSuccess(EditingTarget target)
             {
-               setActiveEditor(target);
+               activeEditor_ = target;
                doActivateSource(afterActivation);
             }
             
@@ -3740,8 +3740,10 @@ public class Source implements InsertSourceHandler,
 
       if (event.getSelectedItem() >= 0)
       {
-         setActiveEditor(editors_.get(event.getSelectedItem()));
+         activeEditor_ = editors_.get(event.getSelectedItem());
          activeEditor_.onActivate();
+         if (tabActivationsAreForUser_)
+            activeEditor_.onActivatedForUser();
          
          // let any listeners know this tab was activated
          events_.fireEvent(new DocTabActivatedEvent(
@@ -3783,13 +3785,6 @@ public class Source implements InsertSourceHandler,
       
       if (initialized_)
          manageCommands();
-   }
-   
-   private void setActiveEditor(EditingTarget target)
-   {
-      activeEditor_ = target;
-      if (tabActivationsAreForUser_)
-         activeEditor_.onActivatedForUser();
    }
 
    private void manageCommands()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -74,6 +74,8 @@ public interface EditingTarget extends IsWidget,
    void onDeactivate();
 
    void onInitiallyLoaded();
+   
+   void onActivatedForUser();
 
    void recordCurrentNavigationPosition();
    void navigateToPosition(SourcePosition position, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -70,13 +70,11 @@ public interface EditingTarget extends IsWidget,
    void verifyNewSqlPrerequisites();
 
    void focus();
-   void onActivate();
+   void onActivate(boolean forUser);
    void onDeactivate();
 
    void onInitiallyLoaded();
    
-   void onActivatedForUser();
-
    void recordCurrentNavigationPosition();
    void navigateToPosition(SourcePosition position, 
                            boolean recordCurrent);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -550,6 +550,11 @@ public class CodeBrowserEditingTarget implements EditingTarget
    }
    
    @Override
+   public void onActivatedForUser()
+   {
+   }
+   
+   @Override
    public void recordCurrentNavigationPosition()
    {
       docDisplay_.recordCurrentNavigationPosition();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -506,7 +506,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
 
    
    @Override
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
       // IMPORTANT NOTE: most of this logic is duplicated in 
       // TextEditingTarget (no straightforward way to create a
@@ -546,11 +546,6 @@ public class CodeBrowserEditingTarget implements EditingTarget
 
    @Override
    public void onInitiallyLoaded()
-   {
-   }
-   
-   @Override
-   public void onActivatedForUser()
    {
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -118,9 +118,9 @@ public class DataEditingTarget extends UrlContentEditingTarget
    }
 
    @Override
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
-      super.onActivate();
+      super.onActivate(forUser);
       if (view_ != null)
       {
          if (queuedRefresh_ != QueuedRefreshType.NoRefresh)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -77,9 +77,9 @@ public class ObjectExplorerEditingTarget
    }
 
    @Override
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
-      super.onActivate();
+      super.onActivate(forUser);
       view_.onActivate();
       isActive_ = true;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -248,7 +248,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    {
    }
 
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
       activeProfilerEditingTarger_ = this;
       
@@ -377,11 +377,6 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    @Override
    public void onInitiallyLoaded()
-   {
-   }
-   
-   @Override
-   public void onActivatedForUser()
    {
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -379,6 +379,11 @@ public class ProfilerEditingTarget implements EditingTarget,
    public void onInitiallyLoaded()
    {
    }
+   
+   @Override
+   public void onActivatedForUser()
+   {
+   }
 
    @Override
    public void recordCurrentNavigationPosition()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2332,7 +2332,7 @@ public class TextEditingTarget implements
       handlers_.fireEvent(event);
    }
 
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
       // IMPORTANT NOTE: most of this logic is duplicated in 
       // CodeBrowserEditingTarget (no straightforward way to create a
@@ -2380,7 +2380,15 @@ public class TextEditingTarget implements
       if (notebook_ != null)
          notebook_.onActivate();
       
-      view_.onActivate();   
+      view_.onActivate();  
+      
+      if (forUser) 
+      {
+         // defer interactions with visual mode b/c it's creation is also deferred
+         Scheduler.get().scheduleDeferred(() -> {
+            visualMode_.onUserEditingDoc();
+         });
+      }
    }
 
    public void onDeactivate()
@@ -2409,16 +2417,6 @@ public class TextEditingTarget implements
    public void onInitiallyLoaded()
    {
       checkForExternalEdit();
-   }
-   
-   @Override
-   public void onActivatedForUser()
-   {
-      // defer interactions with visual mode b/c it's creation is also deferred
-      Scheduler.get().scheduleDeferred(() -> {
-         if (visualMode_.isActivated())
-            visualMode_.onActivatedForUser();
-      });
    }
 
    public boolean onBeforeDismiss()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2380,13 +2380,7 @@ public class TextEditingTarget implements
       if (notebook_ != null)
          notebook_.onActivate();
       
-      view_.onActivate();
-      
-      if (visualMode_ != null && visualMode_.isActivated())
-      {
-         visualMode_.onSwitchToDoc();
-      }
-         
+      view_.onActivate();   
    }
 
    public void onDeactivate()
@@ -2420,6 +2414,11 @@ public class TextEditingTarget implements
    @Override
    public void onActivatedForUser()
    {
+      // defer interactions with visual mode b/c it's creation is also deferred
+      Scheduler.get().scheduleDeferred(() -> {
+         if (visualMode_.isActivated())
+            visualMode_.onActivatedForUser();
+      });
    }
 
    public boolean onBeforeDismiss()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2416,6 +2416,11 @@ public class TextEditingTarget implements
    {
       checkForExternalEdit();
    }
+   
+   @Override
+   public void onActivatedForUser()
+   {
+   }
 
    public boolean onBeforeDismiss()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2380,7 +2380,7 @@ public class TextEditingTarget implements
       if (notebook_ != null)
          notebook_.onActivate();
       
-      view_.onActivate();  
+      view_.onActivate();
       
       if (forUser) 
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
@@ -270,9 +270,10 @@ public class TextEditingTargetVisualMode
       });
    }
    
-   public void onActivatedForUser()
+   public void onUserEditingDoc()
    {
-      syncDevTools();
+      if (isActivated())
+         syncDevTools();
    }
   
   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
@@ -270,7 +270,7 @@ public class TextEditingTargetVisualMode
       });
    }
    
-   public void onSwitchToDoc()
+   public void onActivatedForUser()
    {
       syncDevTools();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -235,7 +235,7 @@ public class UrlContentEditingTarget implements EditingTarget
    {
    }
 
-   public void onActivate()
+   public void onActivate(boolean forUser)
    {
       if (commandReg_ != null)
       {
@@ -258,11 +258,6 @@ public class UrlContentEditingTarget implements EditingTarget
 
    @Override
    public void onInitiallyLoaded()
-   {
-   }
-   
-   @Override
-   public void onActivatedForUser()
    {
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -262,6 +262,11 @@ public class UrlContentEditingTarget implements EditingTarget
    }
    
    @Override
+   public void onActivatedForUser()
+   {
+   }
+   
+   @Override
    public void recordCurrentNavigationPosition()
    {
       events_.fireEvent(new SourceNavigationEvent(


### PR DESCRIPTION
This PR adds an argument to the  `EditingTarget.onActivated()` method that indicates whether the editor tab is being activated for the purpose of user interaction (during startup `onActivated()` is called for each tab being restored irrespective of whether it will actually end up active at the end of startup). 

The motivation is that panmirror does some potentially expensive (depending on the platform) work at startup (calls pandoc twice). On Linux/OSX these calls take sub 10ms however on Windows they can take 100ms+. If a user has dozens of tabs w/ panmirror to be restored, the cost of doing panmirror initialization eagerly could become prohibitive. With this change we can defer this work until the user is actually going to interact with the document.

I could have "fixed" `onActivated()` to not be called during IDE tabset restoration, however I'm sure we have implicit dependencies on this elsewhere and unwinding them seems risky / cost prohibitive.
