### PR TITLE
Improve cursor and output visibility in embedded editors

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/scroll.ts
+++ b/src/gwt/panmirror/src/editor/src/api/scroll.ts
@@ -1,5 +1,5 @@
 /*
- * zenscroll.ts
+ * scroll.ts
  *
  * Copyright (C) 2019-20 by RStudio, PBC
  *

--- a/src/gwt/panmirror/src/editor/src/api/scroll.ts
+++ b/src/gwt/panmirror/src/editor/src/api/scroll.ts
@@ -1,5 +1,5 @@
 /*
- * rmd.ts
+ * zenscroll.ts
  *
  * Copyright (C) 2019-20 by RStudio, PBC
  *

--- a/src/gwt/panmirror/src/editor/src/api/ui.ts
+++ b/src/gwt/panmirror/src/editor/src/api/ui.ts
@@ -32,6 +32,9 @@ export interface EditorUI {
   spelling: EditorUISpelling;
 }
 
+/**
+ * Callbacks supplied to the host to interact with a code chunk and its output.
+ */
 export interface EditorUIChunkCallbacks {
   getPos: () => number;
   scrollIntoView: (ele: HTMLElement) => void;

--- a/src/gwt/panmirror/src/editor/src/api/ui.ts
+++ b/src/gwt/panmirror/src/editor/src/api/ui.ts
@@ -32,9 +32,14 @@ export interface EditorUI {
   spelling: EditorUISpelling;
 }
 
+export interface EditorUIChunkCallbacks {
+  getPos: () => number;
+  scrollIntoView: (ele: HTMLElement) => void;
+}
+
 export interface EditorUIChunks {
   // create a code chunk editor
-  createChunkEditor: (type: string, index: number, getPos: () => number) => ChunkEditor;
+  createChunkEditor: (type: string, index: number, callbacks: EditorUIChunkCallbacks) => ChunkEditor;
 }
 
 export interface ChunkEditor {

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunkCallbacks.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunkCallbacks.java
@@ -1,5 +1,5 @@
 /*
- * PanmirrorUIChunkEditor.java
+ * PanmirrorUIChunkCallbacks.java
  *
  * Copyright (C) 2020 by RStudio, PBC
  *
@@ -16,34 +16,24 @@ package org.rstudio.studio.client.panmirror.ui;
 
 import com.google.gwt.dom.client.Element;
 
-import elemental2.core.JsObject;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsType;
 
 @JsType
-public class PanmirrorUIChunkEditor
+public class PanmirrorUIChunkCallbacks
 {
-   public JsObject editor;
-   public Element element;
-   public SetMode setMode;
-   public Destroy destroy;
-   public ExecuteSelection executeSelection;
-   
+   public ScrollIntoView scrollIntoView;
+   public GetVisualPosition getPos;
+
    @JsFunction
-   public interface SetMode
+   public interface GetVisualPosition
    {
-      void setMode(String mode);
-   }
-   
-   @JsFunction
-   public interface Destroy
-   {
-      void destroy();
+      int getVisualPosition();
    }
 
    @JsFunction
-   public interface ExecuteSelection
+   public interface ScrollIntoView
    {
-      void executeSelection();
+      int scrollIntoView(Element ele);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunks.java
@@ -1,5 +1,5 @@
 /*
- * PanmirrorUIChunkFactory.java
+ * PanmirrorUIChunks.java
  *
  * Copyright (C) 2020 by RStudio, PBC
  *
@@ -21,16 +21,10 @@ import jsinterop.annotations.JsType;
 public class PanmirrorUIChunks
 {
    public CreateChunkEditor createChunkEditor;
-   
-   @JsFunction
-   public interface GetVisualPosition
-   {
-      int getVisualPosition();
-   }
 
    @JsFunction
    public interface CreateChunkEditor
    {
-      PanmirrorUIChunkEditor create(String type, int position, GetVisualPosition getPos);
+      PanmirrorUIChunkEditor create(String type, int position, PanmirrorUIChunkCallbacks callbacks);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputPanmirrorUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkOutputPanmirrorUi.java
@@ -57,6 +57,8 @@ public class ChunkOutputPanmirrorUi extends ChunkOutputUi
          chunk_.setOutputWidget(outputWidget);
          chunk_.setDefinition(def);
       }
+      
+      ensureVisible_ = false;
    }
    
 
@@ -67,6 +69,16 @@ public class ChunkOutputPanmirrorUi extends ChunkOutputUi
       // just cache the height in case the chunk needs to be rendered at a fixed
       // size later (in code view)
       height_ = heightPx;
+      
+      // Perform any deferred scrolling
+      if (ensureVisible_)
+      {
+         if (chunk_ != null)
+         {
+            chunk_.scrollOutputIntoView();
+         }
+         ensureVisible_ = false;
+      }
    }
 
    public ChunkOutputPanmirrorUi(ChunkOutputCodeUi codeOutput, VisualMode visualMode, 
@@ -94,7 +106,6 @@ public class ChunkOutputPanmirrorUi extends ChunkOutputUi
    @Override
    public void onRenderFinished(RenderFinishedEvent event)
    {
-
    }
 
    @Override
@@ -110,8 +121,9 @@ public class ChunkOutputPanmirrorUi extends ChunkOutputUi
    @Override
    public void ensureVisible()
    {
-      // This is used in code view to scroll the widget into view; currently we
-      // don't replicate that behavior in visual mode.
+      // Since chunk sizes are "natural" in visual mode, we wait until the chunk
+      // has been given its new height to scroll it into view.
+      ensureVisible_ = true;
    }
 
    @Override
@@ -188,4 +200,5 @@ public class ChunkOutputPanmirrorUi extends ChunkOutputUi
    }
    
    private VisualModeChunk chunk_;
+   private boolean ensureVisible_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -48,7 +48,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
    public PanmirrorUIChunks uiChunks()
    {
       PanmirrorUIChunks chunks = new PanmirrorUIChunks();
-      chunks.createChunkEditor = (type, index, getPos) ->
+      chunks.createChunkEditor = (type, index, callbacks) ->
       {
          // only know how to create ace instances right now
          if (!type.equals("ace"))
@@ -58,7 +58,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          }
          
          VisualModeChunk chunk = new VisualModeChunk(
-               index, getPos, sentinel_, target_, sync_);
+               index, callbacks, sentinel_, target_, sync_);
 
          // Add the chunk to our index, and remove it when the underlying chunk
          // is removed in Prosemirror


### PR DESCRIPTION
### Intent

This change fixes a couple of issues in which the cursor and/or output of code execution could be offscreen in embedded Ace editors in visual mode. 

Fixes https://github.com/rstudio/rstudio/issues/7739.

### Approach

- When the cursor moves in an embedded Ace editor, we compute whether the cursor element is sufficiently visible using bounding boxes, and scroll it into view if it isn't. This computation is somewhat expensive, so we only do it when moving to a new row (i.e. it won't fire while typing in a line) and only after releasing the mouse/keyboard. 
- When a chunk finishes executing, we ensure that the output it created is visible. This is handled on on the panmirror side via zenscroll, and invoked from GWT-land. 

### QA Notes

The intent here is for you to always be able to see what you're typing and executing, so check around the edges of those scenarios in visual mode. 