### PR TITLE
Ensure toolbar updates when changing YAML to notebook

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -35,6 +35,7 @@
 #include <core/system/Process.hpp>
 #include <core/StringUtils.hpp>
 #include <core/Algorithm.hpp>
+#include <core/YamlUtil.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
@@ -929,7 +930,17 @@ std::string onDetectRmdSourceType(
                                        "<!-- rmarkdown v1 -->") &&
           rmarkdownPackageAvailable())
       {
-         return "rmarkdown";
+         // if we find html_notebook in the YAML header, presume that this is an R Markdown notebook
+         // (this isn't 100% foolproof but this check runs frequently so needs to be fast; more
+         // thorough type introspection is done on the client)
+         std::string yamlHeader = yaml::extractYamlHeader(pDoc->contents());
+         if (boost::algorithm::contains(yamlHeader, "html_notebook"))
+         {
+            return "rmarkdown-notebook";
+         }
+
+         // otherwise, it's a regular R Markdown document
+         return "rmarkdown-document";
       }
    }
    return std::string();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -848,8 +848,8 @@ public class SourceColumn implements SelectionHandler<Integer>,
                       (activeEditor_ != null) &&
                       (activeEditor_.getPath() != null) &&
                       ((activeEditor_.getExtendedFileType() != null &&
-                              activeEditor_.getExtendedFileType() .startsWith(SourceDocument.XT_SHINY_PREFIX)) ||
-                              activeEditor_.getExtendedFileType() == SourceDocument.XT_RMARKDOWN ||
+                              activeEditor_.getExtendedFileType().startsWith(SourceDocument.XT_SHINY_PREFIX)) ||
+                              activeEditor_.getExtendedFileType().startsWith(SourceDocument.XT_RMARKDOWN_PREFIX) ||
                               activeEditor_.getExtendedFileType() == SourceDocument.XT_PLUMBER_API);
       commands_.rsconnectDeploy().setVisible(rsCommandsAvailable);
       if (activeEditor_ != null)
@@ -879,7 +879,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
       boolean rmdCommandsAvailable =
               manager_.getSession().getSessionInfo().getRMarkdownPackageAvailable() &&
                       (activeEditor_ != null) &&
-                      activeEditor_.getExtendedFileType() == SourceDocument.XT_RMARKDOWN;
+                      activeEditor_.getExtendedFileType().startsWith(SourceDocument.XT_RMARKDOWN_PREFIX);
       commands_.editRmdFormatOptions().setVisible(rmdCommandsAvailable);
       commands_.editRmdFormatOptions().setEnabled(rmdCommandsAvailable);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1717,8 +1717,8 @@ public class TextEditingTarget implements
       {
          docDisplay_.addOrUpdateBreakpoint(breakpoint);
       }
-
-      if (extendedType_.equals(SourceDocument.XT_RMARKDOWN))
+      
+      if (extendedType_.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
       {
          // populate the popup menu with a list of available formats
          updateRmdFormatList();
@@ -3028,7 +3028,7 @@ public class TextEditingTarget implements
          return;
 
       view_.adaptToExtendedFileType(extendedType);
-      if (extendedType == SourceDocument.XT_RMARKDOWN)
+      if (extendedType.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
          updateRmdFormatList();
       extendedType_ = extendedType;
    }
@@ -5770,7 +5770,7 @@ public class TextEditingTarget implements
                                                          extendedType,
                                                          fileType_);
 
-      if (extendedType == SourceDocument.XT_RMARKDOWN)
+      if (extendedType.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
       {
          renderRmd();
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1376,7 +1376,7 @@ public class TextEditingTargetWidget
             publishButton_.setContentPath(publishPath, "");
             publishButton_.setContentType(RSConnect.CONTENT_TYPE_APP_SINGLE);
          }
-         else if (type == SourceDocument.XT_RMARKDOWN)
+         else if (type.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
          {
             // don't publish markdown docs as static
             publishButton_.setRmd(publishPath,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
@@ -202,7 +202,9 @@ public class SourceDocument extends JavaScriptObject
       return extendedType != null && extendedType == SourceDocument.XT_R_CUSTOM_SOURCE;
    }
    
-   public final static String XT_RMARKDOWN = "rmarkdown";
+   public final static String XT_RMARKDOWN_PREFIX = "rmarkdown-";
+   public final static String XT_RMARKDOWN_DOCUMENT = "rmarkdown-document";
+   public final static String XT_RMARKDOWN_NOTEBOOK = "rmarkdown-notebook";
    public final static String XT_SHINY_PREFIX = "shiny-";
    public final static String XT_SHINY_DIR = "shiny-dir";
    public final static String XT_SHINY_SINGLE_FILE = "shiny-single-file";


### PR DESCRIPTION
This change fixes an issue in which modifying the YAML header to change `html_document` to/from `html_notebook` in an R Markdown document doesn't trigger the right updates to the toolbar. 

The issue is that we no longer rebuild the toolbars on every file save (https://github.com/rstudio/rstudio/pull/6442). We used to do this but in addition to being wasteful it also made autosave very unpleasant to use. 

We _do_ rebuild the toolbars when the extended type changes, though, so the fix is to give Notebooks their own extended type. This causes us to rebuild the toolbars when a document is switched into or out of Notebook mode. 

Fixes https://github.com/rstudio/rstudio/issues/6643.