### PR TITLE
add 'allowConsole' param

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -568,13 +568,17 @@
    .Call("rs_getPersistentValue", name)
 })
 
-.rs.addApiFunction("documentId", function() {
+.rs.addApiFunction("documentId", function(allowConsole = TRUE) {
+   
+   payload <- list(
+      allow_console = .rs.scalar(allowConsole)
+   )
    
    request <- .rs.api.createRequest(
       type    = .rs.api.eventTypes$TYPE_DOCUMENT_ID,
       sync    = TRUE,
       target  = .rs.api.eventTargets$TYPE_ACTIVE_WINDOW,
-      payload = list()
+      payload = payload
    )
    
    response <- .rs.api.sendRequest(request)
@@ -1028,7 +1032,9 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 .rs.addApiFunction("selectionGet", function(id = NULL)
 {
    # create data payload
-   payload <- list(doc_id = .rs.scalar(id))
+   payload <- list(
+      doc_id = .rs.scalar(id)
+   )
    
    # create request
    request <- .rs.api.createRequest(

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -68,9 +68,9 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       return data_;
    }
    
-   public <T extends JavaScriptObject> T getPayload()
+   public JavaScriptObject getPayload()
    {
-      return data_.getPayload().<T>cast();
+      return data_.getPayload();
    }
    
    private final Data data_;
@@ -136,6 +136,8 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       protected DocumentIdData()
       {
       }
+      
+      public final native boolean getAllowConsole() /*-{ return this["allow_console"]; }-*/;
    }
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2897,7 +2897,7 @@ public class Source implements InsertSourceHandler,
       int type = requestData.getType();
       if (type == RStudioApiRequestEvent.TYPE_GET_EDITOR_SELECTION)
       {
-         RStudioApiRequestEvent.GetEditorSelectionData data = requestEvent.getPayload();
+         RStudioApiRequestEvent.GetEditorSelectionData data = requestEvent.getPayload().cast();
          
          if (apiEventTargetIsConsole(data.getDocId()))
          {
@@ -2921,7 +2921,7 @@ public class Source implements InsertSourceHandler,
       }
       else if (type == RStudioApiRequestEvent.TYPE_SET_EDITOR_SELECTION)
       {
-         RStudioApiRequestEvent.SetEditorSelectionData data = requestEvent.getPayload();
+         RStudioApiRequestEvent.SetEditorSelectionData data = requestEvent.getPayload().cast();
          
          if (apiEventTargetIsConsole(data.getDocId()))
          {
@@ -2947,7 +2947,9 @@ public class Source implements InsertSourceHandler,
       }
       else if (type == RStudioApiRequestEvent.TYPE_DOCUMENT_ID)
       {
-         if (consoleEditorHadFocusLast())
+         RStudioApiRequestEvent.DocumentIdData data = requestEvent.getPayload().cast();
+         
+         if (data.getAllowConsole() && consoleEditorHadFocusLast())
          {
             JsObject response = JsObject.createJsObject();
             response.setString("id", "#console");


### PR DESCRIPTION
### Intent

Users of the `documentId()` API may want to be able to target the last-focused source document, even when the console is currently focused.

### Approach

The `documentId()` function gains the `allowConsole` parameter. When set, if the console is currently focused, then a pseudo-id `#console` is returned; if not set, then we always return the ID of the last-active source document.

### QA Notes

Test that:

```
.rs.api.documentId(allowConsole = FALSE)
```

returns the ID of a source document, even if the Console is focused.