### PR TITLE
implement custom return focus behavior for Source pane elements

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -541,7 +541,8 @@ public abstract class ModalDialogBase extends DialogBox
       }
       catch (Exception e)
       {
-         
+         // intentionally swallow exceptions (as they can occur
+         // for a multitude of reasons and generally are not actionable)
       }
       finally
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
@@ -20,7 +20,6 @@ import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.studio.client.workbench.codesearch.CodeSearch;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -58,16 +57,11 @@ public class CodeSearchDialog extends ModalDialogBase
    @Override
    protected void positionAndShowDialog(final Command onCompleted)
    {
-      setPopupPositionAndShow(new PositionCallback() {
-         @Override
-         public void setPosition(int offsetWidth, int offsetHeight)
-         {
-            int left = (Window.getClientWidth()/2) - (offsetWidth/2);
-            setPopupPosition(left, 15);
-            onCompleted.execute();
-            
-         }
-         
+      setPopupPositionAndShow((int offsetWidth, int offsetHeight) ->
+      {
+         int left = (Window.getClientWidth() / 2) - (offsetWidth / 2);
+         setPopupPosition(left, 15);
+         onCompleted.execute();
       });
    }
    
@@ -88,6 +82,9 @@ public class CodeSearchDialog extends ModalDialogBase
    @Override
    public void onCompleted()
    {
+      // don't restore focus on close, as we'll be separately
+      // navigating the document in response to dialog completion
+      setRestoreFocusOnClose(false);
       closeDialog();  
    }
    
@@ -95,14 +92,7 @@ public class CodeSearchDialog extends ModalDialogBase
    public void onCancel()
    {
       // delay to prevent ESC key from ever getting into the editor
-      Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-         @Override
-         public void execute()
-         {
-            closeDialog(); 
-         }      
-      });
-    
+      Scheduler.get().scheduleDeferred(() -> closeDialog());
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.user.client.Command;
@@ -25,13 +26,17 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
+
+import org.apache.commons.lang3.StringUtils;
 import org.rstudio.core.client.*;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressIndicator;
@@ -268,6 +273,24 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       };
 
       setActive(column.getName());
+      
+      // register custom focus handler for case where ProseMirror
+      // instance (or element within) had focus
+      ModalDialogBase.registerReturnFocusHandler((Element el) ->
+      {
+         Element proseMirrorEl = DomUtils.findParentElement(el, (Element parent) ->
+         {
+            return parent.hasClassName("rstudio_source_panel");
+         });
+         
+         if (proseMirrorEl != null)
+         {
+            commands_.activateSource().execute();
+            return true;
+         }
+         
+         return false;
+      });
    }
 
    public String add()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -278,12 +278,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       ModalDialogBase.registerReturnFocusHandler((Element el) ->
       {
          final String sourceClass = ClassIds.getClassId(ClassIds.SOURCE_PANEL);
-         Element proseMirrorEl = DomUtils.findParentElement(el, (Element parent) ->
+         Element sourceEl = DomUtils.findParentElement(el, (Element parent) ->
          {
             return parent.hasClassName(sourceClass);
          });
          
-         if (proseMirrorEl != null)
+         if (sourceEl != null)
          {
             commands_.activateSource().execute();
             return true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -27,7 +27,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 
-import org.apache.commons.lang3.StringUtils;
 import org.rstudio.core.client.*;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -277,9 +277,10 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       // instance (or element within) had focus
       ModalDialogBase.registerReturnFocusHandler((Element el) ->
       {
+         final String sourceClass = ClassIds.getClassId(ClassIds.SOURCE_PANEL);
          Element proseMirrorEl = DomUtils.findParentElement(el, (Element parent) ->
          {
-            return parent.hasClassName("rstudio_source_panel");
+            return parent.hasClassName(sourceClass);
          });
          
          if (proseMirrorEl != null)


### PR DESCRIPTION
This PR fixes a couple issues when returning focus to the visual editor from a modal dialog (e.g. the fuzzy file finder dialog, opened via <kbd>Ctrl + .</kbd>).

1. Normally, cancelling (closing) a modal dialog will explicitly attempt to return focus to the last-focused element. However, this caused issues in the visual editor, as that focus attempt will cause the document to scroll back to the top of the document. To alleviate this, we now have the notion of custom "return focus handlers" -- if the element to be focused lives within a Source pane, rather than focusing it directly, we execute the `activateSource` command which should then ensure the proper machinery is run during focus.

2. In addition, "accepting" an entry from the fuzzy file finder normally implies a pending navigation attempt. When this occurs, we do not want to immediately return focus to the Source pane, as the soon-to-be-in-flight navigation request will do that for us.