### PR TITLE
Use help server unless R is exactly 4.0.0

### DIFF
--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -52,6 +52,25 @@ using namespace rstudio::core;
 namespace rstudio {
 namespace r {
 namespace util {
+namespace {
+
+bool versionTest(const std::string& comparator, const std::string& version)
+{
+   std::string versionTest("getRversion() " + comparator + " \"" + version + "\"");
+   bool hasVersion = false;
+   Error error = r::exec::evaluateString(versionTest, &hasVersion);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return false;
+   }
+   else
+   {
+      return hasVersion;
+   }
+}
+
+} // anonymous namespace
 
 std::string expandFileName(const std::string& name)
 {
@@ -68,18 +87,12 @@ std::string fixPath(const std::string& path)
 
 bool hasRequiredVersion(const std::string& version)
 {
-   std::string versionTest("getRversion() >= \"" + version + "\"");
-   bool hasRequired = false;
-   Error error = r::exec::evaluateString(versionTest, &hasRequired);
-   if (error)
-   {
-      LOG_ERROR(error);
-      return false;
-   }
-   else
-   {
-      return hasRequired;
-   }
+   return versionTest(">=", version);
+}
+
+bool hasExactVersion(const std::string& version)
+{
+   return versionTest("==", version);
 }
 
 bool hasCapability(const std::string& capability)

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -42,6 +42,8 @@ std::string fixPath(const std::string& path);
 
 bool hasRequiredVersion(const std::string& version);
 
+bool hasExactVersion(const std::string& version);
+
 bool hasCapability(const std::string& capability);
 
 std::string rconsole2utf8(const std::string& encoded);

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2413,12 +2413,11 @@ std::string sessionTempDirUrl(const std::string& sessionTempPath)
       if (*useRHelpServer)
       {
          // There is a known issue serving content from the session temporary folder
-         // on R 4.0+ for Windows, so if we were planning to use it, only do so if
-         // we are on an older version of R.
+         // on R 4.0.0 for Windows
          //
          // https://github.com/rstudio/rstudio/issues/6737
          //
-         useRHelpServer = !r::util::hasRequiredVersion("4.0");
+         useRHelpServer = !r::util::hasExactVersion("4.0.0");
       }
 #endif
    }


### PR DESCRIPTION
This change refines a change introduced in https://github.com/rstudio/rstudio/pull/6804. That change added a workaround for a bug in R, which has since been fixed. Unfortunately the workaround also had a couple of side effects (see related bugs).

The fix is to only use the workaround with the exact version of R that has the bug.

Fixes https://github.com/rstudio/rstudio/issues/6893
Fixes https://github.com/rstudio/rstudio/issues/7046