### PR TITLE
windows dockerfile tweaks

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -4,13 +4,14 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2019
 
 # set RUN commands to use powershell
-SHELL ["powershell"]
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
 # Note: keep installed dependencies in-sync with Install-RStudio-Prereqs.ps1 for consistency
 # between dev machines and the build machine.
 
 # install chocolatey
-RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
+RUN $env:chocolateyUseWindowsCompression = 'true'; `
+    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # install some deps via chocolatey


### PR DESCRIPTION
- use Windows decompression tools instead of 7zip

Worth a try; works on my Dockerfile build (but the original ways was also working so...).