### PR TITLE
add command to Files Pane More menu to copy path to clipboard

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 ### Misc
 
 * The Files pane now sorts file names naturally, so that e.g. `step10.R` comes after `step9.R`. (#5766)
-* New command on More menu copies path in Files Pane to clipboard (#6344)
+* Added command to File pane's "More" menu to copy path to clipboard (#6344)
 
 ### Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,12 +13,10 @@
 
 * Any tab can be hidden from view through Global Options. (#6428)
 
-### Files Pane
-
-* New command on More menu copies path in Files Pane to clipboard (#6344)
 ### Misc
 
 * The Files pane now sorts file names naturally, so that e.g. `step10.R` comes after `step9.R`. (#5766)
+* New command on More menu copies path in Files Pane to clipboard (#6344)
 
 ### Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,10 @@
 
 * Any tab can be hidden from view through Global Options. (#6428)
 
+### Files Pane
+
+* New command on More menu copies path in Files Pane to clipboard (#6344)
+
 ### Bugfixes
 
 * Fixed an issue where hovering mouse cursor over C++ completion popup would steal focus. (#5941)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2254,7 +2254,11 @@ well as menu structures (for main menu and popup menus).
    <cmd id="setAsWorkingDir"
         label="Set As Working Directory"
         rebindable="false"/>
-        
+
+   <cmd id="copyFilesPaneCurrentDirectory"
+        label="Copy Folder Path to Clipboard"
+        rebindable="false"/>
+
    <cmd id="showFolder"
         label="Show Folder in New Window"
         visible="false"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -255,6 +255,7 @@ public abstract class
    public abstract AppCommand layoutZoomFiles();
    public abstract AppCommand goToWorkingDir();
    public abstract AppCommand setAsWorkingDir();
+   public abstract AppCommand copyFilesPaneCurrentDirectory();
    public abstract AppCommand setWorkingDirToFilesPane();
    public abstract AppCommand showFolder();
  

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -26,6 +26,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ColumnSortInfo;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.*;
@@ -580,7 +581,12 @@ public class Files
       view_.bringToFront();
       navigateToDirectory(workbenchContext_.getCurrentWorkingDir());
    }
-   
+
+   void onCopyFilesPaneCurrentDirectory()
+   {
+      DomUtils.copyCodeToClipboard(currentPath_.getPath());
+   }
+
    @Handler
    void onSetAsWorkingDir()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesTab.java
@@ -1,7 +1,7 @@
 /*
  * FilesTab.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -41,6 +41,8 @@ public class FilesTab extends DelayLoadWorkbenchTab<Files>
       public abstract void onSetWorkingDirToFilesPane();
       @Handler
       public abstract void onGoToWorkingDir();
+      @Handler
+      public abstract void onCopyFilesPaneCurrentDirectory();
    }
 
    @Inject

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -1,7 +1,7 @@
 /*
  * FileCommandToolbar.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -49,6 +49,7 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addItem(commands.copyFile().createMenuItem(false));
       moreMenu.addItem(commands.copyFileTo().createMenuItem(false));
       moreMenu.addItem(commands.moveFiles().createMenuItem(false));
+      moreMenu.addItem(commands.copyFilesPaneCurrentDirectory().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands.exportFiles().createMenuItem(false));
       moreMenu.addSeparator();
@@ -58,8 +59,7 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addSeparator();
       moreMenu.addItem(commands.showFolder().createMenuItem(false));
       moreMenu.addSeparator();
-      moreMenu.addItem(new UserPrefMenuItem<Boolean>(
-            prefs.showHiddenFiles(), true, "Show Hidden Files", prefs));
+      moreMenu.addItem(new UserPrefMenuItem<>(prefs.showHiddenFiles(), true, "Show Hidden Files", prefs));
 
       ToolbarMenuButton moreButton = new ToolbarMenuButton(
             "More",


### PR DESCRIPTION
- Fixes #6344

<img width="557" alt="screenshot of Files Pane showing new command on More dropdown menu" src="https://user-images.githubusercontent.com/10569626/79258760-7e49e480-7e40-11ea-93d0-b9bb45f88030.png">
