### PR TITLE
Standardize XDG log file locations on desktop

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -58,9 +58,7 @@ namespace {
 const FilePath kDefaultLogPath("/var/log/rstudio-server");
 #else
 // desktop - store logs under user dir
-const FilePath kDefaultLogPath = core::system::userSettingsPath(core::system::userHomePath(),
-                                                               "RStudio-Desktop",
-                                                                false).completePath("logs");
+const FilePath kDefaultLogPath = core::system:xdg:::userDataDir().completePath("log");
 #endif
 
 std::string logLevelToString(LogLevel logLevel)

--- a/src/cpp/desktop/DesktopUtils.cpp
+++ b/src/cpp/desktop/DesktopUtils.cpp
@@ -63,11 +63,7 @@ void reattachConsoleIfNecessary()
 // SessionOptions.hpp although the code path isn't exactly the same)
 FilePath userLogPath()
 {
-   FilePath userHomePath = core::system::userHomePath("R_USER|HOME");
-   FilePath logPath = core::system::userSettingsPath(
-      userHomePath,
-      "RStudio-Desktop").completeChildPath("log");
-   return logPath;
+   return core::system::xdg::userDataDir().completeChildPath("log");
 }
 
 FilePath userWebCachePath()

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -22,6 +22,7 @@
 #include <core/system/Xdg.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/system/System.hpp>
+#include <core/system/Xdg.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -33,20 +34,11 @@ using namespace rstudio::core;
 
 namespace {
 
-FilePath homePath()
-{
-   return core::system::userHomePath("R_USER|HOME");
-}
-
 // NOTE: this code is duplicated in diagnostics as well (and also in
 // SessionOptions.hpp although the code path isn't exactly the same)
 FilePath userLogPath()
 {
-   FilePath logPath = core::system::userSettingsPath(
-      homePath(),
-      "RStudio-Desktop"
-   ).completeChildPath("log");
-   return logPath;
+   return core::system::xdg::userDataDir().completePath("log");
 }
 
 void writeFile(const std::string& description, const core::FilePath& path, std::ostream& ostr)


### PR DESCRIPTION
We currently still expect to find RStudio Desktop logs in the old `.rstudio-desktop/log` folder in some places. This location is now configurable and defaults to `.local/share/rstudio/log`, so this change updates the remaining references. 

Fixes #7367.