### PR TITLE
ignore .snapshot files when creating notebook

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -111,6 +111,13 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
       # extract the contents from each regular file
       contents <- lapply(files, function(file) {
+         
+         # ignore '.snapshot' files as they are not used here
+         ext <- tools::file_ext(file)
+         if (identical(ext, "snapshot"))
+            return(NULL)
+         
+         # read other files
          .rs.readFile(
             file,
             encoding = "UTF-8",
@@ -118,6 +125,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
                      .rs.endsWith(file, "jpg")  ||
                      .rs.endsWith(file, "jpeg") ||
                      .rs.endsWith(file, "rdf")
+            
          )
       })
       names(contents) <- basename(files)


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6932.

Candidate for v1.3-patch backport as the warning is emitted any time an R Notebook file containing image outputs is saved.