### PR TITLE
Prevent replace exception

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1019,7 +1019,7 @@ private:
          if (!errorMessage.empty())
          {
             json::Array lastErrors = errors.getBack().getArray();
-            errors.erase(errors.end());
+            errors.erase(--errors.end());
             lastErrors.push_back(json::Value(*errorMessage.begin()));
             errors.push_back(lastErrors);
          }


### PR DESCRIPTION
This PR fixes a bug where we would occasionally try to access the wrong iterator.