### PR TITLE
accessibility improvements for main menu shortcut keys

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -515,7 +515,11 @@ well as menu structures (for main menu and popup menus).
                <cmd refid="speakEditorLocation"/>
             </menu>
             <menu label="_Focus">
+               <cmd refid="activateSource"/>
+               <cmd refid="activateConsole"/>
                <cmd refid="focusConsoleOutputEnd"/>
+               <cmd refid="activateTerminal"/>
+               <cmd refid="activateHelp"/>
                <cmd refid="focusMainToolbar"/>
                <cmd refid="toggleTabKeyMovesFocus"/>
                </menu>
@@ -701,7 +705,7 @@ well as menu structures (for main menu and popup menus).
 
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
-         <shortcut refid="activateTerminal" value="Alt+Shift+T"/>
+         <shortcut refid="activateTerminal" value="Alt+Shift+M"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
          <shortcut refid="activateFiles" value="Ctrl+5"/>
@@ -743,7 +747,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="saveSourceDoc" value="Ctrl+S" disableModes="emacs"/>
          <shortcut refid="saveSourceDoc" value="Meta+S" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
-         <shortcut refid="saveAllSourceDocs" value="Cmd+Alt+S"/>
+         <shortcut refid="saveAllSourceDocs" value="Ctrl+Alt+S" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="saveAllSourceDocs" value="Meta+Alt+S" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
          <shortcut refid="newSourceDoc" value="Ctrl+X Ctrl+N" disableModes="default,vim,sublime"/>
          <shortcut refid="newSourceDoc" value="Cmd+Shift+N" if="!org.rstudio.core.client.BrowseCap.isChromeServer()" title="New R Script"/>
@@ -861,15 +866,16 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="showViewMenu" value="Alt+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showPlotsMenu" value="Ctrl+Alt+P" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showPlotsMenu" value="Alt+Shift+P" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="showSessionMenu" value="Ctrl+Alt+Shift+S"/>
+         <shortcut refid="showSessionMenu" value="Ctrl+Alt+S" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showSessionMenu" value="Alt+Shift+S" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showBuildMenu" value="Ctrl+Alt+B" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showBuildMenu" value="Alt+Shift+B" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showDebugMenu" value="Ctrl+Alt+U" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showDebugMenu" value="Alt+Shift+U" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showProfileMenu" value="Ctrl+Alt+O" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showProfileMenu" value="Alt+Shift+I" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="showToolsMenu" value="Ctrl+Alt+L" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="showToolsMenu" value="Alt+Shift+S" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showToolsMenu" value="Ctrl+Alt+T" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="showToolsMenu" value="Alt+Shift+T" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showHelpMenu" value="Ctrl+Alt+H" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="showHelpMenu" value="Alt+Shift+H" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
       </shortcutgroup>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -168,7 +168,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Save all documents</td>
       <td>Ctrl+Alt+S</td>
-      <td>Ctrl+Option+S</td>
+      <td>Command+Option+S</td>
     </tr>
     <tr>
       <td>Close active document (except on Chrome)</td>
@@ -746,8 +746,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Move Focus to Terminal</td>
-      <td>Alt+Shift+T</td>
-      <td>Option+Shift+T</td>
+      <td>Alt+Shift+M</td>
+      <td>Option+Shift+M</td>
     </tr>
     <tr>
       <td>Show History</td>
@@ -884,7 +884,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Command Palette</td>
       <td>Ctrl+Shift+P, Ctrl+Alt+Shift+P (Firefox)</td>
-      <td>Ctrl+Shift+P</td>
+      <td>Shift+Command+P</td>
     </tr>
     <tr>
       <td>Show Keyboard Shortcut Reference</td>
@@ -1071,8 +1071,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Move Focus to Terminal</td>
-      <td>Shift+Alt+T</td>
-      <td>Option+Shift+T</td>
+      <td>Shift+Alt+M</td>
+      <td>Option+Shift+M</td>
     </tr>
     <tr>
       <td>Previous Terminal</td>
@@ -1119,8 +1119,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Session Menu</td>
-      <td>Ctrl+Alt+Shift+S</td>
-      <td>Ctrl+Option+Shift+S</td>
+      <td>Alt+Shift+S</td>
+      <td>Ctrl+Option+S</td>
     </tr>
     <tr>
       <td>Build Menu</td>
@@ -1139,8 +1139,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Tools Menu</td>
-      <td>Alt+Shift+S</td>
-      <td>Ctrl+Option+L</td>
+      <td>Alt+Shift+T</td>
+      <td>Ctrl+Option+T</td>
     </tr>
     <tr>
       <td>Help Menu</td>


### PR DESCRIPTION
- shortcut for "Move Focus to Terminal" is now Alt+Shift+M
- shortcut for activating Tools menu on Server is now Alt+Shift+T on Windows/Linux, Ctrl+Alt+T on Mac
- shortcut for "Save All Source Docs" no longer supports Ctrl+Alt+S variation on Mac, only Command+Alt+S; it previously supported both but has always been shown as Command+Alt+S in menu and keyboard help
- shortcut for activating Session menu on Server is now Alt+Shift+S on Windows/Linux, Ctrl+Alt+S on Mac
- added commands for focusing Terminal, Console, Source pane, and Help pane to the Accessibility / Focus submenu
- Fixes #6929
- Fixes #6924