### PR TITLE
fix ensure visible behavior

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2591,12 +2591,12 @@ body.rstudio-themes-flat .rstudio-themes-dark-grey {
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs table.rstheme_tabLayoutCenter,
 .rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject table.rstheme_tabLayoutCenter {
-   background: THEME_DARKGREY_INACTIVE;
+   background: THEME_DARKGREY_INACTIVE !important;
 }
 
 .rstudio-themes-flat .rstudio-themes-dark-grey .gwt-TabLayoutPanelTabs,
 .rstudio-themes-flat .rstudio-themes-dark-grey .rstheme_minimizedWindowObject .rstheme_center {
-   background: THEME_DARKGREY_MOST_INACTIVE;
+   background: THEME_DARKGREY_MOST_INACTIVE !important;
 }
 
 @if user.agent safari {

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -417,7 +417,6 @@ public class ShellWidget extends Composite implements ShellDisplay,
          prompt = consolify(prompt);
 
       prompt_.getElement().setInnerText(prompt);
-      //input_.clear();
       ensureInputVisible();
 
       // Deal gracefully with multi-line prompts
@@ -433,7 +432,16 @@ public class ShellWidget extends Composite implements ShellDisplay,
    @Override
    public void ensureInputVisible()
    {
-      scrollIntoView();
+      // NOTE: we don't scroll immediately as this is normally called
+      // in response to mutations of the console input buffer, and so
+      // we need to wait until Ace has finished rendering in response
+      // to that change.
+      scrollIntoViewPending_ = true;
+      
+      Scheduler.get().scheduleFinally(() ->
+      {
+         checkForPendingScroll();
+      });
    }
    
    private String getErrorClass()

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -439,11 +439,14 @@ public class ShellWidget extends Composite implements ShellDisplay,
       // in response to mutations of the console input buffer, and so
       // we need to wait until Ace has finished rendering in response
       // to that change.
-      scrollIntoViewPending_ = true;
-      
-      // In case there wasn't an Ace render in-flight, force a check
+      //
+      // In case there wasn't an Ace render in-flight, we also force a check
       // for pending scroll (which will then force the cursor into view)
-      Scheduler.get().scheduleDeferred(() -> checkForPendingScroll());
+      if (!scrollIntoViewPending_)
+      {
+         scrollIntoViewPending_ = true;
+         Scheduler.get().scheduleDeferred(() -> checkForPendingScroll());
+      }
    }
    
    private String getErrorClass()


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6703.

Also bundles a brown-bag CSS fix for IE11 -- the empty space in a tab panel was not being styled for dark themes.

<img width="533" alt="Screen Shot 2020-04-24 at 3 02 02 PM" src="https://user-images.githubusercontent.com/1976582/80261687-f635bd00-863f-11ea-9a91-f6ae7ecfe709.png">


