### PR TITLE
Tolerate missing secondary repos in user prefs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -91,7 +91,14 @@ public class CRANMirror extends UserPrefs.CranMirror
    {
       ArrayList<CRANMirror> repos = new ArrayList<CRANMirror>();
 
-      String[] entries = getSecondary().split("\\|");
+      String secondary = getSecondary();
+      if (StringUtil.isNullOrEmpty(secondary))
+      {
+         // Return empty list of secondary repos if none were defined.
+         return repos;
+      }
+      
+      String[] entries = secondary.split("\\|");
       for (int i = 0; i < entries.length / 2; i++)
       {
          CRANMirror repo = CRANMirror.empty();


### PR DESCRIPTION
This change addresses an issue in which a missing `secondary` value for the CRAN repros value could keep the Options dialog from opening due to a JavaScript exception. This is rare (in fact we just have one user report of it occurring) and we don't know how the state in which it arises, but it's easy enough to tolerate. 

Fixes https://github.com/rstudio/rstudio/issues/7116.