### PR TITLE
enable all unit tests for macOS build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ def run_tests(type, flavor, variant) {
   
   try {
     // attempt to run cpp unit tests
-    // disable known broken tests for now (Jenkins cannot handle the parallel load these induce)
     sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ./rstudio-tests"
   } catch(err) {
     currentBuild.result = "UNSTABLE"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -50,8 +50,7 @@ pipeline {
         script {
           try {
             // attempt to run cpp unit tests
-            // disable known broken tests for now (Jenkins cannot handle the parallel load these induce)
-            sh "cd package/osx/build/src/cpp && ./rstudio-tests --scope core"
+            sh "cd package/osx/build/src/cpp && ./rstudio-tests"
           } catch(err) {
              currentBuild.result = "UNSTABLE"
           }


### PR DESCRIPTION
### Intent

- Fixes #6890

We are running a subset of unit tests on macOS; we should be running the same set we do on Windows and Linux.

### Approach

Tweak the Mac Jenkinsfile to run all the tests. Also removed an obsolete command from the Linux/Windows Jenkinsfile.

### QA Notes

This is a build-time thing. At worst (famous last words) we'll discover we still have issues running these tests on Mac in the official build, resulting in builds marked as "Unstable" and will have to investigate why.


