### PR TITLE
Fix double-rendering of paged table header

### DIFF
--- a/src/cpp/session/resources/pagedtable/pagedtable.css
+++ b/src/cpp/session/resources/pagedtable/pagedtable.css
@@ -161,12 +161,14 @@ a.pagedtable-index-current {
   opacity: 0.3;
 }
 
-td.pagedtable-metacell {
+div.pagedtable-metacell {
   padding-left: 0px;
   padding-bottom: 10px;
+  display: flex;
+  flex-direction: row;
 }
 
-td.pagedtable-metacell div {
+div.pagedtable-metacell div {
   display: inline-block;
   border: solid 1px #E9E9E9;
   border-radius: 3px;
@@ -176,7 +178,7 @@ td.pagedtable-metacell div {
   margin-right: 10px;
 }
 
-td.pagedtable-metacell .pagedtable-metafield {
+div.pagedtable-metacell .pagedtable-metafield {
   color: #999;
   padding-right: 4px;
 }

--- a/src/cpp/session/resources/pagedtable/pagedtable.js
+++ b/src/cpp/session/resources/pagedtable/pagedtable.js
@@ -522,41 +522,50 @@ var PagedTable = function (pagedTable) {
       thead.innerHTML = "";
    };
 
+   var renderMetadata = function(){
+      // show metadata on top of header as long as we have > 1 entry (the first one is always just
+      // dimensions, which we are already displaying)
+      if (Object.keys(options.metadata).length < 1) 
+         return;
+
+      // ignore if we've already rendered
+      if (pagedTable.querySelector(".pagedtable-metacell") !== null)
+         return;
+
+      // create a column that spans the entire header space
+      metaheader = document.createElement("div");
+      var metacell = document.createElement("div");
+      metacell.className = "pagedtable-metacell";
+      metaheader.appendChild(metacell);
+
+      // create a small table cell inside that column to host the metadata
+      for (var metafield in options.metadata) {
+         if (options.metadata.hasOwnProperty(metafield)) {
+            var metadiv = document.createElement("div");
+
+            var field = document.createElement("span");
+            field.innerText = metafield + ":";
+            field.className = "pagedtable-metafield";
+            metadiv.appendChild(field);
+
+            var val = document.createElement("span");
+            val.innerText = options.metadata[metafield];
+            val.className = "pagedtable-metaval";
+            metadiv.appendChild(val);
+
+            metacell.appendChild(metadiv);
+         }
+      }
+
+      // insert the metadata above the table
+      var table = pagedTable.querySelectorAll("table")[0];
+      table.parentElement.insertBefore(metaheader, table);
+   };
+
    var renderHeader = function (clear) {
+      var fragment = document.createDocumentFragment();
       cachedPagedTableClientWidth = pagedTable.clientWidth;
 
-      var fragment = document.createDocumentFragment();
-
-      // show metadata on top of header as long as we have > 1 entry (the first one is always just
-      // dimensions, which we are already displaying
-      if (Object.keys(options.metadata).length > 1) {
-         // create a column that spans the entire header space
-         metaheader = document.createElement("tr");
-         var metacell = document.createElement("td");
-         metacell.className = "pagedtable-metacell";
-         metacell.setAttribute("colspan", columns.total);
-         metaheader.appendChild(metacell);
-
-         // create a small table cell inside that column to host the metadata
-         for (var metafield in options.metadata) {
-            if (options.metadata.hasOwnProperty(metafield)) {
-               var metadiv = document.createElement("div");
-
-               var field = document.createElement("span");
-               field.innerText = metafield + ":";
-               field.className = "pagedtable-metafield";
-               metadiv.appendChild(field);
-
-               var val = document.createElement("span");
-               val.innerText = options.metadata[metafield];
-               val.className = "pagedtable-metaval";
-               metadiv.appendChild(val);
-
-               metacell.appendChild(metadiv);
-            }
-         }
-         fragment.appendChild(metaheader);
-      }
       header = document.createElement("tr");
       fragment.appendChild(header);
 
@@ -606,7 +615,7 @@ var PagedTable = function (pagedTable) {
       if (columns.number + columns.visible < columns.total)
          header.appendChild(renderColumnNavigation(columns.visible, false));
 
-      if (typeof clear == "undefined" || clear) clearHeader();
+      if (typeof clear === "undefined" || clear) clearHeader();
       var thead = pagedTable.querySelectorAll("thead")[0];
       thead.appendChild(fragment);
    };
@@ -1112,6 +1121,7 @@ var PagedTable = function (pagedTable) {
       me.fitColumns(false);
 
       // render header/footer to measure height accurately
+      renderMetadata();
       renderHeader();
       renderFooter();
 


### PR DESCRIPTION
This change fixes an issue in which the new header for paged tables (which shows grouping information; see https://github.com/rstudio/rstudio/pull/6688) can be duplicated when paging through columns in wide datasets.

The fix is to take this metadata out of the table header (which has a somewhat complicated re-rendering and appending situation going on) and to place it in a separate section above the table instead.

Fixes https://github.com/rstudio/rstudio/issues/7048.