### PR TITLE
avoid setting null pointer on R_tryEval error

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -129,7 +129,7 @@ Error evaluateExpressionsUnsafe(SEXP expr,
                                 EvalType evalType)
 {
    // detect if an error occurred (only relevant for EvalTry)
-   int errorCode = 0;
+   int errorOccurred = 0;
    
    // if we have an entire expression list, evaluate its contents one-by-one 
    // and return only the last one
@@ -141,8 +141,8 @@ Error evaluateExpressionsUnsafe(SEXP expr,
       {
          if (evalType == EvalTry)
          {
-            SEXP result = R_tryEval(VECTOR_ELT(expr, i), envir, &errorCode);
-            if (errorCode == 0)
+            SEXP result = R_tryEval(VECTOR_ELT(expr, i), envir, &errorOccurred);
+            if (errorOccurred == 0)
                *pSEXP = result;
          }
          else
@@ -156,10 +156,11 @@ Error evaluateExpressionsUnsafe(SEXP expr,
    else
    {
       DisableDebugScope disableStepInto(envir);
+      
       if (evalType == EvalTry)
       {
-         SEXP result = R_tryEval(expr, envir, &errorCode);
-         if (errorCode == 0)
+         SEXP result = R_tryEval(expr, envir, &errorOccurred);
+         if (errorOccurred == 0)
             *pSEXP = result;
       }
       else
@@ -171,7 +172,7 @@ Error evaluateExpressionsUnsafe(SEXP expr,
    // protect the result
    pProtect->add(*pSEXP);
    
-   if (errorCode)
+   if (errorOccurred)
    {
       // get error message -- note this results in a recursive call to
       // evaluate expressions during the fetching of the error. if this 

--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -1,7 +1,7 @@
 /*
  * RExec.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/session/modules/SessionRTests.cpp
+++ b/src/cpp/session/modules/SessionRTests.cpp
@@ -1,7 +1,7 @@
 /*
- * SessionDiagnosticsTests.cpp
+ * SessionRTests.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/cpp/session/modules/SessionRTests.cpp
+++ b/src/cpp/session/modules/SessionRTests.cpp
@@ -1,0 +1,44 @@
+/*
+ * SessionDiagnosticsTests.cpp
+ *
+ * Copyright (C) 2009-19 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <tests/TestThat.hpp>
+
+#include <r/RExec.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace tests {
+
+test_context("R")
+{
+   test_that("RFunction execution errors don't set result to nullptr")
+   {
+      SEXP result = R_NilValue;
+      r::sexp::Protect protect;
+      
+      Error error = r::exec::RFunction("NoSuchFunction")
+            .call(&result, &protect);
+      
+      expect_true(error != Success());
+      expect_true(result != nullptr);
+      expect_true(result == R_NilValue);
+   }
+}
+
+} // namespace tests
+} // namespace session
+} // namespace rstudio


### PR DESCRIPTION
This PR fixes an issue where a failed invocation of `R_tryEval()` could return null pointers on failure.

This is likely the root cause of the crash that was fixed here:

https://github.com/rstudio/rstudio/commit/6572d9c46d97b5f4c4389ec2ec8ad0493c045c6b

and is also likely the underlying cause of some Data Viewer crashes we had in the past.

I think the invariant we should satisfy here is:

1. On success, we set a `SEXP` output argument;
2. On error, we don't touch the output result.

Here's another example where we use this sort of pattern:

https://github.com/rstudio/rstudio/blob/cc35e89f4eba237c7fc00ff100ee97a57cf4faee/src/cpp/session/modules/environment/SessionEnvironment.cpp#L246-L250

Fortunately, we do seem to check for null pointers anywhere that result value is used, but IMHO it'd be much better to avoid having these null pointers hanging around in the first place!

tl;dr: this PR makes it safe to write the following code.

```
SEXP result = R_NilValue;
Protect protect;
Error error = RFunction("mightFail").call(&result, &protect);
if (error)
  LOG_ERROR(error);
// 'result' is still a valid R value (R_NilValue in this case)
```