### PR TITLE
Disable virtual scrolling when screen reader mode toggled on

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -27,8 +27,6 @@ import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 
-import static elemental2.dom.DomGlobal.document;
-
 /**
  * Displays R Console output to user, with special behaviors for regular output
  * vs. error output.
@@ -191,22 +189,16 @@ public class ConsoleOutputWriter
 
    public void focusEnd()
    {
-      elemental2.dom.Element ele = document.querySelector("#rstudio_console_input > textarea");
-      if (ele != null)
-         ele.focus();
-      else
-      {
-         Node lastChild = output_.getElement().getLastChild();
-         if (lastChild == null)
-            return;
-         Element last = lastChild.cast();
-         last.focus();
-      }
+      Node lastChild = output_.getElement().getLastChild();
+      if (lastChild == null)
+         return;
+      Element last = lastChild.cast();
+      last.focus();
    }
 
    private int maxLines_ = -1;
    private int lines_ = 0;
    private final PreWidget output_;
    private VirtualConsole virtualConsole_;
-   private VirtualConsoleFactory vcFactory_;
+   private final VirtualConsoleFactory vcFactory_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -275,6 +275,10 @@ public class UserPrefs extends UserPrefsComputed
       // on when screen-reader support is disabled as that is the normal default and most
       // users will never touch it.
       RStudioGinjector.INSTANCE.getUserPrefs().reducedMotion().setGlobalValue(enabled);
+
+      // Disable virtual scrolling when screen reader is enabled
+      if (enabled)
+         RStudioGinjector.INSTANCE.getUserPrefs().limitVisibleConsole().setGlobalValue(false);
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -266,6 +266,14 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    @Handler
    void onFocusConsoleOutputEnd()
    {
+      if (prefs_.limitVisibleConsole().getValue())
+      {
+         ariaLive_.announce(AriaLiveService.INACCESSIBLE_FEATURE,
+            "Warning: Focus console output command unavailable when " +
+               prefs_.limitVisibleConsole().getTitle() + " option is enabled.",
+            Timing.IMMEDIATE, Severity.STATUS);
+         return;
+      }
       view_.getConsoleOutputWriter().focusEnd();
    }
 


### PR DESCRIPTION
### Intent
- Fixes #7788

When virtual scrolling feature was added, it broke the "Focus Console Output" command, which is used by screen-reader users to quickly get focus on and read console output. It broke it whether or not the virtual scrolling feature was enabled.

### Approach

Undid the change that was breaking "Focus Console Output" when virtual scrolling was disabled.

When user toggles on screen reader mode, we now disable the virtual scrolling mode, as the way it dynamically structures the HTML presents potential problems to screen reader users (including breaking the focus output command).

Finally, if screen reader mode is on and virtual scrolling also happens to be on, give a live announcement warning when an attempt is made to use the unusable "Focus Console Output" command.

### QA Notes

- Start screen reader and start RStudio Server
- Turn on screen reader mode if not already on
- Generate a bit of console output, e.g. `cat("one\ntwo\n")`
- Try to use the "Focus Console Output" command when (1) virtual scrolling is enabled (Global Options / Console / Limit console display to a subset...) and (2) when it is disabled.
    - When virtual scrolling is disabled, focus should be moved to the console output and you can navigate it with screen reader commands as you could in RStudio 1.3.
    - When virtual scrolling is enabled, you should get a warning announcement about the focus console output command not being available when virtual scrolling is enabled.
- Now, turn off screen reader support (RStudio restarts). Turn on virtual scrolling if it happens to be off. Now turn screen reader mode back on (RStudio restarts) then confirm that virtual scrolling has been turned off.
