### PR TITLE
Fix issues with source navigation buttons

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
@@ -56,7 +56,7 @@ public class SourceAppCommand
 
          if (synced_)
          {
-            setEnabled(buttonVisible_);
+            setEnabled(buttonEnabled_);
             setVisible(buttonVisible_);
          }
 
@@ -175,17 +175,17 @@ public class SourceAppCommand
       handlers_.fireEvent(new VisibleChangedEvent(command_, column_, buttonVisible));
    }
 
-   public void setEnabled(boolean visible)
+   public void setEnabled(boolean enabled)
    {
-      setEnabled(true, visible, visible);
+      setEnabled(true, enabled, enabled);
    }
 
-   public void setEnabled(boolean setCommand, boolean commandEnabled, boolean buttonVisible)
+   public void setEnabled(boolean setCommand, boolean commandEnabled, boolean buttonEnabled)
    {
-      buttonVisible_ = buttonVisible;
+      buttonEnabled_ = buttonEnabled;
       if (setCommand)
          command_.setEnabled(commandEnabled);
-      handlers_.fireEvent((new EnabledChangedEvent(command_, column_, buttonVisible)));
+      handlers_.fireEvent((new EnabledChangedEvent(command_, column_, buttonEnabled)));
    }
 
    private ToolbarButton createToolbarButton(boolean synced)
@@ -207,6 +207,7 @@ public class SourceAppCommand
    }
 
    private boolean buttonVisible_ = false;
+   private boolean buttonEnabled_ = false;
    private final AppCommand command_;
    private final String column_;
    private final SourceColumnManager columnManager_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -616,8 +616,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
       commands_.sourceNavigateBack().setEnabled(
          sourceNavigationHistory_.isBackEnabled());
-      commands_.sourceNavigateBack().setEnabled(
-         sourceNavigationHistory_.isBackEnabled());
+      commands_.sourceNavigateForward().setEnabled(
+         sourceNavigationHistory_.isForwardEnabled());
    }
 
    public EditingTarget addTab(SourceDocument doc, int mode, SourceColumn column)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
@@ -33,10 +33,8 @@ public class EditingTargetToolbar extends Toolbar
       // Buttons are unique to a source column so require SourceAppCommands
       SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();
 
-      addLeftWidget(
-         mgr.getSourceCommand(commands.sourceNavigateBack(), column).createToolbarButton());
-      Widget forwardButton =
-         mgr.getSourceCommand(commands.sourceNavigateForward(), column).createToolbarButton();
+      addLeftWidget(commands.sourceNavigateBack().createToolbarButton());
+      Widget forwardButton = commands.sourceNavigateForward().createToolbarButton();
       forwardButton.getElement().getStyle().setMarginLeft(-6, Unit.PX);
       addLeftWidget(forwardButton);
       addLeftSeparator();


### PR DESCRIPTION
This fix creates the `Source Navigate Forward` and `Source Navigate Back` buttons as traditional command toolbar buttons rather than source command buttons, because whether they are enabled or visible is the same across all columns. Previously we were attempting to enable/disable traditional buttons instead of column buttons so the buttons were not displayed at all. 

If people think it's for the best, I'm open to updating this so that the buttons only appear on the main source column.

This also fixes a terminology issue where `SourceAppCommand` had variables with the word visible instead of enabled and was basing whether to an enable a button on attachment off of the visibility.