### PR TITLE
Restore correct element ID for console's input field

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -423,7 +423,10 @@ public class AceEditor implements DocDisplay,
          if (event.isAttached())
          {
             attachToWidget(widget_.getElement(), AceEditor.this);
-            ElementIds.assignElementId(widget_, ElementIds.SOURCE_TEXT_EDITOR);
+
+            // If the ID was set earlier, as is done for the Console's edit field, don't stomp over it
+            if (StringUtil.isNullOrEmpty(widget_.getElement().getId()))
+               ElementIds.assignElementId(widget_, ElementIds.SOURCE_TEXT_EDITOR);
          }
          else
             detachFromWidget(widget_.getElement());


### PR DESCRIPTION
- See #6805 which I will resolve once I've back-ported this to 1.3-patch
- Regression caused by: 2f3255d6
- Will break automation; fix for that is: https://github.com/rstudio/rstudio-ide-automation/pull/49