### PR TITLE
Fix VirtualConsole handling of specific line rewriting boundary case

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -295,17 +295,27 @@ public class VirtualConsole
                // extend the original range
                overlap.appendLeft(range.text(), delta);
 
-               // If we previously inserted the new range (i.e. overlapped a prior
-               // range that had a different clazz) then undo that and use the one
-               // we found with the same clazz.
-               range.clearText();
-               if (haveInsertedRange)
+               // if the original range becomes empty, then delete it
+               if (overlap.length == 0)
                {
-                  insertions.remove(range);
-                  haveInsertedRange = false;
+                  deletions.add(l);
+                  if (parent_ != null)
+                     parent_.removeChild(overlap.element);
                }
+               else
+               {
+                  // If we previously inserted the new range (i.e. overlapped a prior
+                  // range that had a different clazz) then undo that and use the one
+                  // we found with the same clazz.
+                  range.clearText();
+                  if (haveInsertedRange)
+                  {
+                     insertions.remove(range);
+                     haveInsertedRange = false;
+                  }
 
-               moves.put(l, start);
+                  moves.put(l, start);
+               }
             }
             else
             {

--- a/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
+++ b/src/gwt/test/org/rstudio/core/client/ConsoleOutputWriterTests.java
@@ -670,4 +670,15 @@ public class ConsoleOutputWriterTests extends GWTTestCase
          "<span class=\"myClass\"> zzz\n</span>",
          getInnerHTML(output));
    }
+
+   public void test18()
+   {
+      // https://github.com/rstudio/rstudio/issues/7278
+      ConsoleOutputWriter output = getCOW();
+      output.outputToConsole("B\033[31mx\033[39mA", myClass, notError, ignoreLineCount, false);
+      output.outputToConsole("\r   ", myClass, notError, ignoreLineCount, false);
+      output.outputToConsole("\rMessage\n", myClass, notError, ignoreLineCount, false);
+      Assert.assertEquals(1, output.getCurrentLines());
+      Assert.assertEquals("<span class=\"myClass\">Message\n</span>", getInnerHTML(output));
+   }
 }


### PR DESCRIPTION
- Fixes #7278

Another edge case with ANSI codes and rewriting lines via `\r`.