### PR TITLE
set SDKROOT envvar so libclang can find system headers

### DIFF
--- a/src/cpp/core/include/core/system/Environment.hpp
+++ b/src/cpp/core/include/core/system/Environment.hpp
@@ -18,6 +18,8 @@
 
 #include <string>
 
+#include <boost/noncopyable.hpp>
+
 #include <core/system/Types.hpp>
 
 namespace rstudio {
@@ -88,6 +90,39 @@ bool parseEnvVar(const std::string envVar, Option* pEnvVar);
 // expand environment variables in a string; for example /$USER/foo to
 // /bob/foo when USER=bob
 std::string expandEnvVars(const Options& environment, const std::string& str);
+
+// set an environment variable in some scope (overridding and
+// later restoring a previously-set environment variable)
+class EnvironmentScope : boost::noncopyable
+{
+   
+public:
+   
+   EnvironmentScope(const char* variable,
+                    const char* value)
+      : variable_(variable),
+        value_(::getenv(variable))
+   {
+      core::system::setenv(variable, value);
+   }
+   
+   ~EnvironmentScope()
+   {
+      if (value_)
+      {
+         core::system::setenv(variable_, value_);
+      }
+      else
+      {
+         core::system::unsetenv(variable_);
+      }
+   }
+   
+private:
+   const char* variable_;
+   const char* value_;
+   
+};
 
 } // namespace system
 } // namespace core


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6977.