### PR TITLE
always set role=application on entire page and remove user option

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -10,6 +10,7 @@
 - Adds class attributed to RMarkdown chunks, their control buttons, and their output based on their given labels. (#6787)
 - Add option `www-url-path-prefix` to force a path on auth cookies (Pro #1608)
 - Add additional keyboard shortcut (Ctrl+`) for Focus Console Output accessibility command (#6850)
+- Always set application role for screen readers and removed related accessibility preference checkbox (#6863)
 
 ### Bugfixes
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -302,7 +302,6 @@ namespace prefs {
 #define kDataViewerMaxColumns "data_viewer_max_columns"
 #define kEnableScreenReader "enable_screen_reader"
 #define kTypingStatusDelayMs "typing_status_delay_ms"
-#define kAriaApplicationRole "aria_application_role"
 #define kReducedMotion "reduced_motion"
 #define kTabKeyMoveFocus "tab_key_move_focus"
 #define kAutoSaveOnIdle "auto_save_on_idle"
@@ -1350,12 +1349,6 @@ public:
     */
    int typingStatusDelayMs();
    core::Error setTypingStatusDelayMs(int val);
-
-   /**
-    * Whether to tell screen readers that the entire page is an application.
-    */
-   bool ariaApplicationRole();
-   core::Error setAriaApplicationRole(bool val);
 
    /**
     * Reduce use of animations in the user interface.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2247,19 +2247,6 @@ core::Error UserPrefValues::setTypingStatusDelayMs(int val)
 }
 
 /**
- * Whether to tell screen readers that the entire page is an application.
- */
-bool UserPrefValues::ariaApplicationRole()
-{
-   return readPref<bool>("aria_application_role");
-}
-
-core::Error UserPrefValues::setAriaApplicationRole(bool val)
-{
-   return writePref("aria_application_role", val);
-}
-
-/**
  * Reduce use of animations in the user interface.
  */
 bool UserPrefValues::reducedMotion()
@@ -2576,7 +2563,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDataViewerMaxColumns,
       kEnableScreenReader,
       kTypingStatusDelayMs,
-      kAriaApplicationRole,
       kReducedMotion,
       kTabKeyMoveFocus,
       kAutoSaveOnIdle,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -973,11 +973,6 @@
             "default": 2000,
             "description": "Number of milliseconds to wait after last keystroke before updating live region."
         },
-        "aria_application_role": {
-            "type": "boolean",
-            "default": false,
-            "description": "Whether to tell screen readers that the entire page is an application."
-        },
         "reduced_motion": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1014,19 +1014,16 @@ public class Application implements ApplicationEventHandlers
          commands_.importDatasetFromXLS().remove();
       }
 
-      if (userPrefs_.get().ariaApplicationRole().getValue())
+      Element el = Document.get().getElementById("rstudio_container");
+      if (el == null)
       {
-         Element el = Document.get().getElementById("rstudio_container");
-         if (el == null)
-         {
-            // some satellite windows don't have "rstudio_container"
-            el = view_.getWidget().getElement();
-         }
+         // some satellite windows don't have "rstudio_container"
+         el = view_.getWidget().getElement();
+      }
 
-         // "application" role prioritizes application keyboard handling
-         // over screen-reader shortcuts
-         el.setAttribute("role", "application");
-      } 
+      // "application" role prioritizes application keyboard handling
+      // over screen-reader shortcuts
+      el.setAttribute("role", "application");
 
       // If no project, ensure we show the product-edition title; if there is a project
       // open this was already done

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteApplication.java
@@ -149,12 +149,9 @@ public class SatelliteApplication
       rootPanel.setWidgetTopBottom(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
       rootPanel.setWidgetLeftRight(w, 0, Style.Unit.PX, 0, Style.Unit.PX);
 
-      if (pUserPrefs_.get().ariaApplicationRole().getValue())
-      {
-         // "application" role prioritizes application keyboard handling
-         // over screen-reader shortcuts
-         view_.getWidget().getElement().setAttribute("role", "application");
-      }
+      // "application" role prioritizes application keyboard handling
+      // over screen-reader shortcuts
+      view_.getWidget().getElement().setAttribute("role", "application");
 
       // show the view
       view_.show(satellite_.getParams());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1603,14 +1603,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to tell screen readers that the entire page is an application.
-    */
-   public PrefValue<Boolean> ariaApplicationRole()
-   {
-      return bool("aria_application_role", false);
-   }
-
-   /**
     * Reduce use of animations in the user interface.
     */
    public PrefValue<Boolean> reducedMotion()
@@ -2050,8 +2042,6 @@ public class UserPrefsAccessor extends Prefs
          enableScreenReader().setValue(layer, source.getBool("enable_screen_reader"));
       if (source.hasKey("typing_status_delay_ms"))
          typingStatusDelayMs().setValue(layer, source.getInteger("typing_status_delay_ms"));
-      if (source.hasKey("aria_application_role"))
-         ariaApplicationRole().setValue(layer, source.getBool("aria_application_role"));
       if (source.hasKey("reduced_motion"))
          reducedMotion().setValue(layer, source.getBool("reduced_motion"));
       if (source.hasKey("tab_key_move_focus"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -56,10 +56,6 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       chkScreenReaderEnabled_ = new CheckBox("Screen reader support (requires restart)");
       generalPanel.add(chkScreenReaderEnabled_);
 
-      initialAriaApplicationRole_ = prefs.ariaApplicationRole().getValue();
-      generalPanel.add(chkApplicationRole_ = checkboxPref(
-            "Entire page has application role (requires restart)", prefs.ariaApplicationRole())); 
-
       typingStatusDelay_ = numericPref("Milliseconds after typing before speaking results",
             1, 9999, prefs.typingStatusDelayMs());
       generalPanel.add(indent(typingStatusDelay_));
@@ -136,13 +132,6 @@ public class AccessibilityPreferencesPane extends PreferencesPane
             restartRequirement.setUiReloadRequired(true);
       }
 
-      boolean applicationRoleSetting = chkApplicationRole_.getValue();
-      if (applicationRoleSetting != initialAriaApplicationRole_)
-      {
-         initialAriaApplicationRole_ = applicationRoleSetting;
-         restartRequirement.setUiReloadRequired(true);
-      }
-
       prefs.tabKeyMoveFocus().setGlobalValue(chkTabMovesFocus_.getValue());
       prefs.syncToggleTabKeyMovesFocusState(chkTabMovesFocus_.getValue());
 
@@ -209,13 +198,11 @@ public class AccessibilityPreferencesPane extends PreferencesPane
    private final CheckBox chkScreenReaderEnabled_;
    private final NumericValueWidget typingStatusDelay_;
    private final NumericValueWidget maxOutput_;
-   private final CheckBox chkApplicationRole_;
    private final CheckBox chkTabMovesFocus_;
    private final CheckBoxList announcements_;
 
    // initial values of prefs that can trigger reloads (to avoid unnecessary reloads)
    private boolean initialScreenReaderEnabled_;
-   private boolean initialAriaApplicationRole_;
 
    private final PreferencesDialogResources res_;
    private final AriaLiveService ariaLive_;


### PR DESCRIPTION
- Additional research and usage testing by @jooyoungseo has confirmed we should always set this, and there is no reason to present this (extremely hard to explain) option to screen reader users.
- Very safe fix, removes a checkbox from Accessibility options pane, and always sets a role that was previously conditional
- Fixes #6863