### PR TITLE
Update dark themes based on the new default node-selector color

### DIFF
--- a/src/cpp/session/resources/themes/README.md
+++ b/src/cpp/session/resources/themes/README.md
@@ -1,0 +1,13 @@
+# RStudio Theme Maintenance
+
+Most of the themes the RStudio IDE bundles are maintained by pulling the CSS versions of the themes from ACE and regenerating them using the `compile-themes.R` script in the `src/gwt/tools` folder. In general, changes should not be made to `.rstheme` files manually, as they will be overwritten each time that the themes are regenerated. To (re)generate themes:
+
+1. Naviagate to `src/gwt/tools`
+2. Run `./sync-ace-commits`
+3. Run `Rscript compile-themes.R`
+
+## Manually Maintained Themes
+
+Some themes were contributed to the RStudio IDE as already created `.rstheme` files, and do not have an associated source `.css` file. The following is the current list of themes which need to be updated manually if any changes are required:
+
+* material.rstheme

--- a/src/cpp/session/resources/themes/ambiance.rstheme
+++ b/src/cpp/session/resources/themes/ambiance.rstheme
@@ -184,7 +184,7 @@
   background-color: #343433;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/chaos.rstheme
+++ b/src/cpp/session/resources/themes/chaos.rstheme
@@ -160,7 +160,7 @@
   background-color: #2B2B2A;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/clouds_midnight.rstheme
+++ b/src/cpp/session/resources/themes/clouds_midnight.rstheme
@@ -103,7 +103,7 @@
   background-color: #262626;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/cobalt.rstheme
+++ b/src/cpp/session/resources/themes/cobalt.rstheme
@@ -119,7 +119,7 @@
   background-color: #1A3954;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -141,7 +141,7 @@
   background-color: #3D3F49;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/gob.rstheme
+++ b/src/cpp/session/resources/themes/gob.rstheme
@@ -118,7 +118,7 @@
   background-color: #0A240A;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/idle_fingers.rstheme
+++ b/src/cpp/session/resources/themes/idle_fingers.rstheme
@@ -103,7 +103,7 @@
   background-color: #474747;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/kr_theme.rstheme
+++ b/src/cpp/session/resources/themes/kr_theme.rstheme
@@ -111,7 +111,7 @@
   background-color: #24231F;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/material.rstheme
+++ b/src/cpp/session/resources/themes/material.rstheme
@@ -113,6 +113,12 @@
   z-index: -1;
   background-color: #0E3640;
 }
+.ace_node-selector {
+  background-color: #fb6f1c
+}
+.ace_comment-highlight {
+  background-color: #5C4916
+}
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;

--- a/src/cpp/session/resources/themes/merbivore.rstheme
+++ b/src/cpp/session/resources/themes/merbivore.rstheme
@@ -102,7 +102,7 @@
   background-color: #2B2B2A;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/merbivore_soft.rstheme
+++ b/src/cpp/session/resources/themes/merbivore_soft.rstheme
@@ -103,7 +103,7 @@
   background-color: #313030;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/mono_industrial.rstheme
+++ b/src/cpp/session/resources/themes/mono_industrial.rstheme
@@ -114,7 +114,7 @@
   background-color: #39423E;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/monokai.rstheme
+++ b/src/cpp/session/resources/themes/monokai.rstheme
@@ -112,7 +112,7 @@
   background-color: #3C3D37;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/pastel_on_dark.rstheme
+++ b/src/cpp/session/resources/themes/pastel_on_dark.rstheme
@@ -115,7 +115,7 @@
   background-color: #3F3B3B;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/solarized_dark.rstheme
+++ b/src/cpp/session/resources/themes/solarized_dark.rstheme
@@ -95,7 +95,7 @@
   background-color: #0F3741;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/tomorrow_night.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night.rstheme
@@ -115,7 +115,7 @@
   background-color: #2E3032;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
@@ -113,7 +113,7 @@
   background-color: #1A3A63;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
@@ -128,7 +128,7 @@
   background-color: #222222;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
@@ -115,7 +115,7 @@
   background-color: #3D3D3D;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/twilight.rstheme
+++ b/src/cpp/session/resources/themes/twilight.rstheme
@@ -116,7 +116,7 @@
   background-color: #2B2B2B;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/cpp/session/resources/themes/vibrant_ink.rstheme
+++ b/src/cpp/session/resources/themes/vibrant_ink.rstheme
@@ -101,7 +101,7 @@
   background-color: #272727;
 }
 .ace_node-selector {
-  background-color: #007B97
+  background-color: #fb6f1c
 }
 .ace_comment-highlight {
   background-color: #5C4916

--- a/src/gwt/tools/sync-ace-commits
+++ b/src/gwt/tools/sync-ace-commits
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-BRANCH=rstudio/v1.3
+BRANCH=rstudio/v1.4
 
 PROGRAMS=("git" "npm")
 for PROGRAM in "${PROGRAMS[@]}"; do


### PR DESCRIPTION
Also update material, which needs to be maintained manually, and add a README in the themes folder to explain how to generate themes and which themes are maintained manually. Currently, only material is made manually because ACE added Dracula to their set of CSS themes.