### PR TITLE
Include Tutorial tab in default pane schema, autocorrect incorrect order

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -8,3 +8,4 @@
 - Fix issue where Launcher debug logs could contain user's plain text password (Pro #1687)
 - Fix issue where some log entries could not be displayed on the admin logs page (Pro #1783)
 - Fix "TypeError" when sign-in using IE11 (#7359)
+- Fix problem with moving Console between left and right columns (#7246)

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -176,7 +176,7 @@
                     "Console", 
                     "TabSet1",
                     "TabSet2"],
-                "tabSet1": ["Environment", "History", "Connections", "Build", "VCS", "Presentation"],
+                "tabSet1": ["Environment", "History", "Connections", "Build", "VCS", "Tutorial", "Presentation"],
                 "tabSet2": ["Files", "Plots", "Packages", "Help", "Viewer"],
                 "console_left_on_top": false,
                 "console_right_on_top": true

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.JsArrayString;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
 
@@ -191,8 +192,19 @@ public class PaneConfig extends UserPrefsAccessor.Panes
       // last one in the tabset.
       if (ts1.get(ts1.length() - 1) != "Presentation")
       {
-         Debug.logToConsole("Invaliding tabset config (Presentation index)");
-         return false;
+         // 1.3 released with a bug where Tutorial would be added at the end; autocorrect
+         // https://github.com/rstudio/rstudio/issues/7246
+         if (StringUtil.equals(ts1.get(ts1.length() - 1), "Tutorial") &&
+             StringUtil.equals(ts1.get(ts1.length() - 2), "Presentation"))
+         {
+            ts1.set(ts1.length() - 1, "Presentation");
+            ts1.set(ts1.length() - 2, "Tutorial");
+         }
+         else
+         {
+            Debug.logToConsole("Invaliding tabset config (Presentation index)");
+            return false;
+         }
       }
       
       // If any of these tabs are missing, then they can be added


### PR DESCRIPTION
- Fixes #7246, probably some other quirky problems with pane layouts not sticking or otherwise misbehaving

## QA notes
- this affects anything related to the pane layouts (console on left or right, moving tabs between quadrants, etc)
- try using RStudio 1.3 (pre-goldenrod) and making pane layout changes that don't work such as described in the issue
- then upgrade to 1.3 goldenrod, and see if changes now behave properly
- try variations with and without the presentations tab showing
- try moving the Tutorial tab to TabSet2 (from Pane Layout options dialog)

## Gory details
- Tutorial tab wasn't listed in default pane layout schema, causing it to be added to the end of TabSet1, which violates checks in PaneConfig and can prevent pane layout changes from sticking due to them resetting in the middle of some layout commands

https://github.com/rstudio/rstudio/blob/a2951bfa6ca01ef7d5ed59518e57e556dd4abb79/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java#L187-L196

- Updating the schema only works in a clean-run scenario, so also autocorrect when wrong ordering found (e.g. upgrading from prior 1.3 version)
