### PR TITLE
support view of Python objects in Environment pane

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -201,6 +201,7 @@ const int kReplaceResult = 183;
 const int kReplaceUpdated = 184;
 const int kTutorialCommand = 185;
 const int kTutorialLaunch = 186;
+const int kReticulateEvent = 187;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -558,6 +559,8 @@ std::string ClientEvent::typeName() const
          return "tutorial_command";
       case client_events::kTutorialLaunch:
          return "tutorial_launch";
+      case client_events::kReticulateEvent:
+         return "reticulate_event";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -202,6 +202,7 @@ const int kReplaceUpdated = 184;
 const int kTutorialCommand = 185;
 const int kTutorialLaunch = 186;
 const int kReticulateEvent = 187;
+const int kEnvironmentChanged = 188;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -561,6 +562,8 @@ std::string ClientEvent::typeName() const
          return "tutorial_launch";
       case client_events::kReticulateEvent:
          return "reticulate_event";
+      case client_events::kEnvironmentChanged:
+         return "environment_changed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -235,6 +235,9 @@ void handleClientInit(const boost::function<void()>& initFunction,
    // get alias to console_actions and get limit
    rstudio::r::session::ConsoleActions& consoleActions = rstudio::r::session::consoleActions();
    sessionInfo["console_actions_limit"] = consoleActions.capacity();
+ 
+   // check if reticulate's Python session has been initialized
+   sessionInfo["python_initialized"] = modules::reticulate::isPythonInitialized();
    
    // get current console language
    sessionInfo["console_language"] = modules::reticulate::isReplActive() ? "Python" : "R";

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -261,6 +261,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kEnvironmentRefresh;
       else if (name == "environment_removed")
          type = session::client_events::kEnvironmentRemoved;
+      else if (name == "environment_changed")
+         type = session::client_events::kEnvironmentChanged;
 
       if (type != -1)
       {

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -253,6 +253,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kTutorialCommand;
       else if (name == "tutorial_launch")
          type = session::client_events::kTutorialLaunch;
+      else if (name == "reticulate_event")
+         type = session::client_events::kReticulateEvent;
 
       if (type != -1)
       {
@@ -264,7 +266,7 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          LOG_ERROR_MESSAGE("Unexpected event name from R: " + name);
       }
    }
-   catch(r::exec::RErrorException& e)
+   catch (r::exec::RErrorException& e)
    {
       r::exec::error(e.message());
    }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -255,6 +255,12 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kTutorialLaunch;
       else if (name == "reticulate_event")
          type = session::client_events::kReticulateEvent;
+      else if (name == "environment_assigned")
+         type = session::client_events::kEnvironmentAssigned;
+      else if (name == "environment_refresh")
+         type = session::client_events::kEnvironmentRefresh;
+      else if (name == "environment_removed")
+         type = session::client_events::kEnvironmentRemoved;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -859,6 +859,8 @@ void onBackgroundProcessing(bool isIdle);
 
 void initializeConsoleCtrlHandler();
 
+bool isPythonReplActive();
+
 } // namespace module_context
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -202,6 +202,7 @@ extern const int kReplaceResult;
 extern const int kReplaceUpdated;
 extern const int kTutorialCommand;
 extern const int kTutorialLaunch;
+extern const int kReticulateEvent;
 }
    
 class ClientEvent

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -203,6 +203,7 @@ extern const int kReplaceUpdated;
 extern const int kTutorialCommand;
 extern const int kTutorialLaunch;
 extern const int kReticulateEvent;
+extern const int kEnvironmentChanged;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -146,7 +146,7 @@ options(help_type = "html")
       namespace <- "base"
    else if (is.function(object))
    {
-      envString <- capture.output(environment(object))[1]
+      envString <- format(environment(object))[[1L]]
       
       # Strip out the irrelevant bits of the package name. We'd like
       # to just use 'regexpr' but its output is funky with older versions

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -146,7 +146,7 @@ options(help_type = "html")
       namespace <- "base"
    else if (is.function(object))
    {
-      envString <- format(environment(object))[[1L]]
+      envString <- format.default(environment(object))[[1L]]
       
       # Strip out the irrelevant bits of the package name. We'd like
       # to just use 'regexpr' but its output is funky with older versions

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -606,13 +606,15 @@
 })
 
 .rs.addFunction("explorer.inspectPythonValue", function(object,
-                                                         context = .rs.explorer.createContext())
+                                                        context = .rs.explorer.createContext())
 {
    children <- NULL
    
    if (context$recursive)
    {
-      children <- if (inherits(object, "python.builtin.dict"))
+      children <- if (.rs.explorer.tags$ATTRIBUTES %in% context$tags)
+         .rs.explorer.inspectPythonObject(object, context)
+      else if (inherits(object, "python.builtin.dict"))
          .rs.explorer.inspectPythonDict(object, context)
       else if (.rs.reticulate.isStructSeq(object))
          .rs.explorer.inspectPythonObject(object, context)

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -262,7 +262,7 @@
    cache <- .rs.explorer.getCache()
    cache[[id]] <- entry
    
-   # for Python objects, store a reference in main module
+   # for Python objects, store a reference in our cache
    if (inherits(entry$object, "python.builtin.object"))
    {
       pyid <- paste("_rstudio_viewer", id, sep = "_")
@@ -284,7 +284,7 @@
    if (exists(id, envir = cache))
       rm(list = id, envir = cache)
    
-   # if this is a Python object, remove it from the main module
+   # for Python objects, remove cache reference
    if (.rs.reticulate.isPythonInitialized())
    {
       pyid <- paste("_rstudio_viewer", id, sep = "_")
@@ -1180,7 +1180,7 @@
 {
    # NOTE: technically, these objects are expandable (they have attributes
    # and may even have methods of interest) but since they're usually less
-   # interesting than the object's actual value we ignore those byd default.
+   # interesting than the object's actual value we ignore those by default.
    ignored <- c(
       "python.builtin.bool",
       "python.builtin.int",

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -162,7 +162,7 @@ void onDocPendingRemove(boost::shared_ptr<source_database::SourceDocument> pDoc)
    
    // also attempt to remove from R cache
    using namespace r::exec;
-   error = RFunction(".rs.explorer.removeCachedObject")
+   error = RFunction(".rs.explorer.removeCacheEntry")
          .addParam(id)
          .call();
    

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1134,9 +1134,7 @@ options(reticulate.repl.teardown   = .rs.reticulate.replTeardown)
       # try to infer the completion type
       if (inherits(item, "python.builtin.module"))
          .rs.acCompletionTypes$ENVIRONMENT
-      else if (inherits(item, "python.builtin.builtin_function_or_method") ||
-               inherits(item, "python.builtin.function") ||
-               inherits(item, "python.builtin.instancemethod"))
+      else if (.rs.reticulate.isFunction(item))
          .rs.acCompletionTypes$FUNCTION
       else if (inherits(item, "pandas.core.frame.DataFrame"))
          .rs.acCompletionTypes$DATAFRAME
@@ -1483,7 +1481,7 @@ html.heading = _heading
    # TODO: there isn't really a distinction between an objects "type"
    # and an objects "class" in Python 3
    # get object type, value
-   type <- if (inherits(object, "python.builtin.function"))
+   type <- if (.rs.reticulate.isFunction(object))
       "function"
    else
       builtins$str(builtins$type(object))
@@ -1736,4 +1734,13 @@ html.heading = _heading
       error = function(e) FALSE
    )
 
+})
+
+.rs.addFunction("reticulate.isFunction", function(object)
+{
+   inherits(object, c(
+      "python.builtin.builtin_function_or_method",
+      "python.builtin.function",
+      "python.builtin.instancemethod"
+   ))
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1614,7 +1614,7 @@ html.heading = _heading
 #   ..$ frame: 'rs.scalar' int 0
 #   ..$ local: 'rs.scalar' logi FALSE
 # < ... >
-.rs.addFunction("reticulate.listLoadedModules", function()
+.rs.addFunction("reticulate.listLoadedModules", function(includeBuiltins = FALSE)
 {
    if (!requireNamespace("reticulate", quietly = TRUE))
       return(list())
@@ -1635,7 +1635,12 @@ html.heading = _heading
          variable
       )
       
-      stack$append(as.character(name))
+      # ignore builtins if requested
+      name <- as.character(name)
+      if (!includeBuiltins && name %in% c("builtins", "__builtins__"))
+         return(FALSE)
+      
+      stack$append(name)
       TRUE
       
    })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1814,3 +1814,31 @@ html.heading = _heading
    }
    
 })
+
+.rs.addFunction("reticulate.isStructSeq", function(object)
+{
+   all(
+      reticulate::py_has_attr(object, "n_sequence_fields"),
+      reticulate::py_has_attr(object, "n_fields"),
+      reticulate::py_has_attr(object, "n_unnamed_fields")
+   )
+})
+
+.rs.addFunction("reticulate.listAttributes", function(object, includeDunderMethods = TRUE)
+{
+   attributes <- reticulate::py_list_attributes(object)
+   
+   # remove dunder methods if requested
+   if (!includeDunderMethods)
+      attributes <- grep("^__", attributes, value = TRUE, invert = TRUE)
+   
+   # sort so that dunder methods are shown last
+   indices <- order(
+      .rs.startsWith(attributes, "__"),
+      .rs.startsWith(attributes, "_")
+   )
+
+   # return sorted attributes
+   attributes[indices]
+   
+})

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -13,8 +13,23 @@
 #
 #
 
+# synchronize with ReticulateEvent.java
+.rs.setVar("reticulateEvents", list(
+   PYTHON_INITIALIZED = "python_initialized",
+   REPL_INITIALIZED   = "repl_initialized",
+   REPL_ITERATION     = "repl_iteration",
+   REPL_TEARDOWN      = "repl_teardown"
+))
+
 options(reticulate.initialized = function() {
+   
+   .rs.reticulate.enqueueClientEvent(
+      .rs.reticulateEvents$PYTHON_INITIALIZED,
+      list()
+   )
+   
    .Call("rs_reticulateInitialized", PACKAGE = "(embedding)")
+   
 })
 
 .rs.setVar("python.moduleCache", new.env(parent = emptyenv()))
@@ -185,7 +200,10 @@ options(reticulate.initialized = function() {
    }
    
    # signal a switch to Python context
-   .rs.reticulate.enqueueClientEvent("repl_initialized", list())
+   .rs.reticulate.enqueueClientEvent(
+      .rs.reticulateEvents$REPL_INITIALIZED,
+      list()
+   )
    
 })
 
@@ -193,7 +211,10 @@ options(reticulate.initialized = function() {
 {
    # ensure we call repl_iteration hook on exit
    on.exit(
-      .rs.reticulate.enqueueClientEvent("repl_iteration", list()),
+      .rs.reticulate.enqueueClientEvent(
+         .rs.reticulateEvents$REPL_ITERATION,
+         list()
+      ),
       add = TRUE
    )
    
@@ -241,7 +262,10 @@ options(reticulate.initialized = function() {
    }
    
    # client event
-   .rs.reticulate.enqueueClientEvent("repl_teardown", list())
+   .rs.reticulate.enqueueClientEvent(
+      .rs.reticulateEvents$REPL_TEARDOWN,
+      list()
+   )
 })
 
 .rs.addFunction("reticulate.replIsActive", function()
@@ -1623,4 +1647,10 @@ html.heading = _heading
       })
    })
    
+})
+
+.rs.addFunction("reticulate.isPythonInitialized", function()
+{
+   "reticulate" %in% loadedNamespaces() &&
+      reticulate::py_available(initialize = FALSE)
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1521,7 +1521,7 @@ html.heading = _heading
    
    # obtain a description of each Python object, using the already-understood
    # format used for R objects
-   descriptions <- lapply(objects, .rs.reticulate.describeObject, module = module)
+   descriptions <- lapply(objects, .rs.reticulate.describeObject, parent = module)
    
    # try to get the module name (if any)
    name <- tryCatch(

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1504,7 +1504,7 @@ html.heading = _heading
    size <- sys$getsizeof(object)
    
    # get object length (note: not all objects in Python have a length)
-   length <- tryCatch(builtins$len(object), error = function(e) 0)
+   length <- .rs.reticulate.describeObjectLength(object)
    
    list(
       name              = .rs.scalar(name),
@@ -1524,7 +1524,7 @@ html.heading = _heading
 .rs.addFunction("reticulate.describeObjectType", function(object)
 {
    builtins <- reticulate::import_builtins(convert = TRUE)
-   builtins$str(builtins$type(object))
+   builtins$type(object)$`__name__`
 })
 
 .rs.addFunction("reticulate.describeObjectValue", function(object)
@@ -1557,6 +1557,16 @@ html.heading = _heading
    }
    
 })
+
+.rs.addFunction("reticulate.describeObjectLength", function(object)
+{
+   builtins <- reticulate::import_builtins(convert = TRUE)
+   tryCatch(
+      builtins$len(object),
+      error = function(e) -1L
+   )
+})
+
 .rs.addFunction("reticulate.resolveModule", function(module)
 {
    # return module objects as-is

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -21,6 +21,7 @@
    REPL_TEARDOWN      = "repl_teardown"
 ))
 
+# hook to be invoked when the Python session has been initialized by reticulate
 options(reticulate.initialized = function() {
    
    .rs.reticulate.enqueueClientEvent(
@@ -1841,4 +1842,12 @@ html.heading = _heading
    # return sorted attributes
    attributes[indices]
    
+})
+
+.rs.addFunction("reticulate.explorerCache", function()
+{
+   key <- "reticulate.explorerCacheDictionary"
+   if (!.rs.hasVar(key))
+      .rs.setVar(key, reticulate::dict())
+   .rs.getVar(key)
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -24,6 +24,7 @@
 # hook to be invoked when the Python session has been initialized by reticulate
 options(reticulate.initialized = function() {
    
+   # notify client that Python is being initialized
    .rs.reticulate.enqueueClientEvent(
       .rs.reticulateEvents$PYTHON_INITIALIZED,
       list()

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1490,8 +1490,11 @@ html.heading = _heading
       reticulate:::py_is_module(object)
    )
    
-   # TODO: there isn't really a distinction between an objects "type"
-   # and an objects "class" in Python 3
+   # NOTE: there isn't really a distinction between an objects "type"
+   # and an objects "class" in Python 3; whereas R objects might have
+   # some internal type and multiple (S3, S4, R6) classes, depending
+   # on what form of OOP is used for dispatch
+   
    # get object type, value
    type <- if (.rs.reticulate.isFunction(object))
       "function"

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -82,5 +82,15 @@ Error initialize()
 
 } // end namespace reticulate
 } // end namespace modules
+
+namespace module_context {
+
+bool isPythonReplActive()
+{
+   return modules::reticulate::isReplActive();
+}
+
+} // end namespace module_context
+
 } // end namespace session
 } // end namespace rstudio

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -56,6 +56,27 @@ void onDeferredInit(bool)
 }
 
 } // end anonymous namespace
+
+bool isPythonInitialized()
+{
+   // NOTE: once initialized Python cannot be un-initialized
+   // so we disable this check as soon as we know the answer
+   static bool s_initialized = false;
+   
+   if (!s_initialized)
+   {
+      Error error = 
+            r::exec::RFunction(".rs.reticulate.isPythonInitialized")
+            .call(&s_initialized);
+      
+      if (error)
+         LOG_ERROR(error);
+   }
+   
+   return s_initialized;
+   
+}
+
 bool isReplActive()
 {
    bool active = false;

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -36,8 +36,14 @@ namespace reticulate {
 
 namespace {
 
+// has the Python session been initialized by reticulate yet?
+bool s_pythonInitialized = false;
+
 SEXP rs_reticulateInitialized()
 {
+   // set initialized flag
+   s_pythonInitialized = true;
+   
    // Python will register its own console control handler,
    // which also blocks signals from reaching any previously
    // defined handlers (including RStudio's own). re-initialize
@@ -59,22 +65,7 @@ void onDeferredInit(bool)
 
 bool isPythonInitialized()
 {
-   // NOTE: once initialized Python cannot be un-initialized
-   // so we disable this check as soon as we know the answer
-   static bool s_initialized = false;
-   
-   if (!s_initialized)
-   {
-      Error error = 
-            r::exec::RFunction(".rs.reticulate.isPythonInitialized")
-            .call(&s_initialized);
-      
-      if (error)
-         LOG_ERROR(error);
-   }
-   
-   return s_initialized;
-   
+   return s_pythonInitialized;
 }
 
 bool isReplActive()

--- a/src/cpp/session/modules/SessionReticulate.hpp
+++ b/src/cpp/session/modules/SessionReticulate.hpp
@@ -29,6 +29,7 @@ namespace session {
 namespace modules {
 namespace reticulate {
 
+bool isPythonInitialized();
 bool isReplActive();
 
 core::Error initialize();

--- a/src/cpp/session/modules/environment/EnvironmentConstants.hpp
+++ b/src/cpp/session/modules/environment/EnvironmentConstants.hpp
@@ -1,0 +1,22 @@
+/*
+ * EnvironmentConstants.hpp
+ *
+ * Copyright (C) 2009-20 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_MODULES_ENVIRONMENT_CONSTANTS_HPP
+#define SESSION_MODULES_ENVIRONMENT_CONSTANTS_HPP
+
+#define kEnvironmentLanguageR      "R"
+#define kEnvironmentLanguagePython "Python"
+
+#endif /* SESSION_MODULES_ENVIRONMENT_CONSTANTS_HPP */

--- a/src/cpp/session/modules/environment/EnvironmentMonitor.hpp
+++ b/src/cpp/session/modules/environment/EnvironmentMonitor.hpp
@@ -16,6 +16,9 @@
 #include <r/RSexp.hpp>
 #include <r/RInterface.hpp>
 
+#ifndef SESSION_MODULES_ENVIRONMENT_MONITOR_HPP
+#define SESSION_MODULES_ENVIRONMENT_MONITOR_HPP
+
 namespace rstudio {
 namespace session {
 namespace modules {
@@ -47,3 +50,5 @@ private:
 } // namespace modules
 } // namespace session
 } // namespace rstudio
+
+#endif /* SESSION_MODULES_ENVIRONMENT_MONITOR_HPP */

--- a/src/cpp/session/modules/environment/EnvironmentUtils.hpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.hpp
@@ -13,6 +13,9 @@
  *
  */
 
+#ifndef SESSION_MODULES_ENVIRONMENT_UTILS_HPP
+#define SESSION_MODULES_ENVIRONMENT_UTILS_HPP
+
 #include <shared_core/json/Json.hpp>
 #include <r/RSexp.hpp>
 
@@ -33,3 +36,5 @@ bool hasAltrep(SEXP var);
 } // namespace modules
 } // namespace session
 } // namespace rstudio
+
+#endif /* SESSION_MODULES_ENVIRONMENT_UTILS_HPP */

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -606,7 +606,6 @@ json::Value environmentNames(SEXP env)
 
 json::Object pythonEnvironmentStateData(const std::string& environment)
 {
-   // TODO: Need to pass in 'active' Python module here.
    SEXP state = R_NilValue;
    r::sexp::Protect protect;
    Error error =
@@ -1123,7 +1122,11 @@ Error environmentSetLanguage(const json::JsonRpcRequest& request,
       LOG_ERROR(error);
    
    s_environmentLanguage = language;
-   s_monitoredPythonModule = "__main__";
+   
+   if (language == "Python")
+   {
+      s_monitoredPythonModule = "__main__";
+   }
    
    return Success();
 }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1174,12 +1174,17 @@ SEXP rs_jumpToFunction(SEXP file, SEXP line, SEXP col)
 
 json::Value environmentStateAsJson()
 {
+   if (s_environmentLanguage == "Python")
+      return pythonEnvironmentStateData(s_monitoredPythonModule);
+   
    int contextDepth = 0;
    r::context::getFunctionContext(BROWSER_FUNCTION, &contextDepth);
+   
    // If there's no browser on the stack, stay at the top level even if
    // there are functions on the stack--this is not a user debug session.
    if (!r::context::inBrowseContext())
       contextDepth = 0;
+   
    return commonEnvironmentStateData(contextDepth, 
          s_monitoring, // include contents if actively monitoring
          nullptr);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -631,6 +631,7 @@ json::Object pythonEnvironmentStateData(const std::string& environment)
       return json::Object();
    }
    
+   jsonState["environment_monitoring"] = s_monitoring;
    return jsonState;
 }
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -511,6 +511,10 @@ Error setEnvironment(boost::shared_ptr<int> pContextDepth,
          module_context::enqueClientEvent(event);
       }
    }
+   else
+   {
+      LOG_WARNING_MESSAGE("Unexpected language '" + s_environmentLanguage + "'");
+   }
    
    if (error)
       return error;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -812,7 +812,11 @@ void onDetectChanges(module_context::ChangeSource /* source */)
    // Prevent recursive calls to this function
    DROP_RECURSIVE_CALLS;
 
-   // Check for Python changes.
+   // Ignore if not monitoring
+   if (!s_monitoring)
+      return;
+
+   // Check for Python changes
    if (s_environmentLanguage == kEnvironmentLanguagePython &&
        !s_monitoredPythonModule.empty())
    {
@@ -825,10 +829,6 @@ void onDetectChanges(module_context::ChangeSource /* source */)
          LOG_ERROR(error);
    }
    
-   // Ignore if not monitoring
-   if (!s_monitoring)
-      return;
-
    s_pEnvironmentMonitor->checkForChanges();
    
 }

--- a/src/cpp/session/modules/environment/SessionEnvironment.hpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.hpp
@@ -18,6 +18,8 @@
 
 #include <shared_core/json/Json.hpp>
 
+#include "EnvironmentConstants.hpp"
+
 namespace rstudio {
 namespace core {
    class Error;

--- a/src/gwt/src/org/rstudio/core/client/AriaUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/AriaUtil.java
@@ -1,7 +1,7 @@
 /*
  * AriaUtil.java
  *
- * Copyright (C) 2009-2020 by RStudio, Inc.
+ * Copyright (C) 2009-2020 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/jsinterop/JsVoidFunction.java
+++ b/src/gwt/src/org/rstudio/core/client/jsinterop/JsVoidFunction.java
@@ -1,7 +1,7 @@
 /*
  * JsVoidFunction.java
  *
- * Copyright (C) 2009-20 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/promise/PromiseServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/promise/PromiseServerRequestCallback.java
@@ -1,7 +1,7 @@
 /*
  * PromiseServerRequestCallback.java
  *
- * Copyright (C) 2009-20 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/promise/PromiseWithProgress.java
+++ b/src/gwt/src/org/rstudio/core/client/promise/PromiseWithProgress.java
@@ -1,7 +1,7 @@
 /*
  * PromiseWithProgress.java
  *
- * Copyright (C) 2009-20 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/widget/DockPanelSidebarDragHandler.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DockPanelSidebarDragHandler.java
@@ -1,7 +1,7 @@
 /*
  * DockPanelSidebarDragHandler.java
  *
- * Copyright (C) 2009-20 by RStudio, Inc.
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/widget/IsHideableWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/IsHideableWidget.java
@@ -1,7 +1,7 @@
 /*
  * IsHideableWidget.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-12 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/core/client/widget/SecondaryToolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SecondaryToolbar.java
@@ -28,6 +28,12 @@ public class SecondaryToolbar extends Toolbar
       if (!appearAsPrimary)
          addStyleName(styles_.rstheme_secondaryToolbar());
    }
+   
+   @Override
+   public void manageSeparators()
+   {
+      super.manageSeparators();
+   }
 
    @Override
    public int getHeight()

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -1,0 +1,66 @@
+/*
+ * ReticulateEvent.java
+ *
+ * Copyright (C) 2009-2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      // Event data accessors ----
+      
+   }
+
+   public ReticulateEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onReticulate(ReticulateEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onReticulate(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.events;
 
+import org.rstudio.core.client.Debug;
+
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
@@ -27,17 +29,24 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
       }
 
       // Event data accessors ----
+      public final native String getType() /*-{ return this["type"]; }-*/;
       
    }
 
    public ReticulateEvent(Data data)
    {
+      Debug.logObject(data);
       data_ = data;
    }
 
    public Data getData()
    {
       return data_;
+   }
+   
+   public String getType()
+   {
+      return data_.getType();
    }
 
    private final Data data_;
@@ -62,5 +71,9 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();
+   
+   public static final String TYPE_REPL_INITIALIZED = "repl_initialized";
+   public static final String TYPE_REPL_ITERATION   = "repl_iteration";
+   public static final String TYPE_REPL_TEARDOWN    = "repl_teardown";
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -68,9 +68,11 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
    }
 
    public static final Type<Handler> TYPE = new Type<Handler>();
-   
-   public static final String TYPE_REPL_INITIALIZED = "repl_initialized";
-   public static final String TYPE_REPL_ITERATION   = "repl_iteration";
-   public static final String TYPE_REPL_TEARDOWN    = "repl_teardown";
+ 
+   // synchronize with SessionReticulate.R
+   public static final String TYPE_PYTHON_INITIALIZED = "python_initialized";
+   public static final String TYPE_REPL_INITIALIZED   = "repl_initialized";
+   public static final String TYPE_REPL_ITERATION     = "repl_iteration";
+   public static final String TYPE_REPL_TEARDOWN      = "repl_teardown";
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -14,8 +14,6 @@
  */
 package org.rstudio.studio.client.events;
 
-import org.rstudio.core.client.Debug;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
@@ -35,7 +33,6 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
 
    public ReticulateEvent(Data data)
    {
-      Debug.logObject(data);
       data_ = data;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -1,7 +1,7 @@
 /*
  * ReticulateEvent.java
  *
- * Copyright (C) 2009-2020 by RStudio, Inc.
+ * Copyright (C) 2009-2020 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -191,6 +191,7 @@ class ClientEvent extends JavaScriptObject
    public static final String HighlightUi = "highlight_ui";
    public static final String TutorialCommand = "tutorial_command";
    public static final String TutorialLaunch = "tutorial_launch";
+   public static final String ReticulateEvent = "reticulate_event";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -90,6 +90,7 @@ class ClientEvent extends JavaScriptObject
    public static final String ContextDepthChanged = "context_depth_changed";
    public static final String EnvironmentAssigned = "environment_assigned";
    public static final String EnvironmentRemoved = "environment_removed";
+   public static final String EnvironmentChanged = "environment_changed";
    public static final String BrowserLineChanged = "browser_line_changed";
    public static final String PackageLoaded = "package_loaded";
    public static final String PackageUnloaded = "package_unloaded";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -55,6 +55,8 @@ import org.rstudio.studio.client.common.synctex.events.SynctexEditFileEvent;
 import org.rstudio.studio.client.common.synctex.model.SourceLocation;
 import org.rstudio.studio.client.events.EditorCommandDispatchEvent;
 import org.rstudio.studio.client.events.EditorCommandEvent;
+import org.rstudio.studio.client.events.ReticulateEvent;
+import org.rstudio.studio.client.events.ReticulateReplStatusChangedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewCompletedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewOutputEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewStartedEvent;
@@ -1060,6 +1062,11 @@ public class ClientEventDispatcher
          {
             TutorialLaunchEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new TutorialLaunchEvent(data));
+         }
+         else if (type == ClientEvent.ReticulateEvent)
+         {
+            ReticulateEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new ReticulateEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -56,7 +56,6 @@ import org.rstudio.studio.client.common.synctex.model.SourceLocation;
 import org.rstudio.studio.client.events.EditorCommandDispatchEvent;
 import org.rstudio.studio.client.events.EditorCommandEvent;
 import org.rstudio.studio.client.events.ReticulateEvent;
-import org.rstudio.studio.client.events.ReticulateReplStatusChangedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewCompletedEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewOutputEvent;
 import org.rstudio.studio.client.htmlpreview.events.HTMLPreviewStartedEvent;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -592,6 +592,11 @@ public class ClientEventDispatcher
             String objectName = event.getData();
             eventBus_.dispatchEvent(new EnvironmentObjectRemovedEvent(objectName));
          }
+         else if (type == ClientEvent.EnvironmentChanged)
+         {
+            EnvironmentChangedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new EnvironmentChangedEvent(data));
+         }
          else if (type == ClientEvent.BrowserLineChanged)
          {
             LineData lineData = event.getData();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4548,19 +4548,31 @@ public class RemoteServer implements Server
 
    @Override
    public void getEnvironmentNames(
+         String language,
          ServerRequestCallback<JsArray<EnvironmentFrame>> requestCallback)
    {
+      JSONArray params = new JSONArrayBuilder()
+            .add(language)
+            .get();
+      
       sendRequest(RPC_SCOPE,
                   GET_ENVIRONMENT_NAMES,
+                  params,
                   requestCallback);
    }
    
    @Override
    public void getEnvironmentState(
+         String language,
          ServerRequestCallback<EnvironmentContextData> requestCallback)
    {
+      JSONArray params = new JSONArrayBuilder()
+            .add(language)
+            .get();
+      
       sendRequest(RPC_SCOPE,
                   GET_ENVIRONMENT_STATE,
+                  params,
                   requestCallback);
    }
 
@@ -4569,6 +4581,20 @@ public class RemoteServer implements Server
    {
       sendRequest(RPC_SCOPE,
                   REQUERY_CONTEXT,
+                  requestCallback);
+   }
+   
+   @Override
+   public void environmentSetLanguage(String language,
+                                      ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(language)
+            .get();
+      
+      sendRequest(RPC_SCOPE,
+                  ENVIRONMENT_SET_LANGUAGE,
+                  params,
                   requestCallback);
    }
 
@@ -6483,6 +6509,7 @@ public class RemoteServer implements Server
    private static final String GET_ENVIRONMENT_STATE = "get_environment_state";
    private static final String GET_OBJECT_CONTENTS = "get_object_contents";
    private static final String REQUERY_CONTEXT = "requery_context";
+   private static final String ENVIRONMENT_SET_LANGUAGE = "environment_set_language";
    private static final String SET_ENVIRONMENT_MONITORING = "set_environment_monitoring";
    
    private static final String GET_FUNCTION_STEPS = "get_function_steps";

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4564,10 +4564,12 @@ public class RemoteServer implements Server
    @Override
    public void getEnvironmentState(
          String language,
+         String environment,
          ServerRequestCallback<EnvironmentContextData> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(language)
+            .add(environment)
             .get();
       
       sendRequest(RPC_SCOPE,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -635,8 +635,12 @@ public class SessionInfo extends JavaScriptObject
       return this.project_id;
    }-*/;
    
-   public final native JsArrayString getGraphicsBackends()
-   /*-{
+   public final native JsArrayString getGraphicsBackends() /*-{
      return this.graphics_backends;
    }-*/;
+   
+   public final native boolean getPythonInitialized() /*-{
+      return this.python_initialized;
+   }-*/;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -193,6 +193,9 @@ public class EnvironmentPane extends WorkbenchPane
             (ImageResource) null,
             languageMenu_);
       
+      // don't show the language button at first; instead,
+      // toggle its visibility after the widget is created
+      // depending on whether Python has been initialized
       languageButton_.setVisible(false);
       languageButton_.setEnabled(false);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -100,11 +100,10 @@ public class EnvironmentPane extends WorkbenchPane
       scrollPosition_ = 0;
       isClientStateDirty_ = false;
       environments_ = null;
-      EnvironmentContextData environmentState = 
-            session.getSessionInfo().getEnvironmentState();
+      
+      EnvironmentContextData environmentState = session.getSessionInfo().getEnvironmentState();
       environmentName_ = environmentState.environmentName();
       environmentIsLocal_ = environmentState.environmentIsLocal();
-      
       environmentMonitoring_ = new Value<Boolean>(environmentState.environmentMonitoring());
 
       EnvironmentPaneResources.INSTANCE.environmentPaneStyle().ensureInjected();
@@ -245,6 +244,11 @@ public class EnvironmentPane extends WorkbenchPane
    protected Widget createMainWidget()
    {
       objects_ = new EnvironmentObjects(this);
+      
+      EnvironmentContextData data = session_.getSessionInfo().getEnvironmentState();
+      if (StringUtil.equals(data.language(), "Python"))
+         setPythonEnabled(true, false);
+      
       return objects_;
    }
 
@@ -771,8 +775,8 @@ public class EnvironmentPane extends WorkbenchPane
       languageButton_.setVisible(enabled);
       secondaryToolbar_.manageSeparators();
       
-      if (!enabled)
-         setActiveLanguage("R", syncWithSession);
+      String language = enabled ? "Python" : "R";
+      setActiveLanguage(language, syncWithSession);
    }
    
    // NOTE: 'syncWithSession = false' should only be used

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -512,7 +512,8 @@ public class EnvironmentPane extends WorkbenchPane
    {
       String editCode =
               function + "(" + StringUtil.toRSymbolName(objectName) + ")";
-      SendToConsoleEvent event = new SendToConsoleEvent(editCode, true);
+      
+      SendToConsoleEvent event = new SendToConsoleEvent(editCode, activeLanguage_, true);
       events_.fireEvent(event);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -628,12 +628,18 @@ public class EnvironmentPane extends WorkbenchPane
             
          }
       };
-      // If the frame's an active call frame, set it by its index 
+      
       if (frame.getFrame() > 0)
+      {
+         // If the frame's an active call frame, set it by its index 
          server_.setEnvironmentFrame(frame.getFrame(), callback);
-      // Otherwise, set it by its name
+      }
       else
+      {
+         // Otherwise, set it by its name
+         setEnvironmentName(frame.getName(), frame.isLocal());
          server_.setEnvironment(frame.getName(), callback);
+      }
    }
    
    private String nameOfViewType(int type)
@@ -819,6 +825,11 @@ public class EnvironmentPane extends WorkbenchPane
    public String getActiveLanguage()
    {
       return activeLanguage_;
+   }
+   
+   public String getMonitoredEnvironment()
+   {
+      return environmentName_;
    }
    
    public static final String GLOBAL_ENVIRONMENT_NAME = "Global Environment";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -38,6 +38,7 @@ import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ImageMenuItem;
 import org.rstudio.studio.client.common.Value;
+import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.events.ReticulateEvent;
 import org.rstudio.studio.client.server.ServerError;
@@ -86,7 +87,8 @@ public class EnvironmentPane extends WorkbenchPane
                           GlobalDisplay globalDisplay,
                           EnvironmentServerOperations serverOperations,
                           Session session,
-                          UserPrefs prefs)
+                          UserPrefs prefs,
+                          DependencyManager dependencyManager)
    {
       super("Environment", events);
       
@@ -95,6 +97,7 @@ public class EnvironmentPane extends WorkbenchPane
       globalDisplay_ = globalDisplay;
       session_ = session;
       prefs_ = prefs;
+      dependencyManager_ = dependencyManager;
 
       expandedObjects_ = new ArrayList<String>();
       scrollPosition_ = 0;
@@ -184,7 +187,13 @@ public class EnvironmentPane extends WorkbenchPane
       MenuItem rMenuItem = new MenuItem("R", () -> setActiveLanguage("R", true));
       languageMenu_.addItem(rMenuItem);
       
-      MenuItem pyMenuItem = new MenuItem("Python", () -> setActiveLanguage("Python", true));
+      MenuItem pyMenuItem = new MenuItem("Python", () ->
+      {
+         dependencyManager_.withReticulate(
+               "Viewing Python Objects",
+               "Viewing Python objects",
+               () -> setActiveLanguage("Python", true));
+      });
       languageMenu_.addItem(pyMenuItem);
       
       languageButton_ = new ToolbarMenuButton(
@@ -192,12 +201,6 @@ public class EnvironmentPane extends WorkbenchPane
             ToolbarButton.NoTitle,
             (ImageResource) null,
             languageMenu_);
-      
-      // don't show the language button at first; instead,
-      // toggle its visibility after the widget is created
-      // depending on whether Python has been initialized
-      languageButton_.setVisible(false);
-      languageButton_.setEnabled(false);
       
       toolbar.addLeftWidget(languageButton_);
       toolbar.addLeftSeparator();
@@ -847,6 +850,7 @@ public class EnvironmentPane extends WorkbenchPane
    private final EnvironmentServerOperations server_;
    private final Session session_;
    private final UserPrefs prefs_;
+   private final DependencyManager dependencyManager_;
    private final Value<Boolean> environmentMonitoring_;
    private final Timer refreshTimer_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
+import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -72,6 +73,7 @@ import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFi
 import org.rstudio.studio.client.workbench.views.environment.dataimport.ImportFileSettingsDialogResult;
 import org.rstudio.studio.client.workbench.views.environment.events.BrowserLineChangedEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.ContextDepthChangedEvent;
+import org.rstudio.studio.client.workbench.views.environment.events.EnvironmentChangedEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.EnvironmentObjectAssignedEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.EnvironmentObjectRemovedEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.EnvironmentRefreshEvent;
@@ -243,6 +245,21 @@ public class EnvironmentPresenter extends BasePresenter
          public void onEnvironmentObjectRemoved(EnvironmentObjectRemovedEvent event)
          {
             view_.removeObject(event.getObjectName());
+         }
+      });
+      
+      eventBus.addHandler(EnvironmentChangedEvent.TYPE, (EnvironmentChangedEvent event) ->
+      {
+         EnvironmentChangedEvent.Data data = event.getData();
+         
+         for (RObject object : JsUtil.asIterable(data.getChangedObjects()))
+         {
+            view_.addObject(object);
+         }
+         
+         for (String object : JsUtil.asIterable(data.getRemovedObjects()))
+         {
+            view_.removeObject(object);
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -100,7 +100,7 @@ public class EnvironmentPresenter extends BasePresenter
    
    public interface Display extends WorkbenchView
    {
-      void setActiveLanguage(String language);
+      void setActiveLanguage(String language, boolean syncWithSession);
       String getActiveLanguage();
       void addObject(RObject object);
       void addObjects(JsArray<RObject> objects);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -100,6 +100,8 @@ public class EnvironmentPresenter extends BasePresenter
    
    public interface Display extends WorkbenchView
    {
+      void setActiveLanguage(String language);
+      String getActiveLanguage();
       void addObject(RObject object);
       void addObjects(JsArray<RObject> objects);
       void clearObjects();
@@ -857,6 +859,7 @@ public class EnvironmentPresenter extends BasePresenter
       view_.setProgress(true);
       refreshingView_ = true;
       server_.getEnvironmentState(
+            view_.getActiveLanguage(),
             new ServerRequestCallback<EnvironmentContextData>()
       {
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -102,6 +102,7 @@ public class EnvironmentPresenter extends BasePresenter
    {
       void setActiveLanguage(String language, boolean syncWithSession);
       String getActiveLanguage();
+      String getMonitoredEnvironment();
       void addObject(RObject object);
       void addObjects(JsArray<RObject> objects);
       void clearObjects();
@@ -855,11 +856,13 @@ public class EnvironmentPresenter extends BasePresenter
       {
          return;
       }
+      
       // start showing the progress spinner and initiate the request
       view_.setProgress(true);
       refreshingView_ = true;
       server_.getEnvironmentState(
             view_.getActiveLanguage(),
+            view_.getMonitoredEnvironment(),
             new ServerRequestCallback<EnvironmentContextData>()
       {
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentChangedEvent.java
@@ -1,0 +1,71 @@
+/*
+ * EnvironmentChangedEvent.java
+ *
+ * Copyright (C) 2009-2020 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.environment.events;
+
+import org.rstudio.studio.client.workbench.views.environment.model.RObject;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class EnvironmentChangedEvent extends GwtEvent<EnvironmentChangedEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public final native JsArray<RObject> getChangedObjects() /*-{ return this["changed"]; }-*/;
+      public final native JsArrayString getRemovedObjects()    /*-{ return this["removed"]; }-*/;
+      
+   }
+
+   public EnvironmentChangedEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onEnvironmentChanged(EnvironmentChangedEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onEnvironmentChanged(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentChangedEvent.java
@@ -1,7 +1,7 @@
 /*
  * EnvironmentChangedEvent.java
  *
- * Copyright (C) 2009-2020 by RStudio, Inc.
+ * Copyright (C) 2009-2020 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentContextData.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentContextData.java
@@ -20,6 +20,10 @@ import com.google.gwt.core.client.JsArray;
 public class EnvironmentContextData extends JavaScriptObject
 {
    protected EnvironmentContextData() { }
+
+   public final native int language() /*-{
+      return this.language || "r";
+   }-*/;
    
    public final native int contextDepth() /*-{
       return this.context_depth;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentContextData.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentContextData.java
@@ -21,8 +21,8 @@ public class EnvironmentContextData extends JavaScriptObject
 {
    protected EnvironmentContextData() { }
 
-   public final native int language() /*-{
-      return this.language || "r";
+   public final native String language() /*-{
+      return this.language || "R";
    }-*/;
    
    public final native int contextDepth() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
@@ -63,6 +63,7 @@ public interface EnvironmentServerOperations
    
    void getEnvironmentState(
               String language,
+              String environment,
               ServerRequestCallback<EnvironmentContextData> requestCallback);
    
    void setEnvironmentMonitoring(boolean monitoring,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
@@ -58,9 +58,11 @@ public interface EnvironmentServerOperations
                             ServerRequestCallback<Void> requestCallback);
 
    void getEnvironmentNames(
+              String language,
               ServerRequestCallback<JsArray<EnvironmentFrame>> requestCallback);
    
    void getEnvironmentState(
+              String language,
               ServerRequestCallback<EnvironmentContextData> requestCallback);
    
    void setEnvironmentMonitoring(boolean monitoring,
@@ -71,4 +73,7 @@ public interface EnvironmentServerOperations
               ServerRequestCallback<ObjectContents> requestCallback);
    
    void requeryContext(ServerRequestCallback<Void> requestCallback);
+   
+   void environmentSetLanguage(String language,
+                               ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectGrid.java
@@ -193,7 +193,10 @@ public class EnvironmentObjectGrid extends EnvironmentObjectDisplay
                   @Override
                   public String getValue(RObjectEntry object)
                   {
-                     return (new Integer(object.rObject.getLength())).toString();
+                     int length = object.rObject.getLength();
+                     if (length < 0)
+                        return "<NA>";
+                     return Integer.toString(length);
                   }
               });
       columns_.add(new ObjectGridColumn(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/model/ObjectExplorerHandle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/model/ObjectExplorerHandle.java
@@ -24,9 +24,10 @@ public class ObjectExplorerHandle extends JavaScriptObject
    {
    }
    
-   public final native String getId()    /*-{ return this["id"];    }-*/;
-   public final native String getName()  /*-{ return this["name"];  }-*/;
-   public final native String getTitle() /*-{ return this["title"]; }-*/;
+   public final native String getId()       /*-{ return this["id"];    }-*/;
+   public final native String getName()     /*-{ return this["name"];  }-*/;
+   public final native String getTitle()    /*-{ return this["title"]; }-*/;
+   public final native String getLanguage() /*-{ return this["language"]; }-*/;
    
    public final String getPath()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -305,8 +305,8 @@ public class ObjectExplorerDataGrid
       }
    }
    
-   public static String generateExtractingRCode(Data data,
-                                                String finalReplacement)
+   public static String generateExtractingCode(Data data,
+                                               String finalReplacement)
    {
       if (data == null || data.isMorePlaceholder())
          return null;
@@ -327,17 +327,17 @@ public class ObjectExplorerDataGrid
       // substituting in accessors
       String code = accessors.get(0);
       for (int i = 1; i < n; i++)
-         code = code.replaceAll("#", accessors.get(i));
+         code = code.replace("#", accessors.get(i));
       
       // finally, substitute in the original object
-      code = code.replaceAll("#", finalReplacement);
+      code = code.replace("#", finalReplacement);
       
       return code;
    }
    
-   private String generateExtractingRCode(Data data)
+   private String generateExtractingCode(Data data)
    {
-      return generateExtractingRCode(data, handle_.getTitle());
+      return generateExtractingCode(data, handle_.getTitle());
    }
    
    private class NameCell extends AbstractCell<Data>
@@ -1070,16 +1070,18 @@ public class ObjectExplorerDataGrid
    private void extractCode(int row)
    {
       Data data = getData().get(row);
-      String code = generateExtractingRCode(data);
-      events_.fireEvent(new SendToConsoleEvent(code, false));
+      String code = generateExtractingCode(data);
+      String language = handle_.getLanguage();
+      events_.fireEvent(new SendToConsoleEvent(code, language, false));
    }
    
    private void viewRow(int row)
    {
       Data data = getData().get(row);
-      String code = generateExtractingRCode(data);
+      String code = generateExtractingCode(data);
+      String language = handle_.getLanguage();
       code = "View(" + code + ")";
-      events_.fireEvent(new SendToConsoleEvent(code, true));
+      events_.fireEvent(new SendToConsoleEvent(code, language, true));
    }
    
    private void retrieveMore(int row)
@@ -1119,7 +1121,7 @@ public class ObjectExplorerDataGrid
       }
       
       // no children; make a server RPC request and then call back
-      String extractingCode = generateExtractingRCode(data, "`__OBJECT__`");
+      String extractingCode = generateExtractingCode(data, "`__OBJECT__`");
       server_.explorerInspectObject(
             handle_.getId(),
             extractingCode,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerEditingTargetStatusBar.java
@@ -66,7 +66,7 @@ public class ObjectExplorerEditingTargetStatusBar extends Composite
                return;
             }
             
-            String accessor = ObjectExplorerDataGrid.generateExtractingRCode(
+            String accessor = ObjectExplorerDataGrid.generateExtractingCode(
                   data,
                   widget_.getHandle().getTitle());
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
@@ -1,7 +1,7 @@
 /*
  * TextEditorContainer.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
@@ -1,7 +1,7 @@
 /*
  * TextEditorContainer.java
  *
- * Copyright (C) 2009-12 by RStudio, Inc.
+ * Copyright (C) 2009-12 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/tools/editor-settings/eclipse-templates.xml
+++ b/src/gwt/tools/editor-settings/eclipse-templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java" deleted="false" description="Boilerplate for a GWT event." enabled="true" name="GWTEvent">/*
  * ${event}Event.java
  *
- * Copyright (C) 2020 by RStudio, PBC
+ * Copyright (C) 2009-${year} by RStudio, Inc.
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -14,12 +14,33 @@
  */
 package ${enclosing_package};
 
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
 public class ${event}Event extends GwtEvent&lt;${event}Event.Handler&gt;
 {
-   ${cursor}
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      // Event data accessors ----
+      ${cursor}
+   }
+
+   public ${event}Event(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
    
    // Boilerplate ----
    

--- a/src/gwt/tools/editor-settings/eclipse-templates.xml
+++ b/src/gwt/tools/editor-settings/eclipse-templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java" deleted="false" description="Boilerplate for a GWT event." enabled="true" name="GWTEvent">/*
  * ${event}Event.java
  *
- * Copyright (C) 2009-${year} by RStudio, Inc.
+ * Copyright (C) 2009-${year} by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then

--- a/src/gwt/tools/editor-settings/eclipse-templates.xml
+++ b/src/gwt/tools/editor-settings/eclipse-templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?><templates><template autoinsert="true" context="java" deleted="false" description="Boilerplate for a GWT event." enabled="true" name="GWTEvent">/*
  * ${event}Event.java
  *
- * Copyright (C) 2009-${year} by RStudio, PBC
+ * Copyright (C) ${year} by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then


### PR DESCRIPTION
This PR makes it possible to view Python objects (from a `reticulate` session) within the Environment Pane.

At its core, the Environment Pane will now switch between R and Python depending on whether the "regular" R console is active, versus the `reticulate` Python console. See demo:

![rstudio-python-environment-pane](https://user-images.githubusercontent.com/1976582/81754467-1c928f80-946b-11ea-9737-61a2b95f7302.gif)

After the Python session has been initialized by `reticulate`, an option to view Python environments and modules will be displayed. Arbitrary loaded modules can be viewed.

<img width="420" alt="Screen Shot 2020-05-12 at 4 12 03 PM" src="https://user-images.githubusercontent.com/1976582/81754552-55326900-946b-11ea-85c1-883464d68e1d.png">

---

## TODO

- [x] Audit that I haven't broken any pre-existing implicit contracts between the Environment Pane and the "monitored" environment.
- [x] Handle object removals.
- [x] Ensure behavior is consistent around session restarts, page reloads, and so on.
- [x] Consider whether we could make it possible to `View()` such objects with the Data Viewer or Object Explorer.
