### PR TITLE
use shebang to infer filetype when appropriate

### DIFF
--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -65,15 +65,6 @@ namespace rstudio {
 namespace session {
 namespace source_database {
 
-// static members
-const char * const SourceDocument::SourceDocumentTypeSweave    = "sweave";
-const char * const SourceDocument::SourceDocumentTypeRSource   = "r_source";
-const char * const SourceDocument::SourceDocumentTypeRMarkdown = "r_markdown";
-const char * const SourceDocument::SourceDocumentTypeRHTML     = "r_html";
-const char * const SourceDocument::SourceDocumentTypeCpp       = "cpp";
-const char * const SourceDocument::SourceDocumentTypeJS        = "js";
-const char * const SourceDocument::SourceDocumentTypeSQL       = "sql";
-
 namespace {
 
 // cached mapping of document id to document path (facilitates efficient path

--- a/src/cpp/session/include/session/SessionSourceDatabase.hpp
+++ b/src/cpp/session/include/session/SessionSourceDatabase.hpp
@@ -28,6 +28,17 @@
 
 #include <r/RSexp.hpp>
 
+#define kSourceDocumentTypeCpp       "cpp"
+#define kSourceDocumentTypeJS        "js"
+#define kSourceDocumentTypePython    "python"
+#define kSourceDocumentTypeRHTML     "r_html"
+#define kSourceDocumentTypeRMarkdown "r_markdown"
+#define kSourceDocumentTypeRSource   "r_source"
+#define kSourceDocumentTypeSQL       "sql"
+#define kSourceDocumentTypeShell     "sh"
+#define kSourceDocumentTypeSweave    "sweave"
+
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -127,24 +138,24 @@ public:
       type_ = type;
    }
    
-   bool isRMarkdownDocument() const { return type_ == SourceDocumentTypeRMarkdown; }
+   bool isRMarkdownDocument() const { return type_ == kSourceDocumentTypeRMarkdown; }
    
    // is this an R, or potentially R-containing, source file?
    // TODO: Export these types as an 'enum' and provide converters.
    bool canContainRCode()
    {
       return type_.size() > 0 && (
-               type_ == SourceDocumentTypeSweave ||
-               type_ == SourceDocumentTypeRSource ||
-               type_ == SourceDocumentTypeRMarkdown ||
-               type_ == SourceDocumentTypeRHTML ||
-               type_ == SourceDocumentTypeCpp);
+               type_ == kSourceDocumentTypeSweave ||
+               type_ == kSourceDocumentTypeRSource ||
+               type_ == kSourceDocumentTypeRMarkdown ||
+               type_ == kSourceDocumentTypeRHTML ||
+               type_ == kSourceDocumentTypeCpp);
    }
    
    // is this a straight R source file?
    bool isRFile()
    {
-      return type_.size() > 0 && type_ == SourceDocumentTypeRSource;
+      return type_.size() > 0 && type_ == kSourceDocumentTypeRSource;
    }
 
    core::Error readFromJson(core::json::Object* pDocJson);
@@ -174,16 +185,6 @@ private:
    std::string collabServer_;
    std::string sourceWindow_;
    core::json::Object properties_;
-   
-public:
-   
-   static const char * const SourceDocumentTypeSweave;
-   static const char * const SourceDocumentTypeRSource;
-   static const char * const SourceDocumentTypeRMarkdown;
-   static const char * const SourceDocumentTypeRHTML;
-   static const char * const SourceDocumentTypeCpp;
-   static const char * const SourceDocumentTypeJS;
-   static const char * const SourceDocumentTypeSQL;
 
 };
 

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -69,19 +69,19 @@ Error extractRCode(const std::string& fileContents,
    using namespace source_database;
    Error error = Success();
    
-   if (documentType == SourceDocument::SourceDocumentTypeRSource)
+   if (documentType == kSourceDocumentTypeRSource)
       *pCode = fileContents;
-   else if (documentType == SourceDocument::SourceDocumentTypeRMarkdown)
+   else if (documentType == kSourceDocumentTypeRMarkdown)
       error = extractRCode(fileContents,
                            "^\\s*[`]{3}{\\s*[Rr](?:}|[\\s,].*})\\s*$",
                            "^\\s*[`]{3}\\s*$",
                            pCode);
-   else if (documentType == SourceDocument::SourceDocumentTypeSweave)
+   else if (documentType == kSourceDocumentTypeSweave)
       error = extractRCode(fileContents,
                            "^\\s*<<.*>>=\\s*$",
                            "^\\s*@\\s*$",
                            pCode);
-   else if (documentType == SourceDocument::SourceDocumentTypeCpp)
+   else if (documentType == kSourceDocumentTypeCpp)
       error = extractRCode(fileContents,
                            "^\\s*/[*]{3,}\\s*[rR]\\s*$",
                            "^\\s*[*]+/",

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -82,6 +82,7 @@ std::string inferDocumentType(const FilePath& documentPath,
    // try to read the first line
    std::string line;
    std::getline(ifs, line);
+   ifs.close();
    
    // check for a shebang line
    if (!boost::algorithm::starts_with(line, "#!"))

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -93,7 +93,9 @@ std::string inferDocumentType(const FilePath& documentPath,
    boost::sregex_token_iterator end;
    for (; it != end; ++it)
    {
-      std::cerr << *it << std::endl;
+      // skip things that look like flags
+      if (boost::algorithm::starts_with(*it, "-"))
+         continue;
       
       // check for common shells
       for (auto&& shell : {"sh", "bash", "fish", "zsh"})

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -99,7 +99,7 @@ std::string inferDocumentType(const FilePath& documentPath,
          continue;
       
       // check for common shells
-      for (auto&& shell : {"sh", "bash", "fish", "zsh"})
+      for (auto&& shell : {"bash", "csh", "fish", "ksh", "zsh"})
          if (*it == shell)
             return kSourceDocumentTypeShell;
       

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -103,7 +103,7 @@ std::string inferDocumentType(const FilePath& documentPath,
             return kSourceDocumentTypeShell;
       
       // check for R
-      for (auto&& r : {"R", "Rscript"})
+      for (auto&& r : {"r", "R", "Rscript"})
          if (*it == r)
             return kSourceDocumentTypeRSource;
       

--- a/src/cpp/session/modules/customsource/SessionCustomSource.cpp
+++ b/src/cpp/session/modules/customsource/SessionCustomSource.cpp
@@ -45,7 +45,7 @@ namespace {
 std::string onDetectSourceType(
       boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
-   if ((pDoc->type() == source_database::SourceDocument::SourceDocumentTypeRSource))
+   if ((pDoc->type() == kSourceDocumentTypeRSource))
    {
       static const boost::regex reCustomSourceComment("^#\\s*!source\\s+\\w+.*$");
       std::string contents = pDoc->contents();

--- a/src/cpp/session/modules/preview/SessionPreview.cpp
+++ b/src/cpp/session/modules/preview/SessionPreview.cpp
@@ -46,7 +46,7 @@ namespace {
 std::string onDetectSourceType(
       boost::shared_ptr<source_database::SourceDocument> pDoc)
 {
-   if ((pDoc->type() == source_database::SourceDocument::SourceDocumentTypeJS))
+   if ((pDoc->type() == kSourceDocumentTypeJS))
    {
       static const boost::regex rePreviewComment("^//\\s*!preview\\s+\\w+( |\\().*$");
       std::string contents = pDoc->contents();
@@ -56,7 +56,7 @@ std::string onDetectSourceType(
       }
    }
 
-   if ((pDoc->type() == source_database::SourceDocument::SourceDocumentTypeSQL))
+   if ((pDoc->type() == kSourceDocumentTypeSQL))
    {
       static const boost::regex rePreviewComment("^--\\s*!preview\\s+\\w+.*$");
       std::string contents = pDoc->contents();

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -575,7 +575,7 @@ Error extractRmdFromNotebook(const json::JsonRpcRequest& request,
       using namespace source_database;
 
       boost::shared_ptr<SourceDocument> pDoc(
-            new SourceDocument(SourceDocument::SourceDocumentTypeRMarkdown));
+            new SourceDocument(kSourceDocumentTypeRMarkdown));
       pDoc->setContents(nbRmdContents);
       error = put(pDoc);
       if (error)


### PR DESCRIPTION
For files which have an unknown / "text" file type, attempt to infer an appropriate source filetype based on the shebang in the file (if any).

Closes https://github.com/rstudio/rstudio/issues/5643.