### PR TITLE
Add Apple Event Entitlement to enable knitting to word

### DIFF
--- a/package/osx/entitlements.plist
+++ b/package/osx/entitlements.plist
@@ -21,5 +21,9 @@
   <key>com.apple.security.cs.allow-dyld-environment-variables</key>
   <true/>
 
+  <!-- Required to knit to Word -->
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+
 </dict>
 </plist>


### PR DESCRIPTION
Presumptive fix to #5148. I haven't been able to properly test this since I haven't been able to reproduce the issue.

More information on this entitlement can be found here: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_automation_apple-events
