### PR TITLE
require system libclang on macOS

### DIFF
--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -20,22 +20,27 @@
 
 #include <boost/regex.hpp>
 
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
-#include <core/RegexUtils.hpp>
 #include <shared_core/SafeConvert.hpp>
 
+#include <core/Log.hpp>
+#include <core/RegexUtils.hpp>
+#include <core/system/Environment.hpp>
 #include <core/system/LibraryLoader.hpp>
 
-#define LOAD_CLANG_SYMBOL(name) \
-   error = core::system::loadSymbol(pLib_, "clang_" #name, (void**)&name); \
-   if (error) \
-   { \
-      Error unloadError = unload(); \
-      if (unloadError) \
-         LOG_ERROR(unloadError); \
-      return error; \
-   }
+#define LOAD_CLANG_SYMBOL(name)                                                \
+   do                                                                          \
+   {                                                                           \
+      Error error =                                                            \
+         core::system::loadSymbol(pLib_, "clang_" #name, (void**) &name);      \
+      if (error)                                                               \
+      {                                                                        \
+         Error unloadError = unload();                                         \
+         if (unloadError)                                                      \
+            LOG_ERROR(unloadError);                                            \
+         return error;                                                         \
+      }                                                                        \
+   } while (0);
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -65,31 +65,6 @@ std::vector<std::string> defaultCompileArgs(LibraryVersion version)
    if (FilePath(includePath).exists())
      compileArgs.push_back(std::string("-I") + includePath);
 
-#ifdef __APPLE__
-   // newer versions of macOS (e.g. Mojave) no longer install system
-   // headers into /usr/include by default. attempt to find the headers
-   // made available as part of the default toolchain instead
-   if (!FilePath("/usr/include").exists())
-   {
-      // try multiple locations for path to appropriate system headers
-      std::vector<std::string> usrIncludePaths = {
-         "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include",
-         "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include"
-         "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
-      };
-
-      for (auto&& path : usrIncludePaths)
-      {
-         if (FilePath(path).exists())
-         {
-            compileArgs.insert(compileArgs.begin(), path);
-            compileArgs.insert(compileArgs.begin(), "-isystem");
-            break;
-         }
-      }
-   }
-#endif
-
    return compileArgs;
 }
 
@@ -103,10 +78,9 @@ std::vector<std::string> systemClangVersions()
    // (there seems to be extra orchestration required to get
    // include paths set up; easier to just depend on command
    // line tools since we request their installation in other
-   // contexts)
+   // contexts as well)
    clangVersions = {
-      "/Library/Developer/CommandLineTools/usr/lib/libclang.dylib",
-      "/usr/local/opt/llvm/lib/libclang.dylib",
+      "/Library/Developer/CommandLineTools/usr/lib/libclang.dylib"
    };
 #elif defined(__unix__)
    // default set of versions

--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -167,10 +167,19 @@ bool LibClang::load(EmbeddedLibrary embedded,
    if (!embedded.empty())
       embeddedVersion = embedded.libraryPath();
 
-   // build a list of clang versions to try (start with embedded)
+   // build a list of clang versions to try
    std::vector<std::string> versions;
+   
+   // add version from env var (mostly for debugging)
+   std::string envVersion = core::system::getenv("RSTUDIO_LIBCLANG_PATH");
+   if (!envVersion.empty())
+      versions.push_back(envVersion);
+   
+   // add embedded version
    if (!embeddedVersion.empty())
       versions.push_back(embeddedVersion);
+   
+   // add discovered system versions
    std::vector<std::string> sysVersions = systemClangVersions();
    versions.insert(versions.end(), sysVersions.begin(), sysVersions.end());
 


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6977.

In theory, we allow the use of an optional installation of LLVM, but in practice that seems to never work (and orchestration of include paths etc. to make that work and compatible with what R does isn't worth the effort when users will normally have macOS command line tools installed anyhow).

Given that we're now always binding to the macOS version of libclang, setting up the extra system include paths seems to be no longer necessary.

Candidate for v1.3 backport.