### PR TITLE
Specify window to activate when reloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,3 +104,5 @@
 * Fixed issue where Job Launcher streams could remain open longer than expected when viewing the job details page (Pro #1855)
 * Fixed issue where `rstudioapi::askForPassword()` did not mask user input in some cases.
 * Fixed issue where Job Launcher admin users would have `gid=0` in Slurm Launcher Sessions (Pro #1935)
+* Fixed issue causing script errors when reloading Shiny applications from the editor toolbar (#7762)
+

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -264,7 +264,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
             {
                satelliteManager_.dispatchCommand(commands_.reloadShinyApp(), 
                      ShinyApplicationSatellite.getNameFromId(params.getId()));
-               activateWindow();
+               activateWindow(params);
             } 
             else if (params.getViewerType() == UserPrefs.SHINY_VIEWER_TYPE_PANE &&
                      commands_.viewerRefresh().isEnabled())
@@ -500,15 +500,14 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       }
    }
    
-   private void activateWindow()
-   {
-      activateWindow(null);
-   }
-   
    private void activateWindow(ShinyApplicationParams params)
    {
-      WindowEx win = satelliteManager_.getSatelliteWindowObject(
+      WindowEx win = null;
+      if (params != null)
+      {
+         win = satelliteManager_.getSatelliteWindowObject(
             ShinyApplicationSatellite.getNameFromId(params.getId()));
+      }
 
       boolean isChrome = !Desktop.isDesktop() && BrowseCap.isChrome();
       


### PR DESCRIPTION
### Intent

Addresses an issue in which the Reload App button can cause a script error. Fixes https://github.com/rstudio/rstudio/issues/7762.

### Approach

Ensure that the parameters defining the window to activate on reload are supplied.

### QA Notes

If you're having trouble reproducing, try using the Chrome browser + RStudio Server (the window reload/reactivation requires us to close and reopen the window there).
