### PR TITLE
disable focus on hover for cpp completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,5 +8,6 @@
 
 ### Bugfixes
 
+* Fixed an issue where hovering mouse cursor over C++ completion popup would steal focus. (#5941)
 * Git integration now works properly for project names containing the '!' character. (#6160)
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ScrollableToolbarPopupMenu.java
@@ -95,6 +95,7 @@ public class ScrollableToolbarPopupMenu extends ToolbarPopupMenu
       public ScrollableToolbarMenuBar(boolean vertical)
       {
          super(vertical);
+         setFocusOnHoverEnabled(false);
       }
 
       public HandlerRegistration addSelectionHandler(


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/5941.