### PR TITLE
fix keyboard operation of unfocused ToolbarPopupMenus

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserContextWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserContextWidget.java
@@ -37,19 +37,19 @@ import com.google.gwt.user.client.ui.Image;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.MenuItem;
 
-public class CodeBrowserContextWidget extends Composite 
+public class CodeBrowserContextWidget extends Composite
                                       implements HasSelectionHandlers<String>
 {
    public CodeBrowserContextWidget(
                final CodeBrowserEditingTargetWidget.Styles styles)
    {
       HorizontalPanel panel = new HorizontalPanel();
-      
+
       captionLabel_ = new Label();
       captionLabel_.addStyleName(styles.captionLabel());
       panel.add(captionLabel_);
-      
-     
+
+
       ClickHandler clickHandler = new ClickHandler()
       {
          public void onClick(ClickEvent event)
@@ -57,7 +57,7 @@ public class CodeBrowserContextWidget extends Composite
             if (dropDownImage_.isVisible())
             {
                CodeBrowserPopupMenu menu = new CodeBrowserPopupMenu();
-               
+
                JsArrayString methods = functionDef_.getMethods();
                for (int i=0; i < methods.length(); i++)
                {
@@ -66,63 +66,63 @@ public class CodeBrowserContextWidget extends Composite
                      @Override
                      public void execute()
                      {
-                        SelectionEvent.fire(CodeBrowserContextWidget.this, 
+                        SelectionEvent.fire(CodeBrowserContextWidget.this,
                                             method);
                      }
                   });
                   mi.getElement().getStyle().setPaddingRight(20, Unit.PX);
                   menu.addItem(mi);
                }
-               
+
                menu.showRelativeTo(nameLabel_);
                menu.getElement().getStyle().setPaddingTop(3, Unit.PX);
             }
          }
       };
-      
-      
+
+
       nameLabel_ = new Label();
       nameLabel_.addStyleName(styles.menuElement());
       nameLabel_.addStyleName(styles.functionName());
       nameLabel_.addClickHandler(clickHandler);
       panel.add(nameLabel_);
-      
+
       namespaceLabel_ = new Label();
       namespaceLabel_.addStyleName(styles.menuElement());
       namespaceLabel_.addStyleName(styles.functionNamespace());
       namespaceLabel_.addClickHandler(clickHandler);
       panel.add(namespaceLabel_);
-      
+
       dropDownImage_ = new Image(new ImageResource2x(ThemeResources.INSTANCE.mediumDropDownArrow2x()));
       dropDownImage_.addStyleName(styles.menuElement());
       dropDownImage_.addStyleName(styles.dropDownImage());
       dropDownImage_.addClickHandler(clickHandler);
       panel.add(dropDownImage_);
       dropDownImage_.setVisible(false);
-      
+
       initWidget(panel);
    }
-   
+
    @Override
    public HandlerRegistration addSelectionHandler(
                                        SelectionHandler<String> handler)
    {
       return handlers_.addHandler(SelectionEvent.getType(), handler);
    }
-   
+
    @Override
    public void fireEvent(GwtEvent<?> event)
    {
       handlers_.fireEvent(event);
    }
-   
+
    public void setCurrentFunction(SearchPathFunctionDefinition functionDef)
    {
       functionDef_ = functionDef;
-      
+
       nameLabel_.setText(functionDef.getName());
       namespaceLabel_.setText("(" + functionDef.getNamespace() + ")");
-           
+
       if (functionDef.getMethods().length() > 0)
       {
          captionLabel_.setText("Method:");
@@ -133,26 +133,32 @@ public class CodeBrowserContextWidget extends Composite
          captionLabel_.setText("Function:");
          dropDownImage_.setVisible(false);
       }
-      
-      
+
+
    }
-   
+
    private class CodeBrowserPopupMenu extends ScrollableToolbarPopupMenu
    {
+      public CodeBrowserPopupMenu()
+      {
+         super();
+         setReceivesFocus(ReceivesFocus.NO);
+      }
+
       @Override
       protected int getMaxHeight()
       {
          return Window.getClientHeight() - captionLabel_.getAbsoluteTop() -
                 captionLabel_.getOffsetHeight() - 50;
       }
-      
+
    }
-   
+
    private SearchPathFunctionDefinition functionDef_;
    private Label captionLabel_;
    private Label nameLabel_;
    private Label namespaceLabel_;
    private Image dropDownImage_;
-   
+
    private final HandlerManager handlers_ = new HandlerManager(null);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -51,7 +51,7 @@ public class CppCompletionManager implements CompletionManager
    {
       hideCompletionPopup();
    }
-   
+
    public CppCompletionManager(DocDisplay docDisplay,
                                InitCompletionFilter initFilter,
                                CppCompletionContext completionContext)
@@ -62,7 +62,7 @@ public class CppCompletionManager implements CompletionManager
       completionContext_ = completionContext;
       snippets_ = new SnippetHelper((AceEditor) docDisplay_, completionContext.getDocPath());
       handlers_ = new HandlerRegistrations();
-      
+
       handlers_.add(docDisplay_.addClickHandler(new ClickHandler()
       {
          public void onClick(ClickEvent event)
@@ -71,9 +71,9 @@ public class CppCompletionManager implements CompletionManager
          }
       }));
    }
- 
+
    @Inject
-   void initialize(CppServerOperations server, 
+   void initialize(CppServerOperations server,
                    FileTypeRegistry fileTypeRegistry,
                    UserPrefs uiPrefs)
    {
@@ -82,28 +82,28 @@ public class CppCompletionManager implements CompletionManager
       userPrefs_ = uiPrefs;
       suggestionTimer_ = new SuggestionTimer(this, userPrefs_);
    }
-   
+
    // close the completion popup (if any)
    @Override
    public void close()
    {
       terminateCompletionRequest();
    }
-   
+
    @Override
    public void detach()
    {
       handlers_.removeHandler();
       snippets_.detach();
    }
-   
+
    // perform completion at the current cursor location
    @Override
    public void codeCompletion()
    {
       if (shouldComplete(null))
       {
-         suggestCompletions(true); 
+         suggestCompletions(true);
       }
    }
 
@@ -113,22 +113,22 @@ public class CppCompletionManager implements CompletionManager
    {
       // no implementation here yet since we don't have access
       // to C/C++ help (we could implement this via using libclang
-      // to parse doxygen though)   
+      // to parse doxygen though)
    }
 
    // find the definition of the function at the current cursor location
    @Override
    public void goToDefinition()
-   {  
+   {
       completionContext_.cppCompletionOperation(new CppCompletionOperation(){
 
          @Override
          public void execute(String docPath, int line, int column)
          {
             server_.goToCppDefinition(
-                  docPath, 
-                  line, 
-                  column, 
+                  docPath,
+                  line,
+                  column,
                   new CppCompletionServerRequestCallback<CppSourceLocation>(
                         "Finding definition...") {
                      @Override
@@ -136,8 +136,8 @@ public class CppCompletionManager implements CompletionManager
                      {
                         if (loc != null)
                         {
-                           fileTypeRegistry_.editFile(loc.getFile(), 
-                                 loc.getPosition());  
+                           fileTypeRegistry_.editFile(loc.getFile(),
+                                 loc.getPosition());
                         }
                      }
                   });
@@ -145,22 +145,22 @@ public class CppCompletionManager implements CompletionManager
 
       });
    }
-  
+
    // return false to indicate key not handled
    @Override
    public boolean previewKeyDown(NativeEvent event)
    {
       suggestionTimer_.cancel();
-      
-      // if there is no completion request active then 
-      // check for a key-combo that triggers completion or 
+
+      // if there is no completion request active then
+      // check for a key-combo that triggers completion or
       // navigation / help
       int modifier = KeyboardShortcut.getModifierValue(event);
       if ((request_ == null) || request_.isTerminated())
-      {  
-         // check for user completion key combo 
+      {
+         // check for user completion key combo
          if (CompletionUtils.isCompletionRequest(event, modifier) &&
-             shouldComplete(event)) 
+             shouldComplete(event))
          {
             return suggestCompletions(true);
          }
@@ -188,19 +188,19 @@ public class CppCompletionManager implements CompletionManager
       }
       // otherwise handle keys within the completion popup
       else
-      {   
+      {
          // get the key code
          int keyCode = event.getKeyCode();
-         
+
          // bail on modifier keys
          if (KeyboardHelper.isModifierKey(keyCode))
             return false;
-         
+
          // if there is no popup then bail
          CppCompletionPopupMenu popup = getCompletionPopup();
          if ((popup == null) || !popup.isVisible())
             return false;
-         
+
          // allow emacs-style navigation of popup entries
          if (modifier == KeyboardShortcut.CTRL)
          {
@@ -210,48 +210,38 @@ public class CppCompletionManager implements CompletionManager
             case KeyCodes.KEY_N: return popup.selectNext();
             }
          }
-         
-         // allow navigation with arrow keys
-         // (needs to be handled here as the popup will not be explicitly focused)
-         if (modifier == KeyboardShortcut.NONE)
-         {
-            switch (keyCode)
-            {
-            case KeyCodes.KEY_UP:       popup.selectPrev();        return true;
-            case KeyCodes.KEY_DOWN:     popup.selectNext();        return true;
-            case KeyCodes.KEY_PAGEUP:   popup.moveSelectionBwd(5); return true;
-            case KeyCodes.KEY_PAGEDOWN: popup.moveSelectionFwd(5); return true;
-            case KeyCodes.KEY_HOME:     popup.selectFirst();       return true;
-            case KeyCodes.KEY_END:      popup.selectLast();        return true;
-            case KeyCodes.KEY_ENTER:    popup.acceptSelected();    return true;
-            case KeyCodes.KEY_TAB:      popup.acceptSelected();    return true;
-            }
-         }
-         
+
          // backspace triggers completion if the popup is visible
          if (keyCode == KeyCodes.KEY_BACKSPACE)
          {
             deferredSuggestCompletions(false, false);
             return false;
          }
-         
+
+         // tab accepts the current selection (popup handles Enter)
+         else if (keyCode == KeyCodes.KEY_TAB)
+         {
+            popup.acceptSelected();
+            return true;
+         }
+
          // allow '.' when showing file completions
          else if (popup.getCompletionPosition().getScope() == CompletionPosition.Scope.File &&
                   KeyboardHelper.isPeriodKeycode(keyCode))
          {
             return false;
          }
-         
+
          // non c++ identifier keys (that aren't navigational) close the popup
          else if (!CppCompletionUtils.isCppIdentifierKey(event))
          {
             terminateCompletionRequest();
             return false;
          }
-         
+
          // otherwise leave it alone
          else
-         {   
+         {
             return false;
          }
       }
@@ -273,56 +263,56 @@ public class CppCompletionManager implements CompletionManager
 
       return false;
    }
-   
-   private void deferredSuggestCompletions(final boolean explicit, 
+
+   private void deferredSuggestCompletions(final boolean explicit,
                                            final boolean canDelay)
    {
       Scheduler.get().scheduleDeferred(new ScheduledCommand() {
          @Override
          public void execute()
          {
-            suggestCompletions(explicit, canDelay);  
+            suggestCompletions(explicit, canDelay);
          }
       });
    }
-   
+
    private boolean suggestCompletions(final boolean explicit)
    {
       return suggestCompletions(explicit, false);
    }
-   
+
    private boolean suggestCompletions(final boolean explicit, boolean canDelay)
    {
       suggestionTimer_.cancel();
-      
+
       // check for completions disabled
       if (!completionContext_.isCompletionEnabled())
          return false;
-      
+
       // check for no selection
       InputEditorSelection selection = docDisplay_.getSelection();
       if (selection == null)
          return false;
-      
+
       // check for contiguous selection
       if (!docDisplay_.isSelectionCollapsed())
-         return false;    
-  
-      // calculate explicit value for getting completion position (if a 
+         return false;
+
+      // calculate explicit value for getting completion position (if a
       // previous request was explicit then count this as explicit)
-      boolean positionExplicit = explicit || 
+      boolean positionExplicit = explicit ||
                                  ((request_ != null) && request_.isExplicit());
-      
+
       // see if we even have a completion position
       boolean alwaysComplete = userPrefs_.codeCompletion().getValue() ==
                                             UserPrefs.CODE_COMPLETION_ALWAYS;
       int autoChars = userPrefs_.codeCompletionCharacters().getValue();
-      final CompletionPosition completionPosition = 
+      final CompletionPosition completionPosition =
             CppCompletionUtils.getCompletionPosition(docDisplay_,
                                                      positionExplicit,
                                                      alwaysComplete,
                                                      autoChars);
-      
+
       if (completionPosition == null)
       {
          terminateCompletionRequest();
@@ -334,7 +324,7 @@ public class CppCompletionManager implements CompletionManager
       {
          request_.updateUI(false);
       }
-      else if (canDelay && 
+      else if (canDelay &&
                completionPosition.getScope() == CompletionPosition.Scope.Global)
       {
          suggestionTimer_.schedule(completionPosition);
@@ -343,18 +333,18 @@ public class CppCompletionManager implements CompletionManager
       {
          performCompletionRequest(completionPosition, explicit);
       }
-      
+
       return true;
    }
 
    private void performCompletionRequest(
          final CompletionPosition completionPosition, final boolean explicit)
-   {  
+   {
       terminateCompletionRequest();
-      
-      final Invalidation.Token invalidationToken = 
+
+      final Invalidation.Token invalidationToken =
             completionRequestInvalidation_.getInvalidationToken();
-      
+
       completionContext_.withUpdatedDoc(new CommandWith2Args<String, String>() {
 
          @Override
@@ -362,7 +352,7 @@ public class CppCompletionManager implements CompletionManager
          {
             if (invalidationToken.isInvalid())
                return;
-            
+
             request_ = new CppCompletionRequest(
                docPath,
                docId,
@@ -381,7 +371,7 @@ public class CppCompletionManager implements CompletionManager
          }
       });
    }
-   
+
    private static class SuggestionTimer
    {
       SuggestionTimer(CppCompletionManager manager, UserPrefs uiPrefs)
@@ -397,45 +387,45 @@ public class CppCompletionManager implements CompletionManager
             }
          };
       }
-      
+
       public void schedule(CompletionPosition completionPosition)
       {
          completionPosition_ = completionPosition;
          timer_.schedule(userPrefs_.codeCompletionDelay().getValue());
       }
-      
+
       public void cancel()
       {
          timer_.cancel();
       }
-      
+
       private final CppCompletionManager manager_;
       private final UserPrefs userPrefs_;
       private final Timer timer_;
       private CompletionPosition completionPosition_;
    }
-   
-     
+
+
    private CppCompletionPopupMenu getCompletionPopup()
    {
       CppCompletionPopupMenu popup = request_ != null ?
             request_.getCompletionPopup() : null;
       return popup;
    }
-   
+
    private void hideCompletionPopup()
    {
       CppCompletionPopupMenu popup = getCompletionPopup();
       if (popup != null)
          popup.hide();
    }
-   
+
    private boolean isCompletionPopupVisible()
    {
       CppCompletionPopupMenu popup = getCompletionPopup();
       return (popup != null) && popup.isVisible();
    }
-   
+
    private void terminateCompletionRequest()
    {
       suggestionTimer_.cancel();
@@ -451,7 +441,7 @@ public class CppCompletionManager implements CompletionManager
    {
       return initFilter_ == null || initFilter_.shouldComplete(event);
    }
-   
+
    private CppServerOperations server_;
    private UserPrefs userPrefs_;
    private FileTypeRegistry fileTypeRegistry_;
@@ -462,8 +452,8 @@ public class CppCompletionManager implements CompletionManager
    private final InitCompletionFilter initFilter_;
    private final Invalidation completionRequestInvalidation_ = new Invalidation();
    private final SnippetHelper snippets_;
-   
+
    private final HandlerRegistrations handlers_;
-  
+
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionPopupMenu.java
@@ -24,76 +24,77 @@ import com.google.gwt.user.client.ui.PopupPanel;
 
 public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
 {
-   CppCompletionPopupMenu(DocDisplay docDisplay, 
+   CppCompletionPopupMenu(DocDisplay docDisplay,
                           CompletionPosition completionPosition)
-   {  
+   {
       docDisplay_ = docDisplay;
       completionPosition_ = completionPosition;
-      
+      setReceivesFocus(ReceivesFocus.NO);
+
       addToolTipHandler();
-      
+
       addStyleName(ThemeStyles.INSTANCE.statusBarMenu());
    }
-   
+
    public void setText(String text)
    {
       JsArray<CppCompletion> completions = JsArray.createArray().cast();
       completions.push(CppCompletion.create(text));
       setCompletions(completions, null);
    }
-     
-   public void setCompletions(JsArray<CppCompletion> completions, 
+
+   public void setCompletions(JsArray<CppCompletion> completions,
                               CommandWithArg<CppCompletion> onSelected)
    {
       // save completions and selectable state
       completions_ = completions;
       onSelected_ = onSelected;
-      
+
       // clear existing items
       updatingMenu_ = true;
       menuBar_.clearItems();
-      
+
       // add items (remember first item for programmatic selection)
       MenuItem firstItem = null;
       for (int i = 0; i<completions.length(); i++)
       {
          final CppCompletion completion = completions.get(i);
-         
+
          SafeHtmlBuilder sb = new SafeHtmlBuilder();
-         SafeHtmlUtil.appendImage(sb, 
-                                  RES.styles().itemImage(), 
+         SafeHtmlUtil.appendImage(sb,
+                                  RES.styles().itemImage(),
                                   completion.getIcon());
-         SafeHtmlUtil.appendSpan(sb, 
-                                 RES.styles().itemName(), 
-                                 completion.getTypedText());   
-         
-         
-         MenuItem menuItem = new MenuItem(sb.toSafeHtml(), 
+         SafeHtmlUtil.appendSpan(sb,
+                                 RES.styles().itemName(),
+                                 completion.getTypedText());
+
+
+         MenuItem menuItem = new MenuItem(sb.toSafeHtml(),
                new ScheduledCommand() {
             @Override
             public void execute()
             {
-               docDisplay_.setFocus(true); 
+               docDisplay_.setFocus(true);
                if (isSelectable())
                   onSelected_.execute(completion);
             }
          });
          menuItem.addStyleName(RES.styles().itemMenu());
-           
+
          FontSizer.applyNormalFontSize(menuItem);
-         
+
          addItem(menuItem);
-         
+
          if (i == 0)
             firstItem = menuItem;
       }
       updatingMenu_ = false;
-      
-      
+
+
       // select first item
       if (isSelectable() && (firstItem != null))
          selectItem(firstItem);
-      
+
       if (completions.length() > 0)
       {
          showMenu();
@@ -105,7 +106,7 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
             toolTip_.setVisible(false);
       }
    }
-   
+
    public void acceptSelected()
    {
       int index = getSelectedIndex();
@@ -114,69 +115,69 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
          if (isSelectable())
             onSelected_.execute(completions_.get(index));
       }
-      
+
       hide();
    }
-   
+
    private void showMenu()
    {
       setPopupPositionAndShow(new PositionCallback()
       {
          public void setPosition(int offsetWidth, int offsetHeight)
          {
-            InputEditorPosition position = 
+            InputEditorPosition position =
                docDisplay_.createInputEditorPosition(
-                                    completionPosition_.getPosition());  
+                                    completionPosition_.getPosition());
             Rectangle bounds = docDisplay_.getPositionBounds(position);
-            
-            int windowBottom = Window.getScrollTop() + 
+
+            int windowBottom = Window.getScrollTop() +
                                Window.getClientHeight();
             int cursorBottom = bounds.getBottom();
-            
-            // figure out whether we should show below (do this 
+
+            // figure out whether we should show below (do this
             // only once so that we maintain the menu orientation
             // while filtering)
             if (showBelow_ == null)
                showBelow_ = windowBottom - cursorBottom >= offsetHeight;
-            
+
             final int PAD = 3;
             if (showBelow_)
                setPopupPosition(bounds.getLeft(), cursorBottom + PAD);
             else
-               setPopupPosition(bounds.getLeft(), 
+               setPopupPosition(bounds.getLeft(),
                                 bounds.getTop() - offsetHeight);
          }
       });
    }
-   
+
    private boolean isSelectable()
    {
       return onSelected_ != null;
    }
-   
+
    private void addToolTipHandler()
    {
       toolTip_ = new CppCompletionToolTip();
-      
+
       addSelectionHandler(new SelectionHandler<MenuItem>()
       {
          public void onSelection(SelectionEvent<MenuItem> event)
-         { 
+         {
             // bail if we are updating the menu
             if (updatingMenu_)
                return;
-            
+
             // bail if we have no more tooltip
             if (toolTip_ == null)
                return;
-            
+
             // screen unselectable
             if (!isSelectable())
             {
                toolTip_.setVisible(false);
                return;
             }
-               
+
             // screen unable to find menu or selected item
             final MenuItem selectedItem = event.getSelectedItem();
             if (selectedItem == null)
@@ -184,14 +185,14 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
                toolTip_.setVisible(false);
                return;
             }
-            
+
             int index = menuBar_.getItemIndex(selectedItem);
             if (index == -1)
             {
                toolTip_.setVisible(false);
                return;
             }
-            
+
             // screen no completion text
             CppCompletion completion = completions_.get(index);
             if (completion.getText() == null)
@@ -199,51 +200,51 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
                toolTip_.setVisible(false);
                return;
             }
-            
+
             // only do tooltips for functions and variables
-            if (completion.getType() != CppCompletion.FUNCTION && 
+            if (completion.getType() != CppCompletion.FUNCTION &&
                 completion.getType() != CppCompletion.VARIABLE &&
                 completion.getType() != CppCompletion.SNIPPET)
             {
                toolTip_.setVisible(false);
                return;
             }
-            
+
             // set the tooltip text
             toolTip_.setText(completion.getText().get(0));
-           
+
             // position it in the next event loop
             Scheduler.get().scheduleDeferred(new ScheduledCommand() {
 
                @Override
                public void execute()
-               { 
+               {
                   // bail if there is no longer a tooltip
                   if (toolTip_ == null)
                      return;
-                  
+
                   // some constants
                   final int H_PAD = 12;
                   final int V_PAD = -3;
                   final int H_BUFFER = 100;
                   final int MIN_WIDTH = 300;
-                  
+
                   // candidate left and top
-                  final int left = selectedItem.getAbsoluteLeft() 
+                  final int left = selectedItem.getAbsoluteLeft()
                              + selectedItem.getOffsetWidth() + H_PAD;
                   final int top = selectedItem.getAbsoluteTop() + V_PAD;
-                  
+
                   // do we have enough room to the right? if not then
                   int roomRight = Window.getClientWidth() - left;
                   int maxWidth = Math.min(roomRight - H_BUFFER, 500);
                   final boolean showLeft = maxWidth < MIN_WIDTH;
                   if (showLeft)
                      maxWidth = selectedItem.getAbsoluteLeft() - H_BUFFER;
-                  
+
                   if (toolTip_.getAbsoluteLeft() != left ||
                       toolTip_.getAbsoluteTop() != top)
                   {
-                     toolTip_.setMaxWidth(maxWidth);  
+                     toolTip_.setMaxWidth(maxWidth);
                      toolTip_.setPopupPositionAndShow(new PositionCallback(){
 
                         @Override
@@ -267,12 +268,12 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
                         toolTip_.setVisible(true);
                   }
 
-                  
+
                }
             });
          }
       });
-      
+
       addCloseHandler(new CloseHandler<PopupPanel>() {
 
          @Override
@@ -283,30 +284,30 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
          }
       });
    }
-   
+
    @Override
    protected int getMaxHeight()
    {
       return 180;
    }
-   
+
    public CompletionPosition getCompletionPosition()
    {
       return completionPosition_;
    }
-   
+
    public boolean selectPrev()
    {
       menuBar_.moveSelectionUp();
       return true;
    }
-   
+
    public boolean selectNext()
    {
       menuBar_.moveSelectionDown();
       return true;
    }
-   
+
    private final DocDisplay docDisplay_;
    private final CompletionPosition completionPosition_;
    private JsArray<CppCompletion> completions_;
@@ -314,7 +315,7 @@ public class CppCompletionPopupMenu extends ScrollableToolbarPopupMenu
    private Boolean showBelow_ = null;
    private boolean updatingMenu_ = false;
    private CppCompletionToolTip toolTip_;
-   
+
    private static CppCompletionResources RES = CppCompletionResources.INSTANCE;
-   
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarPopupMenu.java
@@ -23,6 +23,7 @@ public class StatusBarPopupMenu extends ScrollableToolbarPopupMenu
    public StatusBarPopupMenu()
    {
       super();
+      setReceivesFocus(ReceivesFocus.NO);
       addStyleName(ThemeStyles.INSTANCE.statusBarMenu());
    }
 


### PR DESCRIPTION
- Fixes #7070

### Intent

Fix a regression in 1.4 (due to change I made in #6576), whereby popup menus that don't receive keyboard focus would no longer respond to keyboard (e.g. up/down arrows, Enter). One instance of this was previously noticed and fixed here (C/C++ autocompletion popups): #6976

### Approach

There were three separate instances of this, found via code inspection. Rather than duplicating the fix already made for the C++ completion manage, I put handling of this situation directly into the base ToolbarPopMenu class, enabled via new `setReceivesFocus(YES/NO)` method. The default is YES, as most uses of this class are in situation where it does receive keyboard focus, which enables handling of these keys by GWT's `MenuBar` class. When set to `NO`, then the behavior I had previously removed (and now restored) kicks back in, fixing the regression for all three instances. As part of this I removed the previous fix to the `CppCompletionManager` and put code back the way it was.

### QA Notes

Revalidate the previously fixed issues:

- #6576 (keyboard navigation of toolbar menus that have submenus, fairly common in the Visual Editor)
- #6976 (keyboard navigation of C++ completion popups)

Then validate keyboard operation of the newly fixed instances. First, the popups on the bottom toolbar of source editor (Jump To and File Type):

<img width="306" alt="screenshot of file context popup on lower editor toolbar" src="https://user-images.githubusercontent.com/10569626/90169138-08547c00-dd53-11ea-81aa-80326be5efa8.png">

<img width="212" alt="screenshot of file type popup on lower editor toolbar" src="https://user-images.githubusercontent.com/10569626/90169165-160a0180-dd53-11ea-88fa-ef71e342380b.png">

Then the method popup in code browser; for an example, do `View(data)` in console:

<img width="293" alt="screenshot of method popup in code browser toolbar" src="https://user-images.githubusercontent.com/10569626/90169278-3b970b00-dd53-11ea-9d61-b4ba50106289.png">
