### PR TITLE
Properly resize buffer during group enumeration

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -8,3 +8,4 @@
 - Fix issue where Launcher debug logs could contain user's plain text password (Pro #1687)
 - Fix issue where some log entries could not be displayed on the admin logs page (Pro #1783)
 - Fix "TypeError" when sign-in using IE11 (#7359)
+- Fix issue where users belonging to more than 101 groups could not launch Kubernetes sessions (Pro #1796)

--- a/src/cpp/core/system/PosixGroup.cpp
+++ b/src/cpp/core/system/PosixGroup.cpp
@@ -109,10 +109,6 @@ Error userGroups(const std::string& userName, std::vector<Group>* pGroups)
    if (error)
       return error;
 
-   // get the groups for the user - we start with 100 groups which should be enough for most cases
-   // if it is not, resize the buffer with the correct amount of groups and try again
-   int numGroups = 100;
-
    // define a different gid type if we are on Mac vs Linux
    // BSD expects int values, but Linux expects unsigned ints
 #ifndef __APPLE__
@@ -121,13 +117,12 @@ Error userGroups(const std::string& userName, std::vector<Group>* pGroups)
    typedef int GIDTYPE;
 #endif
 
-   boost::shared_ptr<GIDTYPE> pGids(new GIDTYPE[100]);
-   while (!getgrouplist(userName.c_str(), user.getGroupId(), pGids.get(), &numGroups))
+   // get the groups for the user - we start with 100 groups which should be enough for most cases
+   // if it is not, resize the buffer with the correct amount of groups and try again
+   int numGroups = 100;
+   boost::shared_ptr<GIDTYPE> pGids(new GIDTYPE[numGroups]);
+   while (getgrouplist(userName.c_str(), user.getGroupId(), pGids.get(), &numGroups) == -1)
    {
-      // defensive break out in case the OS somehow returns 0 groups for the user
-      if (numGroups == 0)
-         break;
-
       pGids.reset(new GIDTYPE[numGroups]);
    }
 


### PR DESCRIPTION
Fix bug where user group enumeration was not properly checking return code of `getgrouplist` to resize the buffer when needed. 

Fixes https://github.com/rstudio/rstudio-pro/issues/1796