### PR TITLE
fix issue with Ace '#tmp' state from tokenizer

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -813,7 +813,7 @@ var RCodeModel = function(session, tokenizer,
          position = iterator.getCurrentTokenPosition();
 
          // Skip roxygen comments.
-         var state = this.$session.getState(position.row);
+         var state = Utils.getPrimaryState(this.$session, position.row);
          if (state === "rd-start") {
             iterator.moveToEndOfRow();
             continue;
@@ -825,7 +825,7 @@ var RCodeModel = function(session, tokenizer,
          // create a scope when encountered within a chunk.
          var isInRMode = true;
          if (this.$codeBeginPattern)
-            isInRMode = /^r-/.test(this.$session.getState(iterator.$row));
+            isInRMode = /^r-/.test(state);
 
          // Add Markdown headers.
          //

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -63,8 +63,17 @@ var unicode = require("ace/unicode");
    this.primaryState = function(states)
    {
       if (that.isArray(states))
-         return states[0];
-      return states;
+      {
+         for (var i = 0; i < states.length; i++)
+         {
+            var state = states[i];
+            if (state === "#tmp")
+               continue;
+            return state || "start";
+         }
+      }
+
+      return states || "start";
    };
 
    this.activeMode = function(state, major)


### PR DESCRIPTION
With the Ace tokenizer, rules that make use of line-specific metadata (via the "stack" parameters) can cause Ace to emit a temporary state `#tmp`:

https://github.com/ajaxorg/ace/blob/2ccda8c1ba350415de0e949abd50888abb6645fe/lib/ace/tokenizer.js#L354-L357

Normally, that temporary state is only resolved later, in response to `getLineTokens()`:

https://github.com/ajaxorg/ace/blob/2ccda8c1ba350415de0e949abd50888abb6645fe/lib/ace/tokenizer.js#L229-L237

It's not completely clear to me why this `#tmp` state is used; the only documentation I can see is the associated commit:

https://github.com/ajaxorg/ace/commit/7a3a84c8583d49f6acf5948ad6a386737fa7ee17

It _seems_ like it's some implicit way of indicating that state management is being done through the `stack` variable, as opposed to other components of the rule.

Regardless, the fix here is to skip `#tmp` when we observe a stack of states.

Closes https://github.com/rstudio/rstudio/issues/7273.

