### PR TITLE
Legacy spellcheck suggestions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -330,6 +330,13 @@ public class TypoSpellChecker
       context_.invalidateWord(word);
    }
 
+   /* Support old style async suggestion calls for blacklisted dictionaries */
+   public void legacySuggestionList(String word,
+                              ServerRequestCallback<JsArrayString> callback)
+   {
+      spellingService_.suggestionList(word, callback);
+   }
+
    public String[] suggestionList(String word)
    {
       if (typoNative_ == null)


### PR DESCRIPTION
Use the async suggestions callback when Typo.js isn't/can't be loaded. Crossing fingers that this is the final thorn for dotting the i's on all the blacklisting fallout.

Fixes #7018 (finally)