### PR TITLE
Increase tolerance to notarization delays

### DIFF
--- a/docker/jenkins/notarize-release.sh
+++ b/docker/jenkins/notarize-release.sh
@@ -65,13 +65,24 @@ else
     exit 1
 fi
 
+# Counter for the number of queries we have made
+QUERIES=0
+
 # Wait for notarization to complete
 echo "Waiting for notarization to complete. This will take several minutes."
 while true; do 
+
+    # Wait for Apple to do its thing
     sleep 30
-    echo "Checking notarization status..."
+
+    # Use xcrun to inquire about the status of the notarization request we just made
+    ((QUERIES=QUERIES+1))
+    echo "Checking notarization status (query $QUERIES)..."
     xcrun altool --notarization-info $REQUEST_UUID --username $APPLE_ID --password "@env:APPLE_ID_PASSWORD" --output-format xml > $XCRUN_RESULT
+
+    # Use PlistBuddy (ships with macOS) to parse the XML and extract the status
     NOTARIZATION_STATUS=$(/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" $XCRUN_RESULT)
+
     if [ $? -eq 0 ]; then
         if [ "$NOTARIZATION_STATUS" != "in progress" ]; then 
             echo "Notarization ended; result: $NOTARIZATION_STATUS"
@@ -79,8 +90,32 @@ while true; do
         fi
         echo "Notarization still in progress. Waiting 30s to check again."
     else
-        echo "Could not determine notarization status; giving up. Server response:" 
-        cat $XCRUN_RESULT
+        # Sometimes Apple will give us a request UUID, but then deny it exists
+        # when we query its status. This is somewhat rare (perhaps around 5% of
+        # notarization requests); we hypothesize that it's because the
+        # notarization request UUID may take more than 30s to fully register
+        # with Apple's servers. To work around the problem, we retry again with
+        # the same UUID.
+        ERROR_CODE=$(/usr/libexec/PlistBuddy -c "Print :product-errors:0:code" $XCRUN_RESULT)
+        if [ "$ERROR_CODE" -eq "1519" ]; then
+            # Error code 1519 = "Could not find the RequestUUID."
+            echo "Notarization request UUID not ready. Waiting 30s to try again."
+        else 
+            # Some other error, which is not something we know how to handle
+            # and should consequently result in termination.
+            echo "Could not determine notarization status; giving up with unknown error $ERROR_CODE. Server response:" 
+            cat $XCRUN_RESULT
+            exit 1
+        fi
+    fi
+    
+    # We don't want to hang the build indefinitely, so stop now if we have
+    # spent more than 60 minutes waiting for a response (Apple indicates that
+    # this should actually take 5 minutes).
+    #
+    # https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
+    if [ $QUERIES -gt 120 ]; then
+        echo "Notarization not ready after an hour; giving up."
         exit 1
     fi
 done


### PR DESCRIPTION
About once a week we have to investigate a build failure on MacOS that turns out to be due to an intermittent notarization failure, which presents itself as a failure on Apple's side to locate a request UUID that it just told us it created 30 seconds ago. This change attempts to eliminate these failures by adding a retry step, under the presumption that the request UUID just isn't ready yet.

A concern here is that the request UUID will never in fact be ready in some cases (i.e. Apple just dropped it on the floor). We don't want the build to hang in this case, so this change also caps the time spent in notarization at an hour. 

Fixes https://github.com/rstudio/rstudio/issues/5693.