### PR TITLE
open source companion commit for rstudio/rstudio-pro#1951

### DIFF
--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -187,10 +187,10 @@ protected:
       value<bool>(&authEncryptPassword_)->default_value(true),
       "Indicates whether or not to encrypt the password sent from the login form. For security purposes, we strongly recommend you leave this enabled.")
       ("auth-login-page-html",
-      value<std::string>(pAuthLoginPageHtml)->default_value(""),
+      value<std::string>(pAuthLoginPageHtml)->default_value("/etc/rstudio/login.html"),
       "The path to a file containing additional HTML customization for the login page.")
       ("auth-rdp-login-page-html",
-      value<std::string>(pAuthRdpLoginPageHtml)->default_value(""),
+      value<std::string>(pAuthRdpLoginPageHtml)->default_value("/etc/rstudio/rdplogin.html"),
       "The path to a file containing additional HTML customization for the login page, as seen by RDP users.")
       ("auth-required-user-group",
       value<std::string>(&authRequiredUserGroup_)->default_value(""),

--- a/src/cpp/server/server-options.json
+++ b/src/cpp/server/server-options.json
@@ -317,7 +317,7 @@
             "tempType": "string",
             "memberName": "authLoginPageHtml_",
             "type": "string",
-            "defaultValue": "",
+            "defaultValue": "/etc/rstudio/login.html",
             "description": "The path to a file containing additional HTML customization for the login page."
          },
          {
@@ -326,7 +326,7 @@
             "tempType": "string",
             "memberName": "authRdpLoginPageHtml_",
             "type": "string",
-            "defaultValue": "",
+            "defaultValue": "/etc/rstudio/rdplogin.html",
             "description": "The path to a file containing additional HTML customization for the login page, as seen by RDP users."
          },
          {


### PR DESCRIPTION
### Intent

Restore the default values as used in 1.3.

### Approach

Make the default value for the option that add HTML content to the sign in page be the same as 1.3


