### PR TITLE
disable JobsListTests GWT unit test due to slowness

### DIFF
--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -1,7 +1,7 @@
 /*
  * RStudioUnitTestSuite.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -24,7 +24,8 @@ import org.rstudio.core.client.dom.DomUtilsTests;
 import org.rstudio.studio.client.application.model.SessionScopeTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
-import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
+// Disabled in v1.4 due to slowness. See #6613.
+// import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
 // Disabled in v1.3 due to failures. See #4249.
 // import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
@@ -52,7 +53,8 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       // Disabled in v1.3 due to failures. See #4249.
       // suite.addTestSuite(RChunkHeaderParserTests.class);
       suite.addTestSuite(SessionScopeTests.class);
-      suite.addTestSuite(JobsListTests.class);
+      // Disabled in 1.4 due to slowness. See #6613.
+      // suite.addTestSuite(JobsListTests.class);
       suite.addTestSuite(ElementIdsTests.class);
       
       // Pro-only tests


### PR DESCRIPTION
- See #6613 for background