### PR TITLE
add missing default argument for .rs.restartR

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -99,7 +99,7 @@
 })
 
 # provide restart function
-.rs.setOption("restart", function(afterRestartCommand)
+.rs.setOption("restart", function(afterRestartCommand = "")
 {
    .rs.restartR(afterRestartCommand)
 })


### PR DESCRIPTION
Fixes regression from https://github.com/rstudio/rstudio/commit/03287064cb4d50de4b71b10122a53a4727f02c69#diff-60f4e7f40cb9dcaeaa38ed192bf4b469R102-R105.