### PR TITLE
avoid warnings when saving R options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -78,3 +78,4 @@
 * Fixed issue where clicking the filter UI box would sort a data viewer column (#7299)
 * Fixed issue where Windows shortcuts were not resolved correctly in file dialogs. (#7327)
 * Fixed issue where failure to rotate a log file could cause a process crash (Pro #1779)
+* Fixed issue where saving workspace could emit 'package may not be available when loading' warning (#7001)

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -94,18 +94,19 @@
 })
 
 .rs.addApiFunction("diagnosticsReport", function() {
-  invisible(.Call(getNativeSymbolInfo("rs_sourceDiagnostics", PACKAGE="")))
+   invisible(.Call("rs_sourceDiagnostics", PACKAGE = "(embedding)"))
 })
 
 
 .rs.addApiFunction("previewRd", function(rdFile) {
-
-  if (!is.character(rdFile) || (length(rdFile) != 1))
-    stop("rdFile must be a single element character vector.")
-  if (!file.exists(rdFile))
-    stop("The specified rdFile ' ", rdFile, "' does not exist.")
-
-  invisible(.Call(getNativeSymbolInfo("rs_previewRd", PACKAGE=""), rdFile))
+   
+   if (!is.character(rdFile) || (length(rdFile) != 1))
+      stop("rdFile must be a single element character vector.")
+   if (!file.exists(rdFile))
+      stop("The specified rdFile ' ", rdFile, "' does not exist.")
+   
+   invisible(.Call("rs_previewRd", rdFile, PACKAGE = "(embedding)"))
+   
 })
 
 .rs.addApiFunction("viewer", function(url, height = NULL) {
@@ -119,7 +120,7 @@
   if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
      stop("height must be a single element numeric vector or 'maximize'.")
 
-  invisible(.Call(getNativeSymbolInfo("rs_viewer", PACKAGE=""), url, height))
+  invisible(.Call("rs_viewer", url, height, PACKAGE = "(embedding)"))
 })
 
 
@@ -135,7 +136,8 @@
       stop("width argument mut be numeric", call. = FALSE)
    if (!is.numeric(height))
       stop("height argument mut be numeric", call. = FALSE)
-   invisible(.Call("rs_savePlotAsImage", file, format, width, height))
+   
+   invisible(.Call("rs_savePlotAsImage", file, format, width, height, PACKAGE = "(embedding)"))
 })
 
 .rs.addApiFunction("sourceMarkers", function(name,
@@ -208,7 +210,7 @@
    else if (!is.character(basePath))
       stop("basePath parameter is not of type character", call. = FALSE)
 
-   invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect))
+   invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect, PACKAGE = "(embedding)"))
 })
 
 .rs.addApiFunction("navigateToFile", function(filePath, line = 1L, col = 1L) {
@@ -234,7 +236,7 @@
    }
 
    # expand and alias for client
-   filePath <- .rs.normalizePath(filePath, winslash="/", mustWork = TRUE)
+   filePath <- .rs.normalizePath(filePath, winslash = "/", mustWork = TRUE)
    homeDir <- path.expand("~")
    if (identical(substr(filePath, 1, nchar(homeDir)), homeDir)) {
       filePath <- file.path("~", substring(filePath, nchar(homeDir) + 2))
@@ -363,19 +365,19 @@
 # of the 'rstudioapi' package -- it is superceded by
 # '.rs.getLastActiveEditorContext()'.
 .rs.addApiFunction("getActiveDocumentContext", function() {
-   .Call("rs_getEditorContext", 0L)
+   .Call("rs_getEditorContext", 0L, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getLastActiveEditorContext", function() {
-   .Call("rs_getEditorContext", 0L)
+   .Call("rs_getEditorContext", 0L, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getConsoleEditorContext", function() {
-   .Call("rs_getEditorContext", 1L)
+   .Call("rs_getEditorContext", 1L, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getSourceEditorContext", function() {
-   .Call("rs_getEditorContext", 2L)
+   .Call("rs_getEditorContext", 2L, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getActiveProject", function() {
@@ -407,13 +409,20 @@
    .rs.askForPassword(prompt)
 })
 
-.rs.addFunction("dialogIcon", function(name) {
-  list(
-    info = 1,
-    warning = 2,
-    error = 3,
-    question = 4
-  )
+.rs.addFunction("dialogIcon", function(name = NULL) {
+  
+   icons <- list(
+      info = 1,
+      warning = 2,
+      error = 3,
+      question = 4
+   )
+   
+   if (is.null(name))
+      icons
+   else
+      icons[[name]]
+   
 })
 
 .rs.addApiFunction("showDialog", function(title, message, url = "") {
@@ -425,12 +434,13 @@
    .Call("rs_showDialog",
       title = title,
       message = message,
-      dialogIcon = .rs.dialogIcon()$info,
+      dialogIcon = .rs.dialogIcon("info"),
       prompt = FALSE,
       promptDefault = "",
       ok = "OK",
       cancel = "Cancel",
-      url = url)
+      url = url,
+      PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("updateDialog", function(...)
@@ -450,12 +460,13 @@
    .Call("rs_showDialog",
       title = title,
       message = message,
-      dialogIcon = .rs.dialogIcon()$info,
+      dialogIcon = .rs.dialogIcon("info"),
       prompt = TRUE,
       promptDefault = default,
       ok = "OK",
       cancel = "Cancel",
-      url = "")
+      url = "",
+      PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("showQuestion", function(title, message, ok = "OK", cancel = "Cancel") {
@@ -470,12 +481,13 @@
    .Call("rs_showDialog",
       title = title,
       message = message,
-      dialogIcon = .rs.dialogIcon()$question,
+      dialogIcon = .rs.dialogIcon("question"),
       prompt = FALSE,
       promptDefault = NULL,
       ok = ok,
       cancel = cancel,
-      url = NULL)
+      url = NULL,
+      PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("writePreference", function(name, value) {
@@ -673,14 +685,14 @@
    if (is.null(show) || !is.logical(show))
       stop("'show' must be a logical vector")
 
-   .Call("rs_terminalExecute", command, workingDir, env, show)
+   .Call("rs_terminalExecute", command, workingDir, env, show, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("terminalExitCode", function(id) {
    if (is.null(id) || !is.character(id) || (length(id) != 1))
       stop("'id' must be a single element character vector")
 
-   .Call("rs_terminalExitCode", id)
+   .Call("rs_terminalExitCode", id, PACKAGE = "(embedding)")
 })
 
 options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -14,18 +14,20 @@
 #
 
 # get version
-.rs.addGlobalFunction("RStudio.Version", function() {
+.rs.addGlobalFunction("RStudio.Version", function()
+{
    .rs.api.versionInfo()
 })
 
 # custom browseURL implementation
 options(browser = function(url)
 {
-   .Call("rs_browseURL", url) ;
+   .Call("rs_browseURL", url, PACKAGE = "(embedding)")
 })
 
 # default viewer option if not already set
-if (is.null(getOption("viewer"))) {
+if (is.null(getOption("viewer")))
+{
    options(viewer = function(url, height = NULL)
    {
       if (!is.character(url) || (length(url) != 1))
@@ -42,7 +44,8 @@ if (is.null(getOption("viewer"))) {
 }
 
 # default page_viewer option if not already set
-if (is.null(getOption("page_viewer"))) {
+if (is.null(getOption("page_viewer")))
+{
    options(page_viewer = function(url, title = "RStudio Viewer", self_contained = FALSE)
    {
       if (!is.character(url) || (length(url) != 1))
@@ -59,7 +62,8 @@ if (is.null(getOption("page_viewer"))) {
 }
 
 # default shinygadgets.showdialog if not already set
-if (is.null(getOption("shinygadgets.showdialog"))) {
+if (is.null(getOption("shinygadgets.showdialog")))
+{
    options(shinygadgets.showdialog = function(caption,
                                               url,
                                               width = NULL,
@@ -88,16 +92,30 @@ if (is.null(getOption("shinygadgets.showdialog"))) {
 }
 
 # provide askpass function
-options(askpass = .rs.askForPassword)
+options(askpass = function(prompt)
+{
+   .rs.askForPassword(prompt)
+})
 
 # provide asksecret function
-options(asksecret = .rs.askForSecret)
+options(asksecret = function(name,
+                             title = name,
+                             prompt = paste(name, ":", sep = ""))
+{
+   .rs.askForSecret(name, title, prompt)
+})
 
 # provide restart function
-options(restart = .rs.restartR)
+options(restart = function(afterRestartCommand)
+{
+   .rs.restartR(afterRestartCommand)
+})
 
 # custom pager implementation
-options(pager = .rs.pager)
+options(pager = function(files, header, title, delete.file)
+{
+   .rs.pager(files, header, title, delete.file)
+})
 
 # never allow graphical menus
 options(menu.graphics = FALSE)
@@ -118,13 +136,13 @@ local({
    if (platform$GUI != "RStudio") {
       platform$GUI = "RStudio"
       unlockBinding(".Platform", asNamespace("base"))
-      assign(".Platform", platform, inherits=TRUE)
+      assign(".Platform", platform, inherits = TRUE)
       lockBinding(".Platform", asNamespace("base"))
    }
 })
 
 # set default x display (see below for comment on why we need to do this)
-if (is.na(Sys.getenv("DISPLAY", NA)))
+if (is.na(Sys.getenv("DISPLAY", unset = NA)))
    Sys.setenv(DISPLAY = ":0")
 
 # the above two display oriented command affect the behavior of edit.data.frame

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -19,100 +19,93 @@
    .rs.api.versionInfo()
 })
 
-# custom browseURL implementation
-options(browser = function(url)
+# custom browseURL implementation.
+.rs.setOption("browser", function(url)
 {
    .Call("rs_browseURL", url, PACKAGE = "(embedding)")
 })
 
 # default viewer option if not already set
-if (is.null(getOption("viewer")))
+.rs.setOptionDefault("viewer", function(url, height = NULL)
 {
-   options(viewer = function(url, height = NULL)
-   {
-      if (!is.character(url) || (length(url) != 1))
-         stop("url must be a single element character vector.", call. = FALSE)
-      
-      if (identical(height, "maximize"))
-         height <- -1
-
-      if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
-         stop("height must be a single element numeric vector or 'maximize'.", call. = FALSE)
-      
-      invisible(.Call("rs_viewer", url, height))  
-   })
-}
+   if (!is.character(url) || (length(url) != 1))
+      stop("url must be a single element character vector.", call. = FALSE)
+   
+   if (identical(height, "maximize"))
+      height <- -1
+   
+   if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
+      stop("height must be a single element numeric vector or 'maximize'.", call. = FALSE)
+   
+   invisible(.Call("rs_viewer", url, height, PACKAGE = "(embedding)"))
+})
 
 # default page_viewer option if not already set
-if (is.null(getOption("page_viewer")))
+.rs.setOptionDefault("page_viewer", function(url,
+                                             title = "RStudio Viewer",
+                                             self_contained = FALSE)
 {
-   options(page_viewer = function(url, title = "RStudio Viewer", self_contained = FALSE)
-   {
-      if (!is.character(url) || (length(url) != 1))
-         stop("url must be a single element character vector.", call. = FALSE)
-      
-      if (!is.character(title) || (length(title) != 1))
-         stop("title must be a single element character vector.", call. = FALSE)
-      
-      if (!is.logical(self_contained) || (length(self_contained) != 1))
-         stop("self_contained must be a single element logical vector.", call. = FALSE)
-      
-      invisible(.Call("rs_showPageViewer", url, title, self_contained))
-   })
-}
+   if (!is.character(url) || (length(url) != 1))
+      stop("url must be a single element character vector.", call. = FALSE)
+   
+   if (!is.character(title) || (length(title) != 1))
+      stop("title must be a single element character vector.", call. = FALSE)
+   
+   if (!is.logical(self_contained) || (length(self_contained) != 1))
+      stop("self_contained must be a single element logical vector.", call. = FALSE)
+   
+   invisible(.Call("rs_showPageViewer", url, title, self_contained, PACKAGE = "(embedding)"))
+})
 
 # default shinygadgets.showdialog if not already set
-if (is.null(getOption("shinygadgets.showdialog")))
+.rs.setOptionDefault("shinygadgets.showdialog", function(caption,
+                                                         url,
+                                                         width = NULL,
+                                                         height = NULL)
 {
-   options(shinygadgets.showdialog = function(caption,
-                                              url,
-                                              width = NULL,
-                                              height = NULL)
-   {
-      if (!is.character(caption) || (length(caption) != 1))
-         stop("caption must be a single element character vector.", call. = FALSE)
-
-      if (!is.character(url) || (length(url) != 1))
-         stop("url must be a single element character vector.", call. = FALSE)
-
-      # default width and height
-      if (is.null(width))
-         width <- 600
-      if (is.null(height))
-         height <- 600
-
-      # validate width and height
-      if (!is.numeric(width) || (length(width) != 1))
-         stop("width must be a single element numeric vector.", call. = FALSE)
-      if (!is.numeric(height) || (length(height) != 1))
-         stop("height must be a single element numeric vector.", call. = FALSE)
-
-      invisible(.Call("rs_showShinyGadgetDialog", caption, url, width, height))
-   })
-}
+   if (!is.character(caption) || (length(caption) != 1))
+      stop("caption must be a single element character vector.", call. = FALSE)
+   
+   if (!is.character(url) || (length(url) != 1))
+      stop("url must be a single element character vector.", call. = FALSE)
+   
+   # default width and height
+   if (is.null(width))
+      width <- 600
+   if (is.null(height))
+      height <- 600
+   
+   # validate width and height
+   if (!is.numeric(width) || (length(width) != 1))
+      stop("width must be a single element numeric vector.", call. = FALSE)
+   if (!is.numeric(height) || (length(height) != 1))
+      stop("height must be a single element numeric vector.", call. = FALSE)
+   
+   invisible(.Call("rs_showShinyGadgetDialog", caption, url, width, height, PACKAGE = "(embedding)"))
+})
 
 # provide askpass function
-options(askpass = function(prompt)
+.rs.setOption("askpass", function(prompt)
 {
    .rs.askForPassword(prompt)
 })
 
 # provide asksecret function
-options(asksecret = function(name,
-                             title = name,
-                             prompt = paste(name, ":", sep = ""))
+.rs.setOption("asksecret", function(name,
+                                    title = name,
+                                    prompt = paste(name, ":", sep = ""))
 {
    .rs.askForSecret(name, title, prompt)
 })
 
 # provide restart function
-options(restart = function(afterRestartCommand)
+.rs.setOption("restart", function(afterRestartCommand)
 {
    .rs.restartR(afterRestartCommand)
 })
 
 # custom pager implementation
-options(pager = function(files, header, title, delete.file)
+.rs.setOption("pager", function(files, header, title, delete.file)
 {
    .rs.pager(files, header, title, delete.file)
 })

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -27,22 +27,35 @@ assign(".rs.toolsEnv", function()
    .rs.Env
 }, envir = .rs.Env)
 
-# add a function to the tools:rstudio environment
-assign(".rs.addFunction", function(name, FN, attrs = list())
+#' Add a function to the 'tools:rstudio' environment.
+#' 
+#' This environment is placed on the search path, and so is accessible and
+#' readable during regular evaluation in an R session.
+#'
+#' @param name The name of the R function. The prefix '.rs.' will be pre-pended
+#'   to the supplied function name.
+#'
+#' @param FN The \R function to be added.
+#' 
+#' @param attrs An optional list of attributes, to be set on the function.
+#' 
+#' @param envir An optional environment, to be set as the enclosing environment
+#'   for the function `f`. By default, newly-defined functions use the
+#'   'tools:rstudio' environment as the parent function. For functions which
+#'   might be exposed to users (e.g. via options), you may want to instead use
+#'   the base environment to avoid issues with serialization.
+assign(".rs.addFunction", function(name, FN, attrs = list(), envir = .rs.toolsEnv())
 { 
    # add optional attributes
    for (attrib in names(attrs))
       attr(FN, attrib) <- attrs[[attrib]]
    
-   # get tools env
-   envir <- .rs.toolsEnv()
-   
-   # ensure function evaluates in tools env
+   # ensure function evaluates in requested environment
    environment(FN) <- envir
    
    # assign in tools env
    fullName <- paste(".rs.", name, sep = "")
-   assign(fullName, FN, envir = envir)
+   assign(fullName, FN, envir = .rs.toolsEnv())
    
 }, envir = .rs.Env)
 
@@ -69,7 +82,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("addApiFunction", function(name, FN)
 {
    fullName <- paste("api.", name, sep = "")
-   .rs.addFunction(fullName, FN)
+   .rs.addFunction(fullName, FN, envir = globalenv())
 })
 
 .rs.addFunction("setVar", function(name, var)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -114,9 +114,33 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    exists(fullName, envir = envir)
 })
 
-.rs.addFunction( "evalInGlobalEnv", function(code)
+.rs.addFunction("setOption", function(name, value)
 {
-   eval(parse(text=code), envir=globalenv())
+   data <- list(value)
+   names(data) <- name
+   options(data)
+})
+
+.rs.addFunction("setOptionDefault", function(name, value)
+{
+   # if the option is already set, nothing to do
+   if (!is.null(getOption(name)))
+      return(FALSE)
+   
+   # otherwise, set it
+   data <- list(value)
+   names(data) <- name
+   options(data)
+   
+   TRUE
+})
+
+.rs.addFunction("evalInGlobalEnv", function(code)
+{
+   eval(
+      parse(text = code),
+      envir = globalenv()
+   )
 })
 
 # attempts to restore the global environment from a file

--- a/src/cpp/r/include/r/ROptions.hpp
+++ b/src/cpp/r/include/r/ROptions.hpp
@@ -63,45 +63,58 @@ T getOption(const std::string& name,
    if (name.empty())
       return defaultValue;
    
+   // retrieve option (err if not found)
    SEXP valueSEXP = getOption(name);
-   if (valueSEXP != R_NilValue)
-   {
-      T value;
-      core::Error error = sexp::extract(valueSEXP, &value);
-      if (error)
-      {
-         error.addProperty("symbol (option)", name);
-         LOG_ERROR(error);
-         return defaultValue;
-      }
-      
-      return value;
-   }
-   else
+   if (valueSEXP == R_NilValue)
    {
       core::Error error(errc::SymbolNotFoundError, ERROR_LOCATION);
       error.addProperty("symbol (option)", name);
       if (logNotFound)
          LOG_ERROR(error);
+      
       return defaultValue;
    }
+   
+   // attempt to extract SEXP value
+   T value;
+   core::Error error = sexp::extract(valueSEXP, &value);
+   if (error)
+   {
+      error.addProperty("symbol (option)", name);
+      LOG_ERROR(error);
+      return defaultValue;
+   }
+      
+   return value;
 }
    
 template <typename T>
 core::Error setOption(const std::string& name, const T& value)
 {
-   r::exec::RFunction optionsFunction("options");
-   optionsFunction.addParam(name, value);
-   core::Error error = optionsFunction.call();
+   core::Error error = r::exec::RFunction("base:::options")
+         .addParam(name, value)
+         .call();
+   
    if (error)
    {
       error.addProperty("option-name", name);
       return error;
    }
-   else
-   {
+   
+   return core::Success();
+}
+
+template <typename T>
+core::Error setOptionDefault(const std::string& name, const T& value)
+{
+   // retrieve option (bail if unset)
+   SEXP optionSEXP = getOption(name);
+   if (optionSEXP != R_NilValue)
       return core::Success();
-   }
+   
+   // otherwise, override it
+   setOption(name, value);
+   return core::Success();
 }
 
 SEXP setErrorOption(SEXP value);

--- a/src/cpp/session/modules/SessionBuild.R
+++ b/src/cpp/session/modules/SessionBuild.R
@@ -13,55 +13,71 @@
 #
 #
 
-setHook("sourceCpp.onBuild", function(file, fromCode, showOutput) {
-   .Call("rs_sourceCppOnBuild", file, fromCode, showOutput)
+setHook("sourceCpp.onBuild", function(file, fromCode, showOutput)
+{
+   .Call("rs_sourceCppOnBuild", file, fromCode, showOutput, PACKAGE = "(embedding)")
 })
 
-setHook("sourceCpp.onBuildComplete", function(succeeded, output) {
-   .Call("rs_sourceCppOnBuildComplete", succeeded, output)
+setHook("sourceCpp.onBuildComplete", function(succeeded, output)
+{
+   .Call("rs_sourceCppOnBuildComplete", succeeded, output, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("installBuildTools", function(action) {
+.rs.addFunction("installBuildTools", function(action)
+{
+   fmt <- .rs.trimWhitespace("
+%s requires installation of additional build tools.
+
+Do you want to install the additional tools now?
+")
+   
    response <- .rs.userPrompt(
       "question",
       "Install Build Tools",
-      paste(action, " requires installation of additional build tools.\n\n",
-      "Do you want to install the additional tools now?", sep = ""))
-   if (identical(response, "yes")) {
-      .Call("rs_installBuildTools")
-      return(TRUE)
-   } else {
+      sprintf(fmt, action)
+   )
+   
+   if (!identical(response, "yes"))
       return(FALSE)
-   }
+   
+   .Call("rs_installBuildTools", PACKAGE = "(embedding)")
+   return(TRUE)
+   
 })
 
-.rs.addFunction("checkBuildTools", function(action) {
-
-   if (identical(.Platform$pkgType, "mac.binary.mavericks")) {
-      # this will auto-prompt to install on mavericks
-      .Call("rs_canBuildCpp")
-   } else {
-      if (!.Call("rs_canBuildCpp")) {
-        .rs.installBuildTools(action)
-        FALSE
-      }
-      else {
-        TRUE;
-      }
-   }
+.rs.addFunction("checkBuildTools", function(action)
+{
+   # TODO: should this check for other flavors of mac.binary?
+   if (identical(.Platform$pkgType, "mac.binary.mavericks"))
+      return(.Call("rs_canBuildCpp", PACKAGE = "(embedding)"))
+   
+   ok <- .Call("rs_canBuildCpp", PACKAGE = "(embedding)")
+   if (ok)
+      return(TRUE)
+   
+   .rs.installBuildTools(action)
+   FALSE
 })
 
-.rs.addFunction("withBuildTools", function(code) {
+.rs.addFunction("withBuildTools", function(code)
+{
     .rs.addRToolsToPath()
     on.exit(.rs.restorePreviousPath(), add = TRUE)
     force(code)
 })
 
-options(buildtools.check = .rs.checkBuildTools)
-options(buildtools.with = .rs.withBuildTools)
+options(buildtools.check = function(action)
+{
+   .rs.checkBuildTools(action)
+})
 
+options(buildtools.with = function(code)
+{
+   .rs.withBuildTools(code)
+})
 
-.rs.addFunction("websiteOutputDir", function(siteDir) {
+.rs.addFunction("websiteOutputDir", function(siteDir)
+{
    siteGenerator <- rmarkdown::site_generator(siteDir)
    if (!is.null(siteGenerator))
       if (siteGenerator$output_dir != ".")
@@ -72,24 +88,34 @@ options(buildtools.with = .rs.withBuildTools)
       siteDir
 })
 
-.rs.addFunction("builtWithRtoolsGcc493", function() {
+.rs.addFunction("builtWithRtoolsGcc493", function()
+{
    identical(.Platform$OS.type, "windows") &&
-   getRversion() >= "3.3" && 
-   .rs.haveRequiredRSvnRev(70462)
+      getRversion() >= "3.3" && 
+      .rs.haveRequiredRSvnRev(70462)
 })
 
-.rs.addFunction("readShinytestResultRds", function(rdsPath) {
+.rs.addFunction("readShinytestResultRds", function(rdsPath)
+{
    failures <- Filter(function(e) !identical(e$pass, TRUE), readRDS(rdsPath)$results)
    sapply(failures, function(e) e$name)
 })
 
-.rs.addFunction("findShinyTestsDir", function(appDir) {
-   if (exists("findTestsDir", where = asNamespace("shinytest"))) {
-      # Newer versions of shinytest can report their own test directories.
-      shinytest:::findTestsDir(appDir = appDir, mustExist = FALSE, quiet = TRUE)
-   } else {
-      # Older versions require us to know.
-      file.path(appDir, "tests")
-   }
+.rs.addFunction("findShinyTestsDir", function(appDir)
+{
+   tryCatch(
+      
+      expr = shinytest:::findTestsDir(
+         appDir = appDir,
+         mustExit = FALSE,
+         quiet = TRUE
+      ),
+      
+      error = function(e) {
+         file.path(appDir, "tests")
+      }
+      
+   )
+   
 })
 

--- a/src/cpp/session/modules/SessionPlumberViewer.R
+++ b/src/cpp/session/modules/SessionPlumberViewer.R
@@ -15,15 +15,15 @@
 
 .rs.addFunction("invokePlumberPaneViewer", function(url) {
    invisible(.Call("rs_plumberviewer", url, getwd(), "pane", PACKAGE = "(embedding)"))
-}, attrs = list(plumberViewerType = "pane"))
+}, attrs = list(plumberViewerType = "pane"), envir = baseenv())
 
 .rs.addFunction("invokePlumberWindowViewer", function(url) {
    invisible(.Call("rs_plumberviewer", url, getwd(), "window", PACKAGE = "(embedding)"))
-}, attrs = list(plumberViewerType = "window"))
+}, attrs = list(plumberViewerType = "window"), envir = baseenv())
 
 .rs.addFunction("invokePlumberWindowExternal", function(url) {
    invisible(.Call("rs_plumberviewer", url, getwd(), "browser", PACKAGE = "(embedding)"))
-}, attrs = list(plumberViewerType = "browser"))
+}, attrs = list(plumberViewerType = "browser"), envir = baseenv())
 
 .rs.addFunction("setPlumberViewerType", function(type) {
    if (identical(type, "none"))

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -13,17 +13,23 @@
 #
 #
 
-.rs.setOptionDefault("profvis.print", function(x) {
+.rs.setOptionDefault("profvis.print", function(x)
+{
    .rs.profilePrint(x)
 })
 
 .rs.setOptionDefault("profvis.prof_extension", ".Rprof")
 
+.rs.addFunction("profilesPath", function()
+{
+   .Call("rs_profilesPath", PACKAGE = "(embedding)")
+})
+
 .rs.addFunction("profileResources", function()
 {
    tempPath <- getOption(
       "profvis.prof_output",
-      default = .Call("rs_profilesPath", PACKAGE = "(embedding)")
+      default = .rs.profilesPath()
    )
    
    if (!.rs.dirExists(tempPath))

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -13,15 +13,11 @@
 #
 #
 
-if (is.null(getOption("profvis.print"))) {
-   options(profvis.print = function(x) {
-      .rs.profilePrint(x)
-   })
-}
+.rs.setOptionDefault("profvis.print", function(x) {
+   .rs.profilePrint(x)
+})
 
-if (is.null(getOption("profvis.prof_extension"))) {
-   options(profvis.prof_extension = ".Rprof")
-}
+.rs.setOptionDefault("profvis.prof_extension", ".Rprof")
 
 .rs.addFunction("profileResources", function()
 {

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -107,12 +107,16 @@ Error initialize()
    
    source_database::events().onDocPendingRemove.connect(onDocPendingRemove);
 
+   RS_REGISTER_CALL_METHOD(rs_profilesPath);
+   
+   r::options::setOptionDefault(
+            "profvis.prof_output",
+            string_utils::utf8ToSystem(profilesCacheDir()));
+   
    initBlock.addFunctions()
       (boost::bind(module_context::sourceModuleRFile, "SessionProfiler.R"))
       (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/", handleProfilerResReq))
       (boost::bind(module_context::registerUriHandler, kProfilerResourceLocation, handleProfilerResourceResReq));
-
-   RS_REGISTER_CALL_METHOD(rs_profilesPath, 0);
 
    return initBlock.execute();
 }

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1157,9 +1157,6 @@ FunctionInformation getInfoAssociatedWithFunctionAtCursor(
             true,
             true);
    
-   if (error)
-      LOG_ERROR(error);
-   
    return info;
    
 }

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -284,9 +284,20 @@ options(reticulate.initialized = function() {
    active
 })
 
-options(reticulate.repl.initialize = .rs.reticulate.replInitialize)
-options(reticulate.repl.hook       = .rs.reticulate.replHook)
-options(reticulate.repl.teardown   = .rs.reticulate.replTeardown)
+options(reticulate.repl.initialize = function()
+{
+   .rs.reticulate.replInitialize()
+})
+
+options(reticulate.repl.hook = function(buffer, contents, trimmed)
+{
+   .rs.reticulate.replHook(buffer, contents, trimmed)
+})
+
+options(reticulate.repl.teardown = function()
+{
+   .rs.reticulate.replTeardown()
+})
 
 .rs.addFunction("python.tokenizationRules", function() {
    

--- a/src/cpp/session/modules/SessionShinyViewer.R
+++ b/src/cpp/session/modules/SessionShinyViewer.R
@@ -15,19 +15,19 @@
 
 .rs.addFunction("invokeShinyTutorialViewer", function(url, meta) {
    invisible(.Call("rs_shinyviewer", url, getwd(), "tutorial", meta, PACKAGE = "(embedding)"))
-}, attrs = list(shinyViewerType = "tutorial"))
+}, attrs = list(shinyViewerType = "tutorial"), envir = baseenv())
 
 .rs.addFunction("invokeShinyPaneViewer", function(url) {
    invisible(.Call("rs_shinyviewer", url, getwd(), "pane", NULL, PACKAGE = "(embedding)"))
-}, attrs = list(shinyViewerType = "pane"))
+}, attrs = list(shinyViewerType = "pane"), envir = baseenv())
 
 .rs.addFunction("invokeShinyWindowViewer", function(url) {
    invisible(.Call("rs_shinyviewer", url, getwd(), "window", NULL, PACKAGE = "(embedding)"))
-}, attrs = list(shinyViewerType = "window"))
+}, attrs = list(shinyViewerType = "window"), envir = baseenv())
 
 .rs.addFunction("invokeShinyWindowExternal", function(url) {
    invisible(.Call("rs_shinyviewer", url, getwd(), "browser", NULL, PACKAGE = "(embedding)"))
-}, attrs = list(shinyViewerType = "browser"))
+}, attrs = list(shinyViewerType = "browser"), envir = baseenv())
 
 .rs.addFunction("setShinyViewerType", function(type) {
    if (identical(type, "none"))


### PR DESCRIPTION
This PR fixes an issue where saving options, e.g. via:

```
ops <- options()
save(ops, file = tempfile())
```

would emit an R warning, typically of the form:

```
Warning in save(ops, file = tempfile()) :
  'package:stats' may not be available when loading
```

This is caused by us placing helper functions within the R options list, which themselves inherit from the RStudio tools environment. Because that environment lives on the search path, it also "depends" on the environments which come after it, e.g. `package:stats`:

```
> search()
 [1] ".GlobalEnv"        "tools:rstudio"     "package:stats"    
 [4] "package:graphics"  "package:grDevices" "package:utils"    
 [7] "package:datasets"  "local:rprofile"    "package:methods"  
[10] "Autoloads"         "package:base"    
```

There are three main solutions employed here:

1. Define a simple wrapper function that calls the associate RStudio function,
2. Change the enclosing environment of the evaluating function to the R base environment,
3. Change the enclosing environment of the evaluating function to the R global environment.

This PR was ultimately a bit larger than I originally expected it to be -- I did some tidying up of older pieces of code while I found myself working there.

Closes https://github.com/rstudio/rstudio/issues/7001.