### PR TITLE
don't break display math marks on delimiter edit (wait until save)

### DIFF
--- a/src/gwt/panmirror/src/editor/src/marks/math/math-transaction.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/math/math-transaction.ts
@@ -36,17 +36,19 @@ export function mathAppendMarkTransaction(): AppendMarkTransactionHandler {
         const mathRange = getMarkRange(tr.doc.resolve(from), schema.marks.math);
         if (mathRange) {
           const mathAttr = getMarkAttrs(tr.doc, mathRange, schema.marks.math);
-          const mathDelim = delimiterForType(mathAttr.type);
-          const mathText = tr.doc.textBetween(mathRange.from, mathRange.to);
-          const charAfter = tr.doc.textBetween(mathRange.to, mathRange.to + 1);
-          const noDelims = !mathText.startsWith(mathDelim) || !mathText.endsWith(mathDelim);
-          const spaceAtEdge =
-            mathAttr.type === MathType.Inline &&
-            (mathText.startsWith(mathDelim + ' ') || mathText.endsWith(' ' + mathDelim));
-          const numberAfter = mathAttr.type === MathType.Inline && /\d/.test(charAfter);
-          if (noDelims || spaceAtEdge || numberAfter) {
-            tr.removeMark(mathRange.from, mathRange.to, schema.marks.math);
-            tr.removeStoredMark(schema.marks.math);
+          if (mathAttr.type === MathType.Inline) {
+            const mathDelim = delimiterForType(mathAttr.type);
+            const mathText = tr.doc.textBetween(mathRange.from, mathRange.to);
+            const charAfter = tr.doc.textBetween(mathRange.to, mathRange.to + 1);
+            const noDelims = !mathText.startsWith(mathDelim) || !mathText.endsWith(mathDelim);
+            const spaceAtEdge =
+              mathAttr.type === MathType.Inline &&
+              (mathText.startsWith(mathDelim + ' ') || mathText.endsWith(' ' + mathDelim));
+            const numberAfter = mathAttr.type === MathType.Inline && /\d/.test(charAfter);
+            if (noDelims || spaceAtEdge || numberAfter) {
+              tr.removeMark(mathRange.from, mathRange.to, schema.marks.math);
+              tr.removeStoredMark(schema.marks.math);
+            }
           }
         }
       }

--- a/src/gwt/panmirror/src/editor/src/marks/math/math.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/math/math.ts
@@ -167,9 +167,9 @@ const extension = (context: ExtensionContext): Extension | null => {
                     });
                   }
 
+                } else {
                   // user removed the delimiter so write the content literally. when it round trips 
                   // back into editor it will no longer be parsed by pandoc as math
-                } else {
                   output.writeRawMarkdown(math);
                 }
               }

--- a/src/gwt/panmirror/src/editor/src/marks/math/math.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/math/math.ts
@@ -145,22 +145,32 @@ const extension = (context: ExtensionContext): Extension | null => {
                   output.write(math);
                 });
               } else {
-                // strip delimiter
-                const delimiter = delimiterForType(mark.attrs.type);
-                math = math.substr(delimiter.length, math.length - 2 * delimiter.length);
 
-                // if it's just whitespace then it's not actually math (we allow this state
-                // in the editor because it's the natural starting place for new equations)
-                if (math.trim().length === 0) {
-                  output.writeText(delimiter + math + delimiter);
+                // check for delimeter (if it's gone then write this w/o them math mark)
+                const delimiter = delimiterForType(mark.attrs.type);
+                if (math.startsWith(delimiter) && math.endsWith(delimiter)) {
+
+                  // remove delimiter
+                  math = math.substr(delimiter.length, math.length - 2 * delimiter.length);
+
+                  // if it's just whitespace then it's not actually math (we allow this state
+                  // in the editor because it's the natural starting place for new equations)
+                  if (math.trim().length === 0) {
+                    output.writeText(delimiter + math + delimiter);
+                  } else {
+                    output.writeToken(PandocTokenType.Math, () => {
+                      // write type
+                      output.writeToken(
+                        mark.attrs.type === MathType.Inline ? PandocTokenType.InlineMath : PandocTokenType.DisplayMath,
+                      );
+                      output.write(math);
+                    });
+                  }
+
+                  // user removed the delimiter so write the content literally. when it round trips 
+                  // back into editor it will no longer be parsed by pandoc as math
                 } else {
-                  output.writeToken(PandocTokenType.Math, () => {
-                    // write type
-                    output.writeToken(
-                      mark.attrs.type === MathType.Inline ? PandocTokenType.InlineMath : PandocTokenType.DisplayMath,
-                    );
-                    output.write(math);
-                  });
+                  output.writeRawMarkdown(math);
                 }
               }
             },


### PR DESCRIPTION
This is a potential fix for #7107 

The proposal is to not be so finicky about removing display math marks when the user edits them directly. This allows them to easily repair the mark after inadvertently removing a delimiter:

![Jun-12-2020 07-36-26](https://user-images.githubusercontent.com/104391/84499101-e3bf2380-ac7f-11ea-9881-5b352ae44e6d.gif)

Note that there is some feedback that the mark is broken b/c the equation preview now thinks that it's an inline mark.

If the mark continues to be broken when the user saves (or switches to source view) then it will in fact no longer be a display math equation. This is consistent w/ the behavior of source mode (where removing a dollar sign from a display math delimiter causes pandoc to no longer render it as math).
