### PR TITLE
update static html keyboard shortcut help

### DIFF
--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -65,6 +65,16 @@ References on default Ace shortcuts:
       <td>Ctrl+Option+[</td>
     </tr>
     <tr>
+      <td>Focus Next Pane</td>
+      <td>F6</td>
+      <td>F6</td>
+    </tr>
+    <tr>
+      <td>Focus Previous Pane</td>
+      <td>Shift+F6</td>
+      <td>Shift+F6</td>
+    </tr>
+    <tr>
       <td>Focus Main Toolbar</td>
       <td>Alt+Shift+Y</td>
       <td>Ctrl+Option+Y</td>
@@ -864,6 +874,16 @@ References on default Ace shortcuts:
       <td>Ctrl+Option+Shift+F11</td>
     </tr>
     <tr>
+      <td>Show all panes</td>
+      <td>Ctrl+Alt+Shift+0</td>
+      <td>Ctrl+Alt+0</td>
+    </tr>
+    <tr>
+      <td>Add source column</td>
+      <td>Ctrl+F7</td>
+      <td>Ctrl+F7</td>
+    </tr>
+    <tr>
       <td>Global Options</td>
       <td>No shortcut</td>
       <td>Command+, [comma] (Chrome, Desktop) Option+Command+, [comma] (Safari, Firefox)</td>
@@ -974,8 +994,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Finish Function/Loop</td>
-      <td>Shift+F6</td>
-      <td>Shift+F6</td>
+      <td>Shift+F7</td>
+      <td>Shift+F7</td>
     </tr>
     <tr>
       <td>Continue</td>


### PR DESCRIPTION
This is the keyboard shortcut help shown when screen reader mode is enabled or you click the "Show all shortcuts" link in upper-right of regular keyboard shortcuts help pane.

Ideally we'd generate this automatically but this isn't going to get done in 1.4 so I occasionally update it.