### PR TITLE
Make auth-none work like any other auth

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -6,3 +6,4 @@
 - Fix an issue where syslog and monitor log entries could contain newlines in them, preventing the admin logs page from properly displaying log entries (Pro #1782)
 - Fix an issue where failing to open the Slurm job output file could result in hanging `tail -f` child processes (Pro #1856)
 - Fix an issue where a delay in the creation of the Slurm job output file could result in a hanging "Determining session network" page when opening a session (Pro #1792)
+- Fix an issue where `auth-none` would not load sessions (#7575)

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -151,10 +151,7 @@ std::string applicationSignInURL(const http::Request& request,
 
 std::string getUserIdentifier(const core::http::Request& request)
 {
-   if (server::options().authNone())
-      return core::system::username();
-   else
-      return core::http::secure_cookie::readSecureCookie(request, kUserIdCookie);
+   return core::http::secure_cookie::readSecureCookie(request, kUserIdCookie);
 }
 
 std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
@@ -262,6 +259,12 @@ void signIn(const http::Request& request,
       return;
    }
 
+   if (server::options().authNone())
+   {
+      auth::handler::setSignInCookies(request, core::system::username(), false, pResponse);
+      pResponse->setMovedTemporarily(request, "./");
+      return;
+   }
 
    std::map<std::string,std::string> variables;
    variables["action"] = applicationURL(request, kDoSignIn);


### PR DESCRIPTION
Closes #7575 

### Intent

This PR allows `auth-none` to work along with the several changes and fixes made in the authentication by making it close as possible of the usual authentication flow.

### Approach

Cookies like `user-id` and `csrf-token` are required throughout the server for several operations. Previously, the CSRF cookie would be set in the first load of the main page route (`"/"`) and the `user-id` cookie would not be set at this point (surprisingly, we never saw problems because of this). Eventually, the missing cookie would be set by a `refreshAuthCookies` event.

With this change, an initial visit to the main page route (`"/"`) will force a redirect to `/auth-sign-in` which then will verify for `auth-none` and redirect back to with the proper cookies set. The rest of the logic now work like usual PAM auth.

### QA Notes

Test with and without `auth-none=1`.

