### PR TITLE
fix first ESC key press being ignored

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/MiniPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MiniPopupPanel.java
@@ -86,6 +86,7 @@ public class MiniPopupPanel extends DecoratedPopupPanel
    public void show()
    {
       addDragHandler();
+      addEscHandler();
       super.show();
    }
    
@@ -93,27 +94,12 @@ public class MiniPopupPanel extends DecoratedPopupPanel
    public void hide()
    {
       removeDragHandler();
+      removeEscHandler();
       super.hide();
    }
    
    private void commonInit(boolean useStyleSheet)
    {
-      escapeHandler_ = Event.addNativePreviewHandler(new NativePreviewHandler()
-      {
-         @Override
-         public void onPreviewNativeEvent(NativePreviewEvent event)
-         {
-            if (event.getTypeInt() == Event.ONKEYDOWN &&
-                  event.getNativeEvent().getKeyCode() == KeyCodes.KEY_ESCAPE)
-            {
-               event.cancel();
-               escapeHandler_.removeHandler();
-               escapeHandler_ = null;
-               hide();
-            }
-         }
-      });
-      
       if (useStyleSheet)
       {
          addStyleName(RES.styles().popupPanel());
@@ -276,9 +262,36 @@ public class MiniPopupPanel extends DecoratedPopupPanel
    private void removeDragHandler()
    {
       if (dragHandler_ != null)
+      {
          dragHandler_.removeHandler();
+         dragHandler_ = null;
+      }
    }
-   
+
+   private void addEscHandler()
+   {
+      escapeHandler_ = Event.addNativePreviewHandler(nativePreviewEvent ->
+      {
+         if (nativePreviewEvent.getTypeInt() == Event.ONKEYDOWN &&
+               nativePreviewEvent.getNativeEvent().getKeyCode() == KeyCodes.KEY_ESCAPE)
+         {
+            nativePreviewEvent.cancel();
+            escapeHandler_.removeHandler();
+            escapeHandler_ = null;
+            hide();
+         }
+      });
+   }
+
+   private void removeEscHandler()
+   {
+      if (escapeHandler_ != null)
+      {
+         escapeHandler_.removeHandler();
+         escapeHandler_ = null;
+      }
+   }
+
    private int initialPopupLeft_ = 0;
    private int initialPopupTop_ = 0;
    


### PR DESCRIPTION
- Fixes #7045
- Regression introduced via "add API for highlighting arbitrary UI in RStudio" #5867
- eager singleton causing a hidden MiniPopupPanel to be created at startup and that class had a quirk where it would intercept the first ESC keypress and swallow it
- fix is to only attached its key previewer when the panel has been displayed, and remove it when hidden (following existing pattern for drag handler)