### PR TITLE
Add a fallback to the install path for dev Desktop Launches

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -783,6 +783,9 @@ int main(int argc, char* argv[])
          scriptsPath = currentPath.completePath("desktop");
          devMode = true;
       }
+      // Sometimes boost is returning the wrong current path, which leads to not discovering the conf files correctly.
+      // This falls back to checking under the install path. If this file is present there, we probably want to be
+      // running in developer mode.
       else if (installPath.completePath("conf/rdesktop-dev.conf").exists())
       {
          confPath = installPath.completePath("conf/rdesktop-dev.conf");

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -783,6 +783,13 @@ int main(int argc, char* argv[])
          scriptsPath = currentPath.completePath("desktop");
          devMode = true;
       }
+      else if (installPath.completePath("conf/rdesktop-dev.conf").exists())
+      {
+         confPath = installPath.completePath("conf/rdesktop-dev.conf");
+         sessionPath = installPath.completePath("session/rsession");
+         scriptsPath = installPath.completePath("desktop");
+         devMode = true;
+      }
 
       // if there is no conf path then release mode
       if (confPath.isEmpty())


### PR DESCRIPTION
### Intent

Depending on where cmake generation is run, the folder structure of the build directory may have more layers. In that case the`FilePath::safeCurrentPath` call ([here](https://github.com/rstudio/rstudio/blob/fe8d018b122fb7dc91a76ef8ead64669833d3d0a/src/cpp/desktop/DesktopMain.cpp#L778)) is returning a folder higher in the structure than where `rstudio` was run from. In `gdb` printing `pwd` gives the correct current directory, but calling `p boost::filesystem::current_path().string()` returns the incorrect value.

This prevents `./rstudio-dev` from launching correctly. 

### Approach

Whether `conf/rdestkop-dev.conf` exists in the install location or the current directory, we probably want to read it and run `rstudio` in dev mode. This PR falls back to install location if `conf/rdesktop-dev.conf` cannot be found under the current directory.

### QA Notes

No particular QA needed. The important thing is that the release version of RStudio Desktop still launches correctly (i.e. not in dev mode). Here's an example of a failed devmode launch:

![image](https://user-images.githubusercontent.com/37987486/92030062-5984d980-ed1b-11ea-804d-721663722fd5.png)

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


