### PR TITLE
Add ThreadsafeSet class that compiles on Windows

### DIFF
--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -305,6 +305,59 @@ private:
    std::queue<T> queue_;
 };
 
+template <typename T>
+class ThreadsafeSet
+{
+public:
+   bool contains(const T& value) const
+   {
+      LOCK_MUTEX(mutex_)
+      {
+         return set_.find(value) != set_.end();
+      }
+      END_LOCK_MUTEX
+
+      // This will only be hit if we had a problem acquiring the lock, which likely means we have bigger problems.
+      return false;
+   }
+
+   void insert(const T& value)
+   {
+      LOCK_MUTEX(mutex_)
+      {
+         set_.insert(value);
+      }
+      END_LOCK_MUTEX
+   }
+
+   void insert(T&& value)
+   {
+      LOCK_MUTEX(mutex_)
+      {
+         set_.insert(value);
+      }
+      END_LOCK_MUTEX
+   }
+
+   void remove(const T& value)
+   {
+      std::set<std::string> test;
+      LOCK_MUTEX(mutex_)
+      {
+         auto itr = set_.find(value);
+         if (itr != set_.end())
+            set_.erase(value);
+      }
+      END_LOCK_MUTEX
+   }
+
+private:
+   // We need to supply the default std::set template argument values because there's a compiler bug pre MSVC 2019 16.6:
+   // https://developercommunity.visualstudio.com/content/problem/910615/c2976-during-function-template-argument-deduction.html
+   std::set<T, std::less<T>, std::allocator<T> > set_;
+   mutable boost::mutex mutex_;
+};
+
 void safeLaunchThread(boost::function<void()> threadMain,
                       boost::thread* pThread = nullptr);
       


### PR DESCRIPTION
### Intent

Fix a windows compile error (caused by an MSVC bug) and add the class to the OS version of Thread.hpp.

### Approach

Prior to Visual Studio Tools 2019 16.6 MSVC has problems correctly deducing template arguments in some scenarios. As a work-around, I've set the second and third template parameters of `std::set` to what they should be if MSVC had deduced them correctly.

After this merges, I'll pull to pro and resolve the conflicts.

### QA Notes

No QA needed on this one.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


