### PR TITLE
Standardize chunk class names

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -51,13 +51,30 @@ public class ClassIds
       return ElementIds.idSafeString(text);
    }
 
+   public static void removeClassId(Element ele, String classId)
+   {
+      ele.removeClassName(getClassId(classId));
+   }
+
+   public static void removeClassId(Widget widget, String classId)
+   {
+      removeClassId(widget.getElement(), classId);
+   }
+
    public final static String CLASS_PREFIX = "rstudio_";
 
    // Source Panel
    public final static String SOURCE_PANEL = "source_panel";
    public final static String DOC_OUTLINE_CONTAINER = "doc_outline_container";
 
-   // WindowFrameButton (combined with unique suffix for each quadrant
+   // WindowFrameButton (combined with unique suffix for each quadrant)
    public final static String PANEL_MIN_BTN = "panel_min_btn";
    public final static String PANEL_MAX_BTN = "panel_max_btn";
+
+   // Chunk Context (combined with unique suffix for each quadrant)
+   public final static String CHUNK = "chunk";
+   public final static String CHUNK_OUTPUT = "chunk_output";
+   public final static String MODIFY_CHUNK = "modify_chunk";
+   public final static String RUN_CHUNK = "run_chunk";
+   public final static String PREVIEW_CHUNK = "preview_chunk";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Size;
@@ -41,7 +42,6 @@ import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteErro
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteErrorHandler;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteOutputEvent;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleWriteOutputHandler;
-import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextToolbar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputHost;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkOutputUi;
 
@@ -244,23 +244,21 @@ public class ChunkOutputWidget extends Composite
       return state_;
    }
 
-   public void setLabelClass(String value)
+   public void setClassId(String value)
    {
-      // ensure value has the correct prefix
-      if (!value.startsWith(ChunkContextToolbar.CHUNK_CLASS_PREFIX + CHUNK_OUTPUT_PREFIX))
-         value = new String(ChunkContextToolbar.CHUNK_CLASS_PREFIX +
-                            CHUNK_OUTPUT_PREFIX +
-                            value);
-      value = StringUtil.getCssIdentifier(value);
+      if (StringUtil.isNullOrEmpty(value))
+         value = ClassIds.CHUNK;
+      else if (!value.startsWith(ClassIds.CHUNK_OUTPUT))
+         value = new String(ClassIds.CHUNK_OUTPUT + "_" + ClassIds.idSafeString(value));
 
-      if (!StringUtil.equals(value, label_))
+      // The class ID will change if the Chunk's name changes so we need to clear any previous
+      // class ids set here.
+      if (!StringUtil.equals(ClassIds.idSafeString(value), classId_))
       {
-         // if we've already added a label style, remove it
-         if (!StringUtil.isNullOrEmpty(label_))
-            this.removeStyleName(label_);
-
-         label_ = value;
-         this.addStyleName(label_);
+         if (!StringUtil.isNullOrEmpty(classId_))
+            ClassIds.removeClassId(this, classId_);
+         classId_ = value;
+         ClassIds.assignClassId(this, classId_);
       }
    }
 
@@ -954,7 +952,7 @@ public class ChunkOutputWidget extends Composite
    private int lastOutputType_ = RmdChunkOutputUnit.TYPE_NONE;
    private boolean hasErrors_ = false;
    private boolean hideSatellitePopup_ = false;
-   private String label_;
+   private String classId_;
    
    private Timer collapseTimer_ = null;
    private final String documentId_;
@@ -972,7 +970,4 @@ public class ChunkOutputWidget extends Composite
    public final static int CHUNK_READY       = 2;
    public final static int CHUNK_PRE_OUTPUT  = 3;
    public final static int CHUNK_POST_OUTPUT = 4;
-
-   // this may be relied on by API code and should not change
-   public final static String CHUNK_OUTPUT_PREFIX = "output-";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -107,20 +108,21 @@ public class ChunkContextToolbar extends Composite
       chunkTypeLabel_.setText(engine);
    }
    
-   public void setLabelClass(String value)
+   public void setClassId(String value)
    {
-      if (!value.startsWith(CHUNK_CLASS_PREFIX))
-         value = new String(CHUNK_CLASS_PREFIX + value);
-      value = StringUtil.getCssIdentifier(value);
+      if (StringUtil.isNullOrEmpty(value))
+         value = ClassIds.CHUNK;
+      else if (!value.startsWith(ClassIds.CHUNK))
+         value = new String(ClassIds.CHUNK + "_" + ClassIds.idSafeString(value));
 
-      if (!StringUtil.equals(value, label_))
+      // The class ID will change if the Chunk's name changes so we need to remove any previous
+      // class id set here.
+      if (!StringUtil.equals(value, classId_))
       {
-         // if we've already added a label style, remove it
-         if (!StringUtil.isNullOrEmpty(label_))
-            this.removeStyleName(label_);
-
-         label_ = value;
-         this.addStyleName(label_);
+         if (!StringUtil.isNullOrEmpty(classId_))
+            ClassIds.removeClassId(this, classId_);
+         classId_ = value;
+         ClassIds.assignClassId(this, classId_);
       }
    }
 
@@ -133,10 +135,8 @@ public class ChunkContextToolbar extends Composite
          RES.chunkOptionsLight2x()));
 
       options_.addStyleName("rstudio-themes-darkens");
+      ClassIds.assignClassId(options_, ClassIds.MODIFY_CHUNK);
 
-      // this name may be relied on by API code and should not be changed
-      options_.addStyleName("modifyButton");
-      
       DOM.sinkEvents(options_.getElement(), Event.ONCLICK);
       DOM.setEventListener(options_.getElement(), new EventListener()
       {
@@ -156,9 +156,7 @@ public class ChunkContextToolbar extends Composite
       setState(state_);
       run_.setTitle(RStudioGinjector.INSTANCE.getCommands()
                     .executeCurrentChunk().getMenuLabel(false));
-
-      // this name may be relied on by API code and should not be changed
-      run_.addStyleName("runButton");
+      ClassIds.assignClassId(run_, ClassIds.RUN_CHUNK);
 
       DOM.sinkEvents(run_.getElement(), Event.ONCLICK);
       DOM.setEventListener(run_.getElement(), new EventListener()
@@ -192,9 +190,7 @@ public class ChunkContextToolbar extends Composite
       runPrevious_.setResource(new ImageResource2x(
          dark ? RES.runPreviousChunksDark2x() :
          RES.runPreviousChunksLight2x()));
-
-      // this name may be relied on by API code and should not be changed
-      runPrevious_.addStyleName("prevButton");
+      ClassIds.assignClassId(runPrevious_, ClassIds.PREVIEW_CHUNK);
 
       DOM.sinkEvents(runPrevious_.getElement(), Event.ONCLICK);
       DOM.setEventListener(runPrevious_.getElement(), new EventListener()
@@ -304,12 +300,11 @@ public class ChunkContextToolbar extends Composite
 
    private final Host host_;
    private int state_;
-   private String label_;
+   private String classId_;
    
    public final static int STATE_QUEUED    = 0;
    public final static int STATE_EXECUTING = 1;
    public final static int STATE_RESTING   = 2;
 
    public final static String LINE_WIDGET_TYPE = "ChunkToolbar";
-   public final static String CHUNK_CLASS_PREFIX = "rs-chunk-";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextUi.java
@@ -132,7 +132,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
          engine_ = engine;
          toolbar_.setEngine(engine);
       }
-      toolbar_.setLabelClass(getLabel(row));
+      toolbar_.setClassId(getLabel(row));
    }
 
    public void setRenderPass(int pass)
@@ -246,7 +246,7 @@ public class ChunkContextUi implements ChunkContextToolbar.Host
    {
       toolbar_ = new ChunkContextToolbar(this, dark_, !isSetup_, engine_);
       toolbar_.setHeight("0px"); 
-      toolbar_.setLabelClass(getLabel(row));
+      toolbar_.setClassId(getLabel(row));
       lineWidget_ = new PinnedLineWidget(
             ChunkContextToolbar.LINE_WIDGET_TYPE, target_.getDocDisplay(), 
             toolbar_, row, null, host_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 
 import org.rstudio.core.client.Rectangle;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.rmarkdown.model.RmdChunkOptions;
@@ -117,12 +116,9 @@ public class ChunkOutputUi
 
    public void setChunkLabel(String label)
    {
-      if (!StringUtil.equals(label_, label))
-      {
-         label_ = label;
-         if (outputWidget_ != null)
-            outputWidget_.setLabelClass(label);
-      }
+      label_ = label;
+      if (outputWidget_ != null)
+         outputWidget_.setClassId(label);
    }
 
    public Scope getScope()


### PR DESCRIPTION
Closes #6897 
This feature standardizes the logic for assigning chunks and their pieces class names that can easily be used by the API. It adds `rstudio_` to the front of each class name so that the names are available when using the `Show DOM Elements` feature. 

The class names are as follows:

Chunks are assigned `rstudio_chunk` or `rstudio_chunk_<name>` where name is the name assigned in the editor. For example ` ```{r plot} ` is assigned `rstudio_chunk_plot`.

Chunk output: `rstudio_chunk_output` or `rstudio_chunk_output_<name>`

Chunk modify button: `rstudio_modify_chunk`

Run chunk button: `rstudio_run_chunk`

Preview chunk button: `rstudio_preview_chunk`