### PR TITLE
avoid re-encoding character inputs for environment pane display

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -356,6 +356,14 @@ if(UNIX AND NOT APPLE)
 )
 endif()
 
+# configure launch settings (for Visual Studio on Windows)
+if(WIN32)
+   configure_file(
+      "${CMAKE_CURRENT_SOURCE_DIR}/launch.vs.json.in"
+      "${CMAKE_CURRENT_BINARY_DIR}/launch.vs.json"
+      @ONLY)
+endif()
+
 # define executable (Windows & Linux)
 if(NOT APPLE)
 

--- a/src/cpp/desktop/launch.vs.json.in
+++ b/src/cpp/desktop/launch.vs.json.in
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.1",
+  "defaults": {},
+  "configurations": [
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "rstudio.exe (desktop\\rstudio.exe)",
+      "name": "rstudio.exe (desktop\\rstudio.exe)",
+      "env": {
+        "RS_CRASH_HANDLER_PATH": "@RS_CRASH_HANDLER_PATH@",
+        "QT_PLUGIN_PATH": "@QT_PLUGIN_PATH@",
+        "PATH": "@QT_BINARY_PATH@;${env.PATH}"
+      }
+    }
+  ]
+}

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -24,61 +24,94 @@
 .rs.addFunction("valueAsString", function(val)
 {
    tryCatch(
-   {
-      is.scalarOrVector <- function (x) {
-         if (is.null(attributes(x)))
-         {
-            !is.na(c(NULL=TRUE,
-                     logical=TRUE,
-                     double=TRUE,
-                     integer=TRUE,
-                     complex=TRUE,
-                     character=TRUE)[typeof(x)])
-         }
-         else
-         {
-            FALSE
-         }
-      }
+      .rs.valueAsStringImpl(val),
+      error = function(e) "NO_VALUE"
+   )
+})
 
-      if (is.scalarOrVector(val))
+.rs.addFunction("valueAsStringImpl", function(val)
+{
+   if (is.null(val))
+   {
+      "NULL"
+   }
+   else if (is.character(val) && !is.object(val))
+   {
+      # for plain character variables, we 'mock' the behavior of str()
+      # while avoiding the potential for re-encoding (as this could mangle
+      # UTF-8 characters on Windows)
+      n <- length(val)
+      if (n == 0)
       {
-         if (length(val) == 0)
-            return (paste(.rs.getSingleClass(val), " (empty)"))
-         if (length(val) == 1)
-         {
-            quotedVal <- deparse(val)
-            if (nchar(quotedVal) < 1024)
-                return (quotedVal)
-            else
-                return (paste(substr(quotedVal, 1, 1024), " ..."))
-         }
-         else if (length(val) > 1)
-            return (.rs.valueFromStr(val))
-         else
-            return ("NO_VALUE")
+         "character (empty)"
       }
-      else if (is(val, "python.builtin.object")) {
-         return (.rs.valueFromStr(val))
-      }
-      else if (.rs.isFunction(val))
-         return (.rs.getSignature(val))
-      else if (is(val, "Date") || is(val, "POSIXct") || is(val, "POSIXlt")) {
-         if (length(val) == 1)
-           return (format(val))
-         else
-           return (.rs.valueFromStr(val))
+      else if (n == 1)
+      {
+         encodeString(val, quote = "\"", na.encode = FALSE)
       }
       else
-         return ("NO_VALUE")
-   },
-   error = function(e) 
-   { 
-      # Don't print errors--they'll appear in the R console. Instead, let the
-      # client deal with errors by handling the special value NO_VALUE.
-   })
-
-   return ("NO_VALUE")
+      {
+         encoded <- encodeString(
+            head(val, n = 128L),
+            quote = "\"",
+            na.encode = FALSE
+         )
+         
+         fmt <- "chr [1:%i] %s"
+         txt <- sprintf(fmt, n, paste(encoded, collapse = " "))
+         .rs.truncate(txt)
+      }
+   }
+   else if (is.raw(val))
+   {
+      if (length(val) == 0)
+      {
+         "raw (empty)"
+      }
+      else
+      {
+         .rs.valueFromStr(val)
+      }
+   }
+   else if (is.atomic(val) && is.null(attributes(val)))
+   {
+      n <- length(val)
+      if (n == 0)
+      {
+         paste(.rs.getSingleClass(val), " (empty)")
+      }
+      else if (n == 1)
+      {
+         .rs.truncate(.rs.deparse(val), 1024L)
+      }
+      else
+      {
+         .rs.valueFromStr(val)
+      }
+   }
+   else if (inherits(val, "python.builtin.object"))
+   {
+      .rs.valueFromStr(val)
+   }
+   else if (.rs.isFunction(val))
+   {
+      .rs.getSignature(val)
+   }
+   else if (inherits(val, c("Date", "POSIXct", "POSIXlt")))
+   {
+      if (length(val) == 1)
+      {
+         format(val, usetz = TRUE)
+      }
+      else
+      {
+         .rs.valueFromStr(val)
+      }
+   }
+   else
+   {
+      "NO_VALUE"
+   }
 })
 
 .rs.addFunction("valueContents", function(val)


### PR DESCRIPTION
Closes https://github.com/rstudio/rstudio/issues/6877.

Finally, users will be able to view UTF-8 strings within the Environment pane on Windows. :-)

<img width="425" alt="Screen Shot 2020-07-16 at 10 25 02 PM" src="https://user-images.githubusercontent.com/1976582/87751613-480b6080-c7b3-11ea-8966-38d2ff4f45df.png">
