### PR TITLE
Add common statistics terminology to spell checker

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
@@ -6,6 +6,7 @@ afl
 altrep
 altrepisode
 analytics
+anova
 api
 applypatch
 appveyor
@@ -16,6 +17,7 @@ asan
 aspirationally
 async
 atomicity
+autocorrelation
 autotool
 az
 backports
@@ -27,6 +29,7 @@ biblatex
 bibtex
 bioc
 bioconductor
+bioinformatics
 bitbucket
 blogdown
 bom
@@ -41,6 +44,7 @@ bugreports
 bz
 bzip
 ccby
+chemometrics
 chriswhong
 ci
 cifs
@@ -54,6 +58,8 @@ cn
 codecov
 coercible
 config
+correlogram
+covariance
 cpp
 cran
 csl
@@ -80,6 +86,7 @@ dplyr
 dropbox
 drs
 dvipsnames
+econometrics
 Eggenberger
 el
 emacs
@@ -106,6 +113,7 @@ fontenc
 fontspec
 foofy
 forkable
+fourier
 françois
 fread
 frontend
@@ -114,8 +122,10 @@ fs
 funder
 fwf
 gabe
+gauss
 gc
 gcc
+geostatistics
 getgrent
 getpwent
 ggplot
@@ -135,9 +145,15 @@ gzip
 gzipped
 hadley
 hardcoding
+heteroscedastic
+heteroscedasticity
+heteroskedastic
+heteroskedasticity
 hexb
 hexidecimal
 homebrew
+homoscedastic
+homoscedasticity
 hostname
 http
 https
@@ -152,6 +168,7 @@ igraph
 inode
 installable
 instapaper
+interquartile
 interruptible
 io
 ish
@@ -171,6 +188,8 @@ kk
 knitr
 ko
 kr
+kriging
+kurtosis
 lbzip
 learnr
 lexicographically
@@ -199,11 +218,13 @@ mainfont
 makefile
 makefiles
 mandreyel
+markov
 mathfont
 md
 metadata
 microtype
 mio
+misspecification
 misspecify
 mk
 mn
@@ -222,6 +243,7 @@ nfs
 nl
 nodejs
 noncentral
+nonparametric
 nulls
 numpy
 nyc
@@ -240,6 +262,7 @@ parsers
 pats
 pdf
 pdflatex
+pearson
 pid
 pids
 pigz
@@ -248,6 +271,7 @@ pixz
 pkgbuild
 pkgdown
 png
+poisson
 pollable
 Polya
 posixt
@@ -257,10 +281,13 @@ preprocess
 processx
 programmatically
 prs
+psychometrics
 pthread
 pubkey
 purrr
 px
+quantal
+quantile
 Rademacher
 rchk
 rcpp
@@ -301,13 +328,15 @@ rray's
 rsconnect
 rstd
 rstudio
-rstudioapi
 rstudio’s
+rstudioapi
 rticles
 rtools
 ru
 runnable
 sansfont
+scedastic
+scedasticity
 searchability
 setspace
 sha
@@ -323,7 +352,9 @@ sigkill
 signalling
 sitrep
 sk
+skedastic
 Skellam
+skewness
 sl
 soliton
 sr


### PR DESCRIPTION
Added a set of common statistical terms to RStudio spellchecker.

It'd be a treat for these to be automatically in there. 