### PR TITLE
remove detection of chromeframe plugin

### DIFF
--- a/src/cpp/core/BrowserUtils.cpp
+++ b/src/cpp/core/BrowserUtils.cpp
@@ -1,7 +1,7 @@
 /*
  * BrowserUtils.cpp
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -50,14 +50,14 @@ bool hasRequiredBrowserVersion(const std::string& userAgent,
 
 bool isChrome(const std::string& userAgent)
 {
-   return contains(userAgent, "Chrome") || contains(userAgent, "chromeframe");
+   return contains(userAgent, "Chrome");
 }
 
 bool isChromeOlderThan(const std::string& userAgent, double version)
 {
    if (isChrome(userAgent))
    {
-      boost::regex chromeRegEx("(?:Chrome|chromeframe)/(\\d{1,4})");
+      boost::regex chromeRegEx("(?:Chrome)/(\\d{1,4})");
       return !hasRequiredBrowserVersion(userAgent, chromeRegEx, version);
    }
    else

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -1,7 +1,7 @@
 /*
  * Response.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -374,9 +374,7 @@ void Response::setFrameOptionHeaders(const std::string& options)
 // mark this request's user agent compatibility
 void Response::setBrowserCompatible(const Request& request)
 {
-   if (boost::algorithm::contains(request.userAgent(), "chromeframe"))
-      setHeader("X-UA-Compatible", "chrome=1");
-   else if (boost::algorithm::contains(request.userAgent(), "Trident"))
+   if (boost::algorithm::contains(request.userAgent(), "Trident"))
       setHeader("X-UA-Compatible", "IE=edge");
 }
 


### PR DESCRIPTION
Chromeframe was an Internet Explorer plugin that allow hosting Chromium inside IE window. This was retired in 2014 and should not be used by anyone at this point, so we don't need to detect it.

https://www.chromium.org/developers/how-tos/chrome-frame-getting-started