### PR TITLE
Bugfix/panmirror focus fixups

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -119,7 +119,6 @@ public class DocumentOutlineWidget extends Composite
                target_.navigateToPosition(
                      SourcePosition.create(node_.getPreamble().getRow(), node_.getPreamble().getColumn()),
                      true);
-               target_.getDocDisplay().alignCursor(node_.getPreamble(), 0.1);
                
                // Defer focus so it occurs after click has been fully handled
                Scheduler.get().scheduleDeferred(new ScheduledCommand()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetVisualMode.java
@@ -116,6 +116,10 @@ public class TextEditingTargetVisualMode
          docUpdateSentinel_.setBoolProperty(TextEditingTarget.RMD_VISUAL_MODE, false);
          manageUI(false, true, completed);
       }
+      else
+      {
+         completed.execute();
+      }
    }
    
    public void syncToEditor(boolean activatingEditor)


### PR DESCRIPTION
This PR fixes a couple issues in 1.4:

- Navigating using the document outline and Ctrl + . was not working
- Avoid jumpiness when navigating using the document outline