### PR TITLE
Fix tab overflow selection

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -324,19 +324,7 @@ public class Source implements InsertSourceHandler,
       events_.addHandler(NewDocumentWithCodeEvent.TYPE, this);
       events_.addHandler(XRefNavigationEvent.TYPE, this);
 
-      events_.addHandler(SwitchToDocEvent.TYPE, new SwitchToDocHandler()
-      {
-         public void onSwitchToDoc(SwitchToDocEvent event)
-         {
-            columnManager_.ensureVisible(false);
-            
-            // Fire an activation event just to ensure the activated
-            // tab gets focus
-            commands_.activateSource().execute();
-         }
-      });
-
-      events_.addHandler(SourcePathChangedEvent.TYPE, 
+      events_.addHandler(SourcePathChangedEvent.TYPE,
             new SourcePathChangedEvent.Handler()
       {
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -194,6 +194,19 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          }
       });
 
+      events_.addHandler(SwitchToDocEvent.TYPE, new SwitchToDocHandler()
+      {
+         public void onSwitchToDoc(SwitchToDocEvent event)
+         {
+            ensureVisible(false);
+            activeColumn_.setPhysicalTabIndex(event.getSelectedIndex());
+
+            // Fire an activation event just to ensure the activated
+            // tab gets focus
+            commands_.activateSource().execute();
+         }
+      });
+
       sourceNavigationHistory_.addChangeHandler(event -> columnList_.forEach((col) ->
          col.manageSourceNavigationCommands()));
 


### PR DESCRIPTION
Fixes #7274 

The SwitchToDoc event handler needed to be moved from `Source` to `SourceColumnManager` and updated to select the tab on the active column.

This won't work perfectly with the additional source column code. That will be included in a different PR. 