### PR TITLE
Add function to get the type of logger for a log section

### DIFF
--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -293,6 +293,8 @@ void log(log::LogLevel level,
 
 const char* logLevelToStr(log::LogLevel level);
 
+log::LoggerType loggerType(const std::string& logSection = "");
+
 log::LogLevel lowestLogLevel();
 
 // filesystem

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -232,6 +232,20 @@ void initializeLogWriters()
 }
 } // anonymous namespace
 
+log::LoggerType loggerType(const std::string& in_sectionName)
+{
+   RECURSIVE_LOCK_MUTEX(s_loggingMutex)
+      {
+         if (!s_logOptions)
+
+            return s_logOptions->loggerType(in_sectionName);
+      }
+   END_LOCK_MUTEX
+
+   // default return - only occurs if we fail to lock mutex
+   return log::LoggerType::kSysLog;
+}
+
 log::LogLevel lowestLogLevel()
 {
    RECURSIVE_LOCK_MUTEX(s_loggingMutex)


### PR DESCRIPTION
This is required for a bug fix in the pro repo.