### PR TITLE
stop file scanner on exit

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -37,6 +37,7 @@ set (CORE_SOURCE_FILES
    CrashHandler.cpp
    Database.cpp
    DateTime.cpp
+   Debug.cpp
    ExponentialBackoff.cpp
    Exec.cpp
    FileInfo.cpp

--- a/src/cpp/core/Debug.cpp
+++ b/src/cpp/core/Debug.cpp
@@ -1,0 +1,55 @@
+/*
+ * Debug.cpp
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/Debug.hpp>
+
+namespace rstudio {
+namespace core {
+namespace debug {
+
+void logToNotepad(const char* fmt, ...)
+{
+#ifdef _WIN32
+
+   // try to find Notepad window
+   HWND hNotepad = ::FindWindow("Notepad", NULL);
+   if (hNotepad == NULL)
+      return;
+
+   // try to find Notepad's edit surface
+   HWND hEdit = ::FindWindowEx(hNotepad, NULL, "EDIT", NULL);
+   if (hEdit == NULL)
+      return;
+
+   // generate log message
+   char buffer[512];
+   va_list args;
+   va_start(args, fmt);
+   vsprintf(buffer, fmt, args);
+   va_end(args);
+
+   // append newline + null terminator
+   strcat(buffer, "\r\n");
+
+   // send message
+   ::SendMessage(hEdit, EM_REPLACESEL, TRUE, (LPARAM) buffer);
+#endif
+}
+
+} // namespace debug
+} // namespace core
+} // namespace rstudio
+
+

--- a/src/cpp/core/Debug.cpp
+++ b/src/cpp/core/Debug.cpp
@@ -19,10 +19,9 @@ namespace rstudio {
 namespace core {
 namespace debug {
 
+#ifdef _WIN32
 void logToNotepad(const char* fmt, ...)
 {
-#ifdef _WIN32
-
    // try to find Notepad window
    HWND hNotepad = ::FindWindow("Notepad", NULL);
    if (hNotepad == NULL)
@@ -45,8 +44,8 @@ void logToNotepad(const char* fmt, ...)
 
    // send message
    ::SendMessage(hEdit, EM_REPLACESEL, TRUE, (LPARAM) buffer);
-#endif
 }
+#endif
 
 } // namespace debug
 } // namespace core

--- a/src/cpp/core/include/core/Debug.hpp
+++ b/src/cpp/core/include/core/Debug.hpp
@@ -48,9 +48,11 @@ void print(const ConvertibleToArray& object, std::ostream& os = std::cerr)
    os << std::endl;
 }
 
+#ifdef _WIN32
 // log messages to an open Notepad window
 // (useful when you just need to dump logs somewhere easily visible)
 void logToNotepad(const char* fmt, ...);
+#endif
 
 } // namespace debug
 } // namespace core

--- a/src/cpp/core/include/core/Debug.hpp
+++ b/src/cpp/core/include/core/Debug.hpp
@@ -48,6 +48,10 @@ void print(const ConvertibleToArray& object, std::ostream& os = std::cerr)
    os << std::endl;
 }
 
+// log messages to an open Notepad window
+// (useful when you just need to dump logs somewhere easily visible)
+void logToNotepad(const char* fmt, ...);
+
 } // namespace debug
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/system/FileScanner.hpp
+++ b/src/cpp/core/include/core/system/FileScanner.hpp
@@ -60,6 +60,7 @@ inline Error scanFiles(const FileInfo& fromRoot,
    return scanFiles(pTree->set_head(fromRoot), options, pTree);
 }
 
+void stopFileScanner();
 
 } // namespace system
 } // namespace core

--- a/src/cpp/core/include/core/system/FileScanner.hpp
+++ b/src/cpp/core/include/core/system/FileScanner.hpp
@@ -60,8 +60,6 @@ inline Error scanFiles(const FileInfo& fromRoot,
    return scanFiles(pTree->set_head(fromRoot), options, pTree);
 }
 
-void stopFileScanner();
-
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -31,6 +31,8 @@ namespace system {
 
 namespace {
 
+bool s_stopRequested = false;
+
 #if defined(__APPLE__) && !defined(HAVE_SCANDIR_POSIX)
 int entryFilter(struct dirent *entry)
 #else
@@ -97,6 +99,10 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
                 const FileScannerOptions& options,
                 tree<FileInfo>* pTree)
 {
+   // bail if requested
+   if (s_stopRequested)
+      return Success();
+
    // clear all existing
    pTree->erase_children(fromNode);
 
@@ -191,6 +197,11 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
 
    // return success
    return Success();
+}
+
+void stopFileScanner()
+{
+   s_stopRequested = true;
 }
 
 } // namespace system

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -99,10 +99,6 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
                 const FileScannerOptions& options,
                 tree<FileInfo>* pTree)
 {
-   // bail if requested
-   if (s_stopRequested)
-      return Success();
-
    // clear all existing
    pTree->erase_children(fromNode);
 
@@ -130,6 +126,10 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over the names
    for (const std::string& name : names)
    {
+      // bail if requested
+      if (s_stopRequested)
+         return Success();
+
       // compute the path
       std::string path = rootPath.completeChildPath(name).getAbsolutePath();
 

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -31,7 +31,7 @@ namespace system {
 
 namespace {
 
-bool s_stopRequested = false;
+std::atomic<bool> s_stopRequested(false);
 
 #if defined(__APPLE__) && !defined(HAVE_SCANDIR_POSIX)
 int entryFilter(struct dirent *entry)

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -19,8 +19,9 @@
 #include <sys/stat.h>
 
 #include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
+
+#include <core/Log.hpp>
 #include <core/BoostThread.hpp>
 
 #include "config.h"
@@ -30,8 +31,6 @@ namespace core {
 namespace system {
 
 namespace {
-
-std::atomic<bool> s_stopRequested(false);
 
 #if defined(__APPLE__) && !defined(HAVE_SCANDIR_POSIX)
 int entryFilter(struct dirent *entry)
@@ -126,9 +125,8 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over the names
    for (const std::string& name : names)
    {
-      // bail if requested
-      if (s_stopRequested)
-         return Success();
+      // check for interrupts
+      boost::this_thread::interruption_point();
 
       // compute the path
       std::string path = rootPath.completeChildPath(name).getAbsolutePath();
@@ -197,11 +195,6 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
 
    // return success
    return Success();
-}
-
-void stopFileScanner()
-{
-   s_stopRequested = true;
 }
 
 } // namespace system

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -18,6 +18,7 @@
 #include <boost/system/windows_error.hpp>
 
 #include <core/BoostThread.hpp>
+#include <core/Debug.hpp>
 #include <core/FileInfo.hpp>
 #include <core/Log.hpp>
 
@@ -29,6 +30,9 @@ namespace core {
 namespace system {
 
 namespace {
+
+// stop requested by user
+bool s_stopRequested = false;
 
 FileInfo convertToFileInfo(const FilePath& filePath, bool yield, int *pCount)
 {
@@ -115,6 +119,10 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over entries
    for (const FileInfo& childFileInfo : childrenFileInfo)
    {
+      // bail if we've requested a stop
+      if (s_stopRequested)
+         return Success();
+
       // apply filter if we have one
       if (options.filter && !options.filter(childFileInfo))
          continue;
@@ -141,6 +149,10 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    return Success();
 }
 
+void stopFileScanner()
+{
+   s_stopRequested = true;
+}
 
 } // namespace system
 } // namespace core

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -32,7 +32,7 @@ namespace system {
 namespace {
 
 // stop requested by user
-bool s_stopRequested = false;
+std::atomic<bool> s_stopRequested(false);
 
 FileInfo convertToFileInfo(const FilePath& filePath, bool yield, int *pCount)
 {

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -31,9 +31,6 @@ namespace system {
 
 namespace {
 
-// stop requested by user
-std::atomic<bool> s_stopRequested(false);
-
 FileInfo convertToFileInfo(const FilePath& filePath, bool yield, int *pCount)
 {
    // yield every 10 files (defend against pegging the cpu for directories
@@ -119,9 +116,8 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over entries
    for (const FileInfo& childFileInfo : childrenFileInfo)
    {
-      // bail if we've requested a stop
-      if (s_stopRequested)
-         return Success();
+      // check for interrupts
+      boost::this_thread::interruption_point();
 
       // apply filter if we have one
       if (options.filter && !options.filter(childFileInfo))
@@ -147,11 +143,6 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
 
    // return success
    return Success();
-}
-
-void stopFileScanner()
-{
-   s_stopRequested = true;
 }
 
 } // namespace system

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -627,16 +627,16 @@ void initialize()
 
 void stop()
 {
+   // stop the file scanner
+   core::system::stopFileScanner();
+
    if (s_fileMonitorThread.joinable())
    {
       s_fileMonitorThread.interrupt();
-
-      // wait for for the thread to stop
       if (!s_fileMonitorThread.timed_join(boost::posix_time::seconds(3)))
       {
          LOG_WARNING_MESSAGE("file monitor thread didn't stop on its own");
       }
-
       s_fileMonitorThread.detach();
    }
 }

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -21,8 +21,10 @@
 #include <boost/bind.hpp>
 #include <boost/algorithm/string.hpp>
 
-#include <core/Log.hpp>
 #include <shared_core/Error.hpp>
+
+#include <core/Debug.hpp>
+#include <core/Log.hpp>
 #include <core/Thread.hpp>
 #include <core/PeriodicCommand.hpp>
 
@@ -544,7 +546,7 @@ void fileMonitorThreadMain()
       running = true;
       file_monitor::detail::run(boost::bind(checkForInput));
    }
-   catch(const boost::thread_interrupted&)
+   catch (const boost::thread_interrupted&)
    {
    }
    CATCH_UNEXPECTED_EXCEPTION
@@ -564,7 +566,9 @@ void fileMonitorThreadMain()
       // allow the implementation a chance to stop completely (e.g. may
       // need to wait for pending async operations to complete)
       if (running)
+      {
          detail::stop();
+      }
    }
    CATCH_UNEXPECTED_EXCEPTION
 }
@@ -627,9 +631,6 @@ void initialize()
 
 void stop()
 {
-   // stop the file scanner
-   core::system::stopFileScanner();
-
    if (s_fileMonitorThread.joinable())
    {
       s_fileMonitorThread.interrupt();

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -42,9 +42,6 @@ namespace {
 // buffer size for notifications (cannot be > 64kb for network drives)
 const std::size_t kBuffSize = 32768;
 
-// set of currently active monitor handles
-std::set<Handle> s_monitorHandles;
-
 // stop requested for file monitor
 std::atomic<bool> s_stopRequested(false);
 
@@ -587,9 +584,6 @@ Handle registerMonitor(const core::FilePath& filePath,
    // notify the caller that we have successfully registered
    callbacks.onRegistered(pContext->handle, pContext->fileTree);
 
-   // register handle
-   s_monitorHandles.insert(pContext->handle);
-
    // return the handle
    return pContext->handle;
 }
@@ -597,9 +591,6 @@ Handle registerMonitor(const core::FilePath& filePath,
 // unregister a file monitor
 void unregisterMonitor(Handle handle)
 {
-   // remove from registry
-   s_monitorHandles.erase(handle);
-
    // this will end up calling the completion routine with
    // ERROR_OPERATION_ABORTED at which point we'll delete the context
    cleanupContext((FileEventContext*)(handle.pData));


### PR DESCRIPTION
When RStudio is initialized with a project, it registers a file monitor for that project. This entails scanning the files used within that project recursively, which can be slow for projects with many files (e.g. RStudio itself).

When we try to stop the file monitor, we were previously forced to wait for an in-flight registration to complete (or for 3 seconds, after which we just detached the thread and continued trying to exit).

With this change, when we stop the file monitor, we also tell the file scanner to stop (hence "finishing" the registration of the file monitor early), which then gives us a chance to properly close and clean up the file monitor.

As a bonus ... this PR also adds `logToNotepad()`, a simple helper function for logging text to a Notepad window, for cases on Windows where you just need some debug output to show up somewhere easily accessible.

Ultimately, I think this change is probably too risky for v1.3 so I'd say we just take this for v1.4.

Closes https://github.com/rstudio/rstudio/issues/7117.