### PR TITLE
ensure focus on navigate when using fuzzy finder

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -330,6 +330,17 @@ public class FileSystemItem extends JavaScriptObject
    private final native String getMimeTypeInternal() /*-{
       return this.mime_type;
    }-*/;
+   
+   // NOTE: This isn't really the proper place to tag this metadata
+   // but it was the least intrusive way to propagate this state through
+   // all plumbing used when attempting to open a file.
+   public final native void setFocusOnNavigate(boolean focusOnNavigate) /*-{
+      this.focus_on_navigate = focusOnNavigate;
+   }-*/;
+   
+   public final native boolean focusOnNavigate() /*-{
+      return this.focus_on_navigate || false;
+   }-*/;
 
    // NOTE: should be synced with mime type database in FilePath.cpp
    private final static HashMap<String,String> MIME_TYPES =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
@@ -113,6 +113,7 @@ public class CodeSearch
                }
                else
                {
+                  srcItem.setFocusOnNavigate(true);
                   fileTypeRegistry.editFile(srcItem, pos);
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearchDialog.java
@@ -82,6 +82,7 @@ public class CodeSearchDialog extends ModalDialogBase
    @Override
    public void onCompleted()
    {
+      setRestoreFocusOnClose(false);
       closeDialog();  
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1795,12 +1795,13 @@ public class Source implements InsertSourceHandler,
     
    public void onOpenSourceFile(final OpenSourceFileEvent event)
    {
-      doOpenSourceFile(event.getFile(),
-                     event.getFileType(),
-                     event.getPosition(),
-                     null, 
-                     event.getNavigationMethod(),
-                     false);
+      doOpenSourceFile(
+            event.getFile(),
+            event.getFileType(),
+            event.getPosition(),
+            null, 
+            event.getNavigationMethod(),
+            false);
    }
    
    public void onOpenPresentationSourceFile(OpenPresentationSourceFileEvent event)
@@ -1935,6 +1936,9 @@ public class Source implements InsertSourceHandler,
                            null);
                }
             }
+            
+            if (file.focusOnNavigate())
+               target.focus();
          }
          
          private void navigate(final EditingTarget target,


### PR DESCRIPTION
This PR fixes an issue where attempting to navigate using the fuzzy finder would sometimes not send focus to the opened document.