### PR TITLE
fix handling of single quotes in download option

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1895,7 +1895,8 @@
    .Call("rs_base64decode", data, binary)
 })
 
-.rs.addFunction("CRANDownloadOptionsString", function() {
+.rs.addFunction("CRANDownloadOptionsString", function()
+{
    
    # collect options of interest
    options <- options("repos", "download.file.method", "download.file.extra", "HTTPUserAgent")
@@ -1905,10 +1906,21 @@
    # drop NULL entries
    options <- Filter(Negate(is.null), options)
    
-   # deparse values individually (avoid relying on the format
+   # deparse values individually. avoid relying on the format
    # of the deparsed output of the whole expression; see e.g.
-   # https://github.com/rstudio/rstudio/issues/4916)
-   vals <- lapply(options, .rs.deparse)
+   # https://github.com/rstudio/rstudio/issues/4916 for example
+   # of where this can fail
+   vals <- lapply(options, function(option) {
+      
+      # replace single quotes with double quotes, so that
+      # deparse automatically escapes the inner quotes
+      # see: https://github.com/rstudio/rstudio/issues/6597
+      # (note these will be translated to single quotes later)
+      if (is.character(option))
+         option <- gsub("'", "\"", option)
+      
+      .rs.deparse(option)
+   })
    
    # join keys and values
    keyvals <- paste(names(options), vals, sep = " = ")

--- a/src/cpp/tests/testthat/test-codetools.R
+++ b/src/cpp/tests/testthat/test-codetools.R
@@ -1,0 +1,46 @@
+#
+# test-codetools.R
+#
+# Copyright (C) 2009-20 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("codetools")
+
+test_that(".rs.CRANDownloadOptionsString() generates a valid R expression", {
+   
+   # restore options when done
+   op <- options()
+   on.exit(options(op), add = TRUE)
+   
+   options(
+      repos = c(CRAN = "https://cran.rstudio.com"),
+      download.file.method = "libcurl",
+      download.file.extra = NULL,
+      HTTPUserAgent = "dummy"
+   )
+   
+   actual <- .rs.CRANDownloadOptionsString()
+   expected <- "options(repos = c(CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl', HTTPUserAgent = 'dummy')"
+   expect_equal(actual, expected)
+   
+   # https://github.com/rstudio/rstudio/issues/6597
+   options(download.file.extra = "embedded 'quotes'")
+   actual <- .rs.CRANDownloadOptionsString()
+   expected <- "options(repos = c(CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl', download.file.extra = 'embedded \\'quotes\\'', HTTPUserAgent = 'dummy')"
+   expect_equal(actual, expected)
+   
+   options(download.file.extra = "embedded \"quotes\"")
+   actual <- .rs.CRANDownloadOptionsString()
+   expected <- "options(repos = c(CRAN = 'https://cran.rstudio.com'), download.file.method = 'libcurl', download.file.extra = 'embedded \\'quotes\\'', HTTPUserAgent = 'dummy')"
+   expect_equal(actual, expected)
+   
+})


### PR DESCRIPTION
This PR fixes an issue where single quotes within R strings were not correctly escaped when constructing the download file options.

Closes #6597.