### PR TITLE
properly resolve project when completing markdown links

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,4 +88,5 @@
 * Fixed disappearing commands and recent files/projects when RStudio Desktop opens new windows (#3968)
 * Fixed issue where active repositories were not propagated to newly-created `renv` projects (#7136)
 * Fixed issue where .DollarNames methods defined in global environment were not resolved (#7487)
+* Fixed issue where path autocompletion in R Markdown documents did not respect Knit Directory preference (#5412)
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2203,9 +2203,9 @@ assign(x = ".rs.acCompletionTypes",
 
       if (is.null(path) && isRmd)
       {
-         # for R Markdown documents without an explicit working dir, use the
-         # base directory of the file
-         path <- suppressWarnings(.rs.normalizePath(dirname(filePath)))
+         # for R Markdown documents without an explicit working dir,
+         # use preferences instead
+         path <- .rs.markdown.resolveCompletionRoot(filePath)
       }
 
       if (is.null(path))

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -37,9 +37,22 @@
    props <- .rs.getSourceDocumentProperties(path)
    workingDirProp <- props$properties$working_dir
    workingDir <- if (identical(workingDirProp, "project"))
-      props$project_path
+   {
+      # path refers to the full path; project_path refers
+      # to the project-relative path. use that to infer
+      # the path to the project hosting the document
+      # (just in case the user is editing a document that
+      # belongs to an alternate project)
+      substring(
+         props$path,
+         1L,
+         nchar(props$path) - nchar(props$project_path) - 1
+      )
+   }
    else if (identical(workingDirProp, "current"))
+   {
       getwd()
+   }
    
    # check for NULL working dir (don't include as part of if-else check above
    # since some documents may not have an associated project and yet could

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -23,6 +23,36 @@
       return(.rs.markdown.getCompletionsHref(data))
 })
 
+.rs.addFunction("markdown.resolveCompletionRoot", function(path)
+{
+   # figure out working directory
+   props <- .rs.getSourceDocumentProperties(path)
+   workingDirProp <- props$properties$working_dir
+   
+   useProject <-
+      identical(workingDirProp, "project") &&
+      is.character(props$path) &&
+      is.character(props$project_path)
+   
+   if (useProject)
+   {
+      # path refers to the full path; project_path refers
+      # to the project-relative path. use that to infer
+      # the path to the project hosting the document
+      # (just in case the user is editing a document that
+      # belongs to an alternate project)
+      substring(props$path, 1L, nchar(props$path) - nchar(props$project_path) - 1L)
+   }
+   else if (identical(workingDirProp, "current"))
+   {
+      getwd()
+   }
+   else
+   {
+      dirname(path)
+   }
+})
+
 .rs.addFunction("markdown.getCompletionsHref", function(data)
 {
    # extract parameters
@@ -34,31 +64,7 @@
       return(.rs.emptyCompletions())
    
    # figure out working directory
-   props <- .rs.getSourceDocumentProperties(path)
-   workingDirProp <- props$properties$working_dir
-   workingDir <- if (identical(workingDirProp, "project"))
-   {
-      # path refers to the full path; project_path refers
-      # to the project-relative path. use that to infer
-      # the path to the project hosting the document
-      # (just in case the user is editing a document that
-      # belongs to an alternate project)
-      substring(
-         props$path,
-         1L,
-         nchar(props$path) - nchar(props$project_path) - 1
-      )
-   }
-   else if (identical(workingDirProp, "current"))
-   {
-      getwd()
-   }
-   
-   # check for NULL working dir (don't include as part of if-else check above
-   # since some documents may not have an associated project and yet could
-   # be configured to use a project directory)
-   if (is.null(workingDir))
-      workingDir <- dirname(path)
+   workingDir <- .rs.markdown.resolveCompletionRoot(path)
    
    # determine dirname, basename (need to handle trailing slashes properly
    # so can't just use dirname / basename)


### PR DESCRIPTION
### Intent

Ensure Markdown link completions (when the Knit Directory pref is set to Project Directory) function as expected.

<img width="513" alt="Screen Shot 2020-08-17 at 11 30 51 AM" src="https://user-images.githubusercontent.com/1976582/90430961-271d8000-e07d-11ea-9d2d-04ca670d3b0d.png">

<img width="495" alt="Screen Shot 2020-08-17 at 11 30 57 AM" src="https://user-images.githubusercontent.com/1976582/90430954-24228f80-e07d-11ea-8887-2a123e6e88d8.png">

### Approach

Properly use the source document's properties to compute the document's project path. (Previous code erroneously concluded that `project_path` referred to the project path, when in actuality it refers to the project-relative path.)

### QA Notes

Open an R Markdown document, and then (with `|` indicating the cursor position), type:

```
[](|
```

Then press `<TAB>` to request completions. Check that the completions return what you expect as the Knit Directory preference is changed.

Closes https://github.com/rstudio/rstudio/issues/5412.