### PR TITLE
pause a bit before updating infobar status text so JAWS sees the change

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/InfoBar.java
@@ -16,7 +16,6 @@ package org.rstudio.core.client.widget;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.TextDecoration;
 import com.google.gwt.dom.client.Style.Unit;
@@ -40,6 +39,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.workbench.model.Session;
 
@@ -98,9 +98,7 @@ public class InfoBar extends Composite
    public void setText(String text)
    {
       label_.setText(text);
-      Scheduler.get().scheduleDeferred(() -> {
-         live_.setText(text);
-      });
+      Timers.singleShot(AriaLiveService.UI_ANNOUNCEMENT_DELAY, () -> live_.setText(text));
       labelRight_.clear();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -57,6 +57,9 @@ public class AriaLiveService
    // Milliseconds to wait before making an announcement at session load
    public static final int STARTUP_ANNOUNCEMENT_DELAY = 3000;
 
+   // Milliseconds to wait before making an announcement after significant UI change
+   public static final int UI_ANNOUNCEMENT_DELAY = 1000;
+
    @Inject
    public AriaLiveService(EventBus eventBus, Provider<UserPrefs> pUserPrefs)
    {

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/WarningBar.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.application.ui;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -42,6 +41,7 @@ import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.WarningBarClosedEvent;
+import org.rstudio.studio.client.common.Timers;
 
 public class WarningBar extends Composite
       implements HasCloseHandlers<WarningBar>
@@ -97,15 +97,7 @@ public class WarningBar extends Composite
       label_.setInnerText(value);
 
       // Give screen reader time to process page to improve chance it will notice the live region
-      Timer liveTimer = new Timer()
-      {
-         @Override
-         public void run()
-         {
-            live_.setInnerText(value);
-         }
-      };
-      liveTimer.schedule(1500);
+      Timers.singleShot(AriaLiveService.UI_ANNOUNCEMENT_DELAY, () -> live_.setInnerText(value));
    }
 
    public void showLicenseButton(boolean show)


### PR DESCRIPTION
- Fixes #6965
- Warningbar was already doing this so applied same stragegy to infobar (plus moved the highly distasteful timer length into a shared constant)
- Shortened delay from 1.5 to 1 second, still plenty of time for this to work in my testing