### PR TITLE
Install NSIS from S3

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -22,9 +22,15 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-o
   choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
   choco install -y 7zip; `
-  choco install -y nsis; `
   choco install -y ninja --version "1.10.0"
 
+# install NSIS - we do not do this via Chocolatey because the hosting URL of the NSIS
+# executable has gone defunct
+RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
+  Invoke-WebRequest $('https://rstudio-buildtools.s3.amazonaws.com/nsis-3.05-setup.exe') -OutFile 'C:\nsis-3.05-setup.exe' -UseBasicParsing ;`
+  Start-Process c:\nsis-3.05-setup.exe -Wait -ArgumentList '/S' ;`
+  Remove-Item c:\nsis-3.05-setup.exe -Force
+  
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0
 


### PR DESCRIPTION
### Intent

The NSIS Chocolatey package (https://chocolatey.org/packages/nsis and https://chocolatey.org/packages/nsis.install) are currently hosted on a site with an expired certificate, causing our Windows builder to fail to install NSIS, preventing Windows builds from being generated.

### Approach

We now install NSIS from the same executable as the prior Chocolatey package, but we now grab it from our S3 bucket instead, as that is expected to be a stable URL.

### QA Notes

No QA necessary - this is a build change only


