### PR TITLE
Save accurate splitter positions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -196,7 +196,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
             int[] splitterArray = new int[leftList_.size() + 1];
             splitterArray[0] = right_.getOffsetWidth();
             for (int i = 0; i < leftList_.size(); i++)
-               splitterArray[i + 1] = leftList_.get(i).getOffsetWidth();
+               splitterArray[i + 1] = splitterArray[i] + leftList_.get(i).getOffsetWidth();
             state.setSplitterPos(splitterArray);
             return state.cast();
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -235,7 +235,9 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
    public void initialSelect(int index)
    {
-      if (index >= 0 && display_.getTabCount() > index)
+      if (index < 0)
+         return;
+      if (display_.getTabCount() > index)
       {
          display_.selectTab(index);
       }


### PR DESCRIPTION
Previously all vertical splitters being displayed had their state's position saved as the width of the column in front of it. This worked for the first splitter but none of the following ones. This fix determines the splitter's position by adding the splitter position of the previous column to the column on it's right's width. 

For example, given four columns and three splitters the equation would look like the following:
```
splitterPos[0] = rightColumnWidth
splitterPos[1] = splitter[0] + rightColumnWidth2
splitterPos[2] = splitter[1] + rightColumnWidth3
```

This PR also adds an additional safety check to the logic used to select a tab on start up. Before it was possible to attempt to select a tab with iterator position of -1. 