### PR TITLE
priority task queue for initializing visual editor contents

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/PriorityTaskQueue.java
+++ b/src/gwt/src/org/rstudio/core/client/PriorityTaskQueue.java
@@ -1,0 +1,143 @@
+/*
+ * PriorityTaskQueue.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+
+package org.rstudio.core.client;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+import com.google.gwt.user.client.Command;
+
+// Task queue that allows tasks to bump themselves up in priority (even after
+// they have been added to the queue).
+
+public class PriorityTaskQueue
+{
+   public interface Task
+   {
+      String getLabel(); // used for debug/log output 
+      boolean hasPriority();
+      void execute(Command done);
+   }
+   
+   public PriorityTaskQueue()
+   {
+      this(true, false);
+   }
+   
+   public PriorityTaskQueue(boolean safe)
+   {
+      this(safe, false);
+   }
+   
+   public PriorityTaskQueue(boolean safe, boolean log)
+   {
+      log_ = log;
+      safe_ = safe;
+   }
+   
+   public void addTask(Task task)
+   {
+      log("adding " + task.getLabel());
+      taskQueue_.add(task);
+      processQueue();
+   }
+   
+   private void processQueue()
+   {
+      if (processing_)
+      {
+         log("already running");
+         return;
+      }
+      
+      processing_ = true;
+      processNextTask();
+   }
+   
+   private void processNextTask()
+   {
+      log("process next task");
+      
+      if (taskQueue_.isEmpty())
+      {
+         log("done");
+         processing_ = false;
+         return;
+      }
+      
+      // see if any of the tasks have priority
+      Task nextTask = null;
+      for (Task task : taskQueue_)
+      {
+         if (task.hasPriority())
+         {
+            nextTask = task;
+            log("executing " + nextTask.getLabel() + " [Priority]");
+            break;
+         }
+      }
+      
+      // if there is no priority task then just remove from the queue
+      if (nextTask == null)
+      {
+         nextTask = taskQueue_.peek();
+         log("executing " + nextTask.getLabel());  
+      }
+      
+      // remove the task
+      taskQueue_.remove(nextTask);
+      
+      // run the next task and then continue processing. catch any exceptions
+      // so that we can continue processing if 'safe' was requested
+      try
+      {
+         nextTask.execute(() -> {
+            log("continuation");
+            processNextTask(); 
+         });
+      }
+      catch(Exception e)
+      {
+         if (safe_)
+         {
+            log("exception processing " + nextTask.getLabel());
+            Debug.logException(e);
+            processNextTask();
+         }
+         else
+         {
+            throw e;
+         }  
+      }
+      
+   }
+   
+   private void log(String label)
+   {
+      if (log_)
+      {
+         Debug.logToConsole(hashCode() + " " + label + " size=" + taskQueue_.size());
+      }
+   }
+   
+   
+   private Queue<Task> taskQueue_ = new LinkedList<Task>();
+   private boolean processing_ = false;
+   private final boolean log_;
+   private final boolean safe_;
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -19,8 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
+
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.DebouncedCommand;
+import org.rstudio.core.client.PriorityTaskQueue;
 import org.rstudio.core.client.Rendezvous;
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
@@ -352,7 +354,7 @@ public class VisualMode implements VisualModeEditorSync,
    
    
    @Override
-   public void syncFromEditor(CommandWithArg<Boolean> done, boolean focus)
+   public void syncFromEditor(final CommandWithArg<Boolean> done, boolean focus)
    {      
       // flag to prevent the document being set to dirty when loading
       // from source mode
@@ -369,98 +371,126 @@ public class VisualMode implements VisualModeEditorSync,
       
       withPanmirror(() -> {
          
-         String editorCode = getEditorCode();
+         final String editorCode = getEditorCode();
          
-         VisualModeMarkdownWriter.Options writerOptions = visualModeWriterOptions_.optionsFromCode(editorCode);
+         final VisualModeMarkdownWriter.Options writerOptions = visualModeWriterOptions_.optionsFromCode(editorCode);
           
-         panmirror_.setMarkdown(editorCode, writerOptions.options, true, kCreationProgressDelayMs, 
-                                new CommandWithArg<JsObject>() {
+         // serialize these calls (they are expensive on both the server side for the call(s)
+         // to pandoc, and on the client side for initialization of the editor (esp. ace editors)
+         setMarkdownQueue_.addTask(new PriorityTaskQueue.Task()
+         {
             @Override
-            public void execute(JsObject obj)
+            public String getLabel()
             {
-               // get result
-               PanmirrorSetMarkdownResult result = Js.uncheckedCast(obj);
-               
-               // bail on error
-               if (result == null)
-               {
+               return target_.getTitle();
+            }
+            
+            @Override
+            public boolean hasPriority()
+            {
+               return target_.isActiveDocument();
+            }
+           
+            @Override
+            public void execute(final Command taskDone)
+            {
+               // join done commands
+               final CommandWithArg<Boolean> allDone = (result) -> {
+                  taskDone.execute();
                   if (done != null)
-                     done.execute(false);
-                  return;
-               }
+                     done.execute(result);
+               };
                
-               // show warning and terminate if there was unparsed metadata. note that the other 
-               // option here would be to have setMarkdown send the unparsed metadata back to the
-               // server to generate yaml, and then include the metadata as yaml at end the of the
-               // document. this could be done using the method outlined here: 
-               //   https://github.com/jgm/pandoc/issues/2019 
-               // specifically using this template:
-               /*
-                  $if(titleblock)$
-                  $titleblock$
-                  $else$
-                  --- {}
-                  $endif$
-                  */
-               // ...with this command line: 
-               /*
-                  pandoc -t markdown --template=yaml.template foo.md
-               */
-               if (JsObject.keys(result.unparsed_meta).length > 0)
-               {
-                  view_.showWarningBar("Unable to activate visual mode (unsupported front matter format or non top-level YAML block)");
-                  if (done != null)
-                     done.execute(false);
-                  return;
-               }
-               
-               // update flags
-               isDirty_ = false;
-               loadingFromSource_ = false;
-               
-               // if pandoc's view of the document doesn't match the editor's we 
-               // need to reset the editor's code (for both dirty state and 
-               // so that diffs are efficient)
-               if (result.canonical != editorCode)
-               {
-                  getSourceEditor().setCode(result.canonical);
-                  markDirty();
-               }
-               
-               // completed
-               if (done != null)
-                  done.execute(true);
-               
-               Scheduler.get().scheduleDeferred(() -> {
-                      
-                  // if we are being focused it means we are switching from source mode, in that
-                  // case sync our editing location to what it is in source 
-                  if (focus)
-                  { 
-                     panmirror_.focus();
-                     panmirror_.setEditingLocation(
-                        visualModeLocation_.getSourceOutlneLocation(), 
-                        visualModeLocation_.savedEditingLocation()
-                     ); 
-                  }
-                  
-                  // show any warnings
-                  PanmirrorPandocFormat format = panmirror_.getPandocFormat();
-                  if (result.unrecognized.length > 0) 
+               panmirror_.setMarkdown(editorCode, writerOptions.options, true, kCreationProgressDelayMs, 
+                     new CommandWithArg<JsObject>() {
+                  @Override
+                  public void execute(JsObject obj)
                   {
-                     view_.showWarningBar("Unrecognized Pandoc token(s); " + String.join(", ", result.unrecognized));
-                  } 
-                  else if (format.warnings.invalidFormat.length() > 0)
-                  {
-                     view_.showWarningBar("Invalid Pandoc format: " + format.warnings.invalidFormat);
+                     // get result
+                     PanmirrorSetMarkdownResult result = Js.uncheckedCast(obj);
+
+                     // bail on error
+                     if (result == null)
+                     {
+                        allDone.execute(false);
+                        return;
+                     }
+
+                     // show warning and terminate if there was unparsed metadata. note that the other 
+                     // option here would be to have setMarkdown send the unparsed metadata back to the
+                     // server to generate yaml, and then include the metadata as yaml at end the of the
+                     // document. this could be done using the method outlined here: 
+                     //   https://github.com/jgm/pandoc/issues/2019 
+                     // specifically using this template:
+                     /*
+                         $if(titleblock)$
+                         $titleblock$
+                         $else$
+                         --- {}
+                         $endif$
+                      */
+                     /// ...with this command line: 
+                     /*
+                         pandoc -t markdown --template=yaml.template foo.md
+                      */
+                     if (JsObject.keys(result.unparsed_meta).length > 0)
+                     {
+                        view_.showWarningBar("Unable to activate visual mode (unsupported front matter format or non top-level YAML block)");
+                        allDone.execute(false);
+                        return;
+                     }
+
+                     // update flags
+                     isDirty_ = false;
+                     loadingFromSource_ = false;
+
+                     // if pandoc's view of the document doesn't match the editor's we 
+                     // need to reset the editor's code (for both dirty state and 
+                     // so that diffs are efficient)
+                     if (result.canonical != editorCode)
+                     {
+                        getSourceEditor().setCode(result.canonical);
+                        markDirty();
+                     }
+
+                     // completed
+                     allDone.execute(true);
+
+                     Scheduler.get().scheduleDeferred(() -> {
+
+                        // if we are being focused it means we are switching from source mode, in that
+                        // case sync our editing location to what it is in source 
+                        if (focus)
+                        { 
+                           panmirror_.focus();
+                           panmirror_.setEditingLocation(
+                                 visualModeLocation_.getSourceOutlneLocation(), 
+                                 visualModeLocation_.savedEditingLocation()
+                                 ); 
+                        }
+
+                        // show any warnings
+                        PanmirrorPandocFormat format = panmirror_.getPandocFormat();
+                        if (result.unrecognized.length > 0) 
+                        {
+                           view_.showWarningBar("Unrecognized Pandoc token(s); " + String.join(", ", result.unrecognized));
+                        } 
+                        else if (format.warnings.invalidFormat.length() > 0)
+                        {
+                           view_.showWarningBar("Invalid Pandoc format: " + format.warnings.invalidFormat);
+                        }
+                        else if (format.warnings.invalidOptions.length > 0)
+                        {
+                           view_.showWarningBar("Unsupported extensions for markdown mode: " + String.join(", ", format.warnings.invalidOptions));;
+                        }
+                     });          
                   }
-                  else if (format.warnings.invalidOptions.length > 0)
-                  {
-                     view_.showWarningBar("Unsupported extensions for markdown mode: " + String.join(", ", format.warnings.invalidOptions));;
-                  }
-               });          
+               });
+               
             }
          });
+         
+         
       });
    }
 
@@ -1203,9 +1233,12 @@ public class VisualMode implements VisualModeEditorSync,
    private boolean isLoading_ = false;
    private List<ScheduledCommand> onReadyHandlers_ = new ArrayList<ScheduledCommand>(); 
    
-   
    private static final int kCreationProgressDelayMs = 0;
    private static final int kSerializationProgressDelayMs = 5000;
+   
+   // priority task queue for expensive calls to panmirror_.setMarkdown
+   // (currently active tab bumps itself up in priority)
+   private static PriorityTaskQueue setMarkdownQueue_ = new PriorityTaskQueue(true, false);
      
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -22,7 +22,7 @@ import org.rstudio.core.client.BrowseCap;
 
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.DebouncedCommand;
-import org.rstudio.core.client.PriorityTaskQueue;
+import org.rstudio.core.client.PreemptiveTaskQueue;
 import org.rstudio.core.client.Rendezvous;
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
@@ -377,7 +377,7 @@ public class VisualMode implements VisualModeEditorSync,
           
          // serialize these calls (they are expensive on both the server side for the call(s)
          // to pandoc, and on the client side for initialization of the editor (esp. ace editors)
-         setMarkdownQueue_.addTask(new PriorityTaskQueue.Task()
+         setMarkdownQueue_.addTask(new PreemptiveTaskQueue.Task()
          {
             @Override
             public String getLabel()
@@ -386,7 +386,7 @@ public class VisualMode implements VisualModeEditorSync,
             }
             
             @Override
-            public boolean hasPriority()
+            public boolean shouldPreempt()
             {
                return target_.isActiveDocument();
             }
@@ -1238,7 +1238,7 @@ public class VisualMode implements VisualModeEditorSync,
    
    // priority task queue for expensive calls to panmirror_.setMarkdown
    // (currently active tab bumps itself up in priority)
-   private static PriorityTaskQueue setMarkdownQueue_ = new PriorityTaskQueue(true, false);
+   private static PreemptiveTaskQueue setMarkdownQueue_ = new PreemptiveTaskQueue(true, false);
      
 }
 


### PR DESCRIPTION
This PR attempts to mitigate some of the expensive startup cost incurred per IDE tab that has an activated visual editor. 

For each visual editor tab to initialize, a number of things need to occur:

1) Initialize the visual editor 
2) Call the server to render pandoc markdown into the pandoc AST (this involves 3 calls to pandoc, all fast/cheap but it is 3 process launches)
3) Render the pandoc AST into the visual editor
4) Initialize embedded Ace editor instances (this is currently done on a queue that prioritizes currently visible editors)

All of these operations are asynchronous (except the first) so don't in principle "block" use of the IDE. In practice though they are tying up cycles on the server (using multiple cores) and the client (using the single core dedicated to the UI thread), making the IDE pretty unresponsive (delay when typing, etc.) as long as visual editors are being initialized.

My current benchmark is the Mastering Shiny book. I load up visual editor instances for all 29 chapters of the book, then reload the IDE. On my new MacBook Pro it takes ~18 seconds for the active editor tab to load and become responsive. I think this is borderline tolerable but far from ideal. Note that 4.5 seconds of this time is for core IDE startup (i.e. that's how long it takes to load if all 29 chapters are in source mode). For comparison, loading the same project w/ no tabs takes 0.5 seconds. So a perfect optimization of the visual editor startup cost would get us to no better than 4.5 seconds.

I've previously evaluated ways to only enter the initialization sequence for a visual editor (steps 1-4 above) when it's actually an activated tab. Unfortunately the IDE doesn't have unambiguous semantics for this (since during the loading of the source pane all of the tabs become "active" as they are replayed back into the pane). I've attempted to engineer a logical state for this a few times but it gets very complicated and even unreliable (I've had times where an editor tab flat out never loads b/c we don't detect the activated state correctly). It's also very tricky to manage the variation between "logical" activation state (visual mode enabled for a tab) and "physical" activation state (visual editor actually loaded and ready to rock).

This PR takes a more conservative approach, essentially allowing all of the visual editor tabs to perform step 1 (basic initialization) and then placing the more expensive steps 2-4 on a priority task queue (where priority is dynamically granted to the active editor tab). This yields startup performance of ~ 9 seconds (compared to ~18 for the current behavior). Note that 4.5 of these seconds are unavoidable (happen w/ 29 source mode tabs) so even w/ more aggressive/risky optimization schemes we can't improve that much more before we hit the baseline.

Note that after the active tab becomes available for editing, the other non active tabs are loading in the background. The background loading takes ~30 seconds (I think b/c we don't take advantage of server parallelism on pandoc calls) but this seems "free" to me b/c if the user activates one of the background tabs it's brought immediately to the front of the queue. 

So we've essentially traded down on total initialization time but halved the time required for the editor/IDE to be available for interaction.

@jmcphers If you could review the PriorityTaskQueue for correctness that would be great. Also interested in your take on whether we should do more to try to bring down startup cost or if we are happy with where this PR gets us to .
 