### PR TITLE
Pop out navigated URL if known

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,3 +68,5 @@
 * Added CSRF protection to sign-in pages (Pro #1469)
 * Fixed issue that allowed multiple concurrent sign-in requests (#6502)
 * Fixed issue where the admin logs page could sometimes crash due to a malformed log statement (Pro #1768)
+* Fixed issue where the URL popped out by the Viewer pane was incorrect after navigation (#6967)
+

--- a/src/gwt/src/org/rstudio/core/client/dom/IFrameElementEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/IFrameElementEx.java
@@ -28,6 +28,31 @@ public class IFrameElementEx extends IFrameElement
       return this.contentWindow;
    }-*/;
    
+   /**
+    * Gets the URL currently displayed in the IFrame, or null if the URL cannot
+    * be determined.
+    * 
+    * @return The current URL displayed in the IFrame.
+    */
+   public final String getCurrentUrl()
+   {
+      String url = null;
+      try 
+      {
+         if (getContentWindow() != null)
+         {
+            url = getContentWindow().getLocationHref();
+         }
+      }
+      catch (Exception e)
+      {
+         // attempting to get the URL can throw with a DOM security exception if
+         // the current URL is on another domain--in this case we'll just want 
+         // to return null, so eat the exception.
+      }
+      return url;
+   }
+   
    public final void setFocus()
    {
       if (BrowseCap.isInternetExplorer())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -232,6 +232,15 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       {
          globalDisplay_.showHtmlFile(rmdPreviewParams_.getOutputFile());
       }
+      else if (frame_ != null &&
+          !StringUtil.equals(frame_.getIFrame().getCurrentUrl(), getUrl()))
+      {
+         // Typically we navigate to the unmodified URL (i.e. without the
+         // viewer_pane=1 query params, etc.) However, if the URL currently
+         // loaded in the frame is different, the user probably navigated away
+         // from original URL, so load that URL as-is.
+         globalDisplay_.openWindow(frame_.getIFrame().getCurrentUrl());
+      }
       else if (unmodifiedUrl_ != null)
       {
          globalDisplay_.openWindow(unmodifiedUrl_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -233,6 +233,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
          globalDisplay_.showHtmlFile(rmdPreviewParams_.getOutputFile());
       }
       else if (frame_ != null &&
+          frame_.getIFrame().getCurrentUrl() != null &&
           !StringUtil.equals(frame_.getIFrame().getCurrentUrl(), getUrl()))
       {
          // Typically we navigate to the unmodified URL (i.e. without the


### PR DESCRIPTION
This is a drive-by fix for https://github.com/rstudio/rstudio/issues/6967. The bug is effectively that navigating in the Viewer pane causes the pop-out button to not work (it pops out the URL that initially loaded in the pane, not the one you're looking at). 

The reason we don't pop out the current URL is that the current URL has a bunch of goo on it that we don't want to include in the popped out URL (`&viewer_pane=1`, etc. etc). There are also circumstances where we can't read the current URL. 

So the fix is a little more subtle than just using the current URL. We now attempt to figure out whether you've navigated based on whether or not the current URL has changed from the original one. If it has, we show you the new URL instead of the one you were originally looking at.

Fixes https://github.com/rstudio/rstudio/issues/6967.