### PR TITLE
Do not reset active column before start up

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -483,8 +483,9 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public SourceColumn getActive()
    {
       if (activeColumn_ != null &&
+         (!columnList_.get(0).asWidget().isAttached() ||
           activeColumn_.asWidget().isAttached() &&
-          activeColumn_.asWidget().getOffsetWidth() > 0)
+          activeColumn_.asWidget().getOffsetWidth() > 0))
          return activeColumn_;
       setActive(MAIN_SOURCE_NAME);
 


### PR DESCRIPTION
Adjustment to #7476 which prevented access to phantom columns by refusing to access unattached columns. There are a few times we want to access columns _before_ they are attached, this PR adds an additional check before changing the active column to see if the main column itself has been attached. If not, it proceeds with the requested active column. 