### PR TITLE
Fix toolbar buttons being set to visible when they shouldn't be

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -849,7 +849,6 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
    private void manageRMarkdownCommands(boolean active)
    {
-      // !!! reconsider this before PR
       boolean rmdCommandsAvailable = active &&
               manager_.getSession().getSessionInfo().getRMarkdownPackageAvailable() &&
                       activeEditor_ != null &&

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocEvent.java
@@ -45,7 +45,6 @@ public class PopoutDocEvent extends CrossWindowEvent<PopoutDocEvent.Handler>
       originator_ = originator;
       sourcePosition_ = sourcePosition;
       column_ = column;
-      Debug.logToConsole("new PopoutDocEvent for: " + originator_.getDocId());
    }
    
    public PopoutDocInitiatedEvent getOriginator()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/PopoutDocEvent.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.source.events;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.workbench.views.source.SourceColumn;


### PR DESCRIPTION
Enable Changed and Visibility Changed events on `CommandSourceColumnToolbarButton` were being passed to the `AppCommand` handlers rather than their own handler causing buttons to appear when they shouldn't. Their visibility is now properly assigned.