### PR TITLE
Fix an issue were we might try to allocate negative buffers

### DIFF
--- a/src/cpp/shared_core/system/User.cpp
+++ b/src/cpp/shared_core/system/User.cpp
@@ -64,7 +64,7 @@ struct User::Impl
 
       // Get the maximum size of a passwd for this system.
       long buffSize = ::sysconf(_SC_GETPW_R_SIZE_MAX);
-      if (buffSize == 1)
+      if (buffSize < 0)
          buffSize = 4096; // some systems return -1, be conservative!
 
       std::vector<char> buffer(buffSize);


### PR DESCRIPTION
This was a type (`-1` -> `1`), but I just changed it so we allocate a reasonable buffer size if we get any negative integer from the OS.