### PR TITLE
Sync publish path even when type has not changed

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2947,6 +2947,10 @@ public class TextEditingTarget implements
    @Override
    public void adaptToExtendedFileType(String extendedType)
    {
+      // extended type can affect publish options; we need to sync here even if the type
+      // hasn't changed as the path may have changed
+      syncPublishPath(docUpdateSentinel_.getPath());
+
       // ignore if unchanged
       if (StringUtil.equals(extendedType, extendedType_))
          return;
@@ -2955,9 +2959,6 @@ public class TextEditingTarget implements
       if (extendedType == SourceDocument.XT_RMARKDOWN)
          updateRmdFormatList();
       extendedType_ = extendedType;
-
-      // extended type can affect publish options
-      syncPublishPath(docUpdateSentinel_.getPath());
    }
 
    @Override


### PR DESCRIPTION
This change fixes an issue in which the Publish button doesn't treat a file as saved if it was unsaved when the file was first opened.

The problem is that we notify the Publish button that the file has been saved through an oblique path that relies on a side effect of an extended type change; the fix is to restore this path even when the type hasn't actually changed.

A more complete (and better) fix would be to listen for changes to the path in the DocUpdateSentinel and sync the publish button to those changes. That would eliminate this class of bugs entirely and probably get rid of our manual `syncPublishPath` invocations. However as we're very late in 1.3 it's saner to simply restore the existing behavior. 

Fixes https://github.com/rstudio/rstudio/issues/6711. 