### PR TITLE
Ensure RStudio document tabs are reopened on first boot from 1.2 -> 1.3

### DIFF
--- a/src/cpp/session/include/session/prefs/Preferences.hpp
+++ b/src/cpp/session/include/session/prefs/Preferences.hpp
@@ -72,14 +72,14 @@ public:
       return T();
    }
 
-   template <typename T> core::Error writePref(const std::string& name, T value)
+   template <typename T> core::Error writePref(int layerPos, const std::string& name, T value)
    {
       core::Error err;
-      auto layer = layers_[userLayer()];
+      auto layer = layers_[layerPos];
       if (!layer)
       {
          core::Error error(core::json::errc::ParamMissing, ERROR_LOCATION);
-         error.addProperty("description", "missing user layer for preference '" + 
+         error.addProperty("description", "missing user layer for preference '" +
                name + "'");
          return error;
       }
@@ -91,6 +91,11 @@ public:
       }
 
       return err;
+   }
+
+   template <typename T> core::Error writePref(const std::string& name, T value)
+   {
+       return writePref(userLayer(), name, value);
    }
 
    // Read/write accessors for the underlying JSON property values

--- a/src/cpp/session/modules/SessionUserPrefsMigration.cpp
+++ b/src/cpp/session/modules/SessionUserPrefsMigration.cpp
@@ -252,7 +252,13 @@ core::Error migratePrefs(const FilePath& src)
    // Migrate state 
    std::string contextId = settings.get("contextIdentifier");
    if (!contextId.empty())
+   {
+      // remove any computed context identifier to ensure that a value is written for the
+      // user-level context ID
+      userState().writePref(STATE_LAYER_COMPUTED, kContextId, "");
       destState[kContextId] = contextId;
+   }
+
    std::string agreementHash = settings.get("agreedToHash");
    if (!agreementHash.empty())
       destState[kAgreementHash] = agreementHash;


### PR DESCRIPTION
This change fixes an issue in which the very first boot of RStudio 1.3 does not show any of the document tabs that were open in a project in RStudio 1.2. 

The problem is that the document tabs are stored beneath a folder scoped using a context identifier. The context identifier is correctly migrated from RStudio 1.2 to RStudio 1.3, but this migration happens later in the boot process. Consequently, the very first boot doesn't have the right ID.

The fix is to read a context ID from the old user settings file into the computed state layer. This causes it to be used as a fallback automatically when we have not yet migrated the context ID. 

Fixes https://github.com/rstudio/rstudio/issues/6661