### PR TITLE
improve handling of multiline Python blocks in console

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -774,6 +774,14 @@ bool extractCommentHeader(const std::string& contents,
    return true;
 }
 
+std::string extractIndent(const std::string& line)
+{
+   auto index = line.find_first_not_of(" \t");
+   if (index == std::string::npos)
+      return std::string();
+   return line.substr(0, index);
+}
+
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * StringUtils.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -290,6 +290,8 @@ bool extractCommentHeader(const std::string& contents,
                           const std::string& reCommentPrefix,
                           std::string* pHeader);
 
+std::string extractIndent(const std::string& line);
+
 } // namespace string_utils
 
 // wrappers for functions in <cctype>, as those functions normally

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -1,7 +1,7 @@
 /*
  * StringUtils.hpp
  *
- * Copyright (C) 2009-17 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -196,18 +196,6 @@ void fixupPendingConsoleInput()
    // keep track of last line's indent
    std::string indent;
    
-   // pending empty strings whose indent we need to set
-   std::vector<std::string*> pendingStrings;
-   
-   // helper for getting indent of line
-   auto getIndent = [](const std::string& line)
-   {
-      auto index = line.find_first_not_of(" \t");
-      if (index == std::string::npos)
-         return std::string();
-      return line.substr(0, index);
-   };
-   
    // split input into list of commands
    std::vector<std::string> lines = core::algorithm::split(input.text, "\n");
    for (std::size_t i = 0, n = lines.size(); i < n; i++)

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -184,11 +184,7 @@ void fixupPendingConsoleInput()
    
    // if we're about to send code to the Python REPL, then
    // we need to fix whitespace in the code before sending
-   bool pyReplActive = false;
-   Error error =  r::exec::RFunction(".rs.reticulate.replIsActive")
-         .call(&pyReplActive);
-   if (error)
-      LOG_ERROR(error);
+   bool pyReplActive = modules::reticulate::isReplActive();
    
    // pop off current input (we're going to split and re-push now)
    s_consoleInputBuffer.pop();

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -245,9 +245,12 @@ void fixupPendingConsoleInput()
          //    "foo"         <--
          //
          // so update the indent in that case
-         std::string lineIndent = string_utils::extractIndent(line);
-         if (lineIndent.length() < blockIndent.length())
-            blockIndent = lineIndent;
+         else
+         {
+            std::string lineIndent = string_utils::extractIndent(line);
+            if (lineIndent.length() < blockIndent.length())
+               blockIndent = lineIndent;
+         }
       }
       else
       {

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConsoleInput.cpp
  *
- * Copyright (C) 2009-18 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/tests/python/test-code-submit.py
+++ b/src/cpp/tests/python/test-code-submit.py
@@ -30,14 +30,31 @@ def test():
    
 test()
 
+# Test submission of a class definition.
 class HelloWorld(object):
    
    def __init__(self):
       pass
       
    def world(self):
-      
       print("Hello, world!")
 
 hello = HelloWorld()
 hello.world()
+
+
+# Test nested functions.
+def outer():
+   
+   # Define an inner function.
+   def inner():
+
+      print("inner")
+
+   # Now back at 'outer' block scope.
+   inner()
+
+   print("outer")
+   
+# Invoke outer.
+outer()

--- a/src/cpp/tests/python/test-code-submit.py
+++ b/src/cpp/tests/python/test-code-submit.py
@@ -1,0 +1,43 @@
+#
+# test-code-submit.py
+#
+# Copyright (C) 2009-20 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+# This script is used to test interactive submission of code to the Python
+# REPL. In particular, RStudio should transparently fix up the indentation of
+# blank lines within indented blocks when the whole block of code is submitted
+# as a single expression.
+def test():
+
+   # This is the first block.
+   first = "first"
+
+   # This is the second block.
+   second = "second"
+
+   # Let's try to print it.
+   print(first + " " + second)
+   
+test()
+
+class HelloWorld(object):
+   
+   def __init__(self):
+      pass
+      
+   def world(self):
+      
+      print("Hello, world!")
+
+hello = HelloWorld()
+hello.world()


### PR DESCRIPTION
This PR fixes an issue where attempts to submit blocks of Python code with inconsistent indentation (e.g. blank lines between statements) to the `reticulate` REPL would fail. To fix this, we attempt to fix the indentation of blank lines post-hoc when code is submitted to the console.

This, admittedly, feels like a kludge. However, we have one major constraint: `reticulate` relies on R's `readline()`, which reads a single newline-buffered line at a time. Ultimately, that implies the fix needs to occur before the code is submitted to `reticulate`. And since an empty line submitted to `reticulate` is normally treated as the end of a block, we need to explicitly side-step that behavior by adjusting the code indent.

An alternative approach would be to use some sort of special encoding for blocks of code submitted to the `reticulate` REPL, and teach `reticulate` how to unravel those blocks, but this solution has the nice property of being compatible with the existing version of `reticulate` and ultimately feeling transparent.

Closes https://github.com/rstudio/rstudio/issues/5904.