### PR TITLE
Add command focusPreviousPane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -813,7 +813,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="debugBreakpoint" value="Shift+F9"/>
          <shortcut refid="debugStep" value="F10"/>
          <shortcut refid="debugStepInto" value="Shift+F4"/>
-         <!--<shortcut refid="debugFinish" value="Shift+F6"/>-->
+         <shortcut refid="debugFinish" value="Shift+F7"/>
          <shortcut refid="debugContinue" value="Shift+F5"/>
          <shortcut refid="debugStop" value="Shift+F8"/>
       </shortcutgroup>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -521,6 +521,7 @@ well as menu structures (for main menu and popup menus).
                <cmd refid="activateConsole"/>
                <cmd refid="focusConsoleOutputEnd"/>
                <cmd refid="focusNextPane"/>
+               <cmd refid="focusPreviousPane"/>
                <cmd refid="activateTerminal"/>
                <cmd refid="activateHelp"/>
                <cmd refid="focusMainToolbar"/>
@@ -812,7 +813,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="debugBreakpoint" value="Shift+F9"/>
          <shortcut refid="debugStep" value="F10"/>
          <shortcut refid="debugStepInto" value="Shift+F4"/>
-         <shortcut refid="debugFinish" value="Shift+F6"/>
+         <!--<shortcut refid="debugFinish" value="Shift+F6"/>-->
          <shortcut refid="debugContinue" value="Shift+F5"/>
          <shortcut refid="debugStop" value="Shift+F8"/>
       </shortcutgroup>
@@ -889,6 +890,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="focusConsoleOutputEnd" value="Alt+Shift+2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="focusConsoleOutputEnd" value="Ctrl+`"/>
          <shortcut refid="focusNextPane" value="F6"/>
+         <shortcut refid="focusPreviousPane" value="Shift+F6"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Ctrl+Alt+[" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="toggleTabKeyMovesFocus" value="Alt+Shift+[" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="speakEditorLocation" value="Ctrl+Alt+1" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -3800,6 +3802,10 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="focusNextPane"
         menuLabel="_Focus Next Pane"
+        windowMode="main"/>
+
+   <cmd id="focusPreviousPane"
+        menuLabel="_Focus Previous Pane"
         windowMode="main"/>
 
    <cmd id="signOut"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -656,6 +656,7 @@ public abstract class
    public abstract AppCommand speakEditorLocation();
    public abstract AppCommand focusConsoleOutputEnd();
    public abstract AppCommand focusNextPane();
+   public abstract AppCommand focusPreviousPane();
    public abstract AppCommand showAccessibilityHelp();
 
    // Internal

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -525,7 +525,8 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
             consoleRightOnTop = false;
 
          if (displayColumnCount_ != additionalColumnCount_)
-            additionalColumnCount_ = paneManager_.syncAdditionalColumnCount(displayColumnCount_);
+            additionalColumnCount_ =
+               paneManager_.syncAdditionalColumnCount(displayColumnCount_, true);
 
          userPrefs_.panes().setGlobalValue(PaneConfig.create(
                panes, tabSet1, tabSet2, hiddenTabSet,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -290,7 +290,7 @@ public class PaneManager
       // get the widgets for the extra source columns to be displayed
       ArrayList<Widget> sourceColumns = new ArrayList<>();
       additionalSourceCount_ = userPrefs_.panes().getValue().getAdditionalSourceColumns();
-      if (additionalSourceCount_ !=  sourceColumnManager_.getSize() - 1)
+      if (additionalSourceCount_ != sourceColumnManager_.getSize() - 1)
          syncAdditionalColumnCount(additionalSourceCount_, false /* refreshDisplay */);
       if (additionalSourceCount_ > 0)
       {
@@ -605,7 +605,7 @@ public class PaneManager
        if (!userPrefs_.allowSourceColumns().getValue())
           pGlobalDisplay_.get().showMessage(GlobalDisplay.MSG_INFO, "Cannot Add Column",
              "Allow Source Columns preference is disabled.");
-       else if (additionalSourceCount_ == MAX_COLUMN_COUNT)
+       else if (additionalSourceCount_ >= MAX_COLUMN_COUNT)
           pGlobalDisplay_.get().showMessage(GlobalDisplay.MSG_INFO, "Cannot Add Column",
              "You can't add more than " + MAX_COLUMN_COUNT + " columns.");
        else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -290,8 +290,8 @@ public class PaneManager
       // get the widgets for the extra source columns to be displayed
       ArrayList<Widget> sourceColumns = new ArrayList<>();
       additionalSourceCount_ = userPrefs_.panes().getValue().getAdditionalSourceColumns();
-      if (additionalSourceCount_ !=  sourceColumnManager_.getSize())
-         syncAdditionalColumnCount(additionalSourceCount_);
+      if (additionalSourceCount_ !=  sourceColumnManager_.getSize() - 1)
+         syncAdditionalColumnCount(additionalSourceCount_, false /* refreshDisplay */);
       if (additionalSourceCount_ > 0)
       {
          if (userPrefs_.allowSourceColumns().getGlobalValue())
@@ -300,7 +300,7 @@ public class PaneManager
             {
                String name = sourceColumnManager_.get(i).getName();
                if (!StringUtil.equals(name, SourceColumnManager.MAIN_SOURCE_NAME))
-                  sourceColumns.add(createSourceColumnWindow(name));
+                  sourceColumns.add(0, createSourceColumnWindow(name));
             }
          }
          else
@@ -418,7 +418,8 @@ public class PaneManager
          {
             if (additionalSourceCount_ != userPrefs_.panes().getGlobalValue().getAdditionalSourceColumns())
             {
-               syncAdditionalColumnCount(userPrefs_.panes().getGlobalValue().getAdditionalSourceColumns());
+               syncAdditionalColumnCount(
+                  userPrefs_.panes().getGlobalValue().getAdditionalSourceColumns(), true);
             }
          }
       });
@@ -594,7 +595,7 @@ public class PaneManager
                   !StringUtil.equals(currentName, SourceColumnManager.MAIN_SOURCE_NAME))
          {
             nextFocusName = sourceColumnManager_.getNextColumnName();
-            if (StringUtil.isNullOrEmpty(nextFocusName))
+            if (StringUtil.equals(nextFocusName, SourceColumnManager.MAIN_SOURCE_NAME))
                nextFocusName = panes_.get(0).getNormal().getName();
          }
          else
@@ -1227,7 +1228,7 @@ public class PaneManager
       return panesByName_.get("Console");
    }
 
-   public int syncAdditionalColumnCount(int count)
+   public int syncAdditionalColumnCount(int count, boolean refreshDisplay)
    {
       // make sure additionalSourceCount_ is up to date
       additionalSourceCount_ = sourceColumnManager_.getSize() - 1;
@@ -1235,18 +1236,25 @@ public class PaneManager
       if (count == additionalSourceCount_)
     	  return additionalSourceCount_;
 
+      // save originalCount because it may change during processing
       if (count > additionalSourceCount_)
       {
          int difference = count - additionalSourceCount_;
          for (int i = 0; i < difference; i++)
-            createSourceColumn();
+         {
+            if (refreshDisplay)
+               createSourceColumn();
+            else
+               sourceColumnManager_.add();
+         }
       }
       else
       {
          sourceColumnManager_.consolidateColumns(count + 1);
-         panel_.resetLeftWidgets(sourceColumnManager_.getWidgets(true));
-         additionalSourceCount_ = sourceColumnManager_.getSize() - 1;
+         if (refreshDisplay)
+            panel_.resetLeftWidgets(sourceColumnManager_.getWidgets(true));
       }
+      additionalSourceCount_ = sourceColumnManager_.getSize() - 1;
       return additionalSourceCount_;
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1455,7 +1455,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          ArrayList<SourceColumn> moveColumns = new ArrayList<>(columnList_);
          moveColumns.remove(mainColumn);
 
-         // remove columns from the end of the lsit first
+         // remove columns from the end of the list first
          int additionalColumnCount = num - 1;
          if (num > 1 && moveColumns.size() != additionalColumnCount)
             moveColumns = new ArrayList<>(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -251,10 +251,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                return;
             }
 
-            columnState_ = value.cast();
-            for (int i = 0; i < columnState_.getNames().length; i++)
+            State state = value.cast();
+            for (int i = 0; i < state.getNames().length; i++)
             {
-               String name = columnState_.getNames()[i];
+               String name = state.getNames()[i];
                if (!StringUtil.equals(name, MAIN_SOURCE_NAME))
                   add(name, false);
             }
@@ -439,10 +439,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public String getNextColumnName()
    {
       int index = columnList_.indexOf(getActive());
-      if (index == getSize() - 1)
+      if (index < 1)
          return null;
       else
-         return columnList_.get(1 + index).getName();
+         return columnList_.get(index - 1).getName();
    }
 
    // This method sets activeColumn_ to the main column if it is null. It should be used in cases


### PR DESCRIPTION
Implements Shift + F6 to navigate focus to the previous pane. Previously we were using "Shift + F6" for `finishDebug`. I changed this to Shift + F7 as using F6 to navigate between panes is typically standard. 

This PR also fixes a few issues with source columns. Columns were not being properly synced between sessions and stored in a different order on refresh than they were originally added. 