### PR TITLE
Disabled realtime spellcheck error

### DIFF
--- a/NEWS-1.3-patch.md
+++ b/NEWS-1.3-patch.md
@@ -27,6 +27,8 @@
 - Fix auto-activation of JAWS screen reader virtual cursor in Console Output region (#6884)
 - Announce text of warnings bar via screen reader (#6963)
 - Fix issue where R_LIBS_SITE could be forcibly set empty, overriding the value in /etc/R/REnviron (#6982)
+- Fix sign out from the Admin Dashboard when behind a path-rewriting proxy (Pro #1709)
+- Fix "Login as user" from the Admin Dashboard when using Launcher sessions (Pro #1710)
 
 ### RStudio Server Pro
 

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -372,7 +372,8 @@ public class TypoSpellChecker
    {
       final String language = userPrefs_.spellingDictionaryLanguage().getValue();
 
-      if (!userPrefs_.realTimeSpellchecking().getValue() || typoLoaded_ && loadedDict_.equals(language))
+      // don't load a dictionary that's already loaded
+      if (typoLoaded_ && loadedDict_.equals(language))
          return;
 
       // See canRealtimeSpellcheckDict comment, temporary stop gap

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -33,7 +33,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
-import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
We use Typo.js for even non-realtime spellchecking now but we were trying to over-optimize loading the dictionaries and an edge case was missed.

Fixes #7057
Fixes #7018