### PR TITLE
tweaks for bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,6 +7,7 @@ about : Report a bug in RStudio.
 IMPORTANT: Please fill out this template fully! Failure to do so will result in the issue being closed automatically.
 
 This issue tracker is for bugs and feature requests in the RStudio IDE. If you're having trouble with R itself or an R package, see https://www.r-project.org/help.html, and if you want to ask a question rather than report a bug, go to https://community.rstudio.com/. Finally, if you use RStudio Server Pro, get in touch with our Pro support team at support@rstudio.com.
+
 -->
 
 ### System details
@@ -26,8 +27,8 @@ This issue tracker is for bugs and feature requests in the RStudio IDE. If you'r
 Please keep the below portion in your issue, and check `[x]` the applicable boxes.
 -->
 
-- [ ] I have read the guide to submitting good bug reports at https://github.com/rstudio/rstudio/wiki/Writing-Good-Bug-Reports . 
-- [ ] I have installed the latest version of RStudio and confirmed that the issue still persists.
-- [ ] If I am reporting a RStudio crash, I have included a diagnostics report. https://support.rstudio.com/hc/en-us/articles/200321257-Running-a-Diagnostics-Report
+- [ ] I have read the guide for [submitting good bug reports](https://github.com/rstudio/rstudio/wiki/Writing-Good-Bug-Reports).
+- [ ] I have installed the latest version of RStudio, and confirmed that the issue still persists.
+- [ ] If I am reporting a RStudio crash, I have included a [diagnostics report](https://support.rstudio.com/hc/en-us/articles/200321257-Running-a-Diagnostics-Report).
 - [ ] I have done my best to include a minimal, self-contained set of instructions for consistently reproducing the issue.
 

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,6 +1,7 @@
 client.extras
 qtcreator-build*/
 CMakeLists.txt.user
+/build
 cpp-build*/
 cmake-build-*/
 session32/*


### PR DESCRIPTION
### Intent

Tweak the display of the bug report template for GitHub. Right now, some of the checked lines overflow, giving an awkward presentation -- e.g. note the period sitting on its own line.

<img width="845" alt="Screen Shot 2020-09-15 at 10 20 11 AM" src="https://user-images.githubusercontent.com/1976582/93243489-1d9b3c80-f73d-11ea-8392-984576b6a5d9.png">

### Approach

Tweak the text content so that lines are a little shorter.

### QA Notes

Worth validating that the new bug report template fits the available space better.