### PR TITLE
Fix coexistence of git for windows and rtools4

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -10,3 +10,4 @@
 - Allow multiple space-separated domains in `www-frame-origin` for Tutorial API (Pro)
 - Fix dependency installation for untitled buffers (#6762)
 - Add option `www-url-path-prefix` to force a path on auth cookies (Pro #1608)
+- Fix Terminal to works with both Git-Bash and RTools4 MSYS2 installed on Windows (#6696)

--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -10,4 +10,4 @@
 - Allow multiple space-separated domains in `www-frame-origin` for Tutorial API (Pro)
 - Fix dependency installation for untitled buffers (#6762)
 - Add option `www-url-path-prefix` to force a path on auth cookies (Pro #1608)
-- Fix Terminal to works with both Git-Bash and RTools4 MSYS2 installed on Windows (#6696)
+- Fix Terminal to work with both Git-Bash and RTools4 MSYS2 installed on Windows (#6696, #6809)

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -293,8 +293,16 @@ core::FilePath getGitBashShell()
    core::FilePath gitExePath = modules::git::detectedGitExePath();
    if (!gitExePath.isEmpty())
    {
-      core::FilePath gitBashPath =
-            gitExePath.getParent().getParent().completePath("usr/bin/bash.exe");
+      // Prefer git-for-windows bash wrapper; it does some setup before it invokes MSYS2's
+      // usr/bin/bash.exe; not using this wrapper causes problems if other Cygwin-based
+      // Posix environments are on path (such as those in RTools4)
+      core::FilePath gitBashPath = gitExePath.getParent().completePath("bash.exe");
+      if (gitBashPath.exists())
+         return gitBashPath;
+
+      // fall back to old detection behavior in case there's an older version that only
+      // has this installation pattern
+      gitBashPath = gitExePath.getParent().getParent().completePath("usr/bin/bash.exe");
       if (gitBashPath.exists())
          return gitBashPath;
       else


### PR DESCRIPTION
- Fixes #6696
- Fixes #6809
- Stop directly invoking the MSYS2 bash.exe installed with Git for Windows, and instead use the wrapper bash.exe (also installed by Git for Windows) which correctly sets up the environment
- Doing so allows RStudio terminal to use Git-Bash even if RTools4 has been installed and is on the path (as recommended by RTools4 docs); without this fix the path is wrong and can try to use Posix tools from both environments leading to runtime errors

Test notes for QA
-----------------
- Windows-desktop only codepath
- Must have git-for-windows installed
- Confirm that Terminal detects git-bash by default and loads it
- Also double check Tools / Shell (should launch same type of shell as selected for terminal)
- The bug repros only if you install Git for Windows AND RTools4 (including adding to the path in Documents\\.Renviron as described in https://cran.r-project.org/bin/windows/Rtools/
