### PR TITLE
Don't log wrong_protocol_type (EPROTOTYPE) when handling write errors

### DIFF
--- a/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
@@ -515,8 +515,11 @@ private:
          {
             // log the error if it wasn't connection terminated
             Error error(e, ERROR_LOCATION);
-            if (!http::isConnectionTerminatedError(error))
+            if (!http::isConnectionTerminatedError(error) &&
+                !http::isWrongProtocolTypeError((error)))
+            {
                LOG_ERROR(error);
+            }
          }
          
          // close the socket

--- a/src/cpp/core/include/core/http/SocketUtils.hpp
+++ b/src/cpp/core/include/core/http/SocketUtils.hpp
@@ -63,6 +63,11 @@ Error closeSocket(SocketService& socket)
    return Success() ; 
 }
 
+inline bool isWrongProtocolTypeError(const core::Error& error)
+{
+   return error == systemError(boost::system::errc::wrong_protocol_type, ErrorLocation());
+}
+
 inline bool isConnectionTerminatedError(const core::Error& error)
 {
    // look for errors that indicate the client closing the connection


### PR DESCRIPTION
In the development terminal I frequently see EPROTOTYPE errors logged:

<img width="565" alt="Screen Shot 2020-06-12 at 8 41 18 AM" src="https://user-images.githubusercontent.com/104391/84503597-7fed2880-ac88-11ea-97f0-f84f1f0d1a46.png">

This of course makes it much more difficult to see if there are actual errors or problems occurring. 

This is already partially addressed from this particular call site by suppressing error logging if `http::isConnectionTerminatedError()` returns true: https://github.com/rstudio/rstudio/blob/master/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp#L518

This function in turn ignores a wide variety of errors: https://github.com/rstudio/rstudio/blob/3fdda38e9a78a984a25c44e1672cf0869fad19cd/src/cpp/core/include/core/http/SocketUtils.hpp#L66-L84

This PR adds a new helper function to suppress EPROTOTYPE errors from just the call site that I am seeing the extra logging occur at. It is purposely scoped that narrowly b/c I don't want to assume that this error is always equivalent to "connection terminated" product wide, or even that we should suppress logging in the 3 other places in the file where we do so via `http::isConnectionTerminatedError()`. If someone wants to take a closer look at whether that's okay, I could create a helper method for this class (e.g. `shouldLogError()`) and implement it across the board there.


