### PR TITLE
remove unimplemented Search History command entry

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2491,12 +2491,6 @@ well as menu structures (for main menu and popup menus).
         desc="Send the selected commands to the R console (Enter)"
         rebindable="false"/>
         
-   <cmd id="searchHistory"
-        menuLabel="Search History"
-        buttonLabel=""
-        desc="Search history for commands matching a pattern"
-        rebindable="false"/>
-        
    <cmd id="loadHistory"
         menuLabel="_Load History..."
         buttonLabel=""

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
@@ -1,7 +1,7 @@
 /*
  * History.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -446,12 +446,7 @@ public class History extends BasePresenter implements SelectionCommitHandler<Voi
       if (commandString.length() > 0)
          events_.fireEvent(new InsertSourceEvent(commandString, true));
    }
-   
-   void onSearchHistory()
-   {
-      globalDisplay_.showErrorMessage("Message", "onSearchHistory");
-   }
-   
+
    void onLoadHistory()
    {
       view_.bringToFront();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/HistoryTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/HistoryTab.java
@@ -1,7 +1,7 @@
 /*
  * HistoryTab.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -29,9 +29,6 @@ public class HistoryTab extends DelayLoadWorkbenchTab<History>
    public abstract static class Shim
          extends DelayLoadTabShim<History, HistoryTab>
    {
-      @Handler
-      public abstract void onSearchHistory();
-      
       @Handler
       public abstract void onLoadHistory();
       


### PR DESCRIPTION
- Remove command whose sole purpose (currently) is to display a modal dialog saying "onSearchHistory"
- Noticed while playing with new command palette feature (in a branch)

<img width="609" alt="command palette showing search history command" src="https://user-images.githubusercontent.com/10569626/81748909-860ca100-945f-11ea-97aa-683dbfaf27e1.png">

<img width="379" alt="modal dialog saying onSearchHistory" src="https://user-images.githubusercontent.com/10569626/81748918-8a38be80-945f-11ea-9be8-81a9242288be.png">
