### PR TITLE
auto-complete virtual environment names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Python objects can now be viewed using the Data Viewer and Object Explorer. (#6862)
 * The `matplotlib.pyplot.show()` function now displays PNG plots within the Plots pane. (#4965)
 * Plots generated via `matplotlib` are now shown with a higher DPI in the Plots pane when appropriate.
+* The autocompletion system can now auto-complete virtual environment names in `reticulate::virtualenv()`.
 
 ### Plots
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1893,6 +1893,18 @@ assign(x = ".rs.acCompletionTypes",
    }
 })
 
+.rs.addFunction("getCompletionsPythonVirtualEnvironments", function(token)
+{
+   home <- Sys.getenv("WORKON_HOME", unset = "~/.virtualenvs")
+   candidates <- list.files(home)
+   results <- .rs.selectFuzzyMatches(candidates, token)
+   
+   .rs.makeCompletions(token = token,
+                       results = results,
+                       quote = TRUE,
+                       type = .rs.acCompletionTypes$STRING)
+})
+
 .rs.addFunction("getCompletionsEnvironmentVariables", function(token)
 {
    candidates <- names(Sys.getenv())
@@ -2099,6 +2111,14 @@ assign(x = ".rs.acCompletionTypes",
        string[[1]] %in% c("Sys.getenv", "Sys.setenv") &&
        numCommas[[1]] == 0)
       return(.rs.getCompletionsEnvironmentVariables(token))
+   
+   # Python virtual environments
+   if (length(string) &&
+       string[[1]] %in% c("use_virtualenv", "reticulate::use_virtualenv") &&
+       numCommas[[1]] == 0)
+   {
+      return(.rs.getCompletionsPythonVirtualEnvironments(token))
+   }
    
    # No information on completions other than token
    if (!length(string))


### PR DESCRIPTION
### Intent

Allow the autocompletion system to provide completion results for Python virtual environments, normally referenced via `use_virtualenv()`.

### Approach

Relatively straight-forward addition to the autocompletion system.

### QA Notes

Check that the completion results in `use_virtualenv(|` reflect the available Python virtual environments located at `~/.virtualenv`.