### PR TITLE
use single quotes to escape strings for shell

### DIFF
--- a/src/cpp/core/system/PosixShellUtils.cpp
+++ b/src/cpp/core/system/PosixShellUtils.cpp
@@ -24,7 +24,7 @@ namespace shell_utils {
 std::string escape(const std::string& arg)
 {
    boost::regex pattern("'");
-   return "'" + boost::regex_replace(arg, pattern, R"('\\'')") + "'";
+   return "'" + boost::regex_replace(arg, pattern, R"('"'"')") + "'";
 }
 
 std::string escape(const core::FilePath &path)

--- a/src/cpp/core/system/PosixShellUtils.cpp
+++ b/src/cpp/core/system/PosixShellUtils.cpp
@@ -23,8 +23,8 @@ namespace shell_utils {
 
 std::string escape(const std::string& arg)
 {
-   boost::regex pattern("[\\\\$`!\n\"]");
-   return "\"" + boost::regex_replace(arg, pattern, "\\\\$0") + "\"";
+   boost::regex pattern("'");
+   return "'" + boost::regex_replace(arg, pattern, R"('\\'')") + "'";
 }
 
 std::string escape(const core::FilePath &path)

--- a/src/cpp/core/system/PosixShellUtilsTests.cpp
+++ b/src/cpp/core/system/PosixShellUtilsTests.cpp
@@ -50,7 +50,7 @@ test_context("Shell Escaping")
    {
       std::string text = "Text with 'inner quotes'.";
       std::string escaped = escape(text);
-      std::string expected = R"('Text with '\''inner quotes'\''.')";
+      std::string expected = R"('Text with '"'"'inner quotes'"'"'.')";
       expect_true(escaped == expected);
    }
 }

--- a/src/cpp/core/system/PosixShellUtilsTests.cpp
+++ b/src/cpp/core/system/PosixShellUtilsTests.cpp
@@ -34,15 +34,23 @@ test_context("Shell Escaping")
    {
       std::string dollars = "$$$";
       std::string escaped  = escape(dollars);
-      std::string expected = "\"\\$\\$\\$\"";
+      std::string expected = "'$$$'";
       expect_true(escaped == expected);
    }
    
    test_that("Commands with backslashes are escaped")
    {
-      std::string backslashes = "\\\\\\";
+      std::string backslashes = R"(\\\)";
       std::string escaped = escape(backslashes);
-      std::string expected = "\"\\\\\\\\\\\\\"";
+      std::string expected = R"('\\\')";
+      expect_true(escaped == expected);
+   }
+   
+   test_that("Inner quotes are properly handled")
+   {
+      std::string text = "Text with 'inner quotes'.";
+      std::string escaped = escape(text);
+      std::string expected = R"('Text with '\''inner quotes'\''.')";
       expect_true(escaped == expected);
    }
 }


### PR DESCRIPTION
This PR improves the way we escape arguments for shell commands.

Previously, we tried to escape arguments with double-quoted strings, and then backslash-escaped any special inner characters within. Unfortunately, that solution doesn't always work, since whether `!` is treated as a special character (ie: performs history expansion) is dependent on the shell, and how that shell is configured.

Using single quotes is much safer, as within single quotes only another single quote is 'special' (it ends the string) and so that is the only entity that needs escaping.

Closes https://github.com/rstudio/rstudio/issues/6160.

(Note: I'm not sure what the most appropriate label for this is)