### PR TITLE
fix problem entering tilde on German keyboard

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -37,7 +37,6 @@
 - Fix error when some HTML comments are included in R Markdown documents (#6997)
 - Fix issue where toolbar buttons were missing on initialization (#7076)
 - Fix error in Viewer pane when previewing Distill blogs (#6945)
-- Fix problem entering tilde on German keyboard (#7092)
 
 ### RStudio Server Pro
 


### PR DESCRIPTION
- Fixes #7092
- Show Request Log keyboard shortcut (modified in #6850, sigh, no such thing as a safe change) was preventing entry of tilde on German keyboard
- Removed shortcut from that internal diagnostic command, but made it possible to add one via keyboard shortcut customization