### PR TITLE
remove hard-coded console shortcuts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -29,7 +29,6 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
-import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -652,30 +651,6 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                   case 'L':
                      Shell.this.onConsoleClear();
                      event.preventDefault();
-                     break;
-               }
-            }
-            else if (mod == KeyboardShortcut.ALT)
-            {
-               if (KeyboardHelper.isHyphenKeycode(keyCode))
-               {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  input_.replaceSelection(" <- ", true);
-               }
-            }
-            else if (
-                  (BrowseCap.hasMetaKey() && 
-                   (mod == (KeyboardShortcut.META + KeyboardShortcut.SHIFT))) ||
-                  (!BrowseCap.hasMetaKey() && 
-                   (mod == (KeyboardShortcut.CTRL + KeyboardShortcut.SHIFT))))
-            {
-               switch (keyCode)
-               {
-                  case KeyCodes.KEY_M:
-                     event.preventDefault();
-                     event.stopPropagation();
-                     input_.replaceSelection(" %>% ", true);
                      break;
                }
             }


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6593.

Note that these commands are now handled as regular shortcuts, and we have a dispatch mechanism here:

https://github.com/rstudio/rstudio/blob/f70874ee337814ee547103bb17f31bd0cb8418bf/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorCommandDispatcher.java#L75-L81

The idea here is that the command is fired to all Ace instances, and only the one which is currently focused will take any action in response to the shortcut. Since the console is ultimately just another Ace instance, we can just rely on this dispatch and avoid hard-coding the shortcuts here.