### PR TITLE
Speculative fix for persistent crash reporting dialog

### DIFF
--- a/src/cpp/core/CrashHandler.cpp
+++ b/src/cpp/core/CrashHandler.cpp
@@ -189,7 +189,7 @@ FilePath permissionFile()
    return core::system::userSettingsPath(
       core::system::userHomePath(),
       "R",
-      false).completePath("crash-handler-permission");
+      true).completePath("crash-handler-permission");
 }
 
 } // anonymous namespace


### PR DESCRIPTION
Ensure that crash handler permissions file parent directory is automatically created if it doesn't already exist to help mitigate issue where users cannot get the prompt to go away. Closes #7243