### PR TITLE
Add toggle for soft wrap mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * `XDG_CONFIG_DIRS` can be used to specify alternate directories for server configuration files. (Pro #1607)
 * For added security, all cookies are now marked as `SameSite=Lax`. The new option `www-iframe-embedding` marks cookies as `SameSite=None` so RStudio can be used embedded in an IFrame. The new option `www-legacy-cookies` provides a behavior compatible with older browsers. (#6608)
 * RStudio now infers document type from shebang (e.g. #!/usr/bin/env sh) for R, Python and shell scripts (#5643)
+* New option to configure soft wrapping for R Markdown files, and command to change the soft wrap mode of the editor on the fly (#2341)
 
 ### RStudio Server Pro
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -136,6 +136,7 @@ namespace prefs {
 #define kReindentOnPaste "reindent_on_paste"
 #define kVerticallyAlignArgumentsIndent "vertically_align_arguments_indent"
 #define kSoftWrapRFiles "soft_wrap_r_files"
+#define kSoftWrapRmdFiles "soft_wrap_rmd_files"
 #define kFocusConsoleAfterExec "focus_console_after_exec"
 #define kFoldStyle "fold_style"
 #define kFoldStyleBeginOnly "begin-only"
@@ -724,6 +725,12 @@ public:
     */
    bool softWrapRFiles();
    core::Error setSoftWrapRFiles(bool val);
+
+   /**
+    * Whether to soft-wrap R Markdown files (and similar types such as R HTML and R Notebooks)
+    */
+   bool softWrapRmdFiles();
+   core::Error setSoftWrapRmdFiles(bool val);
 
    /**
     * Whether to focus the R console after executing an R command from a script.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -843,6 +843,19 @@ core::Error UserPrefValues::setSoftWrapRFiles(bool val)
 }
 
 /**
+ * Whether to soft-wrap R Markdown files (and similar types such as R HTML and R Notebooks)
+ */
+bool UserPrefValues::softWrapRmdFiles()
+{
+   return readPref<bool>("soft_wrap_rmd_files");
+}
+
+core::Error UserPrefValues::setSoftWrapRmdFiles(bool val)
+{
+   return writePref("soft_wrap_rmd_files", val);
+}
+
+/**
  * Whether to focus the R console after executing an R command from a script.
  */
 bool UserPrefValues::focusConsoleAfterExec()
@@ -2611,6 +2624,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kReindentOnPaste,
       kVerticallyAlignArgumentsIndent,
       kSoftWrapRFiles,
+      kSoftWrapRmdFiles,
       kFocusConsoleAfterExec,
       kFoldStyle,
       kSaveBeforeSourcing,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -411,6 +411,11 @@
             "default": false,
             "description": "Whether to soft-wrap R source files, wrapping the text for display without inserting newline characters."
         },
+        "soft_wrap_rmd_files": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to soft-wrap R Markdown files (and similar types such as R HTML and R Notebooks)"
+        },
         "focus_console_after_exec": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/RWebContentFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/RWebContentFileType.java
@@ -1,7 +1,7 @@
 /*
  * RWebContentFileType.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.common.filetypes;
 import com.google.gwt.resources.client.ImageResource;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
 import org.rstudio.studio.client.workbench.commands.Commands;
 
@@ -74,6 +75,12 @@ public class RWebContentFileType extends TextFileType
       result.add(commands.goToDefinition());
       result.add(commands.insertRoxygenSkeleton());
       return result;
+   }
+
+   @Override
+   public boolean getWordWrap()
+   {
+      return RStudioGinjector.INSTANCE.getUserPrefs().softWrapRmdFiles().getValue();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -1,7 +1,7 @@
 /*
  * TextFileType.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -456,6 +456,7 @@ public class TextFileType extends EditableFileType
       results.add(commands.sendToTerminal());
       results.add(commands.sendFilenameToTerminal());
       results.add(commands.openNewTerminalAtEditorLocation());
+      results.add(commands.toggleSoftWrapMode());
 
       return results;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -208,6 +208,7 @@ well as menu structures (for main menu and popup menus).
          <cmd refid="goToFileFunction"/>
          <separator/>
          <cmd refid="toggleDocumentOutline"/>
+         <cmd refid="toggleSoftWrapMode"/>
          <separator/>
          <cmd refid="showDiagnosticsActiveDocument"/>
          <cmd refid="showDiagnosticsProject"/>
@@ -3272,6 +3273,12 @@ well as menu structures (for main menu and popup menus).
    <cmd id="openPreviousFileOnFilesystem"
         label="Open Previous File on Filesystem"/>
         
+   <cmd id="toggleSoftWrapMode"
+        label="Toggle Soft Wrap Mode"
+        menuLabel="Soft Wrap Long Lines"
+        checkable="true"
+        context="editor"/>
+
    <cmd id="maximizeConsole"
         menuLabel="Maximize Console"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -199,6 +199,7 @@ public abstract class
    public abstract AppCommand insertPipeOperator();
    public abstract AppCommand openNextFileOnFilesystem();
    public abstract AppCommand openPreviousFileOnFilesystem();
+   public abstract AppCommand toggleSoftWrapMode();
  
    // Projects
    public abstract AppCommand newProject();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -652,6 +652,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to soft-wrap R Markdown files (and similar types such as R HTML and R Notebooks)
+    */
+   public PrefValue<Boolean> softWrapRmdFiles()
+   {
+      return bool("soft_wrap_rmd_files", true);
+   }
+
+   /**
     * Whether to focus the R console after executing an R command from a script.
     */
    public PrefValue<Boolean> focusConsoleAfterExec()
@@ -1939,6 +1947,8 @@ public class UserPrefsAccessor extends Prefs
          verticallyAlignArgumentsIndent().setValue(layer, source.getBool("vertically_align_arguments_indent"));
       if (source.hasKey("soft_wrap_r_files"))
          softWrapRFiles().setValue(layer, source.getBool("soft_wrap_r_files"));
+      if (source.hasKey("soft_wrap_rmd_files"))
+         softWrapRmdFiles().setValue(layer, source.getBool("soft_wrap_rmd_files"));
       if (source.hasKey("focus_console_after_exec"))
          focusConsoleAfterExec().setValue(layer, source.getBool("focus_console_after_exec"));
       if (source.hasKey("fold_style"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -23,7 +23,9 @@ import org.rstudio.core.client.js.JsObject;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.JsArray;
+import org.rstudio.core.client.JsArrayUtil;
 
 
 /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -47,9 +47,8 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       
       basic.add(headerLabel("R Markdown"));
       
-      basic.add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
       basic.add(checkboxPref("Show document outline by default", prefs_.showDocOutlineRmd()));
-      basic.add(checkboxPref("Enable chunk background highlight", prefs_.highlightCodeChunks()));
+      basic.add(checkboxPref("Soft-wrap R Markdown files", prefs_.softWrapRmdFiles()));
       
       docOutlineDisplay_ = new SelectWidget(
             "Show in document outline: ",
@@ -134,11 +133,6 @@ public class RMarkdownPreferencesPane extends PreferencesPane
          knitWorkingDir_ = null;
       }
       
-      final CheckBox showRmdRenderCommand = checkboxPref(
-            "Display render command in R Markdown tab",
-            prefs_.showRmdRenderCommand());
-      basic.add(showRmdRenderCommand);
-      
       basic.add(spacedBefore(headerLabel("R Notebooks")));
 
       // auto-execute the setup chunk
@@ -159,7 +153,15 @@ public class RMarkdownPreferencesPane extends PreferencesPane
       VerticalTabPanel advanced = new VerticalTabPanel(ElementIds.RMARKDOWN_ADVANCED_PREFS);
       
      
-      advanced.add(headerLabel("Visual Markdown Editing"));
+      advanced.add(headerLabel("R Markdown"));
+
+      advanced.add(checkboxPref("Enable chunk background highlight", prefs_.highlightCodeChunks()));
+      advanced.add(checkboxPref("Show inline toolbar for R code chunks", prefs_.showInlineToolbarForRCodeChunks()));
+      final CheckBox showRmdRenderCommand = checkboxPref( "Display render command in R Markdown tab",
+            prefs_.showRmdRenderCommand());
+      advanced.add(showRmdRenderCommand);
+      
+      advanced.add(spacedBefore(headerLabel("Visual Markdown Editing")));
           
       Label visualMarkdownLabel = new Label(
             "Visual markdown editing is an experimental feature of " +

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -403,6 +403,7 @@ public class Source implements InsertSourceHandler,
       dynamicCommands_.add(commands.sourceAsJob());
       dynamicCommands_.add(commands.runSelectionAsJob());
       dynamicCommands_.add(commands.runSelectionAsLauncherJob());
+      dynamicCommands_.add(commands.toggleSoftWrapMode());
       for (AppCommand command : dynamicCommands_)
       {
          command.setVisible(false);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -894,7 +894,6 @@ public class AceEditor implements DocDisplay,
       
       handlers_.fireEvent(new EditorModeChangedEvent(getModeId()));
 
-      getSession().setUseWrapMode(fileType_.getWordWrap());
       syncWrapLimit();
    }
 
@@ -2198,7 +2197,7 @@ public class AceEditor implements DocDisplay,
    }
 
    /**
-    * Warning: This will be overridden whenever the file type is set
+    * Sets the soft wrap mode for the editor
     */
    public void setUseWrapMode(boolean useWrapMode)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2203,6 +2203,14 @@ public class AceEditor implements DocDisplay,
    {
       getSession().setUseWrapMode(useWrapMode);
    }
+   
+   /**
+    * Gets whether or not the editor is using soft wrapping
+    */
+   public boolean getUseWrapMode()
+   {
+      return getSession().getUseWrapMode();
+   }
 
    public void setTabSize(int tabSize)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -1,7 +1,7 @@
 /*
  * DocDisplay.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -183,6 +183,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setShowLineNumbers(boolean on);
    void setUseSoftTabs(boolean on);
    void setUseWrapMode(boolean on);
+   boolean getUseWrapMode();
    void setTabSize(int tabSize);
    void autoDetectIndentation(boolean on);
    void setShowPrintMargin(boolean on);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -256,6 +256,7 @@ public class TextEditingTarget implements
       
       void toggleDocumentOutline();
       void toggleRmdVisualMode();
+      void toggleSoftWrapMode();
       
       void setNotebookUIVisible(boolean visible);
 
@@ -3028,10 +3029,7 @@ public class TextEditingTarget implements
    @Handler
    void onToggleSoftWrapMode()
    {
-      docUpdateSentinel_.setBoolProperty(
-            TextEditingTarget.SOFT_WRAP_LINES, 
-            !docUpdateSentinel_.getBoolProperty(
-                  TextEditingTarget.SOFT_WRAP_LINES, false));
+      view_.toggleSoftWrapMode();
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -204,6 +204,8 @@ public class TextEditingTarget implements
    public final static String DOC_OUTLINE_VISIBLE = "docOutlineVisible";
    
    public static final String RMD_VISUAL_MODE = "rmdVisualMode";
+   
+   public static final String SOFT_WRAP_LINES = "softWrapLines";
   
    private static final MyCommandBinder commandBinder =
          GWT.create(MyCommandBinder.class);
@@ -3021,6 +3023,15 @@ public class TextEditingTarget implements
    void onToggleRmdVisualMode()
    {
       view_.toggleRmdVisualMode();
+   }
+   
+   @Handler
+   void onToggleSoftWrapMode()
+   {
+      docUpdateSentinel_.setBoolProperty(
+            TextEditingTarget.SOFT_WRAP_LINES, 
+            !docUpdateSentinel_.getBoolProperty(
+                  TextEditingTarget.SOFT_WRAP_LINES, false));
    }
    
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -199,6 +199,16 @@ public class TextEditingTargetWidget
 
       initWidget(panel_);
       
+      // Update wrap mode on the editor when the soft wrap property changes
+      docUpdateSentinel_.addPropertyValueChangeHandler(
+            TextEditingTarget.SOFT_WRAP_LINES, (newval) ->
+            {
+               boolean wrap = StringUtil.equals(newval.getValue(), 
+                     DocUpdateSentinel.PROPERTY_TRUE);
+               commands_.toggleSoftWrapMode().setChecked(wrap);
+               editor_.setUseWrapMode(wrap);
+            });
+
       userPrefs_.autoSaveOnBlur().addValueChangeHandler((evt) ->
       {
          // Re-adapt to file type when this preference changes; it may bring
@@ -847,6 +857,9 @@ public class TextEditingTargetWidget
       
       toggleVisualModeOutlineButton_.setVisible(visualRmdMode);
       
+      // update wrap mode for filetype
+      syncWrapMode();
+      
       toolbar_.invalidateSeparators();
    }
    
@@ -1078,6 +1091,9 @@ public class TextEditingTargetWidget
    public void onActivate()
    {
       editor_.onActivate();
+      
+      // sync the state of the command marking word wrap mode for this document
+      syncWrapMode();
       
       Scheduler.get().scheduleDeferred(() -> manageToolbarSizes());
    }
@@ -1687,6 +1703,20 @@ public class TextEditingTargetWidget
       
       private boolean activationPending_ = false;
    };
+   
+   private void syncWrapMode()
+   {
+      // set wrap mode from the file type (unless we have a wrap mode specified
+      // explicitly)
+      boolean wrapMode = editor_.getFileType().getWordWrap();
+      if (docUpdateSentinel_.hasProperty(TextEditingTarget.SOFT_WRAP_LINES))
+      {
+         wrapMode = docUpdateSentinel_.getBoolProperty(TextEditingTarget.SOFT_WRAP_LINES, 
+               wrapMode);
+      }
+      editor_.setUseWrapMode(wrapMode);
+      commands_.toggleSoftWrapMode().setChecked(wrapMode);
+   }
 
    private final TextEditingTarget target_;
    private final DocUpdateSentinel docUpdateSentinel_;
@@ -1757,5 +1787,4 @@ public class TextEditingTargetWidget
    private String sourceCommandText_ = "Source";
    private String knitCommandText_ = "Knit";
    private String previewCommandText_ = "Preview";
-
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -240,6 +240,12 @@ public class TextEditingTargetWidget
       }
    }
    
+   public void toggleSoftWrapMode()
+   {
+      docUpdateSentinel_.setBoolProperty(
+            TextEditingTarget.SOFT_WRAP_LINES, !editor_.getUseWrapMode());
+   }
+
    public void toggleDocumentOutline()
    {
       if (isVisualMode())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -76,6 +76,10 @@ public class EditSession extends JavaScriptObject
       return this.setUseWrapMode(useWrapMode);
    }-*/;
    
+   public native final boolean getUseWrapMode() /*-{
+      return this.getUseWrapMode();
+   }-*/;
+   
    public native final void setWrapLimitRange(int min, int max) /*-{
       this.setWrapLimitRange(min, max);
    }-*/;


### PR DESCRIPTION
This is a quick feature that adds two new capabilities:

- Some users (a minority) prefer not to use wrapping with their R Markdown documents. This change adds a new global preference so that this behavior can be changed.

![image](https://user-images.githubusercontent.com/470418/80547106-3791d980-896c-11ea-8240-5f75e68b1dee.png)

- It is now possible to toggle soft wrapping mode off and on for any file. This setting sticks with the file (using document properties), and overrides the file type's default wrap mode if present. This makes it possible to quickly switch into and out of soft wrap mode without changing global preferences, and can be bound to a keyboard shortcut.

![image](https://user-images.githubusercontent.com/470418/80547138-46788c00-896c-11ea-9b10-bfa51ad8d78e.png)

Closes https://github.com/rstudio/rstudio/issues/2341.