### PR TITLE
delegate focus requests to panmirror when visual mode active

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1899,6 +1899,19 @@ public class Source implements InsertSourceHandler,
          @Override
          public void execute(EditingTarget target)
          {
+            // helper command to focus after navigation has completed
+            final Command onNavigationCompleted = () ->
+            {
+               if (file.focusOnNavigate())
+               {
+                  Scheduler.get().scheduleDeferred(() ->
+                  {
+                     target.focus();
+                  });
+               }
+            };
+      
+            
             // the rstudioapi package can use the proxy (-1, -1) position to
             // indicate that source navigation should not occur; ie, we should
             // preserve whatever position was used in the document earlier
@@ -1919,12 +1932,19 @@ public class Source implements InsertSourceHandler,
                   
                   if (Desktop.hasDesktopFrame() &&
                       navMethod != NavigationMethods.DEBUG_END)
+                  {
                       Desktop.getFrame().bringMainFrameToFront();
+                  }
                }
+               
+               SourcePosition startPosition = SourcePosition.create(
+                     position.getLine() - 1,
+                     position.getColumn() - 1);
+               
                navigate(target, 
-                        SourcePosition.create(position.getLine() - 1,
-                                              position.getColumn() - 1),
-                        endPosition);
+                        startPosition,
+                        endPosition,
+                        onNavigationCompleted);
             }
             else if (pattern != null)
             {
@@ -1933,17 +1953,20 @@ public class Source implements InsertSourceHandler,
                {
                   navigate(target, 
                            SourcePosition.create(pos.getRow(), 0),
-                           null);
+                           null,
+                           onNavigationCompleted);
                }
             }
-            
-            if (file.focusOnNavigate())
-               target.focus();
+            else
+            {
+               onNavigationCompleted.execute();
+            }
          }
          
          private void navigate(final EditingTarget target,
                                final SourcePosition srcPosition,
-                               final SourcePosition srcEndPosition)
+                               final SourcePosition srcEndPosition,
+                               final Command onNavigationCompleted)
          {
             Scheduler.get().scheduleDeferred(new ScheduledCommand()
             {
@@ -1971,9 +1994,12 @@ public class Source implements InsertSourceHandler,
                      boolean highlight = 
                            navMethod == NavigationMethods.HIGHLIGHT_LINE &&
                            !userPrefs_.highlightSelectedLine().getValue();
-                     target.navigateToPosition(srcPosition,
-                                               false,
-                                               highlight);
+                     
+                     target.navigateToPosition(
+                           srcPosition,
+                           false,
+                           highlight,
+                           onNavigationCompleted);
                   }
                }
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -84,6 +84,11 @@ public interface EditingTarget extends IsWidget,
    void navigateToPosition(SourcePosition position, 
                            boolean recordCurrent,
                            boolean highlightLine);
+   void navigateToPosition(SourcePosition position,
+                           boolean recordCurrent,
+                           boolean highlightLine,
+                           Command onNavigationCompleted);
+   
    void restorePosition(SourcePosition position);
    SourcePosition currentPosition();
    boolean isAtSourceRow(SourcePosition position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -565,7 +565,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    public void navigateToPosition(final SourcePosition position,
                                   final boolean recordCurrent)
    {
-      navigateToPosition(position, recordCurrent, false);
+      navigateToPosition(position, recordCurrent, false, null);
    }
 
    @Override
@@ -573,15 +573,24 @@ public class CodeBrowserEditingTarget implements EditingTarget
                                   final boolean recordCurrent,
                                   final boolean highlightLine)
    {
-      ensureContext(position.getContext(), new Command() {
-         @Override
-         public void execute()
-         {
-            docDisplay_.navigateToPosition(position,
-                                           recordCurrent,
-                                           highlightLine);
-            view_.scrollToLeft();
-         }
+      navigateToPosition(position, recordCurrent, highlightLine, null);
+   }
+   
+   @Override
+   public void navigateToPosition(SourcePosition position,
+                                  boolean recordCurrent,
+                                  boolean highlightLine,
+                                  Command onNavigationCompleted)
+   {
+      ensureContext(position.getContext(), () ->
+      {
+         docDisplay_.navigateToPosition(
+               position,
+               recordCurrent,
+               highlightLine);
+         
+         if (onNavigationCompleted != null)
+            onNavigationCompleted.execute();
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -412,6 +412,14 @@ public class ProfilerEditingTarget implements EditingTarget,
                                   boolean highlightLine)
    {
    }
+   
+   @Override
+   public void navigateToPosition(SourcePosition position,
+                                  boolean recordCurrent,
+                                  boolean highlightLine,
+                                  Command onNavigationCompleted)
+   {
+   }
 
    @Override
    public void restorePosition(SourcePosition position)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1198,6 +1198,21 @@ public class TextEditingTarget implements
       });
    }
    
+   @Override
+   public void navigateToPosition(SourcePosition position,
+                                  boolean recordCurrent,
+                                  boolean highlightLine,
+                                  Command onNavigationCompleted)
+   {
+      ensureTextEditorActive(() -> {
+         
+         docDisplay_.navigateToPosition(position, recordCurrent, highlightLine);
+         if (onNavigationCompleted != null)
+            onNavigationCompleted.execute();
+         
+      });
+   }
+   
    // These methods are called by SourceNavigationHistory and source pane management
    // features (e.g. external source window and source columns) so need to check for
    // and dispatch to visual mode
@@ -2456,7 +2471,14 @@ public class TextEditingTarget implements
 
    public void focus()
    {
-      view_.editorContainer().focus();
+      if (isVisualModeActivated())
+      {
+         visualMode_.focus();
+      }
+      else
+      {
+         view_.editorContainer().focus();
+      }
    }
 
    public String getSelectedText()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -163,7 +163,7 @@ public class VisualMode implements VisualModeEditorSync,
       return view_.editorContainer().isWidgetActive(panmirror_);
    }
    
-   public void withActivatedVisualEditor(ScheduledCommand completed)
+   public void activate(ScheduledCommand completed)
    {
       if (!isActivated())
       {
@@ -180,11 +180,6 @@ public class VisualMode implements VisualModeEditorSync,
       }
    }
    
-   public void activate(ScheduledCommand completed)
-   {
-      withActivatedVisualEditor(completed);
-   }
-  
    public void deactivate(ScheduledCommand completed)
    {
       if (isActivated())
@@ -680,7 +675,7 @@ public class VisualMode implements VisualModeEditorSync,
 
    public void focus()
    {
-      withActivatedVisualEditor(() -> panmirror_.focus());
+      activate(() -> panmirror_.focus());
    }
    
    private void manageUI(boolean activate, boolean focus)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -163,8 +163,7 @@ public class VisualMode implements VisualModeEditorSync,
       return view_.editorContainer().isWidgetActive(panmirror_);
    }
    
-   
-   public void activate(ScheduledCommand completed)
+   public void withActivatedVisualEditor(ScheduledCommand completed)
    {
       if (!isActivated())
       {
@@ -179,6 +178,11 @@ public class VisualMode implements VisualModeEditorSync,
       {
          completed.execute();
       }
+   }
+   
+   public void activate(ScheduledCommand completed)
+   {
+      withActivatedVisualEditor(completed);
    }
   
    public void deactivate(ScheduledCommand completed)
@@ -676,7 +680,7 @@ public class VisualMode implements VisualModeEditorSync,
 
    public void focus()
    {
-      panmirror_.focus();
+      withActivatedVisualEditor(() -> panmirror_.focus());
    }
    
    private void manageUI(boolean activate, boolean focus)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -674,6 +674,10 @@ public class VisualMode implements VisualModeEditorSync,
       return panmirror_.getCommandPaletteItems();
    }
 
+   public void focus()
+   {
+      panmirror_.focus();
+   }
    
    private void manageUI(boolean activate, boolean focus)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -293,6 +293,14 @@ public class UrlContentEditingTarget implements EditingTarget
                                   boolean highlightLine)
    {
    }
+   
+   @Override
+   public void navigateToPosition(SourcePosition position,
+                                  boolean recordCurrent,
+                                  boolean highlightLine,
+                                  Command onNavigationCompleted)
+   {
+   }
 
    @Override
    public void restorePosition(SourcePosition position)


### PR DESCRIPTION
This PR fixes an issue where attempting to navigate to a file that currently has a visual editor open would open that file, but not send focus to the document within.