### PR TITLE
Implement all relevant editor commands in the visual editor

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.css
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.css
@@ -50,10 +50,11 @@
 }
 
 /*
- * Similarly, hide brackets highlighting due to a match with the invisible
- * cursor position.
+ * Similarly, hide selection and brackets highlighting due to a match with the
+ * invisible cursor position.
  */
-.pm-ace-editor-inactive .ace_marker-layer .ace_bracket {
+.pm-ace-editor-inactive .ace_marker-layer .ace_bracket,
+.pm-ace-editor-inactive .ace_marker-layer .ace_selection {
   display: none;
 }
 

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -444,15 +444,9 @@ export class AceNodeView implements NodeView {
 
     this.aceEditor.on('blur', () => {
       // Add a class to editor; this class contains CSS rules that hide editor
-      // components that Ace cannot hide natively (such as the cursor and
-      // matching bracket indicator)
+      // components that Ace cannot hide natively (such as the cursor,
+      // matching bracket indicator, and active selection)
       this.dom.classList.add("pm-ace-editor-inactive");
-
-      // Clear the selection (otherwise could conflict with Prosemirror's
-      // selection)
-      if (this.editSession) {
-        this.editSession.selection.clearSelection();
-      }
     });
 
     // Add custom escape commands for movement keys (left/right/up/down); these

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -231,6 +231,7 @@ public class TextEditingTarget implements
 
       void findSelectAll();
       void findFromSelection();
+      void findFromSelection(String selectionValue);
 
       StatusBar getStatusBar();
 
@@ -6711,8 +6712,11 @@ public class TextEditingTarget implements
    @Handler
    void onFindFromSelection()
    {
-      view_.findFromSelection();
-      docDisplay_.focus();
+      withActiveEditor((disp) ->
+      {
+         view_.findFromSelection(disp.getSelectionValue());
+         disp.focus();
+      });
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1558,7 +1558,6 @@ public class TextEditingTarget implements
                                           session_,
                                           column);
 
-      roxygenHelper_ = new RoxygenHelper(docDisplay_, view_);
       packageDependencyHelper_ = new TextEditingTargetPackageDependencyHelper(this, docUpdateSentinel_, docDisplay_);
 
       // create notebook and forward resize events
@@ -3426,7 +3425,10 @@ public class TextEditingTarget implements
    @Handler
    void onInsertRoxygenSkeleton()
    {
-      roxygenHelper_.insertRoxygenSkeleton();
+      withActiveEditor((disp) ->
+      {
+         new RoxygenHelper(disp, view_).insertRoxygenSkeleton();
+      });
    }
 
    @Handler
@@ -7959,7 +7961,6 @@ public class TextEditingTarget implements
    private VisualMode visualMode_;
    private TextEditingTargetIdleMonitor bgIdleMonitor_;
    private TextEditingTargetThemeHelper themeHelper_;
-   private RoxygenHelper roxygenHelper_;
    private boolean ignoreDeletes_;
    private boolean forceSaveCommandActive_ = false;
    private final TextEditingTargetScopeHelper scopeHelper_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5934,7 +5934,10 @@ public class TextEditingTarget implements
 
    private void sourceActiveDocument(final boolean echo)
    {
-      docDisplay_.focus();
+      if (!isVisualEditorActive())
+      {
+         docDisplay_.focus();
+      }
 
       // If this is a Python file, use reticulate.
       if (fileType_.isPython())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -486,7 +486,6 @@ public class TextEditingTarget implements
       sqlHelper_ = new TextEditingTargetSqlHelper(docDisplay_);
       presentationHelper_ = new TextEditingTargetPresentationHelper(
                                                                   docDisplay_);
-      reformatHelper_ = new TextEditingTargetReformatHelper(docDisplay_);
       rHelper_ = new TextEditingTargetRHelper(docDisplay_);
 
       docDisplay_.setRnwCompletionContext(compilePdfHelper_);
@@ -3324,14 +3323,17 @@ public class TextEditingTarget implements
    @Handler
    void onReformatCode()
    {
-      // Only allow if entire selection in R mode for now
-      if (!DocumentMode.isSelectionInRMode(docDisplay_))
+      withActiveEditor((disp) ->
       {
-         showRModeWarning("Reformat Code");
-         return;
-      }
+         // Only allow if entire selection in R mode for now
+         if (!DocumentMode.isSelectionInRMode(disp))
+         {
+            showRModeWarning("Reformat Code");
+            return;
+         }
 
-      reformatHelper_.insertPrettyNewlines();
+         new TextEditingTargetReformatHelper(disp).insertPrettyNewlines();
+      });
    }
 
    @Handler
@@ -3434,19 +3436,28 @@ public class TextEditingTarget implements
    @Handler
    void onExpandSelection()
    {
-      docDisplay_.expandSelection();
+      withActiveEditor((disp) ->
+      {
+         disp.expandSelection();
+      });
    }
 
    @Handler
    void onShrinkSelection()
    {
-      docDisplay_.shrinkSelection();
+      withActiveEditor((disp) ->
+      {
+         disp.shrinkSelection();
+      });
    }
 
    @Handler
    void onExpandRaggedSelection()
    {
-      docDisplay_.expandRaggedSelection();
+      withActiveEditor((disp) ->
+      {
+         disp.expandRaggedSelection();
+      });
    }
 
    @Handler
@@ -7956,7 +7967,6 @@ public class TextEditingTarget implements
    private final TextEditingTargetJSHelper jsHelper_;
    private final TextEditingTargetSqlHelper sqlHelper_;
    private final TextEditingTargetPresentationHelper presentationHelper_;
-   private final TextEditingTargetReformatHelper reformatHelper_;
    private final TextEditingTargetRHelper rHelper_;
    private VisualMode visualMode_;
    private TextEditingTargetIdleMonitor bgIdleMonitor_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetFindReplace.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetFindReplace.java
@@ -147,9 +147,8 @@ public class TextEditingTargetFindReplace
          findReplace_.findPrevious();
    }
    
-   public void findFromSelection()
+   public void findFromSelection(String selection)
    {
-      String selection = container_.getEditor().getSelectionValue();
       boolean multiLineSelection = selection.indexOf('\n') != -1;
       if ((selection.length()) > 0 && !multiLineSelection)
       {
@@ -165,6 +164,11 @@ public class TextEditingTargetFindReplace
             findReplace_.activate(selection, true, false);
          }
       }
+   }
+   
+   public void findFromSelection()
+   {
+      findFromSelection(container_.getEditor().getSelectionValue());
    }
    
    public void replaceAndFind()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -827,8 +827,8 @@ public class TextEditingTargetWidget
          canSourceOnSave = (extendedType_.equals(SourceDocument.XT_JS_PREVIEWABLE));
       if (canSourceOnSave && fileType.isSql())
          canSourceOnSave = (extendedType_.equals(SourceDocument.XT_SQL_PREVIEWABLE));
-      boolean canExecuteCode = fileType.canExecuteCode() && !visualRmdMode;
-      boolean canExecuteChunks = fileType.canExecuteChunks() && !visualRmdMode;
+      boolean canExecuteCode = fileType.canExecuteCode();
+      boolean canExecuteChunks = fileType.canExecuteChunks();
       boolean isPlainMarkdown = fileType.isPlainMarkdown();
       boolean isCpp = fileType.isCpp();
       boolean isScript = fileType.isScript();
@@ -855,8 +855,8 @@ public class TextEditingTargetWidget
       // otherwise just show the regular insert chunk button
       insertChunkButton_.setVisible(canExecuteChunks && !isRMarkdown2);
 
-      goToPrevButton_.setVisible(fileType.canGoNextPrevSection() && !visualRmdMode);
-      goToNextButton_.setVisible(fileType.canGoNextPrevSection() && !visualRmdMode);
+      goToPrevButton_.setVisible(fileType.canGoNextPrevSection());
+      goToNextButton_.setVisible(fileType.canGoNextPrevSection());
 
       sourceOnSave_.setVisible(canSourceOnSave);
       srcOnSaveLabel_.setVisible(canSourceOnSave);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1199,6 +1199,12 @@ public class TextEditingTargetWidget
    }
 
    @Override
+   public void findFromSelection(String selectionValue)
+   {
+      findReplace_.findFromSelection(selectionValue);
+   }
+
+   @Override
    public void replaceAndFind()
    {
       findReplace_.replaceAndFind();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1725,36 +1725,34 @@ public class TextEditingTargetWidget
             TextEditingTargetNotebook.CONTENT_PREVIEW_INLINE,
             DocUpdateSentinel.PROPERTY_TRUE));
          menu.addSeparator();
+      }
 
-         if (!isShinyFile)
-         {
-            boolean inline = userPrefs_.rmdChunkOutputInline().getValue();
-            menu.addItem(new DocPropMenuItem(
-               "Chunk Output Inline", docUpdateSentinel_,
-               inline,
-               TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
-               TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE));
-            menu.addItem(new DocPropMenuItem(
-               "Chunk Output in Console", docUpdateSentinel_,
-               !inline,
-               TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
-               TextEditingTargetNotebook.CHUNK_OUTPUT_CONSOLE));
+      if (!isShinyFile)
+      {
+         boolean inline = userPrefs_.rmdChunkOutputInline().getValue();
+         menu.addItem(new DocPropMenuItem(
+            "Chunk Output Inline", docUpdateSentinel_,
+            inline,
+            TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
+            TextEditingTargetNotebook.CHUNK_OUTPUT_INLINE));
+         menu.addItem(new DocPropMenuItem(
+            "Chunk Output in Console", docUpdateSentinel_,
+            !inline,
+            TextEditingTargetNotebook.CHUNK_OUTPUT_TYPE,
+            TextEditingTargetNotebook.CHUNK_OUTPUT_CONSOLE));
 
-            menu.addSeparator();
+         menu.addSeparator();
 
-            SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();
-            menu.addItem(
-               mgr.getSourceCommand(commands_.notebookExpandAllOutput(), column_).createMenuItem());
-            menu.addItem(
-               mgr.getSourceCommand(commands_.notebookCollapseAllOutput(), column_).createMenuItem());
-            menu.addSeparator();
-            menu.addItem(
-               mgr.getSourceCommand(commands_.notebookClearOutput(), column_).createMenuItem());
-            menu.addItem(
-               mgr.getSourceCommand(commands_.notebookClearAllOutput(), column_).createMenuItem());
-            menu.addSeparator();
-         }
-
+         SourceColumnManager mgr = RStudioGinjector.INSTANCE.getSourceColumnManager();
+         menu.addItem(
+            mgr.getSourceCommand(commands_.notebookExpandAllOutput(), column_).createMenuItem());
+         menu.addItem(
+            mgr.getSourceCommand(commands_.notebookCollapseAllOutput(), column_).createMenuItem());
+         menu.addSeparator();
+         menu.addItem(
+            mgr.getSourceCommand(commands_.notebookClearOutput(), column_).createMenuItem());
+         menu.addItem(
+            mgr.getSourceCommand(commands_.notebookClearAllOutput(), column_).createMenuItem());
          menu.addSeparator();
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -184,7 +184,15 @@ public class TextEditingTargetNotebook
             String yaml = RmdEditorOptions.set(
                   YamlFrontMatter.getFrontMatter(docDisplay_), 
                   CHUNK_OUTPUT_TYPE, event.getValue());
-            YamlFrontMatter.applyFrontMatter(docDisplay_, yaml);
+
+            if (editingTarget_.isVisualEditorActive())
+            {
+               editingTarget_.getVisualMode().applyYamlFrontMatter(yaml);
+            }
+            else
+            {
+               YamlFrontMatter.applyFrontMatter(docDisplay_, yaml);
+            }
             
             // change the output mode in the document
             changeOutputMode(event.getValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1702,6 +1702,13 @@ public class TextEditingTargetNotebook
       {
          // clean any error state still attached to the output's scope
          cleanScopeErrorState(output.getScope());
+         output.detach();
+         output.remove();
+      }
+
+      for (ChunkOutputUi output: visualOutputs_.values())
+      {
+         output.detach();
          output.remove();
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -657,8 +657,6 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 
-        commands_.reindent(),
-        commands_.reformatCode(),
         commands_.findSelectAll(),
         commands_.findFromSelection(),
         commands_.executeSetupChunk(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -657,7 +657,6 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 
-        commands_.commentUncomment(),
         commands_.insertRoxygenSkeleton(),
         commands_.reindent(),
         commands_.reformatCode(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -661,7 +661,6 @@ public class VisualMode implements VisualModeEditorSync,
         // embedded editors simultaneously
         commands_.findSelectAll(),
 
-        commands_.executeSetupChunk(),
         commands_.executeAllCode(),
         commands_.executeCode(),
         commands_.executeCodeWithoutFocus(),
@@ -673,7 +672,6 @@ public class VisualMode implements VisualModeEditorSync,
         commands_.executeCurrentStatement(),
         commands_.executeFromCurrentLine(),
         commands_.executeLastCode(),
-        commands_.executeNextChunk(),
         commands_.executeSubsequentChunks(),
         commands_.executeToCurrentLine(),
         commands_.sendToTerminal(),
@@ -718,6 +716,11 @@ public class VisualMode implements VisualModeEditorSync,
    public void executePreviousChunks()
    {
       visualModeChunks_.executePreviousChunks();
+   }
+   
+   public void executeNextChunk()
+   {
+      visualModeChunks_.executeNextChunk();
    }
    
    public DocDisplay getActiveEditor()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -650,14 +650,13 @@ public class VisualMode implements VisualModeEditorSync,
       
       // disable commands
       disableForVisualMode(
+        // Disabled since it just opens the scope tree widget (which doens't
+        // exist in visual mode)
         commands_.jumpTo(),
-        commands_.jumpToMatching(),
+
+        // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
-        commands_.goToHelp(),
-        commands_.goToDefinition(),
-        commands_.extractFunction(),
-        commands_.extractLocalVariable(),
-        commands_.renameInScope(),
+
         commands_.reflowComment(),
         commands_.commentUncomment(),
         commands_.insertRoxygenSkeleton(),
@@ -722,6 +721,16 @@ public class VisualMode implements VisualModeEditorSync,
    public void executePreviousChunks()
    {
       visualModeChunks_.executePreviousChunks();
+   }
+   
+   public DocDisplay getActiveEditor()
+   {
+      return activeEditor_;
+   }
+   
+   public void setActiveEditor(DocDisplay editor)
+   {
+      activeEditor_ = editor;
    }
 
    public void goToNextSection()
@@ -1450,10 +1459,11 @@ public class VisualMode implements VisualModeEditorSync,
    private Commands commands_;
    private UserPrefs prefs_;
    private SourceServerOperations source_;
+   private DocDisplay activeEditor_;  // the current embedded editor
    
    private final TextEditingTarget target_;
    private final TextEditingTarget.Display view_;
-   private final DocDisplay docDisplay_;
+   private final DocDisplay docDisplay_;   // the parent editor
    private final DirtyState dirtyState_;
    private final DocUpdateSentinel docUpdateSentinel_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -657,8 +657,10 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 
+        // Disabled since we can't meaningfully select instances in several
+        // embedded editors simultaneously
         commands_.findSelectAll(),
-        commands_.findFromSelection(),
+
         commands_.executeSetupChunk(),
         commands_.executeAllCode(),
         commands_.executeCode(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -668,9 +668,8 @@ public class VisualMode implements VisualModeEditorSync,
         commands_.unfold(),
         commands_.unfoldAll(),
 
-        commands_.goToLine(),
-        commands_.wordCount(),
-        commands_.profileCode()
+        // Disabled since we don't have line numbers in the visual editor
+        commands_.goToLine()
       );
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -683,10 +683,22 @@ public class VisualMode implements VisualModeEditorSync,
    {
       panmirror_.insertChunk(chunkPlaceholder, rowOffset, colOffset);
    }
-   
+
+   /**
+    * Perform a command after synchronizing the selection state of the visual
+    * editor. Note that the command will not be performed unless focus is in a
+    * code editor (as otherwise we can't map selection 1-1).
+    * 
+    * @param command
+    */
    public void performWithSelection(Command command)
    {
-     visualModeChunks_.performWithSelection(command);
+      // Drive focus to the editing surface. This is necessary so we correctly
+      // identify the active (focused) editor on which to perform the command.
+      panmirror_.focus();
+      
+      // Perform the command in the active code editor, if any.
+      visualModeChunks_.performWithSelection(command);
    }
    
    public DocDisplay getActiveEditor()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -657,7 +657,6 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 
-        commands_.insertRoxygenSkeleton(),
         commands_.reindent(),
         commands_.reformatCode(),
         commands_.findSelectAll(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -661,14 +661,13 @@ public class VisualMode implements VisualModeEditorSync,
         // embedded editors simultaneously
         commands_.findSelectAll(),
 
-        commands_.sourceActiveDocument(),
-        commands_.sourceActiveDocumentWithEcho(),
-        commands_.pasteWithIndentDummy(),
+        // Disabled since code folding doesn't work in embedded editors (there's
+        // no gutter in which to toggle folds)
         commands_.fold(),
         commands_.foldAll(),
         commands_.unfold(),
         commands_.unfoldAll(),
-        commands_.yankAfterCursor(),
+
         commands_.notebookExpandAllOutput(),
         commands_.notebookCollapseAllOutput(),
         commands_.notebookClearAllOutput(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -661,22 +661,6 @@ public class VisualMode implements VisualModeEditorSync,
         // embedded editors simultaneously
         commands_.findSelectAll(),
 
-        commands_.executeAllCode(),
-        commands_.executeCode(),
-        commands_.executeCodeWithoutFocus(),
-        commands_.executeCodeWithoutMovingCursor(),
-        commands_.executeCurrentFunction(),
-        commands_.executeCurrentLine(),
-        commands_.executeCurrentParagraph(),
-        commands_.executeCurrentSection(),
-        commands_.executeCurrentStatement(),
-        commands_.executeFromCurrentLine(),
-        commands_.executeLastCode(),
-        commands_.executeSubsequentChunks(),
-        commands_.executeToCurrentLine(),
-        commands_.sendToTerminal(),
-        commands_.runSelectionAsJob(),
-        commands_.runSelectionAsLauncherJob(),
         commands_.sourceActiveDocument(),
         commands_.sourceActiveDocumentWithEcho(),
         commands_.pasteWithIndentDummy(),
@@ -708,19 +692,9 @@ public class VisualMode implements VisualModeEditorSync,
       panmirror_.insertChunk(chunkPlaceholder, rowOffset, colOffset);
    }
    
-   public void executeChunk()
+   public void performWithSelection(Command command)
    {
-      visualModeChunks_.executeCurrentChunk();
-   }
-   
-   public void executePreviousChunks()
-   {
-      visualModeChunks_.executePreviousChunks();
-   }
-   
-   public void executeNextChunk()
-   {
-      visualModeChunks_.executeNextChunk();
+     visualModeChunks_.performWithSelection(command);
    }
    
    public DocDisplay getActiveEditor()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -657,7 +657,6 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 
-        commands_.reflowComment(),
         commands_.commentUncomment(),
         commands_.insertRoxygenSkeleton(),
         commands_.reindent(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -668,14 +668,8 @@ public class VisualMode implements VisualModeEditorSync,
         commands_.unfold(),
         commands_.unfoldAll(),
 
-        commands_.notebookExpandAllOutput(),
-        commands_.notebookCollapseAllOutput(),
-        commands_.notebookClearAllOutput(),
-        commands_.notebookClearOutput(),
         commands_.goToLine(),
         commands_.wordCount(),
-        commands_.restartRClearOutput(),
-        commands_.restartRRunAllChunks(),
         commands_.profileCode()
       );
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -502,9 +502,31 @@ public class VisualModeChunk
    }
    
    /**
-    * Executes the current selection inside the chunk
+    * Executes the active selection via the parent editor
     */
-   private void executeSelection()
+   public void executeSelection()
+   {
+      performWithSelection(() ->
+      {
+         codeExecution_.executeSelection(false);
+      });
+   }
+
+   /**
+    * Performs an arbitrary command after synchronizing the selection state of
+    * the child editor to the parent.
+    * 
+    * @param command The command to perform.
+    */
+   public void performWithSelection(Command command)
+   {
+      sync_.syncToEditor(SyncType.SyncTypeExecution, () ->
+      {
+         performWithSyncedSelection(command);
+      });
+   }
+   
+   private void performWithSyncedSelection(Command command)
    {
       // Ensure we have a scope. This should always exist since we sync the
       // scope outline prior to executing code.
@@ -532,7 +554,8 @@ public class VisualModeChunk
       
       // Execute selection in the parent
       parent_.setSelectionRange(selectionRange);
-      codeExecution_.executeSelection(false);
+
+      command.execute();
       
       // After the event loop, forward the parent selection back to the child if
       // it's changed (this allows us to advance the cursor after running a line)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -109,9 +109,18 @@ public class VisualModeChunk
       // editors)
       editor_.setUseWrapMode(true);
       
-      // Track activation state
-      editor_.addFocusHandler((evt) -> { active_ = true; });
-      editor_.addBlurHandler((evt) -> { active_ = false; });
+      // Track activation state and notify visual mode
+      editor_.addFocusHandler((evt) -> 
+      { 
+         active_ = true; 
+         target_.getVisualMode().setActiveEditor(editor_);
+      });
+      editor_.addBlurHandler((evt) ->
+      {
+         active_ = false;
+         target_.getVisualMode().setActiveEditor(null);
+      });
+       
 
       // Provide the editor's container element
       host_ = Document.get().createDivElement();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -409,6 +409,14 @@ public class VisualModeChunk
    }
    
    /**
+    * Sets focus to the editor instance inside the chunk.
+    */
+   public void focus()
+   {
+      editor_.focus();
+   }
+   
+   /**
     * Returns the position/index of the chunk in the original Markdown document,
     * if known. Note that this value may not be correct if the Markdown document
     * has been mutated since the chunk was created.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -151,6 +151,27 @@ public class VisualModeChunks implements ChunkDefinition.Provider
    }
    
    /**
+    * Executes the next chunk
+    */
+   public void executeNextChunk()
+   {
+      boolean next = false;
+      for (VisualModeChunk chunk: chunks_)
+      {
+         if (next)
+         {
+            chunk.focus();
+            chunk.execute();
+            break;
+         }
+         if (chunk.isActive())
+         {
+            next = true;
+         }
+      }
+   }
+   
+   /**
     * Make a list of the chunk definitions known in visual mode.
     */
    public JsArray<ChunkDefinition> getChunkDefs()


### PR DESCRIPTION
### Intent

A substantial number of editor commands are currently disabled in the visual editor and hidden in the toolbar when the visual editor is active. Some are disabled because they don't may any sense in visual mode (e.g. Go To Line), but most are disabled because we hadn't yet done the work to hook them up / make them do the right thing in visual mode.

This change implements all the remaining editor commands that make sense for visual mode, including notebook commands (clearing output, switching inline/console mode), code execution commands (various execution gestures), commenting (toggle/reflow), refactoring (extracting functions/vars), etc. 

Fixes https://github.com/rstudio/rstudio/issues/7581.

### Approach

Most of the commands follow one of two forms:

1. Execution-oriented commands work by synchronizing the document and selection state from the visual editor to the code editor, then performing the execution in source mode behind the scenes. 
2. Other commands work by delegating tasks to the visual editor, often by finding the active embedded editor and performing the task inside it. 

### QA Notes

You can find a complete list of the commands that were formerly disabled in visual mode here:

https://github.com/rstudio/rstudio/blob/e3817032269e8dcd98aa6e7d8bf28caa559daa3a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java#L652-L703

These are the commands that remain disabled:

https://github.com/rstudio/rstudio/blob/1fae2cde3b381f79f7594087334859c3b6c42b8c/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java#L651-L673

Any command on the first list but not the second should work in visual mode. Note that many of the commands on this list will not do anything unless your cursor is inside a code chunk editor, since e.g., you can't "run current line" if there's no current line of code. 