### PR TITLE
Fix issue where invalid connections were being added to the connection map

### DIFF
--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -356,8 +356,6 @@ private:
                      this, _1, _2)
       ));
 
-      addConnection(ptrNextConnection_);
-
       // wait for next connection
       acceptorService_.asyncAccept(
          ptrNextConnection_->socket(),
@@ -373,6 +371,7 @@ private:
       {
          if (!ec) 
          {
+            addConnection(ptrNextConnection_);
             ptrNextConnection_->startReading();
          }
          else


### PR DESCRIPTION
This was caused by adding them when `acceptNextConnection()` was called, instead of adding them once the accept has successfully completed, which is the real indicator that a connection has been accepted/started.

The motivation of this fix was noticing that the Launcher tests were hanging fairly frequently recently, and they all seem to hang around calls to `AsyncServerImpl::stop()`, which is where I added the new connection tracking code.

I didn't see any other issues in this area, so I want to see if this is sufficient to fix the unit test hangs.

This is targeted for v1.3 not v1.3-patch - let me know if this should be changed. I wanted this to start showing up in builds to affect the unit tests ASAP.