### PR TITLE
defend against 'undefined' ch at boundary of string

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/patch/SubstringDiff.java
+++ b/src/gwt/src/org/rstudio/core/client/patch/SubstringDiff.java
@@ -74,13 +74,22 @@ public class SubstringDiff
       {
       }
       
+      // Early check for case with no diff.
+      if (olen === nlen && head === tail) {
+         return {
+            "replacement": "",
+            "offset": 0,
+            "length": 0
+         }
+      }
+      
       // Move head and tail to ensure we align on starts of UTF-8 characters.
       // UTF-8 continuation bytes match the byte sequence 10xxxxxx;
       // that is, are values in the range [128, 192). So we want to ensure
       // head + tail land on bytes not containing those values.
       while (head > 0)
       {
-         var ch = o[head];
+         var ch = o[head] || 0;
          if (ch < 128 || ch >= 192)
             break;
          head--;
@@ -88,7 +97,7 @@ public class SubstringDiff
       
       while (tail < olen)
       {
-         var ch = o[tail];
+         var ch = o[tail] || 0;
          if (ch < 128 || ch >= 192)
             break;
          tail++;


### PR DESCRIPTION
This PR fixes an issue where spurious diffs could be emitted for documents that haven't changed. The issue with spurious diffs is caused by the adjustment done for UTF-8 characters here:

https://github.com/rstudio/rstudio/blob/42f759ccd4adb0c74550e47f154f7983088017db/src/gwt/src/org/rstudio/core/client/patch/SubstringDiff.java#L77-L95

In particular, if the two strings are identical (or the original string is a subset of the new string), then the `head` index will point at the end of the original string. When we index that, we get `undefined`, which compares improperly here:

```
         if (ch < 128 || ch >= 192)
            break;
```

This PR fixes that issue, and also adds a precautionary check for empty diffs before UTF-8 adjustment is done.

Closes https://github.com/rstudio/rstudio/issues/6846.