### PR TITLE
fix error in constructing string from wstring

### DIFF
--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -614,7 +614,10 @@ void setFileLocalParseOptions(const std::wstring& rCode,
    {
       std::wstring::const_iterator matchBegin = match[0].second;
       std::wstring::const_iterator matchEnd   = std::find(matchBegin, end, L'\n');
-      std::string command = string_utils::trimWhitespace(std::string(matchBegin, matchEnd));
+      
+      std::string command = string_utils::trimWhitespace(
+               string_utils::wideToUtf8(
+                  std::wstring(matchBegin, matchEnd)));
       
       if (command == "off")
       {


### PR DESCRIPTION
Fixes a small code issue where we were constructing a `std::string` directly from a `std::wstring`, without properly converting it. Noticed the issue on Windows with the associated compiler warning.