### PR TITLE
Fix verify installation errors

### DIFF
--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -405,7 +405,7 @@ Error launchSession(const r_util::SessionContext& context,
       }
       else
       {
-         config.environment.push_back(std::make_pair("XDG_CONFIG_HOME", tmpDir.getAbsolutePath()));
+         core::system::setenv(&config.environment, "XDG_CONFIG_HOME", tmpDir.getAbsolutePath());
       }
    }
 

--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -382,11 +382,32 @@ Error launchSession(const r_util::SessionContext& context,
                     PidType* pPid)
 {
    // launch the session
+   // we use a modified configured home directory to provide a realiable temp dir that can be written to
+   // as the server (service) user most likely does not have a home directory configured
    std::string username = context.username;
    std::string rsessionPath = server::options().rsessionPath();
    std::string runAsUser = core::system::realUserIsRoot() ? username : "";
    core::system::ProcessConfig config = sessionProcessConfig(context,
                                                              extraArgs);
+
+   FilePath tmpDir;
+   Error error = FilePath::tempFilePath(tmpDir);
+   if (error)
+   {
+      LOG_ERROR(error);
+   }
+   else
+   {
+      error = tmpDir.ensureDirectory();
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+      else
+      {
+         config.environment.push_back(std::make_pair("XDG_CONFIG_HOME", tmpDir.getAbsolutePath()));
+      }
+   }
 
    *pPid = -1;
    return core::system::launchChildProcess(rsessionPath,

--- a/src/cpp/server/ServerSessionManager.cpp
+++ b/src/cpp/server/ServerSessionManager.cpp
@@ -382,7 +382,7 @@ Error launchSession(const r_util::SessionContext& context,
                     PidType* pPid)
 {
    // launch the session
-   // we use a modified configured home directory to provide a realiable temp dir that can be written to
+   // we use a modified configured home directory to provide a reliable temp dir that can be written to
    // as the server (service) user most likely does not have a home directory configured
    std::string username = context.username;
    std::string rsessionPath = server::options().rsessionPath();
@@ -419,4 +419,3 @@ Error launchSession(const r_util::SessionContext& context,
 
 } // namespace server
 } // namespace rstudio
-

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1871,53 +1871,56 @@ int main (int argc, char * const argv[])
             "RS_RPOSTBACK_PATH",
             string_utils::utf8ToSystem(rpostback.getAbsolutePath()));
 
-      // determine if this is a new user and get the first project path if so
       std::string firstProjectPath = "";
-      bool newUser = false;
-
-      FilePath userScratchPath = options.userScratchPath();
-      if (userScratchPath.exists())
+      if (!options.verifyInstallation())
       {
-         // if the lists directory has not yet been created,
-         // this is a new user
-         FilePath listsPath = userScratchPath.completeChildPath("monitored/lists");
-         if (!listsPath.exists())
-            newUser = true;
-      }
-      else
-      {
-         // create the scratch path
-         error = userScratchPath.ensureDirectory();
-         if (error)
-            return sessionExitFailure(error, ERROR_LOCATION);
+         // determine if this is a new user and get the first project path if so
+         bool newUser = false;
 
-         newUser = true;
-      }
-
-      if (newUser)
-      {
-         // this is a brand new user
-         // check to see if there is a first project template
-         if (!options.firstProjectTemplatePath().empty())
+         FilePath userScratchPath = options.userScratchPath();
+         if (userScratchPath.exists())
          {
-            // copy the project template to the user's home dir
-            FilePath templatePath = FilePath(options.firstProjectTemplatePath());
-            if (templatePath.exists())
+            // if the lists directory has not yet been created,
+            // this is a new user
+            FilePath listsPath = userScratchPath.completeChildPath("monitored/lists");
+            if (!listsPath.exists())
+               newUser = true;
+         }
+         else
+         {
+            // create the scratch path
+            error = userScratchPath.ensureDirectory();
+            if (error)
+               return sessionExitFailure(error, ERROR_LOCATION);
+
+            newUser = true;
+         }
+
+         if (newUser)
+         {
+            // this is a brand new user
+            // check to see if there is a first project template
+            if (!options.firstProjectTemplatePath().empty())
             {
-               error = templatePath.copyDirectoryRecursive(
-                  options.userHomePath().completeChildPath(
-                     templatePath.getFilename()));
-               if (error)
-                  LOG_ERROR(error);
-               else
+               // copy the project template to the user's home dir
+               FilePath templatePath = FilePath(options.firstProjectTemplatePath());
+               if (templatePath.exists())
                {
-                  FilePath firstProjPath = options.userHomePath().completeChildPath(templatePath.getFilename())
-                                                  .completeChildPath(templatePath.getFilename() + ".Rproj");
-                  if (firstProjPath.exists())
-                     firstProjectPath = firstProjPath.getAbsolutePath();
+                  error = templatePath.copyDirectoryRecursive(
+                     options.userHomePath().completeChildPath(
+                        templatePath.getFilename()));
+                  if (error)
+                     LOG_ERROR(error);
                   else
-                     LOG_WARNING_MESSAGE("Could not find first project path " + firstProjPath.getAbsolutePath() +
-                                         ". Please ensure the template contains an Rproj file.");
+                  {
+                     FilePath firstProjPath = options.userHomePath().completeChildPath(templatePath.getFilename())
+                                                     .completeChildPath(templatePath.getFilename() + ".Rproj");
+                     if (firstProjPath.exists())
+                        firstProjectPath = firstProjPath.getAbsolutePath();
+                     else
+                        LOG_WARNING_MESSAGE("Could not find first project path " + firstProjPath.getAbsolutePath() +
+                                            ". Please ensure the template contains an Rproj file.");
+                  }
                }
             }
          }
@@ -1994,7 +1997,7 @@ int main (int argc, char * const argv[])
       // r options
       rstudio::r::session::ROptions rOptions ;
       rOptions.userHomePath = options.userHomePath();
-      rOptions.userScratchPath = userScratchPath;
+      rOptions.userScratchPath = options.userScratchPath();
       rOptions.scopedScratchPath = module_context::scopedScratchPath();
       rOptions.sessionScratchPath = module_context::sessionScratchPath();
       rOptions.logPath = options.userLogPath();


### PR DESCRIPTION
The verify installation command was producing some directory creation errors because the server user that the session runs as in this case does not usually have a home directory. Fixed this by specifying a tmp dir for verify installation home directory. 

Also fixed a verify hang in pro by not doing first project template copying if in verify mode - otherwise, a project would be set, and project sharing initialization would run which would cause a hang as it connects back to rserver, which is not listening in verify mode.

Fixes #7221 