### PR TITLE
Provide meaningful name for source column landmarks and min/max buttons

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
@@ -45,7 +45,7 @@ public class PrimaryWindowFrame extends WindowFrame
    public PrimaryWindowFrame(String title,
                              Widget mainWidget)
    {
-      super(title);
+      super(title, title);
       ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
 
       panel_ = new ClickFlowPanel();
@@ -88,12 +88,12 @@ public class PrimaryWindowFrame extends WindowFrame
    {
       subtitle_.setText(subtitle);
    }
-   
+
    public void addLeftWidget(Widget widget)
    {
       panel_.add(widget);
    }
-   
+
    private final DoubleClickState doubleClickState_ = new DoubleClickState();
    private final Label subtitle_;
    private final ClickFlowPanel panel_;

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -44,13 +44,14 @@ public class WindowFrame extends Composite
 {
    public WindowFrame(Widget mainWidget, String name)
    {
-      this(name);
+      this(name, name);
       setMainWidget(mainWidget);
    }
 
-   public WindowFrame(String name)
+   public WindowFrame(String name, String accessibleName)
    {
       name_ = name;
+
       RStudioGinjector.INSTANCE.injectMembers(this);
 
       final ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
@@ -61,19 +62,19 @@ public class WindowFrame extends Composite
       borderPositioner_ = new SimplePanel();
       borderPositioner_.add(border_);
 
-      maximizeButton_ = new WindowFrameButton(name, WindowState.MAXIMIZE);
+      maximizeButton_ = new WindowFrameButton(accessibleName, WindowState.MAXIMIZE);
       maximizeButton_.setClassId(ClassIds.PANEL_MAX_BTN, name);
       maximizeButton_.setStylePrimaryName(styles.maximize());
       maximizeButton_.setClickHandler(() -> maximize());
 
-      minimizeButton_ = new WindowFrameButton(name, WindowState.MINIMIZE);
+      minimizeButton_ = new WindowFrameButton(accessibleName, WindowState.MINIMIZE);
       minimizeButton_.setClassId(ClassIds.PANEL_MIN_BTN, name);
       minimizeButton_.setStylePrimaryName(styles.minimize());
       minimizeButton_.setClickHandler(() -> minimize());
 
       frame_ = new LayoutPanel();
       Roles.getRegionRole().set(frame_.getElement());
-      Roles.getRegionRole().setAriaLabelProperty(frame_.getElement(), name);
+      Roles.getRegionRole().setAriaLabelProperty(frame_.getElement(), accessibleName);
       frame_.setStylePrimaryName(styles.windowframe());
       frame_.addStyleName(styles.windowFrameObject());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -104,10 +104,12 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    }
 
    public void loadDisplay(String name,
+                           String accessibleName,
                            Source.Display display,
                            SourceColumnManager manager)
    {
       name_ = name;
+      accessibleName_ = accessibleName;
       display_ = display;
       manager_ = manager;
 
@@ -134,6 +136,11 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    public String getName()
    {
       return name_;
+   }
+
+   public String getAccessibleName()
+   {
+      return accessibleName_;
    }
 
    public EditingTarget getActiveEditor()
@@ -1235,6 +1242,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    private int newTabPending_;
 
    private String name_;
+   private String accessibleName_;
    private Source.Display display_;
    private EditingTarget activeEditor_;
    private final ArrayList<EditingTarget> editors_ = new ArrayList<>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -131,6 +131,34 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    {
    }
 
+   public static class ColumnName
+   {
+      public ColumnName()
+      {
+         name_ = "";
+         accessibleName_ = "";
+      }
+
+      public ColumnName(String name, String accessibleName)
+      {
+         name_ = name;
+         accessibleName_ = accessibleName;
+      }
+
+      public String getName()
+      {
+         return name_;
+      }
+
+      public String getAccessibleName()
+      {
+         return accessibleName_;
+      }
+
+      private final String name_;
+      private final String accessibleName_;
+   }
+
    SourceColumnManager() { RStudioGinjector.INSTANCE.injectMembers(this);}
 
    @Inject
@@ -216,7 +244,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       sourceNavigationHistory_.addChangeHandler(event -> manageSourceNavigationCommands());
 
       SourceColumn column = GWT.create(SourceColumn.class);
-      column.loadDisplay(MAIN_SOURCE_NAME, display, this);
+      column.loadDisplay(MAIN_SOURCE_NAME, MAIN_SOURCE_NAME, display, this);
       columnList_.add(column);
 
       new JSObjectStateValue("source-column-manager",
@@ -293,48 +321,50 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       });
    }
 
-   public String add()
+   public ColumnName add()
    {
       Source.Display display = GWT.create(SourcePane.class);
       return add(display, false);
    }
 
-   public String add(Source.Display display)
+   public ColumnName add(Source.Display display)
    {
       return add(display, false);
    }
 
-   public String add(String name, boolean updateState)
+   public ColumnName add(String name, boolean updateState)
    {
       return add(name, false, updateState);
    }
 
-   public String add (String name, boolean activate, boolean updateState)
+   public ColumnName add (String name, boolean activate, boolean updateState)
    {
       Source.Display display = GWT.create(SourcePane.class);
-      return add(name, display, activate, updateState);
+      return add(name, computeAccessibleName(), display, activate, updateState);
    }
 
-   public String add(Source.Display display, boolean activate)
+   public ColumnName add(Source.Display display, boolean activate)
    {
       return add(display, activate, true);
    }
 
-   public String add(Source.Display display, boolean activate, boolean updateState)
+   public ColumnName add(Source.Display display, boolean activate, boolean updateState)
    {
       return add(COLUMN_PREFIX + StringUtil.makeRandomId(12),
+                  computeAccessibleName(),
                   display,
                   activate,
                   updateState);
    }
 
-   public String add(String name, Source.Display display, boolean activate, boolean updateState)
+   public ColumnName add(String name, String accessibleName, Source.Display display,
+                     boolean activate, boolean updateState)
    {
       if (contains(name))
-         return "";
+         return new ColumnName();
 
       SourceColumn column = GWT.create(SourceColumn.class);
-      column.loadDisplay(name, display, this);
+      column.loadDisplay(name, accessibleName, display, this);
       columnList_.add(column);
 
       if (activate || activeColumn_ == null)
@@ -343,7 +373,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       if (updateState)
          columnState_ = State.createState(JsUtil.toJsArrayString(getNames(false)),
                                           getActive().getName());
-      return column.getName();
+      return new ColumnName(column.getName(), column.getAccessibleName());
    }
 
    public void initialSelect(int index)
@@ -2591,6 +2621,11 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       public final CommandWithArg<EditingTarget> executeOnSuccess;
    }
 
+   private String computeAccessibleName()
+   {
+      return "Source Column " + sourceColumnCounter_++;
+   }
+
    private State columnState_;
    private SourceColumn activeColumn_;
 
@@ -2624,4 +2659,5 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public final static String COLUMN_PREFIX = "Source";
    public final static String MAIN_SOURCE_NAME = COLUMN_PREFIX;
+   static int sourceColumnCounter_ = 1;
 }


### PR DESCRIPTION
### Intent

- Fixes #7805

The source columns and their min/max buttons had accessibility labels containing randomly generated letters and numbers. These need to contain meaningful (and unique) text for each source column.

### Approach

Generate an accessible name of the form "Source Column #" where # starts at 1 and increments each time a new source column is created during this instance of the IDE. Plumb that through creation and recreation of the source columns.

### QA Notes

With a screen reader running, create some source columns then list the landmarks. The source columns should now said "Source Column 1", "Source Column 2", and so on. Same with the min/max buttons on each source column: "Minimize Source Column 1" and so forth, when you get keyboard focus on them. The other landmarks are unchanged (including the standard Source pane, which remains "Source").

It is only necessary to test this with one screen reader (or it would be sufficient to view the page source and look for the phrase "Source Column" in various aria-labels).

- On VoiceOver (Mac) use VO+U then arrow keys to view the landmarks.
- On JAWS (Windows) turn on the virtual PC cursor then Ctrl+JAWS+R to list regions.
- NVDA (Windows) switch off focus mode (NVDA+spacebar), then NVDA+F7 and switch to "Landmarks" type
