### PR TITLE
Set isActive in onActivate in DataEditingTarget

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -121,6 +121,7 @@ public class DataEditingTarget extends UrlContentEditingTarget
    public void onActivate()
    {
       super.onActivate();
+      isActive_ = true;
       if (view_ != null)
       {
          if (queuedRefresh_ != QueuedRefreshType.NoRefresh)


### PR DESCRIPTION
Fixes  #7066 

Really good find by Kevin noticing that onActivate isn't actually setting isActive_ on the DataEditingTarget. The DataViewer actually updates with this change. This is so trivial I think we should sneak it into Water Lily still.