### PR TITLE
tweaks for request handling on Windows w/help server

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -1030,12 +1030,12 @@ Error initialize()
       LOG_ERROR(error);
 
 #ifdef _WIN32
-   // we also need to handle custom session URLs on Windows for R > 4.0
+   // R's help server handler has issues with R 4.0.0; disable it explicitly
+   // when that version of R is in use.
    // (see comments in module_context::sessionTempDirUrl)
-
-   if (!s_handleCustom)
+   if (r::util::hasExactVersion("4.0.0"))
    {
-      s_handleCustom = r::util::hasRequiredVersion("4.0");
+      s_handleCustom = false;
    }
 #endif
 


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/7152.

IIRC, the main issue here was that the version check in SessionHelp.cpp wasn't updated when we changed this code to check for an exact version.

I also updated the code checking whether we're using the R help server for requests to just use a lazily-initialized static boolean rather than a boost optional as it's (IMHO) cleaner.