### PR TITLE
Persist minimized state for main source pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1335,6 +1335,8 @@ public class PaneManager
 
    private Widget createSourceColumnWindow(String name)
    {
+      if (panesByName_.get(name) != null)
+         return panesByName_.get(name).getNormal();
       panesByName_.put(name, createSource(name, sourceColumnManager_.getWidget(name)));
 
       PaneConfig paneConfig = getCurrentConfig();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -338,9 +338,9 @@ public class PaneManager
                StringUtil.equals(column.getName(), SourceColumnManager.MAIN_SOURCE_NAME)) ?
                true : false;
 
-               LogicalWindow columnWindow = mainSourceWindow ?
-                                            sourceLogicalWindows_.get(0) :
-                                            getParentLogicalWindow(column.asWidget().getElement());
+            LogicalWindow columnWindow = mainSourceWindow ?
+                                         sourceLogicalWindows_.get(0) :
+                                         getParentLogicalWindow(column.asWidget().getElement());
 
             if (StringUtil.equals(docWindowId, windowId) &&
                 (columnWindow == null && mainSourceWindow ||

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -334,11 +334,17 @@ public class PaneManager
             // its column, default to the main source window.
             SourceColumn column =
                sourceColumnManager_.getByName(docs.get(i).getSourceDisplayName());
-            LogicalWindow columnWindow = column == null ? sourceLogicalWindows_.get(0) :
-               getParentLogicalWindow(column.asWidget().getElement());
+            boolean mainSourceWindow = (column == null ||
+               StringUtil.equals(column.getName(), SourceColumnManager.MAIN_SOURCE_NAME)) ?
+               true : false;
+
+               LogicalWindow columnWindow = mainSourceWindow ?
+                                            sourceLogicalWindows_.get(0) :
+                                            getParentLogicalWindow(column.asWidget().getElement());
 
             if (StringUtil.equals(docWindowId, windowId) &&
-                window == columnWindow)
+                (columnWindow == null && mainSourceWindow ||
+                 window == columnWindow))
             {
                numDocs++;
             }


### PR DESCRIPTION
### Intent

Fixes #7532 (See Aug 25 comment)

If a user leave RStudio with the main source pane minimized and an edited untitled document, the source pane should be restored with the state set to `MINIMIZED` instead of `HIDE`. This is consistent with previous releases.

### Approach

On restoration, there was a rare case where a document wouldn't be counted when its column was found but the window for that column was not found. This change assumes the window is the main source window, which should always be the case.

### QA Notes

From original PR #7617: 
The logic for how panes are configured at startup is fragile and allowing additional source columns further complicates things. I tested restarting RStudio in a variety of ways with the main source window minimized without any documents (e.g 1-3 columns, columns have untitled docs, dirty docs, etc.) but it could use additional review to make sure it behaves as similarly to 1.3 as possible.


