### PR TITLE
reduce font-size differences between Console and Terminal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -88,4 +88,5 @@
 * Fixed disappearing commands and recent files/projects when RStudio Desktop opens new windows (#3968)
 * Fixed issue where active repositories were not propagated to newly-created `renv` projects (#7136)
 * Fixed issue where .DollarNames methods defined in global environment were not resolved (#7487)
+* Reduced difference in font size and spacing between Terminal and Console (#6382)
 

--- a/src/gwt/src/org/rstudio/core/client/widget/FontSizer.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/FontSizer.css
@@ -1,5 +1,7 @@
 @external windows, macintosh, linux, ubuntu_mono, ubuntu_mono_firefox;
 
+/* keep computed value in sync with FontSizer.getNormalLineHeight() */
+
 .macintosh .normalSize, .macintosh .normalSize td, .macintosh .normalSize pre {
    line-height: 1.45;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FontSizer.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FontSizer.java
@@ -23,6 +23,7 @@ import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.ui.UIObject;
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.studio.client.application.Desktop;
 
 
 public class FontSizer
@@ -74,7 +75,7 @@ public class FontSizer
       // our resource class
       if (document == null || styles == null)
          return;
-      
+
       size = size + BrowseCap.getFontSkew();
 
       final String STYLE_EL_ID = "__rstudio_normal_size";
@@ -98,5 +99,39 @@ public class FontSizer
          oldStyle.removeFromParent();
 
       style.setId(STYLE_EL_ID);
+   }
+
+   /**
+    * Needs to match the size computed in FontSizer.css; used by xterm.js which is not
+    * styled with css but via API calls
+    *
+    * @return css line_height scaling (no units)
+    */
+   public static double getNormalLineHeight()
+   {
+      double lineHeight = 1.25;
+
+      if (BrowseCap.isMacintosh())
+         lineHeight = 1.45;
+
+      if (Desktop.isDesktop())
+      {
+         if (BrowseCap.isWindows())
+            lineHeight = 1.2;
+      }
+      else if (BrowseCap.isFirefox())
+      {
+         if (BrowseCap.isWindows())
+            lineHeight = 1.2;
+      }
+      else if (BrowseCap.isWindows())
+         lineHeight = 1.1;
+
+      if (Document.get().getBody().hasClassName("ubuntu_mono_firefox"))
+         lineHeight = 1.1;
+      else if (Document.get().getBody().hasClassName("ubuntu_mono"))
+         lineHeight = 1.2;
+
+      return lineHeight;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPane.java
@@ -1142,7 +1142,8 @@ public class TerminalPane extends WorkbenchPane
             BrowseCap.isWindowsDesktop(),
             XTermTheme.terminalThemeFromEditorTheme(),
             XTermTheme.getFontFamily(),
-            XTermTheme.adjustFontSize(pFontSizeManager_.get().getSize()));
+            XTermTheme.adjustFontSize(pFontSizeManager_.get().getSize()),
+            XTermTheme.computeLineHeight());
    }
 
    private TerminalDeckPanel terminalSessionsPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalSession.java
@@ -186,6 +186,7 @@ public class TerminalSession extends XTermWidget
             addHandlerRegistration(uiPrefs_.fontSizePoints().bind(arg ->
             {
                updateOption("fontSize", XTermTheme.adjustFontSize(arg));
+               updateOption("lineHeight", XTermTheme.computeLineHeight());
                onResize();
             }));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermOptions.java
@@ -257,7 +257,8 @@ public class XTermOptions
          boolean windowsMode,
          XTermTheme theme,
          String fontFamily,
-         double fontSize)
+         double fontSize,
+         double lineHeight)
    {
       XTermOptions options = new XTermOptions();
       options.bellStyle = bellStyle;
@@ -268,6 +269,7 @@ public class XTermOptions
       options.theme = theme;
       options.fontFamily = fontFamily;
       options.fontSize = fontSize;
+      options.lineHeight = lineHeight;
       return options;
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/XTermTheme.java
@@ -18,9 +18,11 @@ import com.google.gwt.core.client.JsArrayString;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.widget.FontSizer;
 
 /**
  * Contains colors to theme the terminal with (ITheme).
@@ -114,6 +116,8 @@ public class XTermTheme
 
    @JsOverlay public static double adjustFontSize(double size)
    {
+      size += BrowseCap.getFontSkew();
+
       // standard values for sizes we expose in preferences
       if (doubleEqualish(size, 7.0))
          return 9.0;
@@ -141,6 +145,15 @@ public class XTermTheme
          return 48.0;
       else
          return Math.round(size * 1.3333333);
+   }
+
+   @JsOverlay public static double computeLineHeight()
+   {
+      double lineHeight = FontSizer.getNormalLineHeight();
+
+      // due to units oddity, have to scale down before passing to xterm.js
+      // (pixels vs. pts)
+      return lineHeight > 1.0 ? lineHeight * 0.75 : 1.0;
    }
 
    @JsOverlay public static XTermTheme create(


### PR DESCRIPTION
- Fixes #6382

### Intent

The newer xterm.js taken in RStudio 1.3 required a switch from using css to style the terminal to passing it information via an API.

For setting the font-size, it turns out I was missing an adjustment causing it to have a font somewhat larger than the console. 

For the line-spacing, I wasn't passing this at all and the terminal lines were generally showing up with less spacing than the console.

### Approach

For the font-size, apply the `BrowseCap.getFontSkew();` adjustment before passing to xterm.js.

For the line-spacing, pass a value based on the same rules used by the console.

### QA Notes

The terminal has two rendering modes; controlled by the "Hardware acceleration" setting in Global / Terminal preferences.

When this option is off, rendering is done via the DOM, and with this fix in place it works out to be extremely close, size and spacing wise, to the console layout. There can still be subtle differences due to rounding/conversion issues (xterm.js only accepts sizes in pixels, but we compute them in points), but overall should look essentially the same.

When the hardware option is on (the default), xterm renders via an entirely different codepath that doesn't use the DOM, and the resulting output still has some detectable size/spacing differences from the console, but the differences are greatly reduced.

I don't think we can guarantee them to be identical (could get down to browser, graphics card, OS-level issues), but hopefully this improvement is sufficient.

One low-tech way to compare (especially for the hardware technique, when you cannot simply examine the DOM measurements in browser devtools) is to generate same output in console and terminal, and flip back and forth between them.