### PR TITLE
don't increase size of mathjax popup font on windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/display/MathJaxPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/display/MathJaxPopupPanel.css
@@ -8,7 +8,3 @@
    box-shadow: 0 3px 10px rgba(0, 0, 0, 0.4);
    cursor: default;
 }
-
-.popupPanelWindows {
-   font-size: 200% !important;
-}

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/display/MathJaxPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/display/MathJaxPopupPanel.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.common.mathjax.display;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.widget.MiniPopupPanel;
 import org.rstudio.studio.client.common.mathjax.MathJax;
 
@@ -41,8 +40,6 @@ public class MathJaxPopupPanel extends MiniPopupPanel
       setWidget(container_);
       
       addStyleName(RES.styles().popupPanel());
-      if (BrowseCap.isWindowsDesktop())
-         addStyleName(RES.styles().popupPanelWindows());
    }
    
    public Element getContentElement()
@@ -55,7 +52,6 @@ public class MathJaxPopupPanel extends MiniPopupPanel
    public interface Styles extends CssResource
    {
       String popupPanel();
-      String popupPanelWindows();
    }
    
    public interface Resources extends ClientBundle


### PR DESCRIPTION
This was likely needed for QtWebKit but seems unnecessary for QWebEngine

@kevinushey Two other small things I noticed which you may want to look at:

1. The background color of the popup is unthemed (it's always white). Not sure if this was intentional though?

2. There is now a rectangular border around the math which I didn't see previously. This to me doesn't look ideal.
