### PR TITLE
Fix up toolbar buttons and commands

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
@@ -41,6 +41,7 @@ public class SourceAppCommand
                                               String buttonTitle,
                                               ImageResourceProvider imageResourceProvider,
                                               ClickHandler clickHandler,
+                                              /* false when button is managed elsewhere */
                                               boolean synced)
       {
          super(buttonLabel, buttonTitle, imageResourceProvider, clickHandler);
@@ -147,22 +148,9 @@ public class SourceAppCommand
       return createToolbarButton(true);
    }
 
-   public ToolbarButton createToolbarButton(boolean synced)
+   public ToolbarButton createUnsyncedToolbarButton()
    {
-      CommandSourceColumnToolbarButton button =
-         new CommandSourceColumnToolbarButton(
-            this,
-            command_.getButtonLabel(),
-            command_.getDesc(),
-            command_,
-            event -> {
-               columnManager_.setActive(column_);
-               command_.execute();
-            },
-            synced);
-      if (command_.getTooltip() != null)
-         button.setTitle(command_.getTooltip());
-      return button;
+      return createToolbarButton(false);
    }
 
    public MenuItem createMenuItem()
@@ -198,6 +186,24 @@ public class SourceAppCommand
       if (setCommand)
          command_.setEnabled(commandEnabled);
       handlers_.fireEvent((new EnabledChangedEvent(command_, column_, buttonVisible)));
+   }
+
+   private ToolbarButton createToolbarButton(boolean synced)
+   {
+      CommandSourceColumnToolbarButton button =
+         new CommandSourceColumnToolbarButton(
+            this,
+            command_.getButtonLabel(),
+            command_.getDesc(),
+            command_,
+            event -> {
+               columnManager_.setActive(column_);
+               command_.execute();
+            },
+            synced);
+      if (command_.getTooltip() != null)
+         button.setTitle(command_.getTooltip());
+      return button;
    }
 
    private boolean buttonVisible_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -613,7 +613,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    {
       if (activeEditor_ != null)
          return activeEditor_;
-      if (display_.getActiveTabIndex() > 0 &&
+      if (display_.getActiveTabIndex() > -1 &&
          editors_.size() > display_.getActiveTabIndex())
          return editors_.get(display_.getActiveTabIndex());
       return null;
@@ -698,7 +698,6 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       else
       {
          HashSet<AppCommand> commandsToEnable = new HashSet<>(newCommands);
-         commandsToEnable.removeAll(activeCommands_);
 
          for (AppCommand command : commandsToEnable)
          {
@@ -822,6 +821,8 @@ public class SourceColumn implements BeforeShowEvent.Handler,
                      getNextActiveEditor().getExtendedFileType() == SourceDocument.XT_PLUMBER_API));
       boolean cmdEnabled = rsCommandsAvailable && active;
 
+      getSourceCommand(commands_.rsconnectConfigure()).setVisible(false);
+      getSourceCommand(commands_.rsconnectDeploy()).setVisible(false);
       getSourceCommand(commands_.rsconnectDeploy()).setVisible(active, cmdEnabled, rsCommandsAvailable);
       if (active)
       {
@@ -849,13 +850,15 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
    private void manageRMarkdownCommands(boolean active)
    {
-      boolean rmdCommandsAvailable = active &&
+      boolean rmdCommandsAvailable =
               manager_.getSession().getSessionInfo().getRMarkdownPackageAvailable() &&
                       activeEditor_ != null &&
                       activeEditor_.getExtendedFileType() != null &&
                       activeEditor_.getExtendedFileType().startsWith(SourceDocument.XT_RMARKDOWN_PREFIX);
-      getSourceCommand(commands_.editRmdFormatOptions()).setVisible(rmdCommandsAvailable);
-      getSourceCommand(commands_.editRmdFormatOptions()).setEnabled(rmdCommandsAvailable);
+      getSourceCommand(commands_.editRmdFormatOptions()).setVisible(false);
+      getSourceCommand(commands_.editRmdFormatOptions()).setEnabled(false);
+      getSourceCommand(commands_.editRmdFormatOptions()).setVisible(active && rmdCommandsAvailable, rmdCommandsAvailable, rmdCommandsAvailable);
+      getSourceCommand(commands_.editRmdFormatOptions()).setEnabled(active && rmdCommandsAvailable, rmdCommandsAvailable,rmdCommandsAvailable);
    }
 
    private void manageSynctexCommands(boolean active)
@@ -877,6 +880,8 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       }
 
       boolean cmdEnabled = active && synctexAvailable;
+      getSourceCommand(commands_.synctexSearch()).setVisible(false);
+      getSourceCommand(commands_.synctexSearch()).setEnabled(false);
       getSourceCommand(commands_.synctexSearch()).setVisible(active, cmdEnabled, synctexAvailable);
       getSourceCommand(commands_.synctexSearch()).setEnabled(active, cmdEnabled, synctexAvailable);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -141,10 +141,6 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                               Provider<FileMRUList> pMruList,
                               SourceWindowManager windowManager)
    {
-      SourceColumn column = GWT.create(SourceColumn.class);
-      column.loadDisplay(MAIN_SOURCE_NAME, display, this);
-      columnList_.add(column);
-
       commands_ = commands;
       binder.bind(commands_, this);
 
@@ -260,6 +256,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             return columnState_.cast();
          }
       };
+      SourceColumn column = GWT.create(SourceColumn.class);
+      column.loadDisplay(MAIN_SOURCE_NAME, display, this);
+      columnList_.add(column);
+
       setActive(column.getName());
    }
 
@@ -471,7 +471,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public int getPhysicalTabIndex()
    {
-      return activeColumn_.getPhysicalTabIndex();
+      if (getActive() != null)
+         return getActive().getPhysicalTabIndex();
+      else
+         return -1;
    }
 
    public ArrayList<String> getNames(boolean excludeMain)
@@ -602,6 +605,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       commands_.sourceNavigateBack().setEnabled(
          sourceNavigationHistory_.isBackEnabled());
    }
+
    public EditingTarget addTab(SourceDocument doc, int mode, SourceColumn column)
    {
       if (column == null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -351,7 +351,7 @@ public class TextEditingTargetWidget
       toolbar.addLeftWidget(previewHTMLButton_ =
          mgr.getSourceCommand(commands_.previewHTML(), column_).createToolbarButton());
       knitDocumentButton_ =
-         mgr.getSourceCommand(commands_.knitDocument(), column_).createToolbarButton(false);
+         mgr.getSourceCommand(commands_.knitDocument(), column_).createUnsyncedToolbarButton();
       knitDocumentButton_.getElement().getStyle().setMarginRight(0, Unit.PX);
       toolbar.addLeftWidget(knitDocumentButton_);
 
@@ -429,18 +429,18 @@ public class TextEditingTargetWidget
 
       // create button that just runs default chunk insertion
       insertChunkButton_ = 
-         mgr.getSourceCommand(commands_.insertChunk(), column_).createToolbarButton(false);
+         mgr.getSourceCommand(commands_.insertChunk(), column_).createUnsyncedToolbarButton();
       toolbar.addRightWidget(insertChunkButton_);
 
       toolbar.addRightWidget(runButton_ = 
-         mgr.getSourceCommand(commands_.executeCode(), column_).createToolbarButton(false));
+         mgr.getSourceCommand(commands_.executeCode(), column_).createUnsyncedToolbarButton());
       toolbar.addRightSeparator();
       toolbar.addRightWidget(runLastButton_ = 
-         mgr.getSourceCommand(commands_.executeLastCode(), column_).createToolbarButton(false));
+         mgr.getSourceCommand(commands_.executeLastCode(), column_).createUnsyncedToolbarButton());
       toolbar.addRightWidget(goToPrevButton_ = 
-         mgr.getSourceCommand(commands_.goToPrevSection(), column_).createToolbarButton(false));
+         mgr.getSourceCommand(commands_.goToPrevSection(), column_).createUnsyncedToolbarButton());
       toolbar.addRightWidget(goToNextButton_ = 
-         mgr.getSourceCommand(commands_.goToNextSection(), column_).createToolbarButton(false));
+         mgr.getSourceCommand(commands_.goToNextSection(), column_).createUnsyncedToolbarButton());
       toolbar.addRightSeparator();
       final String SOURCE_BUTTON_TITLE = "Source the active document";
 
@@ -457,11 +457,11 @@ public class TextEditingTargetWidget
       toolbar.addRightWidget(sourceButton_);
 
       previewJsButton_ = 
-         mgr.getSourceCommand(commands_.previewJS(), column_).createToolbarButton(false);
+         mgr.getSourceCommand(commands_.previewJS(), column_).createUnsyncedToolbarButton();
       toolbar.addRightWidget(previewJsButton_);
 
       previewSqlButton_ = 
-         mgr.getSourceCommand(commands_.previewSql(), column_).createToolbarButton(false);
+         mgr.getSourceCommand(commands_.previewSql(), column_).createUnsyncedToolbarButton();
       toolbar.addRightWidget(previewSqlButton_);
 
       createTestToolbarButtons(toolbar);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -351,7 +351,7 @@ public class TextEditingTargetWidget
       toolbar.addLeftWidget(previewHTMLButton_ =
          mgr.getSourceCommand(commands_.previewHTML(), column_).createToolbarButton());
       knitDocumentButton_ =
-         mgr.getSourceCommand(commands_.knitDocument(), column_).createToolbarButton();
+         mgr.getSourceCommand(commands_.knitDocument(), column_).createToolbarButton(false);
       knitDocumentButton_.getElement().getStyle().setMarginRight(0, Unit.PX);
       toolbar.addLeftWidget(knitDocumentButton_);
 
@@ -429,18 +429,18 @@ public class TextEditingTargetWidget
 
       // create button that just runs default chunk insertion
       insertChunkButton_ = 
-         mgr.getSourceCommand(commands_.insertChunk(), column_).createToolbarButton();
+         mgr.getSourceCommand(commands_.insertChunk(), column_).createToolbarButton(false);
       toolbar.addRightWidget(insertChunkButton_);
 
       toolbar.addRightWidget(runButton_ = 
-         mgr.getSourceCommand(commands_.executeCode(), column_).createToolbarButton());
+         mgr.getSourceCommand(commands_.executeCode(), column_).createToolbarButton(false));
       toolbar.addRightSeparator();
       toolbar.addRightWidget(runLastButton_ = 
-         mgr.getSourceCommand(commands_.executeLastCode(), column_).createToolbarButton());
+         mgr.getSourceCommand(commands_.executeLastCode(), column_).createToolbarButton(false));
       toolbar.addRightWidget(goToPrevButton_ = 
-         mgr.getSourceCommand(commands_.goToPrevSection(), column_).createToolbarButton());
+         mgr.getSourceCommand(commands_.goToPrevSection(), column_).createToolbarButton(false));
       toolbar.addRightWidget(goToNextButton_ = 
-         mgr.getSourceCommand(commands_.goToNextSection(), column_).createToolbarButton());
+         mgr.getSourceCommand(commands_.goToNextSection(), column_).createToolbarButton(false));
       toolbar.addRightSeparator();
       final String SOURCE_BUTTON_TITLE = "Source the active document";
 
@@ -457,11 +457,11 @@ public class TextEditingTargetWidget
       toolbar.addRightWidget(sourceButton_);
 
       previewJsButton_ = 
-         mgr.getSourceCommand(commands_.previewJS(), column_).createToolbarButton();
+         mgr.getSourceCommand(commands_.previewJS(), column_).createToolbarButton(false);
       toolbar.addRightWidget(previewJsButton_);
 
       previewSqlButton_ = 
-         mgr.getSourceCommand(commands_.previewSql(), column_).createToolbarButton();
+         mgr.getSourceCommand(commands_.previewSql(), column_).createToolbarButton(false);
       toolbar.addRightWidget(previewSqlButton_);
 
       createTestToolbarButtons(toolbar);


### PR DESCRIPTION
This PR adds some functionality #7305 missed when managing command icons across source columns. Specifically, it allows a button to not be synced with its command and the `SourceColumnManager`. 

`SourceAppCommand` now saves whether the button(s) for the command are visible or not so that the buttons can be properly set on attachment if the command was managed before the event handlers were added.