### PR TITLE
avoid using capture.output when getting environment label

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -146,7 +146,7 @@ options(help_type = "html")
       namespace <- "base"
    else if (is.function(object))
    {
-      envString <- capture.output(environment(object))[1]
+      envString <- format.default(environment(object))[1]
       
       # Strip out the irrelevant bits of the package name. We'd like
       # to just use 'regexpr' but its output is funky with older versions


### PR DESCRIPTION
As it puts us at the mercy of packages which provide `print.environment` methods. We really just want the default `format` method here, so it's much easier to invoke that directly.

Closes https://github.com/rstudio/rstudio/issues/6645.