### PR TITLE
Add unique rstudio_foo classes to some source panel elements

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -1,0 +1,63 @@
+/*
+ * ClassIds.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Element classes that are displayed by the Help / Diagnostics / Show DOM Elements command.
+ *
+ * Should remain stable as they may be used via external automation/scripting.
+ *
+ * These are intended for use on User Interface elements which can occur multiple times in
+ * the UI. For example, the same command button might be seen at same time in multiple
+ * toolbars, or exist multiple times due to being part of the editor UI and having several
+ * open documents.
+ *
+ * For elements guaranteed to only exist once, it is more suitable to use elementIds as in ElementIds.java.
+ */
+public class ClassIds
+{
+   public static void assignClassId(Element ele, String classId)
+   {
+      ele.addClassName(getClassId(classId));
+   }
+
+   public static void assignClassId(Widget widget, String classId)
+   {
+      assignClassId(widget.getElement(), classId);
+   }
+
+   public static String getClassId(String classId)
+   {
+      return CLASS_PREFIX + classId;
+   }
+
+   public static String idSafeString(String text)
+   {
+      return ElementIds.idSafeString(text);
+   }
+
+   public final static String CLASS_PREFIX = "rstudio_";
+
+   // Source Panel
+   public final static String SOURCE_PANEL = "source_panel";
+   public final static String DOC_OUTLINE_CONTAINER = "doc_outline_container";
+
+   // WindowFrameButton (combined with unique suffix for each quadrant
+   public final static String PANEL_MIN_BTN = "panel_min_btn";
+   public final static String PANEL_MAX_BTN = "panel_max_btn";
+}

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -443,12 +443,6 @@ public class ElementIds
    public final static String RSC_ACCOUNT_LIST = "rsc_account_list";
    public static String getRscAccountList() { return getElementId(RSC_ACCOUNT_LIST); }
    public final static String RSC_FILES_LIST_LABEL = "rsc_files_list_label";
-   
-   // WindowFrameButton (combined with unique suffix for each quadrant
-   public final static String FRAME_MIN_BTN = "frame_min_btn";
-   public final static String FRAME_MAX_BTN = "frame_max_btn";
-   public final static String MIN_FRAME_MIN_BTN = "min_frame_min_btn";
-   public final static String MIN_FRAME_MAX_BTN = "min_frame_max_btn";
 
    // ProgressDialog
    public final static String PROGRESS_TITLE_LABEL = "progress_title_label";

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -2,7 +2,7 @@
  * 
  * DocTabLayoutPanel.java
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -16,6 +16,7 @@
 package org.rstudio.core.client.theme;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -112,6 +113,7 @@ public class DocTabLayoutPanel
       styles_ = ThemeResources.INSTANCE.themeStyles();
       addStyleName(styles_.docTabPanel());
       addStyleName(styles_.moduleTabPanel());
+      ClassIds.assignClassId(this, ClassIds.SOURCE_PANEL);
       dragManager_ = new DragManager();
       
       // listen for global drag events (these are broadcast from other windows

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
@@ -20,7 +20,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
-import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.events.HasWindowStateChangeHandlers;
 import org.rstudio.core.client.events.WindowStateChangeEvent;
 import org.rstudio.core.client.events.WindowStateChangeHandler;
@@ -93,7 +93,7 @@ public class MinimizedWindowFrame
       }
 
       WindowFrameButton minimize = new WindowFrameButton(accessibleName, WindowState.NORMAL);
-      minimize.setElementId(ElementIds.MIN_FRAME_MIN_BTN + "_" + ElementIds.idSafeString(accessibleName));
+      minimize.setClassId(ClassIds.PANEL_MIN_BTN, accessibleName);
       minimize.setStylePrimaryName(themeStyles.minimize());
       minimize.setClickHandler(() ->
       {
@@ -102,7 +102,7 @@ public class MinimizedWindowFrame
       inner.add(minimize);
 
       WindowFrameButton maximize = new WindowFrameButton(accessibleName, WindowState.MAXIMIZE);
-      maximize.setElementId(ElementIds.MIN_FRAME_MAX_BTN + "_" + ElementIds.idSafeString(accessibleName));
+      maximize.setClassId(ClassIds.PANEL_MAX_BTN, accessibleName);
       maximize.setStylePrimaryName(themeStyles.maximize());
       maximize.setClickHandler(() ->
       {

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -24,7 +24,7 @@ import com.google.inject.Inject;
 
 import java.util.HashMap;
 
-import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.RequiresVisibilityChanged;
 import org.rstudio.core.client.layout.WindowState;
@@ -61,12 +61,12 @@ public class WindowFrame extends Composite
       borderPositioner_.add(border_);
 
       maximizeButton_ = new WindowFrameButton(name, WindowState.MAXIMIZE);
-      maximizeButton_.setElementId(ElementIds.FRAME_MAX_BTN + "_" + ElementIds.idSafeString(name));
+      maximizeButton_.setClassId(ClassIds.PANEL_MAX_BTN, name);
       maximizeButton_.setStylePrimaryName(styles.maximize());
       maximizeButton_.setClickHandler(() -> maximize());
 
       minimizeButton_ = new WindowFrameButton(name, WindowState.MINIMIZE);
-      minimizeButton_.setElementId(ElementIds.FRAME_MIN_BTN + "_" + ElementIds.idSafeString(name));
+      minimizeButton_.setClassId(ClassIds.PANEL_MIN_BTN, name);
       minimizeButton_.setStylePrimaryName(styles.minimize());
       minimizeButton_.setClickHandler(() -> minimize());
 

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
@@ -21,6 +21,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.HTML;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.layout.WindowState;
@@ -131,6 +132,11 @@ public class WindowFrameButton extends FocusWidget
    public void setElementId(String id)
    {
       getElement().setId(id);
+   }
+
+   public void setClassId(String classId, String panelName)
+   {
+      ClassIds.assignClassId(getElement(), classId + "_" + ClassIds.idSafeString(panelName));
    }
 
    private String stateString(WindowState state)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocumentOutlineWidget.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source;
 
 import com.google.gwt.aria.client.OrientationValue;
 import com.google.gwt.aria.client.Roles;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Counter;
 import org.rstudio.core.client.HandlerRegistrations;
@@ -221,6 +222,7 @@ public class DocumentOutlineWidget extends Composite
       
       container_ = new DockLayoutPanel(Unit.PX);
       container_.addStyleName(RES.styles().container());
+      ClassIds.assignClassId(container_, ClassIds.DOC_OUTLINE_CONTAINER);
       target_ = target;
       
       separator_ = new VerticalSeparator();


### PR DESCRIPTION
Fixes #6817

# Overview

You can now discover via Tools / Diagnostics / Show DOM Elements (and thus highlight) the overall source panel, the min/max buttons within the source panel, and the outline, using class-based CSS selectors. For example:

```R
rstudioapi::highlightUi(
  list(
    list(query = ".rstudio_doc_outline_container", parent = 0L),
    list(query = ".rstudio_source_panel", parent = 0L),
    list(query = ".rstudio_panel_min_btn_source", parent = 0L)
  )
)

```
<img width="973" alt="screenshot showing highlighted elements" src="https://user-images.githubusercontent.com/10569626/81327089-9c75bf80-904f-11ea-8b14-d482998eac2b.png">

# Details

Added the `ClassIds.java` file, which conceptually parallels the existing `ElementIds.java` as the place to define unique and stable DOM class names for elements.

Using classes allows elements that can have multiple instances, including most UI in the source editor (because you can open multiple documents), to have the same selector, and by prefixing them with `rstudio_` the `Show DOM Elements` feature reveals them.

ElementIds must be unique (HTML rule and important for accessibility) so our code disambiguates them at runtime, and you end up with IDs with numeric suffixes (_###) whose values depend on the state of the UI and the order things were opened.

For automation purposes such as rstudioapi::highlightUi the unstable ElementIds are not ideal, hence reason for this class-based approach (multiple elements can have the same class applied, of course).