### PR TITLE
Fix startup issues with multiple source columns

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
@@ -513,6 +513,12 @@ public class DualWindowLayoutPanel extends SimplePanel
    public void replaceWindows(LogicalWindow windowA,
                               LogicalWindow windowB)
    {
+      // If there is nothing to replace, we don't want to reset the state and potentially open
+      // something the user had minimized.
+      if (windowA == windowA_ &&
+          windowB == windowB_)
+         return;
+
       unhookEvents();
       windowA_ = windowA;
       windowB_ = windowB;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -106,6 +106,20 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
 
          return true;
       }
+
+      public final boolean validate()
+      {
+         if (hasSplitterPos() && hasWindowWidth())
+         {
+            for (int i = 0; i < getSplitterPos().length; i++)
+            {
+               if (getSplitterPos()[i] < 0 ||
+                   getSplitterPos()[i] > getPanelWidth())
+                  return false;
+            }
+         }
+         return true;
+      }
    }
 
    @Inject
@@ -138,7 +152,9 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
          {
             // If we already have a set state, with the correct number of columns use that
             State state = value == null ? null : (State)value.cast();
-            if (state != null && state.hasSplitterPos() &&
+            if (state != null &&
+                state.validate() &&
+                state.hasSplitterPos() &&
                 state.getSplitterCount() == leftList_.size() + 1)
             {
                if (state.hasPanelWidth() && state.hasWindowWidth()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -329,9 +329,14 @@ public class PaneManager
          for (int i = 0; i < docs.length(); i++)
          {
             String docWindowId = docs.get(i).getSourceWindowId();
-            String columnName = docs.get(i).getSourceDisplayName();
-            LogicalWindow columnWindow =
-               getParentLogicalWindow(sourceColumnManager_.getByName(columnName).asWidget().getElement());
+
+            // Check the SourceColumn of the SourceDocument. If for some reason we cannot find
+            // it's column, default to the main source window.
+            SourceColumn column =
+               sourceColumnManager_.getByName(docs.get(i).getSourceDisplayName());
+            LogicalWindow columnWindow = column == null ? sourceLogicalWindows_.get(0) :
+               getParentLogicalWindow(column.asWidget().getElement());
+
             if (docWindowId == windowId &&
                 window == columnWindow)
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -331,7 +331,7 @@ public class PaneManager
             String docWindowId = docs.get(i).getSourceWindowId();
 
             // Check the SourceColumn of the SourceDocument. If for some reason we cannot find
-            // it's column, default to the main source window.
+            // its column, default to the main source window.
             SourceColumn column =
                sourceColumnManager_.getByName(docs.get(i).getSourceDisplayName());
             LogicalWindow columnWindow = column == null ? sourceLogicalWindows_.get(0) :

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -319,22 +319,26 @@ public class PaneManager
       }
       panel_.initialize(sourceColumns, left_, right_);
 
-      // count the number of source docs assigned to this window
-      JsArray<SourceDocument> docs =
-            session_.getSessionInfo().getSourceDocuments();
-      String windowId = SourceWindowManager.getSourceWindowId();
-      int numDocs = 0;
-      for (int i = 0; i < docs.length(); i++)
-      {
-         String docWindowId = docs.get(i).getSourceWindowId();
-         if (docWindowId == windowId)
-         {
-            numDocs++;
-         }
-      }
-
       for (LogicalWindow window : sourceLogicalWindows_)
       {
+         // count the number of source docs assigned to this window
+         JsArray<SourceDocument> docs =
+            session_.getSessionInfo().getSourceDocuments();
+         String windowId = SourceWindowManager.getSourceWindowId();
+         int numDocs = 0;
+         for (int i = 0; i < docs.length(); i++)
+         {
+            String docWindowId = docs.get(i).getSourceWindowId();
+            String columnName = docs.get(i).getSourceDisplayName();
+            LogicalWindow columnWindow =
+               getParentLogicalWindow(sourceColumnManager_.getByName(columnName).asWidget().getElement());
+            if (docWindowId == windowId &&
+                window == columnWindow)
+            {
+               numDocs++;
+            }
+         }
+
          if (numDocs == 0 && window.getState() != WindowState.HIDE)
          {
             window.onWindowStateChange(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -707,7 +707,7 @@ public class Source implements InsertSourceHandler,
          }
       }
       columnManager_.setDocsRestored();
-      columnManager_.beforeShow();
+      columnManager_.beforeShow(true);
    }
    
    private void openEditPublishedDocs()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -1004,8 +1004,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    public void onBeforeShow()
    {
       // All columns aside from the main column should open with a document
-      if (!StringUtil.equals(name_, SourceColumnManager.MAIN_SOURCE_NAME) &&
-          getTabCount() == 0 && newTabPending_ == 0)
+      if (getTabCount() == 0 && newTabPending_ == 0)
       {
          // Avoid scenarios where the Source tab comes up but no tabs are
          // in it. (But also avoid creating an extra source tab when there

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -1003,7 +1003,9 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
    public void onBeforeShow()
    {
-      if (getTabCount() == 0 && newTabPending_ == 0)
+      // All columns aside from the main column should open with a document
+      if (!StringUtil.equals(name_, SourceColumnManager.MAIN_SOURCE_NAME) &&
+          getTabCount() == 0 && newTabPending_ == 0)
       {
          // Avoid scenarios where the Source tab comes up but no tabs are
          // in it. (But also avoid creating an extra source tab when there

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -406,6 +406,16 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       return editors_.size() > 0;
    }
 
+   public boolean hasDirtyDoc()
+   {
+      for (EditingTarget editor : editors_)
+      {
+         if (editor.dirtyState().getValue())
+            return true;
+      }
+      return false;
+   }
+
    public boolean isSaveCommandActive()
    {
       for (EditingTarget target : editors_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1892,10 +1892,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void beforeShow(boolean excludeMain)
    {
-      columnList_.forEach((column) ->{
-         if (!excludeMain || !StringUtil.equals(column.getName(), MAIN_SOURCE_NAME))
-            column.onBeforeShow();
-      });
+      if (!StringUtil.equals(getActive().getName(), MAIN_SOURCE_NAME))
+         activeColumn_.onBeforeShow();
    }
 
    public void beforeShow(String name)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1890,9 +1890,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       }
    }
 
-   public void beforeShow()
+   public void beforeShow(boolean excludeMain)
    {
-      columnList_.forEach((column) -> column.onBeforeShow());
+      columnList_.forEach((column) ->{
+         if (!excludeMain || !StringUtil.equals(column.getName(), MAIN_SOURCE_NAME))
+            column.onBeforeShow();
+      });
    }
 
    public void beforeShow(String name)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1506,6 +1506,11 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             ArrayList<EditingTarget> editors = column.getEditors();
             for (EditingTarget target : editors)
             {
+               if (!target.dirtyState().getValue())
+               {
+                  column.closeTab(target.asWidget(), false);
+                  continue;
+               }
                server_.getSourceDocument(target.getId(),
                   new ServerRequestCallback<SourceDocument>()
                   {
@@ -1892,8 +1897,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void beforeShow(boolean excludeMain)
    {
-      if (!StringUtil.equals(getActive().getName(), MAIN_SOURCE_NAME))
-         activeColumn_.onBeforeShow();
+      columnList_.forEach((column) ->
+      {
+         if (!excludeMain ||
+             !StringUtil.equals(column.getName(), MAIN_SOURCE_NAME))
+            column.onBeforeShow();
+      });
    }
 
    public void beforeShow(String name)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -702,7 +702,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public EditingTarget addTab(SourceDocument doc, boolean atEnd,
                                int mode, SourceColumn column)
    {
-      if (column == null)
+      if (column == null || getByName(column.getName()) == null)
          column = getActive();
       return column.addTab(doc, atEnd, mode);
    }


### PR DESCRIPTION
### Intent

Fixes #7532 

1. Do not open a new source doc in the main source window on start up. Do open a new doc when the Source's state first becomes Normal. This was an unintended regression while implementing additional source columns.

2. Prevent the Source Pane from opening in a `NORMAL` state when the user previously had it minimized. This only happened when the user had other source columns open.

3. Add safe guard to prevent mysterious "Invalid pane splitter" exception.


### Approach

1. When loading multiple source columns, we need to manually call `beforeShow` (which ensures columns open with a document) because it's only called before `Source` restores previous documents and therefore does nothing. Since we are ok with the main source pane opening without a file, I added a `boolean excludeMain` parameter to `SourceColumnManager::beforeShow`.

2. Previously, we were counting the number of documents open across all source columns to decide if we needed to change the state for each column. Now we only count the documents open in that column.

3. Added an additional step to validate the MainSplitPanel's previous state before attempting to reuse it. I still need to determine what is wrong with how we're saving the state and causing this issue.


### QA Notes

The logic for how panes are configured at startup is fragile and allowing additional source columns further complicates things. I tested restarting RStudio in a variety of ways with the main source window minimized without any documents (e.g 1-3 columns, columns have untitled docs, dirty docs, etc.) but it could use additional review to make sure it behaves as similarly to 1.3 as possible. 