### PR TITLE
set document role on focusable console output spans

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -95,6 +95,7 @@ public class ConsoleOutputWriter
       {
          SpanElement trailing = Document.get().createSpanElement();
          trailing.setTabIndex(-1);
+         Roles.getDocumentRole().set(trailing); // https://github.com/rstudio/rstudio/issues/6884
          outEl.appendChild(trailing);
          virtualConsole_ = vcFactory_.create(trailing);
       }


### PR DESCRIPTION
- Work around an issue with JAWS
- Fixes #6884
- Note to QA: the reported issue was only reproducing part of the time for me, and I could not isolate why behavior varied, but with this fix I haven't been able to reproduce