### PR TITLE
Update URL constructor to handle paths beginning with file:// or ftp://

### DIFF
--- a/src/cpp/core/http/URL.cpp
+++ b/src/cpp/core/http/URL.cpp
@@ -28,7 +28,7 @@ namespace http {
 URL::URL(const std::string& absoluteURL)
 {
    std::string protocol, host, path;
-   boost::regex re("(http|https|file|ftp)://([^/#?]+)(.*)", boost::regex::icase);
+   boost::regex re("(http|https|file|ftp|ftps)://([^/#?]+)(.*)", boost::regex::icase);
    boost::cmatch matches ;
    if (regex_utils::match(absoluteURL.c_str(), matches, re))
    {

--- a/src/cpp/core/http/URL.cpp
+++ b/src/cpp/core/http/URL.cpp
@@ -28,7 +28,7 @@ namespace http {
 URL::URL(const std::string& absoluteURL)
 {
    std::string protocol, host, path;
-   boost::regex re("(http|https)://([^/#?]+)(.*)", boost::regex::icase);
+   boost::regex re("(http|https|file|ftp)://([^/#?]+)(.*)", boost::regex::icase);
    boost::cmatch matches ;
    if (regex_utils::match(absoluteURL.c_str(), matches, re))
    {


### PR DESCRIPTION
Fixes #5724

Update the URL constructor to parse out `file://` and `ftp://`. This will allow users to access and download packages from a Windows fileshare system. 