### PR TITLE
ensure that the text editor is active when rstudioapi retreives the editor context

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -4908,10 +4908,14 @@ public class Source implements InsertSourceHandler,
          EditingTarget target = activeEditor_;
          if (target != null && target instanceof TextEditingTarget)
          {
-            getEditorContext(
-                  target.getId(),
-                  target.getPath(),
-                  ((TextEditingTarget) target).getDocDisplay());
+            TextEditingTarget editingTarget = (TextEditingTarget)target;
+            editingTarget.ensureTextEditorActive(() -> {
+               getEditorContext(
+                  editingTarget.getId(),
+                  editingTarget.getPath(),
+                  editingTarget.getDocDisplay()
+               );
+            });
             return;
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1096,6 +1096,11 @@ public class TextEditingTarget implements
       docDisplay_.recordCurrentNavigationPosition();
    }
    
+   public void ensureTextEditorActive(Command command)
+   {
+      visualMode_.deactivate(command);
+   }
+   
    @Override
    public void navigateToPosition(SourcePosition position, 
                                   boolean recordCurrent)


### PR DESCRIPTION
Visual mode might be active (and have un-synced edits) when an rstudioapi client retrieves the EditingContext. This PR ensure that edits are synced and the text editor is made active before returning the context to the client.
