### PR TITLE
Fix consistency of context-lines dropdown plurals

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -64,10 +64,10 @@
                                     styleName="{res.styles.unstaged}"/>
                      <rs_widget:FormLabel ui:field="lblContext_" display="inline" text="Context" styleName="{res.styles.stagedLabel}"/>
                      <g:ListBox ui:field="contextLines_" visibleItemCount="1" selectedIndex="0">
-                        <g:item value="5">5 line</g:item>
-                        <g:item value="10">10 line</g:item>
-                        <g:item value="25">25 line</g:item>
-                        <g:item value="50">50 line</g:item>
+                        <g:item value="5">5 lines</g:item>
+                        <g:item value="10">10 lines</g:item>
+                        <g:item value="25">25 lines</g:item>
+                        <g:item value="50">50 lines</g:item>
                         <g:item value="-1">All lines</g:item>
                      </g:ListBox>
                       <g:CheckBox ui:field="ignoreWhitespaceCheckbox_"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.ui.xml
@@ -26,10 +26,10 @@
                   <g:FlowPanel styleName="{res.styles.diffViewOptions}">
                      <rs_widget:FormLabel ui:field="lblContext_" display="inline" text="Context" styleName="{res.styles.contextLabel}"/>
                      <g:ListBox ui:field="contextLines_" visibleItemCount="1" selectedIndex="0">
-                        <g:item value="5">5 line</g:item>
-                        <g:item value="10">10 line</g:item>
-                        <g:item value="25">25 line</g:item>
-                        <g:item value="50">50 line</g:item>
+                        <g:item value="5">5 lines</g:item>
+                        <g:item value="10">10 lines</g:item>
+                        <g:item value="25">25 lines</g:item>
+                        <g:item value="50">50 lines</g:item>
                         <g:item value="-1">All lines</g:item>
                      </g:ListBox>
                      <rs_widget:Toolbar ui:field="diffToolbar_"/>


### PR DESCRIPTION
Fixes #7254

Use consistent plurals in vcs dropdown for number of lines of context. I confirmed that the layout expands based on the content of the dropdown (temporarily put something really long in one of them to check).

Not an absolute slam-dunk, I mentioned in the issue that: 

> You could read "Context: 5 line" as shorthand for either "show a 5-line context" or "show 5 lines of context". In any case there's an inconsistency due to the "All lines" being there. :-)