### PR TITLE
fix range analysis warnings in newest clang

### DIFF
--- a/src/cpp/core/ConfigProfile.cpp
+++ b/src/cpp/core/ConfigProfile.cpp
@@ -88,7 +88,7 @@ Error ConfigProfile::parseString(const std::string& profileStr)
    for (const ptree::value_type& child : profileTree)
    {
       boost::optional<Level> matchingLevel;
-      for (const Level& level : sections_)
+      for (Level level : sections_)
       {
          // if the section level starts with the defined section name
          // from a prior call to addSections, we have a matching section level
@@ -109,7 +109,7 @@ Error ConfigProfile::parseString(const std::string& profileStr)
       }
 
       std::map<std::string, std::string> values;
-      for (const ptree::value_type val : child.second)
+      for (const ptree::value_type& val : child.second)
       {
          // check to see if the parameter within the section has been registered
          const std::string& paramName = val.first;

--- a/src/cpp/core/http/Request.cpp
+++ b/src/cpp/core/http/Request.cpp
@@ -264,7 +264,7 @@ void Request::addCookie(const std::string& name, const std::string& value)
 {
    cookies_.push_back(std::make_pair(name, value));
    std::vector<std::string> cookies;
-   for (const auto cookie: cookies_)
+   for (const auto& cookie : cookies_)
    {
       cookies.push_back(cookie.first + "=" + cookie.second);
    }

--- a/src/cpp/core/system/ProcessTests.cpp
+++ b/src/cpp/core/system/ProcessTests.cpp
@@ -277,6 +277,7 @@ test_context("ProcessTests")
 
       // wait for processes to exit
       bool success = supervisor.wait();
+      CHECK(success);
 
       // verify correct exit statuses and outputs
       for (int i = 0; i < 10; ++i)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -650,7 +650,8 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    error = rstudio::r::json::getRpcMethods(&rMethods);
    if (error)
       return error;
-   for (const json::JsonRpcMethod& method : rMethods)
+   
+   for (json::JsonRpcMethod method : rMethods)
    {
       registerRpcMethod(json::adaptMethodToAsync(method));
    }

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -532,7 +532,7 @@ void parseLintOptionGlobals(const std::string& text, FileLocalLintOptions* pOpti
    std::string::const_iterator end = text.end();
    
    ParsedCSVLine parsed = parseCsvLine(begin + 1, end, true);
-   for (const std::string element : parsed.first)
+   for (const std::string& element : parsed.first)
    {
       pOptions->globals.insert(string_utils::trimWhitespace(element));
    }
@@ -564,7 +564,7 @@ void parseLintOption(const std::string& text, FileLocalLintOptions* pOptions)
 FileLocalLintOptions parseLintOptions(const std::vector<std::string>& lintText)
 {
    FileLocalLintOptions options;
-   for (const std::string text : lintText)
+   for (const std::string& text : lintText)
    {
       parseLintOption(text, &options);
    }

--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -414,7 +414,7 @@ std::vector<Error> validate(const ProjectTemplateDescription& description,
    if (description.title.empty())
       result.push_back(errors::missingField("Title", resourcePath, location));
    
-   for (const ProjectTemplateWidgetDescription widget : description.widgets)
+   for (const ProjectTemplateWidgetDescription& widget : description.widgets)
    {
       std::vector<Error> widgetErrors =
             validateWidget(widget, resourcePath, location);

--- a/src/cpp/session/modules/SessionUserPrefs.cpp
+++ b/src/cpp/session/modules/SessionUserPrefs.cpp
@@ -262,7 +262,7 @@ SEXP rs_allPrefs()
    // Sort preference keys alphabetically for convenience
    std::sort(keys.begin(), keys.end());
 
-   for (const auto key: keys) 
+   for (const auto& key : keys) 
    {
       std::string layer;
       auto val = userPrefs().readValue(key, &layer);

--- a/src/cpp/session/modules/presentation/SlideMediaRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideMediaRenderer.cpp
@@ -106,7 +106,7 @@ std::vector<MediaSource> discoverMediaSources(
 std::string atCommandsAsJsonArray(const std::vector<AtCommand>& atCommands)
 {
    json::Array cmdsArray;
-   for (const AtCommand atCmd : atCommands)
+   for (const AtCommand& atCmd : atCommands)
    {
       cmdsArray.push_back(atCmd.asJson());
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -73,7 +73,7 @@ void cleanUnusedCaches()
    }
 
    std::string nbCtxId = notebookCtxId();
-   for (const FilePath cache : caches)
+   for (const FilePath& cache : caches)
    {
       // make sure this looks like a notebook cache
       if (!cache.isDirectory())
@@ -121,7 +121,7 @@ void cleanUnusedCaches()
          continue;
       }
 
-      for (const FilePath context : contexts)
+      for (const FilePath& context : contexts)
       {
          // skip if not our context or the saved context
          if (context.getFilename() != kSavedCtx &&
@@ -431,7 +431,7 @@ void onDocSaved(FilePath path)
       LOG_ERROR(error);
       return;
    }
-   for (const FilePath source : children)
+   for (const FilePath& source : children)
    {
       // compute the target path 
       FilePath target = saved.completePath(source.getFilename());

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
@@ -93,7 +93,7 @@ json::Object NotebookDocQueue::toJson() const
 {
    // serialize all the queue units 
    json::Array units;
-   for (const boost::shared_ptr<NotebookQueueUnit> unit : queue_)
+   for (const boost::shared_ptr<NotebookQueueUnit>& unit : queue_)
    {
       units.push_back(unit->toJson());
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -60,7 +60,7 @@ public:
       // create the text to send to the process (it'll be read on stdin
       // inside R)
       std::string input;
-      for (const FilePath snapshot : snapshotFiles)
+      for (const FilePath& snapshot : snapshotFiles)
       {
          input.append(string_utils::utf8ToSystem(snapshot.getAbsolutePath()));
          input.append("\n");
@@ -224,7 +224,7 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
 
    // look for snapshot files
    std::vector<FilePath> snapshotFiles;
-   for (const std::string chunkId : chunkIds)
+   for (const std::string& chunkId : chunkIds)
    {
       // find the storage location for this chunk output
       FilePath path = chunkOutputPath(docPath, docId, chunkId, notebookCtxId(),
@@ -240,7 +240,8 @@ Error replayPlotOutput(const json::JsonRpcRequest& request,
          LOG_ERROR(error);
          continue;
       }
-      for (const FilePath content : contents)
+      
+      for (const FilePath& content : contents)
       {
          if (content.hasExtensionLowerCase(kDisplayListExt))
             snapshotFiles.push_back(content);
@@ -302,7 +303,7 @@ Error replayChunkPlotOutput(const json::JsonRpcRequest& request,
       return Success();
    }
 
-   for (const FilePath content : contents)
+   for (const FilePath& content : contents)
    {
       if (content.hasExtensionLowerCase(kDisplayListExt))
          snapshotFiles.push_back(content);

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -181,7 +181,7 @@ public:
       const std::string& before)
    {
       // find the document queue corresponding to this unit
-      for (const boost::shared_ptr<NotebookDocQueue> queue : queue_)
+      for (const boost::shared_ptr<NotebookDocQueue>& queue : queue_)
       {
          if (queue->docId() == pUnit->docId())
          {

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -69,7 +69,7 @@ Error fillExecRange(const json::Array& in, std::list<ExecRange>* pOut)
 
 void fillJsonRange(const std::list<ExecRange>& in, json::Array* pOut)
 {
-   for (const ExecRange range : in)
+   for (const ExecRange& range : in)
    {
       pOut->push_back(range.toJson());
    }

--- a/src/cpp/session/prefs/Preferences.cpp
+++ b/src/cpp/session/prefs/Preferences.cpp
@@ -190,7 +190,7 @@ core::Error Preferences::writeLayer(int layer, const core::json::Object& prefs)
    END_LOCK_MUTEX;
 
    // Emit change events for all the preferences we changed
-   for (const auto prefName: changed)
+   for (const auto& prefName: changed)
    {
       onChanged(layers_[layer]->layerName(), prefName);
    }
@@ -208,7 +208,7 @@ boost::optional<core::json::Value> Preferences::readValue(const std::string& nam
    // settings) and working towards the most general (basic defaults)
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
-      for (const auto layer: boost::adaptors::reverse(layers_))
+      for (const auto& layer: boost::adaptors::reverse(layers_))
       {
          boost::optional<core::json::Value> val = layer->readValue(name);
          if (val)
@@ -231,7 +231,7 @@ boost::optional<core::json::Value> Preferences::readValue(const std::string& lay
 {
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
-      for (const auto layer: layers_)
+      for (const auto& layer: layers_)
       {
          if (layer->layerName() == layerName)
          {

--- a/src/cpp/session/prefs/UserPrefsLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.cpp
@@ -72,7 +72,7 @@ void UserPrefsLayer::onPrefsFileChanged()
    }
 
    // Figure out what prefs changed in the file
-   for (const auto key: UserPrefValues::allKeys())
+   for (const auto& key: UserPrefValues::allKeys())
    {
       const auto itOld = old.find(key);
       const auto itNew = cache_->find(key);

--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -1790,7 +1790,7 @@ template <typename T>
 inline Value toJsonValue(const std::vector<T>& in_vector)
 {
    Array results;
-   for (const T& val : in_vector)
+   for (auto&& val : in_vector)
    {
       results.push_back(val);
    }

--- a/src/cpp/shared_core/json/Json.cpp
+++ b/src/cpp/shared_core/json/Json.cpp
@@ -587,12 +587,6 @@ Object Value::getValue<Object>() const
 }
 
 template<>
-const char* Value::getValue<const char*>() const
-{
-   return getString().c_str();
-}
-
-template<>
 std::string Value::getValue<std::string>() const
 {
    return getString();


### PR DESCRIPTION
### Intent

Resolve compiler warnings from `-Wrange-loop-analysis`, introduced in the newest version of Clang.

### Approach

Look at and respond to compiler warnings. Mostly fixed via adding reference qualifier `&` or, in some cases, using `auto&&` (e.g. for `std::vector<T>` where binding to potential proxies for e.g. `std::vector<bool>` could be necessary).

### QA Notes

No QA notes / testing required.