### PR TITLE
allow enter key to click active button in web dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -558,9 +558,10 @@ public abstract class ModalDialogBase extends DialogBox
             if (enterDisabled_)
                break;
 
-            // allow Enter on textareas or anchors (including custom links)
+            // allow Enter on textareas, buttons, or anchors (including custom links)
             Element e = DomUtils.getActiveElement();
             if (e.hasTagName("TEXTAREA") || e.hasTagName("A") ||
+                  e.hasTagName("BUTTON") ||
                   e.hasClassName(allowEnterKeyClass) ||
                   (e.hasAttribute("role") && StringUtil.equals(e.getAttribute("role"), "link")))
                return;


### PR DESCRIPTION
Currently, the Enter key clicks the default button in web dialogs (which can be different than the button with keyboard focus). This matches behavior of MacOS desktop dialogs, and (I think) dialogs in Windows many versions ago, but not current Windows desktop apps and not web applications, where enter or spacebar clicks the focused button even in a dialog with a specified default button.

Change allows buttons in RStudio web dialogs to handle the enter key instead letting the dialog do it. The "default" behavior still kicks in when focus is on other controls, but buttons are now clickable with spacebar or enter key.

Note this also matches aria recommended keyboard handling for buttons, too.

Fixes #6928