### PR TITLE
fix inverted logic for enabling/disabling warning bar announcements

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -24,6 +24,8 @@
 - Fix keybinding failure when global keybindings exists but user keybindings don't (#6870)
 - Fix failure to open source files when debugging some functions in R 4.0.0 (work around R bug in `deparse()`) (#6854)
 - Fixed issue where an attempt to create more sessions than the license limit would fail with a generic error (Pro #1680)
+- Fix auto-activation of JAWS screen reader virtual cursor in Console Output region (#6884)
+- Announce text of warnings bar via screen reader (#6963)
 
 ### RStudio Server Pro
 

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -88,7 +88,7 @@ public class WarningBar extends Composite
       moreButton_.setText("Manage License...");
       moreButton_.addClickHandler(event -> Desktop.getFrame().showLicenseDialog());
       A11y.setARIAHidden(label_);
-      if (ariaLive.isDisabled(AriaLiveService.WARNING_BAR))
+      if (!ariaLive.isDisabled(AriaLiveService.WARNING_BAR))
          Roles.getAlertRole().set(live_);
    }
 


### PR DESCRIPTION
- Fixes #6963
- Update 1.3-patch news with this change and a prior one I forgot to add