### PR TITLE
Fixes an occasional sessions start-up crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 build_*/
 build-*/
 *-build/
+*_build/
+*-build-*/
+*_build_*/
 qtcreator-build
 .DS_Store
 src/gwt/www/js/acesupport.js

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -325,8 +325,48 @@ public:
       // validated!
       return true;
    }
+   
+   bool operator>(const ActiveSession& rhs) const
+   {
+      if (sortConditions_.executing_ == rhs.sortConditions_.executing_)
+      {
+         if (sortConditions_.running_ == rhs.sortConditions_.running_)
+         {
+            if (sortConditions_.lastUsed_ == rhs.sortConditions_.lastUsed_)
+               return id() > rhs.id();
 
-private:
+            return sortConditions_.lastUsed_ > rhs.sortConditions_.lastUsed_;
+         }
+
+         return sortConditions_.running_;
+      }
+      
+      return sortConditions_.executing_;
+   }
+
+ private:
+   struct SortConditions
+   {
+      SortConditions() :
+         executing_(false),
+         running_(false),
+         lastUsed_(0)
+      {
+         
+      }
+
+      bool executing_;
+      bool running_;
+      double lastUsed_;
+   };
+
+   void cacheSortConditions()
+   {
+      sortConditions_.executing_ = executing();
+      sortConditions_.running_ = running();
+      sortConditions_.lastUsed_ = lastUsed();
+   }
+ 
 
    void setRunning(bool running)
    {
@@ -344,6 +384,7 @@ private:
    std::string id_;
    FilePath scratchPath_;
    FilePath propertiesPath_;
+   SortConditions sortConditions_;
 };
 
 

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -107,28 +107,7 @@ namespace {
 bool compareActivityLevel(boost::shared_ptr<ActiveSession> a,
                           boost::shared_ptr<ActiveSession> b)
 {
-   if (a->executing() == b->executing())
-   {
-      if (a->running() == b->running())
-      {
-         if (a->lastUsed() == b->lastUsed())
-         {
-            return a->id() > b->id();
-         }
-         else
-         {
-            return a->lastUsed() > b->lastUsed();
-         }
-      }
-      else
-      {
-         return a->running();
-      }
-   }
-   else
-   {
-      return a->executing();
-   }
+   return *a > *b;
 }
 
 } // anonymous namespace
@@ -159,6 +138,10 @@ std::vector<boost::shared_ptr<ActiveSession> > ActiveSessions::list(
          {
             if (pSession->validate(userHomePath, projectSharingEnabled))
             {
+               // Cache the sort conditions to ensure compareActivityLevel will provide a strict weak ordering.
+               // Otherwise, the conditions on which we sort (e.g. lastUsed()) can be updated on disk during a sort
+               // causing an occasional segfault.
+               pSession->cacheSortConditions();
                sessions.push_back(pSession);
             }
             else


### PR DESCRIPTION
### Intent

When many sessions are being started simultaneously, the `std::sort` of an  `std::vector<boost::shared_ptr<ActiveSession> >` inside `ActiveSessions::lists` segfaults due to a bad memory access. The method is single threaded and the vector being sorted is created on the stack within the method. 

[A valgrind log of the crash](https://github.com/rstudio/rstudio/files/5139040/rsession-diagnostics-maria-6a3f32b2.log.memcheck.txt)

### Approach

~Many different solutions to this problem were tried, including using `std::shared_ptr` or even raw pointers instead of boost pointers. The only change that seems to have worked is this method of creating the `ActiveSession` objects on the stack instead of the heap, sorting that vector, and then transforming the sorted vector to a vector of `shared_ptrs`~

Once we discovered the real problem there were two possible solutions:
1. Don't sort the list of `ActiveSession` objects.
2. Ensure that the state of the `ActiveSession` objects (at least the parts that are used in sort) won't change for the duration of the sort.

The first option is ruled out by the fact that we do occasionally rely on the order of the active sessions to get the most recently used session ([see here for example](https://github.com/rstudio/rstudio-pro/blob/master/src/cpp/session/workspaces/WorkspacesServer.cpp#L311-L318)). 

For the second option, we could have implemented some form of file locking so that the session state files cannot be modified while another session is reading them. We decided this could potentially lead to severe performance issues when many sessions are in use, and is also probably overkill.

Instead, we decided to cache the state that's used for sorting immediately prior to the sort operation and sort based on the cached data instead of the real-time. This can lead to a scenario where the list is not perfectly sorted, however we deemed this an acceptable downside as our usages of "the most recent session" will not fail if the second most recent session (or third, etc.) is accidentally used instead. Additionally, even before this change the state of the sessions could change between the return of `std::sort` and the call to `list.front()`, which means that the list is always in an approximately sorted state anyway.

### QA Notes

This issue is difficult to validate because it occurs only occasionally. It is reproducible in the SolEng Slurm environment (although Slurm itself does not play a direct part in this bug, except by ~maybe impacting timing of the session launch~ allowing many sessions to be launched simultaneously). I would recommend getting environment set up and verifying that the crash is occurring on an older version of the IDE first. I was able to reproduce this by launching 16 sessions in a row as quickly as I could. Once all the sessions have gone from "Pending" to "Idle", some may appear as "Killed" instead.  In the job details page, you should be able to see that the "Killed" sessions exited with code 139 (probably the very last line of the job output). 

I "verified" this issue by repeating the following process  7 - 8 times without a crash:
1. launch 16 sessions as fast as possible
2. wait until all the sessions display as `IDLE`
3. quit each session one at a time (don't use the Quit All button as this sometimes leads to sessions not exiting fully - there's already a bug open for this).
4. wait until all the sessions exit

Prior to the change, the longest number of repeats of the above process before I got at least one crash was 3.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


