### PR TITLE
fix static-initialization order dependency leading to rsession unit test segfault

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -203,8 +203,16 @@ MimeType s_mimeTypes[] =
       { nullptr,        nullptr }
    };
 
-const std::string s_homePathAlias = "~/";
-const std::string s_homePathLeafAlias = "~";
+const std::string& homePathAlias()
+{
+   static const std::string homePathAlias = "~/";
+   return homePathAlias;
+}
+const std::string& homePathLeafAlias()
+{
+   static const std::string homePathLeafAlias = "~";
+   return homePathLeafAlias;
+}
 
 // We use boost::filesystem in one of two ways:
 // - On Windows, we use Filesystem v3 with wide character paths. This is
@@ -398,7 +406,7 @@ std::string FilePath::createAliasedPath(const FilePath& in_filePath, const FileP
 {
    // Special case for "~"
    if (in_filePath == in_userHomePath)
-      return s_homePathLeafAlias;
+      return homePathLeafAlias();
 
 #ifdef _WIN32
    // Also check for case where paths are identical
@@ -415,7 +423,7 @@ std::string FilePath::createAliasedPath(const FilePath& in_filePath, const FileP
    if (in_filePath.isWithin(in_userHomePath))
    {
       std::string homeRelativePath = in_filePath.getRelativePath(in_userHomePath);
-      std::string aliasedPath = s_homePathAlias + homeRelativePath;
+      std::string aliasedPath = homePathAlias() + homeRelativePath;
       return aliasedPath;
    }
    else  // no aliasing
@@ -473,11 +481,11 @@ Error FilePath::makeCurrent(const std::string& in_filePath)
 FilePath FilePath::resolveAliasedPath(const std::string& in_aliasedPath, const FilePath& in_userHomePath)
 {
    // Special case for empty string or "~"
-   if (in_aliasedPath.empty() || (in_aliasedPath == s_homePathLeafAlias))
+   if (in_aliasedPath.empty() || (in_aliasedPath == homePathLeafAlias()))
       return in_userHomePath;
 
    // if the path starts with the home alias then substitute the home path
-   if (in_aliasedPath.find(s_homePathAlias) == 0)
+   if (in_aliasedPath.find(homePathAlias()) == 0)
    {
       std::string resolvedPath = in_userHomePath.getAbsolutePath() +
                                  in_aliasedPath.substr(1);

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -416,7 +416,7 @@ std::string FilePath::createAliasedPath(const FilePath& in_filePath, const FileP
        in_userHomePath.m_impl->Path.generic_path();
 
    if (samePath)
-      return s_homePathLeafAlias;
+      return homePathLeafAlias();
 #endif
 
    // if the path is contained within the home path then alias it


### PR DESCRIPTION
On Centos7 (Desktop), unit tests were failing because global static initialization was causing access to an uninitialized string.

Fix by wrapping the static strings in functions.

The trigger is here: https://github.com/rstudio/rstudio/blob/e6fd9fd85f9088c13e8b2c5b78176111b4f2b485/src/cpp/core/LogOptions.cpp#L61

The crash stack was:
```
#0  0x000055ed09fbbdbe in std::string::size (this=0x55ed0b7d5188 <rstudio::core::(anonymous namespace)::s_homePathLeafAlias>)
    at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/basic_string.h:3817
#1  0x000055ed09fdc60c in std::operator==<char> (__lhs="~/.local/share", __rhs=<error reading variable: Cannot access memory at address 0xffffffffffffffe8>)
    at /opt/rh/devtoolset-7/root/usr/include/c++/7/bits/basic_string.h:6007
#2  0x000055ed0a97ce4c in rstudio::core::FilePath::resolveAliasedPath (in_aliasedPath="~/.local/share", in_userHomePath=...) at /src/src/cpp/shared_core/FilePath.cpp:476
#3  0x000055ed0a832e7f in rstudio::core::system::xdg::(anonymous namespace)::resolveXdgDir (envVar="XDG_DATA_HOME", defaultDir="~/.local/share", user=..., homeDir=...)
    at /src/src/cpp/core/system/Xdg.cpp:97
#4  0x000055ed0a833213 in rstudio::core::system::xdg::userDataDir (user=..., homeDir=...) at /src/src/cpp/core/system/Xdg.cpp:135
#5  0x000055ed0a8972ea in __static_initialization_and_destruction_0 (__initialize_p=1, __priority=65535) at /src/src/cpp/core/LogOptions.cpp:61
#6  0x000055ed0a89740c in _GLOBAL__sub_I_LogOptions.cpp(void) () at /src/src/cpp/core/LogOptions.cpp:347
#7  0x000055ed0aa9580d in __libc_csu_init ()
#8  0x00007f948396c4e5 in __libc_start_main () from /lib64/libc.so.6
#9  0x000055ed09fb44f5 in _start ()
```
 