### PR TITLE
return path to website index, even when output is not the index

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -501,18 +501,24 @@
    normalizePath(subbin[[1]], mustWork = TRUE)
 })
 
-.rs.addFunction("bookdown.renderedOutputPath", function(outputPath)
+.rs.addFunction("bookdown.renderedOutputPath", function(websiteDir, outputPath)
 {
-   # if this is a PDF, use it directly
+   # set encoding
+   Encoding(websiteDir) <- "UTF-8"
+   Encoding(outputPath) <- "UTF-8"
+   
+   # if we have a PDF for this file, use it
    if (tools::file_ext(outputPath) == "pdf")
       return(outputPath)
    
-   # if we have an index, prefer using that
-   index <- file.path(dirname(outputPath), "index.html")
+   # if that fails, use root index file
+   # note that this gets remapped as appropriate to knitted posts; see:
+   # https://github.com/rstudio/rstudio/issues/6945
+   index <- file.path(websiteDir, "index.html")
    if (file.exists(index))
       return(index)
    
-   # otherwise, return the rendered path directly
-   # (typically necessary for self-contained books)
+   # default to using output file path
+   # (necessary for self-contained books, which may not have an index)
    outputPath
 })

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -274,6 +274,7 @@ std::string assignOutputUrl(const std::string& outputFile)
    {
       std::string renderedPath;
       Error error = r::exec::RFunction(".rs.bookdown.renderedOutputPath")
+            .addParam(websiteDir.getAbsolutePath())
             .addParam(outputPath.getAbsolutePath())
             .callUtf8(&renderedPath);
       if (error)


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6945.

This issue occurs because of the way we end up munging the output file path here:

https://github.com/rstudio/rstudio/blob/275964ec5f5c338daf848168e161922fdd14f627/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp#L1178-L1179

Because this is occurring, the right fix here is to point the output file path to the website root, e.g. as `file.path(websiteDir, "index.html")`. Which is awkward, since that path is later munged to point at the "correct" currently knitted file, which is _not_ at the root of the website.

tl;dr: There's something going on here that I don't quite understand, so this PR bears some extra scrutiny. There is probably a more appropriate fix.