### PR TITLE
Capitalize "Parentheses" for consistency

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -3387,7 +3387,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="toggleRainbowParens"
         label="Toggle Rainbow Parentheses Mode"
-        menuLabel="Rainbow parentheses"
+        menuLabel="Rainbow Parentheses"
         checkable="true"
         context="editor"/>
 


### PR DESCRIPTION
Fixes this issue, in which "parentheses" doesn't match the casing of the other commands in the menu.

![image](https://user-images.githubusercontent.com/470418/88343058-67dfde80-ccf5-11ea-8460-0b041e828963.png)
