### PR TITLE
Prevent spurious warning about no-focusable element when showing dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -797,6 +797,9 @@ public abstract class ModalDialogBase extends DialogBox
     */
    public void refreshFocusableElements()
    {
+      if (!DomUtils.isEffectivelyVisible(getElement()))
+         return;
+
       ArrayList<Element> focusable = getFocusableElements();
       if (focusable.size() == 0)
       {


### PR DESCRIPTION
- Fixes #7638
- Caused when setting selected pref pane multiple times during dialog load (before it was actually displayed)
- Fixed by checking if dialog is actually visible (and hence potentially focusable) when determining focusable elements

### Intent

Opening certain modal dialogs (especially the Project Preferences dialog) would trigger a warning in Javascript console saying "No potentially focusable controls found in modal dialog".

### Approach

Caused if code for determining focusable controls in a dialog is triggered before the dialog is actually visible, fixed by checking if dialog is visible before running this code.

### QA Notes

No known end-user problems here, just getting rid of noise in the Javascript console. Leaving in the error check as it is useful to know (as a developer) if we have a dialog that fails to set initial keyboard focus, but that was not the case here; focus was being set successfully.