### PR TITLE
fix pane max/min behavior

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
@@ -88,7 +88,12 @@ public class WindowFrameButton extends FocusWidget
    {
       if (isAttached() && clickHandler_ != null)
       {
-         releaseOnUnload_.add(super.addClickHandler(event -> click()));
+         releaseOnUnload_.add(super.addClickHandler(clickEvent ->
+         {
+            clickEvent.preventDefault();
+            clickEvent.stopPropagation();
+            click();
+         }));
 
          releaseOnUnload_.add(addKeyPressHandler(event ->
          {


### PR DESCRIPTION
- Fixes #6721
- I believe this meets the bar as a ship-stopper (sorry...)
- Caused by missing event suppression when I refactored window frame button click handler into a shared UI component; note that the keyboard handler path was doing this, and continued working properly
- While investigating discovered essentially the same problem exists with double-click, and repros in 1.1, 1.2, and 1.3 (#6724); since that's not a regression and obviously hasn't caused much grief, not fixing in 1.3
- QA notes: please test various pane max/min/restore behaviors, both with and without the reduced UI animation accessibility setting checked; some of this behavior is a bit unintuitive, so best to compare against 1.2 behavior (goal is for it to behave the same way)