### PR TITLE
Prevent access to invisible columns

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -459,7 +459,9 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    // where it is better for the column to be the main column than null.
    public SourceColumn getActive()
    {
-      if (activeColumn_ != null)
+      if (activeColumn_ != null &&
+          activeColumn_.asWidget().isAttached() &&
+          activeColumn_.asWidget().getOffsetWidth() > 0)
          return activeColumn_;
       setActive(MAIN_SOURCE_NAME);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -509,7 +509,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public int getTabCount()
    {
-      return activeColumn_.getTabCount();
+      return getActive().getTabCount();
    }
 
    public int getPhysicalTabIndex()
@@ -624,7 +624,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       for (SourceColumn column : columnList_)
       {
          if (column.isInitialized() &&
-            !StringUtil.equals(activeColumn_.getName(), column.getName()))
+            !StringUtil.equals(getActive().getName(), column.getName()))
             column.manageCommands(forceSync, activeColumn_);
 
          // if one document is dirty then we are enabled
@@ -659,7 +659,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public EditingTarget addTab(SourceDocument doc, int mode, SourceColumn column)
    {
       if (column == null)
-         column = activeColumn_;
+         column = getActive();
       return column.addTab(doc, mode);
    }
 
@@ -667,7 +667,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                                int mode, SourceColumn column)
    {
       if (column == null)
-         column = activeColumn_;
+         column = getActive();
       return column.addTab(doc, atEnd, mode);
    }
 
@@ -827,7 +827,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             @Override
             public void onResponseReceived(SourceDocument response)
             {
-               activeColumn_.addTab(response, Source.OPEN_INTERACTIVE);
+               getActive().addTab(response, Source.OPEN_INTERACTIVE);
             }
          });
    }
@@ -835,7 +835,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public void showOverflowPopout()
    {
       ensureVisible(false);
-      activeColumn_.showOverflowPopout();
+      getActive().showOverflowPopout();
    }
 
    public void showDataItem(DataItem data)
@@ -865,7 +865,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             @Override
             public void onResponseReceived(SourceDocument response)
             {
-               activeColumn_.addTab(response, Source.OPEN_INTERACTIVE);
+               getActive().addTab(response, Source.OPEN_INTERACTIVE);
             }
          });
    }
@@ -876,39 +876,39 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       OperationWithInput<UnsavedChangesDialog.Result> saveOperation,
       Command onCancelled)
    {
-      activeColumn_.showUnsavedChangesDialog(title, dirtyTargets, saveOperation, onCancelled);
+      getActive().showUnsavedChangesDialog(title, dirtyTargets, saveOperation, onCancelled);
    }
 
    public boolean insertSource(String code, boolean isBlock)
    {
       if (!hasActiveEditor())
          return false;
-      return activeColumn_.insertCode(code, isBlock);
+      return getActive().insertCode(code, isBlock);
    }
 
    @Handler
    public void onMoveTabRight()
    {
-      activeColumn_.moveTab(activeColumn_.getPhysicalTabIndex(), 1);
+      getActive().moveTab(activeColumn_.getPhysicalTabIndex(), 1);
    }
 
    @Handler
    public void onMoveTabLeft()
    {
-      activeColumn_.moveTab(activeColumn_.getPhysicalTabIndex(), -1);
+      getActive().moveTab(activeColumn_.getPhysicalTabIndex(), -1);
    }
 
    @Handler
    public void onMoveTabToFirst()
    {
-      activeColumn_.moveTab(activeColumn_.getPhysicalTabIndex(),
+      getActive().moveTab(activeColumn_.getPhysicalTabIndex(),
          activeColumn_.getPhysicalTabIndex() * -1);
    }
 
    @Handler
    public void onMoveTabToLast()
    {
-      activeColumn_.moveTab(activeColumn_.getPhysicalTabIndex(),
+      getActive().moveTab(activeColumn_.getPhysicalTabIndex(),
          (activeColumn_.getTabCount() -
             activeColumn_.getPhysicalTabIndex()) - 1);
    }
@@ -916,7 +916,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    @Handler
    public void onSwitchToTab()
    {
-      if (activeColumn_.getTabCount() == 0)
+      if (getActive().getTabCount() == 0)
          return;
       showOverflowPopout();
    }
@@ -924,12 +924,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    @Handler
    public void onFirstTab()
    {
-      if (activeColumn_.getTabCount() == 0)
+      if (getActive().getTabCount() == 0)
          return;
 
       ensureVisible(false);
-      if (activeColumn_.getTabCount() > 0)
-         activeColumn_.setPhysicalTabIndex(0);
+      if (getActive().getTabCount() > 0)
+         getActive().setPhysicalTabIndex(0);
    }
 
    @Handler
@@ -947,7 +947,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    @Handler
    public void onLastTab()
    {
-      if (activeColumn_.getTabCount() == 0)
+      if (getActive().getTabCount() == 0)
          return;
 
       activeColumn_.ensureVisible(false);
@@ -1046,7 +1046,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    private void doActivateSource(final Command afterActivation)
    {
-      activeColumn_.ensureVisible(false);
+      getActive().ensureVisible(false);
       if (hasActiveEditor())
       {
          activeColumn_.getActiveEditor().focus();
@@ -1196,7 +1196,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void startDebug()
    {
-      activeColumn_.setPendingDebugSelection();
+      getActive().setPendingDebugSelection();
    }
 
    private EditingTarget selectTabWithDocPath(String path)
@@ -1315,7 +1315,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void closeTab(boolean interactive)
    {
-      closeTab(activeColumn_.getActiveEditor(), interactive);
+      if (hasActiveEditor())
+         closeTab(activeColumn_.getActiveEditor(), interactive);
    }
 
    public void closeTab(EditingTarget target, boolean interactive)
@@ -1344,7 +1345,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                @Override
                public void execute(EditingTarget target, Command continuation)
                {
-                  if (excludeActive && target == activeColumn_.getActiveEditor())
+                  if (excludeActive &&
+                     (hasActiveEditor() && target == activeColumn_.getActiveEditor()))
                   {
                      continuation.execute();
                      return;


### PR DESCRIPTION
Begins to address #7471 

This is a temporary failsafe to prevent the IDE from getting into a state where it tries to access a "phantom column" that is not visible to the user. This needs to be addressed more completely so that we don't have these types on invisible columns in the first place but this will prevent the IDE from essentially shutting down. 
`public SourceColumn getActive()` already existed within SourceColumnManager to return the active column or set the main column to active if there was no active column. I updated this to check the widget's presence as well and expanded the places where it's used. 