### PR TITLE
Make /etc/rstudio/logging.conf file configurable

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Xdg.hpp>
 
@@ -35,6 +36,7 @@ namespace log {
 #define kRotate            "rotate"
 #define kMaxSizeMb         "max-size-mb"
 #define kLogConfFile       "logging.conf"
+#define kLogConfEnvVar     "RS_LOG_CONF_FILE"
 
 #define kFileLogger        "file"
 #define kStdErrLogger      "stderr"
@@ -210,14 +212,19 @@ void LogOptions::initProfile()
 
 Error LogOptions::read()
 {
-#ifdef RSTUDIO_SERVER
-   FilePath optionsFile = core::system::xdg::systemConfigFile(kLogConfFile);
-#else
-   // desktop - read user file first, and only read admin file if the user file does not exist
-   FilePath optionsFile = core::system::xdg::userConfigDir().completeChildPath(kLogConfFile);
+   // first, look for config file in a specific environment variable
+   FilePath optionsFile(core::system::getenv(kLogConfEnvVar));
    if (!optionsFile.exists())
-         optionsFile = core::system::xdg::systemConfigFile(kLogConfFile);
-#endif
+   {
+   #ifdef RSTUDIO_SERVER
+      optionsFile = core::system::xdg::systemConfigFile(kLogConfFile);
+   #else
+      // desktop - read user file first, and only read admin file if the user file does not exist
+      optionsFile = core::system::xdg::userConfigDir().completeChildPath(kLogConfFile);
+      if (!optionsFile.exists())
+            optionsFile = core::system::xdg::systemConfigFile(kLogConfFile);
+   #endif
+   }
 
    // if the options file does not exist, that's fine - we'll just use default values
    if (!optionsFile.exists())


### PR DESCRIPTION
This is done via via environment variable `RS_LOG_CONF_FILE`.

Closes #7016 