### PR TITLE
Prevent path traversal: Ignore relative URL path referencing past root

### DIFF
--- a/src/cpp/core/http/URL.cpp
+++ b/src/cpp/core/http/URL.cpp
@@ -125,7 +125,12 @@ public:
 
          if (dirs_.at(i) == "..")
          {
-            if (!result.empty() && result.back() != "..")
+            if (result.empty())
+            {
+               continue;
+            }
+
+            if (result.back() != "..")
             {
                result.pop_back();
                continue;
@@ -185,7 +190,9 @@ std::string getDir(std::string fileOrDirPath)
    return fileOrDirPath;
 }
 
-std::string cleanupPath(std::string path)
+} // anonymous namespace
+
+std::string URL::cleanupPath(std::string path)
 {
    std::string suffix;
    splitParts(path, &path, &suffix);
@@ -195,8 +202,6 @@ std::string cleanupPath(std::string path)
    return richPath.value() + suffix;
 }
 
-} // anonymous namespace
-   
 std::string URL::complete(std::string absoluteUri, std::string targetUri)
 {
    URL uri(targetUri);
@@ -224,7 +229,7 @@ std::string URL::complete(std::string absoluteUri, std::string targetUri)
    else
       path = path + targetUri;
 
-   return prefix + cleanupPath(path);
+   return prefix + URL::cleanupPath(path);
 }
 
 std::string URL::uncomplete(std::string baseUri, std::string targetUri)
@@ -285,6 +290,8 @@ void URL::test()
    BOOST_ASSERT(cleanupPath("/foo/?/../") == "/foo/?/../");
    BOOST_ASSERT(cleanupPath("/foo/#/../") == "/foo/#/../");
    BOOST_ASSERT(cleanupPath("/foo/?/../#/../") == "/foo/?/../#/../");
+   BOOST_ASSERT(cleanupPath("/foo/bar/../../../") == "/");
+   BOOST_ASSERT(cleanupPath("/foo/bar/../../../baz") == "/baz");
 
    BOOST_ASSERT(complete("http://www.example.com", "foo") == "http://www.example.com/foo");
    BOOST_ASSERT(complete("http://www.example.com/foo", "bar") == "http://www.example.com/bar");
@@ -298,8 +305,8 @@ void URL::test()
 
    BOOST_ASSERT(complete("foo/bar/", "baz/qux") == "foo/bar/baz/qux");
    BOOST_ASSERT(complete("foo/bar/", "../baz/qux") == "foo/baz/qux");
-   BOOST_ASSERT(complete("../foo/bar/", "../baz/qux") == "../foo/baz/qux");
-   BOOST_ASSERT(complete("../../foo/bar/", "../baz/qux") == "../../foo/baz/qux");
+   BOOST_ASSERT(complete("../foo/bar/", "../baz/qux") == "foo/baz/qux");
+   BOOST_ASSERT(complete("../../foo/bar/", "../baz/qux") == "foo/baz/qux");
 
    BOOST_ASSERT(uncomplete("/foo/bar/baz", "/foo/qux/quux") == "../qux/quux");
    BOOST_ASSERT(uncomplete("/foo/bar/baz/", "/foo/qux/quux") == "../../qux/quux");

--- a/src/cpp/core/http/URLTests.cpp
+++ b/src/cpp/core/http/URLTests.cpp
@@ -25,6 +25,11 @@ namespace util {
 
 test_context("HttpUtil Tests")
 {
+   test_that("URL pass")
+   {
+      URL::test();
+   }
+
    test_that("Can parse simple url")
    {
       URL url("http://www.google.com");

--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -27,6 +27,7 @@
 #include <boost/regex.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 
+#include <core/http/URL.hpp>
 #include <core/http/Header.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
@@ -376,7 +377,8 @@ std::string pathAfterPrefix(const Request& request,
                             const std::string& pathPrefix)
 {
    // get the raw uri & strip its location prefix
-   std::string uri = request.uri();
+   std::string uri = URL::cleanupPath(request.uri());
+   
    if (!pathPrefix.empty() && !uri.compare(0, pathPrefix.length(), pathPrefix))
       uri = uri.substr(pathPrefix.length());
 

--- a/src/cpp/core/include/core/http/URL.hpp
+++ b/src/cpp/core/include/core/http/URL.hpp
@@ -103,6 +103,7 @@ public:
       return absoluteURL_ != other.absoluteURL_;
    }
    
+   static std::string cleanupPath(std::string path);
    static std::string complete(std::string absoluteUri, std::string targetUri);
    static std::string uncomplete(std::string baseUri, std::string targetUri);
 


### PR DESCRIPTION
Closes #1495

This PR adds a protection against path traversal in some scenarios.
The core of this change is the implementation of `core::http::Path::cleanup()`.
Goal: Pair each occurrence of `../` with a removal of an item from the path.
Before: If there was no matching pair (it was already on the "root") the `../` was preserved.
Now: If there's no matching pair, the `../` is discarded.

The new behavior is similar to how NGINX handles relative paths.
That was detected when comparing open source and pro.

With the change above, `core::http::URL::complete()` will start to discard extraneous `../`.
The `boost::test` gig present in `URL` was included in `core/http/URLTests.cpp` to be sure we keep testing these changes.

The second part of this change is exposing `core::http::URL::cleanupPath()` as a public function.
This function calls `core::http::Path::cleanup()`.

Finally, the `core::http::pathAfterPrefix()` function calls `cleanupPath()` ensuring that we thwart any attempts of path traversal, including `/help` which was the originally affected path.

