### PR TITLE
fix dropdowns that don't repopulate when closed via keyboard shortcut

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -58,6 +58,7 @@
 - Fix issue with chunk toolbars not showing up in some cases (#7067)
 - Fix RStudio Server Pro issue where R version modules would sometimes not be able to modify the PATH environment variable (Pro #1737)
 - Fix dealing with expired sessions due to inactivity or signed out when using multiple browser tabs (Pro #1731, #7205)
+- Fix dropdowns not repopulating after being closed via keyboard shortcut #7215
 
 ### RStudio Server Pro
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -375,10 +375,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    public void onCommand(AppCommand command)
    {
       if (command.getExecutedFromShortcut())
-      {
-         if (menuBar_.isVisible())
-            menuBar_.setVisible(false);
-      }
+         hide();
    }
    
    protected ToolbarMenuBar menuBar_;


### PR DESCRIPTION
- Fixes #7215
- Regression caused by #6190

As @kevinushey noted, code was making the menu invisible instead of actually invoking hide, putting it in an unsupported state and preventing it from working on future attempts to display it. Fix is simply to hide() it; also no need to check if it is visible before doing this (the handler is only hooked up while the menu is visible).

## QA notes

Test wide variety of drop-downs in main toolbar, pane toolbars, and in other windows (popup out source editors, git, etc). Focus on closing the drop-downs by executing commands with keyboard shortcuts, then re-opening the popup and make sure it displays (again) and functions correctly (can invoke commands on the menu, or close it via Esc or clicking outside the menu). 