### PR TITLE
Make sure element isn't hidden before highlighting

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/UserInterfaceHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/UserInterfaceHighlighter.java
@@ -367,18 +367,36 @@ public class UserInterfaceHighlighter
          
          DOMRect bounds = ElementEx.getBoundingClientRect(monitoredEl);
          
-         int top = scrollY + bounds.getTop();
+         int top = bounds.getTop();
          int left = scrollX + bounds.getLeft();
          int width = bounds.getWidth();
          int height = bounds.getHeight();
-         
+
          // Ignore out-of-bounds elements.
          if (width == 0 || height == 0)
          {
             highlightEl.getStyle().setVisibility(Visibility.HIDDEN);
             continue;
          }
-         
+
+         // Ignore if monitoredEl is hidden by a scrollable parent.
+         Element el = monitoredEl.getParentElement();
+         while (el != Document.get().getBody())
+         {
+            bounds = ElementEx.getBoundingClientRect(el);
+            if (bounds.getHeight() > 0 &&
+               ((top + height) <= bounds.getTop() ||
+                 top > bounds.getBottom()))
+            {
+               highlightEl.getStyle().setVisibility(Visibility.HIDDEN);
+               break;
+            }
+            el = el.getParentElement();
+         }
+         if (StringUtil.equals(Visibility.HIDDEN.getCssName(),
+                               highlightEl.getStyle().getVisibility()))
+            continue;
+
          // Avoid using too-narrow highlights.
          if (width < 20)
          {
@@ -386,7 +404,8 @@ public class UserInterfaceHighlighter
             left = left - (rest / 2);
             width = 20;
          }
-         
+
+         top += scrollY;
          style.setTop(top, Unit.PX);
          style.setLeft(left, Unit.PX);
          style.setWidth(width, Unit.PX);


### PR DESCRIPTION
### Intent

Fixes #7607 
On a highlight event, elements were being highlighted even when they were hidden by a parent scrollable widget. 

### Approach

I added an additional check before the highlight is displayed to check the bounds of the element to be highlighted against the bounds of its parent elements.  If the element is outside of any of its parent's bounds then its highlight is hidden.


### QA Notes

See reproduction steps in #7607. 

