### PR TITLE
set defaults in JSNI accessors for prefs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -116,15 +116,15 @@ public class UserPrefsAccessor extends Prefs
       protected CranMirror() {} 
 
       public final native String getName() /*-{
-         return this.name || "";
+         return this.name || "Global (CDN)";
       }-*/;
 
       public final native String getHost() /*-{
-         return this.host || "";
+         return this.host || "RStudio";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url || "";
+         return this.url || "https://cran.rstudio.com/";
       }-*/;
 
       public final native String getRepos() /*-{
@@ -132,7 +132,7 @@ public class UserPrefsAccessor extends Prefs
       }-*/;
 
       public final native String getCountry() /*-{
-         return this.country || "";
+         return this.country || "us";
       }-*/;
 
       public final native String getSecondary() /*-{
@@ -377,15 +377,15 @@ public class UserPrefsAccessor extends Prefs
       public final static String QUADRANTS_HIDDENTABSET = "HiddenTabSet";
 
       public final native JsArrayString getQuadrants() /*-{
-         return this.quadrants || [];
+         return this.quadrants || ["Source","Console","TabSet1","TabSet2","HiddenTabSet"];
       }-*/;
 
       public final native JsArrayString getTabSet1() /*-{
-         return this.tabSet1 || [];
+         return this.tabSet1 || ["Environment","History","Connections","Build","VCS","Tutorial","Presentation"];
       }-*/;
 
       public final native JsArrayString getTabSet2() /*-{
-         return this.tabSet2 || [];
+         return this.tabSet2 || ["Files","Plots","Packages","Help","Viewer"];
       }-*/;
 
       public final native JsArrayString getHiddenTabSet() /*-{
@@ -397,7 +397,7 @@ public class UserPrefsAccessor extends Prefs
       }-*/;
 
       public final native boolean getConsoleRightOnTop() /*-{
-         return this.console_right_on_top || false;
+         return this.console_right_on_top || true;
       }-*/;
 
       public final native int getAdditionalSourceColumns() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -116,27 +116,27 @@ public class UserPrefsAccessor extends Prefs
       protected CranMirror() {} 
 
       public final native String getName() /*-{
-         return this.name;
+         return this.name || "";
       }-*/;
 
       public final native String getHost() /*-{
-         return this.host;
+         return this.host || "";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url;
+         return this.url || "";
       }-*/;
 
       public final native String getRepos() /*-{
-         return this.repos;
+         return this.repos || "";
       }-*/;
 
       public final native String getCountry() /*-{
-         return this.country;
+         return this.country || "";
       }-*/;
 
       public final native String getSecondary() /*-{
-         return this.secondary;
+         return this.secondary || "";
       }-*/;
 
    }
@@ -377,34 +377,31 @@ public class UserPrefsAccessor extends Prefs
       public final static String QUADRANTS_HIDDENTABSET = "HiddenTabSet";
 
       public final native JsArrayString getQuadrants() /*-{
-         return this.quadrants;
+         return this.quadrants || [];
       }-*/;
 
       public final native JsArrayString getTabSet1() /*-{
-         return this.tabSet1;
+         return this.tabSet1 || [];
       }-*/;
 
       public final native JsArrayString getTabSet2() /*-{
-         return this.tabSet2;
+         return this.tabSet2 || [];
       }-*/;
 
       public final native JsArrayString getHiddenTabSet() /*-{
-         return this.hiddenTabSet;
+         return this.hiddenTabSet || [];
       }-*/;
 
       public final native boolean getConsoleLeftOnTop() /*-{
-         return this.console_left_on_top;
+         return this.console_left_on_top || false;
       }-*/;
 
       public final native boolean getConsoleRightOnTop() /*-{
-         return this.console_right_on_top;
+         return this.console_right_on_top || false;
       }-*/;
 
       public final native int getAdditionalSourceColumns() /*-{
-         if (!this.additional_source_columns)
-           return 0;
-
-         return this.additional_source_columns;
+         return this.additional_source_columns || 0;
       }-*/;
 
    }
@@ -2480,15 +2477,15 @@ public class UserPrefsAccessor extends Prefs
       protected DefaultRVersion() {} 
 
       public final native String getVersion() /*-{
-         return this.version;
+         return this.version || "";
       }-*/;
 
       public final native String getRHome() /*-{
-         return this.r_home;
+         return this.r_home || "";
       }-*/;
 
       public final native String getLabel() /*-{
-         return this.label;
+         return this.label || "";
       }-*/;
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -116,27 +116,27 @@ public class UserPrefsAccessor extends Prefs
       protected CranMirror() {} 
 
       public final native String getName() /*-{
-         return this.name || "Global (CDN)";
+         return this && this.name || "Global (CDN)";
       }-*/;
 
       public final native String getHost() /*-{
-         return this.host || "RStudio";
+         return this && this.host || "RStudio";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url || "https://cran.rstudio.com/";
+         return this && this.url || "https://cran.rstudio.com/";
       }-*/;
 
       public final native String getRepos() /*-{
-         return this.repos || "";
+         return this && this.repos || "";
       }-*/;
 
       public final native String getCountry() /*-{
-         return this.country || "us";
+         return this && this.country || "us";
       }-*/;
 
       public final native String getSecondary() /*-{
-         return this.secondary || "";
+         return this && this.secondary || "";
       }-*/;
 
    }
@@ -377,31 +377,31 @@ public class UserPrefsAccessor extends Prefs
       public final static String QUADRANTS_HIDDENTABSET = "HiddenTabSet";
 
       public final native JsArrayString getQuadrants() /*-{
-         return this.quadrants || ["Source","Console","TabSet1","TabSet2","HiddenTabSet"];
+         return this && this.quadrants || ["Source","Console","TabSet1","TabSet2","HiddenTabSet"];
       }-*/;
 
       public final native JsArrayString getTabSet1() /*-{
-         return this.tabSet1 || ["Environment","History","Connections","Build","VCS","Tutorial","Presentation"];
+         return this && this.tabSet1 || ["Environment","History","Connections","Build","VCS","Tutorial","Presentation"];
       }-*/;
 
       public final native JsArrayString getTabSet2() /*-{
-         return this.tabSet2 || ["Files","Plots","Packages","Help","Viewer"];
+         return this && this.tabSet2 || ["Files","Plots","Packages","Help","Viewer"];
       }-*/;
 
       public final native JsArrayString getHiddenTabSet() /*-{
-         return this.hiddenTabSet || [];
+         return this && this.hiddenTabSet || [];
       }-*/;
 
       public final native boolean getConsoleLeftOnTop() /*-{
-         return this.console_left_on_top || false;
+         return this && this.console_left_on_top || false;
       }-*/;
 
       public final native boolean getConsoleRightOnTop() /*-{
-         return this.console_right_on_top || true;
+         return this && this.console_right_on_top || true;
       }-*/;
 
       public final native int getAdditionalSourceColumns() /*-{
-         return this.additional_source_columns || 0;
+         return this && this.additional_source_columns || 0;
       }-*/;
 
    }
@@ -2477,15 +2477,15 @@ public class UserPrefsAccessor extends Prefs
       protected DefaultRVersion() {} 
 
       public final native String getVersion() /*-{
-         return this.version || "";
+         return this && this.version || "";
       }-*/;
 
       public final native String getRHome() /*-{
-         return this.r_home || "";
+         return this && this.r_home || "";
       }-*/;
 
       public final native String getLabel() /*-{
-         return this.label || "";
+         return this && this.label || "";
       }-*/;
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -80,11 +80,11 @@ public class UserStateAccessor extends Prefs
       protected Theme() {} 
 
       public final native String getName() /*-{
-         return this.name || "";
+         return this.name || "Textmate (default)";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url || "";
+         return this.url || "theme/default/textmate.rstheme";
       }-*/;
 
       public final native boolean getIsDark() /*-{
@@ -134,15 +134,15 @@ public class UserStateAccessor extends Prefs
       protected ExportPlotOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width || 0;
+         return this.width || 550;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height || 0;
+         return this.height || 450;
       }-*/;
 
       public final native String getFormat() /*-{
-         return this.format || "";
+         return this.format || "PNG";
       }-*/;
 
       public final native boolean getKeepRatio() /*-{
@@ -282,7 +282,7 @@ public class UserStateAccessor extends Prefs
       protected CompileRMarkdownNotebookPrefs() {} 
 
       public final native String getFormat() /*-{
-         return this.format || "";
+         return this.format || "html_document";
       }-*/;
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -80,15 +80,15 @@ public class UserStateAccessor extends Prefs
       protected Theme() {} 
 
       public final native String getName() /*-{
-         return this.name || "Textmate (default)";
+         return this && this.name || "Textmate (default)";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url || "theme/default/textmate.rstheme";
+         return this && this.url || "theme/default/textmate.rstheme";
       }-*/;
 
       public final native boolean getIsDark() /*-{
-         return this.isDark || false;
+         return this && this.isDark || false;
       }-*/;
 
    }
@@ -134,27 +134,27 @@ public class UserStateAccessor extends Prefs
       protected ExportPlotOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width || 550;
+         return this && this.width || 550;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height || 450;
+         return this && this.height || 450;
       }-*/;
 
       public final native String getFormat() /*-{
-         return this.format || "PNG";
+         return this && this.format || "PNG";
       }-*/;
 
       public final native boolean getKeepRatio() /*-{
-         return this.keepRatio || false;
+         return this && this.keepRatio || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave || false;
+         return this && this.viewAfterSave || false;
       }-*/;
 
       public final native boolean getCopyAsMetafile() /*-{
-         return this.copyAsMetafile || false;
+         return this && this.copyAsMetafile || false;
       }-*/;
 
    }
@@ -176,27 +176,27 @@ public class UserStateAccessor extends Prefs
       protected ExportViewerOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width || 0;
+         return this && this.width || 0;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height || 0;
+         return this && this.height || 0;
       }-*/;
 
       public final native String getFormat() /*-{
-         return this.format || "";
+         return this && this.format || "";
       }-*/;
 
       public final native boolean getKeepRatio() /*-{
-         return this.keepRatio || false;
+         return this && this.keepRatio || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave || false;
+         return this && this.viewAfterSave || false;
       }-*/;
 
       public final native boolean getCopyAsMetafile() /*-{
-         return this.copyAsMetafile || false;
+         return this && this.copyAsMetafile || false;
       }-*/;
 
    }
@@ -218,23 +218,23 @@ public class UserStateAccessor extends Prefs
       protected SavePlotAsPdfOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width || 0;
+         return this && this.width || 0;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height || 0;
+         return this && this.height || 0;
       }-*/;
 
       public final native boolean getPortrait() /*-{
-         return this.portrait || false;
+         return this && this.portrait || false;
       }-*/;
 
       public final native boolean getCairoPdf() /*-{
-         return this.cairo_pdf || false;
+         return this && this.cairo_pdf || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave || false;
+         return this && this.viewAfterSave || false;
       }-*/;
 
    }
@@ -256,11 +256,11 @@ public class UserStateAccessor extends Prefs
       protected CompileRNotebookPrefs() {} 
 
       public final native String getAuthor() /*-{
-         return this.author || "";
+         return this && this.author || "";
       }-*/;
 
       public final native String getType() /*-{
-         return this.type || "";
+         return this && this.type || "";
       }-*/;
 
    }
@@ -282,7 +282,7 @@ public class UserStateAccessor extends Prefs
       protected CompileRMarkdownNotebookPrefs() {} 
 
       public final native String getFormat() /*-{
-         return this.format || "html_document";
+         return this && this.format || "html_document";
       }-*/;
 
    }
@@ -328,11 +328,11 @@ public class UserStateAccessor extends Prefs
       protected PublishAccount() {} 
 
       public final native String getName() /*-{
-         return this.name || "";
+         return this && this.name || "";
       }-*/;
 
       public final native String getServer() /*-{
-         return this.server || "";
+         return this && this.server || "";
       }-*/;
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -80,15 +80,15 @@ public class UserStateAccessor extends Prefs
       protected Theme() {} 
 
       public final native String getName() /*-{
-         return this.name;
+         return this.name || "";
       }-*/;
 
       public final native String getUrl() /*-{
-         return this.url;
+         return this.url || "";
       }-*/;
 
       public final native boolean getIsDark() /*-{
-         return this.isDark;
+         return this.isDark || false;
       }-*/;
 
    }
@@ -134,27 +134,27 @@ public class UserStateAccessor extends Prefs
       protected ExportPlotOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width;
+         return this.width || 0;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height;
+         return this.height || 0;
       }-*/;
 
       public final native String getFormat() /*-{
-         return this.format;
+         return this.format || "";
       }-*/;
 
       public final native boolean getKeepRatio() /*-{
-         return this.keepRatio;
+         return this.keepRatio || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave;
+         return this.viewAfterSave || false;
       }-*/;
 
       public final native boolean getCopyAsMetafile() /*-{
-         return this.copyAsMetafile;
+         return this.copyAsMetafile || false;
       }-*/;
 
    }
@@ -176,27 +176,27 @@ public class UserStateAccessor extends Prefs
       protected ExportViewerOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width;
+         return this.width || 0;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height;
+         return this.height || 0;
       }-*/;
 
       public final native String getFormat() /*-{
-         return this.format;
+         return this.format || "";
       }-*/;
 
       public final native boolean getKeepRatio() /*-{
-         return this.keepRatio;
+         return this.keepRatio || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave;
+         return this.viewAfterSave || false;
       }-*/;
 
       public final native boolean getCopyAsMetafile() /*-{
-         return this.copyAsMetafile;
+         return this.copyAsMetafile || false;
       }-*/;
 
    }
@@ -218,23 +218,23 @@ public class UserStateAccessor extends Prefs
       protected SavePlotAsPdfOptions() {} 
 
       public final native int getWidth() /*-{
-         return this.width;
+         return this.width || 0;
       }-*/;
 
       public final native int getHeight() /*-{
-         return this.height;
+         return this.height || 0;
       }-*/;
 
       public final native boolean getPortrait() /*-{
-         return this.portrait;
+         return this.portrait || false;
       }-*/;
 
       public final native boolean getCairoPdf() /*-{
-         return this.cairo_pdf;
+         return this.cairo_pdf || false;
       }-*/;
 
       public final native boolean getViewAfterSave() /*-{
-         return this.viewAfterSave;
+         return this.viewAfterSave || false;
       }-*/;
 
    }
@@ -256,11 +256,11 @@ public class UserStateAccessor extends Prefs
       protected CompileRNotebookPrefs() {} 
 
       public final native String getAuthor() /*-{
-         return this.author;
+         return this.author || "";
       }-*/;
 
       public final native String getType() /*-{
-         return this.type;
+         return this.type || "";
       }-*/;
 
    }
@@ -282,7 +282,7 @@ public class UserStateAccessor extends Prefs
       protected CompileRMarkdownNotebookPrefs() {} 
 
       public final native String getFormat() /*-{
-         return this.format;
+         return this.format || "";
       }-*/;
 
    }
@@ -328,11 +328,11 @@ public class UserStateAccessor extends Prefs
       protected PublishAccount() {} 
 
       public final native String getName() /*-{
-         return this.name;
+         return this.name || "";
       }-*/;
 
       public final native String getServer() /*-{
-         return this.server;
+         return this.server || "";
       }-*/;
 
    }

--- a/src/gwt/tools/generate-prefs.R
+++ b/src/gwt/tools/generate-prefs.R
@@ -241,9 +241,9 @@ generate <- function (schemaPath, className) {
             propname <- gsub("(^|_)(.)", "\\U\\2\\E", prop, perl = TRUE)
             proptype <- propdef[["type"]]
             
-            default <- propdef[["default"]]
+            default <- propdef[["default"]] %||% def[["default"]][[prop]]
             if (!is.null(default))
-               default <- paste(" ||", default)
+               default <- paste(" ||", jsonlite::toJSON(default, auto_unbox = TRUE))
             
             if (identical(proptype, "array")) {
                proptype <- "JsArrayString"

--- a/src/gwt/tools/generate-prefs.R
+++ b/src/gwt/tools/generate-prefs.R
@@ -267,7 +267,7 @@ generate <- function (schemaPath, className) {
             
             java <- paste0(java,
               "      public final native ", proptype, " get",  propname, "() /*-{\n",
-              "         return this.", prop, default, ";\n",
+              "         return this && this.", prop, default, ";\n",
               "      }-*/;\n\n")
             cppstrings <- paste0(cppstrings,
                                  "#define k", capitalize(camel), propname, " \"", prop, "\"\n")


### PR DESCRIPTION
This PR is a bandaid against unexpected `null` preference values. If the associated preference is not defined or does not exist for some reason, we instead return the default value defined for the preference (if any), or the "zero" value for the associated type.