### PR TITLE
show matplotlib plots in Plots pane when invoked from R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 * Pressing F1 when the Python completion list is shown now opens the relevant Help documentation. (#5982)
 * Python objects are now shown in the Environment Pane when `reticulate` REPL is active. (#6862)
 * Python objects can now be viewed using the Data Viewer and Object Explorer. (#6862)
+* The `matplotlib.pyplot.show()` function now displays PNG plots within the Plots pane. (#4965)
+* Plots generated via `matplotlib` are now shown with a higher DPI in the Plots pane when appropriate.
 
 ### Plots
 

--- a/src/cpp/session/modules/SessionGraphics.cpp
+++ b/src/cpp/session/modules/SessionGraphics.cpp
@@ -20,8 +20,10 @@
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
 #include <r/ROptions.hpp>
+#include <r/RRoutines.hpp>
 
 #include <r/session/RGraphicsConstants.h>
+#include <r/session/RGraphics.hpp>
 
 #include <session/prefs/UserPrefs.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -49,6 +51,13 @@ void syncWithPrefs()
 void onPreferencesSaved()
 {
    syncWithPrefs();
+}
+
+SEXP rs_devicePixelRatio()
+{
+   double ratio = r::session::graphics::device::devicePixelRatio();
+   r::sexp::Protect protect;
+   return r::sexp::create(ratio, &protect);
 }
 
 } // end anonymous namespace
@@ -82,6 +91,8 @@ core::Error initialize()
    events().onPreferencesSaved.connect(onPreferencesSaved);
    
    syncWithPrefs();
+   
+   RS_REGISTER_CALL_METHOD(rs_devicePixelRatio);
    
    using boost::bind;
    ExecBlock initBlock;


### PR DESCRIPTION
### Intent

This PR ensures that `matplotlib` plots created via R code (using the `reticulate` interface) are displayed within the RStudio Plots pane.

### Approach

Previously, RStudio did some work to ensure that the `matplotlib` show function was only hooked when the `reticulate` REPL was active. Now, we ensure that hook is always active.

### QA Notes

Test `matplotlib` plots, both as detailed in https://github.com/rstudio/rstudio/issues/4965, and perhaps by following example code from https://matplotlib.org/3.1.1/tutorials/introductory/sample_plots.html. Note that plots will not show up in the Plots pane until you call the `plt.show()` method.