### PR TITLE
Don't propagate visible/enabled command state from satellites to main window commands

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,3 +82,4 @@
 * Fixed issue where failure to rotate a log file could cause a process crash (Pro #1779)
 * Fixed issue where saving workspace could emit 'package may not be available when loading' warning (#7001)
 * Fixed issue where indented Python chunks could not be run (#3731)
+* Fixed disappearing commands and recent files/projects when RStudio Desktop opens new windows (#3968)

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -37,6 +37,7 @@ import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
+import org.rstudio.studio.client.RStudio;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
@@ -109,7 +110,15 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
 
    public AppCommand()
    {
-      if (Desktop.hasDesktopFrame())
+      // If we're in desktop mode and we're the main window, push command
+      // enabled/visible state from this window into the global app menu managed
+      // by Qt; it is not currently possible for commands to have their per-window
+      // state reflected in the global menu.
+      //
+      // Note that we can't use the more robust check
+      // Satellite.isCurrentWindowSatellite since AppCommand instances are
+      // constructed before satellites are fully online.
+      if (Desktop.hasDesktopFrame() && StringUtil.isNullOrEmpty(RStudio.getSatelliteView()))
       {
          addEnabledChangedHandler((event) -> DesktopMenuCallback.setCommandEnabled(id_, enabled_));
          addVisibleChangedHandler((event) -> DesktopMenuCallback.setCommandVisible(id_, visible_));

--- a/src/gwt/src/org/rstudio/studio/client/RStudio.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudio.java
@@ -280,7 +280,7 @@ public class RStudio implements EntryPoint
    {
       // if we are loading the main window, and we're not a launcher session, 
       // add buttons for bailing out
-      String view = Window.Location.getParameter("view");
+      String view = getSatelliteView();
       if (StringUtil.isNullOrEmpty(view) && !ApplicationAction.isLauncherSession())
       {
          rTimeoutOptions_ = new RTimeoutOptions();
@@ -492,6 +492,11 @@ public class RStudio implements EntryPoint
       el.getStyle().setMargin(-1.0, Unit.PX);
       el.getStyle().setOverflow(Overflow.HIDDEN);
       el.getStyle().setPadding(0.0, Unit.PX);
+   }
+
+   public final static String getSatelliteView()
+   {
+      return Window.Location.getParameter("view");
    }
 
    private Command dismissProgressAnimation_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -27,6 +27,9 @@ well as menu structures (for main menu and popup menus).
       exclusive behavior is not automatic and must be managed in code
    @preventShortcutWhenDisabled: Whether the command's shortcut should be
       suppressed when the command is disabled
+   @visible: Whether the command should initially be visible. You should always 
+      set windowMode to "main" for commands not initially visible, unless all
+      satellite windows manage the command state correctly at startup.
    @windowMode: Which window the command wants to operate on; possible values:
       "any": operates on current window (the default),
       "main": always operates on main window, and raises main window
@@ -1195,21 +1198,21 @@ well as menu structures (for main menu and popup menus).
         buttonLabel=""
         desc="Return to main window"/>
 
-   <cmd id="mru0" visible="false" rebindable="false"/>
-   <cmd id="mru1" visible="false" rebindable="false"/>
-   <cmd id="mru2" visible="false" rebindable="false"/>
-   <cmd id="mru3" visible="false" rebindable="false"/>
-   <cmd id="mru4" visible="false" rebindable="false"/>
-   <cmd id="mru5" visible="false" rebindable="false"/>
-   <cmd id="mru6" visible="false" rebindable="false"/>
-   <cmd id="mru7" visible="false" rebindable="false"/>
-   <cmd id="mru8" visible="false" rebindable="false"/>
-   <cmd id="mru9" visible="false" rebindable="false"/>
-   <cmd id="mru10" visible="false" rebindable="false"/>
-   <cmd id="mru11" visible="false" rebindable="false"/>
-   <cmd id="mru12" visible="false" rebindable="false"/>
-   <cmd id="mru13" visible="false" rebindable="false"/>
-   <cmd id="mru14" visible="false" rebindable="false"/>
+   <cmd id="mru0" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru1" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru2" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru3" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru4" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru5" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru6" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru7" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru8" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru9" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru10" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru11" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru12" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru13" visible="false" windowMode="main" rebindable="false"/>
+   <cmd id="mru14" visible="false" windowMode="main" rebindable="false"/>
    
    <cmd id="clearRecentFiles"
         menuLabel="_Clear List"
@@ -2314,6 +2317,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="showFolder"
         label="Show Folder in New Window"
         visible="false"
+        windowMode="main"
         context="files"
         rebindable="false"/>
         
@@ -2956,6 +2960,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="checkForUpdates"
         label="Check for RStudio Updates"
         menuLabel="Check for _Updates"
+        windowMode="main"
         visible="false"/>
 
    <cmd id="helpUsingRStudio"
@@ -3142,6 +3147,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="diagnosticsReport"
         menuLabel="_Write Diagnostics Report"
         context="diagnostics"
+        windowMode="main"
         visible="false"/>
         
    <cmd id="openDeveloperConsole"
@@ -3223,6 +3229,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="showLogFiles"
         menuLabel="_Show Log Files"
         visible="false"
+        windowMode="main"
         rebindable="false"/>
         
    <cmd id="updateCredentials"
@@ -3242,6 +3249,7 @@ well as menu structures (for main menu and popup menus).
     <cmd id="rstudioLicense"
         menuLabel="RStudio _License"
         visible="false"
+        windowMode="main"
         rebindable="false"/>
 
    <cmd id="buildAll"
@@ -3590,18 +3598,21 @@ well as menu structures (for main menu and popup menus).
         menuLabel="P_ublish..."
         desc="Publish the application or document"
         visible="false"
+        windowMode="main"
         rebindable="false"/>
         
    <cmd id="rsconnectConfigure"
         menuLabel="_Configure Application..."
         desc="Configure the application"
         visible="false"
+        windowMode="main"
         rebindable="false"/>
         
    <cmd id="rsconnectManageAccounts"
         menuLabel="_Manage Accounts..."
         desc="Connect or disconnect accounts"
         visible="false"
+        windowMode="main"
         rebindable="false"/>
         
    <cmd id="showGpuDiagnostics"


### PR DESCRIPTION
This change fixes a long-standing issue which created a number of quirky bugs. 

The symptom is effectively that certain actions which open windows in RStudio Desktop cause various commands and menu items to mysteriously disappear, never to return until RStudio is restarted. For example, running a Shiny app or viewing your Git diff can cause all of your recent files and projects to disappear.

See https://github.com/rstudio/rstudio/issues/3968, https://github.com/rstudio/rstudio/issues/4852, and https://github.com/rstudio/rstudio/issues/7126 for examples.

The underlying issue is that we have a global menu in desktop mode, but every window (including satellite windows) writes state to the global menu, in a sort of free-for-all that causes the global state to not really reflect any one window's state. When the command system initializes in the satellite window, it dutifully pushes all of the commands' state into the desktop frame (this bug does not exist on RStudio Server), meaning that commands that were visible are now hidden again. These commands normally get re-enabled in the main window, but the machinery to re-enable them doesn't get invoked in satellites, so they stay hidden.

The fix is to (a) designate these commands as destined for the main window (which they all are anyway), and (b) prohibit satellites from altering the global state of commands that are meant for the main window. 

As 1.4 is winding down, this is a somewhat scoped fix that does not fully address all of the issues with command enabled/visibility state being managed by satellite windows.

Fixes https://github.com/rstudio/rstudio/issues/3968
Fixes https://github.com/rstudio/rstudio/issues/4852
Fixes https://github.com/rstudio/rstudio/issues/7126
