### PR TITLE
Navigate inside visual source editor if available

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/ui.ts
+++ b/src/gwt/panmirror/src/editor/src/api/ui.ts
@@ -38,6 +38,7 @@ export interface EditorUI {
 export interface EditorUIChunkCallbacks {
   getPos: () => number;
   scrollIntoView: (ele: HTMLElement) => void;
+  scrollCursorIntoView: () => void;
 }
 
 export interface EditorUIChunks {

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -40,7 +40,7 @@ import { EditorEvents } from '../../api/events';
 import { kPlatformMac } from '../../api/platform';
 import { rmdChunk, previousExecutableRmdChunks, mergeRmdChunks } from '../../api/rmd';
 import { ExtensionContext } from '../../api/extension';
-import { DispatchEvent, ResizeEvent } from '../../api/event-types';
+import { DispatchEvent, ResizeEvent, ScrollEvent } from '../../api/event-types';
 import { verticalArrowCanAdvanceWithinTextBlock } from '../../api/basekeys';
 import { handleArrowToAdjacentNode } from '../../api/cursor';
 
@@ -452,7 +452,8 @@ export class AceNodeView implements NodeView {
     this.chunk = this.ui.chunks.createChunkEditor('ace',
       this.node.attrs.md_index, {
       getPos: () => this.getPos(),
-      scrollIntoView: (ele) => this.scrollIntoView(ele)
+      scrollIntoView: (ele) => this.scrollIntoView(ele),
+      scrollCursorIntoView: () => this.scrollCursorIntoView()
     });
 
     // populate initial contents
@@ -685,6 +686,13 @@ export class AceNodeView implements NodeView {
     // new width
     this.subscriptions.push(this.events.subscribe(ResizeEvent, () => {
       this.debounceResize();
+    }));
+
+    // Subscribe to scroll event; invalidates the row we're scrolled to so
+    // scrollback will be triggered if necessary (after e.g., typing after
+    // scrolling offscreen)
+    this.subscriptions.push(this.events.subscribe(ScrollEvent, () => {
+      this.scrollRow = -1;
     }));
   }
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunkCallbacks.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunkCallbacks.java
@@ -23,6 +23,7 @@ import jsinterop.annotations.JsType;
 public class PanmirrorUIChunkCallbacks
 {
    public ScrollIntoView scrollIntoView;
+   public ScrollCursorIntoView scrollCursorIntoView;
    public GetVisualPosition getPos;
 
    @JsFunction
@@ -35,5 +36,11 @@ public class PanmirrorUIChunkCallbacks
    public interface ScrollIntoView
    {
       int scrollIntoView(Element ele);
+   }
+   
+   @JsFunction
+   public interface ScrollCursorIntoView
+   {
+      void scroll();
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -228,6 +228,11 @@ public class VisualModeChunk
       return chunk_;
    }
    
+   public AceEditor getAceInstance()
+   {
+      return editor_;
+   }
+   
    /**
     * Add a callback to be invoked when the chunk editor is destroyed.
     * 
@@ -324,6 +329,15 @@ public class VisualModeChunk
    public int getVisualPosition()
    {
       return chunkCallbacks_.getPos.getVisualPosition();
+   }
+   
+
+   /**
+    * Scrolls the cursor into view.
+    */
+   public void scrollCursorIntoView()
+   {
+      chunkCallbacks_.scrollCursorIntoView.scroll();
    }
    
    /**


### PR DESCRIPTION
### Intent

Prior to this change, gestures that navigated to a specific location in a source file (e.g., navigating to R Markdown render issues) always used source mode. This change allows source navigation to take place inside the embedded editors in visual mode when appropriate.

Fixes https://github.com/rstudio/rstudio/issues/7603.

### Approach

There are three possibilities for navigation to cover:

1. Source mode - when the document is in source mode, the behavior is unchanged (we don't ever switch to visual mode in order to navigate)
2. Navigating to code - when in visual mode and navigating to a location inside a code chunk, we stay inside visual mode and navigate to the location inside the chunk
3. All other cases - in all other situations (the document isn't open, the location isn't in a code chunk, etc.) navigation happens in source mode as before.

### QA Notes

This affects Find in Files, the Markers tab, etc. in addition to the R Markdown Issues list described in #7603. 