### PR TITLE
Change focus rectangle option description to "Always show focus outlines"

### DIFF
--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1199,7 +1199,7 @@
         "show_focus_rectangles": {
             "type": "boolean",
             "default": true,
-            "title": "Show focus rectangles",
+            "title": "Always show focus outlines",
             "description": "Control with keyboard focus displays a visual focus indicator."
         },
         "auto_save_on_idle": {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2557,7 +2557,7 @@ public class UserPrefsAccessor extends Prefs
    {
       return bool(
          "show_focus_rectangles",
-         "Show focus rectangles", 
+         "Always show focus outlines", 
          "Control with keyboard focus displays a visual focus indicator.", 
          true);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -67,7 +67,7 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       generalPanel.add(checkboxPref("Reduce user interface animations", prefs.reducedMotion()));
       chkTabMovesFocus_ = new CheckBox("Tab key always moves focus");
       generalPanel.add(lessSpaced(chkTabMovesFocus_));
-      chkShowFocusRectangles_ = new CheckBox("Show focus rectangles (requires restart)");
+      chkShowFocusRectangles_ = new CheckBox("Always show focus outlines (requires restart)");
       generalPanel.add(chkShowFocusRectangles_);
 
       HelpLink helpLink = new HelpLink("RStudio accessibility help", "rstudio_a11y", false);


### PR DESCRIPTION
- Suggested by @daattali
- Tweak to fix for #7242, which said "Show focus rectangles"
- Better represents what this option does (i.e. when off, not **_all_** focus outlines are suppressed)