### PR TITLE
don't read un-needed library files

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -84,7 +84,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # Set up rnbData structure (if we have a cache, these entries will be filled)
    rnbData[["chunk_info"]] <- list()
    rnbData[["chunk_data"]] <- list()
-   rnbData[["lib"]] <- list()
    
    # early return if we have no cache
    if (!file.exists(cachePath))
@@ -135,19 +134,6 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    })
    names(chunkData) <- basename(chunkDirs)
    rnbData[["chunk_data"]] <- chunkData
-   
-   # Read in the 'libs' directory.
-   rnbData[["lib"]] <- list()
-   
-   libDir <- file.path(cachePath, "lib")
-   if (file.exists(libDir)) {
-      owd <- setwd(libDir)
-      libFiles <- list.files(libDir, recursive = TRUE)
-      libData <- lapply(libFiles, .rs.readFile, encoding = "UTF-8")
-      names(libData) <- libFiles
-      rnbData[["lib"]] <- libData
-      setwd(owd)
-   }
    
    rnbData
 })


### PR DESCRIPTION
This PR again removes some unneeded code that was attempting to read files that were otherwise unused in the Notebook generating process. Was unfortunately missed as part of https://github.com/rstudio/rstudio/issues/6932.

For context, I think I originally read in almost all of the files within the chunk cache folder, under the assumption that I'd need to sue them directly to render the final document. However, these dependencies get automatically picked up and used when we render HTML, and that's handled by `rmarkdown` + `htmlwidgets`.