### PR TITLE
add additional keyboard shortcut for Focus Console Output command

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -11,3 +11,4 @@
 - Fix dependency installation for untitled buffers (#6762)
 - Add option `www-url-path-prefix` to force a path on auth cookies (Pro #1608)
 - Fix Terminal to work with both Git-Bash and RTools4 MSYS2 installed on Windows (#6696, #6809)
+- Add additional keyboard shortcut (Ctrl+`) for Focus Console Output accessibility command (#6850)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -820,7 +820,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="nextPlot" value="Cmd+Shift+PageDown" />
          <shortcut refid="previousPlot" value="Cmd+Alt+F11" />
          <shortcut refid="nextPlot" value="Cmd+Alt+F12" />
-         <shortcut refid="showRequestLog" value="Ctrl+`" />
+         <shortcut refid="showRequestLog" value="Ctrl+Alt+`" />
          <shortcut refid="logFocusedElement" value="Ctrl+Shift+`" />
          <shortcut refid="setWorkingDir" value="Ctrl+Shift+H" />
          <shortcut refid="synctexSearch" value="Cmd+F8" />
@@ -874,6 +874,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="toggleScreenReaderSupport" value="Alt+Shift+/" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+Alt+2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="focusConsoleOutputEnd" value="Ctrl+`"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Alt+Shift+[" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Alt+1" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -75,8 +75,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Focus Console Output</td>
-      <td>Alt+Shift+2</td>
-      <td>⌃⌥2</td>
+      <td>Ctrl+` or Alt+Shift+2</td>
+      <td>Ctrl+` or ⌃⌥2</td>
     </tr>
     <tr>
       <td>Toggle Tab Key Always Moves Focus</td>


### PR DESCRIPTION
- added Ctrl+` in addition to existing shortcut
- leaving existing shortcuts because some keyboards (e.g. Italian) don't have a backtick key
- changed shortcut for showing request log to Ctrl+Alt+`
- Fixes #6850