### PR TITLE
Assign unique ClassIds to toolbar buttons

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -77,4 +77,7 @@ public class ClassIds
    public final static String MODIFY_CHUNK = "modify_chunk";
    public final static String RUN_CHUNK = "run_chunk";
    public final static String PREVIEW_CHUNK = "preview_chunk";
+
+   // ToolbarButton
+   public final static String TOOLBAR_BTN = "tlbr_btn";
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
@@ -170,6 +170,9 @@ public class WindowFrameButton extends FocusWidget
    private boolean maximized_;
    private boolean exclusive_;
 
+   // class name displayed by Help / Diagnostics / Show DOM Elements command
+   private String helpClassId_;
+
    private Command clickHandler_;
    private final HandlerRegistrations releaseOnUnload_ = new HandlerRegistrations();
    private final DoubleClickState doubleClickState_ = new DoubleClickState();

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrameButton.java
@@ -170,9 +170,6 @@ public class WindowFrameButton extends FocusWidget
    private boolean maximized_;
    private boolean exclusive_;
 
-   // class name displayed by Help / Diagnostics / Show DOM Elements command
-   private String helpClassId_;
-
    private Command clickHandler_;
    private final HandlerRegistrations releaseOnUnload_ = new HandlerRegistrations();
    private final DoubleClickState doubleClickState_ = new DoubleClickState();

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -255,7 +255,7 @@ public class ToolbarButton extends FocusWidget
 
    public void setClassId(String name)
    {
-      if (StringUtil.isNullOrEmpty(displayClassId_))
+      if (!StringUtil.isNullOrEmpty(displayClassId_))
          ClassIds.removeClassId(getElement(), displayClassId_);
 
       displayClassId_ = ClassIds.TOOLBAR_BTN + "_" + ClassIds.idSafeString(getTitle());

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -25,6 +25,7 @@ import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.FocusWidget;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.ImageResourceProvider;
 import org.rstudio.core.client.command.SimpleImageResourceProvider;
@@ -102,6 +103,7 @@ public class ToolbarButton extends FocusWidget
       super();
 
       setElement(binder.createAndBindUi(this));
+      setClassId(null);
 
       this.setStylePrimaryName(styles_.toolbarButton());
       this.addStyleName(styles_.handCursor());
@@ -251,6 +253,18 @@ public class ToolbarButton extends FocusWidget
       leftImageWidget_.setResource(imageResource);
    }
 
+   public void setClassId(String name)
+   {
+      if (StringUtil.isNullOrEmpty(displayClassId_))
+         ClassIds.removeClassId(getElement(), displayClassId_);
+
+      displayClassId_ = ClassIds.TOOLBAR_BTN + "_" + ClassIds.idSafeString(getTitle());
+      if (!StringUtil.isNullOrEmpty(name))
+         displayClassId_ += "_" + ClassIds.idSafeString(name);
+
+      ClassIds.assignClassId(getElement(), displayClassId_);
+   }
+
    public void setText(boolean visible, String text)
    {
       if (visible)
@@ -304,6 +318,10 @@ public class ToolbarButton extends FocusWidget
       if (!StringUtil.isNullOrEmpty(title))
          Roles.getButtonRole().setAriaLabelProperty(getElement(), title);
    }
+
+   // Class name displayed by Help / Diagnostics / Show DOM Elements command. A default value is
+   // set in the constructor, but this can be updated to be more specific.
+   private String displayClassId_;
 
    private boolean down_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
@@ -14,7 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.Toolbar;
+import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.SourceColumn;
@@ -28,11 +30,18 @@ public class EditingTargetToolbar extends Toolbar
 {
    public EditingTargetToolbar(Commands commands, boolean includePopout, SourceColumn column)
    {
+      this("", commands, includePopout, column);
+   }
+
+   public EditingTargetToolbar(String id, Commands commands, boolean includePopout,
+                               SourceColumn column)
+   {
       super("Code Editor Tab");
 
       // Buttons are unique to a source column so require SourceAppCommands
       SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();
 
+      id_ = id;
       addLeftWidget(commands.sourceNavigateBack().createToolbarButton());
       Widget forwardButton = commands.sourceNavigateForward().createToolbarButton();
       forwardButton.getElement().getStyle().setMarginLeft(-6, Unit.PX);
@@ -40,17 +49,51 @@ public class EditingTargetToolbar extends Toolbar
       addLeftSeparator();
       if (includePopout)
       {
+         ToolbarButton toolbarBtn = null;
          if (SourceWindowManager.isMainSourceWindow())
          {
-            addLeftWidget(
+            addLeftWidget(toolbarBtn =
                mgr.getSourceCommand(commands.popoutDoc(), column).createToolbarButton());
          }
          else
          {
-            addLeftWidget(
+            addLeftWidget(toolbarBtn =
                mgr.getSourceCommand(commands.returnDocToMain(), column).createToolbarButton());
          }
+         toolbarBtn.setClassId("");
          addLeftSeparator();
       }
    }
+
+   // wrapper methods to add the editing target's id to the class id
+
+   @Override
+   public <TWidget extends Widget> TWidget insertWidget(TWidget widget, TWidget beforeWidget)
+   {
+      widget = super.insertWidget(widget, beforeWidget);
+      return addClassId(widget);
+   }
+
+   @Override
+   public <TWidget extends Widget> TWidget addLeftWidget(TWidget widget)
+   {
+      widget = super.addLeftWidget(widget);
+      return addClassId(widget);
+   }
+
+   @Override
+   public <TWidget extends Widget> TWidget addRightWidget(TWidget widget)
+   {
+      widget = super.addRightWidget(widget);
+      return addClassId(widget);
+   }
+
+   public <TWidget extends Widget> TWidget addClassId(TWidget widget)
+   {
+      if (!StringUtil.isNullOrEmpty(id_) && widget instanceof ToolbarButton)
+         ((ToolbarButton) widget).setClassId(id_);
+      return widget;
+   }
+
+   private String id_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetToolbar.java
@@ -30,11 +30,11 @@ public class EditingTargetToolbar extends Toolbar
 {
    public EditingTargetToolbar(Commands commands, boolean includePopout, SourceColumn column)
    {
-      this("", commands, includePopout, column);
+      this(commands, includePopout, column, "");
    }
 
-   public EditingTargetToolbar(String id, Commands commands, boolean includePopout,
-                               SourceColumn column)
+   public EditingTargetToolbar(Commands commands, boolean includePopout,
+                               SourceColumn column, String id)
    {
       super("Code Editor Tab");
 
@@ -49,18 +49,16 @@ public class EditingTargetToolbar extends Toolbar
       addLeftSeparator();
       if (includePopout)
       {
-         ToolbarButton toolbarBtn = null;
          if (SourceWindowManager.isMainSourceWindow())
          {
-            addLeftWidget(toolbarBtn =
+            addLeftWidget(
                mgr.getSourceCommand(commands.popoutDoc(), column).createToolbarButton());
          }
          else
          {
-            addLeftWidget(toolbarBtn =
+            addLeftWidget(
                mgr.getSourceCommand(commands.returnDocToMain(), column).createToolbarButton());
          }
-         toolbarBtn.setClassId("");
          addLeftSeparator();
       }
    }
@@ -95,5 +93,5 @@ public class EditingTargetToolbar extends Toolbar
       return widget;
    }
 
-   private String id_;
+   private final String id_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -314,7 +314,7 @@ public class TextEditingTargetWidget
 
    private Toolbar createToolbar(TextFileType fileType)
    {
-      Toolbar toolbar = new EditingTargetToolbar(commands_, true, column_);
+      Toolbar toolbar = new EditingTargetToolbar(target_.getId(), commands_, true, column_);
 
       // Buttons are unique to a source column so require SourceAppCommands
       SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -314,7 +314,7 @@ public class TextEditingTargetWidget
 
    private Toolbar createToolbar(TextFileType fileType)
    {
-      Toolbar toolbar = new EditingTargetToolbar(target_.getId(), commands_, true, column_);
+      Toolbar toolbar = new EditingTargetToolbar(commands_, true, column_, target_.getId());
 
       // Buttons are unique to a source column so require SourceAppCommands
       SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();


### PR DESCRIPTION
### Intent

Create a way to predictably identify toolbar buttons, specifically to be used with `rstudioapi::highlightUi`. This will close pro issue 1848 (https://github.com/rstudio/rstudio-pro/issues/1848).

### Approach

Add a toolbar button prefix to `ClassIds` and update the `ToolbarButton` constructor to always append the button's text to this prefix and use that value as the class id. The button's text was used instead of the title because although it's more verbose, some buttons are missing titles. Update `EditingTargetToolbar` to make the class id even more specific by appending the editing target's id. 

### QA Notes

1. Open a few text files in the IDE
2. Set up the IDE to display DOM class names: Help >> Diagnostics >> Show DOM Elements
3. Scroll over toolbar buttons and confirm they have descriptive class names
4. Click into a separate file and scroll over the buttons to confirm these buttons have a class name with a different ID at the end. 
