### PR TITLE
remove checks for older, unsupported R

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -404,21 +404,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    }
 })
 
-# indirection for normalizePath function
-.rs.addFunction("normalizePath", 
-   if(getRversion() < "2.13.0")
-      utils::normalizePath
-   else
-      normalizePath
-)
+# alias for normalizePath function
+.rs.addFunction("normalizePath", normalizePath)
 
-# indirection for path.package function
-.rs.addFunction("pathPackage",
-   if(getRversion() < "2.13.0")
-      .path.package
-   else
-      path.package
-)
+# alias for path.package function
+.rs.addFunction("pathPackage", path.package)
 
 # handle viewing a pdf differently on each platform:
 #  - windows: shell.exec

--- a/src/cpp/session/modules/SessionAuthoring.R
+++ b/src/cpp/session/modules/SessionAuthoring.R
@@ -57,11 +57,9 @@
    sweaveOptions$pdf.version <- "character"
    sweaveOptions$pdf.encoding <- "character"
    sweaveOptions$pdf.compress <-"logical"
-   if (getRversion() >= "2.13.0") {
-      sweaveOptions$png <- "logical"
-      sweaveOptions$jpeg <- "logical"
-      sweaveOptions$grdevice <- "character"
-   }
+   sweaveOptions$png <- "logical"
+   sweaveOptions$jpeg <- "logical"
+   sweaveOptions$grdevice <- "character"
    sweaveOptions$width <- "numeric"
    sweaveOptions$height <- "numeric"
    sweaveOptions$resolution <- "numeric"

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -603,12 +603,7 @@ Error removeAllBreakpoints(const json::JsonRpcRequest&,
 
 bool haveSrcrefAttribute()
 {
-   // check whether this is R 2.14 or greater
-   bool haveSrcref = false;
-   Error error = r::exec::evaluateString("getRversion() >= '2.14.0'", &haveSrcref);
-   if (error)
-      LOG_ERROR(error);
-   return haveSrcref;
+   return true;
 }
 
 bool haveAdvancedStepCommands()

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -76,12 +76,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       .Call("rs_packageUnloaded", pkgname, PACKAGE = "(embedding)")
    }
    
-   # NOTE: `list.dirs()` was introduced with R 2.13 but was buggy until 3.0
-   # (the 'full.names' argument was not properly respected)
-   pkgNames <- if (getRversion() >= "3.0.0")
+   pkgNames <-
       base::list.dirs(.libPaths(), full.names = FALSE, recursive = FALSE)
-   else
-      .packages(TRUE)
    
    sapply(pkgNames, function(packageName)
    {


### PR DESCRIPTION
Now that RStudio requires R >= 3.0.1, we can remove some of these older version checks.