### PR TITLE
improve handling of UNC paths on Windows

### DIFF
--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -30,7 +30,8 @@ namespace {
 // helper for creating a path with the system drive
 // prefixed for Windows. we try to use the current
 // drive if at all possible; if we cannot retrieve
-// that for some reason then we just fall back to C:
+// that for some reason then we just fall back to
+// the default system drive (normally C:)
 std::string getDrivePrefix()
 {
    char buffer[MAX_PATH];

--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -28,13 +28,18 @@ namespace {
 #ifdef _WIN32
 
 // helper for creating a path with the system drive
-// prefixed for Windows
+// prefixed for Windows. we try to use the current
+// drive if at all possible; if we cannot retrieve
+// that for some reason then we just fall back to C:
 std::string getDrivePrefix()
 {
    char buffer[MAX_PATH];
    DWORD n = GetCurrentDirectory(MAX_PATH, buffer);
    if (n < 2)
-      return "C:";
+      return ::getenv("SYSTEMDRIVE");
+
+   if (buffer[1] != ':')
+      return ::getenv("SYSTEMDRIVE");
 
    return std::string(buffer, 2);
 }

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -398,6 +398,17 @@ std::string FilePath::createAliasedPath(const FilePath& in_filePath, const FileP
    if (in_filePath == in_userHomePath)
       return s_homePathLeafAlias;
 
+#ifdef _WIN32
+   // Also check for case where paths are identical
+   // after normalizing separators.
+   bool samePath =
+       in_filePath.m_impl->Path.generic_path() ==
+       in_userHomePath.m_impl->Path.generic_path();
+
+   if (samePath)
+      return s_homePathLeafAlias;
+#endif
+
    // if the path is contained within the home path then alias it
    if (in_filePath.isWithin(in_userHomePath))
    {

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1043,11 +1043,14 @@ FilePath FilePath::getParent() const
 
 std::string FilePath::getRelativePath(const FilePath& in_parentPath) const
 {
-   path_t relativePath =
-      m_impl->Path.lexically_normal().lexically_relative(
-         in_parentPath.m_impl->Path.lexically_normal());
-
-   return BOOST_FS_PATH2STR(relativePath);
+   // NOTE: On Windows, we need to explicitly normalize separators.
+   // We use forward slashes since most of our file APIs prefer
+   // these separators, and Windows APIs transparently translate
+   // forward slashes to backslashes anyhow.
+   path_t self = m_impl->Path.generic_path().lexically_normal();
+   path_t parent = in_parentPath.m_impl->Path.generic_path().lexically_normal();
+   path_t relative = self.lexically_relative(parent);
+   return BOOST_FS_PATH2STR(relative);
 }
 
 uintmax_t FilePath::getSize() const


### PR DESCRIPTION
This PR fixes an issue where attempts to modify files within the home directory, when that directory is referenced with a UNC path, could fail.

Background: On Windows, while `\` is the canonical path separator, most Windows APIs still accept `/` and translate all forward slashes to backslashes behind the scenes. However, we do not normalize separators up-front when creating `FilePath` objects, and some Boost filesystem APIs are indeed sensitive to mismatched separators -- presumedly because `\` is a legal path component on POSIX.

So, when we accept and create `FilePath` objects, we create it with the underlying path as-is. On Windows, we probably should normalize separators (e.g. always use `/` or `\`), but making that change is somewhat aggressive.

So, as a slightly smaller change, this PR instead:

1. Converts separators explicitly within `getRelativePath()` via `generic_path()`, which converts `\` to `/`;

2. Checks generic paths for equality within `createAliasedPath()`, as well.

I believe we should consider backporting this to the v1.3 branch, because it fixes an issue that will be seen quite commonly when RStudio Desktop is used in Windows enterprise environments.

We may want to consider a more aggressive fix (always canonicalize path separators when creating FilePath objects) for v1.4, and any consequences of doing so.

Fixes https://github.com/rstudio/rstudio/issues/6587.