### PR TITLE
Work around R bug in function deparse

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -176,6 +176,23 @@
 #             (otherwise a character vector of lines is returned)
 .rs.addFunction("deparseFunction", function(func, useSource, asString)
 {
+   # If we're being asked to return the source references as-is, read the source
+   # references directly instead of going through deparse (which has a known
+   # issue that corrupts output with backslashes in R 4.0.0 and perhaps other
+   # versions; see R bug 17800).
+   if (useSource)
+   {
+      srcref <- attr(func, "srcref", exact = TRUE)
+      if (!is.null(srcref))
+      {
+         code <- as.character(srcref, useSource = TRUE)
+         if (asString)
+           return(paste(code, collapse = "\n"))
+         else
+           return(code)
+      }
+   }
+
    control <- c("keepInteger", "keepNA")
    if (useSource)
      control <- append(control, "useSource")

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -56,3 +56,16 @@ test_that("all objects are removed when requested", {
    contents <- .rs.invokeRpc("list_environment")
    expect_equal(length(contents), 0)
 })
+
+test_that("functions with backslashes deparse correctly", {
+   # character vector with code for a simple function
+   code <- "function() { \"first line\\nsecond line\" }"
+
+   # parse and evaluate the expression (yielding a function f)
+   eval(parse(text = paste0("f <- ", code)))
+
+   # immediately deparse f back into a string
+   output <- .rs.deparseFunction(f, TRUE, TRUE)
+
+   expect_equal(output, code)
+})


### PR DESCRIPTION
This change works around a bug in R in which `deparse()` returns an incorrect copy of a function when it uses source references and the function contains backslashes. This bug has been reported upstream to R. 

https://bugs.r-project.org/bugzilla/show_bug.cgi?id=17800

The workaround is to read the source references from the function directly, if they are present, rather than going through `deparse()`. 

Fixes https://github.com/rstudio/rstudio/issues/6854 and will be backported to 1.3-patch.