### PR TITLE
Target active column with commands

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -198,7 +198,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
             splitterArray[0] = right_.getOffsetWidth();
             for (int i = 1; i < leftList_.size(); i++)
             {
-               splitterArray[i] = leftList_.get(i).getOffsetWidth();
+               splitterArray[i] = splitterArray[i-1] + leftList_.get(i).getOffsetWidth();
             }
             state.setSplitterPos(splitterArray);
             return state.cast();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -230,6 +230,13 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       deferredSaveWidthPercent();
    }
 
+   public void resetLeftWidgets(ArrayList<Widget> list)
+   {
+      clearForRefresh();
+      leftList_ = new ArrayList<>(list);
+      initialize(leftList_, center_, right_);
+   }
+
    public void addLeftWidget(Widget widget)
    {
       clearForRefresh();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1220,7 +1220,7 @@ public class PaneManager
                new WindowStateChangeEvent(WindowState.HIDE));
       else
       {
-         SourceColumn column = sourceColumnManager_.findByName(name);
+         SourceColumn column = sourceColumnManager_.getByName(name);
 
          if (column.getTabCount() == 0)
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1229,6 +1229,7 @@ public class PaneManager
             panesByName_.remove(name);
 
             additionalSourceCount_ = sourceColumnManager_.getSize() - 1;
+            panel_.resetLeftWidgets(sourceColumnManager_.getWidgets(true));
             PaneConfig paneConfig = getCurrentConfig();
             userPrefs_.panes().setGlobalValue(PaneConfig.create(
                JsArrayUtil.copy(paneConfig.getQuadrants()),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -687,7 +687,7 @@ public class Source implements InsertSourceHandler,
                {
                   String name = doc.getSourceDisplayName();
                   sourceEditor = columnManager_.addTab(doc, true, OPEN_REPLAY,
-                                                       columnManager_.findByName(name));
+                                                       columnManager_.getByName(name));
                }
                else
                   sourceEditor = columnManager_.addTab(doc, true, OPEN_REPLAY, null);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -95,13 +95,6 @@ public class SourceColumn implements SelectionHandler<Integer>,
       editingTargetSource_ = editingTargetSource;
       fileContext_ = fileContext;
       server_ = sourceServerOperations;
-
-
-      events_.addHandler(FileTypeChangedEvent.TYPE, event -> manageCommands(false));
-      events_.addHandler(SourceOnSaveChangedEvent.TYPE, event -> manageSaveCommands());
-      events_.addHandler(SynctexStatusChangedEvent.TYPE, event -> manageSynctexCommands());
-
-      initialized_ = true;
    }
 
    public void loadDisplay(String name,
@@ -119,6 +112,18 @@ public class SourceColumn implements SelectionHandler<Integer>,
       display_.addTabReorderHandler(this);
 
       ensureVisible(false);
+
+      // these handlers cannot be added earlier because they rely on manager_
+      events_.addHandler(FileTypeChangedEvent.TYPE, event -> manageCommands(false));
+      boolean isActive = this == manager_.getActive();
+      events_.addHandler(SourceOnSaveChangedEvent.TYPE, event -> manageSaveCommands(isActive));
+      events_.addHandler(SynctexStatusChangedEvent.TYPE, event -> manageSynctexCommands(isActive));
+      initialized_ = true;
+   }
+
+   public boolean isInitialized()
+   {
+      return initialized_;
    }
 
    public String getName()
@@ -296,7 +301,6 @@ public class SourceColumn implements SelectionHandler<Integer>,
        activeEditor_ = target;
        if (activeEditor_ != null)
           activeEditor_.onActivate();
-       manageCommands();
    }
 
    void setActiveEditor()
@@ -521,7 +525,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
       // adding a tab may enable commands that are only available when
       // multiple documents are open; if this is the second document, go check
       if (editors_.size() == 2)
-         manageMultiTabCommands();
+         manageMultiTabCommands(true);
 
       // if the target had an editing session active, attempt to resume it
       if (doc.getCollabParams() != null)
@@ -648,7 +652,11 @@ public class SourceColumn implements SelectionHandler<Integer>,
 
    public void manageCommands(boolean forceSync)
    {
-      boolean hasDocs = hasDoc();
+      if (manager_ == null)
+         return;
+
+      boolean isActive = this == manager_.getActive();
+      boolean hasDocs = isActive && hasDoc();
 
       commands_.newSourceDoc().setEnabled(true);
       commands_.closeSourceDoc().setEnabled(hasDocs);
@@ -680,17 +688,20 @@ public class SourceColumn implements SelectionHandler<Integer>,
       }
       else
       {
-         HashSet<AppCommand> commandsToEnable = new HashSet<>(newCommands);
-         commandsToEnable.removeAll(activeCommands_);
+         if (isActive)
+         {
+            HashSet<AppCommand> commandsToEnable = new HashSet<>(newCommands);
+            commandsToEnable.removeAll(activeCommands_);
+
+            for (AppCommand command : commandsToEnable)
+            {
+               command.setEnabled(true);
+               command.setVisible(true);
+            }
+         }
 
          HashSet<AppCommand> commandsToDisable = new HashSet<>(activeCommands_);
          commandsToDisable.removeAll(newCommands);
-
-         for (AppCommand command : commandsToEnable)
-         {
-            command.setEnabled(true);
-            command.setVisible(true);
-         }
 
          for (AppCommand command : commandsToDisable)
          {
@@ -707,27 +718,27 @@ public class SourceColumn implements SelectionHandler<Integer>,
       commands_.debugBreakpoint().setVisible(true);
 
       // manage synctex commands
-      manageSynctexCommands();
+      manageSynctexCommands(isActive);
 
       // manage vcs commands
-      manageVcsCommands();
+      manageVcsCommands(isActive);
 
       // manage save and save all
-      manageSaveCommands();
+      manageSaveCommands(isActive);
 
       // manage source navigation
       manageSourceNavigationCommands();
 
       // manage RSConnect commands
-      manageRSConnectCommands();
+      manageRSConnectCommands(isActive);
 
       // manage R Markdown commands
-      manageRMarkdownCommands();
+      manageRMarkdownCommands(isActive);
 
       // manage multi-tab commands
-      manageMultiTabCommands();
+      manageMultiTabCommands(isActive);
 
-      manageTerminalCommands();
+      manageTerminalCommands(isActive);
 
       activeCommands_ = newCommands;
 
@@ -739,10 +750,10 @@ public class SourceColumn implements SelectionHandler<Integer>,
               : "Unsupported commands detected (please add to SourceColumnManager.getDynamicCommands())";
    }
 
-   private void manageSynctexCommands()
+   private void manageSynctexCommands(boolean isActive)
    {
       // synctex commands are enabled if we have synctex for the active editor
-      boolean synctexAvailable = manager_.getSynctex().isSynctexAvailable();
+      boolean synctexAvailable = isActive && manager_.getSynctex().isSynctexAvailable();
       if (synctexAvailable)
       {
          if ((activeEditor_ != null) &&
@@ -760,10 +771,10 @@ public class SourceColumn implements SelectionHandler<Integer>,
       manager_.getSynctex().enableCommands(synctexAvailable);
    }
 
-   private void manageVcsCommands()
+   private void manageVcsCommands(boolean isActive)
    {
       // manage availability of vcs commands
-      boolean vcsCommandsEnabled =
+      boolean vcsCommandsEnabled = isActive &&
               manager_.getSession().getSessionInfo().isVcsEnabled() &&
                       (activeEditor_ != null) &&
                       (activeEditor_.getPath() != null) &&
@@ -810,15 +821,16 @@ public class SourceColumn implements SelectionHandler<Integer>,
       }
    }
 
-   public void manageSaveCommands()
+   public void manageSaveCommands(boolean isActive)
    {
-      boolean saveEnabled = (activeEditor_ != null) &&
-              activeEditor_.isSaveCommandActive();
+      boolean saveEnabled = isActive &&
+                            activeEditor_ != null &&
+                            activeEditor_.isSaveCommandActive();
       commands_.saveSourceDoc().setEnabled(saveEnabled);
-      manageSaveAllCommand();
+      manageSaveAllCommand(isActive);
    }
 
-   private void manageSaveAllCommand()
+   private void manageSaveAllCommand(boolean isActive)
    {
       // if source windows are open, managing state of the command becomes
       // complicated, so leave it enabled
@@ -841,9 +853,10 @@ public class SourceColumn implements SelectionHandler<Integer>,
               manager_.getSourceNavigationHistory().isForwardEnabled());
    }
 
-   private void manageRSConnectCommands()
+   private void manageRSConnectCommands(boolean isActive)
    {
       boolean rsCommandsAvailable =
+              isActive &&
               SessionUtils.showPublishUi(manager_.getSession(), manager_.getUserState()) &&
                       (activeEditor_ != null) &&
                       (activeEditor_.getPath() != null) &&
@@ -874,9 +887,10 @@ public class SourceColumn implements SelectionHandler<Integer>,
       commands_.rsconnectConfigure().setVisible(rsCommandsAvailable);
    }
 
-   private void manageRMarkdownCommands()
+   private void manageRMarkdownCommands(boolean isActive)
    {
       boolean rmdCommandsAvailable =
+              isActive &&
               manager_.getSession().getSessionInfo().getRMarkdownPackageAvailable() &&
                       (activeEditor_ != null) &&
                       activeEditor_.getExtendedFileType() == SourceDocument.XT_RMARKDOWN;
@@ -884,9 +898,9 @@ public class SourceColumn implements SelectionHandler<Integer>,
       commands_.editRmdFormatOptions().setEnabled(rmdCommandsAvailable);
    }
 
-   public void manageMultiTabCommands()
+   public void manageMultiTabCommands(boolean isActive)
    {
-      boolean hasMultipleDocs = hasDoc();
+      boolean hasMultipleDocs = isActive && hasDoc();
 
       // special case--these editing targets always support popout, but it's
       // nonsensical to show it if it's the only tab in a satellite; hide it in
@@ -903,9 +917,9 @@ public class SourceColumn implements SelectionHandler<Integer>,
       commands_.closeOtherSourceDocs().setEnabled(hasMultipleDocs);
    }
 
-   private void manageTerminalCommands()
+   private void manageTerminalCommands(boolean isActive)
    {
-      if (!manager_.getSession().getSessionInfo().getAllowShell())
+      if (isActive && !manager_.getSession().getSessionInfo().getAllowShell())
          commands_.sendToTerminal().setVisible(false);
    }
 
@@ -959,6 +973,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
                       final ResultCallback<EditingTarget, ServerError> resultCallback)
    {
       ensureVisible(true);
+      boolean isActive = activeEditor_ != null;
       server_.newDocument(
             fileType.getTypeId(),
             contents,
@@ -975,7 +990,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
                   if (contents != null)
                   {
                      target.forceSaveCommandActive();
-                     manageSaveCommands();
+                     manageSaveCommands(isActive);
                   }
 
                   if (resultCallback != null)
@@ -1050,7 +1065,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
          }
       }
 
-      manageCommands();
+      manageCommands(true);
    }
 
    @Override
@@ -1179,7 +1194,7 @@ public class SourceColumn implements SelectionHandler<Integer>,
 
    private Commands commands_;
 
-   private boolean initialized_;
+   private boolean initialized_ = false;
    private boolean suspendDocumentClose_ = false;
 
    // If positive, a new tab is about to be created

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -288,7 +288,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          }
          return;
       }
-      setActive(findByName(name));
+
+      // If we can't find the column, use the main column. This may happen on start up.
+      SourceColumn column = getByName(name);
+      if (column == null)
+         column = getByName(MAIN_SOURCE_NAME);
+      setActive(column);
    }
 
    private void setActive(EditingTarget target)
@@ -553,11 +558,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             return column;
       }
       return null;
-   }
-
-   public SourceColumn findByName(String name)
-   {
-      return getByName(name);
    }
 
    public SourceColumn findByPosition(int x)
@@ -2289,7 +2289,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       }
    }
 
-   private SourceColumn getByName(String name)
+   public SourceColumn getByName(String name)
    {
       for (SourceColumn column : columnList_)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -280,7 +280,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
       if (StringUtil.isNullOrEmpty(name))
       {
-         Debug.logWarning("Active column should be set to the main source window instead of null.");
          if (activeColumn_ != null)
          {
             activeColumn_.setActiveEditor("");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1339,7 +1339,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public void closeAllColumns()
    {
       columnList_.forEach((column) -> closeColumn(column.getName()));
-      Debug.logToConsole("closed all columns, new size: " + getSize());
       assert getSize() == 0;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -135,7 +135,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       SourceColumn column = GWT.create(SourceColumn.class);
       column.loadDisplay(MAIN_SOURCE_NAME, display, this);
       columnList_.add(column);
-      setActive(column.getName());
 
       server_ = server;
       commands_ = commands;
@@ -217,6 +216,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             return columnState_.cast();
          }
       };
+      setActive(column.getName());
    }
 
    public String add()
@@ -280,21 +280,24 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
       if (StringUtil.isNullOrEmpty(name))
       {
+         Debug.logWarning("Active column should be set to the main source window instead of null.");
          if (activeColumn_ != null)
+         {
             activeColumn_.setActiveEditor("");
-         activeColumn_ = null;
+            activeColumn_ = null;
+         }
          return;
       }
       setActive(findByName(name));
    }
 
-   public void setActive(EditingTarget target)
+   private void setActive(EditingTarget target)
    {
       setActive(findByDocument(target.getId()));
       activeColumn_.setActiveEditor(target);
    }
 
-   public void setActive(SourceColumn column)
+   private void setActive(SourceColumn column)
    {
       SourceColumn prevColumn = activeColumn_;
       activeColumn_ = column;
@@ -305,13 +308,11 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          prevColumn.setActiveEditor("");
          if (!hasActiveEditor())
             activeColumn_.setActiveEditor();
-      }
-
-      if (prevColumn == null || prevColumn != activeColumn_)
          manageCommands(true);
+      }
    }
 
-   public void setActiveDocId(String docId)
+   private void setActiveDocId(String docId)
    {
       for (SourceColumn column : columnList_)
       {
@@ -1298,7 +1299,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          if (!column.hasDoc())
          {
             if (column == activeColumn_)
-               setActive("");
+               setActive(MAIN_SOURCE_NAME);
             result.add(column.asWidget());
             columnList_.remove(column);
             if (num >= columnList_.size() || num == 1)
@@ -1348,7 +1349,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       if (column.getTabCount() > 0)
          return;
       if (column == activeColumn_)
-         setActive("");
+         setActive(MAIN_SOURCE_NAME);
 
       columnList_.remove(getByName(name));
    }


### PR DESCRIPTION
Commands utilizing the Source Panel and Editing Target are now only enabled on one column at a time. These commands most commonly appear under the `Code` menu list. Whenever the active editor changes, we iterate over the commands for each column and enable/disable them as needed.

This PR also fixes an issue where the panel state was not being saved properly between start ups. It also includes some code clean up.