### PR TITLE
set DEVELOPER_DIR when retrieving diagnostics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -105,4 +105,5 @@
 * Fixed issue where `rstudioapi::askForPassword()` did not mask user input in some cases.
 * Fixed issue where Job Launcher admin users would have `gid=0` in Slurm Launcher Sessions (Pro #1935)
 * Fixed issue causing script errors when reloading Shiny applications from the editor toolbar (#7762)
+* Fixed issue causing C++ diagnostics to fail when Xcode developer tools were active (#7824)
 

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -159,9 +159,19 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
                                                 bool alwaysReparse)
 {
 #ifdef __APPLE__
-   // ensure that SDKROOT is defined so that libclang can find system headers
-   core::system::EnvironmentScope scope(
-            "SDKROOT", "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
+
+   // ensure SDK_ROOT is set
+   boost::scoped_ptr<core::system::EnvironmentScope> sdkRootScope;
+   const char* sdkRootPath("/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk");
+   if (core::system::getenv("SDKROOT").empty() && FilePath(sdkRootPath).exists())
+      sdkRootScope.reset(new core::system::EnvironmentScope("SDKROOT", sdkRootPath));
+
+   // ensure DEVELOPER_DIR is set
+   boost::scoped_ptr<core::system::EnvironmentScope> developerDirScope;
+   const char* developerDirPath = "/Library/Developer/CommandLineTools";
+   if (core::system::getenv("DEVELOPER_DIR").empty() && FilePath(developerDirPath).exists())
+      developerDirScope.reset(new core::system::EnvironmentScope("DEVELOPER_DIR", developerDirPath));
+
 #endif
    
    FilePath filePath(filename);


### PR DESCRIPTION
### Intent

On macOS, one can customize the "default" compiler toolchain to be used, via e.g.

```
sudo xcode-select -s <...>
```

Unfortunately, when Xcode's own developer tools are activated, RStudio's C++ diagnostic machinery breaks -- seemingly due to a mixture of CLT paths and Xcode paths.

### Approach

Use `DEVELOPER_DIR` to force the use of macOS command line tools.

### QA Notes

Note that this issue only affects macOS, and so should be tested on a macOS machine. To test, you can try running the following in the terminal:

```
sudo xcode-select -r
xcode-select -p
```

You should see:

```
$ xcode-select -p
/Applications/Xcode.app/Contents/Developer
```

Then, try to open an R package project including C++ code (for example, https://github.com/thomasp85/euclid). Check that you don't see erroneous C++ diagnostics when opening the C++ files within the `src/` folder.