### PR TITLE
cherry-pick file-monitor crash fix from master

### DIFF
--- a/NEWS-1.3.md
+++ b/NEWS-1.3.md
@@ -7,3 +7,4 @@
 - Fix an issue where failing to open the Slurm job output file could result in hanging `tail -f` child processes (Pro #1856)
 - Fix an issue where a delay in the creation of the Slurm job output file could result in a hanging "Determining session network" page when opening a session (Pro #1792)
 - Fix an issue where `auth-none` would not load sessions (#7575)
+- Fix session crashing on Windows desktop (#7637, #7652, #7665)


### PR DESCRIPTION
We thought this crash only manifested in very obscure scenarios such as forcing the Windows Desktop IDE to reload the embedded browser but users are hitting it via routine use of the Files pane so are now backporting it from master to next 1.3 patch.

See #7641 for more details.

### Intent

Fix crashes in Windows Desktop sessions when reloading the embedded browser or changing directories in the Files pane.

### Approach

Backported fix from master. #7641

### QA Notes

This is a Windows-desktop specific issue. Test by trying scenarios in #7637, #7652, #7665.

