### PR TITLE
Fix navigateToPosition to by default move the cursor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3065,7 +3065,7 @@ public class AceEditor implements DocDisplay,
    public void navigateToPosition(SourcePosition position,
                                   boolean recordCurrent)
    {
-      navigateToPosition(position, recordCurrent, false, true);
+      navigateToPosition(position, recordCurrent, false, false);
    }
 
    @Override


### PR DESCRIPTION
### Intent

Fix code navigation commands so they move the cursor as well as display the desired position.

### Approach

In #7596 I broke this code by setting the new `restoreCursorPosition` to true instead of false in one of the calls to `navigateToPosition`. This change switches it to false to preserve the original behavior.



