### PR TITLE
Ensure RStudio document tabs are reopened on first boot from 1.2 -> 1.3 

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -475,6 +475,10 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // main module context
       (module_context::initialize)
 
+      // prefs (early init required -- many modules including projects below require
+      // preference access)
+      (modules::prefs::initialize)
+
       // projects (early project init required -- module inits below
       // can then depend on e.g. computed defaultEncoding)
       (projects::initialize)
@@ -501,7 +505,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (r_utils::initialize)
 
       // modules with c++ implementations
-      (modules::prefs::initialize)
       (modules::spelling::initialize)
       (modules::lists::initialize)
       (modules::path::initialize)

--- a/src/cpp/session/include/session/prefs/UserPrefs.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefs.hpp
@@ -1,7 +1,7 @@
 /*
  * UserPrefs.hpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -59,6 +59,8 @@ core::json::Array allPrefLayers();
 core::Error initializePrefs();
 
 core::Error initializeSessionPrefs();
+
+core::Error initializeProjectPrefs();
 
 } // namespace prefs
 } // namespace session

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -411,9 +411,14 @@ Error ProjectContext::initialize()
       // update activeSession
       activeSession().setProject(createAliasedPath(directory()));
 
+      // update scratch paths
+      Error error = computeScratchPaths(file_, &scratchPath_, &sharedScratchPath_);
+      if (error)
+          LOG_ERROR(error);
+
       // read build options for the side effect of updating buildOptions_
       RProjectBuildOptions buildOptions;
-      Error error = readBuildOptions(&buildOptions);
+      error = readBuildOptions(&buildOptions);
       if (error)
          LOG_ERROR(error);
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -984,6 +984,11 @@ Error initialize()
    if (error)
       return error;
 
+   // initialize project-level preferences
+   error = prefs::initializeProjectPrefs();
+   if (error)
+      LOG_ERROR(error);
+
    // subscribe to file_monitor for project file changes
    projects::FileMonitorCallbacks cb;
    cb.onFilesChanged = onFilesChanged;


### PR DESCRIPTION
This change fixes an issue in which the very first boot of RStudio 1.3 does not show any of the document tabs that were open in a project in RStudio 1.2.

The problem is that the document tabs are stored beneath a folder scoped using a context identifier. The context identifier is correctly migrated from RStudio 1.2 to RStudio 1.3, but this migration happens later in the boot process. Consequently, the very first boot doesn't have the right ID.

The fix is to slightly alter the boot order as follows:

1. Break the dependency on project initialization by separating the project pref init from the session/user pref init.
2. Initialize the session/prefs before the project. This causes the old ID to be migrated before we attempt to use it. 
3. Initialize the project-level prefs and recompute scratch paths after all prefs are ready. 

Fixes #6661.