### PR TITLE
resolve shortcuts in file dialogs on Windows

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -260,13 +260,15 @@ QString GwtCallback::getOpenFileName(const QString& caption,
 
    dialog.setFileMode(mode);
    dialog.setLabelText(QFileDialog::Accept, label);
-#if QT_VERSION < QT_VERSION_CHECK(5, 13, 0)
-   dialog.setResolveSymlinks(false);
-#else
-   dialog.setOption(QFileDialog::DontResolveSymlinks, true);
-#endif
    dialog.setWindowModality(Qt::WindowModal);
 
+   // don't resolve links on non-Windows platforms
+   // https://github.com/rstudio/rstudio/issues/2476
+   // https://github.com/rstudio/rstudio/issues/7327
+#ifndef _WIN32
+   dialog.setOption(QFileDialog::DontResolveSymlinks, true);
+#endif
+   
    QString result;
    if (dialog.exec() == QDialog::Accepted)
       result = dialog.selectedFiles().value(0);


### PR DESCRIPTION
Closes #7327.

Note: this also re-fixes #2476. It looks like this may have regressed as part of a Qt update? The documentation in https://doc.qt.io/qt-5/qfilesystemmodel.html#resolveSymlinks-prop states, surprisingly:

> This property holds whether the directory model should resolve symbolic links
> 
> This is only relevant on Windows.
> 
> By default, this property is true.

Whereas, no such caveat holds for the `DontResolveSymlinks` flag (https://doc.qt.io/qt-5/qfilesystemmodel.html#Option-enum).

Regardless, it seems like the right solution is to disable resolution of symlinks on non-Windows via the file dialog option.