### PR TITLE
Add comment-highlight FG color and fix theme unit tests

### DIFF
--- a/src/cpp/session/resources/themes/ambiance.rstheme
+++ b/src/cpp/session/resources/themes/ambiance.rstheme
@@ -187,7 +187,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/chaos.rstheme
+++ b/src/cpp/session/resources/themes/chaos.rstheme
@@ -163,7 +163,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/chrome.rstheme
+++ b/src/cpp/session/resources/themes/chrome.rstheme
@@ -136,7 +136,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/clouds.rstheme
+++ b/src/cpp/session/resources/themes/clouds.rstheme
@@ -105,7 +105,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/clouds_midnight.rstheme
+++ b/src/cpp/session/resources/themes/clouds_midnight.rstheme
@@ -106,7 +106,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/cobalt.rstheme
+++ b/src/cpp/session/resources/themes/cobalt.rstheme
@@ -122,7 +122,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/compile-themes.R
+++ b/src/cpp/session/resources/themes/compile-themes.R
@@ -510,14 +510,22 @@
 })
 
 .rs.addFunction("createCommentBgRule", function(themeName, isDark, overrides = list()) {
-   commentBgColor <- overrides[[themeName]]
-   if (is.null(commentBgColor))
-      commentBgColor <- if (isDark) "#D1B78A" else "#FFECCB"
+   commentFgColor <- if (isDark) "#4D4333" else "#3C4C72"
+   commentBgColor <- if (isDark) "#D1B78A" else "#FFECCB"
+   
+   override <- overrides[[themeName]]
+   if (!is.null(override) && !is.null(override$fg))
+      commentFgColor <- override$fg
+   
+   if (!is.null(override) && !is.null(override$bg))
+      commentBgColor <- override$bg
    
    sprintf(paste(sep = "\n",
                  ".ace_comment-highlight {",
-                 "  background-color: %s",
+                 "  color: %s;",
+                 "  background-color: %s;",
                  "}"),
+           commentFgColor,
            commentBgColor)
 })
 

--- a/src/cpp/session/resources/themes/crimson_editor.rstheme
+++ b/src/cpp/session/resources/themes/crimson_editor.rstheme
@@ -127,7 +127,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dawn.rstheme
+++ b/src/cpp/session/resources/themes/dawn.rstheme
@@ -118,7 +118,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -144,7 +144,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/dreamweaver.rstheme
+++ b/src/cpp/session/resources/themes/dreamweaver.rstheme
@@ -152,7 +152,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/eclipse.rstheme
+++ b/src/cpp/session/resources/themes/eclipse.rstheme
@@ -105,7 +105,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/gob.rstheme
+++ b/src/cpp/session/resources/themes/gob.rstheme
@@ -121,7 +121,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/idle_fingers.rstheme
+++ b/src/cpp/session/resources/themes/idle_fingers.rstheme
@@ -106,7 +106,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/iplastic.rstheme
+++ b/src/cpp/session/resources/themes/iplastic.rstheme
@@ -130,7 +130,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/katzenmilch.rstheme
+++ b/src/cpp/session/resources/themes/katzenmilch.rstheme
@@ -132,7 +132,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/kr_theme.rstheme
+++ b/src/cpp/session/resources/themes/kr_theme.rstheme
@@ -114,7 +114,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/merbivore.rstheme
+++ b/src/cpp/session/resources/themes/merbivore.rstheme
@@ -105,7 +105,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/merbivore_soft.rstheme
+++ b/src/cpp/session/resources/themes/merbivore_soft.rstheme
@@ -106,7 +106,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/mono_industrial.rstheme
+++ b/src/cpp/session/resources/themes/mono_industrial.rstheme
@@ -117,7 +117,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/monokai.rstheme
+++ b/src/cpp/session/resources/themes/monokai.rstheme
@@ -115,7 +115,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/pastel_on_dark.rstheme
+++ b/src/cpp/session/resources/themes/pastel_on_dark.rstheme
@@ -118,7 +118,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/solarized_dark.rstheme
+++ b/src/cpp/session/resources/themes/solarized_dark.rstheme
@@ -98,7 +98,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/solarized_light.rstheme
+++ b/src/cpp/session/resources/themes/solarized_light.rstheme
@@ -101,7 +101,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: #FFDDA2
+  color: #5A776B;
+  background-color: #FAE5B7;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/sqlserver.rstheme
+++ b/src/cpp/session/resources/themes/sqlserver.rstheme
@@ -146,7 +146,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/textmate.rstheme
+++ b/src/cpp/session/resources/themes/textmate.rstheme
@@ -138,7 +138,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow.rstheme
@@ -118,7 +118,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night.rstheme
@@ -118,7 +118,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_blue.rstheme
@@ -116,7 +116,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_bright.rstheme
@@ -131,7 +131,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/session/resources/themes/tomorrow_night_eighties.rstheme
@@ -118,7 +118,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/twilight.rstheme
+++ b/src/cpp/session/resources/themes/twilight.rstheme
@@ -119,7 +119,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/vibrant_ink.rstheme
+++ b/src/cpp/session/resources/themes/vibrant_ink.rstheme
@@ -104,7 +104,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/session/resources/themes/xcode.rstheme
+++ b/src/cpp/session/resources/themes/xcode.rstheme
@@ -98,7 +98,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/DebugLine.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/DebugLine.rstheme
@@ -139,7 +139,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/active4d.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/active4d.rstheme
@@ -162,7 +162,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/all_hallows_eve.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/all_hallows_eve.rstheme
@@ -132,7 +132,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/amy.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/amy.rstheme
@@ -165,7 +165,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/blackboard.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/blackboard.rstheme
@@ -139,7 +139,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/brilliance_black.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/brilliance_black.rstheme
@@ -188,7 +188,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/brilliance_dull.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/brilliance_dull.rstheme
@@ -196,7 +196,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/chrome_dev_tools.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/chrome_dev_tools.rstheme
@@ -159,7 +159,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/clouds.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/clouds.rstheme
@@ -157,7 +157,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/clouds_midnight.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/clouds_midnight.rstheme
@@ -158,7 +158,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/cobalt.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/cobalt.rstheme
@@ -161,7 +161,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/dawn.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/dawn.rstheme
@@ -167,7 +167,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/dreamweaver.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/dreamweaver.rstheme
@@ -109,7 +109,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/eiffel.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/eiffel.rstheme
@@ -195,7 +195,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/espresso_libre.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/espresso_libre.rstheme
@@ -200,7 +200,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/git_hub.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/git_hub.rstheme
@@ -211,7 +211,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/i_plastic.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/i_plastic.rstheme
@@ -176,7 +176,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/idle.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/idle.rstheme
@@ -143,7 +143,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/idle_fingers.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/idle_fingers.rstheme
@@ -155,7 +155,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/katzenmilch.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/katzenmilch.rstheme
@@ -193,7 +193,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/kr_theme.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/kr_theme.rstheme
@@ -159,7 +159,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/kuroir_theme.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/kuroir_theme.rstheme
@@ -174,7 +174,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/lazy.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/lazy.rstheme
@@ -139,7 +139,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/magic_wb_amiga.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/magic_wb_amiga.rstheme
@@ -193,7 +193,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/merbivore.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/merbivore.rstheme
@@ -169,7 +169,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/merbivore_soft.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/merbivore_soft.rstheme
@@ -176,7 +176,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/mono_industrial.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/mono_industrial.rstheme
@@ -169,7 +169,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/monokai.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/monokai.rstheme
@@ -188,7 +188,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/pastels_on_dark.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/pastels_on_dark.rstheme
@@ -169,7 +169,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/slush_and_poppies.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/slush_and_poppies.rstheme
@@ -132,7 +132,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/solarized_dark.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/solarized_dark.rstheme
@@ -170,7 +170,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/solarized_light.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/solarized_light.rstheme
@@ -169,7 +169,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/sunburst.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/sunburst.rstheme
@@ -167,7 +167,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/textmate.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/textmate.rstheme
@@ -211,7 +211,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow.rstheme
@@ -204,7 +204,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night.rstheme
@@ -204,7 +204,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_blue.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_blue.rstheme
@@ -204,7 +204,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_bright.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_bright.rstheme
@@ -204,7 +204,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_eighties.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/tomorrow_night_eighties.rstheme
@@ -199,7 +199,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/twilight.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/twilight.rstheme
@@ -177,7 +177,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/vibrant_ink.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/vibrant_ink.rstheme
@@ -155,7 +155,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/xcode_default.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/xcode_default.rstheme
@@ -162,7 +162,8 @@
   background-color: rgb(102, 155, 243)
 }
 .ace_comment-highlight {
-  background-color: rgb(254, 155, 243)
+  color: #3C4C72;
+  background-color: #FFECCB;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/cpp/tests/testthat/themes/rsthemes/zenburnesque.rstheme
+++ b/src/cpp/tests/testthat/themes/rsthemes/zenburnesque.rstheme
@@ -130,7 +130,8 @@
   background-color: #fb6f1c
 }
 .ace_comment-highlight {
-  background-color: #5C4916
+  color: #4D4333;
+  background-color: #D1B78A;
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;

--- a/src/gwt/tools/compile-themes.R
+++ b/src/gwt/tools/compile-themes.R
@@ -101,7 +101,7 @@ node_selector_map <- list(
 )
 
 comment_bg_map <- list(
-   "solarized_light" = "#FFDDA2",
+   "solarized_light" = list( "fg" = "#5A776B", "bg" = "#FAE5B7" ),
    "solarized_dark" = NULL,
    "twilight" = NULL,
    "idle_fingers" = NULL,


### PR DESCRIPTION
Closes #6743.

`ace_comment-highlight` foreground defaults come from here: https://github.com/rstudio/rstudio/blob/736b25ead36ff6c9f396f226eb7e7d8a41b9074e/src/gwt/src/org/rstudio/studio/client/panmirror/theme/PanmirrorThemeCreator.java#L75-L89