### PR TITLE
Fix broken CSV import preview

### DIFF
--- a/src/cpp/session/modules/data/SessionData.cpp
+++ b/src/cpp/session/modules/data/SessionData.cpp
@@ -107,6 +107,7 @@ private:
       std::vector<core::FilePath> sources;
       sources.push_back(pathFromSource("Tools.R"));
       sources.push_back(pathFromModulesSource("ModuleTools.R"));
+      sources.push_back(pathFromModulesSource("SessionCodeTools.R"));
       sources.push_back(pathFromModulesSource("SessionDataViewer.R"));
       sources.push_back(pathFromModulesSource("SessionDataImportV2.R"));
 


### PR DESCRIPTION
### Intent

Addresses an error that happens whenever CSV import is performed from Import Dataset. Fixes https://github.com/rstudio/rstudio/issues/7814. 

### Approach

The background R process which reads the data calls a method that uses `.rs.tryCatch`, but doesn't source the R file which defines this utility function, so this change just sources that file in the background process.

### QA Notes

No impact outside of verifying that #7814 is fixed. 

