### PR TITLE
normalize hyphen keycode used by Firefox

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
@@ -187,14 +187,16 @@ public class KeyCombination
    
    private static int normalizeKeyCode(int keyCode)
    {
-      if (keyCode == 173)
+      switch (keyCode)
       {
-         // convert Firefox hyphens to Chrome hyphens
+      
+      case 109: // NumPad minus
+      case 173: // Firefox hyphen
          return 189;
-      }
-      else
-      {
+         
+      default:
          return keyCode;
+         
       }
    }
    

--- a/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyCombination.java
@@ -43,7 +43,7 @@ public class KeyCombination
       }
       
       key_ = key;
-      keyCode_ = keyCode;
+      keyCode_ = normalizeKeyCode(keyCode);
       modifiers_ = modifiers;
       
    }
@@ -53,7 +53,7 @@ public class KeyCombination
                          int modifiers)
    {
       key_ = key;
-      keyCode_ = keyCode;
+      keyCode_ = normalizeKeyCode(keyCode);
       modifiers_ = modifiers;
    }
 
@@ -183,6 +183,19 @@ public class KeyCombination
       
       String version = BrowseCap.qtWebEngineVersion();
       return Version.compare(version, "5.15.0") < 0;
+   }
+   
+   private static int normalizeKeyCode(int keyCode)
+   {
+      if (keyCode == 173)
+      {
+         // convert Firefox hyphens to Chrome hyphens
+         return 189;
+      }
+      else
+      {
+         return keyCode;
+      }
    }
    
    private final String key_;

--- a/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyboardHelper.java
@@ -173,6 +173,7 @@ public class KeyboardHelper
       
       map[144] = "NumLock";
       map[145] = "ScrollLock";
+      map[173] = "-";
       map[186] = ";";
       map[187] = "=";
       map[188] = ",";


### PR DESCRIPTION
Closes #7169.