### PR TITLE
add support for boost 1.73

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -35,6 +35,7 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeGlobals.txt")
 
 # global directives
 add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
+add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # explicitly do not use new c++ 11 features for websocketpp
 # they currently do not work with our source

--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -18,6 +18,7 @@
 #include <sys/wait.h>
 
 #include <boost/format.hpp>
+#include <boost/bind.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixOutputCapture.cpp
+++ b/src/cpp/core/system/PosixOutputCapture.cpp
@@ -28,6 +28,8 @@
 
 #include <core/system/System.hpp>
 
+#include <boost/bind.hpp>
+
 namespace rstudio {
 namespace core {
 namespace system {

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/range/as_array.hpp>
+#include <boost/bind.hpp>
 
 #include <signal.h>
 #include <fcntl.h>


### PR DESCRIPTION
Boost 1.73 is about to land in Fedora rawhide, and we are rebuilding packages, including RStudio, with this new version. Placeholders were removed from the global namespace in Boost 1.73 to avoid clashes with `std::placeholders`. This patch retains the old behaviour, but note that this is deprecated.

* enable BOOST_BIND_GLOBAL_PLACEHOLDERS to retain placeholders in the global namespace

* add some missing includes of <boost/bind.hpp>
