### PR TITLE
guard against missing bin directory in tinytex install

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -525,9 +525,21 @@
    
    # NOTE: binary directory has a single arch-specific subdir;
    # rather than trying to hard-code the architecture we just
-   # infer it directly
+   # infer it directly.
+   #
+   # some users will end up with tinytex installations that
+   # 'exist', but are broken for some reason (no longer have
+   # a 'bin' directory). detect those cases properly
+   #
+   # https://github.com/rstudio/rstudio/issues/7615
    bin <- file.path(root, "bin")
+   if (!file.exists(bin))
+      return(NULL)
+
    subbin <- list.files(bin, full.names = TRUE)
+   if (length(subbin) == 0)
+      return(NULL)
+
    normalizePath(subbin[[1]], mustWork = TRUE)
 })
 


### PR DESCRIPTION
### Intent

Fix https://github.com/rstudio/rstudio/issues/7615.

### Approach

Properly validate that the TinyTex installation directory contains the directories we expect it to have.

### QA Notes

Test by installing tinytex; e.g.

```
install.packages("tinytex")
tinytex::install_tinytex()
```

And then try removing the `bin` directory; e.g.

```
rootDir <- tinytex:::tinytex_root()
binDir <- file.path(rootDir, "bin")
unlink(binDir, recursive = TRUE)
```

and then follow repro steps in https://github.com/rstudio/rstudio/issues/7615.