### PR TITLE
Install correct Qt libs on Linux

### DIFF
--- a/dependencies/common/install-qt.sh
+++ b/dependencies/common/install-qt.sh
@@ -229,7 +229,13 @@ function compute_url(){
         )
 
         for REMOTE_BASE in ${REMOTE_BASES[*]}; do
-            REMOTE_PATH="$(${CURL} ${BASE_URL}/${REMOTE_BASE}/ | grep -o -E "[[:alnum:]_.\-]*7z" | grep "${COMPONENT}" | tail -1)"
+            if [[ "${HOST_OS}" == "linux_x64" && "${VERSION}" == "5.12.8" ]]; then
+                # Qt 5.12.8 Linux release has multiple files in release folders; install the correct one!
+                # https://github.com/rstudio/rstudio/issues/6782
+                REMOTE_PATH="$(${CURL} ${BASE_URL}/${REMOTE_BASE}/ | grep -o -E "5\.12\.8\-0\-20200405[[:alnum:]_.\-]*7z" | grep "${COMPONENT}" | tail -1)"
+            else
+                REMOTE_PATH="$(${CURL} ${BASE_URL}/${REMOTE_BASE}/ | grep -o -E "[[:alnum:]_.\-]*7z" | grep "${COMPONENT}" | tail -1)"
+            fi
             if [ ! -z "${REMOTE_PATH}" ]; then
                 echo "${BASE_URL}/${REMOTE_BASE}/${REMOTE_PATH}"
                 return 0

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -46,4 +46,5 @@ mkdir -p ${QT_SDK_DIR}
     qttranslations \
     qtwayland \
     qtwebsockets \
+    qtimageformats \
 


### PR DESCRIPTION
The Qt 5.12.8 release folders have two versions of the libraries; a pre-release version and the correct version. The installation script used in our Dockerfiles is pulling in the wrong one and it doesn't have the glibc Chromium fix that is the whole reason we're switching to this version!

Also added qtimageformats component as its absence in Docker build images cause 4 image filter files not to be installed with RStudio that were included when building against a Qt SDK installed via online installer. Don't know if this matters in any way but just trying to reduce all differences between known-good local builds and "official" builds.

Fixes #6782

Will also be ported to master (1.4).