### PR TITLE
re-disable rsession-based unit tests for macOS build

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -50,7 +50,9 @@ pipeline {
         script {
           try {
             // attempt to run cpp unit tests
-            sh "cd package/osx/build/src/cpp && ./rstudio-tests"
+            // problems with rsession finding openssl, so those tests
+            // are disabled until we solve it (#6890)
+            sh "cd package/osx/build/src/cpp && ./rstudio-tests --scope core"
           } catch(err) {
              currentBuild.result = "UNSTABLE"
           }


### PR DESCRIPTION
### Intent

- Due to problems finding openssl in package build; tracked via (reopened) #6890

### Approach

- Will investigate this locally instead of continuing to mess around on the build machine

### QA Notes

Nothing to see here. We weren't running most unit tests on macOS build, then we tried, and it didn't work, so reverting to not trying pending further investigation.