### PR TITLE
Update `plumber.swagger.url` option to `plumber.docs.callback`

### DIFF
--- a/src/cpp/session/modules/SessionPlumberViewer.R
+++ b/src/cpp/session/modules/SessionPlumberViewer.R
@@ -26,18 +26,25 @@
 }, attrs = list(plumberViewerType = "browser"), envir = baseenv())
 
 .rs.addFunction("setPlumberViewerType", function(type) {
-   if (identical(type, "none"))
-      options(plumber.swagger.url = NULL)
-   else if (identical(type, "pane"))
-      options(plumber.swagger.url = .rs.invokePlumberPaneViewer)
-   else if (identical(type, "window"))
-      options(plumber.swagger.url = .rs.invokePlumberWindowViewer)
-   else if (identical(type, "browser"))
-      options(plumber.swagger.url = .rs.invokePlumberWindowExternal)
+   viewer <-
+      if (identical(type, "none"))
+          NULL
+      else if (identical(type, "pane"))
+          .rs.invokePlumberPaneViewer
+      else if (identical(type, "window"))
+          .rs.invokePlumberWindowViewer
+      else if (identical(type, "browser"))
+          .rs.invokePlumberWindowExternal
+  options(
+    # plumber >= v1.0.0
+    plumber.docs.callback = viewer,
+    # plumber < v1.0.0
+    plumber.swagger.url = viewer
+  )
 })
 
 .rs.addFunction("getPlumberViewerType", function() {
-   viewer <- getOption("plumber.swagger.url")
+   viewer <- getOption("plumber.docs.callback", getOption("plumber.swagger.url"))
    if (identical(viewer, FALSE))
       return("none")
    else if (identical(viewer, TRUE))

--- a/src/cpp/session/modules/SessionPlumberViewer.cpp
+++ b/src/cpp/session/modules/SessionPlumberViewer.cpp
@@ -188,7 +188,7 @@ Error getPlumberRunCmd(const json::JsonRpcRequest& request,
 
 Error initPlumberViewerPref(boost::shared_ptr<std::string> pPlumberViewerType)
 {
-   SEXP plumberBrowser = r::options::getOption("plumber.swagger.url");
+   SEXP plumberBrowser = r::options::getOption("plumber.docs.callback");
    *pPlumberViewerType = prefs::userPrefs().plumberViewerType();
    if (plumberBrowser == R_NilValue)
    {


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/7702

### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Related: https://github.com/rstudio/plumber/pull/658/files#diff-336a56f6c4950b52b1c80583d5070e64R96

The new version of plumber would like to listen to `plumber.docs.callback` (vs `plumber.swagger.url`). Currently it works for both, but I'd like to eventually stop support for `plumber.swagger.url`.

Setting both options doesn't seem like it should hurt anything.  This would allow for both legacy support and moving forward.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Set both options. Use the latest option when possible.  

* The option retrieval in the R code and Rcpp code is not consistent 
  * I do not know if you'd like to have a fallback option given both options are actually being set.
  * I do not know how to implement a fallback option in Rcpp. 😞 

### QA Notes

Install the dev version of `plumber`. `remotes::install_github("rstudio/plumber")`

Once an R session is established, set `options(plumber.swagger.url = NULL)`. This should remove the IDE's set option. 

Run a plumber API. `plumber::plumb_api("plumber", "04-mean-sum")$run()`. The api show display in the selected viewer location.

Before this PR, nothing will display if `options(plumber.swagger.url = NULL)`.
