### PR TITLE
Apply themed font to history and VCS panes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryTable.java
@@ -1,7 +1,7 @@
 /*
  * HistoryTable.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -57,6 +57,7 @@ public class HistoryTable extends FastSelectTable<HistoryEntry, String, Long>
 
       final Resources res = GWT.create(Resources.class);
       setStyleName(res.styles().historyTable());
+      addStyleName("rstudio-fixed-width-font");
       FontSizer.applyNormalFontSize(this);
 
       if (searchResult_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableView.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableView.java
@@ -1,7 +1,7 @@
 /*
  * LineTableView.java
  *
- * Copyright (C) 2009-12 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -248,6 +248,7 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
       super(1, res);
 
       FontSizer.applyNormalFontSize(this);
+      addStyleName("rstudio-fixed-width-font");
 
       for (int i = 0; i < filesCompared; i++)
       {


### PR DESCRIPTION
This applies the the user-selected font to a couple of places I missed in the initial implementation of editor fonts for RStudio Server (https://github.com/rstudio/rstudio/pull/6592). 