### PR TITLE
Update to NSIS 3.06.1

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -27,9 +27,9 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-o
 # install NSIS - we do not do this via Chocolatey because the hosting URL of the NSIS
 # executable has gone defunct
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
-  Invoke-WebRequest $('https://rstudio-buildtools.s3.amazonaws.com/nsis-3.05-setup.exe') -OutFile 'C:\nsis-3.05-setup.exe' -UseBasicParsing ;`
-  Start-Process c:\nsis-3.05-setup.exe -Wait -ArgumentList '/S' ;`
-  Remove-Item c:\nsis-3.05-setup.exe -Force
+  Invoke-WebRequest $('https://rstudio-buildtools.s3.amazonaws.com/nsis-3.06.1-setup.exe') -OutFile 'C:\nsis-3.06.1-setup.exe' -UseBasicParsing ;`
+  Start-Process c:\nsis-3.06.1-setup.exe -Wait -ArgumentList '/S' ;`
+  Remove-Item c:\nsis-3.06.1-setup.exe -Force
   
 RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
   choco install -y visualstudio2017-workload-vctools --version 1.3.0


### PR DESCRIPTION
### Intent

RStudio for Windows installer is built using the NSIS toolkit. Version we are using (3.05) is a couple minor releases out of date so updating to the most recent for 1.4.

### Approach

Uploaded newer NSIS toolkit installer to S3, updated Dockerfile.windows to use it. I did a test build using Docker and confirmed the resulting setup exe was installable/uninstallable.

### QA Notes

Basic sanity test for RStudio Desktop for Windows install/uninstall process. Should see no difference other than the version number shown on some of the setup wizard screens.

