### PR TITLE
handle raw strings in backend tokenizer

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -210,6 +210,8 @@ public:
    RToken nextToken();
 
 private:
+   Error matchRawStringLiteral(RToken* pToken);
+   
    RToken matchWhitespace();
    RToken matchStringLiteral();
    RToken matchNumber();

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -99,6 +99,13 @@ void updatePosition(std::wstring::const_iterator pos,
    }
 }
 
+Error tokenizeError(const std::string& reason, const ErrorLocation& location)
+{
+   Error error(boost::system::errc::invalid_argument, location);
+   error.addProperty("reason", reason);
+   return error;
+}
+
 } // anonymous namespace
 
 RToken RTokenizer::nextToken()
@@ -166,9 +173,23 @@ RToken RTokenizer::nextToken()
         return token;
      }
   }
+     
+  case L'r':
+  case L'R':
+  {
+     wchar_t next = peek(1);
+     if (next == L'"' || next == L'\'')
+     {
+        RToken token;
+        Error error = matchRawStringLiteral(&token);
+        if (!error)
+           return token;
+     }
+  }
+     
   case L'"':
   case L'\'':
-     return matchStringLiteral() ;
+     return matchStringLiteral();
   case L'`':
      return matchQuotedIdentifier();
   case L'#':
@@ -215,6 +236,110 @@ RToken RTokenizer::nextToken()
 RToken RTokenizer::matchWhitespace()
 {
    return consumeToken(RToken::WHITESPACE, tokenLength(tokenPatterns().WHITESPACE));
+}
+
+Error RTokenizer::matchRawStringLiteral(RToken* pToken)
+{
+   auto start = pos_;
+   
+   // consume leading 'r' or 'R'
+   wchar_t firstChar = eat();
+   if (!(firstChar == L'r' || firstChar == L'R'))
+   {
+      return tokenizeError(
+               "expected 'r' or 'R' at start of raw string literal",
+               ERROR_LOCATION);
+   }
+   
+   // consume quote character
+   wchar_t quoteChar = eat();
+   if (!(quoteChar == L'"' || quoteChar == L'\''))
+   {
+      return tokenizeError(
+               "expected quote character at start of raw string literal",
+               ERROR_LOCATION);
+   }
+   
+   // consume an optional number of hyphens
+   int hyphenCount = 0;
+   wchar_t ch = eat();
+   while (ch == L'-')
+   {
+      hyphenCount++;
+      ch = eat();
+   }
+   
+   // okay, we're now sitting on open parenthesis
+   wchar_t lhs = ch;
+   
+   // form right boundary character based on consumed parenthesis.
+   // if it wasn't a parenthesis, just look for the associated closing quote
+   wchar_t rhs;
+   if (lhs == L'(')
+   {
+      rhs = L')';
+   }
+   else if (lhs == L'{')
+   {
+      rhs = L'}';
+   }
+   else if (lhs == L'[')
+   {
+      rhs = L']';
+   }
+   else
+   {
+      return tokenizeError(
+               "expected opening bracket at start of raw string literal",
+               ERROR_LOCATION);
+   }
+   
+   // start searching for the end of the raw string
+   bool valid = false;
+   
+   while (true)
+   {
+      // i know, i know -- a label!? we use that here just because
+      // we need to 'break' out of a nested loop below, and just
+      // using a simple goto is cleaner than having e.g. an extra
+      // boolean flag tracking whether we should 'continue'
+      LOOP:
+      
+      if (eol())
+         break;
+      
+      // find the boundary character
+      wchar_t ch = eat();
+      if (ch != rhs)
+         goto LOOP;
+      
+      // consume hyphens
+      for (int i = 0; i < hyphenCount; i++)
+      {
+         ch = eat();
+         if (ch != L'-')
+            goto LOOP;
+      }
+      
+      // consume quote character
+      ch = eat();
+      if (ch != quoteChar)
+         goto LOOP;
+      
+      // we're at the end of the string; break out of the loop
+      valid = true;
+      break;
+   }
+   
+   // update position
+   std::size_t row = row_;
+   std::size_t column = column_;
+   updatePosition(start, pos_ - start, &row_, &column_);
+ 
+   // set token and return success
+   auto type = valid ? RToken::STRING : RToken::ERR;
+   *pToken = RToken(type, start, pos_, start - data_.begin(), row, column);
+   return Success();
 }
 
 RToken RTokenizer::matchStringLiteral()

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -267,6 +267,32 @@ test_context("RTokenizer")
       expect_true(rTokens.at(2).isType(RToken::OPER));
       expect_true(rTokens.at(2).contentEquals(L"**"));
    }
+   
+   test_that("plain raw strings are tokenized properly")
+   {
+      auto lines = {
+         L"r\"(abc)\"",
+         L"R\"(abc)\"",
+         L"r\"{abc}\"",
+         L"r'[abc]'",
+         L"R'{abc}'"
+      };
+      
+      for (auto line : lines)
+      {
+         RTokens rTokens(line);
+         expect_true(rTokens.size() == 1);
+         expect_true(rTokens.at(0).isType(RToken::STRING));
+      }
+   }
+   
+   test_that("unclosed raw strings are tokenized as errors")
+   {
+      RTokens rTokens(L"r'(abc");
+      expect_true(rTokens.size() == 1);
+      expect_true(rTokens.at(0).isType(RToken::ERR));
+   }
+   
 }
 
 } // namespace r_util

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -293,6 +293,16 @@ test_context("RTokenizer")
       expect_true(rTokens.at(0).isType(RToken::ERR));
    }
    
+   test_that("the raw string tokenizer restores iterator state if no raw string consumed")
+   {
+      RTokens rTokens(L"rep('.')");
+      expect_true(rTokens.size() == 4);
+      expect_true(rTokens.at(0).isType(RToken::ID));
+      expect_true(rTokens.at(1).isType(RToken::LPAREN));
+      expect_true(rTokens.at(2).isType(RToken::STRING));
+      expect_true(rTokens.at(3).isType(RToken::RPAREN));
+   }
+   
 }
 
 } // namespace r_util


### PR DESCRIPTION
Part of https://github.com/rstudio/rstudio/issues/6788.

Note that this only updates the backend tokenizer, not the front-end tokenizer. This implies that while code won't be "colored" directly in the Ace editor instance, the diagnostics should nonetheless be correct.

Note: R's raw string literals are described within `?Quotes`. Here's an example:

```
r"---(abc)---"
```

R's raw string literals basically have the following format:

- Can start with `r` or `R`,
- Can be quoted via `'` or `"`,
- Can have an optional number of hyphens,
- Can have an opening bracket `(`, `[` or `{`,
- Raw string literal text,
- Closing complement for opening bracket,
- Same number of hyphens,
- Matching closing quote.

cc: @adamconroy, in case this is relevant for the front-end tokenizer.