### PR TITLE
improve DialogTabLayoutPanel to manage focus loop automatically

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DialogTabLayoutPanel.java
@@ -17,7 +17,9 @@ package org.rstudio.core.client.theme;
 import com.google.gwt.aria.client.Id;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
@@ -25,23 +27,43 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.user.client.ui.TabLayoutPanel;
+import org.rstudio.core.client.widget.FocusHelper;
+
+import java.util.ArrayList;
 
 public class DialogTabLayoutPanel extends TabLayoutPanel
 {
    public DialogTabLayoutPanel(String tabListLabel)
    {
       super(14, Unit.PX, tabListLabel);
-      
+
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
       addStyleName(styles.dialogTabPanel());
-      
+
       // we need to center the tabs and overlay them on the top edge of the
       // content; to do this, it is necessary to nuke a couple of the inline
-      // styles used by the default GWT tab panel. 
+      // styles used by the default GWT tab panel.
       Element tabOuter = (Element) getElement().getChild(1);
       tabOuter.getStyle().setOverflow(Overflow.VISIBLE);
       Element tabInner = (Element) tabOuter.getFirstChild();
       tabInner.getStyle().clearWidth();
+
+      // if the tab panel is the first focusable control in dialog we must keep the
+      // selected Tab marked as first when selection changes
+      focus_ = new FocusHelper(getElement());
+      addSelectionHandler(selectionEvent ->
+      {
+         if (focus_.containsFirst())
+         {
+            ArrayList<Element> focusable = DomUtils.getFocusableElements(getElement());
+            if (focusable.size() == 0)
+            {
+               Debug.logWarning("No potentially focusable controls found in DialogTabLayoutPanel");
+               return;
+            }
+            focus_.setFirst(focusable.get(0));
+         }
+      });
    }
 
    public void add(VerticalTabPanel child, String text, String tabId)
@@ -64,4 +86,6 @@ public class DialogTabLayoutPanel extends TabLayoutPanel
       Roles.getTabpanelRole().setAriaLabelledbyProperty(child.getElement(),
             Id.of(ElementIds.getElementId(VerticalTabPanel.getTabId(tabId))));
    }
+
+   private final FocusHelper focus_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FocusHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FocusHelper.java
@@ -15,28 +15,149 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.client.ui.Focusable;
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.dom.DomUtils;
 
+import java.util.ArrayList;
+
+/**
+ * Helpers for marking first and last focusable element in a dialog or other control.
+ */
 public class FocusHelper
 {
+   public static final String firstFocusClass = "__rstudio_modal_first_focus";
+   public static final String lastFocusClass = "__rstudio_modal_last_focus";
+
+   /**
+    * @param parent top-level element of dialog or control whose focus loop to manage
+    */
+   public FocusHelper(Element parent)
+   {
+      parent_ = parent;
+   }
+
+   /**
+    * @param element first keyboard focusable element
+    */
+   public void setFirst(Element element)
+   {
+      removeExisting(firstFocusClass);
+      element.addClassName(firstFocusClass);
+   }
+
+   /**
+    * @param element last keyboard focusable element
+    */
+   public void setLast(Element element)
+   {
+      removeExisting(lastFocusClass);
+      element.addClassName(lastFocusClass);
+   }
+
+   /**
+    * @param element
+    * @return true if element is marked as the first focusable element
+    */
+   public boolean isFirst(Element element)
+   {
+      return element.hasClassName(firstFocusClass);
+   }
+
+   /**
+    * @param element
+    * @return true if element is marked as last focusable element
+    */
+   public boolean isLast(Element element)
+   {
+      return element.hasClassName(lastFocusClass);
+   }
+
+   /**
+    * @return true if an element in this container is marked as first
+    */
+   public boolean containsFirst()
+   {
+      return getByClass(firstFocusClass) != null;
+   }
+
+   /**
+    * @return true if an element in this container is marked as last
+    */
+   public boolean containsLast()
+   {
+      return getByClass(lastFocusClass) != null;
+   }
+
+   /**
+    * Set focus on first keyboard focusable element in dialog, as set by
+    * refreshFocusableElements or setFirstFocusableElement.
+    *
+    * Invoked when Tabbing off the last control in the modal dialog to set focus back to
+    * the first control, and by default to set initial focus when the dialog is shown.
+    *
+    * To set focus on a different control when the dialog is displayed, override
+    * focusInitialControl, instead.
+    */
+   protected void focusFirstControl()
+   {
+      Element first = getByClass(firstFocusClass);
+      if (first != null)
+         first.focus();
+   }
+
+   /**
+    * Set focus on last keyboard focusable element in dialog, as set by
+    * <code>refreshFocusableElements</code> or <code>setLastFocusableElement</code>.
+    */
+   protected void focusLastControl()
+   {
+      Element last = getByClass(lastFocusClass);
+      if (last != null)
+         last.focus();
+   }
+
+   /**
+    * Gets an ordered list of keyboard-focusable elements
+    */
+   private ArrayList<Element> getFocusableElements()
+   {
+      return DomUtils.getFocusableElements(parent_);
+   }
+
+   private void removeExisting(String classname)
+   {
+      Element current = getByClass(classname);
+      if (current != null)
+         current.removeClassName(classname);
+   }
+
+   private Element getByClass(String classname)
+   {
+      NodeList<Element> current = DomUtils.querySelectorAll(parent_, "." + classname);
+      if (current.getLength() > 1)
+      {
+         Debug.logWarning("Multiple controls found with class: " + classname);
+         return null;
+      }
+      if (current.getLength() == 1)
+      {
+         return current.getItem(0);
+      }
+      return null;
+   }
+
    public static void setFocusDeferred(final CanFocus canFocus)
    {
-      Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-         public void execute()
-         {
-            canFocus.focus();
-         }   
-      });
+      Scheduler.get().scheduleDeferred(() -> canFocus.focus());
    }
-   
+
    public static void setFocusDeferred(final Focusable focusable)
    {
-      Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-         public void execute()
-         {
-            focusable.setFocus(true);
-         }   
-      });
-   } 
+      Scheduler.get().scheduleDeferred(() -> focusable.setFocus(true));
+   }
+
+   private final Element parent_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditCodeBlockDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditCodeBlockDialog.java
@@ -34,7 +34,7 @@ import com.google.gwt.user.client.ui.Widget;
 
 
 public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlockProps>
-{ 
+{
    public PanmirrorEditCodeBlockDialog(
                PanmirrorCodeBlockProps codeBlock,
                boolean attributes,
@@ -45,7 +45,7 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
          // cancel returns null
          operation.execute(null);
       });
-      
+
       // create lang (defer parent until we determine whether we support attributes)
       VerticalTabPanel langTab = new VerticalTabPanel(ElementIds.VISUAL_MD_CODE_BLOCK_TAB_LANGUAGE);
       langTab.addStyleName(RES.styles().dialog());
@@ -56,7 +56,7 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
       FormLabel langInfo = new FormLabel("(optional)");
       langInfo.setElementId(ElementIds.getElementId(ElementIds.VISUAL_MD_CODE_BLOCK_LANG_LABEL2));
       langInfo.addStyleName(RES.styles().inlineInfoLabel());
-      
+
       labelPanel.add(langInfo);
       langTab.add(labelPanel);
       lang_ = new PanmirrorLangSuggestBox(languages);
@@ -67,14 +67,14 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
       lang_.setText(codeBlock.lang);
       PanmirrorDialogsUtil.setFullWidthStyles(lang_);
       langTab.add(lang_);
-      
+
       // create attr
       VerticalTabPanel attributesTab = new VerticalTabPanel(ElementIds.VISUAL_MD_CODE_BLOCK_TAB_ATTRIBUTES);
       attributesTab.addStyleName(RES.styles().dialog());
-      editAttr_ =  new PanmirrorEditAttrWidget();   
+      editAttr_ =  new PanmirrorEditAttrWidget();
       editAttr_.setAttr(codeBlock, null);
       attributesTab.add(editAttr_);
-   
+
       if (attributes)
       {
          DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Code Block");
@@ -83,9 +83,6 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
 
-         // the tab panel is the first focusable control in dialog, but the actual focusable
-         // element changes depending which tab is selected
-         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements()); 
          mainWidget_ = tabPanel;
       }
       else
@@ -93,19 +90,19 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
          mainWidget_ = langTab;
       }
    }
-   
+
    @Override
    protected Widget createMainWidget()
    {
       return mainWidget_;
    }
-   
+
    @Override
    public void focusInitialControl()
    {
       lang_.setFocus(true);
    }
-   
+
    @Override
    protected PanmirrorCodeBlockProps collectInput()
    {
@@ -124,13 +121,13 @@ public class PanmirrorEditCodeBlockDialog extends ModalDialog<PanmirrorCodeBlock
    {
       return true;
    }
-   
+
 
    private static PanmirrorDialogsResources RES = PanmirrorDialogsResources.INSTANCE;
-   
-   private Widget mainWidget_; 
-   
+
+   private Widget mainWidget_;
+
    private SuggestBox lang_;
    private PanmirrorEditAttrWidget editAttr_;
-  
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditImageDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditImageDialog.java
@@ -57,30 +57,30 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       super("Image", Roles.getDialogRole(), operation, () -> {
          // cancel returns null
          operation.execute(null);
-      }); 
-     
+      });
+
       // natural width, height, and containerWidth (will be null if this
       // is an insert image dialog)
       dims_ = dims;
-      
+
       // size props that we are going to reflect back to the caller. the idea is that
-      // if the user makes no explicit edits of size props then we just return 
+      // if the user makes no explicit edits of size props then we just return
       // exactly what we were passed. this allows us to show a width and height
-      // for images that are 'unsized' (i.e. just use natural height and width). the 
+      // for images that are 'unsized' (i.e. just use natural height and width). the
       // in-editor resizing shelf implements the same behavior.
       widthProp_ = props.width;
       heightProp_ = props.height;
       unitsProp_ = props.units;
-      
+
       // image tab
       VerticalTabPanel imageTab = new VerticalTabPanel(ElementIds.VISUAL_MD_IMAGE_TAB_IMAGE);
       imageTab.addStyleName(RES.styles().dialog());
-      
+
       // panel for size controls (won't be added if this is an insert or !editAttributes)
       HorizontalPanel sizePanel = new HorizontalPanel();
       sizePanel.addStyleName(RES.styles().spaced());
       sizePanel.setVerticalAlignment(HasVerticalAlignment.ALIGN_MIDDLE);
-      
+
       // image url picker
       imageTab.add(url_ = new PanmirrorImageChooser(uiContext));
       url_.addStyleName(RES.styles().spaced());
@@ -96,7 +96,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          dims_ = null;
          imageTab.remove(sizePanel);
       });
-      
+
       // width, height, units
       width_ = addSizeInput(sizePanel, ElementIds.VISUAL_MD_IMAGE_WIDTH, "Width:");
       height_ = addSizeInput(sizePanel, ElementIds.VISUAL_MD_IMAGE_HEIGHT, "Height:");
@@ -105,14 +105,14 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       sizePanel.add(heightAuto_);
       units_ = addUnitsSelect(sizePanel);
       initSizeInputs();
-      
+
       // lock ratio
       lockRatio_ = new CheckBox("Lock ratio");
       lockRatio_.addStyleName(RES.styles().lockRatioCheckbox());
       lockRatio_.getElement().setId(ElementIds.VISUAL_MD_IMAGE_LOCK_RATIO);
       lockRatio_.setValue(props.lockRatio);
       sizePanel.add(lockRatio_);
-      
+
       // update widthProp_ and height (if lockRatio) when width text box changes
       width_.addChangeHandler(event -> {
          String width = width_.getText();
@@ -124,7 +124,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          }
          unitsProp_ = units_.getSelectedValue();
       });
-      
+
       // update heightProp_ and width (if lockRatio) when height text box changes
       height_.addChangeHandler(event -> {
          String height = height_.getText();
@@ -136,55 +136,55 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          }
          unitsProp_ = units_.getSelectedValue();
       });
-      
+
       // do applicable unit conversion when units change
       units_.addChangeHandler(event -> {
-         
-         String width = width_.getText();  
-         if (!StringUtil.isNullOrEmpty(width)) 
+
+         String width = width_.getText();
+         if (!StringUtil.isNullOrEmpty(width))
          {
             double widthPixels = uiTools_.unitToPixels(Double.parseDouble(width), prevUnits_, dims_.containerWidth);
             double widthUnit = uiTools_.pixelsToUnit(widthPixels, units_.getSelectedValue(), dims_.containerWidth);
             width_.setText(uiTools_.roundUnit(widthUnit, units_.getSelectedValue()));
             widthProp_ = Double.parseDouble(width_.getValue());
          }
-         
+
          String height = height_.getText();
-         if (!StringUtil.isNullOrEmpty(height)) 
+         if (!StringUtil.isNullOrEmpty(height))
          {
             double heightPixels = uiTools_.unitToPixels(Double.parseDouble(height), prevUnits_, dims_.containerWidth);
             double heightUnit = uiTools_.pixelsToUnit(heightPixels, units_.getSelectedValue(), dims_.containerWidth);
             height_.setText(uiTools_.roundUnit(heightUnit, units_.getSelectedValue()));
             heightProp_ = Double.parseDouble(height_.getValue());
          }
-         
+
          // track previous units for subsequent conversions
          prevUnits_ = units_.getSelectedValue();
-         
+
          // save units prop
          unitsProp_ = units_.getSelectedValue();
-         
+
          manageUnitsUI();
       });
       manageUnitsUI();
-      
-      
+
+
       // only add sizing controls if we support editAttributes, dims have been provided
-      // (i.e. not an insert operation) and there aren't width or height attributes 
+      // (i.e. not an insert operation) and there aren't width or height attributes
       // within props.keyvalue (which is an indicator that they use units unsupported
       // by our sizing UI (e.g. ch, em, etc.)
       if (editAttributes && dims_ != null && hasNaturalSizes(dims) && !hasSizeKeyvalue(props.keyvalue))
       {
          imageTab.add(sizePanel);
       }
-      
+
       // title and alt
       title_ = PanmirrorDialogsUtil.addTextBox(imageTab, ElementIds.VISUAL_MD_IMAGE_TITLE, "Title/Tooltip:", props.title);
-      alt_ = PanmirrorDialogsUtil.addTextBox(imageTab, ElementIds.VISUAL_MD_IMAGE_ALT, "Caption/Alt:", props.alt); 
-         
+      alt_ = PanmirrorDialogsUtil.addTextBox(imageTab, ElementIds.VISUAL_MD_IMAGE_ALT, "Caption/Alt:", props.alt);
+
       // linkto
       linkTo_ = PanmirrorDialogsUtil.addTextBox(imageTab,  ElementIds.VISUAL_MD_IMAGE_LINK_TO, "Link To:", props.linkTo);
-      
+
       // standard pandoc attributes
       editAttr_ =  new PanmirrorEditAttrWidget();
       editAttr_.setAttr(props, null);
@@ -193,16 +193,13 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          VerticalTabPanel attributesTab = new VerticalTabPanel(ElementIds.VISUAL_MD_IMAGE_TAB_ATTRIBUTES);
          attributesTab.addStyleName(RES.styles().dialog());
          attributesTab.add(editAttr_);
-         
+
          DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Image");
          tabPanel.addStyleName(RES.styles().imageDialogTabs());
          tabPanel.add(imageTab, "Image", imageTab.getBasePanelId());
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
 
-         // the tab panel is the first focusable control in dialog, but the actual focusable
-         // element changes depending which tab is selected
-         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements());
          mainWidget_ = tabPanel;
       }
       else
@@ -210,29 +207,29 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          mainWidget_ = imageTab;
       }
    }
-   
+
    @Override
    protected Widget createMainWidget()
    {
       return mainWidget_;
    }
-   
+
    @Override
    public void focusInitialControl()
    {
       url_.getTextBox().setFocus(true);
       url_.getTextBox().setSelectionRange(0, 0);
    }
-   
+
    @Override
    protected PanmirrorImageProps collectInput()
    {
-      // process change event for focused size controls (typically these changes 
-      // only occur on the change event, which won't occur if the dialog is 
+      // process change event for focused size controls (typically these changes
+      // only occur on the change event, which won't occur if the dialog is
       // dismissed while they are focused
       fireChangedIfFocused(width_);
       fireChangedIfFocused(height_);
-      
+
       // collect and return result
       PanmirrorImageProps result = new PanmirrorImageProps();
       result.src = url_.getTextBox().getValue().trim();
@@ -249,7 +246,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       result.keyvalue = attr.keyvalue;
       return result;
    }
-   
+
    @Override
    protected boolean validate(PanmirrorImageProps result)
    {
@@ -277,7 +274,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       }
    }
 
-   
+
    // set sizing UI based on passed width, height, and unit props. note that
    // these can be null (default/natural sizing) and in that case we still
    // want to dispaly pixel sizing in the UI as an FYI to the user
@@ -286,9 +283,9 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       // only init for existing images (i.e. dims passed)
       if (dims_ == null)
          return;
-      
-      String width = null, height = null, units = "px"; 
-      
+
+      String width = null, height = null, units = "px";
+
       // if we have both width and height then use them
       if (widthProp_ != null && heightProp_ != null)
       {
@@ -299,7 +296,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       else if (dims_.naturalHeight != null && dims_.naturalWidth != null)
       {
          units = unitsProp_;
-         
+
          // if there is width only then show computed height
          if (widthProp_ == null && heightProp_ == null)
          {
@@ -318,7 +315,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
             width = uiTools_.roundUnit(heightProp_ * (dims_.naturalWidth/dims_.naturalHeight), units);
          }
       }
-      
+
       // set values into inputs
       width_.setValue(width);
       height_.setValue(height);
@@ -333,13 +330,13 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
          }
       }
    }
-   
-   // show/hide controls and enable/disable lockUnits depending on 
+
+   // show/hide controls and enable/disable lockUnits depending on
    // whether we are using percent sizing
    private void manageUnitsUI()
    {
       boolean percentUnits = units_.getSelectedValue() == uiTools_.percentUnit();
-      
+
       if (percentUnits)
       {
          lockRatio_.setValue(true);
@@ -349,12 +346,12 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       {
          lockRatio_.setEnabled(true);
       }
-      
+
       height_.setVisible(!percentUnits);
       heightAuto_.setVisible(percentUnits);
    }
 
-   
+
    // create a numeric input
    private static NumericTextBox addSizeInput(Panel panel, String id, String labelText)
    {
@@ -369,8 +366,8 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       panel.add(input);
       return input;
    }
-   
-   // create units select list box 
+
+   // create units select list box
    private ListBox addUnitsSelect(Panel panel)
    {
       String[] options = uiTools_.validUnits();
@@ -383,7 +380,7 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       panel.add(units);
       return units;
    }
-   
+
    // create a horizontal label
    private static FormLabel createHorizontalLabel(String text)
    {
@@ -391,15 +388,15 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       label.addStyleName(RES.styles().horizontalLabel());
       return label;
    }
-   
+
    // fire a change event if the widget is currently focused
    private static void fireChangedIfFocused(Widget widget)
    {
-      if (widget.getElement() == DomUtils.getActiveElement()) 
+      if (widget.getElement() == DomUtils.getActiveElement())
          DomEvent.fireNativeEvent(Document.get().createChangeEvent(), widget);
    }
-   
-   // check whether the passed keyvalue attributes has a size (width or height) 
+
+   // check whether the passed keyvalue attributes has a size (width or height)
    private static boolean hasSizeKeyvalue(String[][] keyvalue)
    {
       for (int i=0; i<keyvalue.length; i++)
@@ -410,29 +407,29 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
       }
       return false;
    }
-   
+
    private static boolean hasNaturalSizes(PanmirrorImageDimensions dims)
    {
       return dims.naturalWidth != null && dims.naturalHeight != null;
    }
-   
+
    // resources
    private static PanmirrorDialogsResources RES = PanmirrorDialogsResources.INSTANCE;
-   
+
    // UI utility functions from panmirror
    private final PanmirrorUIToolsImage uiTools_ = new PanmirrorUITools().image;
 
    // original image/container dimensions
    private PanmirrorImageDimensions dims_;
-   
+
    // current 'edited' values for size props
    private Double widthProp_ = null;
    private Double heightProp_ = null;
    private String unitsProp_ = null;
-   
+
    // track previous units for conversions
    private String prevUnits_;
-   
+
    // widgets
    private final Widget mainWidget_;
    private final PanmirrorImageChooser url_;
@@ -445,9 +442,9 @@ public class PanmirrorEditImageDialog extends ModalDialog<PanmirrorImageProps>
    private final TextBox alt_;
    private final TextBox linkTo_;
    private final PanmirrorEditAttrWidget editAttr_;
-   
+
    private static final String WIDTH = "width";
    private static final String HEIGHT = "height";
-   
-   
+
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditLinkDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditLinkDialog.java
@@ -41,8 +41,8 @@ import com.google.gwt.user.client.ui.Widget;
 
 public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult>
 {
-   public PanmirrorEditLinkDialog(PanmirrorLinkProps link, 
-                                  PanmirrorLinkTargets targets, 
+   public PanmirrorEditLinkDialog(PanmirrorLinkProps link,
+                                  PanmirrorLinkTargets targets,
                                   PanmirrorLinkCapabilities capabilities,
                                   OperationWithInput<PanmirrorLinkEditResult> operation)
    {
@@ -50,12 +50,12 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
          // cancel returns null
          operation.execute(null);
       });
-      
+
       initialLink_ = link;
-   
+
       VerticalTabPanel linkTab = new VerticalTabPanel(ElementIds.VISUAL_MD_LINK_TAB_LINK);
       linkTab.addStyleName(RES.styles().dialog());
-      
+
       if (!StringUtil.isNullOrEmpty(link.href))
       {
          ThemedButton removeLinkButton = new ThemedButton("Remove Link");
@@ -74,56 +74,53 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
                }
             });
          });
-         addLeftButton(removeLinkButton, ElementIds.VISUAL_MD_LINK_REMOVE_LINK_BUTTON); 
+         addLeftButton(removeLinkButton, ElementIds.VISUAL_MD_LINK_REMOVE_LINK_BUTTON);
       }
-      
+
       capabilities_ = capabilities;
-      
+
       href_ = new PanmirrorHRefSelect(targets, capabilities);
       href_.addStyleName(RES.styles().hrefSelect());
       href_.addStyleName(RES.styles().spaced());
       linkTab.add(href_);
-      
+
       text_ = PanmirrorDialogsUtil.addTextBox(
-         linkTab, 
-         ElementIds.VISUAL_MD_LINK_TEXT, 
-         textLabel_ = new FormLabel("Text:"), 
+         linkTab,
+         ElementIds.VISUAL_MD_LINK_TEXT,
+         textLabel_ = new FormLabel("Text:"),
          link.text
       );
-      
+
       title_ = PanmirrorDialogsUtil.addTextBox(
-         linkTab, 
-         ElementIds.VISUAL_MD_LINK_TITLE, 
-         titleLabel_ = new FormLabel("Title/Tooltip:"), 
+         linkTab,
+         ElementIds.VISUAL_MD_LINK_TITLE,
+         titleLabel_ = new FormLabel("Title/Tooltip:"),
          link.title
       );
-        
+
       editAttr_ =  new PanmirrorEditAttrWidget();
       editAttr_.setAttr(link, null);
-      
-      
+
+
       href_.addTypeChangedHandler((event) -> {
         manageVisibility();
       });
       href_.setHRef(link.type, link.type == PanmirrorLinkType.Heading ? link.heading : link.href);
       manageVisibility();
-    
-      
+
+
       if (capabilities.attributes)
       {
          VerticalTabPanel attributesTab = new VerticalTabPanel(ElementIds.VISUAL_MD_LINK_TAB_ATTRIBUTES);
          attributesTab.addStyleName(RES.styles().dialog());
          attributesTab.add(editAttr_);
-         
+
          DialogTabLayoutPanel tabPanel = new DialogTabLayoutPanel("Image");
          tabPanel.addStyleName(RES.styles().linkDialogTabs());
          tabPanel.add(linkTab, "Link", linkTab.getBasePanelId());
          tabPanel.add(attributesTab, "Attributes", attributesTab.getBasePanelId());
          tabPanel.selectTab(0);
 
-         // the tab panel is the first focusable control in dialog, but the actual focusable
-         // element changes depending which tab is selected
-         tabPanel.addSelectionHandler(selectionEvent -> refreshFocusableElements());
          mainWidget_ = tabPanel;
       }
       else
@@ -131,20 +128,20 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
          mainWidget_ = linkTab;
       }
    }
-   
+
    @Override
    protected Widget createMainWidget()
    {
       return mainWidget_;
    }
-   
+
    @Override
    public void focusInitialControl()
    {
       href_.focus();
    }
-   
-   
+
+
    @Override
    protected PanmirrorLinkEditResult collectInput()
    {
@@ -173,7 +170,7 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
       }
       return result;
    }
-   
+
    @Override
    protected boolean validate(PanmirrorLinkEditResult result)
    {
@@ -186,12 +183,12 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
          href_.focus();
          return false;
       }
-      else 
+      else
       {
          return true;
       }
    }
-   
+
    private void manageVisibility()
    {
       boolean isHeadingLink = href_.getType() == PanmirrorLinkType.Heading;
@@ -201,19 +198,19 @@ public class PanmirrorEditLinkDialog extends ModalDialog<PanmirrorLinkEditResult
       titleLabel_.setVisible(!isHeadingLink);
       editAttr_.setVisible(!isHeadingLink);
    }
-   
+
    private static PanmirrorDialogsResources RES = PanmirrorDialogsResources.INSTANCE;
-   
+
    private final PanmirrorLinkProps initialLink_;
    private final Widget mainWidget_;
-   
+
    private final PanmirrorHRefSelect href_;
-   
+
    private final FormLabel textLabel_;
    private final TextBox text_;
    private final FormLabel titleLabel_;
    private final TextBox title_;
-   
+
    private final PanmirrorLinkCapabilities capabilities_;
 
    private final PanmirrorEditAttrWidget editAttr_;


### PR DESCRIPTION
Fixes #7098

This relates to any modal dialog where the first focusable control is a Tab Panel, and you select a tab other than the first then try to Shift+Tab past the beginning of the dialog.

Focus should remain in the dialog and wrap to the end, but was leaving the dialog and stepping through controls in the main UI (essentially "under" the modal dialog). This was because the first tab was still marked as the first control (via a class), but not capable of receiving focus (via no tabindex), so browser had to pick some other element.

Some dialogs were managing this manually, e.g. the Visual Editing dialogs such as insert image:

<img width="402" alt="screenshot of visual editing insert image dialog" src="https://user-images.githubusercontent.com/10569626/89692335-343db080-d8c0-11ea-968f-524e7fa985d8.png">

Others, like the standalone Accessibility preferences pane, were not, and exhibited the problem.

<img width="470" alt="screenshot of accessibility preferences pane" src="https://user-images.githubusercontent.com/10569626/89692450-9696b100-d8c0-11ea-8fb0-84037d60aa1a.png">

Other known dialogs to check are the Visual Editor's "edit link" and "edit code block" dialogs, and in Pro the "launcher jobs" dialog and "open shared project" dialogs.

## Implementation Details
This fix makes the DialogTabPanel control handle this scenario on its own, instead of making developer "just know" they have to do something special.

Extracted some of the first/last focus marking code from ModalDialogBase class into the FocusHelper class so it can be used both by the dialog and by controls.