### PR TITLE
Scroll to a specified position in an unknown file

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -218,10 +218,11 @@
                                               col = 1L,
                                               moveCursor = TRUE) {
    # validate file argument
-   if (!is.character(filePath)) {
+   hasFile = !is.null(filePath) && length(filePath) > 0
+   if (hasFile && !is.character(filePath)) {
       stop("filePath must be a character")
    }
-   if (!identical(filePath, character(0)) && !file.exists(filePath)) {
+   if (hasFile && !file.exists(filePath)) {
       stop(filePath, " does not exist.")
    }
    
@@ -238,7 +239,7 @@
       stop("line and column must be numeric values.")
    }
 
-   if (!identical(filePath, character(0)))
+   if (hasFile)
    {
       # expand and alias for client
       filePath <- .rs.normalizePath(filePath, winslash = "/", mustWork = TRUE)

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -213,7 +213,10 @@
    invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect, PACKAGE = "(embedding)"))
 })
 
-.rs.addApiFunction("navigateToFile", function(filePath = character(0), line = 1L, col = 1L) {
+.rs.addApiFunction("navigateToFile", function(filePath = character(0),
+                                              line = 1L,
+                                               col = 1L,
+                                               moveCursor = TRUE) {
    # validate file argument
    if (!is.character(filePath)) {
       stop("filePath must be a character")
@@ -249,7 +252,8 @@
    .rs.enqueClientEvent("jump_to_function", list(
       file_name     = .rs.scalar(filePath),
       line_number   = .rs.scalar(line),
-      column_number = .rs.scalar(col)))
+      column_number = .rs.scalar(col),
+      move_cursor   = .rs.scalar(moveCursor)))
 
    invisible(NULL)
 })

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -213,12 +213,12 @@
    invisible(.Call("rs_sourceMarkers", name, markers, basePath, autoSelect, PACKAGE = "(embedding)"))
 })
 
-.rs.addApiFunction("navigateToFile", function(filePath, line = 1L, col = 1L) {
+.rs.addApiFunction("navigateToFile", function(filePath = character(0), line = 1L, col = 1L) {
    # validate file argument
    if (!is.character(filePath)) {
       stop("filePath must be a character")
    }
-   if (!file.exists(filePath)) {
+   if (!identical(filePath, character(0)) && !file.exists(filePath)) {
       stop(filePath, " does not exist.")
    }
    
@@ -235,11 +235,14 @@
       stop("line and column must be numeric values.")
    }
 
-   # expand and alias for client
-   filePath <- .rs.normalizePath(filePath, winslash = "/", mustWork = TRUE)
-   homeDir <- path.expand("~")
-   if (identical(substr(filePath, 1, nchar(homeDir)), homeDir)) {
-      filePath <- file.path("~", substring(filePath, nchar(homeDir) + 2))
+   if (!identical(filePath, character(0)))
+   {
+      # expand and alias for client
+      filePath <- .rs.normalizePath(filePath, winslash = "/", mustWork = TRUE)
+      homeDir <- path.expand("~")
+      if (identical(substr(filePath, 1, nchar(homeDir)), homeDir)) {
+         filePath <- file.path("~", substring(filePath, nchar(homeDir) + 2))
+      }
    }
 
    # send event to client

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -215,8 +215,8 @@
 
 .rs.addApiFunction("navigateToFile", function(filePath = character(0),
                                               line = 1L,
-                                               col = 1L,
-                                               moveCursor = TRUE) {
+                                              col = 1L,
+                                              moveCursor = TRUE) {
    # validate file argument
    if (!is.character(filePath)) {
       stop("filePath must be a character")

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -218,7 +218,7 @@
                                               col = 1L,
                                               moveCursor = TRUE) {
    # validate file argument
-   hasFile = !is.null(filePath) && length(filePath) > 0
+   hasFile <- !is.null(filePath) && length(filePath) > 0
    if (hasFile && !is.character(filePath)) {
       stop("filePath must be a character")
    }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1176,13 +1176,14 @@ void onConsoleOutput(boost::shared_ptr<LineDebugState> pLineDebugState,
 }
 
 
-SEXP rs_jumpToFunction(SEXP file, SEXP line, SEXP col) 
+SEXP rs_jumpToFunction(SEXP file, SEXP line, SEXP col, SEXP moveCursor)
 {
    json::Object funcLoc;
    FilePath path(r::sexp::safeAsString(file));
    funcLoc["file_name"] = module_context::createAliasedPath(path);
    funcLoc["line_number"] = r::sexp::asInteger(line);
    funcLoc["column_number"] = r::sexp::asInteger(col);
+   funcLoc["move_cursor"] = r::sexp::asLogical(moveCursor);
    ClientEvent jumpEvent(client_events::kJumpToFunction, funcLoc);
    module_context::enqueClientEvent(jumpEvent);
    return R_NilValue;

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
@@ -45,24 +45,34 @@ public class OpenSourceFileEvent extends CrossWindowEvent<OpenSourceFileHandler>
    {
       this(file, position, fileType, NavigationMethods.DEFAULT);
    }
-   
-   public OpenSourceFileEvent(FileSystemItem file, 
-                              FilePosition position, 
+
+   public OpenSourceFileEvent(FileSystemItem file,
+                              FilePosition position,
                               TextFileType fileType,
+                              int navMethod)
+   {
+      this(file, position, fileType, false, NavigationMethods.DEFAULT);
+   }
+
+   public OpenSourceFileEvent(FileSystemItem file,
+                              FilePosition position,
+                              TextFileType fileType,
+                              boolean moveCursor,
                               int navMethod)
    {
       file_ = file;
       position_ = position;
-      fileType_ = fileType;  
+      fileType_ = fileType;
+      moveCursor_ = moveCursor;
       navigationMethod_ = navMethod;
    }
-   
+
    @Override
    public boolean forward()
    {
       return false;
    }
-   
+
    public FileSystemItem getFile()
    {
       return file_;
@@ -80,12 +90,17 @@ public class OpenSourceFileEvent extends CrossWindowEvent<OpenSourceFileHandler>
          return fileType_;
       }
    }
-   
+
+   public boolean getMoveCursor()
+   {
+      return moveCursor_;
+   }
+
    public FilePosition getPosition()
    {
       return position_;
    }
-   
+
    public int getNavigationMethod()
    {
       return navigationMethod_;
@@ -102,9 +117,10 @@ public class OpenSourceFileEvent extends CrossWindowEvent<OpenSourceFileHandler>
    {
       return TYPE;
    }
-   
+
    private FileSystemItem file_;
    private FilePosition position_;
    private TextFileType fileType_;
+   private boolean moveCursor_;
    private int navigationMethod_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -89,6 +89,7 @@ import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserHighlightEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
+import org.rstudio.studio.client.workbench.views.source.events.ScrollToPositionEvent;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
 import java.util.ArrayList;
@@ -309,12 +310,13 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void onJumpToFunction(JumpToFunctionEvent event)
          {
-            FilePosition pos = FilePosition.create(event.getLineNumber(), 
-                  event.getColumnNumber());
             if (StringUtil.isNullOrEmpty(event.getFileName()))
-               pSourceColumnManager_.get().scrollToPosition(pos);
+               eventBus_.fireEvent(new ScrollToPositionEvent(event.getLineNumber(),
+                  event.getColumnNumber()));
             else
             {
+               FilePosition pos = FilePosition.create(event.getLineNumber(),
+                  event.getColumnNumber());
                FileSystemItem destFile = FileSystemItem.createFile(
                   event.getFileName());
                eventBus_.fireEvent(new OpenSourceFileEvent(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -308,7 +308,7 @@ public class EnvironmentPresenter extends BasePresenter
          {
             if (StringUtil.isNullOrEmpty(event.getFileName()))
                eventBus_.fireEvent(new ScrollToPositionEvent(event.getLineNumber(),
-                  event.getColumnNumber()));
+                  event.getColumnNumber(), event.getMoveCursor()));
             else
             {
                FilePosition pos = FilePosition.create(event.getLineNumber(),
@@ -319,6 +319,7 @@ public class EnvironmentPresenter extends BasePresenter
                   destFile,
                   pos,
                   fileTypeRegistry_.getTextTypeForFile(destFile),
+                  event.getMoveCursor(),
                   NavigationMethods.DEFAULT));
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.workbench.views.environment;
 
 import com.google.gwt.core.client.JsArrayString;
 
-import com.google.inject.Provider;
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.RegexUtil;
@@ -85,7 +84,6 @@ import org.rstudio.studio.client.workbench.views.environment.model.EnvironmentSe
 import org.rstudio.studio.client.workbench.views.environment.model.RObject;
 import org.rstudio.studio.client.workbench.views.environment.view.EnvironmentClientState;
 import org.rstudio.studio.client.workbench.views.source.Source;
-import org.rstudio.studio.client.workbench.views.source.SourceColumnManager;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserHighlightEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
@@ -149,8 +147,7 @@ public class EnvironmentPresenter extends BasePresenter
                                Source source,
                                DebugCommander debugCommander,
                                FileTypeRegistry fileTypeRegistry,
-                               DataImportPresenter dataImportPresenter,
-                               Provider<SourceColumnManager> pSourceColumnManager)
+                               DataImportPresenter dataImportPresenter)
    {
       super(view);
       binder.bind(commands, this);
@@ -173,8 +170,7 @@ public class EnvironmentPresenter extends BasePresenter
       session_ = session;
       fileTypeRegistry_ = fileTypeRegistry;
       dataImportPresenter_ = dataImportPresenter;
-      pSourceColumnManager_ = pSourceColumnManager;
-      
+
       requeryContextTimer_ = new Timer()
       {
          @Override
@@ -1021,8 +1017,7 @@ public class EnvironmentPresenter extends BasePresenter
    private final Session session_;
    private final FileTypeRegistry fileTypeRegistry_;
    private final DataImportPresenter dataImportPresenter_;
-   private final Provider<SourceColumnManager> pSourceColumnManager_;
-   
+
    private int contextDepth_;
    private boolean refreshingView_;
    private boolean initialized_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/JumpToFunctionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/JumpToFunctionEvent.java
@@ -38,6 +38,10 @@ public class JumpToFunctionEvent
       public final native int getColumnNumber() /*-{
          return this.column_number;
       }-*/;
+
+      public final native boolean getMoveCursor() /*-{
+         return this.move_cursor;
+      }-*/;
    }
 
    public interface Handler extends EventHandler
@@ -63,6 +67,11 @@ public class JumpToFunctionEvent
    public String getFileName()
    {
       return data_.getFileName();
+   }
+
+   public boolean getMoveCursor()
+   {
+      return data_.getMoveCursor();
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1693,7 +1693,7 @@ public class Source implements InsertSourceHandler,
          return;
       FilePosition pos = FilePosition.create(event.getLine(),
          event.getColumn());
-      columnManager_.scrollToPosition(pos);
+      columnManager_.scrollToPosition(pos, event.getMoveCursor());
    }
 
    public void onNewDocumentWithCode(final NewDocumentWithCodeEvent event)
@@ -1810,7 +1810,8 @@ public class Source implements InsertSourceHandler,
             event.getPosition(),
             null,
             event.getNavigationMethod(),
-            false);
+            false,
+            event.getMoveCursor());
    }
 
    public void onOpenPresentationSourceFile(OpenPresentationSourceFileEvent event)
@@ -1823,6 +1824,7 @@ public class Source implements InsertSourceHandler,
                        event.getPosition(),
                        event.getPattern(),
                        NavigationMethods.HIGHLIGHT_LINE,
+                       true,
                        true);
 
    }
@@ -1884,7 +1886,8 @@ public class Source implements InsertSourceHandler,
                                  final FilePosition position,
                                  final String pattern,
                                  final int navMethod,
-                                 final boolean forceHighlightMode)
+                                 final boolean forceHighlightMode,
+                                 final boolean moveCursor)
    {
       // if the navigation should happen in another window, do that instead
       NavigationResult navResult =
@@ -2008,6 +2011,7 @@ public class Source implements InsertSourceHandler,
                            srcPosition,
                            false,
                            highlight,
+                           moveCursor,
                            onNavigationCompleted);
                   }
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -154,6 +154,7 @@ import org.rstudio.studio.client.workbench.views.source.events.DocTabDragInitiat
 import org.rstudio.studio.client.workbench.views.source.events.DocTabDragStartedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocWindowChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.EditPresentationSourceEvent;
+import org.rstudio.studio.client.workbench.views.source.events.ScrollToPositionEvent;
 import org.rstudio.studio.client.workbench.views.source.events.XRefNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.events.EnsureVisibleSourceWindowEvent;
 import org.rstudio.studio.client.workbench.views.source.events.FileEditEvent;
@@ -212,6 +213,7 @@ public class Source implements InsertSourceHandler,
                                GetEditorContextEvent.Handler,
                                RequestDocumentSaveEvent.Handler,
                                RequestDocumentCloseEvent.Handler,
+                               ScrollToPositionEvent.Handler,
                                EditPresentationSourceEvent.Handler,
                                XRefNavigationEvent.Handler,
                                NewDocumentWithCodeEvent.Handler,
@@ -326,6 +328,7 @@ public class Source implements InsertSourceHandler,
       events_.addHandler(CodeBrowserFinishedEvent.TYPE, this);
       events_.addHandler(CodeBrowserHighlightEvent.TYPE, this);
       events_.addHandler(SnippetsChangedEvent.TYPE, this);
+      events_.addHandler(ScrollToPositionEvent.TYPE, this);
       events_.addHandler(NewDocumentWithCodeEvent.TYPE, this);
       events_.addHandler(XRefNavigationEvent.TYPE, this);
       if (Desktop.hasDesktopFrame())
@@ -334,18 +337,18 @@ public class Source implements InsertSourceHandler,
       events_.addHandler(SourcePathChangedEvent.TYPE,
             new SourcePathChangedEvent.Handler()
       {
-         
+
          @Override
          public void onSourcePathChanged(final SourcePathChangedEvent event)
          {
-            
+
             columnManager_.inEditorForPath(event.getFrom(),
                             new OperationWithInput<EditingTarget>()
             {
                @Override
                public void execute(EditingTarget input)
                {
-                  FileSystemItem toPath = 
+                  FileSystemItem toPath =
                         FileSystemItem.createFile(event.getTo());
                   if (input instanceof TextEditingTarget)
                   {
@@ -378,10 +381,10 @@ public class Source implements InsertSourceHandler,
       });
 
       events_.addHandler(CollabEditStartedEvent.TYPE,
-            new CollabEditStartedEvent.Handler() 
+            new CollabEditStartedEvent.Handler()
       {
          @Override
-         public void onCollabEditStarted(final CollabEditStartedEvent collab) 
+         public void onCollabEditStarted(final CollabEditStartedEvent collab)
          {
             columnManager_.inEditorForPath(collab.getStartParams().getPath(),
                new OperationWithInput<EditingTarget>()
@@ -394,12 +397,12 @@ public class Source implements InsertSourceHandler,
                });
          }
       });
-         
-      events_.addHandler(CollabEditEndedEvent.TYPE, 
+
+      events_.addHandler(CollabEditEndedEvent.TYPE,
             new CollabEditEndedEvent.Handler()
       {
          @Override
-         public void onCollabEditEnded(final CollabEditEndedEvent collab) 
+         public void onCollabEditEnded(final CollabEditEndedEvent collab)
          {
             columnManager_.inEditorForPath(collab.getPath(),
                new OperationWithInput<EditingTarget>()
@@ -412,8 +415,8 @@ public class Source implements InsertSourceHandler,
                });
          }
       });
-         
-      events_.addHandler(NewWorkingCopyEvent.TYPE, 
+
+      events_.addHandler(NewWorkingCopyEvent.TYPE,
             new NewWorkingCopyEvent.Handler()
       {
          @Override
@@ -547,7 +550,7 @@ public class Source implements InsertSourceHandler,
          sequence.add(new KeyCombination("Ctrl+Space", KeyCodes.KEY_SPACE, KeyCodes.KEY_CTRL));
          commands_.codeCompletion().setShortcut(new KeyboardShortcut(sequence));
       }
-      
+
 
       // Suppress 'CTRL + ALT + SHIFT + click' to work around #2483 in Ace
       Event.addNativePreviewHandler(new NativePreviewHandler()
@@ -567,11 +570,11 @@ public class Source implements InsertSourceHandler,
             }
          }
       });
-      
+
       //  handle mouse button navigations
       if (!Desktop.hasDesktopFrame())
          handleMouseButtonNavigations();
-      
+
       // on macOS, we need to aggressively re-sync commands when a new
       // window is selected (since the main menu applies to both main
       // window and satellites)
@@ -663,17 +666,17 @@ public class Source implements InsertSourceHandler,
       {
          // restore the docs assigned to this source window
          SourceDocument doc = docs.get(i);
-         String docWindowId = 
+         String docWindowId =
                doc.getProperties().getString(
                      SourceWindowManager.SOURCE_WINDOW_ID);
          if (docWindowId == null)
             docWindowId = "";
          String currentSourceWindowId = SourceWindowManager.getSourceWindowId();
-         
+
          // it belongs in this window if (a) it's assigned to it, or (b) this
          // is the main window, and the window it's assigned to isn't open.
          if (currentSourceWindowId == docWindowId ||
-             (SourceWindowManager.isMainSourceWindow() && 
+             (SourceWindowManager.isMainSourceWindow() &&
               !pWindowManager_.get().isSourceWindowOpen(docWindowId)))
          {
 
@@ -699,7 +702,7 @@ public class Source implements InsertSourceHandler,
             {
                Debug.logException(e);
             }
-            
+
             // if we couldn't add the tab for this doc, just continue to the
             // next one
             if (sourceEditor == null)
@@ -709,28 +712,28 @@ public class Source implements InsertSourceHandler,
       columnManager_.setDocsRestored();
       columnManager_.beforeShow();
    }
-   
+
    private void openEditPublishedDocs()
    {
       // don't do this if we are switching projects (it
       // will be done after the switch)
       if (ApplicationAction.isSwitchProject())
          return;
-      
+
       // check for edit_published url parameter
       final String kEditPublished = "edit_published";
       String editPublished = StringUtil.notNull(
           Window.Location.getParameter(kEditPublished));
-      
+
       // this is an appPath which we can call the server
-      // to determine source files to edit 
+      // to determine source files to edit
       if (editPublished.length() > 0)
       {
          // remove it from the url
          ApplicationUtils.removeQueryParam(kEditPublished);
-         
+
          server_.getEditPublishedDocs(
-            editPublished, 
+            editPublished,
             new SimpleRequestCallback<JsArrayString>() {
                @Override
                public void onResponseReceived(JsArrayString docs)
@@ -741,15 +744,15 @@ public class Source implements InsertSourceHandler,
          );
       }
    }
-   
 
-   
+
+
    public void onShowContent(ShowContentEvent event)
    {
       // ignore if we're a satellite
       if (!SourceWindowManager.isMainSourceWindow())
          return;
-      
+
       columnManager_.ensureVisible(true);
       ContentItem content = event.getContent();
       server_.newDocument(
@@ -767,14 +770,14 @@ public class Source implements InsertSourceHandler,
                }
             });
    }
-   
+
    @Override
    public void onOpenObjectExplorerEvent(OpenObjectExplorerEvent event)
    {
       // ignore if we're a satellite
       if (!SourceWindowManager.isMainSourceWindow())
          return;
-    
+
       columnManager_.activateObjectExplorer(event.getHandle());
    }
 
@@ -784,10 +787,10 @@ public class Source implements InsertSourceHandler,
       // ignore if we're a satellite
       if (!SourceWindowManager.isMainSourceWindow())
          return;
-      
+
       columnManager_.showDataItem(event.getData());
    }
-   
+
    public void onShowProfiler(OpenProfileEvent event)
    {
       String profilePath = event.getFilePath();
@@ -802,7 +805,7 @@ public class Source implements InsertSourceHandler,
          return;
       }
 
-      // create new profiler 
+      // create new profiler
       columnManager_.ensureVisible(true);
 
       if (event.getDocId() != null)
@@ -814,7 +817,7 @@ public class Source implements InsertSourceHandler,
             {
                columnManager_.addTab(response, OPEN_INTERACTIVE, null);
             }
-            
+
             @Override
             public void onError(ServerError error)
             {
@@ -830,7 +833,7 @@ public class Source implements InsertSourceHandler,
             null,
             (JsObject) ProfilerContents.create(
                   profilePath,
-                  htmlPath, 
+                  htmlPath,
                   htmlLocalPath,
                   event.getCreateProfile()).cast(),
             new SimpleRequestCallback<SourceDocument>("Show Profiler")
@@ -840,7 +843,7 @@ public class Source implements InsertSourceHandler,
                {
                   columnManager_.addTab(response, OPEN_INTERACTIVE, null);
                }
-               
+
                @Override
                public void onError(ServerError error)
                {
@@ -850,7 +853,7 @@ public class Source implements InsertSourceHandler,
             });
       }
    }
-   
+
    @Handler
    public void onNewSourceDoc()
    {
@@ -862,7 +865,7 @@ public class Source implements InsertSourceHandler,
    {
       columnManager_.newDoc(FileTypeRegistry.TEXT, null);
    }
-   
+
    @Handler
    public void onNewRNotebook()
    {
@@ -874,7 +877,7 @@ public class Source implements InsertSourceHandler,
             {
                if (!succeeded)
                {
-                  globalDisplay_.showErrorMessage("Notebook Creation Failed", 
+                  globalDisplay_.showErrorMessage("Notebook Creation Failed",
                         "One or more packages required for R Notebook " +
                         "creation were not installed.");
                   return;
@@ -888,7 +891,7 @@ public class Source implements InsertSourceHandler,
             }
          });
    }
-   
+
    @Handler
    public void onNewCDoc()
    {
@@ -901,26 +904,26 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
-   
+
+
    @Handler
    public void onNewCppDoc()
    {
       columnManager_.newSourceDocWithTemplate(
-          FileTypeRegistry.CPP, 
-          "", 
+          FileTypeRegistry.CPP,
+          "",
           userPrefs_.useRcppTemplate().getValue() ? "rcpp.cpp" : "default.cpp",
           Position.create(0, 0),
           new CommandWithArg<EditingTarget> () {
             @Override
             public void execute(EditingTarget target)
             {
-               target.verifyCppPrerequisites(); 
+               target.verifyCppPrerequisites();
             }
           }
       );
    }
-   
+
    @Handler
    public void onNewHeaderDoc()
    {
@@ -933,14 +936,14 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Handler
    public void onNewMarkdownDoc()
    {
       columnManager_.newDoc(FileTypeRegistry.MARKDOWN, null);
    }
-   
-   
+
+
    @Handler
    public void onNewPythonDoc()
    {
@@ -953,31 +956,31 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Handler
    public void onNewShellDoc()
    {
       columnManager_.newDoc(FileTypeRegistry.SH, null);
    }
-   
+
    @Handler
    public void onNewHtmlDoc()
    {
       columnManager_.newDoc(FileTypeRegistry.HTML, null);
    }
-   
+
    @Handler
    public void onNewJavaScriptDoc()
    {
       columnManager_.newDoc(FileTypeRegistry.JS, null);
    }
-   
+
    @Handler
    public void onNewCssDoc()
    {
       columnManager_.newDoc(FileTypeRegistry.CSS, null);
    }
-   
+
    @Handler
    public void onNewStanDoc()
    {
@@ -992,34 +995,34 @@ public class Source implements InsertSourceHandler,
 
                });
       };
-            
-            
+
+
       dependencyManager_.withStan(
             "Creating Stan script",
             "Creating Stan scripts",
             onStanInstalled);
    }
-   
+
    @Handler
    public void onNewD3Doc()
    {
       columnManager_.newSourceDocWithTemplate(
-         FileTypeRegistry.JS, 
-         "", 
+         FileTypeRegistry.JS,
+         "",
          "d3.js",
          Position.create(5, 0),
          new CommandWithArg<EditingTarget> () {
            @Override
            public void execute(EditingTarget target)
            {
-              target.verifyD3Prerequisites(); 
+              target.verifyD3Prerequisites();
               target.setSourceOnSave(true);
            }
          }
       );
    }
-   
-   
+
+
    @Handler
    public void onNewSweaveDoc()
    {
@@ -1033,20 +1036,20 @@ public class Source implements InsertSourceHandler,
             concordance = "\\SweaveOpts{concordance=TRUE}\n";
       }
       final String concordanceValue = concordance;
-     
+
       // show progress
       final ProgressIndicator indicator = new GlobalProgressDelayer(
             globalDisplay_, 500, "Creating new document...").getIndicator();
 
       // get the template
-      server_.getSourceTemplate("", 
-                                "sweave.Rnw", 
+      server_.getSourceTemplate("",
+                                "sweave.Rnw",
                                 new ServerRequestCallback<String>() {
          @Override
          public void onResponseReceived(String templateContents)
          {
             indicator.onCompleted();
-            
+
             // add in concordance if necessary
             final boolean hasConcordance = concordanceValue.length() > 0;
             if (hasConcordance)
@@ -1056,9 +1059,9 @@ public class Source implements InsertSourceHandler,
                      beginDoc,
                      beginDoc + concordanceValue);
             }
-            
+
             columnManager_.newDoc(FileTypeRegistry.SWEAVE,
-                  templateContents, 
+                  templateContents,
                   new ResultCallback<EditingTarget, ServerError> () {
                @Override
                public void onSuccess(EditingTarget target)
@@ -1076,19 +1079,19 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Handler
    public void onNewRMarkdownDoc()
    {
       SessionInfo sessionInfo = session_.getSessionInfo();
       boolean useRMarkdownV2 = sessionInfo.getRMarkdownPackageAvailable();
-      
+
       if (useRMarkdownV2)
          columnManager_.newRMarkdownV2Doc();
       else
          columnManager_.newRMarkdownV1Doc();
    }
-   
+
    private void doNewRShinyApp(NewShinyWebApplication.Result result)
    {
       server_.createShinyApp(
@@ -1110,21 +1113,21 @@ public class Source implements InsertSourceHandler,
    public void onNewSqlDoc()
    {
       columnManager_.newSourceDocWithTemplate(
-         FileTypeRegistry.SQL, 
-         "", 
+         FileTypeRegistry.SQL,
+         "",
          "query.sql",
          Position.create(2, 0),
          new CommandWithArg<EditingTarget> () {
            @Override
            public void execute(EditingTarget target)
            {
-              target.verifyNewSqlPrerequisites(); 
+              target.verifyNewSqlPrerequisites();
               target.setSourceOnSave(true);
            }
          }
       );
    }
-   
+
    private void doNewRPlumberAPI(NewPlumberAPI.Result result)
    {
       server_.createPlumberAPI(
@@ -1140,7 +1143,7 @@ public class Source implements InsertSourceHandler,
                }
             });
    }
-    
+
    // open a list of source files then focus the first one within the list
    private class SourceFilesOpener extends SerializedCommandQueue
    {
@@ -1164,14 +1167,14 @@ public class Source implements InsertSourceHandler,
                         // record first target if necessary
                         if (firstTarget_ == null)
                            firstTarget_ = target;
-                        
+
                         continuation.execute();
                      }
-                  });  
+                  });
                }
             });
          }
-         
+
          addCommand(new SerializedCommand() {
 
             @Override
@@ -1182,16 +1185,16 @@ public class Source implements InsertSourceHandler,
                   columnManager_.selectTab(firstTarget_);
                   firstTarget_.setCursorPosition(Position.create(0, 0));
                }
-               
+
                continuation.execute();
             }
-            
+
          });
       }
-      
+
       private EditingTarget firstTarget_ = null;
    }
-   
+
    @Handler
    public void onNewRShinyApp()
    {
@@ -1215,7 +1218,7 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Handler
    public void onNewRHTMLDoc()
    {
@@ -1223,13 +1226,13 @@ public class Source implements InsertSourceHandler,
                                               "",
                                               "default.Rhtml");
    }
-   
+
    @Handler
    public void onNewRDocumentationDoc()
    {
       new NewRdDialog(
          new OperationWithInput<NewRdDialog.Result>() {
-           
+
             @Override
             public void execute(final NewRdDialog.Result result)
             {
@@ -1239,16 +1242,16 @@ public class Source implements InsertSourceHandler,
                   {
                      columnManager_.newSourceDocWithTemplate(
                            (TextFileType)FileTypeRegistry.RD,
-                           result.name, 
+                           result.name,
                            "default.Rd",
                            Position.create(3, 7));
-                  }  
+                  }
                };
-               
+
                if (result.type != NewRdDialog.Result.TYPE_NONE)
                {
                   server_.createRdShell(
-                     result.name, 
+                     result.name,
                      result.type,
                      new SimpleRequestCallback<RdShellResult>() {
                         @Override
@@ -1269,19 +1272,19 @@ public class Source implements InsertSourceHandler,
                            {
                               createEmptyDoc.execute();
                            }
-                        }  
+                        }
                    });
-                 
+
                }
                else
                {
                   createEmptyDoc.execute();
                }
-               
+
             }
           }).showModal();
    }
-   
+
    @Handler
    public void onNewRPresentationDoc()
    {
@@ -1291,11 +1294,11 @@ public class Source implements InsertSourceHandler,
             public void execute()
             {
                fileDialogs_.saveFile(
-                  "New R Presentation", 
+                  "New R Presentation",
                   fileContext_,
-                  workbenchContext_.getDefaultFileDialogDir(), 
-                  ".Rpres", 
-                  true, 
+                  workbenchContext_.getDefaultFileDialogDir(),
+                  ".Rpres",
+                  true,
                   new ProgressOperationWithInput<FileSystemItem>() {
 
                      @Override
@@ -1307,15 +1310,15 @@ public class Source implements InsertSourceHandler,
                            indicator.onCompleted();
                            return;
                         }
-                        
+
                         indicator.onProgress("Creating Presentation...");
-                        
+
                         server_.createNewPresentation(
                           input.getPath(),
                           new VoidServerRequestCallback(indicator) {
                              @Override
                              public void onSuccess()
-                             { 
+                             {
                                 columnManager_.openFile(input,
                                    FileTypeRegistry.RPRESENTATION,
                                    new CommandWithArg<EditingTarget>() {
@@ -1326,15 +1329,15 @@ public class Source implements InsertSourceHandler,
                                        server_.showPresentationPane(
                                            input.getPath(),
                                            new VoidServerRequestCallback());
-                                       
+
                                     }
-                                   
+
                                 });
                              }
-                          });  
+                          });
                      }
                });
-               
+
             }
       });
    }
@@ -1344,7 +1347,7 @@ public class Source implements InsertSourceHandler,
    {
       onActivateSource(null);
    }
-   
+
    public void onActivateSource(final Command afterActivation)
    {
       // give the window manager a chance to activate the last source pane
@@ -1352,7 +1355,7 @@ public class Source implements InsertSourceHandler,
          return;
       columnManager_.activateColumn("", afterActivation);
    }
-   
+
    @Handler
    public void onLayoutZoomSource()
    {
@@ -1380,7 +1383,7 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Override
    public void onDocWindowChanged(final DocWindowChangedEvent e)
    {
@@ -1478,7 +1481,7 @@ public class Source implements InsertSourceHandler,
          @Override
          public void execute(EditingTarget editor)
          {
-            // if this is a text editor, ensure that its content is 
+            // if this is a text editor, ensure that its content is
             // synchronized with the server before we pop it out
             if (editor instanceof TextEditingTarget)
             {
@@ -1489,7 +1492,7 @@ public class Source implements InsertSourceHandler,
                   public void execute()
                   {
                      textEditor.syncLocalSourceDb();
-                     events_.fireEvent(new PopoutDocEvent(event, 
+                     events_.fireEvent(new PopoutDocEvent(event,
                         textEditor.currentPosition(),
                         columnManager_.findByDocument(textEditor.getId())));
                   }
@@ -1497,7 +1500,7 @@ public class Source implements InsertSourceHandler,
             }
             else
             {
-               events_.fireEvent(new PopoutDocEvent(event, 
+               events_.fireEvent(new PopoutDocEvent(event,
                      editor.currentPosition(),
                      columnManager_.findByDocument(editor.getId())));
             }
@@ -1520,19 +1523,19 @@ public class Source implements InsertSourceHandler,
    {
       closeAllSourceDocs("Close All",  null, false);
    }
-   
+
    @Handler
    public void onCloseOtherSourceDocs()
    {
       closeAllSourceDocs("Close Other",  null, true);
    }
-   
-   public void closeAllSourceDocs(final String caption, 
+
+   public void closeAllSourceDocs(final String caption,
          final Command onCompleted, final boolean excludeActive)
-   { 
+   {
       if (SourceWindowManager.isMainSourceWindow() && !excludeActive)
       {
-         // if this is the main window, close docs in the satellites first 
+         // if this is the main window, close docs in the satellites first
          pWindowManager_.get().closeAllSatelliteDocs(caption, new Command()
          {
             @Override
@@ -1575,7 +1578,7 @@ public class Source implements InsertSourceHandler,
    {
       saveUnsavedDocuments(null, onCompleted);
    }
-   
+
    public void saveUnsavedDocuments(final Set<String> ids,
                                     final Command onCompleted)
    {
@@ -1587,7 +1590,7 @@ public class Source implements InsertSourceHandler,
             columnManager_.saveChanges(getUnsavedChanges(TYPE_FILE_BACKED, ids), onCompleted);
          }
       };
-      
+
       // if this is the main source window, save all files in satellites first
       if (SourceWindowManager.isMainSourceWindow())
          pWindowManager_.get().saveUnsavedDocuments(ids, saveAllLocal);
@@ -1595,7 +1598,7 @@ public class Source implements InsertSourceHandler,
          saveAllLocal.execute();
    }
 
-   public void saveWithPrompt(UnsavedChangesTarget target, 
+   public void saveWithPrompt(UnsavedChangesTarget target,
                               Command onCompleted,
                               Command onCancelled)
    {
@@ -1604,7 +1607,7 @@ public class Source implements InsertSourceHandler,
       {
          // we are the main window, and we're being asked to save a document
          // that's in a different window; perform the save over there
-         pWindowManager_.get().saveWithPrompt(UnsavedChangesItem.create(target), 
+         pWindowManager_.get().saveWithPrompt(UnsavedChangesItem.create(target),
                onCompleted);
          return;
       }
@@ -1612,7 +1615,7 @@ public class Source implements InsertSourceHandler,
       if (editingTarget != null)
          editingTarget.saveWithPrompt(onCompleted, onCancelled);
    }
-   
+
    public Command revertUnsavedChangesBeforeExitCommand(
                                                final Command onCompleted)
    {
@@ -1632,7 +1635,7 @@ public class Source implements InsertSourceHandler,
             // revert unsaved
             columnManager_.revertUnsavedTargets(onCompleted);
          }
-      };   
+      };
 
       // if this is the main source window, let satellite windows save any
       // changes first
@@ -1653,7 +1656,7 @@ public class Source implements InsertSourceHandler,
          columnManager_.saveChanges(saveTargets, completed);
       }
    }
-   
+
    @Handler
    public void onOpenSourceDoc()
    {
@@ -1684,16 +1687,22 @@ public class Source implements InsertSourceHandler,
             });
    }
 
+   public void onScrollToPosition(final ScrollToPositionEvent event)
+   {
+      if (!isLastFocusedSourceWindow())
+         return;
+      FilePosition pos = FilePosition.create(event.getLine(),
+         event.getColumn());
+      columnManager_.scrollToPosition(pos);
+   }
+
    public void onNewDocumentWithCode(final NewDocumentWithCodeEvent event)
    {
       // The document should only be opened in the last focused window, unless this window is a
       // satellite that has already been closed. When this is the case, open the new doc in the
       // main source window.
-      String lastFocusedWindow = pWindowManager_.get().getLastFocusedSourceWindowId();
-      if (!SourceWindowManager.getSourceWindowId().equals(lastFocusedWindow) &&
-          (!SourceWindowManager.isMainSourceWindow() ||
-           pWindowManager_.get().isSourceWindowOpen(lastFocusedWindow)))
-            return;
+      if (!isLastFocusedSourceWindow())
+         return;
 
       // determine the type
       final EditableFileType docType;
@@ -1703,7 +1712,7 @@ public class Source implements InsertSourceHandler,
          docType = FileTypeRegistry.SQL;
       else
          docType = FileTypeRegistry.RMARKDOWN;
-      
+
       // command to create and run the new doc
       Command newDocCommand = new Command() {
          @Override
@@ -1715,13 +1724,13 @@ public class Source implements InsertSourceHandler,
                public void onSuccess(EditingTarget arg)
                {
                   TextEditingTarget editingTarget = (TextEditingTarget)arg;
-                  
+
                   if (event.getCursorPosition() != null)
                   {
                      editingTarget.navigateToPosition(event.getCursorPosition(),
                                                       false);
                   }
-                  
+
                   if (event.getExecute())
                   {
                      if (docType.equals(FileTypeRegistry.R))
@@ -1742,7 +1751,7 @@ public class Source implements InsertSourceHandler,
             });
          }
       };
-     
+
       // do it
       if (docType.equals(FileTypeRegistry.R))
       {
@@ -1751,7 +1760,7 @@ public class Source implements InsertSourceHandler,
       else
       {
          dependencyManager_.withRMarkdown("R Notebook",
-                                          "Create R Notebook", 
+                                          "Create R Notebook",
                                           newDocCommand);
       }
    }
@@ -1786,49 +1795,49 @@ public class Source implements InsertSourceHandler,
                         doNewRPlumberAPI(input);
                      }
                   });
-         
+
             widget.showModal();
 
          }
       });
    }
-    
+
    public void onOpenSourceFile(final OpenSourceFileEvent event)
    {
       doOpenSourceFile(
             event.getFile(),
             event.getFileType(),
             event.getPosition(),
-            null, 
+            null,
             event.getNavigationMethod(),
             false);
    }
-   
+
    public void onOpenPresentationSourceFile(OpenPresentationSourceFileEvent event)
    {
       // don't do the navigation if the active document is a source
       // file from this presentation module
-      
+
       doOpenSourceFile(event.getFile(),
                        event.getFileType(),
                        event.getPosition(),
                        event.getPattern(),
                        NavigationMethods.HIGHLIGHT_LINE,
                        true);
-      
+
    }
-   
+
    public void onEditPresentationSource(final EditPresentationSourceEvent event)
-   { 
+   {
       columnManager_.openFile(
-            event.getSourceFile(), 
+            event.getSourceFile(),
             FileTypeRegistry.RPRESENTATION,
             new CommandWithArg<EditingTarget>() {
                @Override
                public void execute(final EditingTarget editor)
                {
                   TextEditingTargetPresentationHelper.navigateToSlide(
-                                                         editor, 
+                                                         editor,
                                                          event.getSlideIndex());
                }
          });
@@ -1869,32 +1878,32 @@ public class Source implements InsertSourceHandler,
    {
       return columnManager_.getActiveDocPath();
    }
-   
+
    private void doOpenSourceFile(final FileSystemItem file,
                                  final TextFileType fileType,
                                  final FilePosition position,
                                  final String pattern,
-                                 final int navMethod, 
+                                 final int navMethod,
                                  final boolean forceHighlightMode)
    {
       // if the navigation should happen in another window, do that instead
-      NavigationResult navResult = 
+      NavigationResult navResult =
             pWindowManager_.get().navigateToFile(file, position, navMethod);
-      
+
       // we navigated externally, just skip this
       if (navResult.getType() == NavigationResult.RESULT_NAVIGATED)
          return;
-      
+
       // we're about to open in this window--if it's the main window, focus it
       if (SourceWindowManager.isMainSourceWindow() && Desktop.hasDesktopFrame())
          Desktop.getFrame().bringMainFrameToFront();
-      
-      final boolean isDebugNavigation = 
+
+      final boolean isDebugNavigation =
             navMethod == NavigationMethods.DEBUG_STEP ||
             navMethod == NavigationMethods.DEBUG_END;
-      
-      final CommandWithArg<EditingTarget> editingTargetAction = 
-            new CommandWithArg<EditingTarget>() 
+
+      final CommandWithArg<EditingTarget> editingTargetAction =
+            new CommandWithArg<EditingTarget>()
       {
          @Override
          public void execute(EditingTarget target)
@@ -1910,38 +1919,38 @@ public class Source implements InsertSourceHandler,
                   });
                }
             };
-      
-            
+
+
             // the rstudioapi package can use the proxy (-1, -1) position to
             // indicate that source navigation should not occur; ie, we should
             // preserve whatever position was used in the document earlier
             boolean navigateToPosition =
                   position != null &&
                   (position.getLine() != -1 || position.getColumn() != -1);
-            
+
             if (navigateToPosition)
             {
                SourcePosition endPosition = null;
                if (isDebugNavigation)
                {
-                  DebugFilePosition filePos = 
+                  DebugFilePosition filePos =
                         (DebugFilePosition) position.cast();
                   endPosition = SourcePosition.create(
                         filePos.getEndLine() - 1,
                         filePos.getEndColumn() + 1);
-                  
+
                   if (Desktop.hasDesktopFrame() &&
                       navMethod != NavigationMethods.DEBUG_END)
                   {
                       Desktop.getFrame().bringMainFrameToFront();
                   }
                }
-               
+
                SourcePosition startPosition = SourcePosition.create(
                      position.getLine() - 1,
                      position.getColumn() - 1);
-               
-               navigate(target, 
+
+               navigate(target,
                         startPosition,
                         endPosition,
                         onNavigationCompleted);
@@ -1951,7 +1960,7 @@ public class Source implements InsertSourceHandler,
                Position pos = target.search(pattern);
                if (pos != null)
                {
-                  navigate(target, 
+                  navigate(target,
                            SourcePosition.create(pos.getRow(), 0),
                            null,
                            onNavigationCompleted);
@@ -1962,7 +1971,7 @@ public class Source implements InsertSourceHandler,
                onNavigationCompleted.execute();
             }
          }
-         
+
          private void navigate(final EditingTarget target,
                                final SourcePosition srcPosition,
                                final SourcePosition srcEndPosition,
@@ -1976,8 +1985,8 @@ public class Source implements InsertSourceHandler,
                   if (navMethod == NavigationMethods.DEBUG_STEP)
                   {
                      target.highlightDebugLocation(
-                           srcPosition, 
-                           srcEndPosition, 
+                           srcPosition,
+                           srcEndPosition,
                            true);
                   }
                   else if (navMethod == NavigationMethods.DEBUG_END)
@@ -1989,12 +1998,12 @@ public class Source implements InsertSourceHandler,
                      // force highlight mode if requested
                      if (forceHighlightMode)
                         target.forceLineHighlighting();
-                     
+
                      // now navigate to the new position
-                     boolean highlight = 
+                     boolean highlight =
                            navMethod == NavigationMethods.HIGHLIGHT_LINE &&
                            !userPrefs_.highlightSelectedLine().getValue();
-                     
+
                      target.navigateToPosition(
                            srcPosition,
                            false,
@@ -2020,8 +2029,8 @@ public class Source implements InsertSourceHandler,
             @Override
             public void onError(ServerError error)
             {
-               globalDisplay_.showErrorMessage("Document Tab Move Failed", 
-                     "Couldn't move the tab to this window: \n" + 
+               globalDisplay_.showErrorMessage("Document Tab Move Failed",
+                     "Couldn't move the tab to this window: \n" +
                       error.getMessage());
             }
          });
@@ -2035,13 +2044,13 @@ public class Source implements InsertSourceHandler,
          {
             // set flag indicating we are opening for a source navigation
             columnManager_.setOpeningForSourceNavigation(position != null || pattern != null);
-            
+
             columnManager_.openFile(file,
                      fileType,
                      (target) -> {
                         columnManager_.setOpeningForSourceNavigation(false);
                         editingTargetAction.execute(target);
-                     });      
+                     });
          }
       };
 
@@ -2051,7 +2060,7 @@ public class Source implements InsertSourceHandler,
       if (isDebugNavigation)
       {
          columnManager_.startDebug();
-         
+
          EditingTarget target = columnManager_.findEditorByPath(file.getPath());
          if (target != null)
          {
@@ -2067,7 +2076,7 @@ public class Source implements InsertSourceHandler,
             }
             return;
          }
-         
+
          // If we're here, the target file wasn't open in an editor. Don't
          // open a file just to turn off debug highlighting in the file!
          if (navMethod == NavigationMethods.DEBUG_END)
@@ -2086,7 +2095,7 @@ public class Source implements InsertSourceHandler,
          action.execute(file);
       }
    }
-   
+
    private void processStatQueue()
    {
       if (statQueue_.isEmpty())
@@ -2102,7 +2111,7 @@ public class Source implements InsertSourceHandler,
                      processStatQueue();
                }
             };
-       
+
        server_.stat(entry.file.getPath(), new ServerRequestCallback<FileSystemItem>()
        {
           @Override
@@ -2172,7 +2181,7 @@ public class Source implements InsertSourceHandler,
       if (navigation != null)
          attemptSourceNavigation(navigation, commands_.sourceNavigateForward());
    }
-   
+
    // handle mouse forward and back buttons if the mouse is within a source pane
    private native final void handleMouseButtonNavigations() /*-{
    try {
@@ -2181,17 +2190,17 @@ public class Source implements InsertSourceHandler,
          function handler(nav) {
             return $entry(function(evt) {
                if ((evt.button === 3 || evt.button === 4) &&
-                   self.@org.rstudio.studio.client.workbench.views.source.Source::isMouseEventInSourcePane(Lcom/google/gwt/dom/client/NativeEvent;)(evt)) {  
-                                  
+                   self.@org.rstudio.studio.client.workbench.views.source.Source::isMouseEventInSourcePane(Lcom/google/gwt/dom/client/NativeEvent;)(evt)) {
+
                   // perform navigation
                   if (nav) {
                      if (evt.button === 3) {
                         self.@org.rstudio.studio.client.workbench.views.source.Source::onSourceNavigateBack()();
                      } else if (evt.button === 4) {
-                        self.@org.rstudio.studio.client.workbench.views.source.Source::onSourceNavigateForward()(); 
+                        self.@org.rstudio.studio.client.workbench.views.source.Source::onSourceNavigateForward()();
                      }
                   }
-                 
+
                   // prevent other handling
                   evt.preventDefault();
                   evt.stopPropagation();
@@ -2200,8 +2209,8 @@ public class Source implements InsertSourceHandler,
                }
             });
          }
-         
-         // mask mousedown from ace to prevent selection, mask mouseup from chrome 
+
+         // mask mousedown from ace to prevent selection, mask mouseup from chrome
          // to prevent navigation of the entire browser
          $wnd.addEventListener('mousedown', handler(false), false);
          $wnd.addEventListener('mouseup', handler(true), false);
@@ -2227,25 +2236,35 @@ public class Source implements InsertSourceHandler,
       return false;
    }
 
+   private boolean isLastFocusedSourceWindow()
+   {
+      String lastFocusedWindow = pWindowManager_.get().getLastFocusedSourceWindowId();
+      if (!SourceWindowManager.getSourceWindowId().equals(lastFocusedWindow) &&
+         (!SourceWindowManager.isMainSourceWindow() ||
+            pWindowManager_.get().isSourceWindowOpen(lastFocusedWindow)))
+         return false;
+      return true;
+   }
+
    private boolean isMouseEventInSourcePane(NativeEvent event)
    {
       return isPointInSourcePane(event.getClientX(), event.getClientY());
    }
 
-   
-  
+
+
    @Handler
    public void onOpenNextFileOnFilesystem()
    {
       openAdjacentFile(true);
    }
-   
+
    @Handler
    public void onOpenPreviousFileOnFilesystem()
    {
       openAdjacentFile(false);
    }
-   
+
    @Handler
    public void onSpeakEditorLocation()
    {
@@ -2254,7 +2273,7 @@ public class Source implements InsertSourceHandler,
           Timing.IMMEDIATE,
           Severity.STATUS);
    }
-   
+
    @Handler
    public void onZoomIn()
    {
@@ -2263,7 +2282,7 @@ public class Source implements InsertSourceHandler,
          Desktop.getFrame().zoomIn();
       }
    }
-   
+
    @Handler
    public void onZoomOut()
    {
@@ -2272,7 +2291,7 @@ public class Source implements InsertSourceHandler,
          Desktop.getFrame().zoomOut();
       }
    }
-   
+
    @Handler
    public void onZoomActualSize()
    {
@@ -2281,18 +2300,18 @@ public class Source implements InsertSourceHandler,
          Desktop.getFrame().zoomActualSize();
       }
    }
-   
+
    private void openAdjacentFile(final boolean forward)
    {
       // ensure we have an editor and a titled document is open
       if (!columnManager_.hasActiveEditor() ||
           StringUtil.isNullOrEmpty(columnManager_.getActiveDocPath()))
          return;
-      
+
       final FileSystemItem activePath =
             FileSystemItem.createFile(columnManager_.getActiveDocPath());
       final FileSystemItem activeDir = activePath.getParentPath();
-      
+
       server_.listFiles(
             activeDir,
             false,  // monitor result
@@ -2307,7 +2326,7 @@ public class Source implements InsertSourceHandler,
                   int n = files.length();
                   if (n < 2)
                      return;
-                  
+
                   // find the index of the currently open file
                   int index = -1;
                   for (int i = 0; i < n; i++)
@@ -2319,18 +2338,18 @@ public class Source implements InsertSourceHandler,
                         break;
                      }
                   }
-                  
+
                   // if this failed for some reason, bail
                   if (index == -1)
                      return;
-                  
+
                   // compute index of file to be opened (with wrap-around)
                   int target = (forward ? index + 1 : index - 1);
                   if (target < 0)
                      target = n - 1;
                   else if (target >= n)
                      target = 0;
-                  
+
                   // extract the file and attempt to open
                   FileSystemItem targetItem = files.get(target);
                   columnManager_.openFile(targetItem);
@@ -2430,7 +2449,7 @@ public class Source implements InsertSourceHandler,
             {
                columnManager_.startDebug();
             }
-            
+
             columnManager_.activateCodeBrowser(
                CodeBrowserEditingTarget.getCodeBrowserPath(event.getFunction()),
                !event.serverDispatched(),
@@ -2441,8 +2460,8 @@ public class Source implements InsertSourceHandler,
                   target.showFunction(event.getFunction());
                   if (event.getDebugPosition() != null)
                   {
-                     highlightDebugBrowserPosition(target, 
-                           event.getDebugPosition(), 
+                     highlightDebugBrowserPosition(target,
+                           event.getDebugPosition(),
                            event.getExecuting());
                   }
                }
@@ -2450,7 +2469,7 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Override
    public void onCodeBrowserFinished(final CodeBrowserFinishedEvent event)
    {
@@ -2465,7 +2484,7 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Override
    public void onCodeBrowserHighlight(final CodeBrowserHighlightEvent event)
    {
@@ -2486,16 +2505,16 @@ public class Source implements InsertSourceHandler,
                   // we may need to repopulate it
                   if (StringUtil.isNullOrEmpty(target.getContext()))
                      target.showFunction(event.getFunction());
-                  highlightDebugBrowserPosition(target, event.getDebugPosition(), 
+                  highlightDebugBrowserPosition(target, event.getDebugPosition(),
                         true);
                }
             });
          }
       });
    }
-   
-   private void tryExternalCodeBrowser(SearchPathFunctionDefinition func, 
-         CrossWindowEvent<?> event, 
+
+   private void tryExternalCodeBrowser(SearchPathFunctionDefinition func,
+         CrossWindowEvent<?> event,
          Command withLocalCodeBrowser)
    {
       final String path = CodeBrowserEditingTarget.getCodeBrowserPath(func);
@@ -2512,7 +2531,7 @@ public class Source implements InsertSourceHandler,
                                               boolean executing)
    {
       target.highlightDebugLocation(SourcePosition.create(
-               pos.getLine(), 
+               pos.getLine(),
                pos.getColumn() - 1),
             SourcePosition.create(
                pos.getEndLine(),
@@ -2594,7 +2613,7 @@ public class Source implements InsertSourceHandler,
    {
       onShowProfiler(event);
    }
-   
+
    private void saveDocumentIds(JsArrayString ids, final CommandWithArg<Boolean> onSaveCompleted)
    {
       // we use a timer that fires the document save completed event,
@@ -2613,7 +2632,7 @@ public class Source implements InsertSourceHandler,
          }
       };
       completedTimer.schedule(5000);
-      
+
       final Command onCompleted = new Command()
       {
          @Override
@@ -2623,7 +2642,7 @@ public class Source implements InsertSourceHandler,
             completedTimer.schedule(0);
          }
       };
-      
+
       if (ids == null)
       {
          saveUnsavedDocuments(onCompleted);
@@ -2633,15 +2652,15 @@ public class Source implements InsertSourceHandler,
          final Set<String> idSet = new HashSet<String>();
          for (String id : JsUtil.asIterable(ids))
             idSet.add(id);
-         
+
          saveUnsavedDocuments(idSet, onCompleted);
       }
    }
-   
+
    @Override
    public void onRequestDocumentSave(RequestDocumentSaveEvent event)
    {
-      saveDocumentIds(event.getDocumentIds(), success -> 
+      saveDocumentIds(event.getDocumentIds(), success ->
       {
          if (SourceWindowManager.isMainSourceWindow())
          {
@@ -2650,7 +2669,7 @@ public class Source implements InsertSourceHandler,
          }
       });
    }
-   
+
    @Override
    public void onRequestDocumentClose(RequestDocumentCloseEvent event)
    {
@@ -2659,7 +2678,7 @@ public class Source implements InsertSourceHandler,
       {
          // Close each of the requested tabs
          columnManager_.closeTabs(ids);
-         
+
          // Let the server know we've completed the task
          if (SourceWindowManager.isMainSourceWindow())
          {
@@ -2723,9 +2742,9 @@ public class Source implements InsertSourceHandler,
             }
          });
       }
-      
+
    }
-   
+
    @Override
    public void onSetSelectionRanges(final SetSelectionRangesEvent event)
    {
@@ -2737,13 +2756,13 @@ public class Source implements InsertSourceHandler,
             JsArray<Range> ranges = event.getData().getRanges();
             if (ranges.length() == 0)
                return;
-            
+
             AceEditor editor = (AceEditor) docDisplay;
             editor.setSelectionRanges(ranges);
          }
       });
    }
-   
+
    @Override
    public void onGetEditorContext(GetEditorContextEvent event)
    {
@@ -2779,7 +2798,7 @@ public class Source implements InsertSourceHandler,
             GetEditorContextEvent.SelectionData.create(),
             new VoidServerRequestCallback());
    }
-   
+
    @Override
    public void onReplaceRanges(final ReplaceRangesEvent event)
    {
@@ -2796,18 +2815,18 @@ public class Source implements InsertSourceHandler,
    private void doReplaceRanges(ReplaceRangesEvent event, DocDisplay docDisplay)
    {
       JsArray<ReplacementData> data = event.getData().getReplacementData();
-      
+
       int n = data.length();
       for (int i = 0; i < n; i++)
       {
          ReplacementData el = data.get(n - i - 1);
          Range range = el.getRange();
          String text = el.getText();
-         
+
          // A null range at this point is a proxy to use the current selection
          if (range == null)
             range = docDisplay.getSelectionRange();
-         
+
          docDisplay.replaceRange(range, text);
       }
       docDisplay.focus();
@@ -2815,7 +2834,7 @@ public class Source implements InsertSourceHandler,
 
    private class StatFileEntry
    {
-      public StatFileEntry(FileSystemItem fileIn, 
+      public StatFileEntry(FileSystemItem fileIn,
             CommandWithArg<FileSystemItem> actionIn)
       {
          file = fileIn;
@@ -2842,13 +2861,13 @@ public class Source implements InsertSourceHandler,
    private final RnwWeaveRegistry rnwWeaveRegistry_;
 
    private boolean suspendSourceNavigationAdding_;
-  
+
    private static final String MODULE_SOURCE = "source-pane";
    private static final String KEY_ACTIVETAB = "activeTab";
    private boolean initialized_;
-   
+
    private final Provider<SourceWindowManager> pWindowManager_;
-   
+
    private final DependencyManager dependencyManager_;
 
    public final static int TYPE_FILE_BACKED = 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1691,7 +1691,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       activeColumn_.fireDocTabsChanged();
    }
 
-   public void scrollToPosition(FilePosition position)
+   public void scrollToPosition(FilePosition position, boolean moveCursor)
    {
       // ensure we have an active source column
       getActive();
@@ -1701,8 +1701,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          SourcePosition srcPosition = SourcePosition.create(
             position.getLine() - 1,
             position.getColumn() - 1);
-         activeColumn_.getActiveEditor().navigateToPositionWithoutFocus(
-            srcPosition, false, null);
+         activeColumn_.getActiveEditor().navigateToPosition(
+            srcPosition, false, false, moveCursor, null);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1691,6 +1691,21 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       activeColumn_.fireDocTabsChanged();
    }
 
+   public void scrollToPosition(FilePosition position)
+   {
+      // ensure we have an active source column
+      getActive();
+
+      if (hasActiveEditor())
+      {
+         SourcePosition srcPosition = SourcePosition.create(
+            position.getLine() - 1,
+            position.getColumn() - 1);
+         activeColumn_.getActiveEditor().navigateToPositionWithoutFocus(
+            srcPosition, false, null);
+      }
+   }
+
    private boolean hasDoc()
    {
       for (SourceColumn column : columnList_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -836,7 +836,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       if (!StringUtil.isNullOrEmpty(mostRecentSourceWindow_) &&
           isSourceWindowOpen(mostRecentSourceWindow_))
          events_.fireEventToSatellite(event, getSourceWindowObject(mostRecentSourceWindow_));
-      else
+      else if (!isMainSourceWindow())
          events_.fireEventToMainWindow(event);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -90,7 +90,8 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
                                             CollabEditEndedEvent.Handler,
                                             DocFocusedEvent.Handler,
                                             EditorCommandDispatchEvent.Handler,
-                                            RestartStatusEvent.Handler
+                                            RestartStatusEvent.Handler,
+                                            ScrollToPositionEvent.Handler
 {
    @Inject
    public SourceWindowManager(
@@ -115,7 +116,8 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       userPrefs_ = uiPrefs;
       
       events_.addHandler(DocWindowChangedEvent.TYPE, this);
-      
+      events_.addHandler(ScrollToPositionEvent.TYPE, this);
+
       if (isMainSourceWindow())
       {
          // most event handlers only make sense on the main window
@@ -827,7 +829,17 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
          }
       }
    }
-   
+
+   @Override
+   public void onScrollToPosition(ScrollToPositionEvent event)
+   {
+      if (!StringUtil.isNullOrEmpty(mostRecentSourceWindow_) &&
+          isSourceWindowOpen(mostRecentSourceWindow_))
+         events_.fireEventToSatellite(event, getSourceWindowObject(mostRecentSourceWindow_));
+      else
+         events_.fireEventToMainWindow(event);
+   }
+
    @Override
    public void onDocFocused(final DocFocusedEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -88,7 +88,10 @@ public interface EditingTarget extends IsWidget,
                            boolean recordCurrent,
                            boolean highlightLine,
                            Command onNavigationCompleted);
-   
+   void navigateToPositionWithoutFocus(SourcePosition position,
+                                       boolean highlightLine,
+                                       Command onNavigationCompleted);
+
    void restorePosition(SourcePosition position);
    SourcePosition currentPosition();
    boolean isAtSourceRow(SourcePosition position);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTarget.java
@@ -87,10 +87,8 @@ public interface EditingTarget extends IsWidget,
    void navigateToPosition(SourcePosition position,
                            boolean recordCurrent,
                            boolean highlightLine,
+                           boolean moveCursor,
                            Command onNavigationCompleted);
-   void navigateToPositionWithoutFocus(SourcePosition position,
-                                       boolean highlightLine,
-                                       Command onNavigationCompleted);
 
    void restorePosition(SourcePosition position);
    SourcePosition currentPosition();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -595,6 +595,20 @@ public class CodeBrowserEditingTarget implements EditingTarget
    }
 
    @Override
+   public void navigateToPositionWithoutFocus(SourcePosition position,
+                                              boolean highlightLine,
+                                              Command onNavigationCompleted)
+   {
+      ensureContext(position.getContext(), () ->
+      {
+         docDisplay_.navigateToPositionWithoutFocus(position, highlightLine);
+
+         if (onNavigationCompleted != null)
+            onNavigationCompleted.execute();
+      });
+   }
+
+   @Override
    public void restorePosition(final SourcePosition position)
    {
       ensureContext(position.getContext(), new Command() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -565,7 +565,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    public void navigateToPosition(final SourcePosition position,
                                   final boolean recordCurrent)
    {
-      navigateToPosition(position, recordCurrent, false, null);
+      navigateToPosition(position, recordCurrent, false, true, null);
    }
 
    @Override
@@ -573,13 +573,14 @@ public class CodeBrowserEditingTarget implements EditingTarget
                                   final boolean recordCurrent,
                                   final boolean highlightLine)
    {
-      navigateToPosition(position, recordCurrent, highlightLine, null);
+      navigateToPosition(position, recordCurrent, highlightLine, true, null);
    }
    
    @Override
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent,
                                   boolean highlightLine,
+                                  boolean moveCursor,
                                   Command onNavigationCompleted)
    {
       ensureContext(position.getContext(), () ->
@@ -587,22 +588,9 @@ public class CodeBrowserEditingTarget implements EditingTarget
          docDisplay_.navigateToPosition(
                position,
                recordCurrent,
-               highlightLine);
+               highlightLine,
+               !moveCursor);
          
-         if (onNavigationCompleted != null)
-            onNavigationCompleted.execute();
-      });
-   }
-
-   @Override
-   public void navigateToPositionWithoutFocus(SourcePosition position,
-                                              boolean highlightLine,
-                                              Command onNavigationCompleted)
-   {
-      ensureContext(position.getContext(), () ->
-      {
-         docDisplay_.navigateToPositionWithoutFocus(position, highlightLine);
-
          if (onNavigationCompleted != null)
             onNavigationCompleted.execute();
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -422,6 +422,13 @@ public class ProfilerEditingTarget implements EditingTarget,
    }
 
    @Override
+   public void navigateToPositionWithoutFocus(SourcePosition position,
+                                              boolean highlightLine,
+                                              Command onNavigationCompleted)
+   {
+   }
+
+   @Override
    public void restorePosition(SourcePosition position)
    {
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -417,14 +417,8 @@ public class ProfilerEditingTarget implements EditingTarget,
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent,
                                   boolean highlightLine,
+                                  boolean moveCursor,
                                   Command onNavigationCompleted)
-   {
-   }
-
-   @Override
-   public void navigateToPositionWithoutFocus(SourcePosition position,
-                                              boolean highlightLine,
-                                              Command onNavigationCompleted)
    {
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3065,25 +3065,19 @@ public class AceEditor implements DocDisplay,
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent)
    {
-      navigateToPosition(position, recordCurrent, false);
+      navigateToPosition(position, recordCurrent, false, true);
    }
 
    @Override
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent,
-                                  boolean highlightLine)
+                                  boolean highlightLine,
+                                  boolean restoreCursorPosition)
    {
       if (recordCurrent)
          recordCurrentNavigationPosition();
 
-      navigate(position, true, highlightLine, false);
-   }
-
-   @Override
-   public void navigateToPositionWithoutFocus(SourcePosition position,
-                                              boolean highlightLine)
-   {
-      navigate(position, false, highlightLine, true);
+      navigate(position, true, highlightLine, restoreCursorPosition);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3076,7 +3076,14 @@ public class AceEditor implements DocDisplay,
       if (recordCurrent)
          recordCurrentNavigationPosition();
 
-      navigate(position, true, highlightLine);
+      navigate(position, true, highlightLine, false);
+   }
+
+   @Override
+   public void navigateToPositionWithoutFocus(SourcePosition position,
+                                              boolean highlightLine)
+   {
+      navigate(position, false, highlightLine, true);
    }
 
    @Override
@@ -3178,12 +3185,13 @@ public class AceEditor implements DocDisplay,
 
    private void navigate(SourcePosition srcPosition, boolean addToHistory)
    {
-      navigate(srcPosition, addToHistory, false);
+      navigate(srcPosition, addToHistory, false, false);
    }
 
    private void navigate(SourcePosition srcPosition,
                          boolean addToHistory,
-                         boolean highlightLine)
+                         boolean highlightLine,
+                         boolean restoreCursorPosition)
    {
       // get existing cursor position
       Position previousCursorPos = getCursorPosition();
@@ -3211,8 +3219,11 @@ public class AceEditor implements DocDisplay,
       else
          ensureCursorVisible();
 
-      // set focus
-      focus();
+      // restore original cursor position or set focus
+      if (restoreCursorPosition)
+         setCursorPosition(previousCursorPos);
+      else
+         focus();
 
       if (highlightLine)
          applyLineHighlight(position.getRow());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/NavigableSourceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/NavigableSourceEditor.java
@@ -34,6 +34,9 @@ public interface NavigableSourceEditor
                            boolean recordCurrentPosition,
                            boolean highlightLine);
 
+   void navigateToPositionWithoutFocus(SourcePosition position,
+                                       boolean highlightLine);
+
    void restorePosition(SourcePosition position);
    
    JsArray<ScopeFunction> getAllFunctionScopes();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/NavigableSourceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/NavigableSourceEditor.java
@@ -32,10 +32,8 @@ public interface NavigableSourceEditor
    
    void navigateToPosition(SourcePosition position, 
                            boolean recordCurrentPosition,
-                           boolean highlightLine);
-
-   void navigateToPositionWithoutFocus(SourcePosition position,
-                                       boolean highlightLine);
+                           boolean highlightLine,
+                           boolean restoreCursorPosition);
 
    void restorePosition(SourcePosition position);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1212,7 +1212,19 @@ public class TextEditingTarget implements
          
       });
    }
-   
+
+   @Override
+   public void navigateToPositionWithoutFocus(SourcePosition position,
+                                              boolean highlightLine,
+                                              Command onNavigationComplete)
+   {
+      ensureTextEditorActive(() -> {
+         docDisplay_.navigateToPositionWithoutFocus(position, highlightLine);
+         if (onNavigationComplete != null)
+            onNavigationComplete.execute();
+      });
+   }
+
    // These methods are called by SourceNavigationHistory and source pane management
    // features (e.g. external source window and source columns) so need to check for
    // and dispatch to visual mode

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1194,7 +1194,7 @@ public class TextEditingTarget implements
                                   boolean highlightLine)
    {
       ensureTextEditorActive(() -> {
-         docDisplay_.navigateToPosition(position, recordCurrent, highlightLine);
+         docDisplay_.navigateToPosition(position, recordCurrent, highlightLine, false);
       });
    }
    
@@ -1202,26 +1202,13 @@ public class TextEditingTarget implements
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent,
                                   boolean highlightLine,
+                                  boolean moveCursor,
                                   Command onNavigationCompleted)
    {
       ensureTextEditorActive(() -> {
-         
-         docDisplay_.navigateToPosition(position, recordCurrent, highlightLine);
+         docDisplay_.navigateToPosition(position, recordCurrent, highlightLine, !moveCursor);
          if (onNavigationCompleted != null)
             onNavigationCompleted.execute();
-         
-      });
-   }
-
-   @Override
-   public void navigateToPositionWithoutFocus(SourcePosition position,
-                                              boolean highlightLine,
-                                              Command onNavigationComplete)
-   {
-      ensureTextEditorActive(() -> {
-         docDisplay_.navigateToPositionWithoutFocus(position, highlightLine);
-         if (onNavigationComplete != null)
-            onNavigationComplete.execute();
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -298,14 +298,8 @@ public class UrlContentEditingTarget implements EditingTarget
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent,
                                   boolean highlightLine,
+                                  boolean moveCursor,
                                   Command onNavigationCompleted)
-   {
-   }
-
-   @Override
-   public void navigateToPositionWithoutFocus(SourcePosition position,
-                                              boolean highlightLine,
-                                              Command onNavigationCompleted)
    {
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -303,6 +303,13 @@ public class UrlContentEditingTarget implements EditingTarget
    }
 
    @Override
+   public void navigateToPositionWithoutFocus(SourcePosition position,
+                                              boolean highlightLine,
+                                              Command onNavigationCompleted)
+   {
+   }
+
+   @Override
    public void restorePosition(SourcePosition position)
    {
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
@@ -15,12 +15,12 @@
 package org.rstudio.studio.client.workbench.views.source.events;
 
 import com.google.gwt.event.shared.EventHandler;
+
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 
 @JavaScriptSerializable
-public class ScrollToPositionEvent
-   extends CrossWindowEvent<ScrollToPositionEvent.Handler>
+public class ScrollToPositionEvent extends CrossWindowEvent<ScrollToPositionEvent.Handler>
 {
    public interface Handler extends EventHandler
    {
@@ -63,4 +63,3 @@ public class ScrollToPositionEvent
    private int column_;
    public static final Type<Handler> TYPE = new Type<>();
 }
-

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
@@ -1,0 +1,66 @@
+/*
+ * ScrollToPositionEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import org.rstudio.core.client.js.JavaScriptSerializable;
+import org.rstudio.studio.client.application.events.CrossWindowEvent;
+
+@JavaScriptSerializable
+public class ScrollToPositionEvent
+   extends CrossWindowEvent<ScrollToPositionEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onScrollToPosition(ScrollToPositionEvent event);
+   }
+
+   public ScrollToPositionEvent()
+   {
+   }
+
+   public ScrollToPositionEvent(int line, int column)
+   {
+      line_ = line;
+      column_ = column;
+   }
+
+   public int getLine()
+   {
+      return line_;
+   }
+
+   public int getColumn()
+   {
+      return column_;
+   }
+   
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onScrollToPosition(this);
+   }
+
+   private int line_;
+   private int column_;
+   public static final Type<Handler> TYPE = new Type<>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ScrollToPositionEvent.java
@@ -31,10 +31,11 @@ public class ScrollToPositionEvent extends CrossWindowEvent<ScrollToPositionEven
    {
    }
 
-   public ScrollToPositionEvent(int line, int column)
+   public ScrollToPositionEvent(int line, int column, boolean moveCursor)
    {
       line_ = line;
       column_ = column;
+      moveCursor_ = moveCursor;
    }
 
    public int getLine()
@@ -45,6 +46,11 @@ public class ScrollToPositionEvent extends CrossWindowEvent<ScrollToPositionEven
    public int getColumn()
    {
       return column_;
+   }
+
+   public boolean getMoveCursor()
+   {
+      return moveCursor_;
    }
    
    @Override
@@ -61,5 +67,6 @@ public class ScrollToPositionEvent extends CrossWindowEvent<ScrollToPositionEven
 
    private int line_;
    private int column_;
+   private boolean moveCursor_;
    public static final Type<Handler> TYPE = new Type<>();
 }


### PR DESCRIPTION
### Intent

The goal of this PR is to enhance `rstudioapi` with a call to scroll to a line in the current editor without stealing the cursor's position. It closes pro issue 1850 (https://github.com/rstudio/rstudio-pro/issues/1850). The associated API PR is found here: https://github.com/rstudio/rstudioapi/pull/187. 

### Approach

`rstudioapi::navigateToFile` is enhanced to make the `file` argument optional so that when a file is not provided, the IDE scrolls to the requested position in the file of the most recently used source window. If no arguments are provided to the call, then it does nothing. 

Rather than modifying the existing logic in the `JumpToFunction EventHandler` I added a new event `ScrollToPosition` to fire from the handler when a file name isn't provided. The previous logic executes a fair amount of code to see if the file is opened and open it if not. We could have this logic eventually call `ScrollToPosition` after the file logic but the same effect is gained from a one line call to another method so it's not needed. 

### QA Notes

You'll need to install the most recent version of `rstudioapi` for this to work. I've been doing this by typing the following in the console:
```
install.packages(githubinstall)
gh_install_packages("rstudio/rstudioapi")
```

Then you can try calling `rstudioapi::navigateToFile` with and without a `file` and with/without a `moveCursor`.
