### PR TITLE
Fix issue with column buttons

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1566,7 +1566,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       }
 
       if (column == activeColumn_)
-         setActive("");
+         setActive(MAIN_SOURCE_NAME);
       columnList_.remove(column);
       columnState_ = State.createState(JsUtil.toJsArrayString(getNames(false)),
                                        getActive().getName());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -386,7 +386,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       activeColumn_.setActiveEditor(target);
    }
 
-   private void setActive(SourceColumn column)
+   public void setActive(SourceColumn column)
    {
       SourceColumn prevColumn = activeColumn_;
       activeColumn_ = column;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -281,11 +281,15 @@ public class TextEditingTargetWidget
 
    private void createTestToolbarButtons(Toolbar toolbar)
    {
+      SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();
       compareTestButton_ = new ToolbarButton(
             "Compare Results",
             ToolbarButton.NoTitle,
             commands_.shinyCompareTest().getImageResource(),
-            event -> commands_.shinyCompareTest().execute());
+            event -> {
+               mgr.setActive(column_);
+               commands_.shinyCompareTest().execute();
+            });
       compareTestButton_.setTitle(commands_.shinyCompareTest().getDesc());
 
       toolbar.addRightWidget(compareTestButton_);
@@ -295,7 +299,10 @@ public class TextEditingTargetWidget
             "Run Tests",
             ToolbarButton.NoTitle,
             commands_.testTestthatFile().getImageResource(),
-            event -> commands_.testTestthatFile().execute());
+            event -> {
+               mgr.setActive(column_);
+               commands_.testTestthatFile().execute();
+            });
       testThatButton_.setTitle(commands_.testTestthatFile().getDesc());
 
       toolbar.addRightWidget(testThatButton_);
@@ -305,7 +312,10 @@ public class TextEditingTargetWidget
             "Run Tests",
             ToolbarButton.NoTitle,
             commands_.testShinytestFile().getImageResource(),
-            event -> commands_.testShinytestFile().execute());
+            event -> {
+               mgr.setActive(column_);
+               commands_.testShinytestFile().execute();  
+            });
       testShinyButton_.setTitle(commands_.testShinytestFile().getDesc());
 
       toolbar.addRightWidget(testShinyButton_);
@@ -443,12 +453,12 @@ public class TextEditingTargetWidget
          mgr.getSourceCommand(commands_.goToNextSection(), column_).createUnsyncedToolbarButton());
       toolbar.addRightSeparator();
       final String SOURCE_BUTTON_TITLE = "Source the active document";
-
       sourceButton_ = new ToolbarButton(
             "Source",
             SOURCE_BUTTON_TITLE,
             commands_.sourceActiveDocument().getImageResource(),
             event -> {
+               mgr.setActive(column_);
                if (userPrefs_.sourceWithEcho().getValue())
                   commands_.sourceActiveDocumentWithEcho().execute();
                else
@@ -622,6 +632,7 @@ public class TextEditingTargetWidget
          @Override
          public void run()
          {
+            mgr.setActive(column_);
             String title = commands_.toggleDocumentOutline().getTooltip();
             title = editorPanel_.getWidgetSize(docOutlineWidget_) > 0
                   ? title.replace("Show ", "Hide ")


### PR DESCRIPTION
### Intent

Fixes #7688, #7653 

1. When closing a column the active column was not being reset in some cases, causing the command buttons on all active columns to be disabled.

2. A few toolbar buttons were not taking their column into account when executing their command.

### Approach

1. When the active column is closed, set the active column to the main source column. We were already doing this in other cases.

2. Whenever a button is selected in an editor, reset the active column to itself before executing the command. Again, we were already doing this for most buttons but a few were missing.

### QA Notes

See original issues. 


