### PR TITLE
Fix perpetually busy Git-Bash terminal on Windows

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -90,7 +90,11 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
                                                     procInfo.getCwd();
    options.environment = shellEnv;
    options.smartTerminal = true;
+#ifdef _WIN32
+   options.reportHasSubprocs = false; // child process detection not supported on Windows
+#else
    options.reportHasSubprocs = true;
+#endif
    options.trackCwd = true;
    options.cols = procInfo.getCols();
    options.rows = procInfo.getRows();

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -111,7 +111,11 @@ TEST_CASE("ConsoleProcessInfo")
 
       CHECK_FALSE(cpi.getShowOnOutput());
       CHECK_FALSE(cpi.getExitCode());
+#ifdef _WIN32
+      CHECK_FALSE(cpi.getHasChildProcs());
+#else
       CHECK(cpi.getHasChildProcs());
+#endif
       CHECK((cpi.getShellType() == shellType));
       CHECK((cpi.getChannelMode() == Rpc));
       CHECK(cpi.getChannelId().empty());

--- a/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcessInfo.hpp
@@ -217,7 +217,11 @@ private:
    bool showOnOutput_ = false;
    boost::circular_buffer<char> outputBuffer_ {kOutputBufferSize};
    boost::optional<int> exitCode_;
+#ifdef _WIN32
+   bool childProcs_ = false; // child process detection not supported on Windows
+#else
    bool childProcs_ = true;
+#endif
    bool altBufferActive_ = false;
    TerminalShell::ShellType shellType_ = TerminalShell::ShellType::Default;
    ChannelMode channelMode_ = Rpc;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -67,7 +67,8 @@ public class TerminalInfoDialog extends ModalDialogBase
          diagnostics.append("Handle:      '").append(cpi.getHandle()).append("'\n");
          diagnostics.append("Sequence:    '").append(cpi.getTerminalSequence()).append("'\n");
          diagnostics.append("Restarted:   '").append(cpi.getRestarted()).append("\n");
-         diagnostics.append("Busy:        '").append(cpi.getHasChildProcs()).append("'\n");
+         if (!BrowseCap.isWindowsDesktop())
+            diagnostics.append("Busy:        '").append(cpi.getHasChildProcs()).append("'\n");
          diagnostics.append("Exit Code:   '").append(cpi.getExitCode()).append("'\n");
          diagnostics.append("Full screen: 'client=").append(session.xtermAltBufferActive()).append("/server=").append(cpi.getAltBufferActive()).append("'\n");
          diagnostics.append("Zombie:      '").append(cpi.getZombie()).append("'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalList.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.workbench.views.terminal;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -337,6 +338,9 @@ public class TerminalList implements Iterable<String>,
     */
    public boolean getHasSubprocs(String handle)
    {
+      if (BrowseCap.isWindowsDesktop())
+         return false;
+
       ConsoleProcessInfo data = getMetadataForHandle(handle);
       if (data == null)
       {
@@ -350,6 +354,9 @@ public class TerminalList implements Iterable<String>,
     */
    public boolean haveSubprocs()
    {
+      if (BrowseCap.isWindowsDesktop())
+         return false;
+
       for (final TerminalListData item : terminals_.values())
       {
          if (item.getCPI().getHasChildProcs())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -86,7 +86,7 @@ public class TerminalSession extends XTermWidget
       RStudioGinjector.INSTANCE.injectMembers(this);
       procInfo_ = info;
       createdByApi_ = createdByApi;
-      hasChildProcs_ = new Value<>(info.getHasChildProcs());
+      hasChildProcs_ = new Value<>(!BrowseCap.isWindowsDesktop() && info.getHasChildProcs());
 
       setTitle(info.getTitle());
       socket_ = new TerminalSessionSocket(


### PR DESCRIPTION
- Fixes #7112

The Twisted Tale:

When I fixed how we launch Git-Bash in #6828 that gave us one "bash.exe" launching a second "bash.exe" as a child process (which was intentional). This is then caught by the subprocess-detection and flagged as always busy. Previously, git-bash was a single process.

The crux of this PR is that we never intended to support subprocess detection for Terminals on Windows Desktop, so fully disabling it. It's never been possible for git-bash or WSL because commands run in those environments aren't actually Win32 processes, so can't be detected. It does work (somewhat) on Command Prompt or PowerShell, but the intention was to simply be consistent and not support it. Now that is actually the case.

I've made this change in the safest way I can think of, and it is completely scoped to Windows Desktop-only.

Note that as part of "not supporting it" we've never shown "Ask before killing processes" setting in Global Options on Windows (which would have been a workaround for this if we did).