### PR TITLE
Improve command palette UX for disabled commands

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -181,6 +181,18 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       return enabled_ && isVisible(); // jcheng 06/30/2010: Hmmmm, smells weird.
    }
 
+   /**
+    * Determines whether there are any handlers established that will execute
+    * when this command runs. This is useful for determining if the command
+    * will do anything when executed.
+    * 
+    * @return Whether this command has handlers.
+    */
+   public boolean hasCommandHandlers()
+   {
+      return handlers_.getHandlerCount(CommandEvent.TYPE) > 0;
+   }
+
    public void setEnabled(boolean enabled)
    {
       if (enabled != enabled_)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AppCommandPaletteEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AppCommandPaletteEntry.java
@@ -16,9 +16,12 @@ package org.rstudio.studio.client.application.ui;
 
 import java.util.List;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppCommand.Context;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.core.client.command.KeySequence;
 
 /**
@@ -50,9 +53,43 @@ public class AppCommandPaletteEntry extends CommandPaletteEntry
    
    public void invoke()
    {
-      command_.execute();
+      GlobalDisplay display = RStudioGinjector.INSTANCE.getGlobalDisplay();
+      if (!command_.isVisible())
+      {
+         // This isn't currently likely since we hide commands that aren't
+         // visible.
+         display.showErrorMessage("Command Not Available", 
+               "The command '" + getLabel() + "' is not currently available.");
+      }
+      else if (!command_.isEnabled() || !command_.hasCommandHandlers())
+      {
+         // Don't attempt to execute disabled commands. Treat command with no
+         // handlers as disabled (nothing will happen if we run them except a
+         // runtime exception)
+         display.showErrorMessage("Command Disabled", 
+               "The command '" + getLabel() + "' cannot be used right now. " +
+               "It may be unavailable in this project, file, or view.");
+      }
+      else
+      {
+         // Regular command execution attempt; we still wrap this in a try/catch
+         // so that if anything goes haywire during execution we can tell the user
+         // about it.
+         try
+         {
+            command_.execute();
+         }
+         catch(Exception e)
+         {
+            display.showErrorMessage("Command Execution Failed", 
+                  "The command '" + getLabel() + "' could not be executed.\n\n" +
+                  StringUtil.notNull(e.getMessage()));
+            Debug.logException(e);
+         }
+      }
    }
    
+   @Override
    public String getId()
    {
       return command_.getId();
@@ -74,6 +111,15 @@ public class AppCommandPaletteEntry extends CommandPaletteEntry
       }
 
       return context.toString();
+   }
+
+   @Override
+   public boolean enabled()
+   {
+      // Ensure the command is enabled *and* has handlers. Generally commands
+      // should become invisible or disabled when unavailable, but they also
+      // become unavailable when they have no listeners.
+      return command_.isEnabled() && command_.hasCommandHandlers();
    }
 
    private String label_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPalette.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPalette.java
@@ -161,12 +161,12 @@ public class CommandPalette extends Composite
             continue;
          }
          
-         // Ensure the command can be used. It'd be nice to show all commands in
+         // Ensure the command is visible. It'd be nice to show all commands in
          // the palette for the purposes of examining key bindings, discovery,
-         // etc., but there's no good user experience if a user attempts to
-         // invoke one of those commands.
+         // etc., but invisible commands are generally meaningless in the 
+         // current context.
          AppCommand appCommand = allCommands.get(command);
-         if (!appCommand.isEnabled() || !appCommand.isVisible())
+         if (!appCommand.isVisible())
          {
             continue;
          }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPalette.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPalette.java
@@ -390,7 +390,7 @@ public class CommandPalette extends Composite
       resultsCount_.reportStatus(matches + " " +
             "commands found, press up and down to navigate",
             RStudioGinjector.INSTANCE.getUserPrefs().typingStatusDelayMs().getValue(),
-            Severity.ALERT);
+            Severity.STATUS);
    }
    
    /**

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.java
@@ -49,6 +49,8 @@ public abstract class CommandPaletteEntry extends Composite
       String keyboard();
       String searchMatch();
       String selected();
+      String name();
+      String disabled();
    }
 
    public CommandPaletteEntry(List<KeySequence> keys)
@@ -81,7 +83,15 @@ public abstract class CommandPaletteEntry extends Composite
                ElementIds.idSafeString(id));
       }
 
+      // Apply command label
       name_.setText(getLabel());
+      
+      // If the command is not enabled, style it as disabled.
+      if (!enabled())
+      {
+         addStyleName(styles_.disabled());
+      }
+
       SafeHtmlBuilder b = new SafeHtmlBuilder();
       for (KeySequence k: keys_)
       {
@@ -166,6 +176,7 @@ public abstract class CommandPaletteEntry extends Composite
    abstract public void invoke();
    abstract public String getId();
    abstract public String getContext();
+   abstract public boolean enabled();
    
    private final List<KeySequence> keys_;
    private boolean selected_;

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.java
@@ -90,6 +90,7 @@ public abstract class CommandPaletteEntry extends Composite
       if (!enabled())
       {
          addStyleName(styles_.disabled());
+         Roles.getOptionRole().setAriaDisabledState(getElement(), true);
       }
 
       SafeHtmlBuilder b = new SafeHtmlBuilder();

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/CommandPaletteEntry.ui.xml
@@ -62,12 +62,16 @@
 		.editor_dark .context {
 			background-color: rgba(255, 255, 255, 0.1);
 		}
+		
+		.disabled .name {
+			opacity: 0.5;
+		}
 	</ui:style>
 	<g:HorizontalPanel styleName="{styles_.entry}">
 		<g:cell horizontalAlignment="ALIGN_LEFT">
 			<g:HorizontalPanel>
 				<g:Label visible="false" styleName="{styles_.context}" ui:field="context_"></g:Label>
-				<g:Label ui:field="name_"></g:Label>
+				<g:Label styleName="{styles_.name}" ui:field="name_"></g:Label>
 			</g:HorizontalPanel>
 		</g:cell>
 		<g:cell horizontalAlignment="ALIGN_RIGHT">

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RAddinCommandPaletteEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RAddinCommandPaletteEntry.java
@@ -68,6 +68,13 @@ public class RAddinCommandPaletteEntry extends CommandPaletteEntry
       return "&#9865; " + addin_.getPackage();
    }
 
+   @Override
+   public boolean enabled()
+   {
+      // R Addins are always enabled.
+      return true;
+   }
+
    private String label_;
    private final RAddin addin_;
    private final AddinExecutor executor_;


### PR DESCRIPTION
This change makes two improvements to the command palette:

- It now is symmetric with menus, which means it includes disabled commands ("greyed out") but hides invisible commands. It is debatable how much value a disabled command adds to the palette, but arguably it's good for discovery and helps you know what's possible (plus if you are looking for a command that's disabled it helps you not feel crazy. It was there an hour ago!). 
- Commands with no handlers are now treated as disabled. Technically speaking it's bad for a command to be visible and enabled but have no handlers (which is why this case is a debug assertion), but it is possible for the palette to deal with this gracefully, so we do. 

Fixes https://github.com/rstudio/rstudio/issues/6874.