### PR TITLE
Refine Home/End logic for Mac

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/basekeys.ts
+++ b/src/gwt/panmirror/src/editor/src/api/basekeys.ts
@@ -145,15 +145,22 @@ export function verticalArrowCanAdvanceWithinTextBlock(selection: Selection, dir
   return false;
 }
 
+interface Coords {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
 function homeKey(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView) {
   const selection = state.selection;
   const editingNode = editingRootNode(selection);
   if (editingNode && dispatch && view) {
-    const selectionY = view.coordsAtPos(selection.from).top;
+    const head = view.coordsAtPos(selection.head);
     const beginDocPos = editingNode.start;
     for (let pos = (selection.from - 1); pos >= beginDocPos; pos--) {
-      const posY = view.coordsAtPos(pos).top;
-      if (isOnPreviousLine(selectionY, posY) || pos === beginDocPos) {
+      const coords = view.coordsAtPos(pos);
+      if (isOnPreviousLine(head, coords) || pos === beginDocPos) {
         const tr = state.tr;
         setTextSelection(pos + 1)(tr);
         dispatch(tr);
@@ -168,11 +175,11 @@ function endKey(state: EditorState, dispatch?: (tr: Transaction) => void, view?:
   const selection = state.selection;
   const editingNode = editingRootNode(selection);
   if (editingNode && dispatch && view) {
-    const selectionY = view.coordsAtPos(selection.from).top;
+    const head = view.coordsAtPos(selection.head);
     const endDocPos = editingNode.start + editingNode.node.nodeSize;
     for (let pos = (selection.from + 1); pos < endDocPos; pos++) {
-      const posY = view.coordsAtPos(pos).top;
-      if (isOnNextLine(selectionY, posY)) {
+      const coords = view.coordsAtPos(pos);
+      if (isOnNextLine(head, coords) || pos == endDocPos) {
         const tr = state.tr;
         setTextSelection(pos - 1)(tr);
         dispatch(tr);
@@ -187,14 +194,17 @@ function endKey(state: EditorState, dispatch?: (tr: Transaction) => void, view?:
 
 // y coorinates are sometimes off by 1 or 2 due to margin/padding (e.g. for
 // inline code spans or spelling marks) so the comparision only succeeds if 
-// there is sufficint overall distance between the positions
+// the vertical extents of the two coords don't overlap. If this proves to
+// still have false positives, we could lookahead to the next a few dozen
+// positions to check if we ever "return to" the head's baseline--only a
+// permanent change would indicate that the line has truly changed.
 
-function isOnNextLine(selectionY: number, posY: number) {
-  return Math.abs(posY - selectionY) > 2 && posY > selectionY;
+function isOnNextLine(head: Coords, pos: Coords) {
+  return head.bottom < pos.top;
 }
 
-function isOnPreviousLine(selectionY: number, posY: number) {
-  return Math.abs(posY - selectionY) > 2 && posY < selectionY;
+function isOnPreviousLine(head: Coords, pos: Coords) {
+  return head.top > pos.bottom;
 }
 
 


### PR DESCRIPTION
This PR changes the way our custom home/end logic detects the start of the next line or end of the previous line. Previously, the top of the bounding boxes were compared, if they were within 2 pixels of each other then it'd be considered the same line. Now, we check if the bounding boxes vertically overlap at all, if so then it's considered the same line.

However there still seems to be an issue with the custom logic. With a paragraph like this:

![Screenshot from 2020-08-18 12-26-32](https://user-images.githubusercontent.com/129551/90556893-7a133800-e14e-11ea-9a87-9e768508382a.png)

1. Place cursor anywhere on the first line, and press End. Instead of the end of the first line, the cursor ends up at the beginning of the second line.
2. Place cursor somewhere in the middle of the second line, and press Home. Instead of before `sv_required`, the cursor ends up one position to the right of that (between the `s` and `v`).

These bugs don't happen if the line doesn't begin with a code span.