### PR TITLE
Install openssl on macOS via dependency script

### DIFF
--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -40,6 +40,13 @@ if ! command -v gtimeout &> /dev/null; then
    brew install coreutils
 fi
 
+# openssl needed to run rsession  (including unit tests)
+if brew list | grep openssl@1.1 &> /dev/null; then
+   echo "openssl already installed"
+else
+   brew install openssl
+fi
+
 # pidof and gdb needed for analysis of hung unit tests
 if ! command -v pidof &> /dev/null; then
    brew install pidof


### PR DESCRIPTION
### Intent

Needed on build machines to run rsession unit tests which were just enabled via #7775

### Approach

Install via macOS dependency script.

### QA Notes

Nothing to test here, purely build-time to get unit tests passing on macOS during official builds.