### PR TITLE
Fix default open docs and first project template.

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1878,10 +1878,10 @@ int main (int argc, char * const argv[])
       FilePath userScratchPath = options.userScratchPath();
       if (userScratchPath.exists())
       {
-         std::vector<FilePath> scratchChildren;
-         userScratchPath.getChildren(scratchChildren);
-
-         if (scratchChildren.size() == 0)
+         // if the lists directory has not yet been created,
+         // this is a new user
+         FilePath listsPath = userScratchPath.completeChildPath("monitored/lists");
+         if (!listsPath.exists())
             newUser = true;
       }
       else

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -236,6 +236,10 @@ private:
 
    void augmentRbuildignore();
 
+   // adds default open docs if specified in the project and it has
+   // never been opened before
+   void addDefaultOpenDocs();
+
 private:
    core::FilePath file_;
    core::FilePath directory_;

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -448,6 +448,9 @@ Error ProjectContext::initialize()
       // compute project ID
       projectId = projectToProjectId(module_context::userScratchPath(), FilePath(),
                                      directory().getAbsolutePath()).id();
+
+      // add default open docs if we have them
+      addDefaultOpenDocs();
    }
    else
    {
@@ -725,7 +728,7 @@ json::Object ProjectContext::uiPrefs() const
 json::Array ProjectContext::openDocs() const
 {
    json::Array openDocsJson;
-   std::vector<std::string> docs = projects::collectFirstRunDocs(file());
+   std::vector<std::string> docs = projects::collectFirstRunDocs(scratchPath());
    for (const std::string& doc : docs)
    {
       FilePath docPath = directory().completeChildPath(doc);
@@ -917,6 +920,27 @@ bool ProjectContext::parentBrowseable()
    }
    return browse;
 #endif
+}
+
+void ProjectContext::addDefaultOpenDocs()
+{
+   std::string defaultOpenDocs = config().defaultOpenDocs;
+   if (!defaultOpenDocs.empty() && isNewProject())
+   {
+      std::vector<std::string> docs;
+      boost::algorithm::split(docs, defaultOpenDocs, boost::is_any_of(":"));
+
+      for (std::string& doc : docs)
+      {
+         boost::algorithm::trim(doc);
+
+         FilePath docPath = directory().completePath(doc);
+         if (docPath.exists())
+         {
+            addFirstRunDoc(scratchPath(), doc);
+         }
+      }
+   }
 }
 
 } // namespace projects

--- a/src/cpp/session/projects/SessionProjectFirstRun.cpp
+++ b/src/cpp/session/projects/SessionProjectFirstRun.cpp
@@ -34,39 +34,22 @@ const char* const kFirstRunDocs = "first_run_docs";
 
 } // anonymous namespace
 
-void addFirstRunDoc(const FilePath& projectFile, const std::string& doc)
+void addFirstRunDoc(const FilePath& projectScratchPath, const std::string& doc)
 {
-   FilePath scratchPath;
-   Error error = computeScratchPaths(projectFile, &scratchPath, nullptr);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return;
-   }
-
    std::ostringstream ostr;
    ostr << doc << std::endl;
-   error = core::appendToFile(scratchPath.completeChildPath(kFirstRunDocs), ostr.str());
+   Error error = core::appendToFile(projectScratchPath.completeChildPath(kFirstRunDocs), ostr.str());
    if (error)
       LOG_ERROR(error);
 }
 
-std::vector<std::string> collectFirstRunDocs(const FilePath& projectFile)
+std::vector<std::string> collectFirstRunDocs(const FilePath& projectScratchPath)
 {
    // docs to return
    std::vector<std::string> docs;
 
-   // get the scratch path
-   FilePath scratchPath;
-   Error error = computeScratchPaths(projectFile, &scratchPath, nullptr);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return docs;
-   }
-
    // check for first run file
-   FilePath firstRunDocsPath = scratchPath.completeChildPath(kFirstRunDocs);
+   FilePath firstRunDocsPath = projectScratchPath.completeChildPath(kFirstRunDocs);
    if (firstRunDocsPath.exists())
    {
       Error error = core::readStringVectorFromFile(firstRunDocsPath, &docs);

--- a/src/cpp/session/projects/SessionProjectFirstRun.hpp
+++ b/src/cpp/session/projects/SessionProjectFirstRun.hpp
@@ -29,8 +29,8 @@ namespace rstudio {
 namespace session {
 namespace projects {
 
-void addFirstRunDoc(const core::FilePath& projectFile, const std::string& doc);
-std::vector<std::string> collectFirstRunDocs(const core::FilePath& projectFile);
+void addFirstRunDoc(const core::FilePath& projectScratchPath, const std::string& doc);
+std::vector<std::string> collectFirstRunDocs(const core::FilePath& projectScratchPath);
 
 } // namespace projects
 } // namespace session

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -893,26 +893,6 @@ void startup(const std::string& firstProjectPath)
          module_context::events().onClientInit.connect(boost::bind(onClientInit, openProjectError));
       }
    }
-
-   // add default open docs if specified in the project
-   // and the project has never been opened before
-   std::string defaultOpenDocs = projectContext().config().defaultOpenDocs;
-   if (!defaultOpenDocs.empty() && projects::projectContext().isNewProject())
-   {
-      std::vector<std::string> docs;
-      boost::algorithm::split(docs, defaultOpenDocs, boost::is_any_of(":"));
-
-      for (std::string& doc : docs)
-      {
-         boost::algorithm::trim(doc);
-
-         FilePath docPath = projectContext().directory().completePath(doc);
-         if (docPath.exists())
-         {
-            addFirstRunDoc(projectFilePath, doc);
-         }
-      }
-   }
 }
 
 SEXP rs_writeProjectFile(SEXP projectFilePathSEXP)


### PR DESCRIPTION
First project template just needed code similar to what exists in workspaces.

Default open docs were broken because the scratch path is incorrect during `ProjectContext::startup` and is later correct during `ProjectContext::initialize`.

Fixes #6865
Fixes https://github.com/rstudio/rstudio-pro/issues/1668