### PR TITLE
use html5 header element instead of role=banner

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/BannerWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/BannerWidget.java
@@ -14,18 +14,18 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.gwt.user.client.ui.Widget;
 
 /**
- * A widget with role=banner wrapping another widget
+ * A widget with html5 header (aka role="banner") element wrapping another widget
  */
 public class BannerWidget extends SimplePanel
 {
    public BannerWidget(Widget child)
    {
+      super(DOM.createElement("header"));
       setWidget(child);
-      Roles.getBannerRole().set(getElement());
    }
 }


### PR DESCRIPTION
- small tweak to use semantic HTML for banner instead of applying role to the div
- prompted by conversation in #6863 but doesn't directly address that issue
- the banner is the RStudio logo in upper-left of IDE; on open source is doesn't have any interactive behavior and will generally be ignored by screen readers, on Pro it contains a link back to the RStudio Server Pro home page