### PR TITLE
Use separate state files for desktop and server

### DIFF
--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -83,7 +83,7 @@ void writeUserPrefs(std::ostream& ostr)
          ostr);
    writeFile("System prefs", core::system::xdg::systemConfigFile("rstudio-prefs.json"),
          ostr);
-   writeFile("User state", core::system::xdg::userDataDir().completePath("rstudio-state.json"),
+   writeFile("User state", core::system::xdg::userDataDir().completePath("rstudio-desktop.json"),
          ostr);
 }
 

--- a/src/cpp/session/include/session/prefs/UserState.hpp
+++ b/src/cpp/session/include/session/prefs/UserState.hpp
@@ -1,7 +1,7 @@
 /*
  * SessionUserState.hpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,7 +16,8 @@
 #ifndef SESSION_USER_STATE_HPP
 #define SESSION_USER_STATE_HPP
 
-#define kUserStateFile "rstudio-state.json"
+#define kUserStateFileDesktop "rstudio-desktop.json"
+#define kUserStateFileServer "rstudio-server.json"
 #define kUserStateSchemaFile "user-state-schema.json"
 
 #include "UserStateValues.hpp"

--- a/src/cpp/session/prefs/UserStateLayer.cpp
+++ b/src/cpp/session/prefs/UserStateLayer.cpp
@@ -33,7 +33,10 @@ UserStateLayer::UserStateLayer():
 
 core::Error UserStateLayer::readPrefs()
 {
-   prefsFile_ = core::system::xdg::userDataDir().completePath(kUserStateFile);
+   prefsFile_ = core::system::xdg::userDataDir().completePath(
+         options().programMode() == kSessionProgramModeDesktop ? 
+            kUserStateFileDesktop : 
+            kUserStateFileServer);
 
    return loadPrefsFromFile(prefsFile_,
       options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile));


### PR DESCRIPTION
We currently store RStudio's per-user state in `~/.local/share/rstudio/rstudio-state.json`. This means that both desktop and server share per-user state, which can cause conflicts when RStudio Desktop and RStudio Server are both used with the same account. 

The fix is to store them in separate files in the same folder (`rstudio-desktop.json` and `rstudio-server.json`). This causes them to use different context IDs, which in turn gives them different source databases. 

Fixes https://github.com/rstudio/rstudio/issues/6742.