### PR TITLE
look for versioned python interpreters (e.g. pythonx.y) on PATH

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -197,14 +197,24 @@
    paths <- strsplit(Sys.getenv("PATH"), split = .Platform$path.sep, fixed = TRUE)[[1]]
    for (path in paths) {
       
-      pythonExe <- if (.rs.platform.isWindows) "python.exe" else "python"
-      pythonPath <- file.path(path, pythonExe)
-      if (!file.exists(pythonPath))
-         next
+      # create pattern matching interpreter paths
+      pattern <- if (.rs.platform.isWindows)
+         "^python[[:digit:].]*exe$"
+      else
+         "^python[[:digit:].]*$"
       
-      info <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
+      # look for python installations
+      pythons <- list.files(
+         path       = path,
+         pattern    = pattern,
+         full.names = TRUE
+      )
       
-      interpreters[[length(interpreters) + 1]] <- info
+      # loop over interpreters and add
+      for (python in pythons) {
+         info <- .rs.python.getPythonInfo(python, strict = TRUE)
+         interpreters[[length(interpreters) + 1]] <- info
+      }
       
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -33,6 +33,7 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
       setOkButtonCaption("Select");
       
       widgets_ = new WidgetListBox<PythonInterpreterListEntryUi>();
+      widgets_.setHeight("420px");
       widgets_.setAriaLabel("Python Interpreters");
       
       for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))


### PR DESCRIPTION
### Intent

Currently, RStudio only discovers Python interpreters called `python` (or `python.exe`) on the PATH. However, multiple Python interpreters with versioned names (e.g. `python3.7`) may be available on the PATH as well. This PR makes sure such interpreters are discovered by RStudio.

### Approach

Rather than hardcoding the Python interpreter name, we list files in each directory on the PATH that match an appropriate regular expression.

Note that, in theory, one downside of this approach is that it could be slow when attempting to list files within a very large directory.

### QA Notes

Test that versioned Python executables are discovered in the Python dialog here:

<img width="748" alt="Screen Shot 2020-09-14 at 10 58 33 AM" src="https://user-images.githubusercontent.com/1976582/93121127-3cd09600-f679-11ea-9995-89db30ff4984.png">
