### PR TITLE
Update shinytest folder location

### DIFF
--- a/src/cpp/session/modules/SessionTests.R
+++ b/src/cpp/session/modules/SessionTests.R
@@ -38,8 +38,10 @@
 
    # Find the Shiny app directory
    shinyDir <- dirname(testFile)
-   if (identical(basename(shinyDir), "shinytests")) {
-      # Newer versions of shinytest store tests in a "shinytests" folder
+   if (identical(basename(shinyDir), "shinytests") ||
+       identical(basename(shinyDir), "shinytest")) {
+      # Newer versions of shinytest store tests in a "shinytest" or "shinytests" folder (depending
+      # on version)
       shinyDir <- dirname(shinyDir)
    } 
    if (identical(basename(shinyDir), "tests")) {

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -1200,10 +1200,11 @@ private:
       if (type == kTestShinyFile) {
         shinyTestName = shinyPath.getFilename();
         shinyPath = shinyPath.getParent();
-        if (shinyPath.getFilename() == "shinytests")
+        if (shinyPath.getFilename() == "shinytests" ||
+            shinyPath.getFilename() == "shinytest")
         {
-           // In newer versions of shinytest, tests are stored in a "shinytests" folder under the
-           // "tests" folder.
+           // In newer versions of shinytest, tests are stored in a "shinytest" or "shinytests"
+           // folder under the "tests" folder.
            shinyPath = shinyPath.getParent();
         }
         if (shinyPath.getFilename() == "tests")


### PR DESCRIPTION
The shinytest has made another change to where it stores tests, so we need to adapt the IDE to the change. Fixes https://github.com/rstudio/rstudio/issues/6960.

Will be backported to 1.3-patch.