### PR TITLE
Fix issue preventing some documents from being visible when opened

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -974,6 +974,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
                       final String contents,
                       final ResultCallback<EditingTarget, ServerError> resultCallback)
    {
+      ensureVisible(false);
       boolean isActive = activeEditor_ != null;
       server_.newDocument(
             fileType.getTypeId(),


### PR DESCRIPTION
Certain file types (including RMarkdown) would not force the source pane open when created or opened. This PR ensures the source pane is visible.