### PR TITLE
Specify the `base` namespace for `save.image`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -438,7 +438,7 @@ public class EnvironmentPresenter extends BasePresenter
       consoleDispatcher_.saveFileAsThenExecuteCommand("Save Workspace As",
                                                       ".RData",
                                                       true,
-                                                      "save.image");
+                                                      "base::save.image");
    }
 
    void onLoadWorkspace()


### PR DESCRIPTION
This PR is intended to correct issue #7072.  This has not been tested and the namespace might need to be added to other places.  