### PR TITLE
Fix issues with Console handling of inverted color mode

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -355,14 +355,13 @@ public class AnsiCode
                }
                else
                {
-                  if (extendedColor == FOREGROUND_EXT)
+                  if ((!inverted_ && extendedColor == FOREGROUND_EXT) || (inverted_ && (extendedColor == BACKGROUND_EXT)))
                   {
                      if (codeVal >= 0 && codeVal <= 255)
                      {
                         currentColor_.setExtended(codeVal);
                         resetForeground();
-                        clazzes_.add(Color.clazzForColorIndex(codeVal,
-                              false /*background*/));
+                        clazzes_.add(Color.clazzForColorIndex(codeVal, false /*background*/));
                      }
                   }
                   else
@@ -371,8 +370,7 @@ public class AnsiCode
                      {
                         currentBgColor_.setExtended(codeVal);
                         resetBackground();
-                        clazzes_.add(Color.clazzForColorIndex(codeVal,
-                              true /*background*/));
+                        clazzes_.add(Color.clazzForColorIndex(codeVal, true /*background*/));
                      }
                   }
                   extendedColor = 0;
@@ -632,16 +630,16 @@ public class AnsiCode
          clazzes_.add(Color.clazzForColorIndex(currentBgColor_.code(), false /*background*/));
          return new Color(true /*extended*/, currentBgColor_.code());
       }
-      else if (currentBgColor_.code() >= BACKGROUND_MIN && currentBgColor_.code() <= BACKGROUND_MAX)
+      else if (Color.isNormalBgColorCode(currentBgColor_.code()))
       {
          int newFg = currentBgColor_.code() - (BACKGROUND_MIN - FOREGROUND_MIN);
-         clazzes_.add(FOREGROUND_STYLE + Integer.toString(newFg - FOREGROUND_MIN));
+         clazzes_.add(FOREGROUND_STYLE + (newFg - FOREGROUND_MIN));
          return new Color(false /*extended*/, newFg);
       }
       else
       {
          int newFg = currentBgColor_.code() - (BACKGROUND_INTENSE_MIN - FOREGROUND_INTENSE_MIN);
-         clazzes_.add(FOREGROUND_STYLE + Integer.toString(newFg + 8 - FOREGROUND_INTENSE_MIN));
+         clazzes_.add(FOREGROUND_STYLE + (newFg + 8 - FOREGROUND_INTENSE_MIN));
          return new Color(false /*extended*/, newFg);
       }
    }
@@ -751,6 +749,6 @@ public class AnsiCode
    private Color currentBgColor_ = new Color();
    private boolean inverted_ = false;
 
-   private Set<String> clazzes_ = new LinkedHashSet<String>();
-   private Set<String> blockClazzes_ = new LinkedHashSet<String>();
+   private final Set<String> clazzes_ = new LinkedHashSet<>();
+   private final Set<String> blockClazzes_ = new LinkedHashSet<>();
 }

--- a/src/gwt/src/org/rstudio/core/client/AnsiCode.java
+++ b/src/gwt/src/org/rstudio/core/client/AnsiCode.java
@@ -29,10 +29,10 @@ public class AnsiCode
    // ANSI command constants
    public static final String CSI = "\33[";
    public static final String SGR = "m";
-   
+
    // Move Cursor Horizontal Absolute
    public static final String CHA = "G";
-   
+
    // Erase in Line
    public static final String EL = "K";
 
@@ -79,10 +79,10 @@ public class AnsiCode
    public static final int BACKGROUND_MIN = 40;
    public static final int BACKGROUND_MAX = 47;
    public static final String BACKGROUND_STYLE = "xtermBgColor";
-   
+
    public static final int FOREGROUND_INTENSE_MIN = 90;
    public static final int FOREGROUND_INTENSE_MAX = 97;
-  
+
    public static final int BACKGROUND_INTENSE_MIN = 100;
    public static final int BACKGROUND_INTENSE_MAX = 107;
 
@@ -90,7 +90,7 @@ public class AnsiCode
    public static final int BACKGROUND_EXT = 48;
    public static final int EXT_BY_INDEX = 5;
    public static final int EXT_BY_RGB = 2;
-   
+
    public static final int DEFAULT_FONT = 10;
    public static final int FONT_ONE = 11;
    public static final int FONT_TWO = 12;
@@ -104,14 +104,14 @@ public class AnsiCode
    // Font-nine is used by RStudio to reduce spacing between lines
    public static final int FONT_NINE = 19;
    public static final String FONT_NINE_STYLE = "xtermFont9";
-   
+
    public static final String DEFAULTCOLORS = CSI + RESET + ";" + RESET + SGR;
-   
+
    public static class AnsiClazzes
    {
       // span-level css classes
       public String inlineClazzes = null;
-      
+
       // block-level css classes
       public String blockClazzes = null;
    }
@@ -152,7 +152,7 @@ public class AnsiCode
       public static final String GRAY         = CSI + RESET + ";37" + SGR;
       public static final String DEFAULT_FORE = CSI + "39" + SGR;
    }
-   
+
    public static class BackColor
    {
       public static final String BLACK        = CSI + RESET + ";40" + SGR;
@@ -165,79 +165,127 @@ public class AnsiCode
       public static final String GRAY         = CSI + RESET + ";47" + SGR;
       public static final String DEFAULT_BACK = CSI + RESET + ";49" + SGR;
    }
-   
+
    private static class Color
    {
       public static final int DEFAULT_COLOR = -1;
-      
+
       public Color()
       {
          extended_ = false;
          code_ = DEFAULT_COLOR;
       }
-      
+
       public Color(boolean extended, int code)
       {
          extended_ = extended;
          code_ = code;
       }
-      
+
       public int code() { return code_; }
-      
-      public void setCode(int code) 
+
+      public void setCode(int code)
       {
          extended_ = false;
-         code_ = code; 
+         code_ = code;
       }
-      
-      public void setExtended(int code) 
+
+      public void setExtended(int code)
       {
          extended_ = true;
          code_ = code;
       }
 
-      public void reset() 
+      public void reset()
       {
          extended_ = false;
          code_ = DEFAULT_COLOR;
       }
-      
+
       public boolean defaultColor()
       {
          return code_ == DEFAULT_COLOR;
       }
-      
+
+      public static boolean isNormalFgColorCode(int code)
+      {
+         return (code >= FOREGROUND_MIN && code <= FOREGROUND_MAX);
+      }
+
+      public static boolean isIntenseFgColorCode(int code)
+      {
+         return (code >= FOREGROUND_INTENSE_MIN && code <= FOREGROUND_INTENSE_MAX);
+      }
+
       public static boolean isFgColorCode(int code)
       {
-         return ((code >= FOREGROUND_MIN && code <= FOREGROUND_MAX) ||
-                 (code >= FOREGROUND_INTENSE_MIN && code <= FOREGROUND_INTENSE_MAX));
+         return isNormalFgColorCode(code) || isIntenseFgColorCode(code);
+      }
+
+      public static boolean isNormalBgColorCode(int code)
+      {
+         return (code >= BACKGROUND_MIN && code <= BACKGROUND_MAX);
+      }
+
+      public static boolean isIntenseBgColorCode(int code)
+      {
+         return (code >= BACKGROUND_INTENSE_MIN && code <= BACKGROUND_INTENSE_MAX);
       }
 
       public static boolean isBgColorCode(int code)
       {
-         return ((code >= BACKGROUND_MIN && code <= BACKGROUND_MAX) ||
-                 (code >= BACKGROUND_INTENSE_MIN && code <= BACKGROUND_INTENSE_MAX));
+         return isNormalBgColorCode(code) || isIntenseBgColorCode(code);
       }
-      
+
       public static String clazzForColorIndex(int index, boolean background)
       {
-         return((background ? BACKGROUND_STYLE : FOREGROUND_STYLE) + 
+         return((background ? BACKGROUND_STYLE : FOREGROUND_STYLE) +
                Integer.toString(index));
       }
-      
+
+      /**
+       * Convert a non-extended foreground color to equivalent background color
+       * @param fg foreground value
+       * @return background value
+       */
+      public static int fgToBgColor(int fg)
+      {
+         if (isNormalFgColorCode(fg))
+            return fg + (BACKGROUND_MIN - FOREGROUND_MIN);
+         else if (isIntenseFgColorCode(fg))
+            return fg + (BACKGROUND_INTENSE_MIN - FOREGROUND_INTENSE_MIN);
+         else
+            return fg;
+      }
+
+      /**
+       * Convert a non-extended background color to equivalent foreground color
+       * @param bg background value
+       * @return foreground value
+       */
+      public static int bgToFgColor(int bg)
+      {
+         if (isNormalBgColorCode(bg))
+            return bg - (BACKGROUND_MIN - FOREGROUND_MIN);
+         else if (isIntenseBgColorCode(bg))
+            return bg - (BACKGROUND_INTENSE_MIN - FOREGROUND_INTENSE_MIN);
+         else
+            return bg;
+      }
+
       public boolean isExtended() { return extended_; }
-       
+
       private boolean extended_;
       private int code_;
    }
-   
+
    public AnsiCode()
    {
    }
- 
+
    /**
     * Map an ANSI escape sequence to the appropriate css styles; only handles
-    * colors and visual appearance covered by SGR codes; other sequences 
+    * colors and visual appearance covered by SGR codes; other sequences
     * such as cursor movement are ignored.
     * @param code escape sequence
     * @return AnsiClazzes, containing both span-level and block-level styles
@@ -254,12 +302,12 @@ public class AnsiCode
          blockClazzes_.clear();
          return null;
       }
-      
+
       int extendedColor = 0;
       boolean extendedMarkerSeen = false;
       boolean extendedRGBMarkerSeen = false;
       int extendedRGBColorsSeen = 0;
-      
+
       String[] tokens = code.substring(2, code.length() - 1).split(";");
       for (String token : tokens)
       {
@@ -293,7 +341,7 @@ public class AnsiCode
             else
             {
                // We don't support colors specified via RGB, but parse the
-               // sequence then ignore it in case there are supported 
+               // sequence then ignore it in case there are supported
                // sequences after it
                if (extendedRGBMarkerSeen)
                {
@@ -305,7 +353,7 @@ public class AnsiCode
                      extendedRGBColorsSeen = 0;
                   }
                }
-               else 
+               else
                {
                   if (extendedColor == FOREGROUND_EXT)
                   {
@@ -313,7 +361,7 @@ public class AnsiCode
                      {
                         currentColor_.setExtended(codeVal);
                         resetForeground();
-                        clazzes_.add(Color.clazzForColorIndex(codeVal, 
+                        clazzes_.add(Color.clazzForColorIndex(codeVal,
                               false /*background*/));
                      }
                   }
@@ -323,7 +371,7 @@ public class AnsiCode
                      {
                         currentBgColor_.setExtended(codeVal);
                         resetBackground();
-                        clazzes_.add(Color.clazzForColorIndex(codeVal, 
+                        clazzes_.add(Color.clazzForColorIndex(codeVal,
                               true /*background*/));
                      }
                   }
@@ -421,25 +469,45 @@ public class AnsiCode
          }
          else if (Color.isFgColorCode(codeVal))
          {
-            currentColor_.setCode(codeVal);
-            resetForeground();
-            clazzes_.add(clazzForColor(codeVal));
+            if (!inverted_)
+               setForegroundColor(codeVal);
+            else
+               setBackgroundColor(Color.fgToBgColor(codeVal));
          }
          else if (Color.isBgColorCode(codeVal))
          {
-            currentBgColor_ = new Color(false, codeVal);
-            resetBackground();
-            clazzes_.add(clazzForBgColor(codeVal));
+            if (!inverted_)
+               setBackgroundColor(codeVal);
+            else
+               setForegroundColor(Color.bgToFgColor(codeVal));
          }
          else if (codeVal == RESET_FOREGROUND)
          {
-            currentColor_.reset();
-            resetForeground();
+            if (!inverted_)
+            {
+               currentColor_.reset();
+               resetForeground();
+            }
+            else
+            {
+               currentBgColor_.reset();
+               resetBackground();
+               clazzes_.add(INVERSE_BG_STYLE);
+            }
          }
          else if (codeVal == RESET_BACKGROUND)
          {
-            currentBgColor_.reset();
-            resetBackground();
+            if (!inverted_)
+            {
+               currentBgColor_.reset();
+               resetBackground();
+            }
+            else
+            {
+               currentColor_.reset();
+               resetForeground();
+               clazzes_.add(INVERSE_FG_STYLE);
+            }
          }
          else if (codeVal == FOREGROUND_EXT)
          {
@@ -455,7 +523,7 @@ public class AnsiCode
          {
             blockClazzes_.add(FONT_NINE_STYLE);
          }
-         else if (codeVal == DEFAULT_FONT || 
+         else if (codeVal == DEFAULT_FONT ||
                (codeVal >= FONT_ONE && codeVal <= FONT_EIGHT))
          {
             blockClazzes_.remove(FONT_NINE_STYLE);
@@ -471,7 +539,7 @@ public class AnsiCode
    public static String clazzForColor(int color)
    {
       int index = ForeColorNum.WHITE;
-      
+
       if (color >= FOREGROUND_MIN && color <= FOREGROUND_MAX)
       {
          index = color - FOREGROUND_MIN;
@@ -486,7 +554,7 @@ public class AnsiCode
    public static String clazzForBgColor(int color)
    {
       int index = BackColorNum.BLACK;
-      
+
       if (color >= BACKGROUND_MIN && color <= BACKGROUND_MAX)
       {
          index = color - BACKGROUND_MIN;
@@ -497,11 +565,25 @@ public class AnsiCode
       }
       return Color.clazzForColorIndex(index,  true /*background*/);
    }
-   
+
+   private void setForegroundColor(int codeVal)
+   {
+      currentColor_.setCode(codeVal);
+      resetForeground();
+      clazzes_.add(clazzForColor(codeVal));
+   }
+
+   private void setBackgroundColor(int codeVal)
+   {
+      currentBgColor_ = new Color(false, codeVal);
+      resetBackground();
+      clazzes_.add(clazzForBgColor(codeVal));
+   }
+
    private AnsiClazzes getStyles()
    {
       AnsiClazzes styles = new AnsiClazzes();
-      
+
       if (!clazzes_.isEmpty())
       {
          StringBuilder buildClazzes = new StringBuilder();
@@ -514,7 +596,7 @@ public class AnsiCode
          }
          styles.inlineClazzes = buildClazzes.toString();
       }
-      
+
       if (!blockClazzes_.isEmpty())
       {
          // block styles (line-height via font9)
@@ -528,10 +610,10 @@ public class AnsiCode
          }
          styles.blockClazzes = buildClazzes.toString();
       }
-      
+
       return styles;
    }
-    
+
    /**
     * Calculates inverse foreground color based on current background color,
     * applies style, and returns new foreground color.
@@ -595,7 +677,7 @@ public class AnsiCode
          return new Color(false /*extended*/, newBg);
       }
    }
-    
+
    private void resetForeground()
    {
       for (int i = 0; i < 256; i++)
@@ -613,7 +695,7 @@ public class AnsiCode
       }
       clazzes_.remove(INVERSE_BG_STYLE);
    }
-   
+
    public static String prettyPrint(String input)
    {
       // not efficient but only intended for debug/unit testing
@@ -642,33 +724,33 @@ public class AnsiCode
    public static final String CONTROL_REGEX = "[\r\b\f\n\u001b\u009b]";
 
    // RegEx to match ANSI escape codes copied from https://github.com/chalk/ansi-regex
-   public static final String ANSI_REGEX = 
+   public static final String ANSI_REGEX =
          "[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-PRZcf-nqry=><@]";
-   
+
    // Match ANSI escape sequences
    public static final Pattern ANSI_ESCAPE_PATTERN = Pattern.create(ANSI_REGEX);
 
    // Match control characters and start of ANSI sequences
    public static final Pattern CONTROL_PATTERN = Pattern.create(CONTROL_REGEX);
-   
+
    // RegEx to match complete SGR codes (colors, fonts, appearance)
    public static final String SGR_REGEX =
          "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[m]";
-   
+
    // Match ANSI SGR escape sequences
    public static final Pattern SGR_ESCAPE_PATTERN = Pattern.create(SGR_REGEX);
-   
+
    // RegEx to match partial SGR codes (don't have final "m" yet)
    public static final String SGR_PARTIAL_REGEX =
          "[\u001b\u009b]\\[(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9]";
-   
+
    // Match partial potential ANSI SGR escape sequences
    public static final Pattern SGR_PARTIAL_ESCAPE_PATTERN = Pattern.create(SGR_PARTIAL_REGEX);
-    
+
    private Color currentColor_ = new Color();
    private Color currentBgColor_ = new Color();
    private boolean inverted_ = false;
-   
+
    private Set<String> clazzes_ = new LinkedHashSet<String>();
    private Set<String> blockClazzes_ = new LinkedHashSet<String>();
 }

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -23,7 +23,7 @@ import com.google.gwt.junit.client.GWTTestCase;
 
 import junit.framework.Assert;
 
-// Note on test coverage: the VirtualConsole has two side effects; it operates on a 
+// Note on test coverage: the VirtualConsole has two side effects; it operates on a
 // DOM, if supplied, and also maintains an internal string with the output results.
 // The "consolify" tests are testing the internal string only, and most of the other
 // tests are only testing the DOM. Ideally these should all be extended to do both.
@@ -35,7 +35,7 @@ public class VirtualConsoleTests extends GWTTestCase
    {
       return "org.rstudio.studio.RStudioTests";
    }
-   
+
    private static class FakePrefs implements VirtualConsole.Preferences
    {
       @Override
@@ -43,24 +43,24 @@ public class VirtualConsoleTests extends GWTTestCase
       {
          return truncateLines_;
       }
-   
+
       @Override
       public String consoleAnsiMode()
       {
          return ansiMode_;
       }
-      
+
       @Override
       public boolean screenReaderEnabled()
       {
          return screenReaderEnabled_;
       }
-      
+
       public int truncateLines_ = 1000;
       public String ansiMode_ = UserPrefs.ANSI_CONSOLE_MODE_ON;
       public boolean screenReaderEnabled_ = false;
    }
-   
+
    private static String consolify(String text)
    {
       VirtualConsole console = new VirtualConsole(null, new FakePrefs());
@@ -93,8 +93,18 @@ public class VirtualConsoleTests extends GWTTestCase
       return setCsiCode(AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + color);
    }
 
+   private static String inverseOn()
+   {
+      return setCsiCode(AnsiCode.INVERSE);
+   }
+
+   private static String inverseOff()
+   {
+      return setCsiCode(AnsiCode.INVERSE_OFF);
+   }
+
    // ---- tests start here ----
- 
+
    public void testSimpleText()
    {
       String simple = consolify("foo");
@@ -106,19 +116,19 @@ public class VirtualConsoleTests extends GWTTestCase
       String backspace = consolify("bool\bk");
       Assert.assertEquals("book", backspace);
    }
-   
+
    public void testTrailingBackspace()
    {
       String backspace = consolify("bool\bk");
       Assert.assertEquals("book", backspace);
    }
-    
+
    public void testCarriageReturn()
    {
       String cr = consolify("hello\rj");
       Assert.assertEquals("jello", cr);
    }
-   
+
    public void testNewlineCarriageReturn()
    {
       String cr = consolify("L1\nL2\rL3");
@@ -131,7 +141,7 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit("Error", "error");
       Assert.assertEquals(
-            "<span class=\"error\">Error</span>", 
+            "<span class=\"error\">Error</span>",
             ele.getInnerHTML());
    }
 
@@ -142,11 +152,11 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("Output 1", "one");
       vc.submit("Output 2", "two");
       Assert.assertEquals(
-            "<span class=\"one\">Output 1</span>" + 
+            "<span class=\"one\">Output 1</span>" +
             "<span class=\"two\">Output 2</span>",
             ele.getInnerHTML());
    }
-   
+
    public void testColorOverwrite()
    {
       PreElement ele = Document.get().createPreElement();
@@ -154,11 +164,11 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("XXXX\r", "X");
       vc.submit("YY", "Y");
       Assert.assertEquals(
-            "<span class=\"Y\">YY</span>" + 
+            "<span class=\"Y\">YY</span>" +
             "<span class=\"X\">XX</span>",
             ele.getInnerHTML());
    }
-   
+
    public void testColorSplit()
    {
       PreElement ele = Document.get().createPreElement();
@@ -166,12 +176,12 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("123456");
       vc.submit("\b\b\b\bXX", "X");
       Assert.assertEquals(
-            "<span>12</span>" + 
-            "<span class=\"X\">XX</span>" + 
+            "<span>12</span>" +
+            "<span class=\"X\">XX</span>" +
             "<span>56</span>",
             ele.getInnerHTML());
    }
-   
+
    public void testColorOverlap()
    {
       PreElement ele = Document.get().createPreElement();
@@ -180,12 +190,12 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("456", "B");
       vc.submit("\b\b\b\bXX", "X");
       Assert.assertEquals(
-            "<span class=\"A\">12</span>" + 
-            "<span class=\"X\">XX</span>" + 
+            "<span class=\"A\">12</span>" +
+            "<span class=\"X\">XX</span>" +
             "<span class=\"B\">56</span>",
             ele.getInnerHTML());
    }
-   
+
    public void testFormFeed()
    {
       PreElement ele = Document.get().createPreElement();
@@ -208,9 +218,9 @@ public class VirtualConsoleTests extends GWTTestCase
       // second character to red 'Y'
       vc.submit("\r\033[32mX\033[31mY\033[0m", "a");
       Assert.assertEquals(
-            "<span class=\"a xtermColor2\">X</span>" + 
+            "<span class=\"a xtermColor2\">X</span>" +
             "<span class=\"a xtermColor1\">Y</span>" +
-            "<span class=\"a\">rld</span>", 
+            "<span class=\"a\">rld</span>",
             ele.getInnerHTML());
    }
 
@@ -226,9 +236,9 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("\r\033[32mX\033[31mY\033[0m", "a");
       Assert.assertEquals(
             "<span class=\"a\">Hello\n</span>" +
-            "<span class=\"a xtermColor2\">X</span>" + 
+            "<span class=\"a xtermColor2\">X</span>" +
             "<span class=\"a xtermColor1\">Y</span>" +
-            "<span class=\"a\">rld</span>", 
+            "<span class=\"a\">rld</span>",
             ele.getInnerHTML());
    }
 
@@ -242,33 +252,33 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("\r\033[32m123\033[31m45\033[0m", "a");
       Assert.assertEquals(
             "<span class=\"a\">Hello\n</span>" +
-            "<span class=\"a xtermColor2\">123</span>" + 
+            "<span class=\"a xtermColor2\">123</span>" +
             "<span class=\"a\"></span>" +
             "<span class=\"a xtermColor1\">45</span>",
             ele.getInnerHTML());
    }
-    
+
    public void testAnsiColorStyleHelper()
    {
-      Assert.assertEquals("xtermColor0", 
+      Assert.assertEquals("xtermColor0",
             AnsiCode.clazzForColor(AnsiCode.FOREGROUND_MIN));
-      Assert.assertEquals("xtermColor7", 
+      Assert.assertEquals("xtermColor7",
             AnsiCode.clazzForColor(AnsiCode.FOREGROUND_MAX));
-      Assert.assertEquals("xtermBgColor0", 
+      Assert.assertEquals("xtermBgColor0",
             AnsiCode.clazzForBgColor(AnsiCode.BACKGROUND_MIN));
-      Assert.assertEquals("xtermBgColor7", 
+      Assert.assertEquals("xtermBgColor7",
             AnsiCode.clazzForBgColor(AnsiCode.BACKGROUND_MAX));
    }
 
    public void testAnsiIntenseColorStyleHelper()
    {
-      Assert.assertEquals("xtermColor8", 
+      Assert.assertEquals("xtermColor8",
             AnsiCode.clazzForColor(AnsiCode.FOREGROUND_INTENSE_MIN));
-      Assert.assertEquals("xtermColor15", 
+      Assert.assertEquals("xtermColor15",
             AnsiCode.clazzForColor(AnsiCode.FOREGROUND_INTENSE_MAX));
-      Assert.assertEquals("xtermBgColor8", 
+      Assert.assertEquals("xtermBgColor8",
             AnsiCode.clazzForBgColor(AnsiCode.BACKGROUND_INTENSE_MIN));
-      Assert.assertEquals("xtermBgColor15", 
+      Assert.assertEquals("xtermBgColor15",
             AnsiCode.clazzForBgColor(AnsiCode.BACKGROUND_INTENSE_MAX));
    }
 
@@ -278,7 +288,7 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "Hello");
-      String expected ="<span class=\"xtermColor0\">Hello</span>"; 
+      String expected ="<span class=\"xtermColor0\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -291,15 +301,15 @@ public class VirtualConsoleTests extends GWTTestCase
       String expected ="<span class=\"xtermColor7\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-  
+
    public void testMinAnsiBgColor()
    {
       int color = AnsiCode.BACKGROUND_MIN;
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "pretty");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForBgColor(color) + "\">pretty</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForBgColor(color) + "\">pretty</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -309,8 +319,8 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "colors");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForBgColor(color) + "\">colors</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForBgColor(color) + "\">colors</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -323,9 +333,9 @@ public class VirtualConsoleTests extends GWTTestCase
             setCsiCode(color) + "Hello " +
             setCsiCode(AnsiCode.RESET_FOREGROUND) + "World");
       String expected =
-            "<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello </span>" + 
-            "<span>World</span>"; 
+            "<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello </span>" +
+            "<span>World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -337,8 +347,8 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(
             setCsiCode(color) + "Sunny " +
             setCsiCode(AnsiCode.RESET_BACKGROUND) + "Days");
-      String expected = "<span class=\"" + AnsiCode.clazzForBgColor(color) + 
-            "\">Sunny </span><span>Days</span>"; 
+      String expected = "<span class=\"" + AnsiCode.clazzForBgColor(color) +
+            "\">Sunny </span><span>Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -349,9 +359,9 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + setCsiCode(bgColor) + "Hello");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + " " + 
-            AnsiCode.clazzForBgColor(bgColor) + "\">Hello</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + " " +
+            AnsiCode.clazzForBgColor(bgColor) + "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -365,8 +375,8 @@ public class VirtualConsoleTests extends GWTTestCase
             setCsiCode(color) +
             setCsiCode(bgColor) + "Colorful " +
             setCsiCode(AnsiCode.RESET) + "Bland");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + " " + 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + " " +
             AnsiCode.clazzForBgColor(bgColor) +
             "\">Colorful </span><span>Bland</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
@@ -378,9 +388,9 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "Hello");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + 
-            "\">Hello</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) +
+            "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -390,8 +400,8 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "Hello World");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello World</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -401,8 +411,8 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setCsiCode(color) + "pretty");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForBgColor(color) + "\">pretty</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForBgColor(color) + "\">pretty</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -412,11 +422,11 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(AnsiCode.CSI + color + AnsiCode.SGR + "colors");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForBgColor(color) + "\">colors</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForBgColor(color) + "\">colors</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-   
+
    public void testResetAnsiIntenseForegroundColor()
    {
       int color = AnsiCode.FOREGROUND_INTENSE_MIN + 1;
@@ -426,9 +436,9 @@ public class VirtualConsoleTests extends GWTTestCase
             AnsiCode.CSI + color + AnsiCode.SGR + "Hello " +
             AnsiCode.CSI + AnsiCode.RESET_FOREGROUND + AnsiCode.SGR + "World");
       String expected =
-            "<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello </span>" + 
-            "<span>World</span>"; 
+            "<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello </span>" +
+            "<span>World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -440,16 +450,16 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(
             AnsiCode.CSI + color + AnsiCode.SGR + "Sunny " +
             AnsiCode.CSI + AnsiCode.RESET_BACKGROUND + AnsiCode.SGR + "Days");
-      String expected = "<span class=\"" + AnsiCode.clazzForBgColor(color) + 
-            "\">Sunny </span><span>Days</span>"; 
+      String expected = "<span class=\"" + AnsiCode.clazzForBgColor(color) +
+            "\">Sunny </span><span>Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-   
+
    public void testAnsiInvertDefaultColors()
    {
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
-      vc.submit(AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Sunny Days");
+      vc.submit(inverseOn() + "Sunny Days");
       String expected = "<span class=\"xtermInvertColor xtermInvertBgColor\"" +
             ">Sunny Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
@@ -460,13 +470,13 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Sunny " +
-            AnsiCode.CSI + AnsiCode.INVERSE_OFF + AnsiCode.SGR + "Days");
+            inverseOn() + "Sunny " +
+            inverseOff() + "Days");
       String expected = "<span class=\"xtermInvertColor xtermInvertBgColor\"" +
-            ">Sunny </span><span>Days</span>"; 
+            ">Sunny </span><span>Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-   
+
    public void testAnsiInvertCustomBgColor()
    {
       int bgColor = AnsiCode.BackColorNum.GREEN;
@@ -474,12 +484,12 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(
             AnsiCode.CSI + bgColor + AnsiCode.SGR +
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Sunny Days");
+            inverseOn() + "Sunny Days");
       String expected = "<span class=\"xtermColor2 xtermInvertBgColor\"" +
             ">Sunny Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-   
+
    public void testAnsiInvertCustomFgColor()
    {
       int fgColor = AnsiCode.ForeColorNum.BLUE;
@@ -487,7 +497,7 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(
             AnsiCode.CSI + fgColor + AnsiCode.SGR +
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Sunny Days");
+            inverseOn() + "Sunny Days");
       String expected = "<span class=\"xtermInvertColor xtermBgColor4\"" +
             ">Sunny Days</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
@@ -531,7 +541,7 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(setForegroundIndex(color) + setBackgroundIndex(bgColor) +
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Hello World");
+            inverseOn() + "Hello World");
       String expected ="<span class=\"xtermColor129 xtermBgColor61\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
@@ -541,9 +551,9 @@ public class VirtualConsoleTests extends GWTTestCase
       int color = 77;
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
-      vc.submit(AnsiCode.CSI + AnsiCode.FOREGROUND_EXT + ";" + 
+      vc.submit(AnsiCode.CSI + AnsiCode.FOREGROUND_EXT + ";" +
             AnsiCode.EXT_BY_INDEX + ";" + color + AnsiCode.SGR +
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Hello World");
+            inverseOn() + "Hello World");
       String expected ="<span class=\"xtermInvertColor xtermBgColor77\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
@@ -553,9 +563,9 @@ public class VirtualConsoleTests extends GWTTestCase
       int bgColor = 234;
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
-      vc.submit(AnsiCode.CSI + AnsiCode.BACKGROUND_EXT + ";" + 
+      vc.submit(AnsiCode.CSI + AnsiCode.BACKGROUND_EXT + ";" +
             AnsiCode.EXT_BY_INDEX + ";" + bgColor + AnsiCode.SGR +
-            AnsiCode.CSI + AnsiCode.INVERSE + AnsiCode.SGR + "Hello World");
+            inverseOn() + "Hello World");
       String expected ="<span class=\"xtermColor234 xtermInvertBgColor\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
@@ -567,7 +577,7 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(
-         AnsiCode.CSI + fgColor + ";" + 
+         AnsiCode.CSI + fgColor + ";" +
          AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + bgColor + ";" +
          AnsiCode.BOLD + ";" + AnsiCode.UNDERLINE + ";" + AnsiCode.BOLD_BLURRED_OFF + ";" +
          AnsiCode.INVERSE_OFF + AnsiCode.SGR + "Hello World");
@@ -582,7 +592,7 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(
-         AnsiCode.CSI + fgColor + ";" + 
+         AnsiCode.CSI + fgColor + ";" +
          AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + bgColor + ";" +
          AnsiCode.BOLD + ";" + AnsiCode.UNDERLINE + ";" + AnsiCode.BOLD_BLURRED_OFF + ";" +
          AnsiCode.INVERSE_OFF + AnsiCode.SGR + "Hello World",
@@ -604,7 +614,7 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(
          AnsiCode.CSI + AnsiCode.FOREGROUND_EXT + ";" + AnsiCode.EXT_BY_RGB + ";" +
-         red + ";" + green + ";" + blue + ";" + AnsiCode.BOLD + AnsiCode.SGR + 
+         red + ";" + green + ";" + blue + ";" + AnsiCode.BOLD + AnsiCode.SGR +
          "Hello World");
       String expected ="<span class=\"xtermBold\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
@@ -618,14 +628,14 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(
-         AnsiCode.CSI + AnsiCode.BOLD + ";" + 
+         AnsiCode.CSI + AnsiCode.BOLD + ";" +
          AnsiCode.FOREGROUND_EXT + ";" + AnsiCode.EXT_BY_RGB + ";" +
-         red + ";" + green + ";" + blue + ";" + 
+         red + ";" + green + ";" + blue + ";" +
          AnsiCode.UNDERLINE + ";" +
          AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_RGB + ";" +
          red + ";" + green + ";" + blue + ";" +
          AnsiCode.FOREGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + 255 +
-         AnsiCode.SGR + 
+         AnsiCode.SGR +
          "Hello World");
       String expected ="<span class=\"xtermBold xtermUnderline xtermColor255\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
@@ -638,8 +648,8 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(AnsiCode.CSI + color);
       vc.submit(AnsiCode.SGR + "Hello");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -650,8 +660,8 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(AnsiCode.CSI + color, "myStyle");
       vc.submit(AnsiCode.SGR + "Hello", "myStyle");
-      String expected ="<span class=\"myStyle " + 
-            AnsiCode.clazzForColor(color) + "\">Hello</span>"; 
+      String expected ="<span class=\"myStyle " +
+            AnsiCode.clazzForColor(color) + "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -665,9 +675,9 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(AnsiCode.SGR + AnsiCode.CSI);
       vc.submit(Integer.toString(bgColor));
       vc.submit(AnsiCode.SGR + "Hello");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + " " + 
-            AnsiCode.clazzForBgColor(bgColor) + "\">Hello</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + " " +
+            AnsiCode.clazzForBgColor(bgColor) + "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -679,8 +689,8 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(AnsiCode.CSI + color);
       vc.submit(AnsiCode.SGR);
       vc.submit("Hello");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -693,8 +703,8 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(AnsiCode.SGR);
       vc.submit("Hello");
       vc.submit(" World");
-      String expected ="<span class=\"" + 
-            AnsiCode.clazzForColor(color) + "\">Hello World</span>"; 
+      String expected ="<span class=\"" +
+            AnsiCode.clazzForColor(color) + "\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -705,11 +715,11 @@ public class VirtualConsoleTests extends GWTTestCase
       VirtualConsole vc = getVC(ele);
       vc.submit(AnsiCode.CSI + color + AnsiCode.SGR, "someClazz");
       vc.submit("Hello World", "someClazz");
-      String expected ="<span class=\"someClazz " + 
-            AnsiCode.clazzForColor(color) + "\">Hello World</span>"; 
+      String expected ="<span class=\"someClazz " +
+            AnsiCode.clazzForColor(color) + "\">Hello World</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
-    
+
    public void testAnsiComplexSequence1WithStripping()
    {
       int fgColor = AnsiCode.ForeColorNum.GREEN;
@@ -719,7 +729,7 @@ public class VirtualConsoleTests extends GWTTestCase
       prefs.ansiMode_ = UserPrefs.ANSI_CONSOLE_MODE_STRIP;
       VirtualConsole vc = new VirtualConsole(ele, prefs);
       vc.submit(
-         AnsiCode.CSI + fgColor + ";" + 
+         AnsiCode.CSI + fgColor + ";" +
          AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + bgColor + ";" +
          AnsiCode.BOLD + ";" + AnsiCode.UNDERLINE + ";" + AnsiCode.BOLD_BLURRED_OFF + ";" +
          AnsiCode.INVERSE_OFF + AnsiCode.SGR + "Hello World", "myOriginalStyle");
@@ -736,7 +746,7 @@ public class VirtualConsoleTests extends GWTTestCase
       prefs.ansiMode_ = UserPrefs.ANSI_CONSOLE_MODE_OFF;
       VirtualConsole vc = new VirtualConsole(ele, prefs);
       vc.submit(
-         AnsiCode.CSI + fgColor + ";" + 
+         AnsiCode.CSI + fgColor + ";" +
          AnsiCode.BACKGROUND_EXT + ";" + AnsiCode.EXT_BY_INDEX + ";" + bgColor + ";" +
          AnsiCode.BOLD + ";" + AnsiCode.UNDERLINE + ";" + AnsiCode.BOLD_BLURRED_OFF + ";" +
          AnsiCode.INVERSE_OFF + AnsiCode.SGR + "Hello World", "myOriginalStyle");
@@ -756,7 +766,7 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(AnsiCode.SGR + AnsiCode.CSI);
       vc.submit(Integer.toString(bgColor));
       vc.submit(AnsiCode.SGR + "Hello");
-      String expected ="<span>Hello</span>"; 
+      String expected ="<span>Hello</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
 
@@ -790,7 +800,7 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals("<span>hello world</span>", ele.getInnerHTML());
       Assert.assertEquals("hello world", vc.toString());
    }
-   
+
    public void testSingleSupportedANSICodes()
    {
       // https://github.com/rstudio/rstudio/issues/2248
@@ -799,9 +809,9 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit(AnsiCode.CSI + "?25lBuilding sites \342\200\246 " +
                 AnsiCode.CSI + "?25h\r" + AnsiCode.CSI + "[K");
       Assert.assertEquals("<span>Building sites \342\200\246 </span>", ele.getInnerHTML());
-      Assert.assertEquals("Building sites \342\200\246 ", vc.toString());       
+      Assert.assertEquals("Building sites \342\200\246 ", vc.toString());
    }
-   
+
    public void testMultipleUnknownANSICodes()
    {
       // https://github.com/rstudio/rstudio/issues/2248
@@ -810,7 +820,7 @@ public class VirtualConsoleTests extends GWTTestCase
       vc.submit("We are " + AnsiCode.CSI + "?25lbuilding sites \342\200\246" +
                 AnsiCode.CSI + "?25h\r" + AnsiCode.CSI + "[K");
       Assert.assertEquals("<span>We are building sites \342\200\246</span>", ele.getInnerHTML());
-      Assert.assertEquals("We are building sites \342\200\246", vc.toString());       
+      Assert.assertEquals("We are building sites \342\200\246", vc.toString());
    }
 
    public void testMultiCarriageReturnsWithoutColorsMultiSubmits()
@@ -825,7 +835,7 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals("<span>789x </span>", ele.getInnerHTML());
       Assert.assertEquals("789x ", vc.toString());
    }
-   
+
    public void testMultiCarriageReturnWithoutColors()
    {
       PreElement ele = Document.get().createPreElement();
@@ -841,17 +851,17 @@ public class VirtualConsoleTests extends GWTTestCase
       // cat(c(crayon::red("123"), "x \r", crayon::red("456"), "x \r", crayon::red("789\n")), sep = "")
       String red = AnsiCode.CSI + AnsiCode.ForeColorNum.RED + AnsiCode.SGR;
       String reset = AnsiCode.CSI + AnsiCode.RESET_FOREGROUND + AnsiCode.SGR;
-      
+
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
       vc.submit(red + "123" + reset + "x \r" +
                 red + "456" + reset + "x \r" +
                 red + "789");
-      
+
       String expected =
             "<span class=\"" + AnsiCode.clazzForColor(AnsiCode.ForeColorNum.RED) +
-            "\">789</span><span>x </span>"; 
-      
+            "\">789</span><span>x </span>";
+
       Assert.assertEquals(expected, ele.getInnerHTML());
       Assert.assertEquals("789x ", vc.toString());
    }
@@ -1055,7 +1065,7 @@ public class VirtualConsoleTests extends GWTTestCase
       PreElement ele = Document.get().createPreElement();
       VirtualConsole vc = getVC(ele);
 
-      String testInput = 
+      String testInput =
             setForegroundIndex(232) + setBackgroundIndex(255) + "one" +
             setCsiCode(AnsiCode.RESET_BACKGROUND) + setCsiCode(AnsiCode.RESET_FOREGROUND) + " two";
 
@@ -1078,5 +1088,53 @@ public class VirtualConsoleTests extends GWTTestCase
       String expected = "<span class=\"xtermColor255 xtermBgColor232\">one</span><span> two</span>";
       Assert.assertEquals(expected, ele.getInnerHTML());
       Assert.assertEquals("one two", vc.toString());
+   }
+
+   public void testInverseFgHandling()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = inverseOn() + setCsiCode(AnsiCode.ForeColorNum.RED) +
+         "This is visible in both " + setCsiCode(AnsiCode.RESET_FOREGROUND) +
+         "This is visible only in the terminal" + inverseOff();
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermInvertColor xtermBgColor1\">This is visible in both </span>" +
+                        "<span class=\"xtermInvertColor xtermInvertBgColor\">This is visible only in the terminal</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("This is visible in both This is visible only in the terminal", vc.toString());
+   }
+
+   public void testInverseBgHandling()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = inverseOn() + setCsiCode(103 /*bright yellow background*/) +
+         "Part One " + setCsiCode(AnsiCode.RESET_BACKGROUND) +
+         "Other Part" + inverseOff();
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermInvertBgColor xtermColor11\">Part One </span>" +
+         "<span class=\"xtermInvertBgColor xtermInvertColor\">Other Part</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("Part One Other Part", vc.toString());
+   }
+
+   public void testInverseFgBgHandling()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = inverseOn() + setCsiCode(103 /*bright yellow background*/) + setCsiCode(AnsiCode.ForeColorNum.RED) +
+         "Part One " + setCsiCode(AnsiCode.RESET_BACKGROUND) + setCsiCode(AnsiCode.RESET_FOREGROUND) +
+         "Other Part" + inverseOff();
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermColor11 xtermBgColor1\">Part One </span>" +
+         "<span class=\"xtermInvertColor xtermInvertBgColor\">Other Part</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("Part One Other Part", vc.toString());
    }
 }

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1137,4 +1137,36 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals(expected, ele.getInnerHTML());
       Assert.assertEquals("Part One Other Part", vc.toString());
    }
+
+   public void testInverse256FgHandling()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = inverseOn() + setForegroundIndex(196 /*red*/) +
+         "Inverted with red background " + setCsiCode(AnsiCode.RESET_FOREGROUND) +
+         "Inverted with default background" + inverseOff();
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermInvertColor xtermBgColor196\">Inverted with red background </span>" +
+         "<span class=\"xtermInvertColor xtermInvertBgColor\">Inverted with default background</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("Inverted with red background Inverted with default background", vc.toString());
+   }
+
+   public void testInverse256FgBgHandling()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = inverseOn() + setForegroundIndex(196 /*red*/) + setBackgroundIndex(228 /*yellow*/) +
+         "Inverted with red background yellow foreground " + setCsiCode(AnsiCode.RESET_FOREGROUND) +
+         setCsiCode(AnsiCode.RESET_BACKGROUND) + "Inverted with default colors" + inverseOff();
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermBgColor196 xtermColor228\">Inverted with red background yellow foreground </span>" +
+         "<span class=\"xtermInvertBgColor xtermInvertColor\">Inverted with default colors</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("Inverted with red background yellow foreground Inverted with default colors", vc.toString());
+   }
 }


### PR DESCRIPTION
- Fixes #7250
- Fixes #7557 

# Fix Details
Looks like I had not completed the implementation of handling ANSI "invert" back when I added console ANSI support in RStudio 1.1.

Specifically, when invert is active, setting foreground or background colors and resetting foreground or background colors were not being inverted (e.g. setting foreground should actually set background and so on).

# QA Notes
We have pretty extensive unit testing of this code, and I wrote several new tests to cover this. To exercise it, recommend using the Crayon package and trying examples like the one in the issues themselves and/or issuing escape sequences directly.

Reference: https://en.wikipedia.org/wiki/ANSI_escape_code
