### PR TITLE
Correctly cancel the preview timer

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_symbol/insert_symbol-grid.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_symbol/insert_symbol-grid.tsx
@@ -96,7 +96,7 @@ const SymbolCharacterGrid = React.forwardRef<any, CharacterGridProps>((props, re
   React.useEffect(() => {
     if (mayShowPreview) {
       updatePreviewPosition();
-      maybeShowPreview();
+      return maybeShowPreview();
     }
   }, [props.selectedIndex, mayShowPreview]);
 
@@ -116,6 +116,7 @@ const SymbolCharacterGrid = React.forwardRef<any, CharacterGridProps>((props, re
       previewTimer.current = window.setTimeout(() => {
         setShowPreview(true);
       }, kWaitToShowPreviewMs);
+      return () => { window.clearTimeout(previewTimer.current); };
     }
   }  
   const kWaitToShowPreviewMs = 750;


### PR DESCRIPTION
When the component unmounts, cancel the preview timer. This fixes:

![unnamed](https://user-images.githubusercontent.com/261654/83944923-13c87b80-a7d5-11ea-819b-d9c5217b778e.png)

which is caused by the timer calling back when the component has been closed (reproduces by mousing over the grid, then closing the popup immediately).
