### PR TITLE
cleanup (some) deprecated Qt usage

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # CMakeLists.txt
 #
-# Copyright (C) 2009-19 by RStudio, PBC
+# Copyright (C) 2009-20 by RStudio, PBC
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -108,6 +108,7 @@ set(CMAKE_PREFIX_PATH "${QT_BIN_DIR}//..//lib//cmake")
 add_definitions(
    -DQT_NO_CAST_FROM_ASCII
    -DQT_NO_CAST_TO_ASCII
+   -DQT_DEPRECATED_WARNINGS
    -DQT_NO_SIGNALS_SLOTS_KEYWORDS)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -120,7 +120,7 @@ void initializeSharedSecret()
    core::system::setenv("RS_SHARED_SECRET", value);
 }
 
-void initializeWorkingDirectory(int argc,
+void initializeWorkingDirectory(int /*argc*/,
                                 char* argv[],
                                 const QString& filename)
 {
@@ -481,7 +481,7 @@ boost::optional<SessionServer> getLaunchServerFromUrl(const std::string& url)
    return boost::optional<SessionServer>();
 }
 
-ProgramStatus initializeOptions(const QStringList& arguments)
+ProgramStatus initializeOptions(const QStringList& /*arguments*/)
 {
    return ProgramStatus::run();
 }
@@ -917,7 +917,7 @@ int main(int argc, char* argv[])
             showError(nullptr,
                       QString::fromUtf8("Invalid session server"),
                       QString::fromStdString("Session server " + sessionServer + " does not exist"),
-                      QString::null);
+                      QString());
             return EXIT_FAILURE;
          }
       }
@@ -1100,10 +1100,10 @@ int main(int argc, char* argv[])
 }
 
 #ifdef _WIN32
-int WINAPI WinMain(HINSTANCE hInstance,
-                   HINSTANCE hPrevInstance,
-                   LPSTR lpCmdLine,
-                   int nShowCmd)
+int WINAPI WinMain(HINSTANCE /*hInstance*/,
+                   HINSTANCE /*hPrevInstance*/,
+                   LPSTR /*lpCmdLine*/,
+                   int /*nShowCmd*/)
 {
    return main(__argc, __argv);
 }

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopOptions.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -389,7 +389,7 @@ QString Options::rBinDir() const
    // should be ignored) and the other case by using null for this case and
    // empty string for the other.
    if (!settings_.contains(QString::fromUtf8("RBinDir")))
-      return QString::null;
+      return QString();
 
    QString value = settings_.value(QString::fromUtf8("RBinDir")).toString();
    return value.isNull() ? QString() : value;

--- a/src/cpp/desktop/DesktopRVersion.cpp
+++ b/src/cpp/desktop/DesktopRVersion.cpp
@@ -1,7 +1,7 @@
 /*
  * DesktopRVersion.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,7 @@
 
 #include <windows.h>
 
-#include <QtAlgorithms>
+#include <algorithm>
 #include <QMessageBox>
 
 #include <core/system/System.hpp>
@@ -287,7 +287,7 @@ QList<RVersion> allRVersions(QList<RVersion> versions)
    }
 
    // Sort and de-duplicate
-   qSort(versions);
+   std::sort(versions.begin(), versions.end());
    for (int i = 1; i < versions.size(); i++)
    {
       if (versions.at(i) == versions.at(i-1))


### PR DESCRIPTION
- turn on deprecation warnings (this is on by default starting with Qt 5.13)
- QString::null has been deprecated since Qt 5.9, replace with QString() as recommended
- QtAlgorithms::qSort has been deprecated since Qt 5.2, replace with std::sort as recommended
- comment out more unused parameters to reduce warnings

Note there are additional things we use that are deprecated starting with Qt 5.11 and will give warnings when building with Qt 5.12; once we've stopped building anything with Qt 5.10 I'll clean those up as well, see #6585.