### PR TITLE
Only set R_LIBS_SITE if it is not empty

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -26,6 +26,7 @@
 - Fixed issue where an attempt to create more sessions than the license limit would fail with a generic error (Pro #1680)
 - Fix auto-activation of JAWS screen reader virtual cursor in Console Output region (#6884)
 - Announce text of warnings bar via screen reader (#6963)
+- Fix issue where R_LIBS_SITE could be forcibly set empty, overriding the value in /etc/R/REnviron (#6982)
 
 ### RStudio Server Pro
 

--- a/src/cpp/core/include/core/r_util/RVersionsPosix.hpp
+++ b/src/cpp/core/include/core/r_util/RVersionsPosix.hpp
@@ -98,7 +98,11 @@ public:
    void setLibrary(const std::string& library)
    {
       library_ = library;
-      core::system::setenv(&environment_, "R_LIBS_SITE", library);
+
+      // only set R_LIBS_SITE env var if it is non-empty
+      // setting an empty site library will cause the default system configuration to be lost
+      if (!library.empty())
+         core::system::setenv(&environment_, "R_LIBS_SITE", library);
    }
 
    bool operator<(const RVersion& other) const


### PR DESCRIPTION
Setting it empty will generally break the default system-wide setting in `/etc/R/Renviron`.

Fixes #6982.