### PR TITLE
Allow focus stealing for new tabs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -241,20 +241,36 @@ public class DocTabLayoutPanel
       fireEvent(event);
    }
 
-   @Override
-   public void selectTab(int index)
+   /**
+    * Selects the given tab.
+    * 
+    * @param index       The tab to select.
+    * @param alwaysFocus Whether to focus the tab regardless of whether we
+    *                    previously had input focus.
+    */
+   public void selectTab(int index, boolean alwaysFocus)
    {
       // select the tab, but don't fire events (we need to fire our own)
       super.selectTab(index, false);
-      
-      // determine whether focus is currently inside the container
-      boolean focused = DomUtils.contains(getElement(), DomUtils.getActiveElement());
+
+      boolean focused = alwaysFocus;
+      if (!focused)
+      {
+         // determine whether focus is currently inside the container
+         focused = DomUtils.contains(getElement(), DomUtils.getActiveElement());
+      }
      
       // fire our own selection event
       fireEvent(new DocTabSelectionEvent(index, focused));
       
       // ensure the newly selected tab is visible
       ensureSelectedTabIsVisible(!RStudioGinjector.INSTANCE.getUserPrefs().reducedMotion().getValue());
+   }
+
+   @Override
+   public void selectTab(int index)
+   {
+      selectTab(index, false);
    }
 
    public void ensureSelectedTabIsVisible(boolean animate)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourcePane.java
@@ -112,7 +112,7 @@ public class SourcePane extends Composite implements Display,
    {
       tabPanel_.add(widget, icon, docId, name, tooltip, position);
       if (switchToTab)
-         tabPanel_.selectTab(widget);
+         tabPanel_.selectTab(widget, true /* focus newly added tab */);
    }
 
    public void closeTab(Widget child, boolean interactive)


### PR DESCRIPTION
In RStudio 1.3, we made a change (#6056) which prevents the Source tabs from stealing input focus. This is largely an improvement but, but it turns out that sometimes we _want_ this behavior; in particular when creating new files we want to grab focus and send it to the new file. 

Fixes https://github.com/rstudio/rstudio/issues/7103.