### PR TITLE
Change default sqlite database path from /var/run to /var/lib to ensure it is not deleted on reboot

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -557,6 +557,7 @@ int main(int argc, char * const argv[])
       if (error)
          return core::system::exitFailure(error, ERROR_LOCATION);
 
+      boost::optional<system::User> serverUser;
       if (core::system::effectiveUserIsRoot())
       {
          auto shouldChown = [&](int depth, const FilePath& file)
@@ -574,12 +575,14 @@ int main(int argc, char * const argv[])
             return true;
          };
 
-         system::User serverUser;
-         error = system::User::getUserFromIdentifier(options.serverUser(), serverUser);
+         system::User serverUserObj;
+         error = system::User::getUserFromIdentifier(options.serverUser(), serverUserObj);
          if (error)
             return core::system::exitFailure(error, ERROR_LOCATION);
 
-         error = serverDataDir.changeOwnership(serverUser, true, shouldChown);
+         serverUser = serverUserObj;
+
+         error = serverDataDir.changeOwnership(serverUserObj, true, shouldChown);
          if (error)
          {
             error.addProperty("description",
@@ -632,7 +635,7 @@ int main(int argc, char * const argv[])
          return core::system::exitFailure(error, ERROR_LOCATION);
 
       // initialize database connectivity
-      error = server_core::database::initialize(true);
+      error = server_core::database::initialize(true, serverUser);
       if (error)
          return core::system::exitFailure(error, ERROR_LOCATION);
 

--- a/src/cpp/server/extras/conf/database.conf
+++ b/src/cpp/server/extras/conf/database.conf
@@ -12,7 +12,7 @@
 # Specifies the database provider to use
 #provider=sqlite
 # Directory in which the sqlite database will be written
-#directory=/var/run/rstudio-server
+#directory=/var/lib/rstudio-server
 # =========================================================================================================
 # postgresql configuration
 # =========================================================================================================

--- a/src/cpp/server_core/include/server_core/ServerDatabase.hpp
+++ b/src/cpp/server_core/include/server_core/ServerDatabase.hpp
@@ -16,23 +16,21 @@
 #ifndef SERVER_CORE_SERVER_DATABASE_HPP
 #define SERVER_CORE_SERVER_DATABASE_HPP
 
+#include <boost/optional.hpp>
+
 #include <core/Database.hpp>
+
 #include <shared_core/Error.hpp>
+#include <shared_core/system/User.hpp>
 
 namespace rstudio {
-
-namespace core {
-
-class Error;
-
-} // namespace core
-
 namespace server_core {
 namespace database {
 
 // initialize server database, optionally performing migration
 // to the latest database schema version
-core::Error initialize(bool updateSchema = false);
+core::Error initialize(bool updateSchema = false,
+                       const boost::optional<core::system::User>& databaseFileUser = boost::none);
 
 boost::shared_ptr<core::database::IConnection> getConnection();
 bool getConnection(const boost::posix_time::time_duration& waitTime,


### PR DESCRIPTION
Let me know if you think this indeed does need the XDG treatment. Reading through the spec it looked to me like there was only a concept for a user data dir, not a system data dir, so I've forgone the XDG treatment.

Fixes #6706