### PR TITLE
mask user input if prompt contains 'password'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -97,4 +97,4 @@
 * Reduced difference in font size and spacing between Terminal and Console (#6382)
 * Fixed issue where path autocompletion in R Markdown documents did not respect Knit Directory preference (#5412)
 * Fixed issue where Job Launcher streams could remain open longer than expected when viewing the job details page (Pro #1855)
-
+* Fixed issue where `rstudioapi::askForPassword()` did not mask user input in some cases.

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/AskPassManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/AskPassManager.java
@@ -81,10 +81,19 @@ public class AskPassManager
             
             String prompt = e.getPrompt();
             
+            // default to password prompt
             String title = "Password";
             int dialogType = MessageDisplay.INPUT_PASSWORD;
-            if (prompt.toLowerCase().indexOf("username") != -1)
+
+            if (prompt.toLowerCase().indexOf("password") != -1)
             {
+               // if password is mentioned in prompt, treat as password
+               title = "Password";
+               dialogType = MessageDisplay.INPUT_PASSWORD;
+            }
+            else if (prompt.toLowerCase().indexOf("username") != -1)
+            {
+               // if username is mentioned in prmopt, treat as username
                title = "Username";
                dialogType = MessageDisplay.INPUT_USERNAME;
             }


### PR DESCRIPTION
### Intent

When a password is requested from the user via e.g. `.rs.askForPassword()`, we choose to mask user input based on whether "username" is located in the prompt string. This fails for cases in https://github.com/rstudio/rstudioapi/issues/195 where both "password" and "username" are mentioned in the prompt.

### Approach

If "password" is contained in the prompt, treat it as a password entry, regardless of whether "username" is present.

### QA Notes

Test with `rstudioapi::askForPassword("Enter password for username USER:")` -- input should be masked.

---

Closes https://github.com/rstudio/rstudioapi/issues/195.