### PR TITLE
better handle attempts to save / re-open mis-encoded documents

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -525,7 +525,9 @@ Error saveDocumentDiff(const json::JsonRpcRequest& request,
    if (pDoc->hash() != hash)
       return Success();
    
-   // attempt the document save
+   // attempt the document save. note that if this fails,
+   // we won't set a response hash and RStudio will take this as a signal
+   // to attempt a 'full' document save rather than just a diff-based save
    try
    {
       std::string contents(pDoc->contents());

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -536,7 +536,7 @@ Error saveDocumentDiff(const json::JsonRpcRequest& request,
       // constructed a diff to be saved; we leave this in while still
       // going down this code path just to ensure that any code that
       // runs in response to a document save (even if that save fails)
-      // stil has a change to run
+      // still has a chance to run
       if (valid)
       {
          // the offsets we receive are in bytes, so we can replace the contents

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -7572,12 +7572,7 @@ public class TextEditingTarget implements
       // Cancel any existing autosave timer
       autoSaveTimer_.cancel();
       
-      // Bail if autosaves are suspended for now
-      if (autoSaveSuspended_)
-         return;
-      
-      // Bail if disalbed
-      // Start new timer if enabled
+      // Bail if not enabled
       if (prefs_.autoSaveOnIdle().getValue() != UserPrefs.AUTO_SAVE_ON_IDLE_COMMIT)
          return;
       
@@ -7656,7 +7651,6 @@ public class TextEditingTarget implements
    private EditingTargetCodeExecution codeExecution_;
    
    // Timer for autosave
-   private boolean autoSaveSuspended_;
    private Timer autoSaveTimer_ = new Timer()
    {
       @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3245,7 +3245,7 @@ public class TextEditingTarget implements
                () -> action.execute(),
                () -> {},
                () -> {},
-               "Open Document",
+               "Reopen Document",
                "Cancel",
                true);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -722,10 +722,15 @@ public class DocUpdateSentinel
       }
    }
    
+   public void suspendAutosave(boolean value)
+   {
+      suspendAutosave_ = value;
+   }
+   
    public void onValueChange(ValueChangeEvent<Void> voidValueChangeEvent)
    {
       changesPending_ = true;
-      if (autosaver_ != null)
+      if (autosaver_ != null && !suspendAutosave_)
          autosaver_.nudge();
    }
 
@@ -733,7 +738,7 @@ public class DocUpdateSentinel
    public void onFoldChange(FoldChangeEvent event)
    {
       changesPending_ = true;
-      if (autosaver_ != null)
+      if (autosaver_ != null && !suspendAutosave_)
          autosaver_.nudge();
    }
    
@@ -833,6 +838,7 @@ public class DocUpdateSentinel
       }
    }
    
+   private boolean suspendAutosave_ = false;
    private boolean changesPending_ = false;
    private final ChangeTracker changeTracker_;
    private final SourceServerOperations server_;


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6709.

This PR bundles a few changes together:

1. We disable the autosaver when first initializing a document, as we want to avoid "spurious" document saves when the document is first opened. This is especially important for the case where the document has been opened with an incorrect encoding (and so the repesentation of that document within the RStudio editor is incorrect).

2. We handle exceptions that occur when attempting to save a document diff, since `.replace()` can throw an exception here.

3. When attempting to re-open a document with a different encoding, we no longer attempt a save before re-opening the document. This is for the same reason as in (1) -- if the user is attempting to re-open a document in a particular encoding, it's likely because the document was not correctly decoded in the current encoding, and so it's unlikely the user wants to save the document before re-opening.

Candidate for v1.3-patch backport, which is a bit uncomfortable given the lower-level changes here but I believe it's necessary.