### PR TITLE
cleanup additional legacy state

### DIFF
--- a/scripts/clean-rstudio
+++ b/scripts/clean-rstudio
@@ -14,6 +14,7 @@ rm -f ~/.Rhistory
 
 # global options
 rm -rf ~/.config/rstudio
+rm -rf ~/.r/rstudio
 
 # settings and session state
 rm -rf ~/.rstudio
@@ -23,6 +24,10 @@ rm -rf ~/.local/share/rstudio
 
 # desktop state
 rm -rf ~/.rstudio-desktop
+
+# crash handler state
+rm -f ~/.r/crash-handler-permission
+rm -f ~/.r/crash-handler.conf
 
 if [ "${PLATFORM}" = "Darwin" ]; then
   # macOS desktop settings

--- a/scripts/clean-rstudio.bat
+++ b/scripts/clean-rstudio.bat
@@ -12,6 +12,12 @@ if EXIST "%localappdata%\RStudio\" (
 if EXIST "%appdata%\RStudio\" (
     rd /q /s "%appdata%\RStudio"
 )
+if EXIST "%localappdata%\R\crash-handler-permission" (
+    del "%localappdata%\R\crash-handler-permission"
+)
+if EXIST "%localappdata%\R\crash-handler.conf" (
+    del "%localappdata%\R\crash-handler.conf"
+)
 
 for /f "tokens=*" %%i in ('powershell /command "[System.Environment]::GetFolderPath([Environment+SpecialFolder]::MyDocuments)"') do set MyDocsDir=%%i
 if EXIST "%MyDocsDir%\.RData" (
@@ -19,6 +25,9 @@ if EXIST "%MyDocsDir%\.RData" (
 )
 if EXIST "%MyDocsDir%\.Rhistory" (
     del "%MyDocsDir%\.Rhistory"
+)
+if EXIST "%MyDocsDir%\.R\rstudio\" (
+    rd /q /s "%MyDocsDir%\.R\rstudio"
 )
 if EXIST "%MyDocsDir%\.Renviron" (
     echo Note: "%MyDocsDir%\.Renviron" found, not deleting


### PR DESCRIPTION
### Intent

Utility script (`clean-studio` / `clean-rstudio.bat`) for resetting a machine to a first-run RStudio state; noticed I wasn't being prompted for sending crash reports after running this script, and keyboard shortcuts and add-ins customized in pre 1.4 version weren't going away.

### Approach

Delete these, too.

### QA Notes

Nothing to test (but if you've been using these scripts for anything be sure to grab new copies).