### PR TITLE
Fix bug where you cannot open HTML file in browser in RDP->RSP session

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.*;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.ConsoleDispatcher;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -700,9 +701,16 @@ public class Files
    {
       // show the file in a new window if we can get a file url for it
       String fileURL = server_.getFileUrl(file);
-      if (fileURL !=  null)
+      if (fileURL != null)
       {
-         globalDisplay_.openWindow(fileURL);
+         if (!Desktop.isRemoteDesktop())
+         {
+            globalDisplay_.openWindow(fileURL);
+         }
+         else
+         {
+            Desktop.getFrame().browseUrl(fileURL);
+         }
       }
    }
    


### PR DESCRIPTION
The attached issue was partially fixed - buttoning up another place where `openWindow` does not work with RSP->RSP mode. See issue's first PR for more detail.

Closes https://github.com/rstudio/rstudio-pro/issues/1625