### PR TITLE
Remove inline-block attribute from largeCells

### DIFF
--- a/src/cpp/session/resources/grid/dtstyles.css
+++ b/src/cpp/session/resources/grid/dtstyles.css
@@ -310,7 +310,6 @@ th:focus {
 }
 
 .largeCell {
-    display: inline-block;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
Fixes #6469 

Large cells still had `inline-block` which doesn't play nicely with text-align. Removing this attribute also makes column resizing feel a bit nicer.

![re2ueYn](https://user-images.githubusercontent.com/136863/81228645-65a29980-8fbc-11ea-82ba-2aac8f77b3e0.png)
![mp072xD](https://user-images.githubusercontent.com/136863/81228654-6804f380-8fbc-11ea-8eff-9e8927e80b6d.png)
