### PR TITLE
add support for Rtools 4.0

### DIFF
--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -65,7 +65,9 @@ private:
 
 std::ostream& operator<<(std::ostream& os, const RToolsInfo& info);
 
-void scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools);
+void scanForRTools(bool usingMingwGcc49,
+                   const std::string& rtoolsHomeEnvVar,
+                   std::vector<RToolsInfo>* pRTools);
 
 template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -22,7 +22,7 @@
 #include <core/Log.hpp>
 #include <core/http/URL.hpp>
 #include <core/StringUtils.hpp>
-#include <core/system/Types.hpp>
+#include <core/system/System.hpp>
 
 #include <core/system/RegistryKey.hpp>
 
@@ -187,6 +187,41 @@ RToolsInfo::RToolsInfo(const std::string& name,
       clangArgs.push_back(
             "-I" + installPath.completeChildPath(bitsInc).getAbsolutePath());
    }
+   else if (name == "4.0")
+   {
+      versionMin = "4.0.0";
+      versionMax = "5.0.0";
+
+      // PATH for utilities
+      relativePathEntries.push_back("usr/bin");
+
+      // set BINPREF
+      environmentVars.push_back({"BINPREF", "/mingw$(WIN)/bin/"});
+
+      // set clang args
+#ifdef _WIN64
+      std::string baseDir = "mingw64";
+      std::string arch = "x86_64";
+#else
+      std::string baseDir = "mingw32";
+      std::string arch = "i686";
+#endif
+
+      // path to mingw includes
+      boost::format mgwIncFmt("%1%/%2%-w64-mingw32/include");
+      std::string mingwIncludeSuffix = boost::str(mgwIncFmt % baseDir % arch);
+      FilePath mingwIncludePath = installPath.completeChildPath(mingwIncludeSuffix);
+      clangArgs.push_back("-I" + mingwIncludePath.getAbsolutePath());
+
+      // path to C++ headers
+      std::string cppSuffix = "c++/8.3.0";
+      FilePath cppIncludePath = installPath.completeChildPath(cppSuffix);
+      clangArgs.push_back("-I" + cppIncludePath.getAbsolutePath());
+   }
+   else
+   {
+      LOG_DEBUG_MESSAGE("Unrecognized Rtools installation at path '" + installPath.getAbsolutePath() + "'");
+   }
 
    // build version predicate and path list if we can
    if (!versionMin.empty())
@@ -206,10 +241,23 @@ RToolsInfo::RToolsInfo(const std::string& name,
 
 std::string RToolsInfo::url(const std::string& repos) const
 {
-   // strip period from name
-   std::string ver = boost::algorithm::replace_all_copy(name(), ".", "");
-   std::string url = core::http::URL::complete(
-                        repos, "bin/windows/Rtools/Rtools" + ver + ".exe");
+   std::string url;
+
+   if (name() == "4.0")
+   {
+      // TODO: Currently, Rtools 4.0 is only available from the 'testing'
+      // sub-directory. Update this URL once it's been promoted.
+      std::string arch = core::system::isWin64() ? "x86_64" : "i686";
+      std::string suffix = "bin/windows/testing/rtools40-" + arch + ".exe";
+      url = core::http::URL::complete(repos, suffix);
+   }
+   else
+   {
+      std::string version = boost::algorithm::replace_all_copy(name(), ".", "");
+      std::string suffix = "bin/windows/Rtools/Rtools" + version + ".exe";
+      url = core::http::URL::complete(repos, suffix);
+   }
+
    return url;
 }
 
@@ -230,6 +278,36 @@ std::ostream& operator<<(std::ostream& os, const RToolsInfo& info)
 }
 
 namespace {
+
+Error scanEnvironmentForRTools(bool usingMingwGcc49,
+                               const std::string& envvar,
+                               std::vector<RToolsInfo>* pRTools)
+{
+   // nothing to do if we have no envvar
+   if (envvar.empty())
+      return Success();
+
+   // read value
+   std::string envval = core::system::getenv(envvar);
+   if (envval.empty())
+      return Success();
+
+   // build info
+   FilePath installPath(envval);
+   RToolsInfo toolsInfo("4.0", installPath, usingMingwGcc49);
+
+   // check that recorded path is valid
+   bool ok =
+       toolsInfo.isStillInstalled() &&
+       toolsInfo.isRecognized();
+
+   // use it if all looks well
+   if (ok)
+      pRTools->push_back(toolsInfo);
+
+   return Success();
+
+}
 
 Error scanRegistryForRTools(HKEY key,
                             bool usingMingwGcc49,
@@ -333,11 +411,14 @@ void scanFoldersForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools
 
 } // end anonymous namespace
 
-void scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools)
+void scanForRTools(bool usingMingwGcc49,
+                   const std::string& rtoolsHomeEnvVar,
+                   std::vector<RToolsInfo>* pRTools)
 {
    std::vector<RToolsInfo> rtoolsInfo;
 
    // scan for Rtools
+   scanEnvironmentForRTools(usingMingwGcc49, rtoolsHomeEnvVar, &rtoolsInfo);
    scanRegistryForRTools(usingMingwGcc49, &rtoolsInfo);
    scanFoldersForRTools(usingMingwGcc49, &rtoolsInfo);
 
@@ -347,6 +428,8 @@ void scanForRTools(bool usingMingwGcc49, std::vector<RToolsInfo>* pRTools)
    {
       if (knownPaths.count(info.installPath()))
          continue;
+
+      knownPaths.insert(info.installPath());
       pRTools->push_back(info);
    }
 

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -136,7 +136,7 @@ void runEmbeddedR(const core::FilePath& rHome,
 
    // more configuration
    pRP->CharacterMode = RGui;
-   pRP->R_Slave = FALSE;
+   pRP->R_NoEcho = FALSE;
    pRP->R_Quiet = quiet ? TRUE : FALSE;
    pRP->R_Interactive = TRUE;
    pRP->SaveAction = defaultSaveAction;

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -18,6 +18,7 @@
 #undef FALSE
 
 #define R_INTERNAL_FUNCTIONS
+#include <Rversion.h>
 #include <r/RInternal.hpp>
 
 #define Win32
@@ -136,7 +137,11 @@ void runEmbeddedR(const core::FilePath& rHome,
 
    // more configuration
    pRP->CharacterMode = RGui;
+#if R_VERSION < R_Version(4, 0, 0)
+   pRP->R_Slave = FALSE;
+#else
    pRP->R_NoEcho = FALSE;
+#endif
    pRP->R_Quiet = quiet ? TRUE : FALSE;
    pRP->R_Interactive = TRUE;
    pRP->SaveAction = defaultSaveAction;

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -28,6 +28,7 @@
 #include <core/r_util/RToolsInfo.hpp>
 
 #include <r/RExec.hpp>
+#include <r/RVersionInfo.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -135,10 +136,17 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
        return false;
     }
 
+    std::string rtoolsHomeEnvVar;
+
+    // Rtools 4.0 will set RTOOLS40_HOME
+    auto rVersion = r::version_info::currentRVersion();
+    if (rVersion.versionMajor() == 4)
+       rtoolsHomeEnvVar = "RTOOLS40_HOME";
+
     // ok so scan for R tools
     bool usingGcc49 = module_context::usingMingwGcc49();
     std::vector<r_util::RToolsInfo> rTools;
-    core::r_util::scanForRTools(usingGcc49, &rTools);
+    core::r_util::scanForRTools(usingGcc49, rtoolsHomeEnvVar, &rTools);
 
     // enumerate them to see if we have a compatible version
     // (go in reverse order for most recent first)

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -37,6 +37,7 @@
 #include <core/libclang/LibClang.hpp>
 
 #include <r/RExec.hpp>
+#include <r/RVersionInfo.hpp>
 
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -989,10 +990,16 @@ std::vector<std::string> RCompilationDatabase::rToolsArgs() const
 #ifdef _WIN32
    if (rToolsArgs_.empty())
    {
+      // Rtools 4.0 will set RTOOLS40_HOME
+      std::string rtoolsHomeEnvVar;
+      auto rVersion = r::version_info::currentRVersion();
+      if (rVersion.versionMajor() == 4)
+         rtoolsHomeEnvVar = "RTOOLS40_HOME";
+
       // scan for Rtools
       bool usingMingwGcc49 = module_context::usingMingwGcc49();
       std::vector<core::r_util::RToolsInfo> rTools;
-      core::r_util::scanForRTools(usingMingwGcc49, &rTools);
+      core::r_util::scanForRTools(usingMingwGcc49, rtoolsHomeEnvVar, &rTools);
 
       // enumerate them to see if we have a compatible version
       // (go in reverse order for most recent first)


### PR DESCRIPTION
NOTE: Not quite ready for merge; pending confirmation on the URL to use for the Rtools installer.

---

The PR adds support for Rtools 4.0, the toolchain used to build packages for the R 4.x.x series.

Note that there are two installers: one for users on 32bit Windows (providing only a 32bit toolchain), and one for 64bit Windows (providing both 32bit and 64bit toolchains). While RStudio itself is now a 64bit application (and hence should only be used with 64bit Windows), I did add indirection for the Rtools installer in any case.