### PR TITLE
Allow for package dependency discovery in untitled buffers

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1004,11 +1004,15 @@ public class TextEditingTargetWidget
          for (String pkg: packages)
             deps.add(Dependency.cranPackage(pkg));
          
+         String scriptName = StringUtil.isNullOrEmpty(docUpdateSentinel_.getPath()) ?
+            "R Script" :
+            FilePathUtils.friendlyFileName(docUpdateSentinel_.getPath());
+            
          // Install them using the dependency manager; provide a "prompt"
          // function that just accepts the list (since the user has already been
          // prompted here in the editor)
          RStudioGinjector.INSTANCE.getDependencyManager().withDependencies(
-               "Install " + FilePathUtils.friendlyFileName(docUpdateSentinel_.getPath()) + " dependencies", 
+               "Install " + scriptName + " dependencies", 
                (String dependencies, CommandWithArg<Boolean> result) -> result.execute(true),
                deps, false, null);
          hideWarningBar();


### PR DESCRIPTION
This change makes it possible to discover dependencies in untitled buffers; this regressed when we started doing this in a background job that required a job name derived from the path of the buffer. 

Fixes https://github.com/rstudio/rstudio/issues/6762.