### PR TITLE
add script for minifying the data viewer JS

### DIFF
--- a/src/cpp/session/resources/grid/minify.sh
+++ b/src/cpp/session/resources/grid/minify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+# minified js using closure
+minify () {
+    echo "Minifying $1 to $2"
+    CC_OPTS="--warning_level QUIET"
+    java -Xmx128M -jar "../../../../../../gwt/tools/compiler/compiler.jar" $CC_OPTS --js $1 --js_output_file $2
+}
+
+minify dataTables.scroller.js dataTables.scroller.min.js
+minify jquery.dataTables.js jquery.dataTables.min.js
+
+


### PR DESCRIPTION
### Intent

The IDE data viewer uses javascript that needs to be minified, and we didn't have a script or instructions on how we perform this.

### Approach

Added a bash script `minify.sh` to the folder where the Javascript lives, which minifies via the Closure compiler we use in other similar situations. For now a no-op, since I didn't actually modify the Javascript files.

### QA Notes

Nothing to see here. This is a manually executed script used by developers after they modify some source code, and that source code was not modified. Just making it easier in the future.
