### PR TITLE
use 'save::save.image()' if 'save.image()' is masked

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -13,6 +13,35 @@
 #
 #
 
+.rs.addJsonRpcHandler("is_function_masked", function(functionName,
+                                                     packageName)
+{
+   result <- tryCatch(
+      .rs.isFunctionMasked(functionName, packageName),
+      error = function(e) FALSE
+   )
+   
+   .rs.scalar(result)
+})
+
+.rs.addFunction("isFunctionMasked", function(functionName,
+                                             packageName)
+{
+   globalValue  <- get(
+      x = functionName,
+      envir = globalenv(),
+      mode = "function"
+   )
+   
+   packageValue <- get(
+      x = functionName,
+      envir = asNamespace(packageName),
+      mode = "function"
+   )
+   
+   identical(globalValue, packageValue)
+})
+
 .rs.addFunction("valueFromStr", function(val)
 {
    .rs.withTimeLimit(1, fail = "<truncated>", {

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -39,7 +39,7 @@
       mode = "function"
    )
    
-   identical(globalValue, packageValue)
+   !identical(globalValue, packageValue)
 })
 
 .rs.addFunction("valueFromStr", function(val)

--- a/src/gwt/src/org/rstudio/studio/client/common/SimpleRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/SimpleRequestCallback.java
@@ -40,6 +40,11 @@ public class SimpleRequestCallback<T> extends ServerRequestCallback<T>
       caption_ = caption;
       useClientInfoMsg_ = useClientInfoMsg;
    }
+   
+   @Override
+   public void onResponseReceived(T response)
+   {
+   }
 
    @Override
    public void onError(ServerError error)

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
@@ -760,6 +760,10 @@ public class BreakpointManager
       // set previously
       for (FileFunction function: functions)
       {
+         // There's a possibility here that the breakpoints were  
+         // not successfully cleared, so we may be in a temporarily  
+         // confusing state, but no error message will be less 
+         // confusing. 
          server_.setFunctionBreakpoints(
                function.functionName,
                function.fileName,

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.common.debugging.model.BreakpointState;
 import org.rstudio.studio.client.common.debugging.model.FunctionState;
 import org.rstudio.studio.client.common.debugging.model.FunctionSteps;
 import org.rstudio.studio.client.common.satellite.Satellite;
+import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -764,17 +765,7 @@ public class BreakpointManager
                function.fileName,
                function.packageName,
                new ArrayList<String>(),
-               new ServerRequestCallback<Void>()
-               {
-                  @Override
-                  public void onError(ServerError error)
-                  {
-                     // There's a possibility here that the breakpoints were
-                     // not successfully cleared, so we may be in a temporarily
-                     // confusing state, but no error message will be less
-                     // confusing.
-                  }
-               });
+               new QuietServerRequestCallback<Void>());
       }
 
       server_.removeAllBreakpoints(new VoidServerRequestCallback());

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ErrorManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ErrorManager.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.debugging.events.ErrorHandlerChangedEvent;
 import org.rstudio.studio.client.common.debugging.model.ErrorManagerState;
+import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -170,16 +171,7 @@ public class ErrorManager
 
    private void setErrorManagementType(String type)
    {
-      setErrorManagementType(type,
-            new ServerRequestCallback<Void>()
-      {
-         @Override
-         public void onError(ServerError error)
-         {
-            // No action necessary--the server emits an event when the handler
-            // type changes
-         }
-      });
+      setErrorManagementType(type, new QuietServerRequestCallback<Void>());
    }
 
    private void syncHandlerCommandsCheckedState()

--- a/src/gwt/src/org/rstudio/studio/client/server/ErrorLoggingServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/ErrorLoggingServerRequestCallback.java
@@ -1,5 +1,5 @@
 /*
- * ServerRequestCallback.java
+ * ErrorLoggingServerRequestCallback.java
  *
  * Copyright (C) 2020 by RStudio, PBC
  *
@@ -15,31 +15,19 @@
 
 package org.rstudio.studio.client.server;
 
-import org.rstudio.core.client.jsonrpc.RpcRequest;
+import org.rstudio.core.client.Debug;
 
-public abstract class ServerRequestCallback<T>
+public class ErrorLoggingServerRequestCallback<T> extends ServerRequestCallback<T>
 { 
-   public abstract void onResponseReceived(T response);
-   public abstract void onError(ServerError error);
-   
-   public void onRequestInitiated(RpcRequest request)
+   @Override
+   public void onResponseReceived(T response)
    {
-      request_ = request;
-   }
-
-   public void cancel()
-   {
-      if (request_ != null)
-         request_.cancel();
-      cancelled_ = true;
-   }
-
-   public boolean cancelled() 
-   {
-      return cancelled_;
    }
    
-   private boolean cancelled_ = false;
-   private RpcRequest request_;
+   @Override
+   public void onError(ServerError error)
+   {
+      Debug.logError(error);
+   }
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/server/QuietServerRequestCallback.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/QuietServerRequestCallback.java
@@ -1,5 +1,5 @@
 /*
- * ServerRequestCallback.java
+ * QuietServerRequestCallback.java
  *
  * Copyright (C) 2020 by RStudio, PBC
  *
@@ -15,31 +15,16 @@
 
 package org.rstudio.studio.client.server;
 
-import org.rstudio.core.client.jsonrpc.RpcRequest;
-
-public abstract class ServerRequestCallback<T>
+public class QuietServerRequestCallback<T> extends ServerRequestCallback<T>
 { 
-   public abstract void onResponseReceived(T response);
-   public abstract void onError(ServerError error);
-   
-   public void onRequestInitiated(RpcRequest request)
+   @Override
+   public void onResponseReceived(T response)
    {
-      request_ = request;
-   }
-
-   public void cancel()
-   {
-      if (request_ != null)
-         request_.cancel();
-      cancelled_ = true;
-   }
-
-   public boolean cancelled() 
-   {
-      return cancelled_;
    }
    
-   private boolean cancelled_ = false;
-   private RpcRequest request_;
+   @Override
+   public void onError(ServerError error)
+   {
+   }
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4619,6 +4619,19 @@ public class RemoteServer implements Server
                   REQUERY_CONTEXT,
                   requestCallback);
    }
+   
+   @Override
+   public void isFunctionMasked(String functionName,
+                                String packageName,
+                                ServerRequestCallback<Boolean> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(functionName)
+            .add(packageName)
+            .get();
+      
+      sendRequest(RPC_SCOPE, IS_FUNCTION_MASKED, params, requestCallback);
+   }
 
    @Override
    public void environmentSetLanguage(String language,
@@ -6656,6 +6669,7 @@ public class RemoteServer implements Server
    private static final String REQUERY_CONTEXT = "requery_context";
    private static final String ENVIRONMENT_SET_LANGUAGE = "environment_set_language";
    private static final String SET_ENVIRONMENT_MONITORING = "set_environment_monitoring";
+   private static final String IS_FUNCTION_MASKED = "is_function_masked";
 
    private static final String GET_FUNCTION_STEPS = "get_function_steps";
    private static final String SET_FUNCTION_BREAKPOINTS = "set_function_breakpoints";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -290,7 +290,13 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       view_.clearLiveRegion();
       server_.consoleInput(event.getInput(), 
                            event.getConsole(),
-                           new ServerRequestCallback<Void>() {
+                           new ServerRequestCallback<Void>()
+      {
+         @Override
+         public void onResponseReceived(Void response)
+         {
+         }
+         
          @Override
          public void onError(ServerError error) 
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -37,6 +37,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ImageMenuItem;
+import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.Value;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.icons.StandardIcons;
@@ -383,14 +384,9 @@ public class EnvironmentPane extends WorkbenchPane
    @Override
    public void changeContextDepth(int newDepth)
    {
-      server_.setContextDepth(newDepth, new ServerRequestCallback<Void>()
-      {
-         @Override
-         public void onError(ServerError error)
-         {
-            globalDisplay_.showErrorMessage("Error opening call frame", error.getUserMessage());
-         }
-      });
+      server_.setContextDepth(
+            newDepth,
+            new SimpleRequestCallback<Void>("Error opening call frame"));
    }
 
    public boolean clientStateDirty()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.environment;
 
 import com.google.gwt.core.client.JsArrayString;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.RegexUtil;
@@ -442,7 +443,7 @@ public class EnvironmentPresenter extends BasePresenter
       server_.isFunctionMasked(
             "save.image",
             "base",
-            new ErrorLoggingServerRequestCallback<Boolean>()
+            new ServerRequestCallback<Boolean>()
             {
                public void onResponseReceived(Boolean isMasked)
                {
@@ -455,6 +456,19 @@ public class EnvironmentPresenter extends BasePresenter
                         ".RData",
                         true,
                         code);
+               }
+
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+                  
+                  consoleDispatcher_.saveFileAsThenExecuteCommand(
+                        "Save Workspace As",
+                        ".RData",
+                        true,
+                        "save.image");
+                  
                };
             });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.common.filetypes.events.OpenDataFileEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenDataFileHandler;
 import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
 import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -438,10 +439,24 @@ public class EnvironmentPresenter extends BasePresenter
    {
       view_.bringToFront();
 
-      consoleDispatcher_.saveFileAsThenExecuteCommand("Save Workspace As",
-                                                      ".RData",
-                                                      true,
-                                                      "save.image");
+      server_.isFunctionMasked(
+            "save.image",
+            "base",
+            new ErrorLoggingServerRequestCallback<Boolean>()
+            {
+               public void onResponseReceived(Boolean isMasked)
+               {
+                  String code = isMasked
+                        ? "base::save.image"
+                        : "save.image";
+                  
+                  consoleDispatcher_.saveFileAsThenExecuteCommand(
+                        "Save Workspace As",
+                        ".RData",
+                        true,
+                        code);
+               };
+            });
    }
 
    void onLoadWorkspace()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.common.filetypes.events.OpenDataFileEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenDataFileHandler;
 import org.rstudio.studio.client.common.filetypes.events.OpenSourceFileEvent;
 import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
+import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -176,13 +177,7 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void run()
          {
-            server_.requeryContext(new ServerRequestCallback<Void>()
-            {
-               @Override
-               public void onError(ServerError error)
-               {
-               }
-            });
+            server_.requeryContext(new QuietServerRequestCallback<Void>());
          }
       };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -30,6 +30,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.common.reditor.EditorLanguage;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -493,14 +494,9 @@ public class DataImport extends Composite
    {
       if (localFiles_ != null)
       {
-         server_.previewDataImportClean(getOptions(), new ServerRequestCallback<Void>()
-         {
-            @Override
-            public void onError(ServerError error)
-            {
-               Debug.logError(error);
-            }
-         });
+         server_.previewDataImportClean(
+               getOptions(),
+               new ErrorLoggingServerRequestCallback<Void>());
       }
       
       localFiles_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/model/EnvironmentServerOperations.java
@@ -77,4 +77,8 @@ public interface EnvironmentServerOperations
    
    void environmentSetLanguage(String language,
                                ServerRequestCallback<Void> requestCallback);
+   
+   void isFunctionMasked(String functionName,
+                         String packageName,
+                         ServerRequestCallback<Boolean> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
@@ -387,15 +388,10 @@ public class JobManager implements JobRefreshEvent.Handler,
             code,
             spec ->
             {
-               server_.startJob(spec, new ServerRequestCallback<String>() {
-                  @Override
-                  public void onError(ServerError error)
-                  {
-                     Debug.logError(error);
-                  }
-               });
+               server_.startJob(spec, new ErrorLoggingServerRequestCallback<String>());
             }
       );
+      
       dialog.showModal();
    }
 
@@ -415,14 +411,9 @@ public class JobManager implements JobRefreshEvent.Handler,
                }
 
                // tell the server to start running this script
-               server_.startJob(spec, new ServerRequestCallback<String>() {
-                  @Override
-                  public void onError(ServerError error)
-                  {
-                     Debug.logError(error);
-                  }
-               });
+               server_.startJob(spec, new ErrorLoggingServerRequestCallback<String>());
             });
+      
       dialog.showModal();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -25,6 +25,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -227,14 +228,7 @@ public class DataEditingTarget extends UrlContentEditingTarget
                {
                   server_.removeCachedData(
                         oldCacheKey,
-                        new ServerRequestCallback<Void>() {
-
-                           @Override
-                           public void onError(ServerError error)
-                           {
-                              Debug.logError(error);
-                           }
-                        });
+                        new ErrorLoggingServerRequestCallback<Void>());
 
                   data.fillProperties(doc_.getProperties());
                   reloadDisplay();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -40,6 +40,7 @@ import org.rstudio.studio.client.rmarkdown.events.RmdChunkOutputFinishedEvent;
 import org.rstudio.studio.client.rmarkdown.model.NotebookQueueUnit;
 import org.rstudio.studio.client.rmarkdown.model.RMarkdownServerOperations;
 import org.rstudio.studio.client.rmarkdown.model.RmdChunkOptions;
+import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -143,14 +144,7 @@ public class ChunkSatelliteWindow extends SatelliteWindow
             server_.cleanReplayNotebookChunkPlots(
                chunkWindowParams_.getDocId(), 
                chunkWindowParams_.getChunkId(),
-                  new ServerRequestCallback<Void>()
-                  {
-                     @Override
-                     public void onError(ServerError error)
-                     {
-                     }
-                  }
-            );
+               new QuietServerRequestCallback<Void>());
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.SourceColumn;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
@@ -362,15 +363,9 @@ public class UrlContentEditingTarget implements EditingTarget
 
    public void onDismiss(int dismissType)
    {
-      server_.removeContentUrl(getContentUrl(),
-                               new ServerRequestCallback<org.rstudio.studio.client.server.Void>()
-                               {
-                                  @Override
-                                  public void onError(ServerError error)
-                                  {
-                                     Debug.logError(error);
-                                  }
-                               });
+      server_.removeContentUrl(
+            getContentUrl(),
+            new VoidServerRequestCallback());
    }
 
    protected String getContentTitle()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -148,14 +149,9 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       updateTerminalCommands();
 
       // inform server of the selection
-      server_.processNotifyVisible(activeTerminalHandle_, new ServerRequestCallback<Void>() {
-
-         @Override
-         public void onError(ServerError error)
-         {
-            Debug.logError(error);
-         }
-      });
+      server_.processNotifyVisible(
+            activeTerminalHandle_,
+            new ErrorLoggingServerRequestCallback<Void>());
    }
 
    /**


### PR DESCRIPTION
### Intent

Packages and user code might mask the `save.image()` function, which interferes with the Save action in the Environments pane.

### Approach

Detect this state, and emit `base::save.image()` when masked, and `save.image()` otherwise.

### QA Notes

Try running the following code:

```
save.image <- function(...) { stop("oh no") }
```

Then using the Save icon in the Environment pane to save the global environment. You should see an error; e.g.

<img width="426" alt="Screen Shot 2020-08-31 at 2 45 13 PM" src="https://user-images.githubusercontent.com/1976582/91771860-96749300-eb98-11ea-8ee6-94141f6e4dc9.png">

Closes https://github.com/rstudio/rstudio/pull/7073.

---

This PR also adds in the helper classes `ErrorLoggingServerRequestCallback` and `QuietServerRequestCallback`, capturing some of the more common `ServerRequestCallback` implementations. It also makes `onResponseReceived()` from `ServerRequestCallback` abstract, so that IDE autocompletion will automatically fill in the method name when creating new methods (since you almost always want to implement that anyhow; if you didn't you'd be using one of the other helper classes)