### PR TITLE
fix issue with file monitor taking long time to shut down

### DIFF
--- a/src/cpp/.gitignore
+++ b/src/cpp/.gitignore
@@ -1,6 +1,7 @@
-CMakeLists.txt.user*
+.vs/
 .ycm_extra_conf.py
 .ycm_extra_conf.pyc
-.vs/
+CMakeLists.txt.user*
+CMakeSettings.json
 compile_commands.json
-
+out/

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -124,6 +124,9 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over the names
    for (const std::string& name : names)
    {
+      // check for interrupt
+      boost::this_thread::interruption_point();
+
       // compute the path
       std::string path = rootPath.completeChildPath(name).getAbsolutePath();
 

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -125,7 +125,8 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    for (const std::string& name : names)
    {
       // check for interrupt
-      boost::this_thread::interruption_point();
+      if (boost::this_thread::interruption_requested())
+         return core::systemError(boost::system::errc::interrupted, ERROR_LOCATION);
 
       // compute the path
       std::string path = rootPath.completeChildPath(name).getAbsolutePath();

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -115,6 +115,9 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over entries
    for (const FileInfo& childFileInfo : childrenFileInfo)
    {
+      // check for interrupts
+      boost::this_thread::interruption_point();
+
       // apply filter if we have one
       if (options.filter && !options.filter(childFileInfo))
          continue;

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -116,7 +116,8 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    for (const FileInfo& childFileInfo : childrenFileInfo)
    {
       // check for interrupts
-      boost::this_thread::interruption_point();
+      if (boost::this_thread::interruption_requested())
+         return core::systemError(boost::system::errc::interrupted, ERROR_LOCATION);
 
       // apply filter if we have one
       if (options.filter && !options.filter(childFileInfo))

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -93,7 +93,8 @@ void safeCloseHandle(HANDLE hObject, const ErrorLocation& location)
    {
       if (!::CloseHandle(hObject))
       {
-         LOG_ERROR(LAST_SYSTEM_ERROR());
+         auto error = LAST_SYSTEM_ERROR();
+         core::log::logError(error, location);
       }
    }
 }
@@ -238,7 +239,7 @@ void processFileChanges(FileEventContext* pContext,
 
    // cycle through the entries in the buffer
    char* pBuffer = (char*)&pContext->handlingBuffer[0];
-   while(true)
+   while (true)
    {
       // check for buffer pointer which has overflowed the end (apparently this
       // can happen if the underlying directory is deleted)
@@ -424,7 +425,7 @@ VOID CALLBACK FileChangeCompletionRoutine(DWORD dwErrorCode,
    // check for buffer overflow. this means there are too many file changes
    // for the systme to keep up with -- in this case try to restart monitoring
    // (after a 1 second delay) and repeat the restart up to 10 times
-   if(dwNumberOfBytesTransfered == 0)
+   if (dwNumberOfBytesTransfered == 0)
    {
       // attempt to restart monitoring
       enqueRestartMonitoring(pContext);

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -25,6 +25,7 @@
 
 #include <shared_core/FilePath.hpp>
 
+#include <core/BoostThread.hpp>
 #include <core/system/FileScanner.hpp>
 #include <core/system/System.hpp>
 
@@ -537,15 +538,17 @@ Handle registerMonitor(const core::FilePath& filePath,
    options.yield = true;
    options.filter = filter;
    error = scanFiles(FileInfo(filePath), options, &pContext->fileTree);
+
    if (error)
    {
-       // cleanup
-       cleanupContext(pContext);
+      // cleanup
+      cleanupContext(pContext);
 
-       // return error
-       callbacks.onRegistrationError(error);
+      // return error
+      callbacks.onRegistrationError(error);
 
-       return Handle();
+      // otherwise just return empty handle
+      return Handle();
    }
 
    // now that we have finished the file listing we know we have a valid

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -606,11 +606,15 @@ void run(const boost::function<void()>& checkForInput)
 void stop()
 {
    // stop any active requests
-   for (Handle handle : s_handleRegistry)
+   LOCK_MUTEX(s_handleMutex)
    {
-      FileEventContext* pContext = (FileEventContext*) handle.pData;
-      cleanupContext(pContext);
+      for (Handle handle : s_handleRegistry)
+      {
+         FileEventContext* pContext = (FileEventContext*)handle.pData;
+         cleanupContext(pContext);
+      }
    }
+   END_LOCK_MUTEX
 }
 
 } // namespace detail


### PR DESCRIPTION
When RStudio is initialized with a project, it registers a file monitor for that project. This entails scanning the files used within that project recursively, which can be slow for projects with many files (e.g. RStudio itself).

When we try to stop the file monitor, we were previously forced to wait for an in-flight registration to complete (or for 3 seconds, after which we just detached the thread and continued trying to exit).

This PR instead allows us to eagerly clean up and delete the context when a stop is requested. In case any completion requests are made after the context has been removed, we just check to see if the operation was aborted before attempting to access the associated context.

It seems like a lot of care was put into making sure the completion handler is the one to clean up the completion context struct, but I don't think this is necessary -- ultimately, the completion routine is just run on the same thread at an appropriate time, e.g. in response to `::SleepEx(..., TRUE)` as is done in the main thread's loop. We just need to check whether the completion routine was cancelled before attempting to run it.

Closes #7117.

