### PR TITLE
Ensure that we always serve the latest theme css

### DIFF
--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -563,6 +563,14 @@ void onDeferredInit(bool)
    s_deferredInitComplete = true;
 }
 
+void setCacheableFile(const FilePath& filePath,
+                      const http::Request& request,
+                      http::Response* pResponse)
+{
+   pResponse->setCacheWithRevalidationHeaders();
+   pResponse->setCacheableFile(filePath, request);
+}
+
 } // anonymous namespace
 
 /**
@@ -576,7 +584,7 @@ void handleDefaultThemeRequest(const http::Request& request,
 {
    std::string prefix = "/" + kDefaultThemeLocation;
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
-   pResponse->setCacheableFile(getDefaultThemePath().completeChildPath(fileName), request);
+   setCacheableFile(getDefaultThemePath().completeChildPath(fileName), request, pResponse);
 }
 
 /**
@@ -593,9 +601,10 @@ void handleGlobalCustomThemeRequest(const http::Request& request,
    std::string prefix = "/" + kGlobalCustomThemeLocation;
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
    FilePath requestedTheme = getGlobalCustomThemePath().completeChildPath(fileName);
-   pResponse->setCacheableFile(
+   setCacheableFile(
       requestedTheme.exists() ? requestedTheme : getDefaultTheme(request),
-      request);
+      request,
+      pResponse);
 }
 
 /**
@@ -613,10 +622,10 @@ void handleLocalCustomThemeRequest(const http::Request& request,
    std::string fileName = http::util::pathAfterPrefix(request, prefix);
 
    FilePath requestedTheme = getLocalCustomTheme(fileName);
-
-   pResponse->setCacheableFile(
+   setCacheableFile(
       requestedTheme.exists() ? requestedTheme : getDefaultTheme(request),
-      request);
+      request,
+      pResponse);
 }
 
 Error syncThemePrefs()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -73,7 +73,8 @@ public class AceThemes
       themeUrl.append(GWT.getHostPageBaseURL())
          .append(theme.getUrl())
          .append("?dark=")
-         .append(theme.isDark() ? "1" : "0");
+         .append(theme.isDark() ? "1" : "0")
+         .append("&refresh=1");
       
       LinkElement currentStyleEl = document.createLinkElement();
       currentStyleEl.setType("text/css");


### PR DESCRIPTION
We now call setCacheWithRevalidationHeaders when serving theme css to make sure that the browser doesn't use an older copy of the theme (now at a minimum the browser must get back a 304 to use a cached copy).

There are several other places in the codebase where a similar change is likely warranted.

Note that we also add a do-nothing URL parameter ("refresh=1") to the theme request to work around any existing cached themes.