### PR TITLE
ensure Ace loaded before initializing command manager

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ResetEditorCommandsEvent;
 import org.rstudio.studio.client.application.events.SetEditorCommandBindingsEvent;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceCommand;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceCommandManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
@@ -101,6 +102,11 @@ public class EditorCommandManager
    }
    
    public EditorCommandManager()
+   {
+      AceEditor.load(() -> finishInit());
+   }
+   
+   private void finishInit()
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -245,7 +251,7 @@ public class EditorCommandManager
       return manager_.getRelevantCommands();
    }
    
-   private final ConfigFileBacked<EditorKeyBindings> bindings_;
+   private ConfigFileBacked<EditorKeyBindings> bindings_;
    private AceCommandManager manager_;
    
    private boolean isBindingsLoaded_ = false;


### PR DESCRIPTION
Fixes an issue where some GWT components depending on Ace could fail to initialize due to their attempt to run before Ace itself had been loaded.

This is a somewhat hacky fix -- a more appropriate fix, I think, would be to eschew the use of the Ace loaders altogether and instead just include Ace (+ our other polyfills) into a single `.js` bundle that we load on startup. However, I wanted to get something in quickly to at least fix builds (+ releases!)

Closes https://github.com/rstudio/rstudio/issues/6913.