### PR TITLE
Extend package description

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -191,7 +191,7 @@ endif()
 string(TOLOWER "${CPACK_PACKAGE_FILE_NAME}" CPACK_PACKAGE_FILE_NAME)
 
 # variables to be re-used in package description fields
-set(PACKAGE_LONG_DESCRIPTION "RStudio is a set of integrated tools designed to help you be more productive with R. It includes a console, syntax-highlighting editor that supports direct code execution, as well as tools for plotting, history, and workspace management.")
+set(PACKAGE_LONG_DESCRIPTION "RStudio is a set of integrated tools designed to help you be more productive with modern data science tools, especially R, but including support for Python, C++, and more. It includes a console, syntax-highlighting editor that supports direct code execution, as well as tools for plotting, history, and workspace management.")
 
 # debian-specific
 set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "${CPACK_PACKAGE_DESCRIPTION}\n ${PACKAGE_LONG_DESCRIPTION}")


### PR DESCRIPTION
### Intent

I don't expect this to be the final commit here, but I noticed this description when I was installing from .deb just now and it struck me as being maybe a bit stale. The blame says this hasn't changed in 10 years so that kind of confirmed my suspicions.

This PR is mainly to draw attention to this, and offer a suggested improvement, but feel free to make further edits here as you see fit.