### PR TITLE
Remove the hidden tab set from the panes list

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -808,9 +808,12 @@ public class PaneManager
    {
       ArrayList<LogicalWindow> results = new ArrayList<>();
 
+      // Do not include hiddenTabSet in panes since it should never be displayed
       JsArrayString panes = config.getQuadrants();
       for (int i = 0; i < panes.length(); i++)
       {
+         if (StringUtil.equals(panes.get(i), "HiddenTabSet"))
+            continue;
          results.add(panesByName_.get(panes.get(i)));
       }
       return results;


### PR DESCRIPTION
Fixes #7186

Fixes a bug where the placeholder hidden tabset pane was added to `PaneManager panes_` causing its null variables to be accessed and throw an exception.