### PR TITLE
Fix HTML widget viewing on R 4.0 for Windows

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2390,7 +2390,30 @@ bool isSessionTempPath(FilePath filePath)
 
 std::string sessionTempDirUrl(const std::string& sessionTempPath)
 {
-   if (session::options().programMode() == kSessionProgramModeDesktop)
+   static boost::optional<bool> useRHelpServer;
+
+   if (!useRHelpServer)
+   {
+      // Initialize the flag indicating whether we should use the R help server;
+      // in desktop mode we can have R itself handle requests for content in
+      // the session temporary folder.
+      useRHelpServer = session::options().programMode() == kSessionProgramModeDesktop;
+
+#ifdef _WIN32
+      if (*useRHelpServer)
+      {
+         // There is a known issue serving content from the session temporary folder
+         // on R 4.0+ for Windows, so if we were planning to use it, only do so if
+         // we are on an older version of R.
+         //
+         // https://github.com/rstudio/rstudio/issues/6737
+         //
+         useRHelpServer = !r::util::hasRequiredVersion("4.0");
+      }
+#endif
+   }
+
+   if (*useRHelpServer)
    {
       boost::format fmt("http://localhost:%1%/session/%2%");
       return boost::str(fmt % rLocalHelpPort() % sessionTempPath);

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -295,10 +295,9 @@ SEXP rs_viewer(SEXP urlSEXP, SEXP heightSEXP)
          if (error)
             LOG_ERROR(error);
 
-         // if it's in the temp dir and we're running R >= 2.14 then
-         // we can serve it via the help server, otherwise we need
-         // to show it in an external browser
-         if (filePath.isWithin(tempDir) && r::util::hasRequiredVersion("2.14"))
+         // if it's in the temp dir then we can serve it via the help server,
+         // otherwise we need to show it in an external browser
+         if (filePath.isWithin(tempDir))
          {
             // calculate the relative path
             std::string path = filePath.getRelativePath(tempDir);


### PR DESCRIPTION
In RStudio Desktop, we currently use R's HTTP server to serve files from the session temp folder, including HTML widgets. There appears to be a bug in this server in R 4.0 for Windows, which causes the widgets not to display and burns a bunch of CPU until R is restarted. See #6737 for the gory details.

This change is a minimal fix for the issue which is intended to work around this specific problem; it is intended for the RStudio 1.3 release. Consequently it only touches this specific combination (R 4.0, Windows). Since we already have a mechanism for serving these files in RStudio Server, we just use it in desktop mode when necessary.

We might consider a follow-up to change (for RStudio 1.4) which simplifies all this code by using our internal server all the time; I don't see any immediate advantage to proxying these requests to R but I could be missing something.

I also couldn't resist cleaning up some old tests for R < 3.0 which we no longer support.

Fixes #6737. 