### PR TITLE
Sort file names naturally in the Files pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 
 * Any tab can be hidden from view through Global Options. (#6428)
 
+### Misc
+
+* The Files pane now sorts file names naturally, so that e.g. `step10.R` comes after `step9.R`. (#5766)
+
 ### Bugfixes
 
 * Fixed an issue where hovering mouse cursor over C++ completion popup would steal focus. (#5941)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -239,6 +239,7 @@ namespace prefs {
 #define kShowRmdRenderCommand "show_rmd_render_command"
 #define kEnableTextDrag "enable_text_drag"
 #define kShowHiddenFiles "show_hidden_files"
+#define kSortFileNamesNaturally "sort_file_names_naturally"
 #define kJobsTabVisibility "jobs_tab_visibility"
 #define kJobsTabVisibilityClosed "closed"
 #define kJobsTabVisibilityShown "shown"
@@ -1141,6 +1142,12 @@ public:
     */
    bool showHiddenFiles();
    core::Error setShowHiddenFiles(bool val);
+
+   /**
+    * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R
+    */
+   bool sortFileNamesNaturally();
+   core::Error setSortFileNamesNaturally(bool val);
 
    /**
     * The visibility of the Jobs tab.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1753,6 +1753,19 @@ core::Error UserPrefValues::setShowHiddenFiles(bool val)
 }
 
 /**
+ * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R
+ */
+bool UserPrefValues::sortFileNamesNaturally()
+{
+   return readPref<bool>("sort_file_names_naturally");
+}
+
+core::Error UserPrefValues::setSortFileNamesNaturally(bool val)
+{
+   return writePref("sort_file_names_naturally", val);
+}
+
+/**
  * The visibility of the Jobs tab.
  */
 std::string UserPrefValues::jobsTabVisibility()
@@ -2642,6 +2655,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kShowRmdRenderCommand,
       kEnableTextDrag,
       kShowHiddenFiles,
+      kSortFileNamesNaturally,
       kJobsTabVisibility,
       kShowLauncherJobsTab,
       kLauncherJobsSort,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -771,6 +771,11 @@
             "default": false,
             "description": "Whether to show hidden files in the Files pane."
         },
+        "sort_file_names_naturally": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to sort file names naturally, so that e.g., file10.R comes after file9.R"
+        },
         "jobs_tab_visibility": {
             "type": "string",
             "enum": ["closed", "shown", "default"],

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1451,6 +1451,21 @@ public class StringUtil
       return result;
    }
    
+   /**
+    * Perform a natural order comparison between two strings. Natural ordering
+    * preserves ascending numbers, such that e.g. item10 comes after item9.
+    * 
+    * @param str1 The source string
+    * @param str2 The target string
+    * @return
+    */
+   public static native int naturalOrderCompare(String str1, String str2) /*-{
+      // Coerce null/undefined to empty
+      var val1 = str1 ? str1 : "";
+      var val2 = str2 ? str2 : "";
+      return val1.localeCompare(val2, [], { "numeric": true });
+   }-*/;
+   
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1255,6 +1255,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R
+    */
+   public PrefValue<Boolean> sortFileNamesNaturally()
+   {
+      return bool("sort_file_names_naturally", true);
+   }
+
+   /**
     * The visibility of the Jobs tab.
     */
    public PrefValue<String> jobsTabVisibility()
@@ -2055,6 +2063,8 @@ public class UserPrefsAccessor extends Prefs
          enableTextDrag().setValue(layer, source.getBool("enable_text_drag"));
       if (source.hasKey("show_hidden_files"))
          showHiddenFiles().setValue(layer, source.getBool("show_hidden_files"));
+      if (source.hasKey("sort_file_names_naturally"))
+         sortFileNamesNaturally().setValue(layer, source.getBool("sort_file_names_naturally"));
       if (source.hasKey("jobs_tab_visibility"))
          jobsTabVisibility().setValue(layer, source.getString("jobs_tab_visibility"));
       if (source.hasKey("show_launcher_jobs_tab"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesPane.java
@@ -48,6 +48,7 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.PopupPositioner;
 import org.rstudio.studio.client.workbench.views.files.model.DirectoryListing;
@@ -66,7 +67,8 @@ public class FilesPane extends WorkbenchPane implements Files.Display
                     EventBus events,
                     FileTypeRegistry fileTypeRegistry,
                     Session session,
-                    Provider<FileCommandToolbar> pFileCommandToolbar)
+                    Provider<FileCommandToolbar> pFileCommandToolbar,
+                    Provider<UserPrefs> pPrefs)
    {
       super("Files", events);
       globalDisplay_ = globalDisplay;
@@ -74,6 +76,7 @@ public class FilesPane extends WorkbenchPane implements Files.Display
       fileDialogs_ = fileDialogs;
       fileTypeRegistry_ = fileTypeRegistry;
       pFileCommandToolbar_ = pFileCommandToolbar;
+      pPrefs_ = pPrefs;
       session_ = session;
       ensureWidget();
    }
@@ -299,7 +302,10 @@ public class FilesPane extends WorkbenchPane implements Files.Display
             session_.getSessionInfo().getCloudFolderEnabled());
 
       // create file list and file progress
-      filesList_ = new FilesList(new DisplayObserverProxy(), fileTypeRegistry_);
+      filesList_ = new FilesList(new DisplayObserverProxy(), fileTypeRegistry_,
+            pPrefs_.get().sortFileNamesNaturally().getValue() ? 
+               FilesList.SortOrder.Natural :
+               FilesList.SortOrder.Lexicographic);
 
       DockLayoutPanel dockPanel = new DockLayoutPanel(Unit.PX);
       dockPanel.addNorth(filePathToolbar_, filePathToolbar_.getHeight());
@@ -349,4 +355,5 @@ public class FilesPane extends WorkbenchPane implements Files.Display
    private final FileTypeRegistry fileTypeRegistry_;
    private final Commands commands_;
    private final Provider<FileCommandToolbar> pFileCommandToolbar_;
+   private final Provider<UserPrefs> pPrefs_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesList.java
@@ -1,7 +1,7 @@
 /*
  * FilesList.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -60,10 +60,18 @@ import com.google.gwt.view.client.ProvidesKey;
 
 public class FilesList extends Composite
 {
+   public enum SortOrder
+   {
+      Lexicographic,
+      Natural
+   };
+   
    public FilesList(final Files.Display.Observer observer,
-                    final FileTypeRegistry fileTypeRegistry)
+                    final FileTypeRegistry fileTypeRegistry,
+                    SortOrder order)
    {
       observer_ = observer;
+      order_ = order;
       
       // create data provider and sort handler
       dataProvider_ = new ListDataProvider<FileSystemItem>();
@@ -204,7 +212,17 @@ public class FilesList extends Composite
          @Override
          public int doCompare(FileSystemItem arg0, FileSystemItem arg1)
          {
-            return arg0.getName().compareToIgnoreCase(arg1.getName());
+            if (order_ == SortOrder.Natural)
+            {
+               // Natural ordering (the default) preserves ascending sequences
+               // in filenames
+               return StringUtil.naturalOrderCompare(arg0.getName(), arg1.getName());
+            }
+            else
+            {
+               // Lexicographic ordering is simpler (just goes char by char)
+               return arg0.getName().compareToIgnoreCase(arg1.getName());
+            }
          }
       });
       
@@ -669,6 +687,7 @@ public class FilesList extends Composite
    private final LinkColumn<FileSystemItem> nameColumn_;
    private final TextColumn<FileSystemItem> sizeColumn_;
    private final TextColumn<FileSystemItem> modifiedColumn_;
+   private final SortOrder order_;
    private boolean activeSortColumnAscending_ = true;
    private boolean applyingProgrammaticSort_ = false;
    


### PR DESCRIPTION
This is a small improvement suggested by @mine-cetinkaya-rundel; the Files pane now sorts filenames naturally, preserving ascending sequences. There is a new pref so that this can be turned off by people who really don't like it, but it defaults to on and doesn't have any UI for toggling since we expect most people will prefer natural ordering.

Closes https://github.com/rstudio/rstudio/issues/5766. 