### PR TITLE
Fix bug where rmd files were not properly initialized

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -107,7 +107,6 @@ public class TextEditingTargetChunks
    @Inject
    private void initialize(UserPrefs prefs, UserState state)
    {
-      initialized_ = true;
       prefs_ = prefs;
       state_ = state;
       dark_ = state.theme().getValue().getIsDark();
@@ -193,6 +192,7 @@ public class TextEditingTargetChunks
                toolbars_.remove(toolbar);
             }
          }
+         initialized_ = true;
       }
 
       if (currentScope != null)


### PR DESCRIPTION
Text editing targets were being marked as initialized too early and therefore the buttons to manage the chunks were not appearing until the toolbar was refreshed. This PR sets the initialized variable properly. 