### PR TITLE
Fix issue where multiple data viewers were displayed for one object

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -876,7 +876,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void showDataItem(DataItem data)
    {
-      columnList_.forEach((column) -> {
+      for (SourceColumn column : columnList_)
+      {
          for (EditingTarget target : column.getEditors())
          {
             String path = target.getPath();
@@ -889,7 +890,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                return;
             }
          }
-      });
+      }
 
       ensureVisible(true);
       server_.newDocument(


### PR DESCRIPTION
### Intent

Fixes #7723 

Fixes 1.4 regression where multiple data viewer tabs could be opened for the same object. Instead, the open tab should refresh.

### Approach

Use for loop instead of forEach.

### QA Notes

See original ticket.


