### PR TITLE
fix C++ warnings related to raw literals and unused parameters

### DIFF
--- a/src/cpp/desktop/DesktopBrowserWindow.cpp
+++ b/src/cpp/desktop/DesktopBrowserWindow.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopBrowserWindow.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -48,8 +48,8 @@ void initializeWebchannel(BrowserWindow* pWindow)
    webChannelJsFile.close();
 
    // append our WebChannel initialization code
-   const char* webChannelInit = 1 + R"EOF(
-new QWebChannel(qt.webChannelTransport, function(channel) {
+   const char* webChannelInit =
+R"EOF(new QWebChannel(qt.webChannelTransport, function(channel) {
 
    // export channel objects to the main window
    for (var key in channel.objects) {

--- a/src/cpp/desktop/DesktopGwtCallbackMac.mm
+++ b/src/cpp/desktop/DesktopGwtCallbackMac.mm
@@ -1,7 +1,7 @@
 /*
  * DesktopGwtCallbackMac.mm
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -37,8 +37,8 @@ RS_BEGIN_NAMESPACE(desktop)
 
 RS_BEGIN_NAMESPACE()
 
-static const char* const s_openWordDocumentFormatString = 1 + R"EOF(
-tell application "Microsoft Word"
+static const char* const s_openWordDocumentFormatString =
+R"EOF(tell application "Microsoft Word"
    activate
    set reopened to false
    repeat with i from 1 to (count of documents)
@@ -60,8 +60,8 @@ tell application "Microsoft Word"
 end tell
 )EOF";
 
-static const char* const s_openPptPresFormatString = 1 + R"EOF(
-tell application "Microsoft PowerPoint"
+static const char* const s_openPptPresFormatString =
+R"EOF(tell application "Microsoft PowerPoint"
 	activate
 	set reopened to false
 	repeat with i from 1 to (count of presentations)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2630,8 +2630,8 @@ namespace {
 
 void warnXcodeLicense()
 {
-   const char* msg = 1 + R"EOF(
-Warning: macOS is reporting that you have not yet agreed to the Xcode license.
+   const char* msg =
+R"EOF(Warning: macOS is reporting that you have not yet agreed to the Xcode license.
 This can occur if Xcode has been updated or reinstalled (e.g. as part of a macOS update).
 Some features (e.g. Git / SVN) may be disabled.
 

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionBuild.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -69,8 +69,8 @@ std::string preflightPackageBuildErrorMessage(
       const std::string& message,
       const FilePath& buildDirectory)
 {
-   std::string fmt = 1 + R"EOF(
-ERROR: Package build failed.
+   std::string fmt =
+R"EOF(ERROR: Package build failed.
 
 %1%
 
@@ -1432,7 +1432,7 @@ private:
                                                      cb);
    }
 
-   void executeCustomBuild(const std::string& type,
+   void executeCustomBuild(const std::string& /*type*/,
                            const FilePath& customScriptPath,
                            const core::system::ProcessOptions& options,
                            const core::system::ProcessCallbacks& cb)
@@ -1880,7 +1880,7 @@ Error startBuild(const json::JsonRpcRequest& request,
 
 
 
-Error terminateBuild(const json::JsonRpcRequest& request,
+Error terminateBuild(const json::JsonRpcRequest& /*request*/,
                      json::JsonRpcResponse* pResponse)
 {
    if (isBuildRunning())
@@ -1891,7 +1891,7 @@ Error terminateBuild(const json::JsonRpcRequest& request,
    return Success();
 }
 
-Error getCppCapabilities(const json::JsonRpcRequest& request,
+Error getCppCapabilities(const json::JsonRpcRequest& /*request*/,
                          json::JsonRpcResponse* pResponse)
 {
    json::Object capsJson;
@@ -1916,7 +1916,7 @@ Error installBuildTools(const json::JsonRpcRequest& request,
    return Success();
 }
 
-Error devtoolsLoadAllPath(const json::JsonRpcRequest& request,
+Error devtoolsLoadAllPath(const json::JsonRpcRequest& /*request*/,
                      json::JsonRpcResponse* pResponse)
 {
    pResponse->setResult(module_context::pathRelativeTo(
@@ -2092,7 +2092,7 @@ SEXP rs_installPackage(SEXP pkgPathSEXP, SEXP libPathSEXP)
    return R_NilValue;
 }
 
-Error getBookdownFormats(const json::JsonRpcRequest& request,
+Error getBookdownFormats(const json::JsonRpcRequest& /*request*/,
                          json::JsonRpcResponse* pResponse)
 {
    json::Object responseJson;


### PR DESCRIPTION
The trick for ignoring the leading newline in raw string literal generates below warning so stopped doing it. Also comment out some unused parameters.

```
/Users/gary/rstudio/src/cpp/session/SessionModuleContext.cpp:2633:24: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
   const char* msg = 1 + R"EOF(
                     ~~^~~~~~~~
/Users/gary/rstudio/src/cpp/session/SessionModuleContext.cpp:2633:24: note: use array indexing to silence this warning
```