### PR TITLE
show correct symbol for Return key on Mac menus

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 * R6Class method defintions are now indexed and accessible by the fuzzy finder (Ctrl + .)
 * The 'Preview' command for R documentation files now passes along RdMacros declared from the package DESCRIPTION file. (#6871)
 * Some panes didn't have commands for making them visible, now they do (#5775)
+* Show correct symbol for Return key in Mac menus (#6524)
 
 ### RStudio Server Pro
 

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -219,6 +219,10 @@ void MenuCallback::addCommand(QString commandId,
    // on macOS, replace instances of 'Ctrl' with 'Meta'; QKeySequence renders "Ctrl" using the
    // macOS command symbol, but we want the menu to show the literal Ctrl symbol (^)
    shortcut.replace(QStringLiteral("Ctrl"), QStringLiteral("Meta"));
+
+   // on Mac the enter key and return keys have different symbols
+   // https://github.com/rstudio/rstudio/issues/6524
+   shortcut.replace(QStringLiteral("Enter"), QStringLiteral("Return"));
 #endif
 
    // replace instances of 'Cmd' with 'Ctrl' -- note that on macOS


### PR DESCRIPTION
### Intent

- Fixes #6524

Since RStudio 1.2 we've been showing the wrong symbol for the <kbd>Return</kbd> key in the Mac desktop IDE's menus. We were showing the symbol for <kbd>Enter</kbd>, instead.

### Approach

On Mac desktop only, notify Qt that we _really_ meant the <kbd>Return</kbd> key so it shows the expected symbol.

### QA Notes

Check that any command on Mac Desktop shows the expected symbol for commands using "Enter" in their shortcut, and that these keyboard shortcuts still work. In my testing with a full Mac keyboard, both the Enter and Return keys work as expected, but mainly we care about the Return key (the one on Mac laptops).

The code change is in Mac-only desktop code, and only impacts the main menu.