### PR TITLE
Restore project if it starts successfully

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -290,6 +290,7 @@ namespace prefs {
 #define kViewDirAfterRCmdCheck "view_dir_after_r_cmd_check"
 #define kHideObjectFiles "hide_object_files"
 #define kRestoreLastProject "restore_last_project"
+#define kProjectSafeStartupSeconds "project_safe_startup_seconds"
 #define kUseTinytex "use_tinytex"
 #define kCleanTexi2dviOutput "clean_texi2dvi_output"
 #define kLatexShellEscape "latex_shell_escape"
@@ -1313,6 +1314,12 @@ public:
     */
    bool restoreLastProject();
    core::Error setRestoreLastProject(bool val);
+
+   /**
+    * The number of seconds after which a project is deemed to have successfully started.
+    */
+   int projectSafeStartupSeconds();
+   core::Error setProjectSafeStartupSeconds(int val);
 
    /**
     * Use tinytex to compile .tex files.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2130,6 +2130,19 @@ core::Error UserPrefValues::setRestoreLastProject(bool val)
 }
 
 /**
+ * The number of seconds after which a project is deemed to have successfully started.
+ */
+int UserPrefValues::projectSafeStartupSeconds()
+{
+   return readPref<int>("project_safe_startup_seconds");
+}
+
+core::Error UserPrefValues::setProjectSafeStartupSeconds(int val)
+{
+   return writePref("project_safe_startup_seconds", val);
+}
+
+/**
  * Use tinytex to compile .tex files.
  */
 bool UserPrefValues::useTinytex()
@@ -2658,6 +2671,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kViewDirAfterRCmdCheck,
       kHideObjectFiles,
       kRestoreLastProject,
+      kProjectSafeStartupSeconds,
       kUseTinytex,
       kCleanTexi2dviOutput,
       kLatexShellEscape,

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionProjects.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -706,11 +706,26 @@ Error writeProjectVcsOptions(const json::JsonRpcRequest& request,
    return Success();
 }
 
-
-void onQuit()
+void saveLastProjectPath()
 {
    projects::ProjectsSettings(options().userScratchPath()).
                         setLastProjectPath(s_projectContext.file());
+}
+
+void onQuit()
+{
+   saveLastProjectPath();
+}
+
+void afterSessionInitHook(bool newSession)
+{
+   // After fully successful startup, wait 30 seconds (default) and then write the last project
+   // path. This project path will get restored at startup, so we want to be very confident it
+   // doesn't crash or misbehave on load.
+   module_context::scheduleDelayedWork(
+         boost::posix_time::seconds(
+            prefs::userPrefs().projectSafeStartupSeconds()),
+         saveLastProjectPath, true);
 }
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
@@ -975,8 +990,9 @@ Error initialize()
    cb.onMonitoringDisabled = onMonitoringDisabled;
    s_projectContext.subscribeToFileMonitor("", cb);
 
-   // subscribe to quit for setting last project path
+   // subscribe to quit/deferred init for setting last project path
    module_context::events().onQuit.connect(onQuit);
+   module_context::events().afterSessionInitHook.connect(afterSessionInitHook);
 
    // reset switch to project path so it's a one shot deal; we only do this after successful init so
    // that we can retry a project switch if it doesn't get off the ground the first time

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -915,6 +915,11 @@
             "default": true,
             "description": "Whether to restore the last project when starting RStudio."
         },
+        "project_safe_startup_seconds": {
+            "type": "integer",
+            "default": 30,
+            "description": "The number of seconds after which a project is deemed to have successfully started."
+        },
         "use_tinytex": {
             "type": "boolean",
             "default": false,
@@ -1109,4 +1114,3 @@
         }
     }
 }
-

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1513,6 +1513,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * The number of seconds after which a project is deemed to have successfully started.
+    */
+   public PrefValue<Integer> projectSafeStartupSeconds()
+   {
+      return integer("project_safe_startup_seconds", 30);
+   }
+
+   /**
     * Use tinytex to compile .tex files.
     */
    public PrefValue<Boolean> useTinytex()
@@ -2100,6 +2108,8 @@ public class UserPrefsAccessor extends Prefs
          hideObjectFiles().setValue(layer, source.getBool("hide_object_files"));
       if (source.hasKey("restore_last_project"))
          restoreLastProject().setValue(layer, source.getBool("restore_last_project"));
+      if (source.hasKey("project_safe_startup_seconds"))
+         projectSafeStartupSeconds().setValue(layer, source.getInteger("project_safe_startup_seconds"));
       if (source.hasKey("use_tinytex"))
          useTinytex().setValue(layer, source.getBool("use_tinytex"));
       if (source.hasKey("clean_texi2dvi_output"))


### PR DESCRIPTION
Today, if an R session crashes, the next session that starts will be in the empty project. This is an intentional safety feature that allows users to escape a crash loop: if the contents of a directory cause RStudio to crash when started there, there would be no escape if we kept restarting RStudio in that directory.

However, most crashes are not startup crashes, and so this behavior is usually unwanted. In some configurations it can also lead to data loss because of source database detachment.

This change allows the R session to keep starting in the same directory even after a crash, presuming that the session was alive for a suitable period of time after startup. It does this by writing the `last-project-path` setting (formerly written only on a clean quit).

Fixes https://github.com/rstudio/rstudio/issues/3220.