### PR TITLE
avoid accidental duplication of editing target impls

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -463,9 +463,15 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
    public EditingTarget addTab(SourceDocument doc, Integer position, int mode)
    {
-      final String defaultNamePrefix = editingTargetSource_.getDefaultNamePrefix(doc);
       final EditingTarget target = editingTargetSource_.getEditingTarget(
-            doc, fileContext_, () -> getNextDefaultName(defaultNamePrefix));
+            doc,
+            fileContext_,
+            (EditingTarget et) ->
+            {
+               String prefix = et.getDefaultNamePrefix();
+               return getNextDefaultName(prefix);
+            });
+      
       final Widget widget = createWidget(target);
 
       if (position == null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
 import org.rstudio.studio.client.workbench.model.UnsavedChangesTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetSource.EditingTargetNameProvider;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartParams;
 import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
@@ -135,7 +136,7 @@ public interface EditingTarget extends IsWidget,
    void initialize(SourceDocument document,
                    FileSystemContext fileContext,
                    FileType type,
-                   Provider<String> defaultNameProvider);
+                   EditingTargetNameProvider defaultNameProvider);
 
    /**
     * Any bigger than this, and the file should NOT be allowed to open

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetSource.java
@@ -29,11 +29,15 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceDocument;
 
 public interface EditingTargetSource
 {
+   public interface EditingTargetNameProvider
+   {
+      public String defaultNamePrefix(EditingTarget target);
+   }
+   
    EditingTarget getEditingTarget(FileType fileType);
    EditingTarget getEditingTarget(SourceDocument document,
                                   RemoteFileSystemContext fileContext,
-                                  Provider<String> defaultNameProvider);
-   String getDefaultNamePrefix(SourceDocument doc);
+                                  EditingTargetNameProvider defaultNameProvider);
 
    public static class Impl implements EditingTargetSource
    {
@@ -74,26 +78,16 @@ public interface EditingTargetSource
       }
 
       public EditingTarget getEditingTarget(final SourceDocument document,
-                                   final RemoteFileSystemContext fileContext,
-                                   final Provider<String> defaultNameProvider)
+                                            final RemoteFileSystemContext fileContext,
+                                            final EditingTargetNameProvider defaultNameProvider)
       {
-         FileType type = getTypeFromDocument(document);
-         
-         final FileType finalType = type;
+         final FileType type = getTypeFromDocument(document);
          EditingTarget target = getEditingTarget(type);
          target.initialize(document,
                            fileContext,
-                           finalType,
+                           type,
                            defaultNameProvider);
          return target;
-      }
-      
-      public String getDefaultNamePrefix(SourceDocument document)
-      {
-         FileType type = getTypeFromDocument(document);
-         EditingTarget target = getEditingTarget(type);
-         
-         return target.getDefaultNamePrefix();
       }
       
       private FileType getTypeFromDocument(SourceDocument document)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -57,6 +57,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEdito
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetCodeExecution;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetSource.EditingTargetNameProvider;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
@@ -157,7 +158,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    public void initialize(SourceDocument document,
                           FileSystemContext fileContext,
                           FileType type,
-                          Provider<String> defaultNameProvider)
+                          EditingTargetNameProvider defaultNameProvider)
    {
       doc_ = document;
       codeExecution_ = new EditingTargetCodeExecution(docDisplay_, getId());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -66,6 +66,7 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.RemoteFileSystemContext;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetSource.EditingTargetNameProvider;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfileOperationResponse;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfilerContents;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfilerServerOperations;
@@ -512,12 +513,14 @@ public class ProfilerEditingTarget implements EditingTarget,
       if (!StringUtil.isNullOrEmpty(name)) {
          return name;
       }
-      else if (createProfile) {
-         String defaultName = defaultNameProvider_.get();
+      else if (createProfile)
+      {
+         String defaultName = defaultNameProvider_.defaultNamePrefix(this);
          persistDocumentProperty("name", defaultName);
          return defaultName;
       }
-      else {
+      else
+      {
          String nameFromFile = FileSystemItem.getNameFromPath(getPath());
          persistDocumentProperty("name", nameFromFile);
          return nameFromFile;
@@ -527,7 +530,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    public void initialize(SourceDocument document,
                           FileSystemContext fileContext,
                           FileType type,
-                          Provider<String> defaultNameProvider)
+                          EditingTargetNameProvider defaultNameProvider)
    {
       // initialize doc, view, and presenter
       doc_ = document;
@@ -881,7 +884,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    private final RemoteFileSystemContext fileContext_;
    private final WorkbenchContext workbenchContext_;
    private final EventBus eventBus_;
-   private Provider<String> defaultNameProvider_;
+   private EditingTargetNameProvider defaultNameProvider_;
    private final FileTypeRegistry fileTypeRegistry_;
 
    private ProfilerType fileType_ = new ProfilerType();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -146,6 +146,7 @@ import org.rstudio.studio.client.workbench.views.source.Source;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetCodeExecution;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetSource.EditingTargetNameProvider;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper.RmdSelectedTemplate;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceAfterCommandExecutedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold;
@@ -1389,7 +1390,7 @@ public class TextEditingTarget implements
    public void initialize(final SourceDocument document,
                           FileSystemContext fileContext,
                           FileType type,
-                          Provider<String> defaultNameProvider)
+                          EditingTargetNameProvider defaultNameProvider)
    {
       id_ = document.getId();
       fileContext_ = fileContext;
@@ -1454,7 +1455,8 @@ public class TextEditingTarget implements
          }
       });
 
-      name_.setValue(getNameFromDocument(document, defaultNameProvider), true);
+      String name = getNameFromDocument(document, defaultNameProvider);
+      name_.setValue(name, true);
       String contents = document.getContents();
 
       // disable change detection when setting code (since we're just doing
@@ -2212,7 +2214,7 @@ public class TextEditingTarget implements
    }
 
    private String getNameFromDocument(SourceDocument document,
-                                      Provider<String> defaultNameProvider)
+                                      EditingTargetNameProvider defaultNameProvider)
    {
       if (document.getPath() != null)
          return FileSystemItem.getNameFromPath(document.getPath());
@@ -2221,7 +2223,7 @@ public class TextEditingTarget implements
       if (!StringUtil.isNullOrEmpty(name))
          return name;
 
-      String defaultName = defaultNameProvider.get();
+      String defaultName = defaultNameProvider.defaultNamePrefix(this);
       docUpdateSentinel_.setProperty("tempName", defaultName, null);
       return defaultName;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -45,6 +45,7 @@ import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTargetSource.EditingTargetNameProvider;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.events.CollabEditStartParams;
 import org.rstudio.studio.client.workbench.views.source.events.DocWindowChangedEvent;
@@ -401,7 +402,7 @@ public class UrlContentEditingTarget implements EditingTarget
    public void initialize(SourceDocument document,
                           FileSystemContext fileContext,
                           FileType type,
-                          Provider<String> defaultNameProvider)
+                          EditingTargetNameProvider defaultNameProvider)
    {
       doc_ = document;
       view_ = createDisplay();


### PR DESCRIPTION
This PR fixes a somewhat long-standing issue, where calling `getDefaultNamePrefix()` could cause the instantiation of a separate, standalone EditingTarget; separate from the one actually used. See https://github.com/rstudio/rstudio/issues/7066#issuecomment-650363848 for extra investigation.

If I understand correctly, the assumption we were making was that, for a single `Provider<Foo> foo` instance, calling `foo.get()` would return a reference to the _same_ `Foo` instance. This appears to not be the case; each invocation of `get()` may return a reference to a separate instance entirely.

We resolve this issue by de-coupling name provision from the editing target source class. Instead, we create a simple interface that takes an EditingTarget, and returns a default name prefix given that target. That interface can then just delegate back to `target.getDefaultNamePrefix()`, which helps ensure that we're using the same already-initialized target as opposed to a separate instance provided by dependency injection.

