### PR TITLE
don't log monitor interrupt errors

### DIFF
--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -124,9 +124,13 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    // iterate over the names
    for (const std::string& name : names)
    {
-      // check for interrupt
+      // check for interrupt (mark as expected to suppress logging)
       if (boost::this_thread::interruption_requested())
-         return core::systemError(boost::system::errc::interrupted, ERROR_LOCATION);
+      {
+         Error error = core::systemError(boost::system::errc::interrupted, ERROR_LOCATION);
+         error.setExpected();
+         return error;
+      }
 
       // compute the path
       std::string path = rootPath.completeChildPath(name).getAbsolutePath();

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -80,7 +80,7 @@ void addToSystemPath(const FilePath& path, bool prepend)
 
 int exitFailure(const Error& error, const ErrorLocation& loggedFromLocation)
 {
-   if (!error.isExpected())
+   if (error)
       core::log::logError(error, loggedFromLocation);
    return EXIT_FAILURE;
 }

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -291,8 +291,7 @@ int RReadConsole (const char *pmt,
                error = initError;
 
             // log the error if it was unexpected
-            if (!error.isExpected())
-               LOG_ERROR(error);
+            LOG_ERROR(error);
             
             // terminate the session (use suicide so that no special
             // termination code runs -- i.e. call to setAbnormalEnd(false)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1594,9 +1594,8 @@ namespace {
 int sessionExitFailure(const core::Error& error,
                        const core::ErrorLocation& location)
 {
-   if (!error.isExpected())
+   if (error)
       core::log::logError(error, location);
-
    return EXIT_FAILURE;
 }
 

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -37,9 +37,6 @@ namespace core {
 
 namespace {
 
-constexpr const char* s_errorExpected = "expected";
-constexpr const char* s_errorExpectedValue = "yes";
-
 constexpr const char* s_occurredAt = "OCCURRED AT";
 constexpr const char* s_causedBy = "CAUSED BY";
 
@@ -182,6 +179,7 @@ struct Error::Impl
    ErrorProperties Properties;
    Error Cause;
    ErrorLocation Location;
+   bool Expected = false;
 };
 
 // This is a shallow copy because deep copy will only be performed on a write.
@@ -423,12 +421,12 @@ std::string Error::getSummary() const
 
 bool Error::isExpected() const
 {
-   return getProperty(s_errorExpected) == s_errorExpectedValue;
+   return m_impl->Expected;
 }
 
 void Error::setExpected()
 {
-   addProperty(s_errorExpected, s_errorExpectedValue);
+   m_impl->Expected = true;
 }
 
 void Error::copyOnWrite()

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -287,27 +287,32 @@ std::string cleanDelimiters(const std::string& in_str)
 
 void logError(const Error& in_error)
 {
-   logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString());
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString());
 }
 
 void logError(const Error& in_error, const ErrorLocation& in_location)
 {
-   logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString(), "", in_location);
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::ERR, in_error.asString(), "", in_location);
 }
 
 void logErrorAsWarning(const Error& in_error)
 {
-   logger().writeMessageToDestinations(LogLevel::WARN, in_error.asString());
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::WARN, in_error.asString());
 }
 
 void logErrorAsInfo(const Error& in_error)
 {
-   logger().writeMessageToDestinations(LogLevel::INFO, in_error.asString());
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::INFO, in_error.asString());
 }
 
 void logErrorAsDebug(const Error& in_error)
 {
-   logger().writeMessageToDestinations(LogLevel::DEBUG, in_error.asString());
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::DEBUG, in_error.asString());
 }
 
 void logErrorMessage(const std::string& in_message, const std::string& in_section)

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -494,6 +494,8 @@ public:
 
    /**
     * @brief Sets the property that indicates that this error was expected.
+    *        Errors are unexpected by default; only unexpected errors will be logged.
+    *        Expected errors can be marked as such to suppress logging of those errors.
     */
    void setExpected();
 


### PR DESCRIPTION
### Intent

Fix an issue where noisy file monitor errors could be logged on session restart.

### Approach

Mark file monitor errors as expected; suppress logging of expected errors.

### QA Notes

This is an issue that reproduces purely in development builds -- nothing to verify for QA.