### PR TITLE
suppress focus outlines for console output regions

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -24,6 +24,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
+import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 
 /**
  * Displays R Console output to user, with special behaviors for regular output
@@ -90,11 +91,12 @@ public class ConsoleOutputWriter
 
       Element outEl = output_.getElement();
 
-      // create trailing output console if it doesn't already exist 
+      // create trailing output console if it doesn't already exist
       if (virtualConsole_ == null)
       {
          SpanElement trailing = Document.get().createSpanElement();
          trailing.setTabIndex(-1);
+         trailing.setClassName(ConsoleResources.INSTANCE.consoleStyles().outputChunk());
          Roles.getDocumentRole().set(trailing); // https://github.com/rstudio/rstudio/issues/6884
          outEl.appendChild(trailing);
          virtualConsole_ = vcFactory_.create(trailing);
@@ -123,7 +125,7 @@ public class ConsoleOutputWriter
       return false;
    }
 
-   // Elements added by last submit call; only captured if 
+   // Elements added by last submit call; only captured if
    // outputToConsole/isError was true for performance reasons
    public List<Element> getNewElements()
    {
@@ -146,7 +148,7 @@ public class ConsoleOutputWriter
          }
          // clear the virtual console so we start with a fresh slate
          virtualConsole_ = null;
-      } 
+      }
    }
 
    public int getCurrentLines()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleResources.java
@@ -31,6 +31,7 @@ public interface ConsoleResources extends ClientBundle
       String input();
       String prompt();
       String output();
+      String outputChunk();
       String command();
       String completionPopup();
       String completionGrid();
@@ -49,6 +50,6 @@ public interface ConsoleResources extends ClientBundle
       String packageDescription();
       String truncatedLabel();
    }
-   
+
    public static final String KEYWORD_CLASS_NAME = " ace_keyword";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/consoleStyles.css
@@ -6,6 +6,7 @@
 
 @external rstudio-themes-flat;
 @external rstudio-themes-dark-menus;
+@external js-focus-visible, focus-visible;
 
 @eval THEME_DARKGREY_MENU_SELECTED org.rstudio.core.client.theme.ThemeColors.darkGreyMenuSelected;
 
@@ -38,6 +39,17 @@
    user-select: text
 }
 .output .command, .input {
+}
+
+.outputChunk {
+   outline: none;
+}
+
+/* .console needed to increase specificity so it wins over focus-visible.css */
+/* !important needed because .focus-visible uses it as well */
+.js-focus-visible .console .output.focus-visible,
+.js-focus-visible .console .outputChunk.focus-visible {
+   outline-style: none !important;
 }
 
 .error {}


### PR DESCRIPTION
- Fixes #6518

### Intent

When selecting text from the Console output region, keyboard focus rectangles were being shown if you pressed a key (e.g. using Shift to extend the selection; these could be quite ugly and don't serve any real purpose, so this change gets rid of them.

It gets much uglier if you turn off the (relatively new) accessibility option "Always show focus outlines". Then just clicking on it was enough to trigger focus outlines.

### Approach

Use CSS to suppress focus rectangles. Sometimes focus was being placed on the `div` that wraps the entire output region, sometimes it was being placed on the individual spans used to wrap each output "chunk" so the css needed to handle both.
 
### QA Notes

Generate some console output, then click on it, then tap Shift key (or any key). Previously you'd see something like this:

<img width="542" alt="screenshot of console showing jagged focus outline around console output" src="https://user-images.githubusercontent.com/10569626/89945588-6dcf2e00-dbd6-11ea-81ea-70e6bbb66406.png">

It was much worse if you had the "Always show focus outlines" option unchecked.

<img width="505" alt="another screenshot of console showing jagged focus outlines" src="https://user-images.githubusercontent.com/10569626/89945854-df0ee100-dbd6-11ea-95cb-194a33515b87.png">

With the fix those focus outlines should no longer display whether or not the "Always show focus outlines" option is enabled.

### Other Notes

This focus-rectangle suppression is itself a minor accessibility issue, but the main scenario for putting focus on the console output via keyboard is for screen reader users via the "Focus Console Output" command, in which case focus-rectangles are not necessary since the screen reader will announce that focus is in the console output.

If we ever support selection of console output via keyboard-only, then we'll have to revisit this. #6077