### PR TITLE
better handle certain usages of pipe operators

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3639,7 +3639,36 @@ public class AceEditor implements DocDisplay,
             }
          }
          
-      } while (false);
+      }
+      while (false);
+      
+      // check for binary operator on start line
+      if (rowEndsInBinaryOp(startRow))
+      {
+         // move token cursor to that row
+         c.moveToEndOfRow(startRow);
+
+         // skip comments, operators, etc.
+         while (c.hasType("text", "comment", "virtual-comment", "keyword.operator"))
+         {
+            if (c.isRightBracket())
+               break;
+
+            if (!c.moveToPreviousToken())
+               break;
+         }
+
+         // if we landed on a closing bracket, look for its match
+         // and then continue search from that row. otherwise,
+         // just look back a single row
+         if (c.valueEquals(")") || c.valueEquals("]"))
+         {
+            if (c.bwdToMatchingToken())
+            {
+               startRow = c.getRow();
+            }
+         }
+      }
       
       // discover start of current statement
       while (startRow >= startRowLimit)
@@ -3648,7 +3677,7 @@ public class AceEditor implements DocDisplay,
          if (startRow <= 0)
             break;
          
-         // if the row starts with an open bracket, expand to its match
+         // if the row starts with a closing bracket, expand to its match
          if (rowStartsWithClosingBracket(startRow))
          {
             c.moveToStartOfRow(startRow);
@@ -3659,15 +3688,50 @@ public class AceEditor implements DocDisplay,
             }
          }
          
-         // keep going if the line is empty or previous ends w/binary op
-         if (rowEndsInBinaryOp(startRow - 1) || rowIsEmptyOrComment(startRow - 1))
+         // check for binary operator on previous line
+         int prevRow = startRow - 1;
+         if (rowEndsInBinaryOp(prevRow))
+         {
+            // move token cursor to that row
+            c.moveToEndOfRow(prevRow);
+            
+            // skip comments, operators, etc.
+            while (c.hasType("text", "comment", "virtual-comment", "keyword.operator"))
+            {
+               if (c.isRightBracket())
+                  break;
+                  
+               if (!c.moveToPreviousToken())
+                  break;
+            }
+          
+            // if we landed on a closing bracket, look for its match
+            // and then continue search from that row. otherwise,
+            // just look back a single row
+            if (c.valueEquals(")") || c.valueEquals("]"))
+            {
+               if (c.bwdToMatchingToken())
+               {
+                  startRow = c.getRow();
+                  continue;
+               }
+            }
+            else
+            {
+               startRow--;
+               continue;
+            }
+         }
+         
+         // keep going over blank, commented lines
+         if (rowIsEmptyOrComment(prevRow))
          {
             startRow--;
             continue;
          }
          
          // keep going if we're in a multiline string
-         String state = getSession().getState(startRow - 1);
+         String state = getSession().getState(prevRow);
          if (state == "qstring" || state == "qqstring")
          {
             startRow--;

--- a/src/gwt/test/test-multiline-expr.R
+++ b/src/gwt/test/test-multiline-expr.R
@@ -1,5 +1,7 @@
 # To test here, try typing 'Cmd + Enter' and ensure that the cursor
 # executes and jumps from the consecutively numbered blocks.
+library(dplyr)
+library(data.table)
 
 # 1
 {
@@ -77,7 +79,7 @@ x <- f(a = 1,
        # d = 4
 )
 
-# 12 -- data.table style
+# 12: data.table style
 dt[ , sequence := seq_len( nrow( dt ) )
 
     ][ , normal := rnorm( nrow( dt ) )
@@ -93,6 +95,20 @@ third"
 # expression system; e.g.
 #' [name](link)
 statement <- 1 + 1
+
+# 15: certain pipe styles
+mtcars %>%
+   filter(
+      mpg > 20
+   ) %>%
+   select(everything())
+
+# 16: certain pipe styles
+mtcars %>%
+   filter(
+      mpg > 20) %>%
+   select(everything())
+
 
 # cursor should end here after executing all lines
 EOF


### PR DESCRIPTION
This PR improves the heuristics used to find the extent of an R statement, via:

- Checking for lines that end with something like `) +`, and using the right bracket to motivate a search for the "start" of the associated expression;
- Performing a one-time check for the current line, to see if it matches the aforementioned state (only done once since we normally want to look at previous lines to see if they end with a binary operator / something that would require more input and hence attach to the current line)

Closes https://github.com/rstudio/rstudio/issues/6248.

Note: if we ever want to delve into this code again, I think we ought to just build a proper R parser in the client side that tracks source references, because this code is getting pretty funky...