### PR TITLE
Stamp a default host header on outgoing connections to make them HTTP compliant

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -26,3 +26,4 @@
 ### RStudio Server Pro
 
 - New option `server-project-sharing-root-dir` allows project sharing outside user home directories (Pro #1340)
+- Fix issue where Launcher address could not be set to an external load balancer due to missing Host header (Pro #1681)

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -129,6 +129,11 @@ public:
       if (chunkHandler)
          chunkHandler_ = chunkHandler;
 
+      // if the host header is not already set, make sure we stamp a default one
+      // this is required by the http standard
+      if (request_.host().empty())
+         request_.setHost(getDefaultHostHeader());
+
       // connect and write request (implmented in a protocol
       // specific manner by subclassees)
       connectAndWriteRequest();
@@ -313,7 +318,7 @@ protected:
 private:
 
    virtual void connectAndWriteRequest() = 0;
-
+   virtual std::string getDefaultHostHeader() = 0;
 
    bool retryConnectionIfRequired(const Error& connectionError,
                                   Error* pOtherError)

--- a/src/cpp/core/include/core/http/LocalStreamAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/LocalStreamAsyncClient.hpp
@@ -105,6 +105,11 @@ private:
                      boost::asio::placeholders::error));
    }
 
+   virtual std::string getDefaultHostHeader()
+   {
+      return "localhost";
+   }
+
    void handleConnect(const boost::system::error_code& ec)
    {
       try

--- a/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/NamedPipeAsyncClient.hpp
@@ -94,6 +94,11 @@ private:
       CATCH_UNEXPECTED_ASYNC_CLIENT_EXCEPTION
    }
 
+   virtual std::string getDefaultHostHeader()
+   {
+      return "localhost";
+   }
+
    // detect when we've got the whole response and force a
    // response + close of the socket
    // note we do not do this if we are streaming chunked encoding

--- a/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
@@ -74,6 +74,11 @@ private:
 
    }
 
+   virtual std::string getDefaultHostHeader()
+   {
+      return address_ + ":" + port_;
+   }
+
    const boost::shared_ptr<TcpIpAsyncClient> sharedFromThis()
    {
       boost::shared_ptr<AsyncClient<boost::asio::ip::tcp::socket> > ptrShared

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -141,6 +141,11 @@ protected:
             connectionTimeout_);
    }
 
+   virtual std::string getDefaultHostHeader()
+   {
+      return address_ + ":" + port_;
+   }
+
 
 private:
 


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio-pro/issues/1681