### PR TITLE
provide hook for simulating RPC delays

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -69,6 +69,7 @@
 
 #include <session/http/SessionRequest.hpp>
 
+#include "SessionRpc.hpp"
 #include "SessionClientEventQueue.hpp"
 #include "SessionMainProcess.hpp"
 
@@ -527,6 +528,13 @@ SEXP rs_getPersistentValue(SEXP nameSEXP)
    {
       return R_NilValue;
    }
+}
+
+SEXP rs_setRpcDelay(SEXP delayMsSEXP)
+{
+   int delayMs = r::sexp::asInteger(delayMsSEXP);
+   rstudio::session::rpc::setRpcDelay(delayMs);
+   return delayMsSEXP;
 }
 
 } // anonymous namespace
@@ -2796,6 +2804,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_sourceDiagnostics);
    RS_REGISTER_CALL_METHOD(rs_threadSleep);
    RS_REGISTER_CALL_METHOD(rs_userPrompt);
+   RS_REGISTER_CALL_METHOD(rs_setRpcDelay);
 
    // initialize monitored scratch dir
    initializeMonitoredUserScratchDir();

--- a/src/cpp/session/SessionRpc.cpp
+++ b/src/cpp/session/SessionRpc.cpp
@@ -36,6 +36,9 @@ namespace rstudio {
 namespace session {
 namespace {
 
+// a delay used when processing RPC methods (used to simulate network latency)
+int s_rpcDelayMs = -1;
+
 // json rpc methods
 core::json::JsonRpcAsyncMethods* s_pJsonRpcMethods = nullptr;
    
@@ -256,6 +259,12 @@ void handleRpcRequest(const core::json::JsonRpcRequest& request,
                       boost::shared_ptr<HttpConnection> ptrConnection,
                       http_methods::ConnectionType connectionType)
 {
+   // delay handling this RPC if requested
+   if (s_rpcDelayMs > 0)
+   {
+      boost::this_thread::sleep_for(boost::chrono::milliseconds(s_rpcDelayMs));
+   }
+   
    // record the time just prior to execution of the event
    // (so we can determine if any events were added during execution)
    using namespace boost::posix_time;
@@ -305,6 +314,11 @@ void handleRpcRequest(const core::json::JsonRpcRequest& request,
 
       endHandleRpcRequestDirect(ptrConnection, executeStartTime, executeError, nullptr);
    }
+}
+
+void setRpcDelay(int delayMs)
+{
+   s_rpcDelayMs = delayMs;
 }
 
 Error initialize()

--- a/src/cpp/session/SessionRpc.hpp
+++ b/src/cpp/session/SessionRpc.hpp
@@ -24,7 +24,6 @@
 
 namespace rstudio {
 namespace session {
-
 namespace rpc {
 
 void formatRpcRequest(SEXP name,
@@ -36,6 +35,8 @@ void raiseJsonRpcResponseError(core::json::JsonRpcResponse& response);
 void handleRpcRequest(const core::json::JsonRpcRequest& request,
                       boost::shared_ptr<HttpConnection> ptrConnection,
                       http_methods::ConnectionType connectionType);
+
+void setRpcDelay(int delayMs);
 
 core::Error initialize();
 


### PR DESCRIPTION
This PR makes it possible to force a delay when executing RPCs, via:

```
.Call("rs_setRpcDelay", <delay>)
```

The primary intention is to help debugging bugs that appear timing related -- for example, I've seen issues where the autocompletion results are not properly inserted in high-latency environments, and having this makes it easier to reproduce and understand the issue locally.