### PR TITLE
Fix exception from creating a new Terminal menu

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
@@ -125,11 +125,6 @@ public class LogicalWindow implements HasWindowStateChangeHandlers,
       return state_;
    }
 
-   public boolean equals(LogicalWindow window)
-   {
-      return normal_.equals(window.normal_);
-   }
-
    @Override
    public void onEnsureHeight(EnsureHeightEvent event)
    {


### PR DESCRIPTION
Fixes #7457 Removed a method added in #7408 that was not actually needed and was causing a null exception.