### PR TITLE
Disable completions in YAML frontmatter

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -156,8 +156,13 @@ public class VisualModeChunks
       case "sql":
          editor.setFileType(FileTypeRegistry.SQL);
          break;
-      case "yaml":
       case "yaml-frontmatter":
+         editor.setFileType(FileTypeRegistry.YAML);
+         // Turn off all of Ace's built-in YAML completion as it's not helpful
+         // for embedded YAML front matter
+         editor.getWidget().getEditor().setCompletionOptions(false, false, false, 0, 0);
+         break;
+      case "yaml":
          editor.setFileType(FileTypeRegistry.YAML);
          break;
       case "java":


### PR DESCRIPTION
This change disables Ace's built in YAML completers for embedded Ace editors in visual mode, which are too aggressive in the YAML front matter in R Markdown docs.