### PR TITLE
Fall back rstudio service installation path to /usr/lib/systemd

### DIFF
--- a/package/linux/debian-control/postinst.in
+++ b/package/linux/debian-control/postinst.in
@@ -77,7 +77,16 @@ if test "$INIT_SYSTEM" = "systemd"
 then
    systemctl stop rstudio-server.service 2>/dev/null
    systemctl disable rstudio-server.service 2>/dev/null
-   cp ${CMAKE_INSTALL_PREFIX}/extras/systemd/rstudio-server.service /lib/systemd/system/rstudio-server.service
+  
+   if test -f /lib/systemd
+   then
+      SYSTEMD_PREFIX="/lib/systemd"
+   else
+      SYSTEMD_PREFIX="/usr/lib/systemd"
+   fi
+
+   cp ${CMAKE_INSTALL_PREFIX}/extras/systemd/rstudio-server.service $${EMPTY}{SYSTEMD_PREFIX}/system/rstudio-server.service
+  
    systemctl daemon-reload
    systemctl enable rstudio-server.service
    systemctl start rstudio-server.service

--- a/package/linux/debian-control/postrm.in
+++ b/package/linux/debian-control/postrm.in
@@ -30,6 +30,7 @@ then
    systemctl stop rstudio-server.service 2>/dev/null
    systemctl disable rstudio-server.service 2>/dev/null
    rm -rf /lib/systemd/system/rstudio-server.service
+   rm -rf /usr/lib/systemd/system/rstudio-server.service
    systemctl daemon-reload
 fi
 

--- a/package/linux/rpm-script/postinst.sh.in
+++ b/package/linux/rpm-script/postinst.sh.in
@@ -102,7 +102,16 @@ then
    
    systemctl stop rstudio-server.service 2>/dev/null
    systemctl disable rstudio-server.service 2>/dev/null
-   cp ${CMAKE_INSTALL_PREFIX}/extras/systemd/rstudio-server.redhat.service /lib/systemd/system/rstudio-server.service
+
+   if test -f /lib/systemd
+   then
+      SYSTEMD_PREFIX="/lib/systemd"
+   else
+      SYSTEMD_PREFIX="/usr/lib/systemd"
+   fi
+
+   cp ${CMAKE_INSTALL_PREFIX}/extras/systemd/rstudio-server.redhat.service $${EMPTY}{SYSTEMD_PREFIX}/system/rstudio-server.service
+
    systemctl daemon-reload
    systemctl enable rstudio-server.service
    systemctl start rstudio-server.service

--- a/package/linux/rpm-script/postrm.sh.in
+++ b/package/linux/rpm-script/postrm.sh.in
@@ -33,6 +33,7 @@ then
       systemctl stop rstudio-server.service 2>/dev/null
       systemctl disable rstudio-server.service 2>/dev/null
       rm -rf /lib/systemd/system/rstudio-server.service
+      rm -rf /usr/lib/systemd/system/rstudio-server.service
       systemctl daemon-reload
    fi
 


### PR DESCRIPTION
Fall back on installing rstudio service scripts at `/usr/lib/systemd` if `/lib/systemd` does not exist.

Fixes https://github.com/rstudio/rstudio-pro/issues/1612