### PR TITLE
pass along navMethod when invoking ctor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
@@ -51,7 +51,7 @@ public class OpenSourceFileEvent extends CrossWindowEvent<OpenSourceFileHandler>
                               TextFileType fileType,
                               int navMethod)
    {
-      this(file, position, fileType, true, NavigationMethods.DEFAULT);
+      this(file, position, fileType, true, navMethod);
    }
 
    public OpenSourceFileEvent(FileSystemItem file,


### PR DESCRIPTION
### Intent

The currently-debugged line was not being highlighted when the debugger was active.

### Approach

A parameter was not being passed along as expected. (https://github.com/rstudio/rstudio/commit/b134c4b11e8ad527356990767fb2c9707acd4530#diff-91600fcd8b751bc5240ddf738ee9605fR54)

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/7749.