### PR TITLE
Fix console handling of a carriage-return / partial overwrite scenario

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -314,7 +314,7 @@ public class VirtualConsole
                      haveInsertedRange = false;
                   }
 
-                  moves.put(l, start);
+                  moves.put(l, overlap.start);
                }
             }
             else

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1169,4 +1169,23 @@ public class VirtualConsoleTests extends GWTTestCase
       Assert.assertEquals(expected, ele.getInnerHTML());
       Assert.assertEquals("Inverted with red background yellow foreground Inverted with default colors", vc.toString());
    }
+
+   public void testCarriageReturnPartialEndOverwrite()
+   {
+      // Case where a span is partially overwritten after a carriage-return
+      // and thus must be moved to a new position; it was being moved to an incorrect location
+      // causing output to be lost.
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+
+      String testInput = "⠹ [ \033[32mPASS\033[39m x632 \033[31mFAIL\033[39m x16 \033[35mWARN\033[39m x4" +
+         "\r" +
+         "\033[32m✓\033[39m |   4       | reporter-zzz\033[36m [\033[0m";
+
+      vc.submit(testInput);
+      String expected = "<span class=\"xtermColor2\">✓</span><span> |   4       | reporter-zzz</span>" +
+         "<span></span><span class=\"xtermColor6\"> [</span>";
+      Assert.assertEquals(expected, ele.getInnerHTML());
+      Assert.assertEquals("✓ |   4       | reporter-zzz [", vc.toString());
+   }
 }


### PR DESCRIPTION
### Intent

- Fixes #7649
- Another case where overwriting previous output (via carriage-return) messes up in complex case involving ANSI codes

### Approach

- Created a unit test that catches this specific issue, then debugged and fixed the underlying problem
- To trigger, the original output (before the carriage-return) must have a span with one style (e.g. color) that gets partially overwritten (at its beginning) with output with a different style; this results in the origin span being marked for a move (to compensate for it being shortened and "pushed right"), but the code was setting the wrong destination index causing it to mess up subsequent output

### QA Notes

- Test the new case as described in the issue, make sure output now matches
- This code has extensive unit testing, and thus regression of existing behavior should be reasonably unlikely
