### PR TITLE
Use system config alone when user config is missing

### DIFF
--- a/src/cpp/session/modules/SessionConfigFile.cpp
+++ b/src/cpp/session/modules/SessionConfigFile.cpp
@@ -1,7 +1,7 @@
 /*
  * SessionConfigFile.cpp
  *
- * Copyright (C) 2009-19 by RStudio, PBC
+ * Copyright (C) 2009-20 by RStudio, PBC
  *
  * Unless you have received this program directly from RStudio pursuant
  * to the terms of a commercial license agreement with RStudio, then
@@ -194,11 +194,18 @@ Error readConfigJSON(const core::json::JsonRpcRequest& request,
                return error;
             }
          }
-         else if (systemJson.getType() == json::Type::OBJECT &&
-                  configJson.getType() == json::Type::OBJECT)
+         else if (systemJson.getType() == json::Type::OBJECT)
          {
-            // If we have successfully read two config sources, merge them
-            configJson = json::Object::mergeObjects(configJson.getObject(), systemJson.getObject());
+            if (configJson.getType() == json::Type::OBJECT)
+            {
+               // We have successfully read two config sources; merge them
+               configJson = json::Object::mergeObjects(configJson.getObject(), systemJson.getObject());
+            }
+            else
+            {
+               // We only have one config source (the system); use it
+               configJson = systemJson;
+            }
          }
       }
    }


### PR DESCRIPTION
This change fixes an issue that arises when there's a global configuration JSON file but no accompanying user configuration JSON file. When this is the case, an attempt is made to merge the global JSON file with nothing, which goes about as well as you'd expect.

Fixes https://github.com/rstudio/rstudio/issues/6870.