### PR TITLE
remove grep color encodings when contents is not encoded

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -769,8 +769,7 @@ private:
       size_t eMatchOn = 0;
       size_t eMatchOff = 0;
 
-      if (!encoding_.empty())
-         cleanLineAndGetMatches(&pLineInfo->encodedContents, &eMatchOnArray, &eMatchOffArray);
+      cleanLineAndGetMatches(&pLineInfo->encodedContents, &eMatchOnArray, &eMatchOffArray);
 
       while (findResults().isRunning() &&
              inputLineNum_ < lineNum && std::getline(*inputStream_, line))
@@ -800,17 +799,15 @@ private:
                Error error;
                Replacer replacer(findResults().ignoreCase(), encoding_);
 
-               if (!encoding_.empty())
-               {
-                  eMatchOn =
-                     static_cast<size_t>(eMatchOnArray.getValueAt(static_cast<size_t>(pos)).getInt());
-                  eMatchOff =
-                     static_cast<size_t>(eMatchOffArray.getValueAt(static_cast<size_t>(pos)).getInt());
-               }
+               eMatchOn =
+                   static_cast<size_t>(eMatchOnArray.getValueAt(static_cast<size_t>(pos)).getInt());
+               eMatchOff =
+                   static_cast<size_t>(eMatchOffArray.getValueAt(static_cast<size_t>(pos)).getInt());
+
 
                // If we found a different number of matches searching the encoded string,
                // we shouldn't perform the replace as the expected vs actual results may differ.
-               if (!encoding_.empty() && eMatchOnArray.getSize() != matchOnArray.getSize())
+               if (eMatchOnArray.getSize() != matchOnArray.getSize())
                {
                   core::Error error(
                      errc::findCategory(),
@@ -834,12 +831,6 @@ private:
                }
                else // perform replace
                {
-                  if (encoding_.empty())
-                  {
-                     eMatchOn = matchOn;
-                     eMatchOff = matchOff;
-                  }
-
                   pProgress->addUnits(1);
 
                   if (findResults().regex())
@@ -849,22 +840,19 @@ private:
                      replacer.replaceLiteral(eMatchOn, eMatchOff, replacePattern,
                            &pLineInfo->encodedContents, &replaceMatchOff);
 
-                  if (!encoding_.empty())
-                  {
-                     // calculate utf8 matchOff
-                     size_t utf8Length;
-                     error = string_utils::utf8Distance(pLineInfo->decodedContents.begin(),
-                                                        pLineInfo->decodedContents.end(),
-                                                        &utf8Length);
-                     pLineInfo->decodedContents =
-                        replacer.decode(pLineInfo->encodedContents);
-   
-                     size_t newUtf8Length;
-                     error = string_utils::utf8Distance(pLineInfo->decodedContents.begin(),
-                                                        pLineInfo->decodedContents.end(),
-                                                        &newUtf8Length);
-                     replaceMatchOff = matchOff + (newUtf8Length - utf8Length);
-                  }
+                  // calculate utf8 matchOff
+                  size_t utf8Length;
+                  error = string_utils::utf8Distance(pLineInfo->decodedContents.begin(),
+                                                     pLineInfo->decodedContents.end(),
+                                                     &utf8Length);
+                  pLineInfo->decodedContents =
+                     replacer.decode(pLineInfo->encodedContents);
+
+                  size_t newUtf8Length;
+                  error = string_utils::utf8Distance(pLineInfo->decodedContents.begin(),
+                                                     pLineInfo->decodedContents.end(),
+                                                     &newUtf8Length);
+                  replaceMatchOff = matchOff + (newUtf8Length - utf8Length);
                }
 
                // Handle side-effects when replace is successful
@@ -1363,6 +1351,8 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    std::string encoding = projects::projectContext().hasProject() ?
                           projects::projectContext().defaultEncoding() :
                           prefs::userPrefs().defaultEncoding();
+   if (encoding.empty())
+      encoding = "UTF-8";
    std::string encodedString;
    error = r::util::iconvstr(grepOptions.searchPattern(),
                              "UTF-8",
@@ -1674,15 +1664,8 @@ Error Replacer::replacePreview(const size_t dMatchOn, const size_t dMatchOff,
                                std::string* pEncodedLine, std::string* pDecodedLine,
                                size_t* pReplaceMatchOff) const
 {
-   // if we're not encoded, we can avoid some logic
-   if (encoding_.empty())
-   {
-      eMatchOn = dMatchOn;
-      eMatchOff = dMatchOff;
-   }
-
    // attempt to perform the replace based on the encoded data
-   std::string previewLine(encoding_.empty() ? *pDecodedLine : *pEncodedLine);
+   std::string previewLine(*pEncodedLine);
    std::string originalValue = previewLine.substr(eMatchOn, eMatchOff  - eMatchOn);
    Error error = replaceRegex(eMatchOn, eMatchOff,
                               findResults().searchPattern(),
@@ -1699,27 +1682,23 @@ Error Replacer::replacePreview(const size_t dMatchOn, const size_t dMatchOff,
       replaceString.insert(0, originalValue);
       replaceLiteral(eMatchOn, eMatchOff, replaceString, pEncodedLine, pReplaceMatchOff);
 
-      if (encoding_.empty())
-         pDecodedLine = pEncodedLine;
-      else
-      {
-         // adjust pReplaceMatchOff for display
+      // adjust pReplaceMatchOff for display
 
-         size_t originalDecodedSize;
-         error = string_utils::utf8Distance(pDecodedLine->begin(),
-                                            pDecodedLine->end(),
-                                            &originalDecodedSize);
-   
-         *pDecodedLine = decode(*pEncodedLine);
-   
-         size_t newDecodedSize;
-         error = string_utils::utf8Distance(pDecodedLine->begin(),
-                                            pDecodedLine->end(),
-                                            &newDecodedSize);
-   
-         *pReplaceMatchOff = dMatchOff + (newDecodedSize - originalDecodedSize);
-      }
+      size_t originalDecodedSize;
+      error = string_utils::utf8Distance(pDecodedLine->begin(),
+                                         pDecodedLine->end(),
+                                         &originalDecodedSize);
+
+      *pDecodedLine = decode(*pEncodedLine);
+
+      size_t newDecodedSize;
+      error = string_utils::utf8Distance(pDecodedLine->begin(),
+                                         pDecodedLine->end(),
+                                         &newDecodedSize);
+
+      *pReplaceMatchOff = dMatchOff + (newDecodedSize - originalDecodedSize);
    }
+
    return error;
 }
 

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1351,8 +1351,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    std::string encoding = projects::projectContext().hasProject() ?
                           projects::projectContext().defaultEncoding() :
                           prefs::userPrefs().defaultEncoding();
-   if (encoding.empty())
-      encoding = "UTF-8";
    std::string encodedString;
    error = r::util::iconvstr(grepOptions.searchPattern(),
                              "UTF-8",


### PR DESCRIPTION
### Intent

Fixes #7736 

If a user was outside of a project and didn't specify an encoding via Global Options, global replace would update files to include pieces of the color encodings from the grep command. used to find the pattern. 

### Approach

Some pieces of code were written under the impression that if no encoding was provided, there wasn't a need to decode the line. Decoding is not just for encodings different from UTF8, but is also used to parse the grep command.

### QA Notes

This specific issue occurred when the `Default text encoding` option was set to [Ask], but making changes to this code has a chance of affecting behavior on different operating systems. The changes here shouldn't affect the way global find/replace works for different encodings but it may be worth testing some anyways.

Note there is an existing issue for issues with Windows and regexes that has been around since 1.2 (maybe 1.1) being tracked here: https://github.com/rstudio/rstudio/issues/7012
