### PR TITLE
reenable legacy spellchecker due to blacklisted dictionaries

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -215,6 +215,7 @@ public class TypoSpellChecker
    @Inject
    void initialize(SpellingService spellingService, WorkbenchListManager workbenchListManager, UserPrefs uiPrefs)
    {
+      spellingService_ = spellingService;
       userDictionary_ = workbenchListManager.getUserDictionaryList();
       userPrefs_ = uiPrefs;
 
@@ -274,6 +275,15 @@ public class TypoSpellChecker
 
    public void checkSpelling(List<String> words, final ServerRequestCallback<SpellCheckerResult> callback)
    {
+      // If realtime is turned off call the backend spellchecker because we haven't loaded a
+      // dictionary on the frontend. Ideally we DO load the frontend dictionary but currently
+      // Typo.js isn't compatible with some of our dictionaries (see: TypoSpellChecker.realtimeBlacklist)
+      // so we need to keep the legacy call for now.
+      if (!userPrefs_.realTimeSpellchecking().getValue()) {
+         spellingService_.checkSpelling(words, callback);
+         return;
+      }
+
       // allocate results
       final SpellCheckerResult spellCheckerResult = new SpellCheckerResult();
 
@@ -372,7 +382,7 @@ public class TypoSpellChecker
    {
       final String language = userPrefs_.spellingDictionaryLanguage().getValue();
 
-      if (typoLoaded_ && loadedDict_.equals(language))
+      if (!userPrefs_.realTimeSpellchecking().getValue() || typoLoaded_ && loadedDict_.equals(language))
          return;
 
       // See canRealtimeSpellcheckDict comment, temporary stop gap
@@ -499,6 +509,7 @@ public class TypoSpellChecker
    private final ExternalJavaScriptLoader typoLoader_ =
          new ExternalJavaScriptLoader(TypoResources.INSTANCE.typojs().getSafeUri().asString());
 
+   private SpellingService spellingService_;
    private UserPrefs userPrefs_;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -279,7 +279,8 @@ public class TypoSpellChecker
       // dictionary on the frontend. Ideally we DO load the frontend dictionary but currently
       // Typo.js isn't compatible with some of our dictionaries (see: TypoSpellChecker.realtimeBlacklist)
       // so we need to keep the legacy call for now.
-      if (!userPrefs_.realTimeSpellchecking().getValue()) {
+      if (!userPrefs_.realTimeSpellchecking().getValue())
+      {
          spellingService_.checkSpelling(words, callback);
          return;
       }
@@ -382,7 +383,8 @@ public class TypoSpellChecker
    {
       final String language = userPrefs_.spellingDictionaryLanguage().getValue();
 
-      if (!userPrefs_.realTimeSpellchecking().getValue() || typoLoaded_ && loadedDict_.equals(language))
+      if (!userPrefs_.realTimeSpellchecking().getValue() ||
+           typoLoaded_ && loadedDict_.equals(language))
          return;
 
       // See canRealtimeSpellcheckDict comment, temporary stop gap


### PR DESCRIPTION
I had forgotten that I changed the manual spellchecker to also use Typo.js when I had to blacklist some dictionaries and that broke manual spellchecking for those dictionaries entirely. Bringing back the old CPP Hunspell until we can fix 6116.

Fixes #7018 