### PR TITLE
convert some xterm.js support code from jsni to jsinterop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalInfoDialog.java
@@ -78,14 +78,6 @@ public class TerminalInfoDialog extends ModalDialogBase
          diagnostics.append("Interactive: '").append(cpi.getInteractionModeName()).append("'\n");
          diagnostics.append("WebSockets:  '").append(userPrefs_.terminalWebsockets().getValue()).append("'\n");
 
-         diagnostics.append("\nCurrent Terminal Emulator Settings\n------------------------------------\n");
-         for (String optionName : XTermOptions.stringOptions)
-            diagnostics.append(optionName).append(": ").append(session.getStringOption(optionName)).append("\n");
-         for (String optionName : XTermOptions.boolOptions)
-            diagnostics.append(optionName).append(": ").append(session.getBoolOption(optionName)).append("\n");
-         for (String optionName : XTermOptions.numberOptions)
-            diagnostics.append(optionName).append(": ").append(session.getNumberOption(optionName)).append("\n");
-
          diagnostics.append("\nSystem Information\n------------------\n");
          diagnostics.append("Desktop:    '").append(Desktop.isDesktop()).append("'\n");
          diagnostics.append("Remote:     '").append(Desktop.isRemoteDesktop()).append("'\n");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermDimensions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermDimensions.java
@@ -15,23 +15,15 @@
 
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
-import com.google.gwt.core.client.JavaScriptObject;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
 /**
- * Size of xterm in rows and columns of text. A dimension will be returned
- * as -1 if it could not be computed.
+ * Size of xterm in rows and columns of text.
  */
-public class XTermDimensions extends JavaScriptObject
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class XTermDimensions
 {
-   protected XTermDimensions() {}
-
-   public final native int getCols() /*-{
-      if (this.cols !== this.cols) { return -1; } // isNaN
-      return this.cols;
-   }-*/;
-
-   public final native int getRows() /*-{
-      if (this.rows !== this.rows) { return -1; } // isNaN
-      return this.rows;
-   }-*/;
+   public int cols;
+   public int rows;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermNative.java
@@ -160,18 +160,6 @@ public class XTermNative extends JavaScriptObject
          }));
    }-*/;
 
-   public final native String getStringOption(String optionName) /*-{
-      return this.getOption(optionName);
-   }-*/;
-
-   public final native boolean getBoolOption(String optionName) /*-{
-      return this.getOption(optionName);
-   }-*/;
-
-   public final native double getNumberOption(String optionName) /*-{
-      return this.getOption(optionName);
-   }-*/;
-
    public final native void updateTheme(XTermTheme theme) /*-{
       this.setOption("theme", theme);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermOptions.java
@@ -14,31 +14,26 @@
  */
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
-import com.google.gwt.core.client.JavaScriptObject;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
 /**
  * xterm.js ITerminalOptions
  */
-public class XTermOptions extends JavaScriptObject
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class XTermOptions
 {
-   public static final String[] stringOptions = {
-         "bellStyle", "cursorStyle", "fontFamily", "fontWeight", "fontWeightBold", "rendererType"
-   };
+   public String bellStyle;
+   public boolean cursorBlink;
+   public boolean screenReaderMode;
+   public String rendererType;
+   public boolean windowsMode;
+   public XTermTheme theme;
+   public String fontFamily;
+   public double fontSize;
 
-   public static final String[] boolOptions = {
-         "allowTransparency", "cancelEvents", "convertEol", "cursorBlink", "disableStdin",
-         "drawBoldTextInBrightColors", "macOptionClickForcesSelection", "macOptionIsMeta",
-         "rightClickSelectsWord", "screenReaderMode", "windowsMode"
-   };
-
-   public static final String[] numberOptions = {
-         "fontSize", "letterSpacing", "lineHeight", "tabStopWidth", "scrollback"
-   };
-
-   // Required by JavaScriptObject subclasses
-   protected XTermOptions() {}
-
-   public final native static XTermOptions create(
+   @JsOverlay public static XTermOptions create(
          String bellStyle,
          boolean cursorBlink,
          boolean screenReaderMode,
@@ -46,16 +41,17 @@ public class XTermOptions extends JavaScriptObject
          boolean windowsMode,
          XTermTheme theme,
          String fontFamily,
-         double fontSize) /*-{
-      return {
-         "bellStyle": bellStyle,
-         "cursorBlink": cursorBlink,
-         "screenReaderMode": screenReaderMode,
-         "rendererType": rendererType,
-         "windowsMode": windowsMode,
-         "theme": theme,
-         "fontFamily": fontFamily,
-         "fontSize": fontSize
-     };
-   }-*/;
+         double fontSize)
+   {
+      XTermOptions options = new XTermOptions();
+      options.bellStyle = bellStyle;
+      options.cursorBlink = cursorBlink;
+      options.screenReaderMode = screenReaderMode;
+      options.rendererType = rendererType;
+      options.windowsMode = windowsMode;
+      options.theme = theme;
+      options.fontFamily = fontFamily;
+      options.fontSize = fontSize;
+      return options;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
@@ -14,8 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.views.terminal.xterm;
 
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -23,19 +25,39 @@ import org.rstudio.core.client.dom.DomUtils;
 /**
  * xterm.js ITheme
  */
-public class XTermTheme extends JavaScriptObject
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class XTermTheme
 {
-   public static double XTERM_SELECTION_ALPHA = 0.3;
+   @JsOverlay public static double XTERM_SELECTION_ALPHA = 0.3;
 
-   // Required by JavaScriptObject subclasses
-   protected XTermTheme() {}
+   public String foreground;
+   public String background;
+   public String cursor;
+   public String cursorAccent;
+   public String selection;
+   public String black;
+   public String red;
+   public String green;
+   public String yellow;
+   public String blue;
+   public String magenta;
+   public String cyan;
+   public String white;
+   public String brightBlack;
+   public String brightRed;
+   public String brightGreen;
+   public String brightYellow;
+   public String brightBlue;
+   public String brightMagenta;
+   public String brightCyan;
+   public String brightWhite;
 
    /**
     * Create a terminal theme matching current editor theme. Unlike xterm 2.x,
     * xterm 3.x does not directly use css for styling, so we must sync the theme
     * with the css.
     */
-   public final static XTermTheme terminalThemeFromEditorTheme()
+   @JsOverlay public static XTermTheme terminalThemeFromEditorTheme()
    {
       // extract terminal selection color from existing theme, and add alpha
       JsArrayString classes = JsArrayString.createArray().cast();
@@ -79,17 +101,17 @@ public class XTermTheme extends JavaScriptObject
       );
    }
 
-   public static String getFontFamily()
+   @JsOverlay public static String getFontFamily()
    {
       return DomUtils.extractCssValue("ace_editor", "font-family");
    }
 
-   private static boolean doubleEqualish(double d1, double d2)
+   @JsOverlay private static boolean doubleEqualish(double d1, double d2)
    {
       return MathUtil.isEqual(d1, d2, 0.0001);
    }
 
-   public static double adjustFontSize(double size)
+   @JsOverlay public static double adjustFontSize(double size)
    {
       // standard values for sizes we expose in preferences
       if (doubleEqualish(size, 7.0))
@@ -120,7 +142,7 @@ public class XTermTheme extends JavaScriptObject
          return Math.round(size * 1.3333333);
    }
 
-   public final native static XTermTheme create(
+   @JsOverlay public static XTermTheme create(
          String background, // default background color
          String foreground, // default foreground color
          String cursor, // cursor color
@@ -141,31 +163,32 @@ public class XTermTheme extends JavaScriptObject
          String brightBlue, // ANSI bright blue: \x1b[1;34m (xtermColor12)
          String brightMagenta, // ANSI bright magenta: \x1b[1;35m (xtermColor13)
          String brightCyan, // ANSI bright cyan: \x1b[1;36m (xtermColor14)
-         String brightWhite // ANSI bright white: \x1b[1;37m (xtermColor15)
+         String brightWhite) // ANSI bright white: \x1b[1;37m (xtermColor15)
+   {
+      XTermTheme theme = new XTermTheme();
 
-   ) /*-{
-      return {
-         "background": background,
-         "black": black,
-         "blue": blue,
-         "brightBlack": brightBlack,
-         "brightBlue": brightBlue,
-         "brightCyan": brightCyan,
-         "brightGreen": brightGreen,
-         "brightMagenta": brightMagenta,
-         "brightRed": brightRed,
-         "brightWhite": brightWhite,
-         "brightYellow": brightYellow,
-         "cursor": cursor,
-         "cursorAccent": cursorAccent,
-         "cyan": cyan,
-         "foreground": foreground,
-         "green": green,
-         "magenta": magenta,
-         "red": red,
-         "selection": selection,
-         "white": white,
-         "yellow": yellow
-     };
-   }-*/;
+      theme.background = background;
+      theme.black = black;
+      theme.blue = blue;
+      theme.brightBlack = brightBlack;
+      theme.brightBlue = brightBlue;
+      theme.brightCyan = brightCyan;
+      theme.brightGreen = brightGreen;
+      theme.brightMagenta = brightMagenta;
+      theme.brightRed = brightRed;
+      theme.brightWhite = brightWhite;
+      theme.brightYellow = brightYellow;
+      theme.cursor = cursor;
+      theme.cursorAccent = cursorAccent;
+      theme.cyan = cyan;
+      theme.foreground = foreground;
+      theme.green = green;
+      theme.magenta = magenta;
+      theme.red = red;
+      theme.selection = selection;
+      theme.white = white;
+      theme.yellow = yellow;
+
+      return theme;
+   }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermWidget.java
@@ -221,16 +221,13 @@ public class XTermWidget extends Widget
       {
          XTermDimensions size = getTerminalSize();
 
-         int cols = size.getCols();
-         int rows = size.getRows();
-
          // ignore if a reasonable size couldn't be computed
-         if (cols < 1 || rows < 1)
+         if (size.cols < 1 || size.rows < 1)
          {
             return;
          }
 
-         resizePTY(cols, rows);
+         resizePTY(size.cols, size.rows);
       }
    };
 
@@ -383,21 +380,6 @@ public class XTermWidget extends Widget
    public HandlerRegistration addXTermTitleHandler(Handler handler)
    {
       return addHandler(handler, XTermTitleEvent.TYPE);
-   }
-
-   public String getStringOption(String option)
-   {
-      return terminal_.getStringOption(option);
-   }
-
-   public boolean getBoolOption(String option)
-   {
-      return terminal_.getBoolOption(option);
-   }
-
-   public double getNumberOption(String option)
-   {
-      return terminal_.getNumberOption(option);
    }
 
    public void updateTheme(XTermTheme theme)


### PR DESCRIPTION
- removed extra logging in terminal diagnostics dialog I had added while upgrading xterm.js last year (no real value to showing it)
- no longer checking XTermDimension for NaN (this was fixed in xterm.js a couple years ago; could track down the issue if anybody cares)
- still need to convert the `XTermNative` class but wanted to get first part in