### PR TITLE
Fix issue with zoom column commands

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1528,8 +1528,8 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="layoutZoomLeftColumn"
         checkable="true"
-        label="Zoom Left Column"
-        menuLabel="_Zoom Left Column"/>
+        label="Zoom Left / Center Column"
+        menuLabel="_Zoom Left / Center Column"/>
 
    <cmd id="layoutZoomRightColumn"
         checkable="true"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -265,6 +265,14 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
+   public double getLeftWidgetsSize()
+   {
+      double sum = 0.0;
+      for (Widget w : leftList_)
+         sum += getWidgetSize(w);
+      return sum;
+   }
+   
    public void removeLeftWidget(Widget widget)
    {
       clearForRefresh();
@@ -272,16 +280,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
-   public double getLeftWidgetSize()
-   {
-      double size = 0.0;
-      for (Widget w : leftList_)
-      {
-         size += getWidgetSize(w);
-      }
-      return size;
-   }
-   
+   /*
    public void resizeLeftWidgets(double size)
    {
       double difference = size - getLeftWidgetSize();
@@ -321,6 +320,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
          }
       }
    }
+    */
    
    public void onSplitterResized(SplitterResizedEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -280,48 +280,6 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
-   /*
-   public void resizeLeftWidgets(double size)
-   {
-      double difference = size - getLeftWidgetSize();
-      if (leftList_.isEmpty() || difference == 0.0)
-         return;
-      
-      // if we are increasing the size, spread it evenly acorss the columns
-      if (difference > 0)
-      {
-         double perColumn = difference / leftList_.size();
-         for (int i = 0; i < leftList_.size(); i++)
-         {
-            double newSize = perColumn + getWidgetSize(leftList_.get(i));
-            setWidgetSize(leftList_.get(i), newSize);
-         }
-      }
-      else
-      {
-         for (int i =0;
-              i < leftList_.size() && difference < 0.0;
-              i++)
-         {
-            double currentSize = getWidgetSize(leftList_.get(i));
-            if (currentSize > 0)
-            {
-               if (currentSize >= -difference)
-               {
-                  setWidgetSize(leftList_.get(i), currentSize + difference);
-                  difference = 0.0;
-               }
-               else
-               {
-                  difference += currentSize;
-                  setWidgetSize(leftList_.get(i), 0.0);
-               }
-            }
-         }
-      }
-   }
-    */
-   
    public void onSplitterResized(SplitterResizedEvent event)
    {
       enforceBoundaries();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -272,6 +272,18 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
+   public void showLeftWidgets()
+   {
+      for (Widget w : leftList_)
+         w.setVisible(true);
+   }
+
+   public void hideLeftWidgets()
+   {
+      for (Widget w : leftList_)
+         w.setVisible(false);
+   }
+   
    public void onSplitterResized(SplitterResizedEvent event)
    {
       enforceBoundaries();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -273,6 +273,14 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       return sum;
    }
    
+   public ArrayList<Double> getLeftWidgetSizes()
+   {
+      ArrayList<Double> result = new ArrayList<>();
+      for (Widget w : leftList_)
+         result.add(getWidgetSize(w));
+      return result;
+   }
+   
    public void removeLeftWidget(Widget widget)
    {
       clearForRefresh();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -272,18 +272,51 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
-   public void setLeftWidgetsVisible(boolean visible)
+   public double getLeftWidgetSize()
    {
+      double size = 0.0;
       for (Widget w : leftList_)
-         w.setVisible(visible);
+      {
+         size += getWidgetSize(w);
+      }
+      return size;
    }
-
-   @Override
-   public void setWidgetSize(Widget widget, double size)
+   
+   public void resizeLeftWidgets(double size)
    {
-      if (leftList_.isEmpty())
-         super.setWidgetSize(widget, size);
-
+      double difference = size - getLeftWidgetSize();
+      if (leftList_.isEmpty() || difference == 0.0)
+         return;
+      
+      // if we are increasing the size, spread it evenly acorss the columns
+      if (difference > 0)
+      {
+         double perColumn = difference / leftList_.size();
+         for (int i = 0; i < leftList_.size(); i++)
+            setWidgetSize(leftList_.get(i), perColumn);
+      }
+      else
+      {
+         for (int i =0;
+              i < leftList_.size() && difference < 0.0;
+              i++)
+         {
+            double currentSize = getWidgetSize(leftList_.get(i));
+            if (currentSize > 0)
+            {
+               if (currentSize >= -difference)
+               {
+                  setWidgetSize(leftList_.get(i), currentSize + difference);
+                  difference = 0.0;
+               }
+               else
+               {
+                  difference += currentSize;
+                  setWidgetSize(leftList_.get(i), 0.0);
+               }
+            }
+         }
+      }
    }
    
    public void onSplitterResized(SplitterResizedEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -293,7 +293,10 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       {
          double perColumn = difference / leftList_.size();
          for (int i = 0; i < leftList_.size(); i++)
-            setWidgetSize(leftList_.get(i), perColumn);
+         {
+            double newSize = perColumn + getWidgetSize(leftList_.get(i));
+            setWidgetSize(leftList_.get(i), newSize);
+         }
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -272,16 +272,18 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
-   public void showLeftWidgets()
+   public void setLeftWidgetsVisible(boolean visible)
    {
       for (Widget w : leftList_)
-         w.setVisible(true);
+         w.setVisible(visible);
    }
 
-   public void hideLeftWidgets()
+   @Override
+   public void setWidgetSize(Widget widget, double size)
    {
-      for (Widget w : leftList_)
-         w.setVisible(false);
+      if (leftList_.isEmpty())
+         super.setWidgetSize(widget, size);
+
    }
    
    public void onSplitterResized(SplitterResizedEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -251,13 +251,6 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       deferredSaveWidthPercent();
    }
 
-   public void resetLeftWidgets(ArrayList<Widget> list)
-   {
-      clearForRefresh();
-      leftList_ = new ArrayList<>(list);
-      initialize(leftList_, center_, right_);
-   }
-
    public void addLeftWidget(Widget widget)
    {
       clearForRefresh();
@@ -265,7 +258,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
-   public double getLeftWidgetsSize()
+   public double getLeftSize()
    {
       double sum = 0.0;
       for (Widget w : leftList_)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1117,12 +1117,7 @@ public class PaneManager
          if (leftWidgetSizePriorToZoom_.size() != leftList_.size())
             leftEnd = getValidColumnWidths(leftList_, leftWidgetSizePriorToZoom_, false);
          else
-         {
-            // Copy leftWidgetSizePriorToZoom_ rather than passing it directly because it may be
-            // cleared before animation completes
-            for (Double size : leftWidgetSizePriorToZoom_)
-               leftEnd.add(size);
-         }
+            leftEnd.addAll(leftWidgetSizePriorToZoom_);
       }
 
       resizeHorizontally(panel_.getWidgetSize(right_), widgetSizePriorToZoom_, leftStart, leftEnd);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -284,7 +284,7 @@ public class PaneManager
       int splitterSize = RStudioThemes.isFlat(userPrefs) ? 7 : 3;
 
       panes_ = createPanes(config);
-      left_ = createSplitWindow(panes_.get(0), panes_.get(1), LEFT_COLUMN, 0.4, splitterSize);
+      center_ = createSplitWindow(panes_.get(0), panes_.get(1), LEFT_COLUMN, 0.4, splitterSize);
       right_ = createSplitWindow(panes_.get(2), panes_.get(3), RIGHT_COLUMN, 0.6, splitterSize);
       panel_ = pSplitPanel.get();
 
@@ -300,7 +300,7 @@ public class PaneManager
             {
                String name = sourceColumnManager_.get(i).getName();
                if (!StringUtil.equals(name, SourceColumnManager.MAIN_SOURCE_NAME))
-                  leftColumnList_.add(0, createSourceColumnWindow(name));
+                  leftList_.add(0, createSourceColumnWindow(name));
             }
          }
          else
@@ -317,7 +317,7 @@ public class PaneManager
                0).cast());
          }
       }
-      panel_.initialize(leftColumnList_, left_, right_);
+      panel_.initialize(leftList_, center_, right_);
 
       for (LogicalWindow window : sourceLogicalWindows_)
       {
@@ -368,7 +368,7 @@ public class PaneManager
          ArrayList<LogicalWindow> newPanes = createPanes(
                validateConfig(evt.getValue().cast()));
          panes_ = newPanes;
-         left_.replaceWindows(newPanes.get(0), newPanes.get(1));
+         center_.replaceWindows(newPanes.get(0), newPanes.get(1));
          right_.replaceWindows(newPanes.get(2), newPanes.get(3));
 
          tabSet1TabPanel_.clear();
@@ -580,7 +580,7 @@ public class PaneManager
    @Handler
    public void onFocusLeftSeparator()
    {
-      left_.focusSplitter();
+      center_.focusSplitter();
    }
 
    @Handler
@@ -820,14 +820,14 @@ public class PaneManager
          pane.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL));
 
       boolean isLeftWidget =
-            DomUtils.contains(left_.getElement(), window.getActiveWidget().getElement());
+            DomUtils.contains(center_.getElement(), window.getActiveWidget().getElement());
 
       window.onWindowStateChange(new WindowStateChangeEvent(WindowState.EXCLUSIVE));
 
       ArrayList<Double> leftStart = new ArrayList<>();
       ArrayList<Double> leftEnd = new ArrayList<>();
       leftWidgetSizePriorToZoom_.clear();
-      for (Widget column : leftColumnList_)
+      for (Widget column : leftList_)
       {
          leftWidgetSizePriorToZoom_.add(panel_.getWidgetSize(column));
          leftStart.add(panel_.getWidgetSize(column));
@@ -880,7 +880,7 @@ public class PaneManager
    {
       // the left lists must be equal to the number of left widgets or empty
       assert((leftStart.size() == leftEnd.size() &&
-              leftStart.size() == leftColumnList_.size()) ||
+              leftStart.size() == leftList_.size()) ||
              (leftStart.isEmpty() && leftEnd.isEmpty()));
 
       double tempStartSum = 0.0;
@@ -914,17 +914,17 @@ public class PaneManager
                double difference = currentSize - size;
                for (int i = 0; i < leftStart.size() && difference > 0; i++)
                {
-                  double widgetSize = panel_.getWidgetSize(leftColumnList_.get(i));
+                  double widgetSize = panel_.getWidgetSize(leftList_.get(i));
                   if (widgetSize > 0)
                   {
                      if (widgetSize > difference)
                      {
-                        panel_.setWidgetSize(leftColumnList_.get(i), widgetSize - difference);
+                        panel_.setWidgetSize(leftList_.get(i), widgetSize - difference);
                         difference = 0.0;
                      }
                      else
                      {
-                        panel_.setWidgetSize(leftColumnList_.get(i), 0.0);
+                        panel_.setWidgetSize(leftList_.get(i), 0.0);
                         difference -= widgetSize;
                      }
                   }
@@ -935,17 +935,17 @@ public class PaneManager
                // iterate backwards
                for (int i = leftStart.size() - 1; i >= 0 && size > 0; i--)
                {
-                  double widgetSize = panel_.getWidgetSize(leftColumnList_.get(i));
+                  double widgetSize = panel_.getWidgetSize(leftList_.get(i));
                   if (widgetSize < leftEnd.get(i))
                   {
                      if (size > leftEnd.get(i))
                      {
-                        panel_.setWidgetSize(leftColumnList_.get(i), leftEnd.get(i));
+                        panel_.setWidgetSize(leftList_.get(i), leftEnd.get(i));
                         size -= leftEnd.get(i);
                      }
                      else
                      {
-                        panel_.setWidgetSize(leftColumnList_.get(i), size);
+                        panel_.setWidgetSize(leftList_.get(i), size);
                         size = 0.0;
                      }
                   }
@@ -981,7 +981,7 @@ public class PaneManager
       // If we're currently zoomed, then use that to provide the previous
       // 'non-zoom' state.
       if (maximizedWindow_ != null &&
-          leftColumnList_.size() == leftWidgetSizePriorToZoom_.size())
+          leftList_.size() == leftWidgetSizePriorToZoom_.size())
          restoreSavedLayout();
       else
          restorePaneLayout();
@@ -1053,7 +1053,7 @@ public class PaneManager
    private void restoreColumnLayout()
    {
       setValidColumnWidth(right_);
-      setValidColumnWidths(leftColumnList_, leftWidgetSizePriorToZoom_);
+      setValidColumnWidths(leftList_, leftWidgetSizePriorToZoom_);
       invalidateSavedLayoutState(true);
    }
 
@@ -1065,7 +1065,7 @@ public class PaneManager
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
 
       ArrayList<Double> leftStart = new ArrayList<>();
-      for (int i = 0; i < leftColumnList_.size(); i++)
+      for (int i = 0; i < leftList_.size(); i++)
          leftStart.add(0.0);
       
       maximizedWindow_.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
@@ -1350,7 +1350,7 @@ public class PaneManager
    {
       final double rightInitialSize = panel_.getWidgetSize(right_);
       final ArrayList<Double> leftInitialSize = new ArrayList<>();
-      for (Widget w : leftColumnList_)
+      for (Widget w : leftList_)
          leftInitialSize.add(panel_.getWidgetSize(w));
 
       String currentZoomedColumn = getZoomedColumn();
@@ -1386,7 +1386,7 @@ public class PaneManager
       }
       if (!unZooming)
       {
-         for (Widget w : leftColumnList_)
+         for (Widget w : leftList_)
             leftTargetSize.add(0.0);
       }
 
@@ -1407,9 +1407,9 @@ public class PaneManager
       {
          if (widgetSizePriorToZoom_ < 0)
             widgetSizePriorToZoom_ = panel_.getWidgetSize(right_);
-         if (leftWidgetSizePriorToZoom_.size() != leftColumnList_.size())
+         if (leftWidgetSizePriorToZoom_.size() != leftList_.size())
          {
-            for (Widget w : leftColumnList_)
+            for (Widget w : leftList_)
                leftWidgetSizePriorToZoom_.add(panel_.getWidgetSize(w));
          }
       }
@@ -1483,7 +1483,7 @@ public class PaneManager
       
       Widget panel = createSourceColumnWindow(name);
       panel_.addLeftWidget(panel);
-      leftColumnList_.add(panel);
+      leftList_.add(panel);
       sourceColumnManager_.beforeShow(name);
    }
 
@@ -1532,7 +1532,7 @@ public class PaneManager
          {
             if (window.equals(panesByName_.get(name)))
             {
-               leftColumnList_.remove(window);
+               leftList_.remove(window);
                panesByName_.remove(name);
                panel_.removeLeftWidget(window.getNormal());
                sourceLogicalWindows_.remove(window);
@@ -1883,9 +1883,9 @@ public class PaneManager
    private final HashMap<Tab, Integer> tabToIndex_ = new HashMap<>();
    private final HashMap<WorkbenchTab, Tab> wbTabToTab_ = new HashMap<>();
    private HashMap<String, LogicalWindow> panesByName_;
-   private final DualWindowLayoutPanel left_;
+   private final DualWindowLayoutPanel center_;
    private final DualWindowLayoutPanel right_;
-   private final ArrayList<Widget> leftColumnList_ = new ArrayList<>();
+   private final ArrayList<Widget> leftList_ = new ArrayList<>();
    private ArrayList<LogicalWindow> panes_;
    private ConsoleTabPanel consoleTabPanel_;
    private WorkbenchTabPanel tabSet1TabPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -893,22 +893,11 @@ public class PaneManager
      
       final double leftStartSum = tempStartSum;
       final double leftEndSum = tempEndSum;
-      Debug.logToConsole("=== horizontalResizeAnimation ===");
-      Debug.logToConsole(" === leftStart ===");
-      for (int i = 0; i < leftStart.size(); i++)
-         Debug.logToConsole("  >" + leftStart.get(i) + "< ");
-      Debug.logToConsole(" === leftEnd ===");
-      for (int i = 0; i < leftEnd.size(); i++)
-         Debug.logToConsole("  >" + leftEnd.get(i) + "< ");
-      
-      Debug.logToConsole(" leftStartSum: " + leftStartSum);
-      Debug.logToConsole(" leftEndSum: " + leftEndSum);
       return new Animation()
       {
          @Override
          protected void onUpdate(double progress)
          {
-            Debug.logToConsole("  === onUpdate ===");
             double size = (1 - progress) * rightStart +
                progress * rightEnd;
             panel_.setWidgetSize(right_, size);
@@ -919,18 +908,13 @@ public class PaneManager
             size = (1 - progress) * leftStartSum +
                progress * leftEndSum;
 
-            Debug.logToConsole("  size: " + size);
             double currentSize = panel_.getLeftWidgetsSize();
-            Debug.logToConsole("  currentSize: " + currentSize);
             if (currentSize > size) // we are shrinking
             {
-               Debug.logToConsole("  === shrinking ===");
                double difference = currentSize - size;
-               Debug.logToConsole("  difference: " + difference);
                for (int i = 0; i < leftStart.size() && difference > 0; i++)
                {
                   double widgetSize = panel_.getWidgetSize(leftColumnList_.get(i));
-                  Debug.logToConsole("   widget" + i + " size: " + widgetSize);
                   if (widgetSize > 0)
                   {
                      if (widgetSize > difference)
@@ -943,23 +927,15 @@ public class PaneManager
                         panel_.setWidgetSize(leftColumnList_.get(i), 0.0);
                         difference -= widgetSize;
                      }
-                     Debug.logToConsole("   widget" + i + " newSize: " + panel_.getWidgetSize(leftColumnList_.get(i)));
-                     Debug.logToConsole("   difference: " + difference);
                   }
                }
             }
             else if (currentSize < size)// we are growing
             {
-               Debug.logToConsole("  === growing ===");
-               Debug.logToConsole("     === endSizes ===");
-               for (int i = 0; i < leftEnd.size(); i++)
-                     Debug.logToConsole("      widget" + i + " endSize: " + leftEnd.get(i));
-               Debug.logToConsole("   size: " + size);
                // iterate backwards
                for (int i = leftStart.size() - 1; i >= 0 && size > 0; i--)
                {
                   double widgetSize = panel_.getWidgetSize(leftColumnList_.get(i));
-                  Debug.logToConsole("   widget" + i + " size: " + widgetSize);
                   if (widgetSize < leftEnd.get(i))
                   {
                      if (size > leftEnd.get(i))
@@ -977,13 +953,7 @@ public class PaneManager
                   {
                      size -= widgetSize;
                   }
-                  Debug.logToConsole("   widget" + i + " newSize: " + panel_.getWidgetSize(leftColumnList_.get(i)));
-                  Debug.logToConsole("   size: " + size);
                }
-            }
-            else
-            {
-               Debug.logToConsole("  === equal ===");
             }
          }  
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -823,6 +823,7 @@ public class PaneManager
             DomUtils.contains(left_.getElement(), window.getActiveWidget().getElement());
 
       window.onWindowStateChange(new WindowStateChangeEvent(WindowState.EXCLUSIVE));
+      panel_.hideLeftWidgets();
 
       final double initialSize = panel_.getWidgetSize(right_);
 
@@ -917,6 +918,7 @@ public class PaneManager
       // widgets to size themselves vertically.
       for (LogicalWindow window : panes_)
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
+      panel_.showLeftWidgets();
 
       restoreTwoColumnLayout();
 
@@ -944,6 +946,7 @@ public class PaneManager
       // hidden windows to display themselves, and so on.
       for (LogicalWindow window : panes_)
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
+      panel_.showLeftWidgets();
 
       maximizedWindow_.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
       resizeHorizontally(panel_.getWidgetSize(right_), widgetSizePriorToZoom_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1735,6 +1735,7 @@ public class PaneManager
       LogicalWindow sourceWindow = new LogicalWindow(
             sourceFrame,
             new MinimizedWindowFrame(frameName, frameName));
+      sourceWindow.transitionToState(WindowState.NORMAL);
       sourceLogicalWindows_.add(sourceWindow);
       return sourceWindow;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -823,7 +823,7 @@ public class PaneManager
             DomUtils.contains(left_.getElement(), window.getActiveWidget().getElement());
 
       window.onWindowStateChange(new WindowStateChangeEvent(WindowState.EXCLUSIVE));
-      panel_.hideLeftWidgets();
+      panel_.setLeftWidgetsVisible(false);
 
       final double initialSize = panel_.getWidgetSize(right_);
 
@@ -899,7 +899,7 @@ public class PaneManager
       if (maximizedWindow_ != null)
          restoreSavedLayout();
       else
-         restoreFourPaneLayout();
+         restorePaneLayout();
    }
 
    private void invalidateSavedLayoutState(boolean enableSplitter)
@@ -911,20 +911,18 @@ public class PaneManager
       manageLayoutCommands();
    }
 
-   private void restoreFourPaneLayout()
+   private void restorePaneLayout()
    {
       // Ensure that all windows are in the 'normal' state. This allows
       // hidden windows to display themselves, and so on. This also forces
       // widgets to size themselves vertically.
       for (LogicalWindow window : panes_)
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
-      panel_.showLeftWidgets();
 
-      restoreTwoColumnLayout();
-
+      restoreColumnLayout();
    }
 
-   private void restoreTwoColumnLayout()
+   private void restoreColumnLayout()
    {
       double rightWidth = panel_.getWidgetSize(right_);
       double panelWidth = panel_.getOffsetWidth();
@@ -936,6 +934,9 @@ public class PaneManager
          resizeHorizontally(rightWidth, minThreshold);
       else if (rightWidth >= maxThreshold)
          resizeHorizontally(rightWidth, maxThreshold);
+      
+      // show any additional source columns
+      panel_.setLeftWidgetsVisible(true);
 
       invalidateSavedLayoutState(true);
    }
@@ -946,7 +947,7 @@ public class PaneManager
       // hidden windows to display themselves, and so on.
       for (LogicalWindow window : panes_)
          window.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
-      panel_.showLeftWidgets();
+      panel_.setLeftWidgetsVisible(true);
 
       maximizedWindow_.onWindowStateChange(new WindowStateChangeEvent(WindowState.NORMAL, true));
       resizeHorizontally(panel_.getWidgetSize(right_), widgetSizePriorToZoom_);
@@ -1239,7 +1240,7 @@ public class PaneManager
          if (widgetSizePriorToZoom_ < 0)
          {
             // no prior position to restore to, just show defaults
-            restoreTwoColumnLayout();
+            restoreColumnLayout();
             return;
          }
          targetSize = widgetSizePriorToZoom_;
@@ -1263,9 +1264,16 @@ public class PaneManager
          targetSize = 0;
 
       if (unZooming)
+      {
+         panel_.setLeftWidgetsVisible(true);
          widgetSizePriorToZoom_ = -1;
-      else if (widgetSizePriorToZoom_ < 0)
-         widgetSizePriorToZoom_ = panel_.getWidgetSize(right_);
+      }
+      else
+      {
+         panel_.setLeftWidgetsVisible(false);
+         if (widgetSizePriorToZoom_ < 0)
+            widgetSizePriorToZoom_ = panel_.getWidgetSize(right_);
+      }
 
       resizeHorizontally(initialSize, targetSize, () -> manageLayoutCommands());
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1359,14 +1359,7 @@ public class Source implements InsertSourceHandler,
    @Handler
    public void onLayoutZoomSource()
    {
-      onActivateSource(new Command()
-      {
-         @Override
-         public void execute()
-         {
-            events_.fireEvent(new ZoomPaneEvent("Source"));
-         }
-      });
+      events_.fireEvent(new ZoomPaneEvent("Source"));
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1359,7 +1359,14 @@ public class Source implements InsertSourceHandler,
    @Handler
    public void onLayoutZoomSource()
    {
-      events_.fireEvent(new ZoomPaneEvent("Source"));
+      onActivateSource(new Command()
+      {
+         @Override
+         public void execute()
+         {
+            events_.fireEvent(new ZoomPaneEvent("Source"));
+         }
+      });
    }
 
    @Override


### PR DESCRIPTION
### Intent

Fixes #7687 

The main purpose of this PR is to fix an issue affecting the `Zoom Left Column` and `Zoom Right Column` commands when user has additional source columns open. The issue is primarily caused by the fact that the "left column" is no longer the left column with additional source columns. 
This also fixes and issue where`WindowEnsureVisibleEvent` was never updated to handle multiple source windows but was being initiated by source columns.

### Approach

This PR only ensure both commands work as they used to (zooming on the right column or left/center column). Another one will need to be created to have the wording of the commands updated and commands to zoom on the additional source columns.

The majority of the new logic is to ensure clean animation when transitioning to/from a zoomed state. Existing logic was only for the right side which always has one panel. For the left side, I need to calculate the total size to be displayed and then allocate those pixels so that they loaded left -> right or right -> left.

### QA Notes

These issues only happen when using additional source columns. We should make sure different orderings of the zoom commands work as they did in 1.3. 

