### PR TITLE
send focus to console after closing all tabs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.workbench.views.source;
 
 import org.rstudio.core.client.command.ShortcutViewer;
 
+import com.google.gwt.user.client.Command;
+
 public class SourceVimCommands
 {
    public final native void save(SourceColumnManager source) /*-{
@@ -94,14 +96,14 @@ public class SourceVimCommands
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("quit", "q", callback);
    }-*/;
    
-   public native final void closeAllTabs(SourceColumnManager source) /*-{
+   public native final void closeAllTabs(SourceColumnManager source, Command onCompleted) /*-{
       var callback = $entry(function(cm, params) {
       
          var interactive = true;
          if (params.argString && params.argString === "!")
             interactive = false;
          
-         source.@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::closeAllTabs(ZZ)(interactive, false);
+         source.@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::closeAllTabs(ZZLcom/google/gwt/user/client/Command;)(interactive, false, onCompleted);
       });
        
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("qall", "qa", callback);


### PR DESCRIPTION
### Intent

This PR ensures that the Vim command `:qa!` sends focus to the Console after all tabs have been closed.

### Approach

Pass along an appropriate onCompleted command to be executed after closing all tabs.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/7810.