### PR TITLE
redact UID, PWD from diagnostics

### DIFF
--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -26,7 +26,7 @@ redact_regex <- function() {
   
   words <- c(
     "API", "AUTH", "GITHUB", "HOST", "HOST", "KEY", "LOGNAME",
-    "PASSWORD", "PAT", "SECRET", "TOKEN", "USERNAME"
+    "PASSWORD", "PAT", "PWD", "SECRET", "TOKEN", "UID", "USERNAME"
   )
   
   fmt <- "\\b%s\\b"


### PR DESCRIPTION
As some users, by convention, might use `_UID` and `_PWD` to indicate user IDs and passwords.