### PR TITLE
Read old RStudio 1.3 state file if it exists

### DIFF
--- a/src/cpp/session/prefs/UserStateLayer.cpp
+++ b/src/cpp/session/prefs/UserStateLayer.cpp
@@ -1,7 +1,7 @@
 /*
  * UserStateLayer.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -33,18 +33,34 @@ UserStateLayer::UserStateLayer():
 
 core::Error UserStateLayer::readPrefs()
 {
-   prefsFile_ = core::system::xdg::userDataDir().completePath(
+   FilePath schemaFile = options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile);
+
+   // desktop and server versions of RStudio use separate state files so that mixing desktop and server
+   // on the same machine is possible w/o side effects like sharing a source database
+   stateFile_ = core::system::xdg::userDataDir().completePath(
          options().programMode() == kSessionProgramModeDesktop ? 
             kUserStateFileDesktop : 
             kUserStateFileServer);
 
-   return loadPrefsFromFile(prefsFile_,
-      options().rResourcesPath().completePath("schema").completePath(kUserStateSchemaFile));
+   if (!stateFile_.exists())
+   {
+      // if there's no state file yet, check for a state file left by an older version of RStudio 1.3
+      FilePath oldStateFile = core::system::xdg::userDataDir().completePath("rstudio-state.json");
+      if (oldStateFile.exists())
+      {
+          // found an old file; attempt to migrate it
+          Error error = oldStateFile.move(stateFile_);
+          if (error)
+              LOG_ERROR(error);
+      }
+   }
+
+   return loadPrefsFromFile(stateFile_, schemaFile);
 }
 
 core::Error UserStateLayer::writePrefs(const core::json::Object &prefs)
 {
-   if (prefsFile_.isEmpty())
+   if (stateFile_.isEmpty())
    {
       return fileNotFoundError(ERROR_LOCATION);
    }
@@ -55,7 +71,7 @@ core::Error UserStateLayer::writePrefs(const core::json::Object &prefs)
    }
    END_LOCK_MUTEX
 
-   return writePrefsToFile(*cache_, prefsFile_);
+   return writePrefsToFile(*cache_, stateFile_);
 }
 
 } // namespace prefs

--- a/src/cpp/session/prefs/UserStateLayer.hpp
+++ b/src/cpp/session/prefs/UserStateLayer.hpp
@@ -1,7 +1,7 @@
 /*
  * UserStateLayer.hpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,7 +29,7 @@ public:
    core::Error readPrefs();
    core::Error writePrefs(const core::json::Object &prefs);
 private:
-   core::FilePath prefsFile_;
+   core::FilePath stateFile_;
 };
 
 } // namespace prefs


### PR DESCRIPTION
We recently moved to separate state files for desktop and server (see https://github.com/rstudio/rstudio/issues/6742). However, they were both new files, which means that if you used an older version of the 1.3 preview you'll lose your context ID and therefore your open tabs.

This change fixes that issue by migrating the old state file if it exists. 

(note: user preferences tag is because this is closely related to the preference system)

Will be backported to 1.3.