### PR TITLE
Move URL::test to testthat

### DIFF
--- a/src/cpp/core/http/URL.cpp
+++ b/src/cpp/core/http/URL.cpp
@@ -274,45 +274,6 @@ std::string URL::uncomplete(std::string baseUri, std::string targetUri)
    return to.value() + targetExtra;
 }
 
-void URL::test()
-{
-   BOOST_ASSERT(cleanupPath("") == "");
-   BOOST_ASSERT(cleanupPath("/") == "/");
-   BOOST_ASSERT(cleanupPath("./") == "");
-   BOOST_ASSERT(cleanupPath("/./") == "/");
-   BOOST_ASSERT(cleanupPath("/.") == "/.");
-   BOOST_ASSERT(cleanupPath("/foo/../") == "/");
-   BOOST_ASSERT(cleanupPath("foo/../") == "");
-   BOOST_ASSERT(cleanupPath("/foo/bar/../../") == "/");
-   BOOST_ASSERT(cleanupPath("foo/bar/../../") == "");
-   BOOST_ASSERT(cleanupPath("/foo/bar/../../") == "/");
-   BOOST_ASSERT(cleanupPath("/foo/bar/../..") == "/foo/..");
-   BOOST_ASSERT(cleanupPath("/foo/?/../") == "/foo/?/../");
-   BOOST_ASSERT(cleanupPath("/foo/#/../") == "/foo/#/../");
-   BOOST_ASSERT(cleanupPath("/foo/?/../#/../") == "/foo/?/../#/../");
-   BOOST_ASSERT(cleanupPath("/foo/bar/../../../") == "/");
-   BOOST_ASSERT(cleanupPath("/foo/bar/../../../baz") == "/baz");
-
-   BOOST_ASSERT(complete("http://www.example.com", "foo") == "http://www.example.com/foo");
-   BOOST_ASSERT(complete("http://www.example.com/foo", "bar") == "http://www.example.com/bar");
-   BOOST_ASSERT(complete("http://www.example.com/foo/", "bar") == "http://www.example.com/foo/bar");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/", "/bar") == "http://www.example.com:80/bar");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/bar", "baz/qux") == "http://www.example.com:80/foo/baz/qux");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/bar", "../baz/qux") == "http://www.example.com:80/baz/qux");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/bar/", "../baz/qux") == "http://www.example.com:80/foo/baz/qux");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/bar/", "baz/../qux") == "http://www.example.com:80/foo/bar/qux");
-   BOOST_ASSERT(complete("http://www.example.com:80/foo/bar", "http://baz") == "http://baz");
-
-   BOOST_ASSERT(complete("foo/bar/", "baz/qux") == "foo/bar/baz/qux");
-   BOOST_ASSERT(complete("foo/bar/", "../baz/qux") == "foo/baz/qux");
-   BOOST_ASSERT(complete("../foo/bar/", "../baz/qux") == "foo/baz/qux");
-   BOOST_ASSERT(complete("../../foo/bar/", "../baz/qux") == "foo/baz/qux");
-
-   BOOST_ASSERT(uncomplete("/foo/bar/baz", "/foo/qux/quux") == "../qux/quux");
-   BOOST_ASSERT(uncomplete("/foo/bar/baz/", "/foo/qux/quux") == "../../qux/quux");
-   BOOST_ASSERT(uncomplete("/bar/baz", "/qux/quux") == "../qux/quux");
-}
- 
 } // namespace http
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/http/URLTests.cpp
+++ b/src/cpp/core/http/URLTests.cpp
@@ -1,7 +1,7 @@
 /*
  * URLTests.cpp
  *
- * Copyright (C) 2018 by RStudio, PBC
+ * Copyright (C) 2018-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -25,11 +25,6 @@ namespace util {
 
 test_context("HttpUtil Tests")
 {
-   test_that("URL pass")
-   {
-      URL::test();
-   }
-
    test_that("Can parse simple url")
    {
       URL url("http://www.google.com");
@@ -95,6 +90,51 @@ test_context("HttpUtil Tests")
       URL url("127.0.0.1");
 
       expect_false(url.isValid());
+   }
+
+   test_that("Can clean up paths")
+   {
+      expect_equal(URL::cleanupPath(""), "");
+      expect_equal(URL::cleanupPath("/"), "/");
+      expect_equal(URL::cleanupPath("./"), "");
+      expect_equal(URL::cleanupPath("/./"), "/");
+      expect_equal(URL::cleanupPath("/."), "/.");
+      expect_equal(URL::cleanupPath("/foo/../"), "/");
+      expect_equal(URL::cleanupPath("foo/../"), "");
+      expect_equal(URL::cleanupPath("/foo/bar/../../"), "/");
+      expect_equal(URL::cleanupPath("foo/bar/../../"), "");
+      expect_equal(URL::cleanupPath("/foo/bar/../../"), "/");
+      expect_equal(URL::cleanupPath("/foo/bar/../.."), "/foo/..");
+      expect_equal(URL::cleanupPath("/foo/?/../"), "/foo/?/../");
+      expect_equal(URL::cleanupPath("/foo/#/../"), "/foo/#/../");
+      expect_equal(URL::cleanupPath("/foo/?/../#/../"), "/foo/?/../#/../");
+      expect_equal(URL::cleanupPath("/foo/bar/../../../"), "/");
+      expect_equal(URL::cleanupPath("/foo/bar/../../../baz"), "/baz");
+   }
+
+   test_that("Can complete URLs")
+   {
+      expect_equal(URL::complete("http://www.example.com", "foo"), "http://www.example.com/foo");
+      expect_equal(URL::complete("http://www.example.com/foo", "bar"), "http://www.example.com/bar");
+      expect_equal(URL::complete("http://www.example.com/foo/", "bar"), "http://www.example.com/foo/bar");
+      expect_equal(URL::complete("http://www.example.com:80/foo/", "/bar"), "http://www.example.com:80/bar");
+      expect_equal(URL::complete("http://www.example.com:80/foo/bar", "baz/qux"), "http://www.example.com:80/foo/baz/qux");
+      expect_equal(URL::complete("http://www.example.com:80/foo/bar", "../baz/qux"), "http://www.example.com:80/baz/qux");
+      expect_equal(URL::complete("http://www.example.com:80/foo/bar/", "../baz/qux"), "http://www.example.com:80/foo/baz/qux");
+      expect_equal(URL::complete("http://www.example.com:80/foo/bar/", "baz/../qux"), "http://www.example.com:80/foo/bar/qux");
+      expect_equal(URL::complete("http://www.example.com:80/foo/bar", "http://baz"), "http://baz");
+
+      expect_equal(URL::complete("foo/bar/", "baz/qux"), "foo/bar/baz/qux");
+      expect_equal(URL::complete("foo/bar/", "../baz/qux"), "foo/baz/qux");
+      expect_equal(URL::complete("../foo/bar/", "../baz/qux"), "foo/baz/qux");
+      expect_equal(URL::complete("../../foo/bar/", "../baz/qux"), "foo/baz/qux");
+   }
+
+   test_that("Can uncomplete URLs")
+   {
+      expect_equal(URL::uncomplete("/foo/bar/baz", "/foo/qux/quux"), "../qux/quux");
+      expect_equal(URL::uncomplete("/foo/bar/baz/", "/foo/qux/quux"), "../../qux/quux");
+      expect_equal(URL::uncomplete("/bar/baz", "/qux/quux"), "../qux/quux");
    }
 }
 

--- a/src/cpp/core/include/core/http/URL.hpp
+++ b/src/cpp/core/include/core/http/URL.hpp
@@ -107,8 +107,6 @@ public:
    static std::string complete(std::string absoluteUri, std::string targetUri);
    static std::string uncomplete(std::string baseUri, std::string targetUri);
 
-   static void test();
-
 private:
   
    void assign(const URL& rhs)


### PR DESCRIPTION
Quick change to move URL tests from BOOST_ASSERT to testthat like the rest of our tests.