### PR TITLE
Reduce number of cores used for official build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def compile_package(os, type, flavor, variant) {
 
   // currently our nodes have access to 4 cores, so spread out the compile job
   // a little (currently using up all 4 cores causes problems)
-  env = "${env} MAKEFLAGS=-j3"
+  env = "${env} MAKEFLAGS=-j2"
 
   // perform the compilation
   sh "cd package/linux && ${env} ./make-${flavor}-package ${type} clean ${variant} && cd ../.."


### PR DESCRIPTION
### Intent

Open-source build pipeline keeps failling, killing all the jobs with what looks like memory errors.

### Approach

Reduce parallel build number to see if that gets us some working builds while we investigate a better solution such as serializing the Java and C++ portion of the builds.

### QA Notes

Purely a build issue; if builds stop failing, this worked.
