### PR TITLE
Fix "Move Focus to Console"

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -57,7 +57,9 @@ public class ConsolePane extends WorkbenchPane
                       Commands commands,
                       Session session)
    {
-      super("Console", events);
+      // We pass null in place of events here to prevent ActivePaneEvent from being called.
+      // ActivatePaneEvent isn't necessary and causes an exception for the Console Pane.
+      super("Console", null);
 
       consoleProvider_ = consoleProvider;
       progressProvider_ = progressProvider;


### PR DESCRIPTION
PR #6428 broke 'Move focus to Console' by calling the ActivatePaneEvent for it when this command doesn't work properly for the Console Pane. This fix prevents the event from being fired. 