### PR TITLE
add support for ragg renderer

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -489,7 +489,7 @@ std::string getErrorMessage()
 
 void warning(const std::string& warning)
 {
-   Rf_warning(warning.c_str());
+   Rf_warning("%s", warning.c_str());
 }
 
 void message(const std::string& message)

--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -21,6 +21,8 @@
 
 #include <core/BoostSignals.hpp>
 
+#include "RGraphicsConstants.h"
+
 namespace rstudio {
 namespace r {
 namespace session {
@@ -73,6 +75,9 @@ namespace rstudio {
 namespace r {
 namespace session {
 namespace graphics {
+
+std::string getDefaultBackend();
+std::string getDefaultAntialiasing();
 
 namespace device {
 

--- a/src/cpp/r/session/graphics/RGraphicsUtils.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsUtils.cpp
@@ -104,6 +104,22 @@ bool hasRequiredGraphicsDevices(std::string* pMessage)
 
 } // anonymous namespace
 
+std::string getDefaultBackend()
+{
+   return r::options::getOption<std::string>(
+            kGraphicsOptionBackend,
+            "default",
+            false);
+}
+
+std::string getDefaultAntialiasing()
+{
+   return r::options::getOption<std::string>(
+            kGraphicsOptionAntialias,
+            "default",
+            false);
+}
+
 void setCompatibleEngineVersion(int version)
 {
    s_compatibleEngineVersion = version;
@@ -164,10 +180,7 @@ std::string extraBitmapParams()
       return "";
    }
    
-   std::string backend = r::options::getOption<std::string>(
-            kGraphicsOptionBackend,
-            "default",
-            false);
+   std::string backend = getDefaultBackend();
    
    // if the requested backend is not supported, silently use the default
    // (this could happen if a package's configuration was migrated from
@@ -182,17 +195,14 @@ std::string extraBitmapParams()
    if (backend != "default")
       params.push_back("type = \"" + backend + "\"");
    
-   std::string antialias = r::options::getOption<std::string>(
-            kGraphicsOptionAntialias,
-            "default",
-            false);
-
 #ifdef _WIN32
    // fix up antialias for windows backend
    if ((backend == "windows" || backend == "default") && antialias == "subpixel")
       antialias = "cleartype";
 #endif
 
+   std::string antialias = getDefaultAntialiasing();
+   
    if (antialias != "default")
       params.push_back("antialias = \"" + antialias + "\"");
    

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -328,6 +328,7 @@ namespace prefs {
 #define kGraphicsBackendCairoPng "cairo-png"
 #define kGraphicsBackendQuartz "quartz"
 #define kGraphicsBackendWindows "windows"
+#define kGraphicsBackendRagg "ragg"
 #define kGraphicsAntialiasing "graphics_antialiasing"
 #define kGraphicsAntialiasingDefault "default"
 #define kGraphicsAntialiasingNone "none"

--- a/src/cpp/session/modules/SessionGraphics.R
+++ b/src/cpp/session/modules/SessionGraphics.R
@@ -23,7 +23,9 @@
          "quartz",
       
       if (.rs.hasCapability("cairo"))
-         c("cairo", "cairo-png")
+         c("cairo", "cairo-png"),
+      
+      "ragg"
    )
    
 })

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -180,6 +180,11 @@
             "location": "cran",
             "source": true
         },
+        "ragg": {
+            "version": "0.1.5",
+            "location": "cran",
+            "source": false
+        },
         "rJava": {
             "version": "0.4-15",
             "location": "cran",
@@ -517,6 +522,12 @@
             "description": "Database Interface",
             "packages": [
                 "DBI"
+            ]
+        },
+        "ragg": {
+            "description": "R Interface to AGG",
+            "packages": [
+                "ragg"
             ]
         },
         "rsqlite": {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1053,7 +1053,7 @@
         },
         "graphics_backend": {
             "type": "string",
-            "enum": ["default", "cairo", "cairo-png", "quartz", "windows"],
+            "enum": ["default", "cairo", "cairo-png", "quartz", "windows", "ragg"],
             "default": "default",
             "description": "R graphics backend."
         },

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -760,6 +760,17 @@ public class DependencyManager implements InstallShinyEvent.Handler,
             });
    }
    
+   public void withRagg(String userAction, final CommandWithArg<Boolean> command)
+   {
+      withDependencies(
+            "AGG",
+            "Using the AGG renderer",
+            getFeatureDescription("ragg"),
+            getFeatureDependencies("ragg"),
+            true,
+            command);
+   }
+   
    private ArrayList<Dependency> connectionPackageDependencies(
               String packageName,
               String packageVersion)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1735,6 +1735,7 @@ public class UserPrefsAccessor extends Prefs
    public final static String GRAPHICS_BACKEND_CAIRO_PNG = "cairo-png";
    public final static String GRAPHICS_BACKEND_QUARTZ = "quartz";
    public final static String GRAPHICS_BACKEND_WINDOWS = "windows";
+   public final static String GRAPHICS_BACKEND_RAGG = "ragg";
 
    /**
     * Type of anti-aliasing to be used for generated R plots.


### PR DESCRIPTION
This PR adds support for the AGG renderer as provided by the `ragg` package.

The implementation here is fairly simple -- rather than using `grDevices:::png()`, we use `ragg:::agg_png()` to open the graphics device, and let our shadow graphics device operate as usual.

See https://ragg.r-lib.org/ for some documentation on `ragg`.