### PR TITLE
update to pandoc 2.10.1

### DIFF
--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -20,7 +20,7 @@ set -e
 source rstudio-tools
 
 # variables that control download + installation process
-PANDOC_VERSION="2.9.2.1"
+PANDOC_VERSION="2.10.1"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
 PANDOC_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/pandoc/${PANDOC_VERSION}"
 

--- a/dependencies/tools/upload-pandoc.sh
+++ b/dependencies/tools/upload-pandoc.sh
@@ -8,7 +8,7 @@
 # filenames, so tweaking for new releases is expected.
 
 # Modify to set the Pandoc version to upload
-PANDOC_VERSION=2.9.2.1
+PANDOC_VERSION=2.10.1
 
 for PLATFORM in linux-amd64.tar.gz macOS.zip windows-x86_64.zip; do
 

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -19,7 +19,7 @@ set WINPTY_FILES=winpty-0.4.3-msys2-2.7.0.zip
 set OPENSSL_FILES=openssl-1.1.1d.zip
 set BOOST_FILES=boost-1.69.0-win-msvc141.zip
 
-set PANDOC_VERSION=2.9.2.1
+set PANDOC_VERSION=2.10.1
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -547,7 +547,7 @@ if (NOT RSTUDIO_SESSION_WIN32)
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
 
    # install pandoc
-   set(PANDOC_VERSION "2.9.2.1" CACHE INTERNAL "Pandoc version")
+   set(PANDOC_VERSION "2.10.1" CACHE INTERNAL "Pandoc version")
 
    set(PANDOC_BIN "${RSTUDIO_DEPENDENCIES_DIR}/common/pandoc/${PANDOC_VERSION}")
    file(GLOB PANDOC_FILES "${PANDOC_BIN}/pandoc*")

--- a/src/gwt/panmirror/src/editor/src/api/pandoc.ts
+++ b/src/gwt/panmirror/src/editor/src/api/pandoc.ts
@@ -135,6 +135,7 @@ export interface PandocExtensions {
   tex_math_single_backslash: boolean;
   yaml_metadata_block: boolean;
   gutenberg: boolean;
+  // attributes: boolean; (not yet)
   [key: string]: boolean;
 }
 

--- a/src/gwt/panmirror/src/editor/src/api/pandoc_format.ts
+++ b/src/gwt/panmirror/src/editor/src/api/pandoc_format.ts
@@ -27,6 +27,7 @@ export const kMarkdownMmdFormat = 'markdown_mmd';
 export const kMarkdownStrictFormat = 'markdown_strict';
 export const kGfmFormat = 'gfm';
 export const kCommonmarkFormat = 'commonmark';
+export const kCommonmarkXFormat = 'commonmark_x';
 
 export interface PandocFormat {
   mode: string;
@@ -210,6 +211,7 @@ export async function resolvePandocFormat(pandoc: PandocServer, format: EditorFo
   // additional markdown variants we support
   const kMarkdownVariants: { [key: string]: string[] } = {
     [kCommonmarkFormat]: commonmarkExtensions(),
+    [kCommonmarkXFormat]: commonmarkXExtensions(),
     [kGfmFormat]: gfmExtensions(),
     goldmark: goldmarkExtensions(format),
     blackfriday: blackfridayExtensions(format),
@@ -232,6 +234,7 @@ export async function resolvePandocFormat(pandoc: PandocServer, format: EditorFo
       kMarkdownStrictFormat,
       kGfmFormat,
       kCommonmarkFormat,
+      kCommonmarkXFormat
     ]
       .concat(Object.keys(kMarkdownVariants))
       .includes(baseName)
@@ -243,15 +246,6 @@ export async function resolvePandocFormat(pandoc: PandocServer, format: EditorFo
   // format options we will be building
   let formatOptions: string;
 
-  // determine valid options (normally all options, but for gfm and commonmark then
-  // the valid optoins are constrained)
-  let validOptions: string = '';
-  if ([kGfmFormat, kCommonmarkFormat].includes(baseName)) {
-    validOptions = await pandoc.listExtensions(baseName);
-  } else {
-    // will fill in below when retreiving formatOptions (don't want to make 2 calls)
-  }
-
   // if we are using a variant then get it's base options and merge with user options
   if (kMarkdownVariants[baseName]) {
     const variant = kMarkdownVariants[baseName];
@@ -259,11 +253,8 @@ export async function resolvePandocFormat(pandoc: PandocServer, format: EditorFo
     baseName = 'markdown_strict';
   }
 
-  // query for format options (set validOptions if we don't have them yet)
+  // query for format options
   formatOptions = await pandoc.listExtensions(baseName);
-  if (!validOptions) {
-    validOptions = formatOptions;
-  }
 
   // active pandoc extensions
   const pandocExtensions: { [key: string]: boolean } = {};
@@ -274,7 +265,8 @@ export async function resolvePandocFormat(pandoc: PandocServer, format: EditorFo
   });
 
   // now parse extensions for user options (validate and build format name)
-  const validOptionNames = parseExtensions(validOptions).map(option => option.name);
+  const validOptionNames = parseExtensions(formatOptions).map(option => option.name);
+
   let fullName = baseName;
   parseExtensions(options).forEach(option => {
     // validate that the option is valid
@@ -343,6 +335,32 @@ export function hasShortcutHeadingLinks(pandocExtensions: PandocExtensions) {
 
 function commonmarkExtensions() {
   const extensions = ['+raw_html'];
+  return extensions;
+}
+
+// https://github.com/jgm/pandoc/commit/0aed9dd589189a9bbe5cae99e0e024e2d4a92c36
+function commonmarkXExtensions() {
+  const extensions = [
+    '+pipe_tables',
+    '+raw_html',
+    '+auto_identifiers',
+    '+strikeout',
+    '+task_lists',
+    '+emoji',
+    '+raw_tex',
+    '+smart',
+    '+tex_math_dollars',
+    '+superscript',
+    '+subscript',
+    '+definition_lists',
+    '+footnotes',
+    '+fancy_lists',
+    '+fenced_divs',
+    '+bracketed_spans',
+    '+raw_attribute',
+    '+implicit_header_references',
+    // '+attributes' (not yet)
+  ];
   return extensions;
 }
 


### PR DESCRIPTION
This PR updates the embedded version of pandoc to [v2.10.1](https://pandoc.org/releases.html#pandoc-2.10.1-2020-07-23) (we are currently at 2.9.2.1). The 2.10 series isn't likely final, but since we are close to entering preview mode I think it would be good for us to get 2.10.1 in front of our preview testers so any issues can be identified and resolved before we release.

Note that this release of pandoc adds support for `--number-sections` to docx output, which will be great for bookdown users that want to create MS Word output. @yihui If you plan on adding an MS Word output option to bookdown let us know and we will try to make sure we hookup Bookdown preview of MS Word book outputs.



