### PR TITLE
Add class attributes to chunks

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1,7 +1,7 @@
 /*
  * StringUtil.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -944,6 +944,40 @@ public class StringUtil
       return getExtension(string, 1);
    }
    
+   public static String getCssIdentifier(String string)
+   {
+      // Each character must be one of the following:
+      // alphanumeric, an ISO 10646 character U+00A0 or higher, a hyphen, or an underscore.
+      // Identifiers cannot start with a hyphen, two hyphens, or a hyphen followed by a digit.
+      // This implementation considers escaped characters invalid.
+      // If an invalid character is found, it is replaced with an 'x'.
+      
+
+      // return the string if it's already valid,
+      // otherwise replace invalid characters with 'x'
+      Pattern pattern =
+         Pattern.create("(^[a-zA-Z][a-zA-Z0-9\\-\\_]+$)|(^-[a-zA-Z][a-zA-Z0-9\\-\\_]+$)");
+      if (pattern.test(string))
+         return string;
+      else
+      {
+         StringBuilder builder = new StringBuilder();
+         for (int i = 0; i < string.length(); i++)
+         {
+            char c = string.charAt(i);
+            if (c == '_' ||
+                c > 0x00A0 ||
+                (c >= 'a' && c <= 'z') ||
+                (c >= 'A' && c <= 'Z') ||
+                (i > 0 && (c == '-' || (c >= '0' && c <= '9'))))
+               builder.append(c);
+            else
+               builder.append("x");
+         }
+         return builder.toString();
+      }
+   }
+
    public static String getToken(String string,
                                  int pos,
                                  String tokenRegex,

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -955,7 +955,7 @@ public class StringUtil
 
       // return the string if it's already valid,
       // otherwise replace invalid characters with '_'
-      Pattern pattern = Pattern.create("(^-?[a-zA-Z][a-zA-Z0-9\\-\\_]+$)");
+      Pattern pattern = Pattern.create("(^-?[a-zA-Z_][a-zA-Z0-9\\-_]+$)");
       if (pattern.test(string))
          return string;
       else

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -950,13 +950,12 @@ public class StringUtil
       // alphanumeric, an ISO 10646 character U+00A0 or higher, a hyphen, or an underscore.
       // Identifiers cannot start with a hyphen, two hyphens, or a hyphen followed by a digit.
       // This implementation considers escaped characters invalid.
-      // If an invalid character is found, it is replaced with an 'x'.
+      // If an invalid character is found, it is replaced with an underscore.
       
 
       // return the string if it's already valid,
-      // otherwise replace invalid characters with 'x'
-      Pattern pattern =
-         Pattern.create("(^[a-zA-Z][a-zA-Z0-9\\-\\_]+$)|(^-[a-zA-Z][a-zA-Z0-9\\-\\_]+$)");
+      // otherwise replace invalid characters with '_'
+      Pattern pattern = Pattern.create("(^-?[a-zA-Z][a-zA-Z0-9\\-\\_]+$)");
       if (pattern.test(string))
          return string;
       else
@@ -972,7 +971,7 @@ public class StringUtil
                 (i > 0 && (c == '-' || (c >= '0' && c <= '9'))))
                builder.append(c);
             else
-               builder.append("x");
+               builder.append("_");
          }
          return builder.toString();
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -1,7 +1,7 @@
 /*
  * ChunkOutputWidget.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteErro
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteErrorHandler;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteOutputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteOutputHandler;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextToolbar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputHost;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
 
@@ -243,10 +244,24 @@ public class ChunkOutputWidget extends Composite
       return state_;
    }
 
-   public void setId(String id)
+   public void setLabelClass(String value)
    {
-      this.getElement().setPropertyString("id",
-                                          StringUtil.getCssIdentifier(id));
+      // ensure value has the correct prefix
+      if (!value.startsWith(ChunkContextToolbar.CHUNK_CLASS_PREFIX + CHUNK_OUTPUT_PREFIX))
+               value = new String(ChunkContextToolbar.CHUNK_CLASS_PREFIX +
+                                  CHUNK_OUTPUT_PREFIX +
+                                  value);
+      value = StringUtil.getCssIdentifier(value);
+
+      if (value != label_)
+      {
+         // if we've already added a label style, remove it
+         if (!StringUtil.isNullOrEmpty(label_))
+            this.removeStyleName(label_);
+
+         label_ = value;
+         this.addStyleName(label_);
+      }
    }
 
    public void setOptions(RmdChunkOptions options)
@@ -939,6 +954,7 @@ public class ChunkOutputWidget extends Composite
    private int lastOutputType_ = RmdChunkOutputUnit.TYPE_NONE;
    private boolean hasErrors_ = false;
    private boolean hideSatellitePopup_ = false;
+   private String label_;
    
    private Timer collapseTimer_ = null;
    private final String documentId_;
@@ -956,4 +972,7 @@ public class ChunkOutputWidget extends Composite
    public final static int CHUNK_READY       = 2;
    public final static int CHUNK_PRE_OUTPUT  = 3;
    public final static int CHUNK_POST_OUTPUT = 4;
+
+   // this may be relied on by API code and should not change
+   public final static String CHUNK_OUTPUT_PREFIX = "output-";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ProgressSpinner;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -240,6 +241,12 @@ public class ChunkOutputWidget extends Composite
    public int getState()
    {
       return state_;
+   }
+
+   public void setId(String id)
+   {
+      this.getElement().setPropertyString("id",
+                                          StringUtil.getCssIdentifier(id));
    }
 
    public void setOptions(RmdChunkOptions options)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -248,12 +248,12 @@ public class ChunkOutputWidget extends Composite
    {
       // ensure value has the correct prefix
       if (!value.startsWith(ChunkContextToolbar.CHUNK_CLASS_PREFIX + CHUNK_OUTPUT_PREFIX))
-               value = new String(ChunkContextToolbar.CHUNK_CLASS_PREFIX +
-                                  CHUNK_OUTPUT_PREFIX +
-                                  value);
+         value = new String(ChunkContextToolbar.CHUNK_CLASS_PREFIX +
+                            CHUNK_OUTPUT_PREFIX +
+                            value);
       value = StringUtil.getCssIdentifier(value);
 
-      if (value != label_)
+      if (!StringUtil.equals(value, label_))
       {
          // if we've already added a label style, remove it
          if (!StringUtil.isNullOrEmpty(label_))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -107,6 +107,7 @@ public class TextEditingTargetChunks
    @Inject
    private void initialize(UserPrefs prefs, UserState state)
    {
+      initialized_ = true;
       prefs_ = prefs;
       state_ = state;
       dark_ = state.theme().getValue().getIsDark();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -1,7 +1,7 @@
 /*
  * ChunkContextToolbar.java
  *
- * Copyright (C) 2009-16 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
@@ -108,7 +109,8 @@ public class ChunkContextToolbar extends Composite
    
    public void setId(String id)
    {
-      this.getElement().setPropertyString("id", id);
+      this.getElement().setPropertyString("id",
+                                          StringUtil.getCssIdentifier(id));
    }
 
    // Private methods ---------------------------------------------------------

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -106,6 +106,11 @@ public class ChunkContextToolbar extends Composite
       chunkTypeLabel_.setText(engine);
    }
    
+   public void setId(String id)
+   {
+      this.getElement().setPropertyString("id", id);
+   }
+
    // Private methods ---------------------------------------------------------
    
    private void initOptions(boolean dark)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -107,10 +107,21 @@ public class ChunkContextToolbar extends Composite
       chunkTypeLabel_.setText(engine);
    }
    
-   public void setId(String id)
+   public void setLabelClass(String value)
    {
-      this.getElement().setPropertyString("id",
-                                          StringUtil.getCssIdentifier(id));
+      if (!value.startsWith(CHUNK_CLASS_PREFIX))
+         value = new String(CHUNK_CLASS_PREFIX + value);
+      value = StringUtil.getCssIdentifier(value);
+
+      if (value != label_)
+      {
+         // if we've already added a label style, remove it
+         if (!StringUtil.isNullOrEmpty(label_))
+            this.removeStyleName(label_);
+
+         label_ = value;
+         this.addStyleName(label_);
+      }
    }
 
    // Private methods ---------------------------------------------------------
@@ -122,6 +133,9 @@ public class ChunkContextToolbar extends Composite
          RES.chunkOptionsLight2x()));
 
       options_.addStyleName("rstudio-themes-darkens");
+
+      // this name may be relied on by API code and should not be changed
+      options_.addStyleName("modifyButton");
       
       DOM.sinkEvents(options_.getElement(), Event.ONCLICK);
       DOM.setEventListener(options_.getElement(), new EventListener()
@@ -142,6 +156,10 @@ public class ChunkContextToolbar extends Composite
       setState(state_);
       run_.setTitle(RStudioGinjector.INSTANCE.getCommands()
                     .executeCurrentChunk().getMenuLabel(false));
+
+      // this name may be relied on by API code and should not be changed
+      run_.addStyleName("runButton");
+
       DOM.sinkEvents(run_.getElement(), Event.ONCLICK);
       DOM.setEventListener(run_.getElement(), new EventListener()
       {
@@ -174,6 +192,10 @@ public class ChunkContextToolbar extends Composite
       runPrevious_.setResource(new ImageResource2x(
          dark ? RES.runPreviousChunksDark2x() :
          RES.runPreviousChunksLight2x()));
+
+      // this name may be relied on by API code and should not be changed
+      runPrevious_.addStyleName("prevButton");
+
       DOM.sinkEvents(runPrevious_.getElement(), Event.ONCLICK);
       DOM.setEventListener(runPrevious_.getElement(), new EventListener()
       {
@@ -210,6 +232,7 @@ public class ChunkContextToolbar extends Composite
    private void initChangeChunkEngine(String engine)
    {
       chunkTypeLabel_.setText(engine);
+      chunkTypeLabel_.setStyleName("changeTypeLabel");
       DOM.sinkEvents(chunkTypePanel_.getElement(), Event.ONCLICK);
       DOM.setEventListener(chunkTypePanel_.getElement(), new EventListener()
       {
@@ -281,10 +304,12 @@ public class ChunkContextToolbar extends Composite
 
    private final Host host_;
    private int state_;
+   private String label_;
    
    public final static int STATE_QUEUED    = 0;
    public final static int STATE_EXECUTING = 1;
    public final static int STATE_RESTING   = 2;
 
    public final static String LINE_WIDGET_TYPE = "ChunkToolbar";
+   public final static String CHUNK_CLASS_PREFIX = "rs-chunk-";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -113,7 +113,7 @@ public class ChunkContextToolbar extends Composite
          value = new String(CHUNK_CLASS_PREFIX + value);
       value = StringUtil.getCssIdentifier(value);
 
-      if (value != label_)
+      if (!StringUtil.equals(value, label_))
       {
          // if we've already added a label style, remove it
          if (!StringUtil.isNullOrEmpty(label_))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -1,7 +1,7 @@
 /*
  * ChunkContextUi.java
  *
- * Copyright (C) 2009-16 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -72,7 +72,12 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
       // if we found neither an '=' nor a ',', then the label
       // must be all the text following the first space
       if (firstEqualsIdx == -1 && firstCommaIdx == -1)
-         return extractedChunkHeader.substring(firstSpaceIdx + 1).trim();
+      {
+         extractedChunkHeader = extractedChunkHeader.substring(firstSpaceIdx + 1).trim();
+         if (extractedChunkHeader.endsWith("}"))
+            extractedChunkHeader = extractedChunkHeader.substring(0, extractedChunkHeader.length() -1);
+         return extractedChunkHeader;
+      }
 
       // if we found an '=' before we found a ',' (or we didn't find
       // a ',' at all), that implies a chunk header like:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -92,6 +92,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
          engine_ = engine;
          toolbar_.setEngine(engine);
       }
+      toolbar_.setId(chunk_.getLabel());
    }
    
    public void setRenderPass(int pass)
@@ -205,6 +206,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
    {
       toolbar_ = new ChunkContextToolbar(this, dark_, !isSetup_, engine_);
       toolbar_.setHeight("0px"); 
+      toolbar_.setId(chunk_.getLabel());
       lineWidget_ = new PinnedLineWidget(
             ChunkContextToolbar.LINE_WIDGET_TYPE, target_.getDocDisplay(), 
             toolbar_, row, null, host_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -127,7 +127,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
          engine_ = engine;
          toolbar_.setEngine(engine);
       }
-      toolbar_.setId(getLabel(row));
+      toolbar_.setLabelClass(getLabel(row));
    }
 
    public void setRenderPass(int pass)
@@ -241,7 +241,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
    {
       toolbar_ = new ChunkContextToolbar(this, dark_, !isSetup_, engine_);
       toolbar_.setHeight("0px"); 
-      toolbar_.setId(getLabel(row));
+      toolbar_.setLabelClass(getLabel(row));
       lineWidget_ = new PinnedLineWidget(
             ChunkContextToolbar.LINE_WIDGET_TYPE, target_.getDocDisplay(), 
             toolbar_, row, null, host_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import org.rstudio.core.client.Rectangle;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.rmarkdown.model.RmdChunkOptions;
@@ -65,6 +66,8 @@ public class ChunkOutputUi
       }
 
       outputWidget_ = widget;
+      // label_ should only be set by this function
+      setChunkLabel(def.getChunkLabel());
       
       // sync the widget's expanded/collapsed state to the underlying chunk
       // definition (which is persisted)
@@ -107,6 +110,21 @@ public class ChunkOutputUi
       return def_.getChunkId();
    }
    
+   public String getChunkLabel()
+   {
+      return label_;
+   }
+
+   public void setChunkLabel(String label)
+   {
+      if (!StringUtil.equals(label_, label))
+      {
+         label_ = label;
+         if (outputWidget_ != null)
+            outputWidget_.setId("output_" + label_);
+      }
+   }
+
    public Scope getScope()
    {
       return display_.getCurrentChunk(Position.create(getCurrentRow(), 1));
@@ -131,6 +149,7 @@ public class ChunkOutputUi
    {
       def_.setOptions(options);
       outputWidget_.setOptions(options);
+      setChunkLabel(def_.getChunkLabel());
    }
    
    public void remove()
@@ -255,6 +274,8 @@ public class ChunkOutputUi
    private final String chunkId_;
    private final String docId_;
    private final ChunkDefinition def_;
+
+   private String label_;
 
    private boolean attached_ = false;
    private HandlerRegistration renderHandlerReg_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -1,7 +1,7 @@
 /*
  * ChunkOutputUi.java
  *
- * Copyright (C) 2009-16 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -121,7 +121,7 @@ public class ChunkOutputUi
       {
          label_ = label;
          if (outputWidget_ != null)
-            outputWidget_.setId("output_" + label_);
+            outputWidget_.setLabelClass(label);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1108,13 +1108,15 @@ public class TextEditingTargetNotebook
       {
          Position thisStart = thisScope.getBodyStart();
          Position thisEnd = thisScope.getEnd();
+         String chunkId = getCurrentChunkId();
+
          if (((lastStart_ == null && thisStart == null) ||
               (lastStart_ != null && lastStart_.compareTo(thisStart) == 0)) &&
              ((lastEnd_ == null && thisEnd == null) ||
-              (lastEnd_ != null && lastEnd_.compareTo(thisEnd) == 0))) 
-         {
+              (lastEnd_ != null && lastEnd_.compareTo(thisEnd) == 0)) &&
+             ((chunkId != null && outputs_.containsKey(chunkId)) &&
+              outputs_.get(chunkId).getChunkLabel() == thisScope.getLabel()))
             return;
-         }
 
          lastStart_ = Position.create(thisScope.getBodyStart());
          lastEnd_ = Position.create(thisScope.getEnd());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1139,6 +1139,8 @@ public class TextEditingTargetNotebook
                   docUpdateSentinel_.getId(), output.getChunkId(), "", 0, 
                   ChunkChangeEvent.CHANGE_REMOVE));
          }
+         if (!StringUtil.equals(scope.getChunkLabel(), output.getChunkLabel()))
+            output.setChunkLabel(scope.getChunkLabel());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUi;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -141,39 +142,6 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       return label;
    }
    
-   private String extractChunkLabel(String extractedChunkHeader)
-   {
-      // if there are no spaces within the chunk header,
-      // there cannot be a label
-      int firstSpaceIdx = extractedChunkHeader.indexOf(' ');
-      if (firstSpaceIdx == -1)
-         return "";
-      
-      // find the indices of the first '=' and ',' characters
-      int firstEqualsIdx = extractedChunkHeader.indexOf('=');
-      int firstCommaIdx  = extractedChunkHeader.indexOf(',');
-      
-      // if we found neither an '=' nor a ',', then the label
-      // must be all the text following the first space
-      if (firstEqualsIdx == -1 && firstCommaIdx == -1)
-         return extractedChunkHeader.substring(firstSpaceIdx + 1).trim();
-      
-      // if we found an '=' before we found a ',' (or we didn't find
-      // a ',' at all), that implies a chunk header like:
-      //
-      //    ```{r message=TRUE, echo=FALSE}
-      //
-      // and so there is no label.
-      if (firstCommaIdx == -1)
-         return "";
-         
-      if (firstEqualsIdx != -1 && firstEqualsIdx < firstCommaIdx)
-         return "";
-      
-      // otherwise, the text from the first space to that comma gives the label
-      return extractedChunkHeader.substring(firstSpaceIdx + 1, firstCommaIdx).trim();
-   }
-   
    private void parseChunkHeader(String line, HashMap<String, String> chunkOptions)
    {
       String modeId = display_.getModeId();
@@ -194,9 +162,9 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       String extracted = match.getGroup(1);
       chunkPreamble_ = extractChunkPreamble(extracted, modeId);
       
-      String chunkLabel = extractChunkLabel(extracted);
+      String chunkLabel = ChunkContextUi.extractChunkLabel(extracted);
       if (!StringUtil.isNullOrEmpty(chunkLabel))
-         tbChunkLabel_.setText(extractChunkLabel(extracted));
+         tbChunkLabel_.setText(ChunkContextUi.extractChunkLabel(extracted));
       
       // if we had a chunk label, then we want to navigate our cursor to
       // the first comma in the chunk header; otherwise, we start at the

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -164,7 +164,7 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
       
       String chunkLabel = ChunkContextUi.extractChunkLabel(extracted);
       if (!StringUtil.isNullOrEmpty(chunkLabel))
-         tbChunkLabel_.setText(ChunkContextUi.extractChunkLabel(extracted));
+         tbChunkLabel_.setText(chunkLabel);
       
       // if we had a chunk label, then we want to navigate our cursor to
       // the first comma in the chunk header; otherwise, we start at the

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -1,7 +1,7 @@
 /*
  * StringUtilTests.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -238,6 +238,40 @@ public class StringUtilTests extends GWTTestCase
       assertEquals("2:02:01:01", days);
    }
   
+   public void testGetCssIdentifier()
+   {
+      for (int pass = 0; pass < 5; pass++)
+      {
+         String input, expected, result;
+         switch (pass) {
+            case 0:
+               input = "-_perfectlyfine";
+               expected = input;
+               break;
+            case 1:
+               input = "--verybad";
+               expected = "_-verybad";
+               break;
+            case 2:
+               input = "-2badagain?";
+               expected = "_2badagain_";
+               break;
+            case 3:
+               input = "great342_-↲";
+               expected = input;
+               break;
+            case 4:
+               input = "4abc_bad";
+               expected = "_abc_bad";
+               break;
+            default:
+               input = expected  = "";
+         }
+         result = StringUtil.getCssIdentifier(input);
+         assertTrue(StringUtil.equals(expected, result));
+      }
+   }
+
    public void testEscapeBashPathNoSpecialChars()
    {
       String input = "NothingSpecialHere.129,._+@%/-";

--- a/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
+++ b/src/gwt/test/org/rstudio/core/client/StringUtilTests.java
@@ -15,6 +15,8 @@
 package org.rstudio.core.client;
 
 import java.util.Date;
+import java.util.List;
+import java.util.ArrayList;
 
 import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.junit.client.GWTTestCase;
@@ -240,35 +242,17 @@ public class StringUtilTests extends GWTTestCase
   
    public void testGetCssIdentifier()
    {
-      for (int pass = 0; pass < 5; pass++)
+      List<Pair<String, String>> testList = new ArrayList<>();
+      testList.add(new Pair<>("4abc_bad",        "_abc_bad"));
+      testList.add(new Pair<>("--verybad",       "_-verybad"));
+      testList.add(new Pair<>("-2badagain?",     "_2badagain_"));
+      testList.add(new Pair<>("great342_-↲",     "great342_-↲"));
+      testList.add(new Pair<>("-_perfectlyfine", "-_perfectlyfine"));
+
+      for (Pair<String, String> td  : testList)
       {
-         String input, expected, result;
-         switch (pass) {
-            case 0:
-               input = "-_perfectlyfine";
-               expected = input;
-               break;
-            case 1:
-               input = "--verybad";
-               expected = "_-verybad";
-               break;
-            case 2:
-               input = "-2badagain?";
-               expected = "_2badagain_";
-               break;
-            case 3:
-               input = "great342_-↲";
-               expected = input;
-               break;
-            case 4:
-               input = "4abc_bad";
-               expected = "_abc_bad";
-               break;
-            default:
-               input = expected  = "";
-         }
-         result = StringUtil.getCssIdentifier(input);
-         assertTrue(StringUtil.equals(expected, result));
+         String result = StringUtil.getCssIdentifier(td.first);
+         assertTrue(StringUtil.equals(td.second, result));
       }
    }
 

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -29,6 +29,7 @@ import org.rstudio.studio.client.workbench.views.jobs.view.JobsListTests;
 // import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChunkHeaderParserTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalLocalEchoTests;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalSessionSocketTests;
+import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextUiTests;
 
 import com.google.gwt.junit.tools.GWTTestSuite;
 
@@ -54,6 +55,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(SessionScopeTests.class);
       suite.addTestSuite(JobsListTests.class);
       suite.addTestSuite(ElementIdsTests.class);
+      suite.addTestSuite(ChunkContextUiTests.class);
       
       // Pro-only tests
       

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
@@ -15,7 +15,10 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import com.google.gwt.junit.client.GWTTestCase;
+import org.rstudio.core.client.Pair;
 
+import java.util.List;
+import java.util.ArrayList;
 
 public class ChunkContextUiTests extends GWTTestCase
 {
@@ -27,8 +30,15 @@ public class ChunkContextUiTests extends GWTTestCase
    
    public void testExtractChunkLabel()
    {
-      String input = "```{r testingChunks, echo=FALSE}";
-      String result = ChunkContextUi.extractChunkLabel(input);
-      assertTrue(result.equals("testingChunks"));
+      List<Pair<String, String>> testList = new ArrayList<>();
+      testList.add(new Pair<>("```{r echo=FALSE}",        ""));
+      testList.add(new Pair<>("```{r testingChunks}",        "testingChunks"));
+      testList.add(new Pair<>("```{r testingChunks, echo=FALSE}",        "testingChunks"));
+
+      for (Pair<String, String> td  : testList)
+      {
+         String result = ChunkContextUi.extractChunkLabel(td.first);
+         assertTrue(result.equals(td.second));
+      }
    }
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUiTests.java
@@ -1,0 +1,34 @@
+/*
+ * ChunkContextUiTests.java
+ *
+ * Copyright (C) 2009-20 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+
+public class ChunkContextUiTests extends GWTTestCase
+{
+   @Override
+   public String getModuleName()
+   {
+      return "org.rstudio.studio.RStudioTests";
+   }
+   
+   public void testExtractChunkLabel()
+   {
+      String input = "```{r testingChunks, echo=FALSE}";
+      String result = ChunkContextUi.extractChunkLabel(input);
+      assertTrue(result.equals("testingChunks"));
+   }
+}


### PR DESCRIPTION
This PR implements items 1-3 of #6652 

It adds `getCssIdentifier` to `StringUtil` which builds a string valid as a CSS id, replacing invalid characters with an 'x'. This function is invoked to add an `id` to chunks so their child elements can be easily referenced. The `id` is set to the chunk's label and adds the prefix `output_` to the chunk's output.
In particular this can be used with to highlight buttons and output associated with a chunk. 

Running `>rstudioapi::highlightUi("#pressure [title='Run Current Chunk']")` will yield:

![image](https://user-images.githubusercontent.com/5323711/80772141-84abb200-8b0a-11ea-82e6-0e129caaae0a.png)




Running `>rstudioapi::highlightUi("#output_pressure")` will yield:

![image](https://user-images.githubusercontent.com/5323711/80772211-d3f1e280-8b0a-11ea-98a9-be017adbc283.png)

