### PR TITLE
Always show focus rectangle after using Focus Main Toolbar command

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
+++ b/src/gwt/src/org/rstudio/core/client/a11y/A11y.java
@@ -68,7 +68,7 @@ public class A11y
       else
          element.setAttribute("aria-current", value);
    }
-   
+
    /**
     * Set aria-current value on an element
     * @param widget widget to mark
@@ -125,10 +125,10 @@ public class A11y
    {
       el.removeClassName(ThemeStyles.INSTANCE.visuallyHidden());
    }
-   
+
    public static void setARIANotExpanded(Element el)
    {
-      // aria best-practices recommends not including aria-expanded property at all instead 
+      // aria best-practices recommends not including aria-expanded property at all instead
       // of setting it to false
       el.removeAttribute("aria-expanded");
    }
@@ -146,14 +146,24 @@ public class A11y
          el.removeAttribute("inert");
       }
    }
-   
+
    public static void setARIAAutocomplete(Element el, String val)
    {
       el.setAttribute("aria-autocomplete", val);
    }
-   
+
    public static void setARIAAutocomplete(Widget widget, String val)
    {
       setARIAAutocomplete(widget.getElement(), val);
+   }
+
+   /**
+    * Add a focus outline to the element; will be automatically removed when
+    * focus leaves the element. See the focus-visible.js polyfill for more details.
+    */
+   public static void showFocusOutline(Element el)
+   {
+      el.addClassName("focus-visible");
+      el.setAttribute("data-focus-visible-added", "");
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/GlobalToolbar.java
@@ -15,6 +15,8 @@
 package org.rstudio.studio.client.application.ui;
 
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.CanFocus;
@@ -39,17 +41,17 @@ import com.google.inject.Provider;
 
 public class GlobalToolbar extends Toolbar
 {
-   public GlobalToolbar(Commands commands, 
+   public GlobalToolbar(Commands commands,
                         Provider<CodeSearch> pCodeSearch)
    {
       super("Main");
-      
+
       commands_ = commands;
       pCodeSearch_ = pCodeSearch;
       ThemeResources res = ThemeResources.INSTANCE;
       addStyleName(res.themeStyles().globalToolbar());
-      
-      
+
+
       // add new source doc commands
       newMenu_ = new ToolbarPopupMenu();
       newMenu_.addItem(commands.newSourceDoc().createMenuItem(false));
@@ -71,7 +73,7 @@ public class GlobalToolbar extends Toolbar
       newMenu_.addItem(commands.newRHTMLDoc().createMenuItem(false));
       newMenu_.addItem(commands.newRPresentationDoc().createMenuItem(false));
       newMenu_.addItem(commands.newRDocumentationDoc().createMenuItem(false));
-      
+
       // create and add new menu
       StandardIcons icons = StandardIcons.INSTANCE;
       newButton_ = new ToolbarMenuButton(ToolbarButton.NoText,
@@ -81,13 +83,13 @@ public class GlobalToolbar extends Toolbar
       ElementIds.assignElementId(newButton_, ElementIds.NEW_FILE_MENUBUTTON);
       addLeftWidget(newButton_);
       addLeftSeparator();
-      
+
       addLeftWidget(commands.newProject().createToolbarButton());
       addLeftSeparator();
-      
+
       // open button + mru
       addLeftWidget(commands.openSourceDoc().createToolbarButton());
-      
+
       ToolbarPopupMenu mruMenu = new ToolbarPopupMenu();
       mruMenu.addItem(commands.mru0().createMenuItem(false));
       mruMenu.addItem(commands.mru1().createMenuItem(false));
@@ -106,10 +108,10 @@ public class GlobalToolbar extends Toolbar
       mruMenu.addItem(commands.mru14().createMenuItem(false));
       mruMenu.addSeparator();
       mruMenu.addItem(commands.clearRecentFiles().createMenuItem(false));
-      
-      ToolbarMenuButton mruButton = new ToolbarMenuButton(ToolbarButton.NoText, 
-                                                          "Open recent files", 
-                                                          mruMenu, 
+
+      ToolbarMenuButton mruButton = new ToolbarMenuButton(ToolbarButton.NoText,
+                                                          "Open recent files",
+                                                          mruMenu,
                                                           false);
       ElementIds.assignElementId(mruButton, ElementIds.OPEN_MRU_MENUBUTTON);
       addLeftWidget(mruButton);
@@ -118,9 +120,9 @@ public class GlobalToolbar extends Toolbar
       addLeftWidget(commands.saveSourceDoc().createToolbarButton());
       addLeftWidget(commands.saveAllSourceDocs().createToolbarButton());
       addLeftSeparator();
-      
+
       addLeftWidget(commands.printSourceDoc().createToolbarButton());
-      
+
       addLeftSeparator();
       CodeSearch codeSearch = pCodeSearch_.get();
       codeSearch.setObserver(new CodeSearch.Observer()
@@ -131,32 +133,32 @@ public class GlobalToolbar extends Toolbar
             // Experimental workaround for crashes observed on El Capitan
             Scheduler.get().scheduleFinally(() -> codeSearchFocusContext_.restore());
          }
-         
+
          @Override
          public void onCompleted()
          {
             Scheduler.get().scheduleFinally(() -> codeSearchFocusContext_.clear());
          }
-         
+
          @Override
          public String getCueText()
          {
             return null;
          }
       });
-      
+
       searchWidget_ = codeSearch.getSearchWidget();
-      addLeftWidget(searchWidget_); 
+      addLeftWidget(searchWidget_);
    }
-   
+
    public void completeInitialization(SessionInfo sessionInfo)
-   { 
+   {
       StandardIcons icons = StandardIcons.INSTANCE;
-      
+
       if (sessionInfo.isVcsEnabled())
       {
          addLeftSeparator();
-      
+
          ToolbarPopupMenu vcsMenu = new ToolbarPopupMenu();
          vcsMenu.addItem(commands_.vcsFileDiff().createMenuItem(false));
          vcsMenu.addItem(commands_.vcsFileLog().createMenuItem(false));
@@ -174,27 +176,27 @@ public class GlobalToolbar extends Toolbar
          vcsMenu.addItem(commands_.vcsShowHistory().createMenuItem(false));
          vcsMenu.addSeparator();
          vcsMenu.addItem(commands_.versionControlProjectSetup().createMenuItem(false));
-      
+
          ImageResource vcsIcon = null;
-         if (sessionInfo.getVcsName() == VCSConstants.GIT_ID)
+         if (StringUtil.equals(sessionInfo.getVcsName(), VCSConstants.GIT_ID))
             vcsIcon = new ImageResource2x(icons.git2x());
-         else if (sessionInfo.getVcsName() == VCSConstants.SVN_ID)
+         else if (StringUtil.equals(sessionInfo.getVcsName(), VCSConstants.SVN_ID))
             vcsIcon = new ImageResource2x(icons.svn2x());
-         
+
          ToolbarMenuButton vcsButton = new ToolbarMenuButton(
                ToolbarButton.NoText,
                "Version control",
-               vcsIcon, 
+               vcsIcon,
                vcsMenu);
          ElementIds.assignElementId(vcsButton, ElementIds.VCS_MENUBUTTON);
          addLeftWidget(vcsButton);
       }
-      
+
       // zoom button
       addLeftSeparator();
-      
+
       ToolbarPopupMenu paneLayoutMenu = new ToolbarPopupMenu();
-      
+
       paneLayoutMenu.addItem(commands_.layoutEndZoom().createMenuItem(false));
       paneLayoutMenu.addSeparator();
       paneLayoutMenu.addItem(commands_.layoutConsoleOnLeft().createMenuItem(false));
@@ -215,7 +217,7 @@ public class GlobalToolbar extends Toolbar
       paneLayoutMenu.addItem(commands_.layoutZoomVcs().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomBuild().createMenuItem(false));
       paneLayoutMenu.addItem(commands_.layoutZoomConnections().createMenuItem(false));
-      
+
       ImageResource paneLayoutIcon = new ImageResource2x(ThemeResources.INSTANCE.paneLayoutIcon2x());
       ToolbarMenuButton paneLayoutButton = new ToolbarMenuButton(
             ToolbarButton.NoText,
@@ -224,10 +226,10 @@ public class GlobalToolbar extends Toolbar
             paneLayoutMenu);
       ElementIds.assignElementId(paneLayoutButton, ElementIds.PANELAYOUT_MENUBUTTON);
       addLeftWidget(paneLayoutButton);
-      
+
       // addins menu
       addLeftWidget(new AddinsToolbarButton());
-      
+
       // project popup menu
       if (sessionInfo.getAllowFullUI())
       {
@@ -236,24 +238,28 @@ public class GlobalToolbar extends Toolbar
          addRightWidget(projectMenu.getToolbarButton());
       }
    }
-   
+
    @Override
    public int getHeight()
    {
       return 27;
    }
-   
+
    public void focusGoToFunction()
    {
       codeSearchFocusContext_.record();
       FocusHelper.setFocusDeferred((CanFocus)searchWidget_);
    }
-     
+
    public void setFocus()
    {
-      Scheduler.get().scheduleDeferred(() -> newButton_.setFocus(true));
+      Scheduler.get().scheduleDeferred(() ->
+      {
+         newButton_.setFocus(true);
+         A11y.showFocusOutline(newButton_.getElement());
+      });
    }
-   
+
    private final Commands commands_;
    private final ToolbarPopupMenu newMenu_;
    private final ToolbarMenuButton newButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchPane.java
@@ -18,6 +18,7 @@ import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Command;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.WorkbenchView;
@@ -70,8 +71,7 @@ public abstract class WorkbenchPane extends ToolbarPane
       {
          Element el = focusableElements.get(0);
          el.focus();
-         el.addClassName("focus-visible");
-         addRemoveFocusVisibleHandler(el);
+         A11y.showFocusOutline(el);
       }
       else
          Debug.logWarning("Could not set focus, no focusable element on " + title_ + " pane");
@@ -88,7 +88,7 @@ public abstract class WorkbenchPane extends ToolbarPane
    {
       return false;
    }
-   
+
    @Override
    public void confirmClose(Command onConfirmed)
    {
@@ -103,13 +103,6 @@ public abstract class WorkbenchPane extends ToolbarPane
       super.bringToFront();
    }
 
-   private native void addRemoveFocusVisibleHandler(Element el) /*-{
-      el.addEventListener('blur', function(e) {
-         el.classList.remove('focus-visible');
-      });
-
-   }-*/;
-
-   private String title_;
+   private final String title_;
    protected final EventBus events_;
 }


### PR DESCRIPTION
- Fixes #6619

### Intent

The "Focus Main Toolbar" command is intended for keyboard users so focus rectangle should always show on the selected toolbar button after using, but sometimes it wasn't. Timing related, so was inconsistent (varying by whether keyboard shortcut was used, or the menu itself).

### Approach

Rather than relying on the focus-visible polyfill to correctly deduce that focus should be displayed, do it explicitly in code.

Also changed a couple of unrelated string comparisons to the preferred `StringUtil.equals` approach while I was in there.

### QA Notes

Ensure the focus rectangle is shown after using the Help / Accessibility / Focus / Focus Main Toolbar command, whether via keyboard shortcut or the main menu (desktop or server). Note there are known cosmetic issues with this focus rectangle, see #7604.

Also make sure the focus rectangle goes away when focus goes elsewhere both by using the keyboard (Tab or another keyboard shortcut that moves focus) or by clicking somewhere else.

Also do a very quick check that the focus indicators shown when using "F6 - Focus Next Pane" and "Shift+F6 - Focus Previous Pane" are being removed as focus moves around as I touched that code as well.