### PR TITLE
Fixes a bug in json::readObject for optional sets and vectors

### DIFF
--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -2139,7 +2139,6 @@ Error readObject(const Object& in_object, const std::string& in_name, boost::opt
    else if (!error)
       out_values = values;
 
-   out_values = values;
    return Success();
 }
 

--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -2105,12 +2105,14 @@ template <typename T>
 Error readObject(const Object& in_object, const std::string& in_name, boost::optional<std::vector<T> >& out_values)
 {
    out_values = boost::none;
+
    std::vector<T> values;
    Error error = readObject(in_object, in_name, values);
    if (error && !isMissingMemberError(error))
       return error;
+   else if (!error)
+      out_values = values;
 
-   out_values = values;
    return Success();
 }
 
@@ -2134,6 +2136,8 @@ Error readObject(const Object& in_object, const std::string& in_name, boost::opt
    Error error = readObject(in_object, in_name, values);
    if (error && !isMissingMemberError(error))
       return error;
+   else if (!error)
+      out_values = values;
 
    out_values = values;
    return Success();


### PR DESCRIPTION
Previously, the optional value would be set to an empty list/vector if the value wasn't found instead of an empty optional.