### PR TITLE
ensure chunk output from alternate engines is UTF-8

### DIFF
--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -51,7 +51,6 @@ class Protect;
 // environments and namespaces
 SEXP asEnvironment(std::string name);
 core::Error asPrimitiveEnvironment(SEXP envirSEXP, SEXP* pTargetSEXP, Protect* pProtect);
-std::vector<std::string> getLoadedNamespaces();
 SEXP findNamespace(const std::string& name);
 SEXP asNamespace(const std::string& name);
 
@@ -101,6 +100,7 @@ bool isNumeric(SEXP object);
 
 // type coercions
 std::string asString(SEXP object);
+std::string asUtf8String(SEXP object);
 std::string safeAsString(SEXP object, 
                          const std::string& defValue = std::string());
 int asInteger(SEXP object);

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -262,7 +262,7 @@ Error save(const FilePath& statePath)
       // screen out UserDefinedDatabase elements (attempting to perisist
       // a UserDefinedDatabase caused mischief in at least one case (e.g. see
       // RProtoBuf:DescriptorPool) so we exclude it globally.
-      if (r::sexp::classOf(envSEXP) == "UserDefinedDatabase")
+      if (r::sexp::inherits(envSEXP, "UserDefinedDatabase"))
          continue;
 
       // get the name of the search path element and add it to our list

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1661,7 +1661,7 @@ SEXP rs_base64decode(SEXP dataSEXP, SEXP binarySEXP)
 
 SEXP rs_resolveAliasedPath(SEXP pathSEXP)
 {
-   std::string path = r::sexp::asString(pathSEXP);
+   std::string path = r::sexp::asUtf8String(pathSEXP);
    FilePath resolved = module_context::resolveAliasedPath(path);
    r::sexp::Protect protect;
    return r::sexp::create(resolved.getAbsolutePath(), &protect);
@@ -1897,7 +1897,8 @@ bool isRScriptInPackageBuildTarget(const FilePath &filePath)
 SEXP rs_isRScriptInPackageBuildTarget(SEXP filePathSEXP)
 {
    r::sexp::Protect protect;
-   FilePath filePath = module_context::resolveAliasedPath(r::sexp::asString(filePathSEXP));
+   FilePath filePath = module_context::resolveAliasedPath(
+      r::sexp::asUtf8String(filePathSEXP));
    return r::sexp::create(isRScriptInPackageBuildTarget(filePath), &protect);
 }
 

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -628,7 +628,8 @@ Error runUserDefinedEngine(const std::string& docId,
    // generic engine output (as a single string of console output)
    if (isString(outputSEXP))
    {
-      emitText(asString(outputSEXP), kChunkConsoleOutput);
+      std::string text = asUtf8String(outputSEXP);
+      emitText(text, kChunkConsoleOutput);
    }
    else if (inherits(outputSEXP, "htmlwidget"))
    {
@@ -665,7 +666,8 @@ Error runUserDefinedEngine(const std::string& docId,
          else if (inherits(elSEXP, "knit_image_paths"))
          {
             // handle a plot provided by e.g. knitr::include_graphics()
-            Error error = emitImage(r::sexp::asString(elSEXP));
+            std::string path = asUtf8String(elSEXP);
+            Error error = emitImage(path);
             if (error)
             {
                LOG_ERROR(error);
@@ -694,7 +696,8 @@ Error runUserDefinedEngine(const std::string& docId,
          else if (isString(elSEXP) || isNumeric(elSEXP))
          {
             // plain old console text output -- emit as-is
-            Error error = emitText(asString(elSEXP), kChunkConsoleOutput);
+            std::string text = asUtf8String(elSEXP);
+            Error error = emitText(text, kChunkConsoleOutput);
             if (error)
             {
                LOG_ERROR(error);

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -182,8 +182,9 @@ Error NotebookQueueUnit::parseOptions(json::Object* pOptions)
 
 Error NotebookQueueUnit::innerCode(std::string* pCode)
 {
-   return r::exec::RFunction(".rs.extractChunkInnerCode", 
-         string_utils::wideToUtf8(code_)).call(pCode);
+   return r::exec::RFunction(".rs.extractChunkInnerCode")
+       .addParam(string_utils::wideToUtf8(code_))
+       .callUtf8(pCode);
 }
 
 bool NotebookQueueUnit::hasPendingRanges()


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6254.

Note that this raises a somewhat larger issue. Normally, code in RStudio using `std::string` assumes that string is UTF-8 encoded. However, this isn't true for calls to `r::sexp::asString()`, which returns strings in the native encoding, which (e.g. on Windows) will correspond to whatever the active code page is.

This implies that there are a lot of spots in the codebase where we might want to consider switching from `asString()` to `asUtf8String()`, but such changes would need to be done carefully since some R APIs do require strings to be in the native encoding as opposed to UTF-8.