### PR TITLE
remove remaining hardcoded Rmd extended types

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -78,6 +78,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Positio
 import org.rstudio.studio.client.workbench.views.source.editors.text.ui.NewRMarkdownDialog;
 import org.rstudio.studio.client.workbench.views.source.events.FileEditEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
+import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
 
 public class TextEditingTargetRMarkdownHelper
 {
@@ -135,7 +136,7 @@ public class TextEditingTargetRMarkdownHelper
           fileType.isMarkdown() &&
           useRMarkdownV2(contents))
       {
-         return "rmarkdown";
+         return SourceDocument.XT_RMARKDOWN_DOCUMENT;
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -751,7 +751,8 @@ public class TextEditingTargetWidget
       boolean isPlainMarkdown = fileType.isPlainMarkdown();
       boolean isCpp = fileType.isCpp();
       boolean isScript = fileType.isScript();
-      boolean isRMarkdown2 = extendedType_ == "rmarkdown";
+      boolean isRMarkdown2 = extendedType_ != null && 
+                             extendedType_.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX);
       boolean canPreviewFromR = fileType.canPreviewFromR();
       boolean terminalAllowed = session_.getSessionInfo().getAllowShell();
 


### PR DESCRIPTION
Change https://github.com/rstudio/rstudio/pull/7051 removed the generic `rmarkdown` extended type and replaced it with two more specific types. However, it missed a couple of instances of the old type that were present in the code as hardcoded strings (didn't use the `XT_RMARKDOWN` constant). 

The fix is to use the appropriate `XT_RMARKDOWN` constant. 

Fixes https://github.com/rstudio/rstudio/issues/7166.