### PR TITLE
tweak reporting of autosave errors

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -71,6 +71,24 @@ namespace {
 module_context::WaitForMethodFunction s_waitForRequestDocumentSave;
 module_context::WaitForMethodFunction s_waitForRequestDocumentClose;
 
+Error sourceDatabaseError(Error error)
+{
+   if (isFileNotFoundError(error))
+   {
+      // The regular message (no such file or directory) is not useful
+      // to end users when attempting to save files (especially for autsoaves),
+      // since they typically have no knowledge that the source database exists.
+      // Instead, log this as unexpected error.
+      return Error(
+               boost::system::errc::no_such_file_or_directory,
+               "An internal error occurred",
+               error.getLocation());
+   }
+   else
+   {
+      return error;
+   }
+}
 std::string inferDocumentType(const FilePath& documentPath,
                               const std::string& defaultType)
 {
@@ -508,7 +526,7 @@ Error saveDocument(const json::JsonRpcRequest& request,
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
    error = source_database::get(id, pDoc);
    if (error)
-      return error;
+      return sourceDatabaseError(error);
    
    // check if the document contents have changed
    bool hasChanges = contents != pDoc->contents();
@@ -573,7 +591,7 @@ Error saveDocumentDiff(const json::JsonRpcRequest& request,
    boost::shared_ptr<SourceDocument> pDoc(new SourceDocument());
    error = source_database::get(id, pDoc);
    if (error)
-      return error;
+      return sourceDatabaseError(error);
    
    // Don't even attempt anything if we're not working off the same original
    if (pDoc->hash() != hash)

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -76,9 +76,9 @@ Error sourceDatabaseError(Error error)
    if (isFileNotFoundError(error))
    {
       // The regular message (no such file or directory) is not useful
-      // to end users when attempting to save files (especially for autsoaves),
+      // to end users when attempting to save files (especially for autosaves),
       // since they typically have no knowledge that the source database exists.
-      // Instead, log this as unexpected error.
+      // Instead, log this as a generic 'internal error'.
       return Error(
                boost::system::errc::no_such_file_or_directory,
                "An internal error occurred",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
@@ -28,10 +28,13 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
    public static final GwtEvent.Type<SaveFailedEvent.Handler> TYPE =
       new GwtEvent.Type<SaveFailedEvent.Handler>();
    
-   public SaveFailedEvent(String path, String id)
+   public SaveFailedEvent(String path,
+                          String id,
+                          boolean isAutosave)
    {
       path_ = path;
       id_ = id;
+      isAutosave_ = isAutosave;
    }
    
    public String getPath()
@@ -42,6 +45,11 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
    public String getId()
    {
       return id_;
+   }
+   
+   public boolean isAutosave()
+   {
+      return isAutosave_;
    }
    
    @Override
@@ -58,4 +66,5 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
    
    private final String path_;
    private final String id_;
+   private final boolean isAutosave_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
@@ -29,12 +29,10 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
       new GwtEvent.Type<SaveFailedEvent.Handler>();
    
    public SaveFailedEvent(String path,
-                          String id,
-                          boolean isAutosave)
+                          String id)
    {
       path_ = path;
       id_ = id;
-      isAutosave_ = isAutosave;
    }
    
    public String getPath()
@@ -45,11 +43,6 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
    public String getId()
    {
       return id_;
-   }
-   
-   public boolean isAutosave()
-   {
-      return isAutosave_;
    }
    
    @Override
@@ -66,5 +59,4 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
    
    private final String path_;
    private final String id_;
-   private final boolean isAutosave_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -478,15 +478,15 @@ public class DocUpdateSentinel
                   // Always log save errors.
                   Debug.logError(error);
                   
-                  // Inform the user once (via R console) that save has failed.
-                  if (isAutosave && !loggedSaveError_)
+                  // Inform the user once if this was an autosave failure.
+                  if (isAutosave && !loggedAutosaveError)
                   {
-                     loggedSaveError_ = true;
+                     loggedAutosaveError = true;
 
                      RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                            "Error Autosaving File",
                            "RStudio was unable to autosave this file. You may need " +
-                           "to restart the R session.");
+                           "to restart RStudio.");
                   }
                  
                   // Avoid reporting auto-save errors to the user via the indicator,
@@ -904,7 +904,7 @@ public class DocUpdateSentinel
    private HandlerRegistration lastChanceSaveHandlerReg_;
    private final HashMap<String, ValueChangeHandlerManager<String>> 
                  propertyChangeHandlers_;
-   private boolean loggedSaveError_ = false;
+   private boolean loggedAutosaveError = false;
    
    public final static String PROPERTY_TRUE = "true";
    public final static String PROPERTY_FALSE = "false";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -479,9 +479,9 @@ public class DocUpdateSentinel
                   Debug.logError(error);
                   
                   // Inform the user once if this was an autosave failure.
-                  if (isAutosave && !loggedAutosaveError)
+                  if (isAutosave && !loggedAutosaveError_)
                   {
-                     loggedAutosaveError = true;
+                     loggedAutosaveError_ = true;
 
                      RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
                            "Error Autosaving File",
@@ -904,7 +904,7 @@ public class DocUpdateSentinel
    private HandlerRegistration lastChanceSaveHandlerReg_;
    private final HashMap<String, ValueChangeHandlerManager<String>> 
                  propertyChangeHandlers_;
-   private boolean loggedAutosaveError = false;
+   private boolean loggedAutosaveError_ = false;
    
    public final static String PROPERTY_TRUE = "true";
    public final static String PROPERTY_FALSE = "false";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -188,7 +188,7 @@ public class DocUpdateSentinel
                   {
                      // We're quitting. Save one last time.
                      final Token token = event.acquire();
-                     boolean saving = doSave(null, null, null, false,
+                     boolean saving = doSave(null, null, null,
                            new ProgressIndicator()
                      {
                         public void onProgress(String message)
@@ -240,7 +240,7 @@ public class DocUpdateSentinel
    {
       if (changeTracker_.hasChanged())
       {
-         boolean saved = doSave(null, null, null, false, new ProgressIndicator() {
+         boolean saved = doSave(null, null, null, new ProgressIndicator() {
 
             @Override
             public void onCompleted()
@@ -272,7 +272,7 @@ public class DocUpdateSentinel
    {
       if (changeTracker_.hasChanged())
       {
-         return doSave(null, null, null, true, new ProgressIndicator()
+         return doSave(null, null, null, new ProgressIndicator()
          {
             
             @Override
@@ -293,7 +293,7 @@ public class DocUpdateSentinel
             @Override
             public void onError(String message)
             {
-               // Inform the user once if this was an autosave failure.
+               // Inform the user only once if this was an autosave failure.
                if (!loggedAutosaveError_)
                {
                   loggedAutosaveError_ = true;
@@ -303,6 +303,10 @@ public class DocUpdateSentinel
                         "RStudio was unable to autosave this file. You may need " +
                         "to restart RStudio.");
                }
+               
+               // Use regular completed callback for indicator.
+               if (progress_ != null)
+                  progress_.onCompleted();
             }
             
             @Override
@@ -353,7 +357,7 @@ public class DocUpdateSentinel
       if (autosaver_ != null)
          autosaver_.suspend();
       
-      doSave(path, fileType, encoding, false, new ProgressIndicator()
+      doSave(path, fileType, encoding, new ProgressIndicator()
       {
          public void onProgress(String message)
          {
@@ -395,13 +399,12 @@ public class DocUpdateSentinel
    private boolean doSave(String path,
                           String fileType,
                           String encoding,
-                          boolean isAutosave,
                           ProgressIndicator progress)
    {
       boolean didSave = false;
       try
       {
-         didSave = doSaveImpl(path, fileType, encoding, isAutosave, progress);
+         didSave = doSaveImpl(path, fileType, encoding, progress);
       }
       catch (Exception ex)
       {
@@ -443,7 +446,6 @@ public class DocUpdateSentinel
    private boolean doSaveImpl(final String path,
                               final String fileType,
                               final String encoding,
-                              final boolean isAutosave,
                               final ProgressIndicator progress)
    {
       /* We need to fork the change tracker so that we can "mark" the moment
@@ -539,7 +541,7 @@ public class DocUpdateSentinel
                   {
                      if (path != null)
                      {
-                        eventBus_.fireEvent(new SaveFailedEvent(path, getId(), isAutosave));
+                        eventBus_.fireEvent(new SaveFailedEvent(path, getId()));
                      }
                   }
                   catch (Exception e)
@@ -593,7 +595,7 @@ public class DocUpdateSentinel
                   {
                      // We just hit a race condition where two updates
                      // happened at once. Try again
-                     doSave(path, fileType, encoding, isAutosave, progress);
+                     doSave(path, fileType, encoding, progress);
                   }
                   else
                   {


### PR DESCRIPTION
This PR tweaks the reporting of save and autosave errors.

When an autosave error occurs, a one-time dialog is shown indicating roughly that "something bad happened".

<img width="440" alt="Screen Shot 2020-07-23 at 11 35 22 AM" src="https://user-images.githubusercontent.com/1976582/88324471-99967c80-ccd8-11ea-885d-d018a34b9126.png">

After this point, RStudio will no longer report subsequent autosave errors to the user.

Attempts to explicitly save files will still be reported, with a somewhat clearer error message:

<img width="435" alt="Screen Shot 2020-07-23 at 11 36 13 AM" src="https://user-images.githubusercontent.com/1976582/88324566-b763e180-ccd8-11ea-9ad1-0099d834140a.png">

This "An internal error occurred" message indicates that we were unable to retrieve the document from our source database. (not sure if we want to surface more information here?)

Note that this PR doesn't do anything to recover from this state; it just adjusts how this state is reported to the user.

Small bandaid for https://github.com/rstudio/rstudio/issues/7427.