### PR TITLE
Refactor editor events

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/event-types.ts
+++ b/src/gwt/panmirror/src/editor/src/api/event-types.ts
@@ -1,0 +1,26 @@
+/*
+ * event-types.ts
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { makeEventType } from "./events";
+import { Transaction } from "prosemirror-state";
+
+export const UpdateEvent = makeEventType("Update");
+export const OutlineChangeEvent = makeEventType("OutlineChange");
+export const StateChangeEvent = makeEventType("StateChange");
+export const ResizeEvent = makeEventType("Resize");
+export const LayoutEvent = makeEventType("Layout");
+export const ScrollEvent = makeEventType("Scroll");
+export const FocusEvent = makeEventType("Focus");
+export const DispatchEvent = makeEventType<Transaction>("Dispatch");

--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -31,7 +31,8 @@ import { ExtensionManager, initExtensions } from './editor-extensions';
 import { PandocEngine, PandocWriterOptions } from '../api/pandoc';
 import { PandocCapabilities, getPandocCapabilities } from '../api/pandoc_capabilities';
 import { fragmentToHTML } from '../api/html';
-import { EditorEvent } from '../api/events';
+import { EventHandler, EventType, DOMEditorEvents, EditorEvents } from '../api/events';
+import { ScrollEvent, UpdateEvent, OutlineChangeEvent, StateChangeEvent, ResizeEvent, LayoutEvent, FocusEvent, DispatchEvent } from '../api/event-types';
 import {
   PandocFormat,
   resolvePandocFormat,
@@ -189,6 +190,7 @@ export class Editor {
   // core context passed from client
   private readonly parent: HTMLElement;
   private readonly context: EditorContext;
+  private readonly events: EditorEvents;
 
   // options (derived from defaults + config)
   private readonly options: EditorOptions;
@@ -219,9 +221,6 @@ export class Editor {
   // keep track of whether the last transaction was selection-only
   // (indicates that we should use a cursorSentinel when going to source mode)
   private lastTrSelectionOnly = false;
-
-  // event sinks
-  private readonly events: ReadonlyMap<string, Event>;
 
   // create the editor -- note that the markdown argument does not substitute for calling
   // setMarkdown, rather it's used to read the format comment to determine how to
@@ -298,15 +297,13 @@ export class Editor {
   ) {
     // initialize references
     this.parent = parent;
+    this.events = new DOMEditorEvents(parent);
     this.context = context;
     this.options = options;
     this.format = format;
     this.keybindings = {};
     this.pandocFormat = pandocFormat;
     this.pandocCapabilities = pandocCapabilities;
-
-    // initialize custom events
-    this.events = this.initEvents();
 
     // create extensions
     this.extensions = this.initExtensions();
@@ -375,7 +372,7 @@ export class Editor {
         () => {
           if (!ticking) {
             window.requestAnimationFrame(() => {
-              this.emitEvent(EditorEvent.Scroll);
+              this.emitEvent(ScrollEvent);
               ticking = false;
             });
             ticking = true;
@@ -390,15 +387,8 @@ export class Editor {
     this.view.destroy();
   }
 
-  public subscribe(event: EditorEvent, handler: VoidFunction): VoidFunction {
-    if (!this.events.has(event)) {
-      const valid = Array.from(this.events.keys()).join(', ');
-      throw new Error(`Unknown event ${event}. Valid events are ${valid}`);
-    }
-    this.parent.addEventListener(event, handler);
-    return () => {
-      this.parent.removeEventListener(event, handler);
-    };
+  public subscribe<TDetail>(event: EventType<TDetail>, handler: EventHandler<TDetail>): VoidFunction {
+    return this.events.subscribe(event, handler);
   }
 
   public setTitle(title: string) {
@@ -449,9 +439,9 @@ export class Editor {
 
     // notify listeners if requested
     if (emitUpdate) {
-      this.emitEvent(EditorEvent.Update);
-      this.emitEvent(EditorEvent.OutlineChange);
-      this.emitEvent(EditorEvent.StateChange);
+      this.emitEvent(UpdateEvent);
+      this.emitEvent(OutlineChangeEvent);
+      this.emitEvent(StateChangeEvent);
     }
 
     // return our current markdown representation (so the caller know what our
@@ -566,7 +556,7 @@ export class Editor {
   public resize() {
     this.syncContentWidth();
     this.applyFixupsOnResize();
-    this.emitEvent(EditorEvent.Resize);
+    this.emitEvent(ResizeEvent);
   }
 
   public enableDevTools(initFn: (view: EditorView, stateClass: any) => void) {
@@ -641,41 +631,28 @@ export class Editor {
     this.view.updateState(this.state);
 
     // notify listeners of state change
-    this.emitEvent(EditorEvent.StateChange);
+    this.emitEvent(StateChangeEvent);
 
     // notify listeners of updates
     if (tr.docChanged || tr.storedMarksSet) {
       // fire updated (unless this was a fixup)
       if (!tr.getMeta(kFixupTransaction)) {
-        this.emitEvent(EditorEvent.Update);
+        this.emitEvent(UpdateEvent);
       }
 
       // fire outline changed if necessary
       if (getOutline(this.state) !== previousOutline) {
-        this.emitEvent(EditorEvent.OutlineChange);
+        this.emitEvent(OutlineChangeEvent);
       }
     }
 
-    this.emitEvent(EditorEvent.Layout);
+    this.emitEvent(DispatchEvent, tr);
+
+    this.emitEvent(LayoutEvent);
   }
 
-  private emitEvent(name: string) {
-    const event = this.events.get(name);
-    if (event) {
-      this.parent.dispatchEvent(event);
-    }
-  }
-
-  private initEvents(): ReadonlyMap<string, Event> {
-    const events = new Map<string, Event>();
-    events.set(EditorEvent.Update, new Event(EditorEvent.Update));
-    events.set(EditorEvent.OutlineChange, new Event(EditorEvent.OutlineChange));
-    events.set(EditorEvent.StateChange, new Event(EditorEvent.StateChange));
-    events.set(EditorEvent.Resize, new Event(EditorEvent.Resize));
-    events.set(EditorEvent.Layout, new Event(EditorEvent.Layout));
-    events.set(EditorEvent.Scroll, new Event(EditorEvent.Scroll));
-    events.set(EditorEvent.Focus, new Event(EditorEvent.Focus));
-    return events;
+  private emitEvent<TDetail>(eventType: EventType<TDetail>, detail?: TDetail) {
+    this.events.emit(eventType, detail);
   }
 
   private initExtensions() {
@@ -738,7 +715,7 @@ export class Editor {
       props: {
         handleDOMEvents: {
           focus: (view: EditorView, event: Event) => {
-            this.emitEvent(EditorEvent.Focus);
+            this.emitEvent(FocusEvent);
             return false;
           },
         },
@@ -804,7 +781,7 @@ export class Editor {
     if (!docChanged) {
       // If applyFixupsOnResize returns true, then layout has already
       // been fired; if it hasn't, we must do so now
-      this.emitEvent(EditorEvent.Layout);
+      this.emitEvent(LayoutEvent);
     }
   }
 

--- a/src/gwt/panmirror/src/editor/src/marks/math/math-preview.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/math/math-preview.ts
@@ -22,7 +22,8 @@ import zenscroll from 'zenscroll';
 
 import { EditorUI } from "../../api/ui";
 import { getMarkRange } from "../../api/mark";
-import { EditorEvents, EditorEvent } from "../../api/events";
+import { EditorEvents } from "../../api/events";
+import { ScrollEvent, ResizeEvent } from "../../api/event-types";
 import { applyStyles } from "../../api/css";
 import { editingRootNodeClosestToPos, editingRootNode } from "../../api/node";
 import { createPopup } from "../../api/widgets/widgets";
@@ -80,8 +81,8 @@ export class MathPreviewPlugin extends Plugin {
 
     // update position on scroll
     this.updatePopup = this.updatePopup.bind(this);
-    this.scrollUnsubscribe = events.subscribe(EditorEvent.Scroll, () => this.updatePopup());
-    this.resizeUnsubscribe = events.subscribe(EditorEvent.Resize,  () => this.updatePopup());
+    this.scrollUnsubscribe = events.subscribe(ScrollEvent, () => this.updatePopup());
+    this.resizeUnsubscribe = events.subscribe(ResizeEvent, () => this.updatePopup());
   }
 
   private updatePopup($mousePos?: ResolvedPos) {

--- a/src/gwt/panmirror/src/editor/src/nodes/image/image-view.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/image/image-view.ts
@@ -20,7 +20,8 @@ import { NodeSelection, PluginKey, Plugin } from 'prosemirror-state';
 import { EditorUI, ImageType } from '../../api/ui';
 import { PandocExtensions, imageAttributesAvailable } from '../../api/pandoc';
 import { isElementVisible } from '../../api/dom';
-import { EditorEvents, EditorEvent } from '../../api/events';
+import { EditorEvents } from '../../api/events';
+import { ResizeEvent } from '../../api/event-types';
 
 import { imageDialog } from './image-dialog';
 import {
@@ -193,7 +194,7 @@ class ImageNodeView implements NodeView {
     this.updateSizeOnVisible();
 
     // update image size whenever the container is resized
-    this.unregisterOnResize = editorEvents.subscribe(EditorEvent.Resize, () => {
+    this.unregisterOnResize = editorEvents.subscribe(ResizeEvent, () => {
       this.updateImageSize();
     });
   }

--- a/src/gwt/panmirror/src/editor/src/polyfill/custom-event.ts
+++ b/src/gwt/panmirror/src/editor/src/polyfill/custom-event.ts
@@ -1,0 +1,18 @@
+/**
+ * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent
+ * 
+ * From https://developer.mozilla.org/en-US/docs/MDN/About:
+ * "Any copyright is dedicated to the Public Domain. http://creativecommons.org/publicdomain/zero/1.0/"
+ */
+export default function() {
+  if ( typeof window.CustomEvent === "function" ) return false;
+
+  function CustomEvent (event: any, params: any) {
+    params = params || { bubbles: false, cancelable: false, detail: null };
+    var evt = document.createEvent( 'CustomEvent' );
+    evt.initCustomEvent( event, params.bubbles, params.cancelable, params.detail );
+    return evt;
+   }
+
+  window.CustomEvent = CustomEvent as any;
+}

--- a/src/gwt/panmirror/src/editor/src/polyfill/index.ts
+++ b/src/gwt/panmirror/src/editor/src/polyfill/index.ts
@@ -14,9 +14,11 @@
  */
 
 import polyfillIsConnected from './isconnected';
+import polyfillCustomEvent from './custom-event';
 
 function polyfill() {
   polyfillIsConnected();
+  polyfillCustomEvent();
 }
 
 export default polyfill;


### PR DESCRIPTION
Modify event system to allow events to (optionally) have additional
data attached. The definitions of the different types of events are
now in event-types.ts; see DispatchEvent for an example of an event
type that needs additional data (a Transaction object in this case).