### PR TITLE
allow the enter key to insert a paragraph above rmd and yaml blocks 

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/node.ts
+++ b/src/gwt/panmirror/src/editor/src/api/node.ts
@@ -68,6 +68,7 @@ export interface CodeViewOptions {
   lineNumbers?: boolean;
   bookdownTheorems?: boolean;
   lineNumberFormatter?: (lineNumber: number, lineCount?: number, line?: string) => string;
+  isRequiredFirstLine?: (line: string) => boolean;
 }
 
 export type NodeTraversalFn = (

--- a/src/gwt/panmirror/src/editor/src/nodes/rmd_chunk/rmd_chunk.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/rmd_chunk/rmd_chunk.ts
@@ -82,6 +82,8 @@ const extension = (context: ExtensionContext): Extension | null => {
           executeRmdChunkFn: ui.execute.executeRmdChunk
             ? (chunk: EditorRmdChunk) => ui.execute.executeRmdChunk!(chunk)
             : undefined,
+
+          isRequiredFirstLine: (line: string) => /^\{/.test(line)
         },
 
         pandoc: {

--- a/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
@@ -56,7 +56,6 @@ const extension = (context: ExtensionContext): Extension => {
         code_view: {
           lang: () => 'yaml-frontmatter',
           classes: ['pm-metadata-background-color', 'pm-yaml-metadata-block'],
-          isRequiredFirstLine: (line: string) => /^---/.test(line)
         },
 
         pandoc: {

--- a/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
@@ -56,6 +56,7 @@ const extension = (context: ExtensionContext): Extension => {
         code_view: {
           lang: () => 'yaml-frontmatter',
           classes: ['pm-metadata-background-color', 'pm-yaml-metadata-block'],
+          isRequiredFirstLine: (line: string) => /^---/.test(line)
         },
 
         pandoc: {

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -441,6 +441,36 @@ export class AceNodeView implements NodeView {
       }
     });
 
+    // allow the enter key to insert a paragraph above in some circumstances
+    this.aceEditor.commands.addCommand({
+      name: "returnKey",
+      bindKey: "Return",
+      exec: () => {
+        // check to see if this is an Enter key at the beginning of a code block
+        // for which any content before the first line is invalid
+        if (this.options.isRequiredFirstLine && this.view.state.selection.empty) {
+          const pos = this.aceEditor?.getCursorPosition();
+          if (pos && pos.column === 0 && pos.row === 0) {
+            if (this.options.isRequiredFirstLine(this.editSession?.getLine(0) || '')) {
+              // noticed that if I hit enter very soon after navigating to the first
+              // character that ace would actually have the editor selection wrong
+              // (perhaps there is an async component to selection propagation?)
+              if (!this.updating) {
+                this.forwardSelection();
+              }
+              if (insertParagraph(this.view.state, this.view.dispatch)) {
+                this.arrowMaybeEscape('line', -1, "golineup");
+                return;
+              }
+            }
+          }
+        }
+
+        // default handling
+        this.aceEditor?.execCommand("insertstring", "\n");
+      }
+    });
+
     // Add custom escape commands for movement keys (left/right/up/down); these
     // will check to see whether the movement should leave the editor, and if
     // so will do so instead of moving the cursor.


### PR DESCRIPTION
This goal of this is similar to previous changes that allowed for gap cursor's between code blocks: to make it easier to insert content around code blocks. The gap cursor provides a "virtual" selection between code blocks that can be made either via arrow keys or the mouse. 

This change overrides the Enter key for Ace and in the case that you are at the very start of a code block that already has a valid first line, we go ahead and insert a paragraph above. This will match better with user's intuition about how to create blocks above the current one.

Currently we implement this for Rmd Chunks and YAML blocks, both of which have unambiguous patterns for a valid first line (in fact they will be broken on render w/o that valid first line). This does create some inconsistency with plain fenced code and raw blocks, but those are infrequent/advanced enough that it seems worth it to make the 90% case much better.

Ace doesn't have a documented command for "Return" so I am just using `"insertstring"` with a `\n`. This might run afoul of other considerations I'm not aware of though. 

@jmcphers LMK if you agree with this change and if so whether there is anything else we need to do to make it fully robust.
