### PR TITLE
avoid popping console input on failure to read

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -329,8 +329,10 @@ bool rConsoleRead(const std::string& prompt,
          LOG_ERROR(error);
          *pConsoleInput = rstudio::r::session::RConsoleInput("", "");
       }
-      
-      popConsoleInput(pConsoleInput);
+      else
+      {
+         popConsoleInput(pConsoleInput);
+      }
    }
 
    // fire onBeforeExecute and onConsoleInput events if this isn't a cancel


### PR DESCRIPTION
Potential fix for crashes of this form:

https://sentry.io/organizations/rstudio/issues/1629008167/?project=1379214&query=_platform_memmove%24VARIANT%24Haswell&statsPeriod=14d

My hypothesis: if an attempt to read console input fails, we still attempt to pop an RConsoleInput object off of the (currently empty) buffer of pending inputs. This basically gives us a pointer to garbage memory, and we later see a crash when attempts to use that memory fail (evidently, occurring within a Boost signal handler).

That said, it seems equally unlikely that we could get an invalid `console_input` RPC request, so this is mainly speculative.