### PR TITLE
set default -j value lower on Mac for local docker builds

### DIFF
--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -113,13 +113,15 @@ fi
 ENV="$ENV GIT_COMMIT=$(git rev-parse HEAD)"
 ENV="$ENV BUILD_ID=local"
 
-# if we have an nproc command, use it to infer make parallelism
-if hash nproc 2>/dev/null; then
+# infer make parallelism
+if hash sysctl 2>/dev/null; then
+    # macos; we could use `sysctl -n hw.ncpu` but that would likely be too
+    # high. Docker for Mac defaults to half that value. Instead, use -j2 
+    # to match what we currently do in the official build.
+    ENV="$ENV MAKEFLAGS=-j2"
+elif hash nproc 2>/dev/null; then
     # linux
     ENV="$ENV MAKEFLAGS=-j$(nproc --all)"
-elif hash sysctl 2>/dev/null; then
-    # macos
-    ENV="$ENV MAKEFLAGS=-j$(sysctl -n hw.ncpu)"
 fi
 
 # forward build type if set


### PR DESCRIPTION


### Intent

Safe default for number of cores used for build parallelization on macOS when using the docker-compile.sh utility script.
 
### Approach

- The default was equalling number of cores on the machine, but Docker for Mac defaults to half that value (and can be adjusted via preferences)
- Set to -j2 as a safe default; edit the script if you want a higher value
- Also reversed order of the `nproc` vs `sysctl` check; a Mac with `coreutils` installed also has the `nproc` command and want the Mac branch to be used on the Mac to reduce confusion

### QA Notes

Purely a developer utility, not used for official builds or anything impacting customers.
