### PR TITLE
fix various accessibility issues in Visual Editor dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -458,7 +458,9 @@ public class ElementIds
    
    // Visual Markdown Editing dialogs
    public final static String VISUAL_MD_RAW_FORMAT_SELECT = "visual_md_raw_format_select";
+   public static String getVisualMdRawFormatSelect() { return getElementId(VISUAL_MD_RAW_FORMAT_SELECT); }
    public final static String VISUAL_MD_RAW_FORMAT_CONTENT = "visual_md_raw_format_content";
+   public static String getVisualMdRawContent() { return getElementId(VISUAL_MD_RAW_FORMAT_CONTENT); }
    public final static String VISUAL_MD_RAW_FORMAT_REMOVE_BUTTON = "visual_md_raw_format_remove_button";
    public final static String VISUAL_MD_INSERT_TABLE_ROWS = "visual_md_insert_table_rows";
    public static String getVisualMdInsertTableRows() { return getElementId(VISUAL_MD_INSERT_TABLE_ROWS); }
@@ -468,21 +470,46 @@ public class ElementIds
    public static String getVisualMdInsertTableCaption() { return getElementId(VISUAL_MD_INSERT_TABLE_CAPTION); }
    public final static String VISUAL_MD_INSERT_TABLE_HEADER = "visual_md_insert_table_heaeder";
    public final static String VISUAL_MD_ATTR_REMOVE_BUTTON = "visual_md_attr_remove_button";
+   public final static String VISUAL_MD_ATTR_ID_LABEL1 = "visual_md_attr_id_label1";
+   public static String getVisualMdAttrIdLabel1() { return getElementId(VISUAL_MD_ATTR_ID_LABEL1); }
+   public final static String VISUAL_MD_ATTR_ID_LABEL2 = "visual_md_attr_id_label2";
+   public static String getVisualMdAttrIdLabel2() { return getElementId(VISUAL_MD_ATTR_ID_LABEL2); }
    public final static String VISUAL_MD_ATTR_ID = "visual_md_attr_id";
+   public static String getVisualMdAttrId() { return getElementId(VISUAL_MD_ATTR_ID); }
+   public final static String VISUAL_MD_ATTR_CLASSES_LABEL1 = "visual_md_attr_classes_label1";
+   public static String getVisualMdAttrClassesLabel1() { return getElementId(VISUAL_MD_ATTR_CLASSES_LABEL1); }
+   public final static String VISUAL_MD_ATTR_CLASSES_LABEL2 = "visual_md_attr_classes_label2";
+   public static String getVisualMdAttrClassesLabel2() { return getElementId(VISUAL_MD_ATTR_CLASSES_LABEL2); }
    public final static String VISUAL_MD_ATTR_CLASSES = "visual_md_attr_classes";
+   public static String getVisualMdAttrClasses() { return getElementId(VISUAL_MD_ATTR_CLASSES); }
+   public final static String VISUAL_MD_ATTR_STYLE_LABEL1 = "visual_md_attr_style_label1";
+   public static String getVisualMdAttrStyleLabel1() { return getElementId(VISUAL_MD_ATTR_STYLE_LABEL1); }
+   public final static String VISUAL_MD_ATTR_STYLE_LABEL2 = "visual_md_attr_style_label2";
+   public static String getVisualMdAttrStyleLabel2() { return getElementId(VISUAL_MD_ATTR_STYLE_LABEL2); }
    public final static String VISUAL_MD_ATTR_STYLE = "visual_md_attr_style";
+   public static String getVisualMdAttrStyle() { return getElementId(VISUAL_MD_ATTR_STYLE); }
+   public final static String VISUAL_MD_ATTR_KEYVALUE_LABEL1 = "visual_md_attr_keyvalue_label1";
+   public static String getVisualMdAttrKeyValueLabel1() { return getElementId(VISUAL_MD_ATTR_KEYVALUE_LABEL1); }
+   public final static String VISUAL_MD_ATTR_KEYVALUE_LABEL2 = "visual_md_attr_keyvalue_label2";
+   public static String getVisualMdAttrKeyValueLabel2() { return getElementId(VISUAL_MD_ATTR_KEYVALUE_LABEL2); } 
    public final static String VISUAL_MD_ATTR_KEYVALUE = "visual_md_attr_keyvalue";
+   public static String getVisualMdAttrKeyValue() { return getElementId(VISUAL_MD_ATTR_KEYVALUE); }
    public final static String VISUAL_MD_CITATION_ID = "visual_md_citation_id";
    public static String getVisualMdCitationId() { return getElementId(VISUAL_MD_CITATION_ID); }
    public final static String VISUAL_MD_CITATION_LOCATOR = "visual_md_citation_locator";
    public static String getVisualMdCitationLocator() { return getElementId(VISUAL_MD_CITATION_LOCATOR); }
    public final static String VISUAL_MD_LIST_TYPE = "visual_md_list_type";
+   public static String getVisualMdListType() { return getElementId(VISUAL_MD_LIST_TYPE); }
    public final static String VISUAL_MD_LIST_ORDER = "visual_md_list_order";
+   public static String getVisualMdListOrder() { return getElementId(VISUAL_MD_LIST_ORDER); }
    public final static String VISUAL_MD_LIST_NUMBER_STYLE = "visual_md_list_number_style";
+   public static String getVisualMdListNumberStyle() { return getElementId(VISUAL_MD_LIST_NUMBER_STYLE); }
    public final static String VISUAL_MD_LIST_NUMBER_DELIM = "visual_md_list_number_delim";
+   public static String getVisualMdListNumberDelim() { return getElementId(VISUAL_MD_LIST_NUMBER_DELIM); }
+   public final static String VISUAL_MD_LIST_NUMBER_DELIM_NOTE = "visual_md_list_number_delim_note";
+   public static String getVisualMdListNumberDelimNote() { return getElementId(VISUAL_MD_LIST_NUMBER_DELIM_NOTE); }
    public final static String VISUAL_MD_LIST_TIGHT = "visual_md_ordered_list_tight";
    public final static String VISUAL_MD_IMAGE_TAB_IMAGE = "visual_md_image_tab_image";
-   public final static String VISUAL_MD_IMAGE_SRC = "visual_md_image_src";
    public final static String VISUAL_MD_IMAGE_WIDTH = "visual_md_image_width";
    public final static String VISUAL_MD_IMAGE_HEIGHT = "visual_md_image_height";
    public final static String VISUAL_MD_IMAGE_UNITS = "visual_md_image_units";
@@ -502,6 +529,8 @@ public class ElementIds
    public final static String VISUAL_MD_LINK_TAB_ATTRIBUTES = "visual_md_link_tab_attributes";
    public final static String VISUAL_MD_CODE_BLOCK_TAB_LANGUAGE = "visual_md_code_block_tab_language";
    public final static String VISUAL_MD_CODE_BLOCK_TAB_ATTRIBUTES = "visual_md_code_block_tab_attributes";
+   public final static String VISUAL_MD_CODE_BLOCK_LANG_LABEL1 = "visual_md_code_block_lang_label1";
+   public final static String VISUAL_MD_CODE_BLOCK_LANG_LABEL2 = "visual_md_code_block_lang_label2";
    public final static String VISUAL_MD_CODE_BLOCK_LANG = "visual_md_code_block_tab_lang";
 
    

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -692,7 +692,13 @@ public abstract class ModalDialogBase extends DialogBox
 
    /**
     * Set focus on first keyboard focusable element in dialog, as set by
-    * <code>refreshFocusableElements</code> or <code>setFirstFocusableElement</code>.
+    * refreshFocusableElements or setFirstFocusableElement.
+    *
+    * Invoked when Tabbing off the last control in the modal dialog to set focus back to
+    * the first control, and by default to set initial focus when the dialog is shown.
+    *
+    * To set focus on a different control when the dialog is displayed, override
+    * focusInitialControl, instead.
     */
    protected void focusFirstControl()
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/NumericTextBox.java
@@ -17,6 +17,7 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.user.client.ui.TextBox;
 
 public class NumericTextBox extends TextBox
+                                    implements CanSetControlId
 {
    public NumericTextBox()
    {
@@ -32,5 +33,11 @@ public class NumericTextBox extends TextBox
    public void setMin(int min)
    {
       getElement().setAttribute("min", String.valueOf(min));
+   }
+
+   @Override
+   public void setElementId(String id)
+   {
+      getElement().setId(id);
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.core.client.widget;
 
+import com.google.gwt.aria.client.Id;
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.theme.res.ThemeResources;
 
@@ -28,6 +30,7 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
 
 public class SelectWidget extends Composite
+                          implements CanSetControlId
 {
    public static String ExternalLabel = null;
 
@@ -260,6 +263,18 @@ public class SelectWidget extends Composite
       listBox_.insertItem(label, value, index);
    }
    
+   @Override
+   public void setElementId(String id)
+   {
+      listBox_.getElement().setId(id);
+      label_.setFor(id);
+   }
+
+   public void setDescribedBy(String id)
+   {
+      Roles.getListboxRole().setAriaDescribedbyProperty(listBox_.getElement(), Id.of(id));
+   }
+
    private HorizontalPanel horizontalPanel_ = null;
    private FlowPanel flowPanel_ = null;
    private FormLabel label_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditAttrWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditAttrWidget.java
@@ -17,7 +17,7 @@
 package org.rstudio.studio.client.panmirror.dialogs;
 
 
-
+import com.google.gwt.aria.client.Roles;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.FormTextArea;
 import org.rstudio.studio.client.panmirror.dialogs.model.PanmirrorAttrEditInput;
@@ -41,9 +41,20 @@ public class PanmirrorEditAttrWidget extends SimplePanel
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
       setWidget(mainWidget_);
       id_.getElement().setId(ElementIds.VISUAL_MD_ATTR_ID);
-      classes_.getElement().setId(ElementIds.VISUAL_MD_ATTR_CLASSES);
-      style_.getElement().setId(ElementIds.VISUAL_MD_ATTR_STYLE);
-      attributes_.getElement().setId(ElementIds.VISUAL_MD_ATTR_KEYVALUE);
+
+      // form controls each have two labels; markup for screen reader
+      Roles.getTextboxRole().setAriaLabelledbyProperty(id_.getElement(),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_ID_LABEL1),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_ID_LABEL2));
+      Roles.getTextboxRole().setAriaLabelledbyProperty(classes_.getElement(),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_CLASSES_LABEL1),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_CLASSES_LABEL2));
+      Roles.getTextboxRole().setAriaLabelledbyProperty(style_.getElement(),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_STYLE_LABEL1),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_STYLE_LABEL2));
+      Roles.getTextboxRole().setAriaLabelledbyProperty(attributes_.getElement(),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_KEYVALUE_LABEL1),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_ATTR_KEYVALUE_LABEL2));
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditAttrWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditAttrWidget.ui.xml
@@ -3,6 +3,7 @@
              xmlns:rw="urn:import:org.rstudio.core.client.widget">
 
    <ui:with field="res" type="org.rstudio.studio.client.panmirror.dialogs.PanmirrorDialogsResources" />
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
    
    .editAttr {
@@ -14,26 +15,30 @@
    <g:VerticalPanel styleName="{style.editAttr}">
       
       <g:HorizontalPanel>
-         <g:Label text="ID"></g:Label><g:Label text="(e.g. #overview)" styleName="{res.styles.inlineInfoLabel}"></g:Label>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrIdLabel1}" text="ID"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrIdLabel2}" text="(e.g. #overview)" styleName="{res.styles.inlineInfoLabel}"/>
       </g:HorizontalPanel>
-      <g:TextBox styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="id_"></g:TextBox>
+      <rw:FormTextBox elementId="{ElementIds.getVisualMdAttrId}" styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="id_"/>
      
       <g:HorizontalPanel>
-         <g:Label text="Classes"></g:Label><g:Label text="(e.g. .illustration)" styleName="{res.styles.inlineInfoLabel}"></g:Label>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrClassesLabel1}" text="Classes"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrClassesLabel2}" text="(e.g. .illustration)" styleName="{res.styles.inlineInfoLabel}"/>
       </g:HorizontalPanel>
-      <g:TextBox styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="classes_"></g:TextBox>
-    
+      <rw:FormTextBox elementId="{ElementIds.getVisualMdAttrClasses}" styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="classes_"/>
+     
       <g:HorizontalPanel>
-         <g:Label text="CSS styles"></g:Label><g:Label text="(e.g. color: gray;)" styleName="{res.styles.inlineInfoLabel}"></g:Label>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrStyleLabel1}" text="CSS styles"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrStyleLabel2}" text="(e.g. color: gray;)" styleName="{res.styles.inlineInfoLabel}"/>
       </g:HorizontalPanel>
-      <g:TextBox styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="style_"></g:TextBox>
-    
+      <rw:FormTextBox elementId="{ElementIds.getVisualMdAttrStyle}" styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="style_"/>
+     
       <g:HorizontalPanel>
-         <g:Label text="Other"/><g:Label text="(key=value, one per line)" styleName="{res.styles.inlineInfoLabel}"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrKeyValueLabel1}" text="Other"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdAttrKeyValueLabel2}" text="(key=value, one per line)" styleName="{res.styles.inlineInfoLabel}"/>
       </g:HorizontalPanel>
       
-      <rw:FormTextArea styleName="{res.styles.textArea} {res.styles.spaced}"
-                       ui:field="attributes_" visibleLines="3" ariaLabel="Attributes">
+      <rw:FormTextArea elementId="{ElementIds.getVisualMdAttrKeyValue}" styleName="{res.styles.textArea} {res.styles.spaced}"
+                       ui:field="attributes_" visibleLines="3">
       </rw:FormTextArea>
    </g:VerticalPanel>
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditCodeBlockDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditCodeBlockDialog.java
@@ -51,13 +51,20 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
       VerticalTabPanel langTab = new VerticalTabPanel(ElementIds.VISUAL_MD_CODE_BLOCK_TAB_LANGUAGE);
       langTab.addStyleName(RES.styles().dialog());
       HorizontalPanel labelPanel = new HorizontalPanel();
-      labelPanel.add(new FormLabel("Language"));
-      Label langInfo = new Label("(optional)");
+      FormLabel labelLanguage = new FormLabel("Language");
+      labelLanguage.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG_LABEL1));
+      labelPanel.add(labelLanguage);
+      FormLabel langInfo = new FormLabel("(optional)");
+      langInfo.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG_LABEL2));
       langInfo.addStyleName(RES.styles().inlineInfoLabel());
+      
       labelPanel.add(langInfo);
       langTab.add(labelPanel);
       lang_ = new PanmirrorLangSuggestBox(languages);
-      lang_.getElement().setId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG);
+      lang_.getElement().setId(ElementIds.getElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG));
+      Roles.getTextboxRole().setAriaLabelledbyProperty(lang_.getElement(),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG_LABEL1),
+         ElementIds.getAriaElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG_LABEL2));
       lang_.setText(codeBlock.lang);
       PanmirrorDialogsUtil.setFullWidthStyles(lang_);
       langTab.add(lang_);
@@ -76,7 +83,10 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
          tabPanel.add(langTab, "Language", langTab.getBasePanelId());
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
-      
+
+         // the tab panel is the first focusable control in dialog, but the actual focusable
+         // element changes depending which tab is selected
+         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements()); 
          mainWidget_ = tabPanel;
       }
       else
@@ -92,7 +102,7 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
    }
    
    @Override
-   public void focusFirstControl()
+   public void focusInitialControl()
    {
       lang_.setFocus(true);
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditImageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditImageDialog.java
@@ -199,6 +199,10 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          tabPanel.add(imageTab, "Image", imageTab.getBasePanelId());
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
+
+         // the tab panel is the first focusable control in dialog, but the actual focusable
+         // element changes depending which tab is selected
+         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements());
          mainWidget_ = tabPanel;
       }
       else
@@ -214,7 +218,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
    }
    
    @Override
-   public void focusFirstControl()
+   public void focusInitialControl()
    {
       url_.getTextBox().setFocus(true);
       url_.getTextBox().setSelectionRange(0, 0);
@@ -375,6 +379,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       for (int i = 0; i < options.length; i++)
          units.addItem(options[i], options[i]);
       units.getElement().setId(ElementIds.VISUAL_MD_IMAGE_UNITS);
+      Roles.getListboxRole().setAriaLabelProperty(units.getElement(), "Units");
       panel.add(units);
       return units;
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditLinkDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditLinkDialog.java
@@ -109,7 +109,7 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
       
       if (capabilities.attributes)
       {
-         VerticalTabPanel attributesTab = new VerticalTabPanel(ElementIds.VISUAL_MD_IMAGE_TAB_ATTRIBUTES);
+         VerticalTabPanel attributesTab = new VerticalTabPanel(ElementIds.VISUAL_MD_LINK_TAB_ATTRIBUTES);
          attributesTab.addStyleName(RES.styles().dialog());
          attributesTab.add(editAttr_);
          
@@ -118,7 +118,10 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
          tabPanel.add(linkTab, "Link", linkTab.getBasePanelId());
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
-         
+
+         // the tab panel is the first focusable control in dialog, but the actual focusable
+         // element changes depending which tab is selected
+         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements());
          mainWidget_ = tabPanel;
       }
       else
@@ -134,7 +137,7 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
    }
    
    @Override
-   public void focusFirstControl()
+   public void focusInitialControl()
    {
       href_.focus();
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.java
@@ -53,7 +53,6 @@ public class PanmirrorEditListDialog extends ModalDialog<PanmirrorListProps>
       
       mainWidget_ = GWT.<Binder>create(Binder.class).createAndBindUi(this);
       
-      listType_.getListBox().getElement().setId(ElementIds.VISUAL_MD_LIST_TYPE);
       listType_.setChoices(new String[] {
          PanmirrorListType.Ordered,
          PanmirrorListType.Bullet
@@ -63,19 +62,14 @@ public class PanmirrorEditListDialog extends ModalDialog<PanmirrorListProps>
          orderedOptionsPanel_.setVisible(listType_.getValue().equals(PanmirrorListType.Ordered));
       });
       
-      
       tight_.getElement().setId(ElementIds.VISUAL_MD_LIST_TIGHT);
-   
-      
       
       startingNumber_.setMin(1);
-      startingNumber_.getElement().setId(ElementIds.VISUAL_MD_LIST_ORDER);
       
       startingNumber_.setVisible(capabilities.order);
       numberStyle_.setVisible(capabilities.fancy);
       numberDelimiter_.setVisible(capabilities.fancy);
       
-      numberStyle_.getListBox().getElement().setId(ElementIds.VISUAL_MD_LIST_NUMBER_STYLE);
       List<String> numberStyleChoices = new ArrayList<String>();
       numberStyleChoices.add("DefaultStyle");
       numberStyleChoices.add("Decimal");
@@ -92,9 +86,8 @@ public class PanmirrorEditListDialog extends ModalDialog<PanmirrorListProps>
          "DefaultDelim",
          "Period",
          "OneParen",
-         "TwoParens",   
+         "TwoParens",
       });
-      numberDelimiter_.getListBox().getElement().setId(ElementIds.VISUAL_MD_LIST_NUMBER_DELIM);
 
       
       listType_.setValue(props.type);
@@ -102,7 +95,8 @@ public class PanmirrorEditListDialog extends ModalDialog<PanmirrorListProps>
       startingNumber_.setValue(props.order + "");
       numberStyle_.setValue(props.number_style);
       numberDelimiter_.setValue(props.number_delim);
-     
+      numberDelimiter_.setDescribedBy(
+         ElementIds.getElementId(ElementIds.VISUAL_MD_LIST_NUMBER_DELIM_NOTE));
       
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.ui.xml
@@ -3,6 +3,7 @@
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget">
    <ui:with field="res" type="org.rstudio.studio.client.panmirror.dialogs.PanmirrorDialogsResources" />
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
       .orderedOptions {
          margin-top: 10px;
@@ -11,22 +12,28 @@
    
    <g:VerticalPanel styleName="{res.styles.dialog}">
    
-      <g:Label text="List type:"/>
-      <rw:SelectWidget styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="listType_"></rw:SelectWidget>
+      <rw:FormLabel for="{ElementIds.getVisualMdListType}" text="List type:"/>
+      <rw:SelectWidget elementId="{ElementIds.getVisualMdListType}" styleName="{res.styles.fullWidth} {res.styles.spaced}"
+                       ui:field="listType_"/>
   
-      <g:CheckBox styleName="{res.styles.checkBox} {res.styles.spaced}" text="Tight layout (less vertical space between list items)" ui:field="tight_"></g:CheckBox>
+      <g:CheckBox styleName="{res.styles.checkBox} {res.styles.spaced}" text="Tight layout (less vertical space between list items)"
+                  ui:field="tight_"/>
   
        <g:VerticalPanel styleName="{style.orderedOptions}" ui:field="orderedOptionsPanel_">
        
-         <g:Label text="Starting number:"/>
-         <rw:NumericTextBox value="1" styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="startingNumber_"></rw:NumericTextBox>
+         <rw:FormLabel for="{ElementIds.getVisualMdListOrder}" text="Starting number:"/>
+         <rw:NumericTextBox elementId="{ElementIds.getVisualMdListOrder}" value="1" styleName="{res.styles.fullWidth} {res.styles.spaced}"
+                            ui:field="startingNumber_"/>
       
-         <g:Label text="Number style:"/>
-         <rw:SelectWidget styleName="{res.styles.fullWidth} {res.styles.spaced}" ui:field="numberStyle_"></rw:SelectWidget>
+         <rw:FormLabel for="{ElementIds.getVisualMdListNumberStyle}" text="Number style:"/>
+         <rw:SelectWidget elementId="{ElementIds.getVisualMdListNumberStyle}" styleName="{res.styles.fullWidth} {res.styles.spaced}"
+                          ui:field="numberStyle_"/>
          
-         <g:Label text="Number delimiter:"/>
-         <rw:SelectWidget styleName="{res.styles.fullWidth}" ui:field="numberDelimiter_"></rw:SelectWidget>
-         <g:Label styleName="{res.styles.infoLabel} {res.styles.spaced}" text="Pandoc HTML output does not support custom number delimiters, so the editor will always display the Period style" />
+         <rw:FormLabel for="{ElementIds.getVisualMdListNumberDelim}" text="Number delimiter:"/>
+         <rw:SelectWidget elementId="{ElementIds.getVisualMdListNumberDelim}"  styleName="{res.styles.fullWidth}"
+                          ui:field="numberDelimiter_"/>
+         <rw:FormLabel elementId="{ElementIds.getVisualMdListNumberDelimNote}" styleName="{res.styles.infoLabel} {res.styles.spaced}"
+                       text="Pandoc HTML output does not support custom number delimiters, so the editor will always display the Period style" />
        
        </g:VerticalPanel>  	
       	

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditRawDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditRawDialog.java
@@ -59,11 +59,9 @@ public class PanmirrorEditRawDialog extends ModalDialog<PanmirrorRawFormatResult
    
       rawFormatSelect_.setFormats(outputFormats, raw.format);
       rawFormatSelect_.setValue(StringUtil.notNull(raw.format));
-      rawFormatSelect_.getListBox().getElement().setId(ElementIds.VISUAL_MD_RAW_FORMAT_SELECT);
       
       rawContent_.setValue(raw.content);
       PanmirrorDialogsUtil.setFullWidthStyles(rawContent_);
-      rawContent_.getElement().setId(ElementIds.VISUAL_MD_RAW_FORMAT_CONTENT);
       
       if (!inline_)
       {
@@ -108,7 +106,7 @@ public class PanmirrorEditRawDialog extends ModalDialog<PanmirrorRawFormatResult
    }
    
    @Override
-   protected void focusFirstControl()
+   protected void focusInitialControl()
    {
       if (rawFormatSelect_.getValue().length() > 0)
       {

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditRawDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditRawDialog.ui.xml
@@ -4,6 +4,7 @@
    xmlns:rw="urn:import:org.rstudio.core.client.widget"
    xmlns:dialogs="urn:import:org.rstudio.studio.client.panmirror.dialogs">
    <ui:with field="res" type="org.rstudio.studio.client.panmirror.dialogs.PanmirrorDialogsResources" />
+   <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
    <ui:style>
      
       @eval fixedWidthFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
@@ -24,13 +25,14 @@
    
    <g:HTMLPanel styleName="{res.styles.dialog} {style.rawDialog}">
    
-      <dialogs:PanmirrorRawFormatSelect styleName="{style.formatSelect} {res.styles.spaced}" ui:field="rawFormatSelect_">
+      <dialogs:PanmirrorRawFormatSelect elementId="{ElementIds.getVisualMdRawFormatSelect}" 
+                                        styleName="{style.formatSelect} {res.styles.spaced}" ui:field="rawFormatSelect_">
       </dialogs:PanmirrorRawFormatSelect>
    		
-      <g:Label text="Content:" ui:field="rawContentLabel_"/>
-      <g:TextBox  styleName="{style.rawContent} {res.styles.spaced}"
+      <rw:FormLabel for="{ElementIds.getVisualMdRawContent}" text="Content:" ui:field="rawContentLabel_"/>
+      <rw:FormTextBox elementId="{ElementIds.getVisualMdRawContent}" styleName="{style.rawContent} {res.styles.spaced}"
                  	ui:field="rawContent_">
-      </g:TextBox>
+      </rw:FormTextBox>
       	
    </g:HTMLPanel>
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorHRefSelect.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorHRefSelect.java
@@ -16,8 +16,13 @@
 
 package org.rstudio.studio.client.panmirror.dialogs;
 
+import com.google.gwt.aria.client.Roles;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.FocusHelper;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.FormListBox;
+import org.rstudio.core.client.widget.FormTextBox;
 import org.rstudio.studio.client.panmirror.dialogs.model.PanmirrorLinkCapabilities;
 import org.rstudio.studio.client.panmirror.dialogs.model.PanmirrorLinkHeadingTarget;
 import org.rstudio.studio.client.panmirror.dialogs.model.PanmirrorLinkTargets;
@@ -30,10 +35,7 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.SimplePanel;
-import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 
 
@@ -50,7 +52,8 @@ public class PanmirrorHRefSelect extends Composite implements CanFocus
       controls_ = new HorizontalPanel();
       controls_.setWidth("100%");
       
-      type_ = new ListBox();
+      type_ = new FormListBox();
+      type_.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_LINK_TYPE));
       type_.addItem("URL", Integer.toString(PanmirrorLinkType.URL));
       
       if (capabilities.headings && targets.headings.length > 0)
@@ -66,10 +69,14 @@ public class PanmirrorHRefSelect extends Composite implements CanFocus
       controls_.add(hrefContainer_);
       controls_.setCellWidth(hrefContainer_, "100%");
       
-      href_ = new TextBox();
+      href_ = new FormTextBox();
+      href_.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_LINK_HREF));
+      Roles.getTextboxRole().setAriaLabelProperty(href_.getElement(), "HRef");
       href_.setWidth("100%");
       
-      headings_ = new ListBox(); 
+      headings_ = new FormListBox(); 
+      headings_.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_LINK_SELECT_HEADING));
+      Roles.getListboxRole().setAriaLabelProperty(headings_.getElement(), "Heading");
       headings_.setWidth("100%");
       for (PanmirrorLinkHeadingTarget target : targets_.headings)
       {
@@ -77,7 +84,9 @@ public class PanmirrorHRefSelect extends Composite implements CanFocus
             headings_.addItem(target.text);
       }
       
-      ids_ = new ListBox();
+      ids_ = new FormListBox();
+      ids_.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_LINK_SELECT_ID));
+      Roles.getListboxRole().setAriaLabelProperty(ids_.getElement(), "IDs");
       ids_.setWidth("100%");
       for (String id : targets_.ids)
       {
@@ -90,7 +99,7 @@ public class PanmirrorHRefSelect extends Composite implements CanFocus
       });
       
       VerticalPanel container = new VerticalPanel();
-      container.add(new Label("Link To:"));
+      container.add(new FormLabel("Link To:", type_));
       container.add(controls_);
       
       initWidget(container);
@@ -207,9 +216,9 @@ public class PanmirrorHRefSelect extends Composite implements CanFocus
    
    private final HorizontalPanel controls_;
    private final SimplePanel hrefContainer_;
-   private final ListBox type_;
-   private final TextBox href_; 
-   private final ListBox headings_;
-   private final ListBox ids_;
+   private final FormListBox type_;
+   private final FormTextBox href_; 
+   private final FormListBox headings_;
+   private final FormListBox ids_;
    
 }


### PR DESCRIPTION
- Fixes #7080
- Fixes #7081
- Fixes #7082
- Fixes #7083
- Fixes #7084
- Fixes #7085

Details:

- make sure controls have properly associated labels
- use `focusInitialControl` instead of `focusFirstControl` to prevent breaking Tab order
- refresh dialog tab focus order when switching Tabs
- some controls have multiple labels which requires a slightly different approach not previously used in the IDE codbase (aria-labelledby with multiple IDs).
- annotate extended description in Format List dialog so additional information about Pandoc support for custom number delimiters in HTML is read as part of the control