### PR TITLE
avoid unintentional IDE restarts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPythonPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPythonPreferencesPane.java
@@ -14,12 +14,11 @@
  */
 package org.rstudio.studio.client.projects.ui.prefs;
 
-import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.workbench.prefs.views.PythonDialogResources;
+import org.rstudio.studio.client.workbench.prefs.views.PythonInterpreter;
 import org.rstudio.studio.client.workbench.prefs.views.PythonPreferencesPaneBase;
 import org.rstudio.studio.client.workbench.prefs.views.PythonServerOperations;
 
@@ -45,41 +44,13 @@ public class ProjectPythonPreferencesPane extends PythonPreferencesPaneBase<RPro
    @Override
    public RestartRequirement onApply(RProjectOptions options)
    {
-      RestartRequirement requirement = new RestartRequirement();
-      RProjectConfig config = options.getConfig();
-      
-      String oldValue = config.getPythonPath();
-      String newValue = tbPythonInterpreter_.getText();
-      
-      if (StringUtil.equals(newValue, placeholderText_))
-         newValue = "";
-      
-      FileSystemItem projDir = session_.getSessionInfo().getActiveProjectDir();
-      if (projDir.exists() && newValue.startsWith(projDir.getPath()))
-         newValue = newValue.substring(projDir.getLength() + 1);
-      
-      boolean isSet =
-            interpreter_ != null &&
-            interpreter_.isValid() &&
-            !StringUtil.isNullOrEmpty(newValue);
-      
-      if (isSet && !StringUtil.equals(oldValue, newValue))
+      return onApply(true, (PythonInterpreter interpreter) ->
       {
-         config.setPythonType(interpreter_.getType());
-         config.setPythonVersion(interpreter_.getVersion());
-         config.setPythonPath(interpreter_.getPath());
-      }
-      else
-      {
-         config.setPythonType("");
-         config.setPythonVersion("");
-         config.setPythonPath("");
-      }
-      
-      if (!StringUtil.equals(oldValue, newValue))
-         requirement.setRestartRequired();
-      
-      return requirement;
+         RProjectConfig config = options.getConfig();
+         config.setPythonType(interpreter.getType());
+         config.setPythonVersion(interpreter.getVersion());
+         config.setPythonPath(interpreter.getPath());
+      });
    }
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonInterpreter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonInterpreter.java
@@ -22,10 +22,15 @@ public class PythonInterpreter extends JavaScriptObject
    {
    }
    
-   public final native String getPath()          /*-{ return this["path"];        }-*/;
-   public final native String getType()          /*-{ return this["type"];        }-*/;
-   public final native String getVersion()       /*-{ return this["version"];     }-*/;
-   public final native String getDescription()   /*-{ return this["description"]; }-*/;
-   public final native boolean isValid()         /*-{ return this["valid"];       }-*/;
-   public final native String getInvalidReason() /*-{ return this["reason"];      }-*/;
+   public static final native PythonInterpreter create()
+   /*-{
+      return {};
+   }-*/;
+   
+   public final native String getPath()          /*-{ return this["path"]        || "";    }-*/;
+   public final native String getType()          /*-{ return this["type"]        || "";    }-*/;
+   public final native String getVersion()       /*-{ return this["version"]     || "";    }-*/;
+   public final native String getDescription()   /*-{ return this["description"] || "";    }-*/;
+   public final native boolean isValid()         /*-{ return this["valid"]       || false; }-*/;
+   public final native String getInvalidReason() /*-{ return this["reason"]      || "";    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPane.java
@@ -63,36 +63,21 @@ public class PythonPreferencesPane extends PythonPreferencesPaneBase<UserPrefs>
    @Override
    public RestartRequirement onApply(UserPrefs prefs)
    {
-      RestartRequirement requirement = new RestartRequirement();
-      
-      String oldValue = prefs.pythonPath().getGlobalValue();
-      String newValue = tbPythonInterpreter_.getText();
-      
-      if (StringUtil.equals(newValue, placeholderText_))
-         newValue = "";
-      
-      boolean isSet =
-            interpreter_ != null &&
-            interpreter_.isValid() &&
-            !StringUtil.isNullOrEmpty(newValue);
-      
-      if (isSet && !StringUtil.equals(oldValue, newValue))
+      return onApply(false, (PythonInterpreter interpreter) ->
       {
-         prefs.pythonType().setGlobalValue(interpreter_.getType());
-         prefs.pythonVersion().setGlobalValue(interpreter_.getVersion());
-         prefs.pythonPath().setGlobalValue(interpreter_.getPath());
-      }
-      else
-      {
-         prefs.pythonType().removeGlobalValue(true);
-         prefs.pythonVersion().removeGlobalValue(true);
-         prefs.pythonPath().removeGlobalValue(true);
-      }
-      
-      if (!StringUtil.equals(oldValue, newValue))
-         requirement.setRestartRequired();
-      
-      return requirement;
+         if (interpreter.isValid())
+         {
+            prefs.pythonType().setGlobalValue(interpreter.getType());
+            prefs.pythonVersion().setGlobalValue(interpreter.getVersion());
+            prefs.pythonPath().setGlobalValue(interpreter.getPath());
+         }
+         else
+         {
+            prefs.pythonType().removeGlobalValue(true);
+            prefs.pythonVersion().removeGlobalValue(true);
+            prefs.pythonPath().removeGlobalValue(true);
+         }
+      });
    }
    
    private final Label overrideLabel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -185,7 +185,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    
    private void updateDescriptionImpl()
    {
-      String path = tbPythonInterpreter_.getText();
+      String path = tbPythonInterpreter_.getText().trim();
       
       // reset to default when empty
       if (StringUtil.isNullOrEmpty(path))
@@ -203,7 +203,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       }
       
       server_.pythonInterpreterInfo(
-            tbPythonInterpreter_.getText(),
+            path,
             new ServerRequestCallback<PythonInterpreter>()
             {
                @Override
@@ -362,14 +362,13 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       }
       
       // check if the interpreter appears to have been set by the user
-      boolean isSet =
+      boolean isValidInterpreterSet =
             interpreter_ != null &&
             interpreter_.isValid() &&
             !StringUtil.isNullOrEmpty(newValue);
       
-      // if the interpreter was set and changed from the prior value,
-      // update the requisite preferences
-      if (isSet && !StringUtil.equals(initialPythonPath_, newValue))
+      // if an interpreter was set, update to the new value
+      if (isValidInterpreterSet)
       {
          update.execute(interpreter_);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -353,7 +353,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       if (StringUtil.equals(newValue, placeholderText_))
          newValue = "";
       
-      // for project preferences, use relate project path for interpreter
+      // for project preferences, use project-relative path to interpreter
       if (isProjectPrefs)
       {
          FileSystemItem projDir = session_.getSessionInfo().getActiveProjectDir();


### PR DESCRIPTION
### Intent

As a result of the recent Python PR (https://github.com/rstudio/rstudio/pull/7656) the IDE was restarting every time the Project Options dialog was used. This was caused by an erroneous attempt to detect changes to project preferences; I was previously under the impression that the `onApply(RProjectOptions options)` method received the _old_ project preferences, but it in fact receives a _blank_ set of project preferences (and so it is nonsensical to compare values in that object).

### Approach

Cache the 'initial' Python path set when the dialog is opened, and then compare that to the 'new' value set by the user when the dialog is closed.

### QA Notes

Try changing project options. The IDE should not restart if nothing has changed.