### PR TITLE
Preview WebP images in R Markdown

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -83,6 +83,7 @@ MimeType s_mimeTypes[] =
       { "jpeg",         "image/jpeg" },
       { "jpe",          "image/jpeg" },
       { "png",          "image/png" },
+      { "webp",         "image/webp" },
       { "js",           "text/javascript" },
       { "pdf",          "application/pdf" },
       { "svg",          "image/svg+xml" },

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -218,7 +218,7 @@ public class FileSystemItem extends JavaScriptObject
       else if (lowerExt.equals(".jpg") || lowerExt.equals(".jpeg") ||
                lowerExt.equals(".gif") || lowerExt.equals(".bmp")  ||
                lowerExt.equals(".tiff")   || lowerExt.equals(".tif") ||
-               lowerExt.equals(".png"))
+               lowerExt.equals(".png") || lowerExt.equals(".webp"))
       {
          return FileIcon.IMAGE_ICON;
       }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -443,6 +443,7 @@ public class FileTypeRegistry
       registerIcon(".tiff", new FileIcon(new ImageResource2x(icons.iconPng2x()), "TIFF"));
       registerIcon(".tif", new FileIcon(new ImageResource2x(icons.iconPng2x()), "TIF"));
       registerIcon(".png", new FileIcon(new ImageResource2x(icons.iconPng2x()), "PNG"));
+      registerIcon(".webp", new FileIcon(new ImageResource2x(icons.iconPng2x()), "WEBP"));
 
       registerIcon(".pdf", FileIcon.PDF_ICON);
       registerIcon(".csv", FileIcon.CSV_ICON);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -497,7 +497,8 @@ public class ImagePreviewer
           href.endsWith(".jpg")  ||
           href.endsWith(".jpeg") ||
           href.endsWith(".gif")  ||
-          href.endsWith(".svg");
+          href.endsWith(".svg")  ||
+          href.endsWith(".webp");
    }
    
    public static String imgSrcPathFromHref(DocUpdateSentinel sentinel, String href)


### PR DESCRIPTION
This change adds very basic support for WebP images in R Markdown. WebP images are now correctly identified as images in the Files pane, and are displayed inline while editing R Markdown documents.

![image](https://user-images.githubusercontent.com/470418/85896528-7944d200-b7ad-11ea-8b48-f7dbb531a58e.png)
