### PR TITLE
fix cpp unit tests on macos

### DIFF
--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -3,7 +3,7 @@
 #
 # install-dependencies-osx
 #
-# Copyright (C) 2009-19 by RStudio, PBC
+# Copyright (C) 2009-20 by RStudio, PBC
 #
 # Unless you have received this program directly from RStudio pursuant
 # to the terms of a commercial license agreement with RStudio, then
@@ -33,6 +33,11 @@ if brew list | grep postgresql &> /dev/null; then
    echo "postgresql already installed"
 else
    brew install postgresql
+fi
+
+# coreutils needed for unit tests (specifically gtimeout)
+if ! command -v gtimeout &> /dev/null; then
+   brew install coreutils
 fi
 
 cd ../common

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -35,9 +35,9 @@ runWatchdogProcess()
 {
    if [[ "$OSTYPE" == "darwin"* ]]; then
       # requires brew install coreutils
-      TIMEOUT=gtimeout
+      TIMEOUT_CMD=gtimeout
    else
-      TIMEOUT=timeout
+      TIMEOUT_CMD=timeout
    fi
    timeout=$1
    privileged=$2
@@ -57,9 +57,9 @@ runWatchdogProcess()
       fi
    else
       if [ "$privileged" = true ]; then
-         sudo $TIMEOUT --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         sudo $TIMEOUT_CMD --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       else
-         $TIMEOUT --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         $TIMEOUT_CMD --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       fi
    fi
 

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -33,6 +33,12 @@ findLibSegFault()
 
 runWatchdogProcess()
 {
+   if [[ "$OSTYPE" == "darwin"* ]]; then
+      # requires brew install coreutils
+      TIMEOUT=gtimeout
+   else
+      TIMEOUT=timeout
+   fi
    timeout=$1
    privileged=$2
    command=$3
@@ -51,9 +57,9 @@ runWatchdogProcess()
       fi
    else
       if [ "$privileged" = true ]; then
-         sudo timeout --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         sudo $TIMEOUT --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       else
-         timeout --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         $TIMEOUT --foreground $timeout /bin/bash -c "LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       fi
    fi
 


### PR DESCRIPTION
Tests now relying on timeout command, which isn't on macOS. Use gtimeout from brew coreutils, instead

Fixes #6888