### PR TITLE
Parallelize Windows Builds

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -23,7 +23,7 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-o
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
   choco install -y 7zip; `
   choco install -y nsis; `
-  choco install -y ninja --verion 1.10.0
+  choco install -y ninja --verion "Ninja 1.10.0"
 
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
@@ -46,11 +46,11 @@ RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
 # install qt (note that we are using the current directory's context)
-RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; ` 
+RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
   (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.8-msvc2017_64.7z', 'c:\QtSDK-5.12.8-msvc2017_64.7z'); `
   7z x c:\QtSDK-5.12.8-msvc2017_64.7z -oc:\ ; `
   Remove-Item c:\QtSDK-5.12.8-msvc2017_64.7z -Force
-    
+
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -22,11 +22,12 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-o
   choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
   choco install -y 7zip; `
-  choco install -y nsis
-  
+  choco install -y nsis; `
+  choco install -y ninja --verion 1.10.0
+
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
-  
+
 # install aws cli
 RUN choco install -y awscli
 

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -18,8 +18,12 @@ cd %WIN32_BUILD_PATH%
 if exist CMakeCache.txt del CMakeCache.txt
 
 REM Build the project
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -clean_env -no_logo || goto :error
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0 -no_logo || goto :error
+set VS_DEV_CMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
+if not exist %VS_DEV_CMD% set VS_DEV_CMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+if not exist %VS_DEV_CMD% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2017 Build tools are installed." && exit /b 1
+
+call %VS_DEV_CMD% -clean_env -no_logo || goto :error
+call %VS_DEV_CMD% -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0 -no_logo || goto :error
 cmake -G "Ninja" ^
       -DCMAKE_INSTALL_PREFIX:String=%INSTALL_PATH% ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -18,7 +18,8 @@ cd %WIN32_BUILD_PATH%
 if exist CMakeCache.txt del CMakeCache.txt
 
 REM Build the project
-"%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat" -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -clean_env -no_logo || goto :error
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0 -no_logo || goto :error
 cmake -G "Ninja" ^
       -DCMAKE_INSTALL_PREFIX:String=%INSTALL_PATH% ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -18,14 +18,16 @@ cd %WIN32_BUILD_PATH%
 if exist CMakeCache.txt del CMakeCache.txt
 
 REM Build the project
-cmake -G"Visual Studio 15 2017" ^
-      -T host=x86 ^
+"%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat" -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0
+cmake -G "Ninja" ^
       -DCMAKE_INSTALL_PREFIX:String=%INSTALL_PATH% ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
       -DRSTUDIO_TARGET=SessionWin32 ^
       -DRSTUDIO_PACKAGE_BUILD=1 ^
+      -DCMAKE_C_COMPILER=cl.exe ^
+      -DCMAKE_CXX_COMPILER=cl.exe ^
       ..\..\.. || goto :error
-cmake --build . --config %CMAKE_BUILD_TYPE% --target install || goto :error
+cmake --build . %MAKEFLAGS% --config %CMAKE_BUILD_TYPE% --target install || goto :error
 cd ..
 
 endlocal

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -39,15 +39,14 @@ if exist "%BUILD_DIR%/_CPack_Packages" rmdir /s /q "%BUILD_DIR%\_CPack_Packages"
 
 REM Configure and build the project. (Note that Windows / MSVC builds require
 REM that we specify the build type both at configure time and at build time)
-set VSINSTALLDIR="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools"
-set VCINSTALLDIR="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\VC"
-"%VSINSTALLDIR%\Common7\Tools\VsDevCmd.bat" -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.17134.0
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -clean_env -no_logo || goto :error
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.17134.0 -no_logo || goto :error
 cmake -G "Ninja" ^
       -DRSTUDIO_TARGET=Desktop ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^
       -DRSTUDIO_PACKAGE_BUILD=1 ^
-      -DCMAKE_C_COMPILER=cl.exe ^
-      -DCMAKE_CXX_COMPILER=cl.exe ^
+      -DCMAKE_C_COMPILER=cl ^
+      -DCMAKE_CXX_COMPILER=cl ^
       ..\..\.. || goto :error
 cmake --build . %MAKEFLAGS% --config %CMAKE_BUILD_TYPE% || goto :error
 cd ..

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -39,8 +39,12 @@ if exist "%BUILD_DIR%/_CPack_Packages" rmdir /s /q "%BUILD_DIR%\_CPack_Packages"
 
 REM Configure and build the project. (Note that Windows / MSVC builds require
 REM that we specify the build type both at configure time and at build time)
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -clean_env -no_logo || goto :error
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.17134.0 -no_logo || goto :error
+set VS_DEV_CMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools\VsDevCmd.bat"
+if not exist %VS_DEV_CMD% set VS_DEV_CMD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat"
+if not exist %VS_DEV_CMD% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2017 Build tools are installed." && exit /b 1
+
+call %VS_DEV_CMD% -clean_env -no_logo || goto :error
+call %VS_DEV_CMD% -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.17134.0 -no_logo || goto :error
 cmake -G "Ninja" ^
       -DRSTUDIO_TARGET=Desktop ^
       -DCMAKE_BUILD_TYPE=%CMAKE_BUILD_TYPE% ^


### PR DESCRIPTION
This PR changes our make program from `nmake` to `ninja` in our windows builds to allow use to compile multiple files in parallel. It also sets the Windows SDK version to ensure we're building with the desired SDK version (based on the Dockerfile).