### PR TITLE
fix unit test hang analysis on macOS

### DIFF
--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -40,6 +40,15 @@ if ! command -v gtimeout &> /dev/null; then
    brew install coreutils
 fi
 
+# pidof and gdb needed for analysis of hung unit tests
+if ! command -v pidof &> /dev/null; then
+   brew install pidof
+fi
+if ! command -v gdb &> /dev/null; then
+   brew install gdb
+   grep -qxF 'set startup-with-shell off' ~/.gdbinit || echo "set startup-with-shell off" >> ~/.gdbinit
+fi
+
 cd ../common
 ./install-common --install-crashpad-sudo
 cd ../osx

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -67,8 +67,14 @@ runWatchdogProcess()
    if [ $RETCODE == 124 ]; then
       # process is hanging - use gdb to collect a stack trace to find out why
       echo "Hang detected. Dumping backtrace..."
-      sudo gdb -q -batch -ex 'thread apply all backtrace' -p $(pidof $command)
-      sudo kill -9 $(pidof $command)
+      if [[ "$OSTYPE" == "darwin"* ]]; then
+         # pidof on Mac doesn't support fully qualified process names
+         commandbase="$(basename $command)"
+      else
+         commandbase=$command
+      fi
+      sudo gdb -q -batch -ex 'thread apply all backtrace' -p "$(pidof $commandbase)"
+      sudo kill -9 "$(pidof $commandbase)"
       UNIT_TEST_FAILURE=true
    elif [ $RETCODE != 0 ]; then
       UNIT_TEST_FAILURE=true
@@ -80,8 +86,8 @@ runWatchdogProcess()
 findLibSegFault
 
 TEST_SCOPE=
-if [ "$1" == "--scope" ]; then 
-   if [ "$#" == 1 ]; then 
+if [ "$1" == "--scope" ]; then
+   if [ "$#" == 1 ]; then
       printf "Specify scope (core, rsession, or r).\n"
       exit 1
    fi
@@ -98,7 +104,7 @@ elif [ "$1" == "--filter" ]; then
    TEST_FILTER="$2"
    shift 2
 
-elif [ "$1" == "--help" ]; then 
+elif [ "$1" == "--help" ]; then
    printf "%s\n\n" "Runs RStudio unit tests. Available flags: "
    printf "%s\n" "--help    Show this help"
    printf "%s\n" "--scope   Run only tests with the given scope (core, rsession, or r)"
@@ -114,7 +120,7 @@ else
    VALGRIND="valgrind --dsymutil=yes $@"
 fi
 
-## On a Debug Mac IDE build via xcodebuild, the executables 
+## On a Debug Mac IDE build via xcodebuild, the executables
 ## will be in a Debug folder
 if [ ! -e "${CMAKE_CURRENT_BINARY_DIR}/core/rstudio-core-tests" ]
 then
@@ -156,7 +162,7 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "rsession" ]; then
     export RS_CRASHPAD_HANDLER_PATH="/opt/rstudio-tools/crashpad/crashpad/out/Default/crashpad_handler"
     runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN" --run-tests --config-file="$SESSION_CONF_FILE"
 fi
-   
+
 if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
     echo Running 'r' tests...
 


### PR DESCRIPTION
### Intent

When unit tests timeout (5 minutes), getting a stack trace of the hang on macOS wasn't working.

### Approach

- brew install pidof and gdb, and write necessary goo to .gdbinit needed on macOS
- pidof doesn't support fully qualified paths on macOS, so pass the basename only

### QA Notes

Purely a dev/build environment thing. No product or customer impact.
