### PR TITLE
enable wordwrap and selection of message in RSA key creation error dialog

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -137,6 +137,7 @@ public interface ThemeStyles extends CssResource
    
    String showFile();
    String showFileFixed();
+   String showFilePreFixed();
    
    String fileUploadPanel();
    String fileUploadField();

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1763,6 +1763,17 @@ body.ubuntu_mono .searchBox {
    background-color: white;
 }
 
+.showFilePreFixed {
+   overflow-x: auto;
+   white-space: pre-wrap;
+   white-space: -moz-pre-wrap;
+   word-wrap: break-word;
+   -ms-user-select: text;
+   -moz-user-select: text;
+   -webkit-user-select: text;
+   user-select: text;
+}
+
 .fileUploadPanel {
    width: 350px;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/ShowContentDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShowContentDialog.java
@@ -44,7 +44,8 @@ public class ShowContentDialog extends ModalDialogBase
       }
       else
       {
-         content_ = "<pre>" + content + "</pre>";
+         content_ = "<pre class=\"" + ThemeResources.INSTANCE.themeStyles().showFilePreFixed() +
+            "\">" + content + "</pre>";
          styleName_ = ThemeResources.INSTANCE.themeStyles().showFileFixed();
          isFixedFont_ = true;
       }


### PR DESCRIPTION
- Fixes #6771
- Came from a customer request for RSP (see bug)
- ShowContentDialog is only used for this particular scenario (and for the obsolete agreement dialog being removed in #6774)

Before (with a long string I injected for testing):

<img width="862" alt="screenshot of error dialog with clipped text" src="https://user-images.githubusercontent.com/10569626/80650855-9d906680-8a29-11ea-999e-18360d4b4fb4.png">

After showing wordwrap and ability to select text (and thus copy it):

<img width="862" alt="screenshot of error dialog with fixes applied" src="https://user-images.githubusercontent.com/10569626/80650893-b26cfa00-8a29-11ea-91ef-2cdc709b8d32.png">


