### PR TITLE
enable options dialog to show a single preference pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.java
@@ -38,12 +38,15 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
 {
    protected PreferencesDialogBase(String caption,
                                    String panelContainerStyle,
+                                   String panelContainerStyleNoChooser,
                                    boolean showApplyButton,
                                    PreferencesDialogPaneBase<T>[] panes)
    {
       super(Roles.getDialogRole());
       setText(caption);
       panes_ = panes;
+      panelContainerStyle_ = panelContainerStyle;
+      panelContainerStyleNoChooser_ = panelContainerStyleNoChooser;
 
       PreferencesDialogBaseResources res = PreferencesDialogBaseResources.INSTANCE;
 
@@ -64,7 +67,7 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
 
       progressIndicator_ = addProgressIndicator(false);
       panel_ = new DockLayoutPanel(Unit.PX);
-      panel_.setStyleName(panelContainerStyle);
+      panel_.setStyleName(panelContainerStyle_);
       container_ = new FlowPanel();
       container_.getElement().getStyle().setPaddingLeft(10, Unit.PX);
 
@@ -132,6 +135,21 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
             activatePane(i);
             break;
          }
+      }
+   }
+
+   public void setShowPaneChooser(boolean showPaneChooser)
+   {
+      panel_.setWidgetHidden(sectionChooser_, !showPaneChooser);
+      if (showPaneChooser)
+      {
+         panel_.removeStyleName(panelContainerStyleNoChooser_);
+         panel_.addStyleName(panelContainerStyle_);
+      }
+      else
+      {
+         panel_.removeStyleName(panelContainerStyle_);
+         panel_.addStyleName(panelContainerStyleNoChooser_);
       }
    }
 
@@ -232,4 +250,6 @@ public abstract class PreferencesDialogBase<T> extends ModalDialogBase
    private Integer currentIndex_;
    private final ProgressIndicator progressIndicator_;
    private final SectionChooser sectionChooser_;
+   private final String panelContainerStyle_;
+   private final String panelContainerStyleNoChooser_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -825,13 +825,13 @@ public class Projects implements OpenProjectFileHandler,
    @Handler
    public void onProjectOptions()
    {
-      showProjectOptions(ProjectPreferencesDialog.GENERAL);
+      showProjectOptions(ProjectPreferencesDialog.GENERAL, true);
    }
 
    @Handler
    public void onProjectSweaveOptions()
    {
-      showProjectOptions(ProjectPreferencesDialog.SWEAVE);
+      showProjectOptions(ProjectPreferencesDialog.SWEAVE, true);
    }
 
    @Handler
@@ -849,7 +849,7 @@ public class Projects implements OpenProjectFileHandler,
       }
       else
       {
-         showProjectOptions(ProjectPreferencesDialog.BUILD);
+         showProjectOptions(ProjectPreferencesDialog.BUILD, true);
       }
    }
 
@@ -870,23 +870,23 @@ public class Projects implements OpenProjectFileHandler,
       }
       else
       {
-         showProjectOptions(ProjectPreferencesDialog.VCS);
+         showProjectOptions(ProjectPreferencesDialog.VCS, true);
       }
    }
 
    @Handler
    public void onPackratBootstrap()
    {
-      showProjectOptions(ProjectPreferencesDialog.RENV);
+      showProjectOptions(ProjectPreferencesDialog.RENV, true);
    }
 
    @Handler
    public void onPackratOptions()
    {
-      showProjectOptions(ProjectPreferencesDialog.RENV);
+      showProjectOptions(ProjectPreferencesDialog.RENV, true);
    }
 
-   public void showProjectOptions(final int initialPane)
+   public void showProjectOptions(final int initialPane, boolean showPaneChooser)
    {
       final ProgressIndicator indicator = globalDisplay_.getProgressIndicator(
                                                       "Error Reading Options");
@@ -902,6 +902,7 @@ public class Projects implements OpenProjectFileHandler,
             ProjectPreferencesDialog dlg = pPrefDialog_.get();
             dlg.initialize(options);
             dlg.activatePane(initialPane);
+            dlg.setShowPaneChooser(showPaneChooser);
             dlg.showModal();
          }});
    }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.css
@@ -6,12 +6,17 @@
    height: 425px;
 }
 
+.panelContainerNoChooser {
+   width: 403px;
+   height: 425px;
+}
+
 .buildToolsPanel {
    width: 100%;
 }
 
 .workspaceGrid {
-   margin-bottom: 10px; 
+   margin-bottom: 10px;
    width: 375px;
 }
 
@@ -36,7 +41,7 @@
 }
 
 .encodingChooser {
-   margin-top: 3px; 
+   margin-top: 3px;
    margin-left: 10px;
    margin-bottom: 15px;
 }
@@ -104,7 +109,7 @@
 .infoLabel {
    margin-top: 6px;
    font-style: italic;
-   font-size: 0.9em; 
+   font-size: 0.9em;
 }
 
 .websiteOutputFormat {

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -63,6 +63,7 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
    {
       super("Project Options",
             RES.styles().panelContainer(),
+            RES.styles().panelContainerNoChooser(),
             false,
             new ProjectPreferencesPane[] {general, editing, compilePdf, build,
                                           source, renv, sharing});

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialogResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialogResources.java
@@ -24,6 +24,7 @@ public interface ProjectPreferencesDialogResources extends ClientBundle
    interface Styles extends CssResource
    {
       String panelContainer();
+      String panelContainerNoChooser();
       String buildToolsPanel();
       String workspaceGrid();
       String enableCodeIndexing();

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
@@ -170,7 +170,7 @@ public class RSAccountConnector implements EnableRStudioConnectUIEvent.Handler
       }
       else
       {
-         optionsLoader_.showOptions(PublishingPreferencesPane.class);
+         optionsLoader_.showOptions(PublishingPreferencesPane.class, true);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.css
@@ -6,6 +6,11 @@
    height: 500px;
 }
 
+.panelContainerNoChooser {
+   width: 448px;
+   height: 500px;
+}
+
 .sshKeyWidget {
    margin-top: 20px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
@@ -61,6 +61,7 @@ public class PreferencesDialog extends PreferencesDialogBase<UserPrefs>
    {
       super("Options",
             res.styles().panelContainer(),
+            res.styles().panelContainerNoChooser(),
             true,
             new PreferencesPane[] {pR.get(),
                                    source,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialogResources.java
@@ -23,6 +23,7 @@ public interface PreferencesDialogResources extends ClientBundle
    interface Styles extends CssResource
    {
       String panelContainer();
+      String panelContainerNoChooser();
       String paneLayoutTable();
       String themeChooser();
       String sshKeyWidget();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/OptionsLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/OptionsLoader.java
@@ -32,7 +32,7 @@ public class OptionsLoader
    public abstract static class Shim extends AsyncShim<OptionsLoader>
    {
       public abstract void showOptions();
-      public abstract void showOptions(Class<?> paneClass);
+      public abstract void showOptions(Class<?> paneClass, boolean showPaneChooser);
    }
 
    @Inject
@@ -51,15 +51,16 @@ public class OptionsLoader
 
    public void showOptions()
    {
-      showOptions(null);
+      showOptions(null, true);
    }
 
-   public void showOptions(final Class<?> paneClass)
+   public void showOptions(final Class<?> paneClass, boolean showPaneChooser)
    {
       PreferencesDialog prefDialog = pPrefDialog_.get();
       prefDialog.initialize(RStudioGinjector.INSTANCE.getUserPrefs());
       if (paneClass != null)
          prefDialog.activatePane(paneClass);
+      prefDialog.setShowPaneChooser(showPaneChooser);
       prefDialog.showModal();
 
       // if the user changes global sweave or latex options notify

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -558,7 +558,7 @@ public class PaneManager
    @Handler
    public void onPaneLayout()
    {
-      optionsLoader_.showOptions(PaneLayoutPreferencesPane.class);
+      optionsLoader_.showOptions(PaneLayoutPreferencesPane.class, true);
    }
 
    private <T> boolean equals(T lhs, T rhs)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -395,13 +395,13 @@ public class WorkbenchScreen extends Composite
    @Handler
    void onShowAccessibilityOptions()
    {
-      optionsLoader_.showOptions(AccessibilityPreferencesPane.class);
+      optionsLoader_.showOptions(AccessibilityPreferencesPane.class, false);
    }
 
    @Handler
    void onShowTerminalOptions()
    {
-      optionsLoader_.showOptions(TerminalPreferencesPane.class);
+      optionsLoader_.showOptions(TerminalPreferencesPane.class, true);
    }
 
    @Handler


### PR DESCRIPTION
- Fixes #6847
- General mechanism for global options or project options dialogs to display a single-pane by hiding section chooser
- Currently only used for Help / Accessibility / Accessibility Options entry-point

<img width="472" alt="screenshot of Accessibility Options in single-pane mode" src="https://user-images.githubusercontent.com/10569626/84086269-54bebc80-a99c-11ea-801e-1d8f13de9976.png">
