### PR TITLE
Make style consistent for named args in chunk opts

### DIFF
--- a/src/cpp/session/resources/templates/document.Rmd
+++ b/src/cpp/session/resources/templates/document.Rmd
@@ -1,4 +1,4 @@
-```{r setup, include=FALSE}
+```{r setup, include = FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
@@ -16,7 +16,7 @@ summary(cars)
 
 You can also embed plots, for example:
 
-```{r pressure, echo=FALSE}
+```{r pressure, echo = FALSE}
 plot(pressure)
 ```
 


### PR DESCRIPTION
The `include=FALSE` (no spaces) immediately followed by `echo = TRUE` (with spaces) is inconsistent. Should apply to other skeletons as well.