### PR TITLE
added gwt build-time check for menu access keys

### DIFF
--- a/src/gwt/src/org/rstudio/core/rebind/command/CommandBundleGenerator.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/CommandBundleGenerator.java
@@ -86,6 +86,7 @@ class CommandBundleGeneratorHelper
       commandMethods_ = getMethods(true, false, false);
       menuMethods_ = getMethods(false, true, false);
       shortcutsMethods_ = getMethods(false, false, true);
+      commandProps_ = getCommandProperties();
       packageName_ = bundleType_.getPackage().getName();
    }
 
@@ -132,15 +133,12 @@ class CommandBundleGeneratorHelper
    }
 
    private void emitConstructor(SourceWriter writer, ImageResourceInfo images)
-         throws UnableToCompleteException
    {
       writer.println("public " + simpleName_ + "() {");
 
-      // Get additional properties from XML resource file, if exists
-      Map<String, Element> props = getCommandProperties();
       // Implement the methods for the commands
       for (JMethod method : commandMethods_)
-         emitCommandInitializers(writer, props, method, images);
+         emitCommandInitializers(writer, method, images);
 
       writer.println();
       writer.indentln("__registerShortcuts();");
@@ -149,7 +147,6 @@ class CommandBundleGeneratorHelper
    }
 
    private void emitCommandFields(SourceWriter writer)
-                             throws UnableToCompleteException
    {
       // Declare the fields for the commands
       for (JMethod method : commandMethods_)
@@ -180,6 +177,7 @@ class CommandBundleGeneratorHelper
          String menuClass = new MenuEmitter(logger_,
                                             context_,
                                             bundleType_,
+                                            commandProps_,
                                             (Element) nodes.item(0)).generate();
 
          writer.println("public void " + name + "(MenuCallback callback) {");
@@ -215,7 +213,7 @@ class CommandBundleGeneratorHelper
                                 boolean includeShortcuts)
          throws UnableToCompleteException
    {
-      ArrayList<JMethod> methods = new ArrayList<JMethod>();
+      ArrayList<JMethod> methods = new ArrayList<>();
       for (JMethod method : bundleType_.getMethods())
       {
          if (!method.isAbstract())
@@ -309,28 +307,27 @@ class CommandBundleGeneratorHelper
     * }
     */
    private void emitCommandInitializers(SourceWriter writer,
-                                  Map<String, Element> props,
                                   JMethod method,
                                   ImageResourceInfo images)
    {
       String name = method.getName();
       writer.println(name + "_ = new AppCommand();");
 
-      setProperty(writer, name, props.get(name), "id");
-      setProperty(writer, name, props.get(name), "desc");
-      setProperty(writer, name, props.get(name), "label");
-      setProperty(writer, name, props.get(name), "buttonLabel");
-      setProperty(writer, name, props.get(name), "menuLabel");
-      setProperty(writer, name, props.get(name), "windowMode");
-      setProperty(writer, name, props.get(name), "context");
+      setProperty(writer, name, commandProps_.get(name), "id");
+      setProperty(writer, name, commandProps_.get(name), "desc");
+      setProperty(writer, name, commandProps_.get(name), "label");
+      setProperty(writer, name, commandProps_.get(name), "buttonLabel");
+      setProperty(writer, name, commandProps_.get(name), "menuLabel");
+      setProperty(writer, name, commandProps_.get(name), "windowMode");
+      setProperty(writer, name, commandProps_.get(name), "context");
       // Any additional textual properties would be added here...
 
-      setPropertyBool(writer, name, props.get(name), "visible");
-      setPropertyBool(writer, name, props.get(name), "enabled");
-      setPropertyBool(writer, name, props.get(name), "checkable");
-      setPropertyBool(writer, name, props.get(name), "checked");
-      setPropertyBool(writer, name, props.get(name), "rebindable");
-      setPropertyBool(writer, name, props.get(name), "radio");
+      setPropertyBool(writer, name, commandProps_.get(name), "visible");
+      setPropertyBool(writer, name, commandProps_.get(name), "enabled");
+      setPropertyBool(writer, name, commandProps_.get(name), "checkable");
+      setPropertyBool(writer, name, commandProps_.get(name), "checked");
+      setPropertyBool(writer, name, commandProps_.get(name), "rebindable");
+      setPropertyBool(writer, name, commandProps_.get(name), "radio");
       
       if (images.hasImage(name))
       {
@@ -453,7 +450,7 @@ class CommandBundleGeneratorHelper
 
    public Map<String, Element> getCommandProperties() throws UnableToCompleteException
    {
-      Map<String, Element> properties = new HashMap<String, Element>();
+      Map<String, Element> properties = new HashMap<>();
 
       NodeList nodes = getConfigDoc("/commands/cmd");
 
@@ -499,6 +496,7 @@ class CommandBundleGeneratorHelper
    @SuppressWarnings("unused")
    private final JMethod[] shortcutsMethods_;
    private final String packageName_;
+   private final Map<String, Element> commandProps_;
    private String simpleName_;
 }
 
@@ -526,5 +524,5 @@ class ImageResourceInfo
    }
 
    private final String imagesRefPath_;
-   private final HashSet<String> imageIds_ = new HashSet<String>();
+   private final HashSet<String> imageIds_ = new HashSet<>();
 }

--- a/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
@@ -25,12 +25,90 @@ import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 
 import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 
 public class MenuEmitter
 {
+   private class AccessKeyTracker
+   {
+      public AccessKeyTracker(String menuName)
+      {
+         menuName_ = menuName;
+         Character[] alphabet = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'};
+         availableKeys_ = new LinkedHashSet<>(Arrays.asList(alphabet));
+      }
+
+      public void processMenu(String menuText)
+      {
+         int index = menuText.indexOf('_');
+         if (index < 0 || index == menuText.length() - 1)
+         {
+            missingKeys_.add("SUBMENU: " + menuText);
+            return;
+         }
+
+         char accessKey = menuText.charAt(index + 1);
+         availableKeys_.remove(accessKey);
+      }
+
+      public void processCommand(String commandId) throws UnableToCompleteException
+      {
+         // special handling for the "mru" commands; these have no default menu labels
+         if (commandId.matches("mru[0-9]+") ||
+             commandId.matches("projectMru[0-9]+"))
+            return;
+
+         String menuText = commandProps_.get(commandId).getAttribute("menuLabel");
+         if (menuText == null || menuText.isEmpty())
+            menuText = commandProps_.get(commandId).getAttribute("label");
+         if (menuText == null || menuText.isEmpty())
+         {
+            logger_.log(TreeLogger.Type.ERROR, "No menuLabel or label for " + commandId);
+            throw new UnableToCompleteException();
+         }
+         int index = menuText.indexOf('_');
+         if (index < 0 || index == menuText.length() - 1)
+         {
+            missingKeys_.add(commandId);
+            return;
+         }
+
+         char accessKey = menuText.charAt(index + 1);
+         availableKeys_.remove(accessKey);
+      }
+
+      public void report()
+      {
+         if (missingKeys_.isEmpty())
+            return;
+
+         logger_.log(TreeLogger.Type.WARN, "Menu [" + menuName_ + "]");
+         for (String commandId : missingKeys_)
+            logger_.log(TreeLogger.Type.WARN, "   [" + commandId + "] has no access key");
+
+         StringBuilder message = new StringBuilder("   Available keys are: [");
+         for (char ch : availableKeys_)
+         {
+            message.append(ch);
+         }
+         message.append("]");
+         logger_.log(TreeLogger.Type.INFO, message.toString());
+      }
+
+      private final List<String> missingKeys_ = new ArrayList<>();
+      private final LinkedHashSet<Character> availableKeys_;
+      private final String menuName_;
+   }
+
    public MenuEmitter(TreeLogger logger,
                       GeneratorContext context,
                       JClassType bundleType,
+                      Map<String, Element> commandProps,
                       Element menuEl) throws UnableToCompleteException
    {
       logger_ = logger;
@@ -38,6 +116,7 @@ public class MenuEmitter
       bundleType_ = bundleType;
       menuEl_ = menuEl;
       menuId_ = menuEl.getAttribute("id");
+      commandProps_ = commandProps;
       if (menuId_.length() == 0)
       {
          logger.log(TreeLogger.Type.ERROR, "Menu must have an id attribute");
@@ -94,15 +173,16 @@ public class MenuEmitter
 
       writer.println("callback.beginMainMenu();");
       // Vertical defaults to true
-      emitMenu(writer, menuEl_);
+      emitMenu(writer, menuEl_, "main");
       writer.println("callback.endMainMenu();");
 
       writer.outdent();
       writer.println("}");
    }
 
-   private void emitMenu(SourceWriter writer, Element el) throws UnableToCompleteException
+   private void emitMenu(SourceWriter writer, Element el, String menuName) throws UnableToCompleteException
    {
+      AccessKeyTracker accessKeys = new AccessKeyTracker(menuName);
       for (Node n = el.getFirstChild(); n != null; n = n.getNextSibling())
       {
          if (n.getNodeType() != Node.ELEMENT_NODE)
@@ -116,6 +196,7 @@ public class MenuEmitter
             writer.print("callback.addCommand(");
             writer.print("\"" + Generator.escape(cmdId) + "\", ");
             writer.println("this.cmds." + cmdId + "());");
+            accessKeys.processCommand(cmdId);
          }
          else if (child.getTagName().equals("separator"))
          {
@@ -127,8 +208,9 @@ public class MenuEmitter
             writer.println("callback.beginMenu(\"" +
                            Generator.escape(label) +
                            "\");");
-            emitMenu(writer, child);
+            emitMenu(writer, child, label);
             writer.println("callback.endMenu();");
+            accessKeys.processMenu(label);
          }
          else if (child.getTagName().equals("dynamic"))
          {
@@ -142,6 +224,7 @@ public class MenuEmitter
             throw new UnableToCompleteException();
          }
       }
+      accessKeys.report();
    }
 
    private final TreeLogger logger_;
@@ -150,4 +233,5 @@ public class MenuEmitter
    private final String menuId_;
    private final Element menuEl_;
    private final String packageName_;
+   private final Map<String, Element> commandProps_;
 }

--- a/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
@@ -78,7 +78,7 @@ public class MenuEmitter
             return;
          }
 
-         char accessKey = menuText.charAt(index + 1);
+         char accessKey = Character.toLowerCase(menuText.charAt(index + 1));
          availableKeys_.remove(accessKey);
       }
 
@@ -98,6 +98,7 @@ public class MenuEmitter
          }
          message.append("]");
          logger_.log(TreeLogger.Type.ERROR, message.toString());
+         throw new UnableToCompleteException();
       }
 
       private final List<String> missingKeys_ = new ArrayList<>();

--- a/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
@@ -52,7 +52,7 @@ public class MenuEmitter
             return;
          }
 
-         char accessKey = menuText.charAt(index + 1);
+         char accessKey = Character.toLowerCase(menuText.charAt(index + 1));
          availableKeys_.remove(accessKey);
       }
 
@@ -98,7 +98,6 @@ public class MenuEmitter
          }
          message.append("]");
          logger_.log(TreeLogger.Type.ERROR, message.toString());
-         throw new UnableToCompleteException();
       }
 
       private final List<String> missingKeys_ = new ArrayList<>();

--- a/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/MenuEmitter.java
@@ -82,14 +82,14 @@ public class MenuEmitter
          availableKeys_.remove(accessKey);
       }
 
-      public void report()
+      public void report() throws UnableToCompleteException
       {
          if (missingKeys_.isEmpty())
             return;
 
-         logger_.log(TreeLogger.Type.WARN, "Menu [" + menuName_ + "]");
+         logger_.log(TreeLogger.Type.ERROR, "Menu [" + menuName_ + "]");
          for (String commandId : missingKeys_)
-            logger_.log(TreeLogger.Type.WARN, "   [" + commandId + "] has no access key");
+            logger_.log(TreeLogger.Type.ERROR, "   [" + commandId + "] has no access key");
 
          StringBuilder message = new StringBuilder("   Available keys are: [");
          for (char ch : availableKeys_)
@@ -97,7 +97,8 @@ public class MenuEmitter
             message.append(ch);
          }
          message.append("]");
-         logger_.log(TreeLogger.Type.INFO, message.toString());
+         logger_.log(TreeLogger.Type.ERROR, message.toString());
+         throw new UnableToCompleteException();
       }
 
       private final List<String> missingKeys_ = new ArrayList<>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -488,7 +488,7 @@ well as menu structures (for main menu and popup menus).
             <separator/>
             <cmd refid="activateJobs"/>
           </menu>
-         <menu label="Launcher">
+         <menu label="_Launcher">
             <cmd refid="startLauncherJob"/>
             <separator/>
             <cmd refid="activateLauncherJobs"/>
@@ -955,7 +955,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="setWorkingDirToProjectDir"
         label="Set Working Directory to Project Directory"
         buttonLabel=""
-        menuLabel="To Project Directory"
+        menuLabel="To _Project Directory"
         desc="Change working directory to project root directory"/>
 
    <cmd id="setWorkingDirToActiveDoc"
@@ -1243,7 +1243,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="shareProject"
         label="Share Project..."
-        menuLabel="Share Project..."
+        menuLabel="S_hare Project..."
         buttonLabel=""
         desc="Share this project with others"
         windowMode="main"/>
@@ -1413,7 +1413,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="activateLauncherJobs"
         label="Show Launcher Pane"
-        menuLabel = "Show Launcher"
+        menuLabel = "Show _Launcher"
         windowMode="main"/>
 
    <cmd id="layoutZoomSource"
@@ -1472,7 +1472,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="layoutZoomVcs"
         checkable="true"
         label="Zoom VCS"
-        menuLabel="Zoom VCS"
+        menuLabel="Zoom _VCS"
         windowMode="main"/>
 
    <cmd id="layoutZoomTutorial"
@@ -1582,7 +1582,7 @@ well as menu structures (for main menu and popup menus).
         menuLabel="_Go to Line..."/>
 
    <cmd id="toggleFullScreen"
-        menuLabel="Toggle Full Screen"/>
+        menuLabel="Toggle _Full Screen"/>
 
    <cmd id="findFromSelection"
         context="editor"
@@ -1864,12 +1864,12 @@ well as menu structures (for main menu and popup menus).
         context="editor"/>
 
    <cmd id="executePreviousChunks"
-        menuLabel="Run All Chunks Above"
+        menuLabel="_Run All Chunks Above"
         desc="Run all above the current one"
         context="r"/>
 
    <cmd id="executeSubsequentChunks"
-        menuLabel="Run All Chunks Below"
+        menuLabel="Run All C_hunks Below"
         desc="Run all chunks after the current one"
         context="r"/>
 
@@ -1936,12 +1936,12 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="previewJS"
         buttonLabel="Preview"
-        menuLabel="Preview JS"
+        menuLabel="Preview J_S"
         desc="Preview the active JavaScript document"/>
 
    <cmd id="previewSql"
         buttonLabel="Preview"
-        menuLabel="Preview SQL"
+        menuLabel="Preview S_QL"
         desc="Preview the active SQL document"/>
 
    <cmd id="sourceActiveDocument"
@@ -2151,7 +2151,7 @@ well as menu structures (for main menu and popup menus).
    <cmd id="previewHTML"
         label="Preview Document as HTML"
         buttonLabel="Preview"
-        menuLabel="Preview"
+        menuLabel="Previe_w"
         desc="Show a preview of the current document as HTML"
         context="markdown"/>
 
@@ -2192,7 +2192,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="notebookExpandAllOutput"
         buttonLabel=""
-        menuLabel="Expand All Output"
+        menuLabel="E_xpand All Output"
         desc="Expand all code chunk output in the current file"/>
 
    <cmd id="notebookToggleExpansion"
@@ -2202,17 +2202,17 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="notebookCollapseAllOutput"
         buttonLabel=""
-        menuLabel="Collapse All Output"
+        menuLabel="Collapse All _Output"
         desc="Collapse all code chunk output in the current file"/>
 
    <cmd id="notebookClearOutput"
         buttonLabel=""
-        menuLabel="Clear Output"
+        menuLabel="Cl_ear Output"
         desc="Clear the output of the current notebook chunk" />
 
    <cmd id="notebookClearAllOutput"
         buttonLabel=""
-        menuLabel="Clear All Output"
+        menuLabel="Clear A_ll Output"
         desc="Remove all code chunk output in the current file"/>
 
    <cmd id="synctexSearch"
@@ -2447,12 +2447,12 @@ well as menu structures (for main menu and popup menus).
 
   <cmd id="restartRClearOutput"
         label="Restart R Session and Clear Chunk Output"
-        menuLabel="Restart R and Clear Output"
+        menuLabel="Restart R and Clear _Output"
         desc="Restart R session and clear chunk output" />
 
    <cmd id="restartRRunAllChunks"
         label="Restart R Session and Run All Chunks"
-        menuLabel="Restart R and Run All Chunks"
+        menuLabel="Restart R and Run _All Chunks"
         desc="Restart R session and run all chunks" />
 
    <cmd id="terminateR"
@@ -3198,7 +3198,7 @@ well as menu structures (for main menu and popup menus).
         visible="false"/>
 
    <cmd id="openDeveloperConsole"
-        menuLabel="Open Developer Console"
+        menuLabel="_Open Developer Console"
         rebindable="false"
         context="diagnostics"
         windowMode="main"/>
@@ -3741,7 +3741,7 @@ well as menu structures (for main menu and popup menus).
          windowMode="any"/>
 
     <cmd id="startLauncherJob"
-         menuLabel="Start Launcher Job..."
+         menuLabel="Start Launcher _Job..."
          buttonLabel="Start Launcher Job"
          desc="Run a background job on a cluster"
          windowMode="main"/>
@@ -3752,7 +3752,7 @@ well as menu structures (for main menu and popup menus).
          windowMode="any"/>
 
     <cmd id="runSelectionAsLauncherJob"
-         menuLabel="Run Selection as Launcher Job"
+         menuLabel="Run Selection as _Launcher Job"
          desc="Run the selected code as a launcher job"
          windowMode="any"/>
 
@@ -3891,7 +3891,7 @@ well as menu structures (for main menu and popup menus).
         windowMode="main"/>
 
    <cmd id="focusSourceColumnSeparator"
-        menuLabel="Adjust Source Column Splitter"
+        menuLabel="Adjust Source Column Spli_tter"
         windowMode="main"/>
 
    <cmd id="showShortcutCommand"


### PR DESCRIPTION
### Intent

RStudio Desktop on Windows (and possibly some Linux desktop managers), shows menu-access keys on the main menu. These are the underlined characters you can use to quickly select a command via keyboard.

We devs often forget to add these to new commands, and have relied on them being noticed as missing after the fact.

Adding them is a pain because they are only visible on Windows Desktop, and figuring out what letters are unused on a given menu is tedious. Plus some commands are only visible on the menu in certain scenarios, so even more likely to miss those.

### Approach

Added code at GWT build time to check that every menu command has an access key defined, and write warnings that show which commands are missing access keys, which menu they are on, and what letters remain available for use on a given menu.

I did not make it a fatal build-time error (could if we think that's appropriate).

### QA Notes

This is purely a developer diagnostic thing that happens at build time. At this moment, it provides the following warnings which I will fix in a separate PR:

```
 Menu [_File]
    [shareProject] has no access key
    [previewHTML] has no access key
    Available keys are: [bdgmyz]
 Menu [_Edit]
    [notebookExpandAllOutput] has no access key
    [notebookCollapseAllOutput] has no access key
    [notebookClearOutput] has no access key
    [notebookClearAllOutput] has no access key
    Available keys are: [behjlmoqxyz]
 Menu [Run Regi_on]
    [executePreviousChunks] has no access key
    [executeSubsequentChunks] has no access key
    Available keys are: [dghijklmopqrtuvwxyz]
 Menu [_Code]
    [runSelectionAsLauncherJob] has no access key
    [previewJS] has no access key
    [previewSql] has no access key
    Available keys are: [kqyz]
 Menu [P_anes]
    [layoutZoomVcs] has no access key
    [focusSourceColumnSeparator] has no access key
    Available keys are: [fgkqvx]
 Menu [_View]
    [toggleFullScreen] has no access key
    [activateLauncherJobs] has no access key
    Available keys are: [gqx]
 Menu [Set _Working Directory]
    [setWorkingDirToProjectDir] has no access key
    Available keys are: [abdeghijklmnopqrtuvwxyz]
 Menu [_Session]
    [restartRClearOutput] has no access key
    [restartRRunAllChunks] has no access key
    Available keys are: [abdefghjkmopuvxyz]
 Menu [Launcher]
    [startLauncherJob] has no access key
    [activateLauncherJobs] has no access key
    Available keys are: [abcdefghijklmnopqrstuvwxyz]
 Menu [_Tools]
    [SUBMENU: Launcher] has no access key
    Available keys are: [bdefhilnoqrwxyz]
 Menu [Dia_gnostics]
    [openDeveloperConsole] has no access key
    Available keys are: [abfhjlmnoqxyz]
```