### PR TITLE
Prevent crash on startup

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -241,9 +241,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
             if (value == null)
             {
+               // default to main column name here because we haven't loaded any columns yet
                columnState_ =
                   State.createState(JsUtil.toJsArrayString(getNames(false)),
-                                    getActive().getName());
+                                    MAIN_SOURCE_NAME);
                return;
             }
 


### PR DESCRIPTION
The code previously attempted to retrieve the name of a source column before any columns had been created. This fixes that change.