### PR TITLE
bug fix for opening large files 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -3343,7 +3343,7 @@ public class Source implements InsertSourceHandler,
 
    private void confirmOpenLargeFile(FileSystemItem file,
                                      Operation openOperation,
-                                     Operation cancelOperation)
+                                     Operation noOperation)
    {
       StringBuilder msg = new StringBuilder();
       msg.append("The source file '" + file.getName() + "' is large (");
@@ -3353,7 +3353,9 @@ public class Source implements InsertSourceHandler,
       globalDisplay_.showYesNoMessage(GlobalDisplay.MSG_WARNING,
                                       "Confirm Open",
                                       msg.toString(),
+                                      false, // Don't include cancel
                                       openOperation,
+                                      noOperation,
                                       false);   // 'No' is default
    }
 


### PR DESCRIPTION
Fixes #6637 
The Yes/No call for opening large files was not clearing the file from `openFileQueue_` when the user chose to not open it. This was preventing future files from being opened.
![image](https://user-images.githubusercontent.com/5323711/79031314-d20fb180-7b52-11ea-998f-8ea55d9110fa.png)
