### PR TITLE
Dictionary check error

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -292,7 +292,7 @@ public class TypoSpellChecker
          }
          else
          {
-            if (typoNative_.check(word))
+            if (typoNative_.check(word) || checkCustomDicts(word))
             {
                spellCheckerResult.getCorrect().add(word);
             }
@@ -372,7 +372,7 @@ public class TypoSpellChecker
    {
       final String language = userPrefs_.spellingDictionaryLanguage().getValue();
 
-      if (!userPrefs_.realTimeSpellchecking().getValue() || typoLoaded_ && loadedDict_.equals(language))
+      if (typoLoaded_ && loadedDict_.equals(language))
          return;
 
       // See canRealtimeSpellcheckDict comment, temporary stop gap

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -33,7 +33,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
-import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
We use Typo.js for even non-realtime spellchecking now but we were trying to over-optimize loading the dictionaries and an edge case was missed.

Fixes #7057
Fixes #7018

I also fixed non-realtime checking working with custom dictionaries so those will be synced.