### PR TITLE
Fix Javascript exception on first-run related to obsolete addins_mru

### DIFF
--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -45,7 +45,6 @@ const char * const kProjectMru = kProjectMruList;
 const char * const kHelpHistory = "help_history_links";
 const char * const kUserDictioanry = "user_dictionary";
 const char * const kPlotPublishMru = "plot_publish_mru";
-const char * const kAddinsMru = "addins_mru";
 
 // path to lists dir
 FilePath s_listsPath;
@@ -298,7 +297,6 @@ Error initialize()
    s_lists[kHelpHistory] = 15;
    s_lists[kPlotPublishMru] = 15;
    s_lists[kUserDictioanry] = 10000;
-   s_lists[kAddinsMru] = 15;
 
    // monitor the lists directory
    s_listsPath = module_context::registerMonitoredUserScratchDir(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchListManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/WorkbenchListManager.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench;
 import java.util.ArrayList;
 import java.util.HashMap;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.events.ListChangedEvent;
@@ -103,7 +104,13 @@ public class WorkbenchListManager
     
    private void updateList(String name, ArrayList<String> list)
    {
-      listContexts_.get(name).setList(list);
+      ListContext context = listContexts_.get(name);
+      if (context == null)
+      {
+         Debug.logWarning("Unknown workbench list: " + name);
+         return;
+      }
+      context.setList(list);
    }
     
    private class ListContext implements WorkbenchList


### PR DESCRIPTION
- Removed the long-obsolete addins_mru constant that was triggering client-side attempt to index a map using a non-existent key
- Also made the code more resilient so it logs an error instead of throwing an exception
- Fixes #7395


This exception also happens in 1.3, but don't know of any specific problems it causes, so targeting master/1.4.