### PR TITLE
Add commands for showing each Global Options pane directly

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@
 * The Data Viewer now uses the `format()` methods defined for columns entries when available (#7239)
 * Add support for navigating source history with mouse forward/back buttons (#7272)
 * Improved error logging of mistyped usernames when using PAM authentication (#7501)
+* Add ability to go directly to various Global Option panes via Command Palette (#7678)
 
 ### RStudio Server Pro
 

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -876,6 +876,12 @@ public class Application implements ApplicationEventHandlers
          removeTerminalCommands();
       }
 
+      if (!sessionInfo.getAllowVcs())
+         commands_.showVcsOptions().remove();
+
+      if (!sessionInfo.getAllowPublish())
+         commands_.showPublishingOptions().remove();
+
       if (!sessionInfo.getAllowFullUI())
       {
          removeProjectCommands();
@@ -1163,6 +1169,7 @@ public class Application implements ApplicationEventHandlers
       commands_.sendFilenameToTerminal().remove();
       commands_.openNewTerminalAtFilePaneLocation().remove();
       commands_.setTerminalToCurrentDirectory().remove();
+      commands_.closeAllTerminals().remove();
    }
 
    private void removeProjectCommands()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1535,10 +1535,6 @@ well as menu structures (for main menu and popup menus).
         label="Zoom Right Column"
         menuLabel="Zoo_m Right Column"/>
 
-   <cmd id="paneLayout"
-        menuLabel="Pane Layo_ut..."
-        windowMode="main"/>
-
    <cmd id="jumpTo"
         label="Jump To..."
         menuLabel="_Jump To..."
@@ -2920,10 +2916,6 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Send to _Terminal"
         desc="Send the current line or selection to terminal"/>
 
-   <cmd id="showTerminalOptions"
-        menuLabel="_Terminal Options..."
-        windowMode="main"/>
-
    <cmd id="sendFilenameToTerminal"
         menuLabel="Send _Filename to Terminal"
         windowMode="main"/>
@@ -2951,6 +2943,59 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="showOptions"
         menuLabel="_Global Options..."
+        windowMode="main"/>
+
+   <cmd id="showCodeOptions"
+        label="Code Options..."
+        windowMode="main"/>
+
+   <cmd id="showConsoleOptions"
+        label="Console Options..."
+        windowMode="main"/>
+
+   <cmd id="showAppearanceOptions"
+        label="Appearance Options..."
+        windowMode="main"/>
+
+   <cmd id="paneLayout"
+        menuLabel="Pane Layo_ut..."
+        label="Pane Layout Options..."
+        windowMode="main"/>
+
+   <cmd id="showPackagesOptions"
+        label="Packages Options..."
+        windowMode="main"/>
+
+   <cmd id="showRMarkdownOptions"
+        label="R Markdown Options..."
+        windowMode="main"/>
+
+   <cmd id="showSweaveOptions"
+        label="Sweave Options..."
+        windowMode="main"/>
+
+   <cmd id="showSpellingOptions"
+        label="Spelling Options..."
+        windowMode="main"/>
+
+   <cmd id="showVcsOptions"
+        label="Git/SVN Version Control Options..."
+        windowMode="main"/>
+
+   <cmd id="showPublishingOptions"
+        label="Publishing Options..."
+        windowMode="main"/>
+
+   <cmd id="showTerminalOptions"
+        menuLabel="_Terminal Options..."
+        windowMode="main"/>
+
+   <cmd id="showAccessibilityOptions"
+        menuLabel="Accessibility _Options..."
+        windowMode="main"/>
+
+   <cmd id="showPythonOptions"
+        label="Python Options..."
         windowMode="main"/>
 
    <cmd id="modifyKeyboardShortcuts"
@@ -3789,10 +3834,6 @@ well as menu structures (for main menu and popup menus).
    <cmd id="toggleScreenReaderSupport"
         menuLabel="_Screen Reader Support"
         checkable="true"
-        windowMode="main"/>
-
-   <cmd id="showAccessibilityOptions"
-        menuLabel="Accessibility _Options..."
         windowMode="main"/>
 
    <cmd id="showAccessibilityHelp"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -419,6 +419,16 @@ public abstract class
    public abstract AppCommand showShellDialog();
    public abstract AppCommand macPreferences();
    public abstract AppCommand showOptions();
+   public abstract AppCommand showCodeOptions();
+   public abstract AppCommand showConsoleOptions();
+   public abstract AppCommand showAppearanceOptions();
+   public abstract AppCommand showPackagesOptions();
+   public abstract AppCommand showRMarkdownOptions();
+   public abstract AppCommand showSweaveOptions();
+   public abstract AppCommand showSpellingOptions();
+   public abstract AppCommand showVcsOptions();
+   public abstract AppCommand showPublishingOptions();
+   public abstract AppCommand showPythonOptions();
    public abstract AppCommand modifyKeyboardShortcuts();
    public abstract AppCommand showCommandPalette();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.workbench.prefs.views;
 
 import com.google.gwt.core.client.GWT;
 import com.google.inject.Inject;
-import com.google.inject.Provider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +40,11 @@ import org.rstudio.studio.client.workbench.prefs.model.UserState;
 
 public class PreferencesDialog extends PreferencesDialogBase<UserPrefs>
 {
+   /**
+    * Implementation note, when adding a new PreferencesPane, also add a
+    * command for directly showing that pane from the Command Palette. See
+    * WorkbenchScreen.onShowCodeOptions() for an example.
+    */
    @Inject
    public PreferencesDialog(WorkbenchServerOperations server,
                             Session session,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -53,6 +53,16 @@ import org.rstudio.studio.client.workbench.events.*;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.WorkbenchMetrics;
 import org.rstudio.studio.client.workbench.prefs.views.AccessibilityPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.AppearancePreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.CompilePdfPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.ConsolePreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.EditingPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.PackagesPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.PublishingPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.PythonPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.RMarkdownPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.SourceControlPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.SpellingPreferencesPane;
 import org.rstudio.studio.client.workbench.prefs.views.TerminalPreferencesPane;
 import org.rstudio.studio.client.workbench.ui.PaneManager.Tab;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
@@ -384,6 +394,66 @@ public class WorkbenchScreen extends Composite
    void onShowOptions()
    {
       optionsLoader_.showOptions();
+   }
+
+   @Handler
+   void onShowCodeOptions()
+   {
+      optionsLoader_.showOptions(EditingPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowConsoleOptions()
+   {
+      optionsLoader_.showOptions(ConsolePreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowAppearanceOptions()
+   {
+      optionsLoader_.showOptions(AppearancePreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowPackagesOptions()
+   {
+      optionsLoader_.showOptions(PackagesPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowRMarkdownOptions()
+   {
+      optionsLoader_.showOptions(RMarkdownPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowSweaveOptions()
+   {
+      optionsLoader_.showOptions(CompilePdfPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowSpellingOptions()
+   {
+      optionsLoader_.showOptions(SpellingPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowVcsOptions()
+   {
+      optionsLoader_.showOptions(SourceControlPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowPublishingOptions()
+   {
+      optionsLoader_.showOptions(PublishingPreferencesPane.class, true);
+   }
+
+   @Handler
+   void onShowPythonOptions()
+   {
+      optionsLoader_.showOptions(PythonPreferencesPane.class, true);
    }
 
    @Handler


### PR DESCRIPTION
### Intent

Provide ability to go directly to each pane in the Global Options dialog from the command palette.

Fixes #7678

### Approach

Added new commands for panes that didn't already have one (terminal, accessibility, and pane layout already had such commands). The command are:

- Global Options (goes to General pane)
- Code Options...
- Console Options...
- Appearance Options...
- Pane Layout Options...
- Packages Options...
- R Markdown Options...
- Sweave Options...
- Spelling Options...
- Git/SVN Version Control Options...
- Publishing Options...
- Terminal Options...
- Accessibility Options... (note this is a special case as it opens JUST the accessibility pane, no other panes available, this is on purpose to reduce potential confusion for screen reader users)
- Python Options...

### QA Notes

Verify that each commands opens the corresponding pane in Global Options.

Note that three of these panes can be hidden via feature limits in RSP (`allow_shell` for terminal, `allow_publish` for publishing, `allow-vcs` for version control); ensure that when such limits are set, the corresponding command is not shown in the command palette.

Also fixed a tiny issue that was introduced via #3564; if Terminal is disallowed via the "allow_shell" feature limit (RSP) the "Close all Terminals" was not being removed, causing the Tools / Terminal menu to still appear, so now hiding it
