### PR TITLE
prefer use_python to RETICULATE_PYTHON

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1135,6 +1135,21 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    length(cap) && cap
 })
 
+# NOTE: registered hooks will be run immediately if the
+# package has already been loaded.
+.rs.addFunction("registerPackageLoadHook", function(package, hook)
+{
+   if (package %in% loadedNamespaces())
+      return(hook())
+   
+   setHook(
+      hookName = packageEvent(package, "onLoad"),
+      value    = hook,
+      action   = "append"
+   )
+      
+})
+
 .rs.addFunction("initTools", function()
 {
    ostype <- .Platform$OS.type

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -13,18 +13,6 @@
 #
 #
 
-# NOTE: registered hooks will be run immediately if the
-# package has already been loaded.
-.rs.addFunction("registerPackageLoadHook", function(package, hook)
-{
-   # if the package is already loaded, run the hook;
-   # otherwise, register a load hook
-   if (package %in% loadedNamespaces())
-      hook()
-   else
-      setHook(packageEvent(package, "onLoad"), hook)
-})
-
 .rs.registerPackageLoadHook("rstudioapi", function(...)
 {
    # bail if we're not version 0.7

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -273,3 +273,15 @@
    info <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    .rs.scalarListFromList(info)
 })
+
+.rs.registerPackageLoadHook("reticulate", function(...)
+{
+   python <- .rs.readUiPref("python_default_interpreter")
+   
+   if (is.character(python) &&
+       length(python) == 1 &&
+       file.exists(python))
+   {
+      reticulate::use_python(python, required = TRUE)
+   }
+})

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -277,11 +277,5 @@
 .rs.registerPackageLoadHook("reticulate", function(...)
 {
    python <- .rs.readUiPref("python_default_interpreter")
-   
-   if (is.character(python) &&
-       length(python) == 1 &&
-       file.exists(python))
-   {
-      reticulate::use_python(python, required = TRUE)
-   }
+   .rs.reticulate.usePython(python)
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1906,10 +1906,19 @@ html.heading = _heading
 
 .rs.addFunction("reticulate.usePython", function(python)
 {
+   # sanity check value of param
+   ok <-
+      is.character(python) &&
+      length(python) == 1 &&
+      file.exists(python)
+   
+   if (!ok)
+      return(FALSE)
+   
    # no-op if Python has already been initialized
    if (reticulate::py_available(initialize = FALSE))
       return(FALSE)
    
-   # otherwise, request use of Python
+   # ok, request use of Python
    reticulate::use_python(python, required = TRUE)
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1903,3 +1903,13 @@ html.heading = _heading
       .rs.setVar(key, reticulate::dict())
    .rs.getVar(key)
 })
+
+.rs.addFunction("reticulate.usePython", function(python)
+{
+   # no-op if Python has already been initialized
+   if (reticulate::py_available(initialize = FALSE))
+      return(FALSE)
+   
+   # otherwise, request use of Python
+   reticulate::use_python(python, required = TRUE)
+})


### PR DESCRIPTION
This PR fixes an issue where user calls to e.g.

```
reticulate::use_python(..., required = TRUE)
```

were being ignored. This is because `RETICULATE_PYTHON` overrides any other existing Python requests. We want the version of Python set via global options to act as a default version of Python, but it should still be possible for users to override this if required (either via `RETICULATE_PYTHON` or their own calls to `reticulate::use_python()` and friends).