### PR TITLE
user option to display Console error/message/warning output in normal color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * New option to configure soft wrapping for R Markdown files, and command to change the soft wrap mode of the editor on the fly (#2341)
 * Add option `www-url-path-prefix` to force a path on auth cookies (Pro #1608)
 * New Command Palette for searching and running build-in commands and add-ins (#5168)
+* Option to display Console error and message output in same color as regular output (#7029)
 
 ### RStudio Server Pro
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -143,6 +143,7 @@ namespace prefs {
 #define kFoldStyleBeginAndEnd "begin-and-end"
 #define kSaveBeforeSourcing "save_before_sourcing"
 #define kSyntaxColorConsole "syntax_color_console"
+#define kHighlightConsoleErrors "highlight_console_errors"
 #define kScrollPastEndOfDocument "scroll_past_end_of_document"
 #define kHighlightRFunctionCalls "highlight_r_function_calls"
 #define kConsoleLineLengthLimit "console_line_length_limit"
@@ -759,6 +760,12 @@ public:
     */
    bool syntaxColorConsole();
    core::Error setSyntaxColorConsole(bool val);
+
+   /**
+    * Whether to display error, warning, and message output in a different color.
+    */
+   bool highlightConsoleErrors();
+   core::Error setHighlightConsoleErrors(bool val);
 
    /**
     * Whether to allow scrolling past the end of a file.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -908,6 +908,19 @@ core::Error UserPrefValues::setSyntaxColorConsole(bool val)
 }
 
 /**
+ * Whether to display error, warning, and message output in a different color.
+ */
+bool UserPrefValues::highlightConsoleErrors()
+{
+   return readPref<bool>("highlight_console_errors");
+}
+
+core::Error UserPrefValues::setHighlightConsoleErrors(bool val)
+{
+   return writePref("highlight_console_errors", val);
+}
+
+/**
  * Whether to allow scrolling past the end of a file.
  */
 bool UserPrefValues::scrollPastEndOfDocument()
@@ -2642,6 +2655,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kFoldStyle,
       kSaveBeforeSourcing,
       kSyntaxColorConsole,
+      kHighlightConsoleErrors,
       kScrollPastEndOfDocument,
       kHighlightRFunctionCalls,
       kConsoleLineLengthLimit,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -437,6 +437,11 @@
             "default": false,
             "description": "Whether to use syntax highlighting in the R console."
         },
+        "highlight_console_errors": {
+            "type": "boolean",
+            "default": true,
+            "description": "Whether to display error, warning, and message output in a different color."
+        },
         "scroll_past_end_of_document": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -451,9 +451,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
    
    private String getErrorClass()
    {
-      return styles_.error() + " " + 
-             AceTheme.getThemeErrorClass(
-                RStudioGinjector.INSTANCE.getUserState().theme().getValue().cast());
+      return styles_.error() + 
+         (prefs_.highlightConsoleErrors().getValue() ? 
+            " " + AceTheme.getThemeErrorClass(
+                RStudioGinjector.INSTANCE.getUserState().theme().getValue().cast()) : 
+            "");
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -695,6 +695,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to display error, warning, and message output in a different color.
+    */
+   public PrefValue<Boolean> highlightConsoleErrors()
+   {
+      return bool("highlight_console_errors", true);
+   }
+
+   /**
     * Whether to allow scrolling past the end of a file.
     */
    public PrefValue<Boolean> scrollPastEndOfDocument()
@@ -1969,6 +1977,8 @@ public class UserPrefsAccessor extends Prefs
          saveBeforeSourcing().setValue(layer, source.getBool("save_before_sourcing"));
       if (source.hasKey("syntax_color_console"))
          syntaxColorConsole().setValue(layer, source.getBool("syntax_color_console"));
+      if (source.hasKey("highlight_console_errors"))
+         highlightConsoleErrors().setValue(layer, source.getBool("highlight_console_errors"));
       if (source.hasKey("scroll_past_end_of_document"))
          scrollPastEndOfDocument().setValue(layer, source.getBool("scroll_past_end_of_document"));
       if (source.hasKey("highlight_r_function_calls"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -44,6 +44,7 @@ import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.core.client.widget.TextBoxWithButton;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.DiagnosticsHelpLink;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
@@ -203,10 +204,11 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(checkboxPref("Show indent guides", prefs_.showIndentGuides()));
       displayPanel.add(checkboxPref("Blinking cursor", prefs_.blinkingCursor()));
       displayPanel.add(checkboxPref("Show syntax highlighting in console input", prefs_.syntaxColorConsole()));
+      displayPanel.add(checkboxPref("Different color for Console stderr output (requires restart)",
+         prefs_.highlightConsoleErrors()));
       displayPanel.add(checkboxPref("Allow scroll past end of document", prefs_.scrollPastEndOfDocument()));
       displayPanel.add(checkboxPref("Allow drag and drop of text", prefs_.enableTextDrag()));
-      displayPanel.add(extraSpaced(checkboxPref("Highlight R function calls", 
-            prefs_.highlightRFunctionCalls(), false /*defaultSpace*/)));
+      displayPanel.add(checkboxPref("Highlight R function calls", prefs_.highlightRFunctionCalls()));
        
       foldMode_ = new SelectWidget(
             "Fold Style:",
@@ -557,6 +559,8 @@ public class EditingPreferencesPane extends PreferencesPane
       {
          autoSaveIdleMs_.setValue("1000");
       }
+
+      _initialHighlightConsoleErrors = prefs.highlightConsoleErrors().getValue();
    }
    
    @Override
@@ -595,6 +599,14 @@ public class EditingPreferencesPane extends PreferencesPane
       prefs_.autoSaveOnIdle().setGlobalValue(autoSaveOnIdle_.getValue());
       prefs_.autoSaveIdleMs().setGlobalValue(StringUtil.parseInt(autoSaveIdleMs_.getValue(), 1000));
       
+      if (prefs_.highlightConsoleErrors().getValue() != _initialHighlightConsoleErrors)
+      {
+         _initialHighlightConsoleErrors = prefs_.highlightConsoleErrors().getValue();
+         if (Desktop.isDesktop())
+            restartRequirement.setDesktopRestartRequired(true);
+         else
+            restartRequirement.setUiReloadRequired(true);
+      }
       return restartRequirement;
    }
  
@@ -650,4 +662,5 @@ public class EditingPreferencesPane extends PreferencesPane
    private final SelectWidget autoSaveIdleMs_;
    private final TextBoxWithButton encoding_;
    private String encodingValue_;
+   private boolean _initialHighlightConsoleErrors;
 }


### PR DESCRIPTION
- Fixes #7029, motivated by more difficult request in #2574
- Space in Options / Code / Display is getting very tight; squeezed this in by removing extra spacing before the "Fold Style" dropdown (otherwise we probably need a whole new "Console" pane

<img width="593" alt="screenshot of preferences pane showing Code / Display with new setting" src="https://user-images.githubusercontent.com/10569626/83575019-7b37b000-a4e3-11ea-82dd-3ea480bcc5c9.png">
