### PR TITLE
improve handling of chunk toolbars in modified documents

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetCodeExecution.java
@@ -310,7 +310,7 @@ public class EditingTargetCodeExecution
       // if we're in a chunk with in-line output, execute it there instead
       if (!onlyUseConsole && docDisplay_.showChunkOutputInline())
       {
-         Scope scope = docDisplay_.getCurrentChunk(range.getStart());
+         Scope scope = docDisplay_.getChunkAtPosition(range.getStart());
          if (scope != null)
          {
             events_.fireEvent(new SendToChunkConsoleEvent(docId_, 
@@ -409,7 +409,7 @@ public class EditingTargetCodeExecution
             Scope scope = null;
             if (docDisplay_.showChunkOutputInline())
             {
-               scope = docDisplay_.getCurrentChunk(
+               scope = docDisplay_.getChunkAtPosition(
                   lastExecutedCode_.getRange().getStart());
             }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2495,13 +2495,14 @@ public class AceEditor implements DocDisplay,
             row);
    }
 
+   @Override
    public Scope getCurrentChunk()
    {
-      return getCurrentChunk(getCursorPosition());
+      return getChunkAtPosition(getCursorPosition());
    }
 
    @Override
-   public Scope getCurrentChunk(Position position)
+   public Scope getChunkAtPosition(Position position)
    {
       return getSession().getMode().getCodeModel().getCurrentChunk(position);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -291,9 +291,11 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    
    Scope getCurrentScope();
    Scope getCurrentChunk();
-   Scope getCurrentChunk(Position position);
-   ScopeFunction getCurrentFunction(boolean allowAnonymous);
    Scope getCurrentSection();
+   ScopeFunction getCurrentFunction(boolean allowAnonymous);
+   
+   Scope getScopeAtPosition(Position position);
+   Scope getChunkAtPosition(Position position);
    ScopeFunction getFunctionAtPosition(Position position, boolean allowAnonymous);
    Scope getSectionAtPosition(Position position);
    boolean hasCodeModelScopeTree();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/PinnedLineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/PinnedLineWidget.java
@@ -19,10 +19,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.FoldChangeEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
 
 import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.ui.Widget;
 
@@ -36,8 +34,7 @@ import com.google.gwt.user.client.ui.Widget;
  * - A notification is emitted to the host when Ace removes the LineWidget.
  */
 public class PinnedLineWidget
-             implements FoldChangeEvent.Handler,
-                        RenderFinishedEvent.Handler
+             implements FoldChangeEvent.Handler
 {
    public interface Host
    {
@@ -60,17 +57,14 @@ public class PinnedLineWidget
       lineWidget_ = LineWidget.create(type, row, widget_.getElement(), data);
       lineWidget_.setFixedWidth(true); 
 
-      // delay attaching the line widget to the editor surface until the next
-      // render pass
-      renderFinishedReg_ = display_.addRenderFinishedHandler(this);
+      renderLineWidget();
       
       // the Ace line widget manage emits a 'changeFold' event when a line
       // widget is destroyed; this is our only signal that it's been
       // removed, so when it happens, we need check to see if the widget
       // has been removed
       registrations_ = new HandlerRegistrations(
-         display_.addFoldChangeHandler(this),
-         renderFinishedReg_);
+         display_.addFoldChangeHandler(this));
 
       startAnchor_ = display_.createAnchor(Position.create(row, 0));
 
@@ -130,16 +124,14 @@ public class PinnedLineWidget
       checkForRemove_ = true;
    }
 
-   @Override
-   public void onRenderFinished(RenderFinishedEvent event)
+   private void renderLineWidget()
    {
-      // add the widget to the document and notify the host
+      // add the widget to the document
       display_.addLineWidget(lineWidget_);
+      
+      // notify host if available
       if (host_ != null)
          host_.onLineWidgetAdded(lineWidget_);
-
-      // remove the handler (single shot)
-      renderFinishedReg_.removeHandler();
    }
 
    // Private methods ---------------------------------------------------------
@@ -262,7 +254,6 @@ public class PinnedLineWidget
    private final Widget widget_;
    private final Host host_;
    private final HandlerRegistrations registrations_;
-   private final HandlerRegistration renderFinishedReg_;
    private int lastWidgetRow_;
 
    private Anchor endAnchor_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetScopeHelper.java
@@ -37,7 +37,7 @@ public class TextEditingTargetScopeHelper
    public Scope getCurrentSweaveChunk(Position position)
    {
       if (position != null)
-         return docDisplay_.getCurrentChunk(position);
+         return docDisplay_.getChunkAtPosition(position);
       else
          return docDisplay_.getCurrentChunk();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputUi.java
@@ -123,7 +123,7 @@ public class ChunkOutputUi
 
    public Scope getScope()
    {
-      return display_.getCurrentChunk(Position.create(getCurrentRow(), 1));
+      return display_.getChunkAtPosition(Position.create(getCurrentRow(), 1));
    }
 
    public LineWidget getLineWidget()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1035,7 +1035,7 @@ public class TextEditingTargetNotebook
          {
             // save scope and widget
             int terminalLine = widget.getRow() - 1;
-            Scope scope = docDisplay_.getCurrentChunk(Position.create(
+            Scope scope = docDisplay_.getChunkAtPosition(Position.create(
                   terminalLine, 1));
             ChunkOutputWidget outputWidget = output.getOutputWidget();
 
@@ -1150,7 +1150,7 @@ public class TextEditingTargetNotebook
          ScopeList scopes)
    {
       // find the chunk at this row
-      Scope chunk = display.getCurrentChunk(Position.create(row, 0));
+      Scope chunk = display.getChunkAtPosition(Position.create(row, 0));
       if (chunk == null)
          return "";
       


### PR DESCRIPTION
This PR makes two changes:

1. When updating chunk toolbars, we use the most recent set of edits in the editor to decide which toolbars need to be updated. This is necessary since a document might not necessarily be mutated at the cursor position -- for example, when inserting text via the `rstudioapi` package.

2. We no longer defer adding line widgets according to the next Ace render. It looks like this was responsible for some of the challenging-to-reproduce behaviors around chunk toolbars occasionally failing to show up, or showing up "slowly", or even in some cases sticking around after a chunk was deleted.

Closes https://github.com/rstudio/rstudio/issues/7067.

Note for (2): this behavior was added a while ago, as part of efforts to eliminate "floating" Ace line widgets. However, I believe this particular behavior is essentially made superfluous by https://github.com/rstudio/rstudio/pull/795. 