### PR TITLE
Switch away from Jobs pane after successful package installation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -1,7 +1,7 @@
 /*
  * DependencyManager.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.views.console.events.ConsoleActivateEvent;
 import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobUpdate;
@@ -966,6 +967,21 @@ public class DependencyManager implements InstallShinyEvent.Handler,
                                     final boolean silentEmbeddedUpdate,
                                     final CommandWithArg<Boolean> onComplete)
    {
+    
+      // Command to run when dependency installation is complete
+      CommandWithArg<Boolean> onCompletion = satisfied ->
+      {
+         // Confirmed: dependencies are in place. Switch
+         // away from the Jobs tab to put the user back in
+         // context.
+         if (satisfied)
+         {
+            events_.fireEvent(new ConsoleActivateEvent(false));
+         }
+         
+         onComplete.execute(satisfied);
+      };
+
       server_.installDependencies(
          context,
          dependencies, 
@@ -988,7 +1004,10 @@ public class DependencyManager implements InstallShinyEvent.Handler,
                      // are now satisfied
                      ifDependenciesSatisifed(dependencies, 
                            silentEmbeddedUpdate, 
-                           onComplete);
+                           onCompletion);
+
+                     // Remove handler so we don't get notified on another job
+                     // completion.
                      reg.getValue().removeHandler();
                   }
                   else if (update.job.state == JobConstants.STATE_FAILED ||


### PR DESCRIPTION
This change returns the user to the Console pane after implicit dependency installation in the Jobs tab (see associated issue for justification). 

Fixes https://github.com/rstudio/rstudio/issues/6535