### PR TITLE
add explicit document open API

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -22,7 +22,8 @@
    TYPE_GET_EDITOR_SELECTION = 1L,
    TYPE_SET_EDITOR_SELECTION = 2L,
    TYPE_DOCUMENT_ID          = 3L,
-   TYPE_DOCUMENT_OPEN        = 4L
+   TYPE_DOCUMENT_OPEN        = 4L,
+   TYPE_DOCUMENT_NEW         = 5L
 ))
 
 # list of potential event targets
@@ -642,26 +643,35 @@
 
 .rs.addApiFunction("documentNew", function(type,
                                            code,
-                                           row = 0,
-                                           column = 0,
+                                           row = -1L,
+                                           column = -1L,
                                            execute = FALSE)
 {
-   
-   type <- switch(type,
+   type <- switch(
+      type,
+      rmd       = "r_markdown",
       rmarkdown = "r_markdown",
-      sql = "sql",
+      sql       = "sql",
       "r_script"
    )
 
-   .rs.enqueClientEvent("new_document_with_code", list(
-      type = .rs.scalar(type),
-      code = .rs.scalar(code),
-      row = .rs.scalar(row),
-      column = .rs.scalar(column),
+   payload <- list(
+      type    = .rs.scalar(type),
+      code    = .rs.scalar(paste(code, collapse = "\n")),
+      row     = .rs.scalar(row),
+      column  = .rs.scalar(column),
       execute = .rs.scalar(execute)
-   ))
-
-   invisible(NULL)
+   )
+   
+   request <- .rs.api.createRequest(
+      type = .rs.api.eventTypes$TYPE_DOCUMENT_NEW,
+      sync = TRUE,
+      target = .rs.api.eventTargets$TYPE_ACTIVE_WINDOW,
+      payload = payload
+   )
+   
+   response <- .rs.api.sendRequest(request)
+   response$id
 })
 
 .rs.addApiFunction("documentOpen", function(path) {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -21,7 +21,8 @@
    TYPE_UNKNOWN              = 0L,
    TYPE_GET_EDITOR_SELECTION = 1L,
    TYPE_SET_EDITOR_SELECTION = 2L,
-   TYPE_DOCUMENT_ID          = 3L
+   TYPE_DOCUMENT_ID          = 3L,
+   TYPE_DOCUMENT_OPEN        = 4L
 ))
 
 # list of potential event targets
@@ -661,6 +662,24 @@
    ))
 
    invisible(NULL)
+})
+
+.rs.addApiFunction("documentOpen", function(path) {
+   
+   payload <- list(
+      path = .rs.scalar(path)
+   )
+   
+   request <- .rs.api.createRequest(
+      type   = .rs.api.eventTypes$TYPE_DOCUMENT_OPEN,
+      sync   = TRUE,
+      target = .rs.api.eventTargets$TYPE_ACTIVE_WINDOW,
+      payload = payload
+   )
+   
+   response <- .rs.api.sendRequest(request)
+   response$id
+   
 })
 
 .rs.addApiFunction("documentClose", function(id = NULL, save = TRUE) {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -643,8 +643,8 @@
 
 .rs.addApiFunction("documentNew", function(type,
                                            code,
-                                           row = -1L,
-                                           column = -1L,
+                                           row = 0,
+                                           column = 0,
                                            execute = FALSE)
 {
    type <- switch(
@@ -658,8 +658,8 @@
    payload <- list(
       type    = .rs.scalar(type),
       code    = .rs.scalar(paste(code, collapse = "\n")),
-      row     = .rs.scalar(row),
-      column  = .rs.scalar(column),
+      row     = .rs.scalar(as.integer(row)),
+      column  = .rs.scalar(as.integer(column)),
       execute = .rs.scalar(execute)
    )
    

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -106,6 +106,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
    public static final int TYPE_GET_EDITOR_SELECTION = 1;
    public static final int TYPE_SET_EDITOR_SELECTION = 2;
    public static final int TYPE_DOCUMENT_ID          = 3;
+   public static final int TYPE_DOCUMENT_OPEN        = 4;
    
    // list of potential event targets (keep in sync with Api.R)
    public static final int TARGET_UNKNOWN       = 0;
@@ -139,6 +140,16 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       
       public final native boolean getAllowConsole() /*-{ return this["allow_console"]; }-*/;
    }
+   
+   public static class DocumentOpenData extends JavaScriptObject
+   {
+      protected DocumentOpenData()
+      {
+      }
+      
+      public final native String getPath() /*-{ return this["path"]; }-*/;
+   }
+   
    
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -107,6 +107,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
    public static final int TYPE_SET_EDITOR_SELECTION = 2;
    public static final int TYPE_DOCUMENT_ID          = 3;
    public static final int TYPE_DOCUMENT_OPEN        = 4;
+   public static final int TYPE_DOCUMENT_NEW         = 5;
    
    // list of potential event targets (keep in sync with Api.R)
    public static final int TARGET_UNKNOWN       = 0;
@@ -149,6 +150,20 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       
       public final native String getPath() /*-{ return this["path"]; }-*/;
    }
+   
+   public static class DocumentNewData extends JavaScriptObject
+   {
+      protected DocumentNewData()
+      {
+      }
+      
+      public final native String  getType()       /*-{ return this["type"];    }-*/;
+      public final native String  getCode()       /*-{ return this["code"];    }-*/;
+      public final native int     getRow()        /*-{ return this["row"];     }-*/;
+      public final native int     getColumn()     /*-{ return this["column"];  }-*/;
+      public final native boolean getExecute()    /*-{ return this["execute"]; }-*/;
+   }
+   
    
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -62,6 +62,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.Completion
 import org.rstudio.studio.client.workbench.views.console.shell.assist.HistoryCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager;
 import org.rstudio.studio.client.workbench.views.console.shell.editor.InputEditorDisplay;
+import org.rstudio.studio.client.workbench.views.console.shell.events.SuppressNextShellFocusEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.DebugModeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.SourceSatellite;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
@@ -84,7 +85,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                               SendToConsoleEvent.Handler,
                               DebugModeChangedEvent.Handler,
                               RunCommandWithDebugEvent.Handler,
-                              UnhandledErrorEvent.Handler
+                              UnhandledErrorEvent.Handler,
+                              SuppressNextShellFocusEvent.Handler
 {
    static interface Binder extends CommandBinder<Commands, Shell>
    {
@@ -169,6 +171,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus.addHandler(DebugModeChangedEvent.TYPE, this);
       eventBus.addHandler(RunCommandWithDebugEvent.TYPE, this);
       eventBus.addHandler(UnhandledErrorEvent.TYPE, this);
+      eventBus.addHandler(SuppressNextShellFocusEvent.TYPE, this);
 
       final CompletionManager completionManager
                   = new RCompletionManager(view_.getInputEditorDisplay(),
@@ -705,6 +708,12 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       @SuppressWarnings("unused")
       private boolean lastKeyCodeWasZero_;
    }
+   
+   @Override
+   public void onSuppressNextShellFocus(SuppressNextShellFocusEvent event)
+   {
+      restoreFocus_ = false;
+   }
 
    private boolean isBrowsePrompt()
    {
@@ -778,6 +787,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          view_.enableLiveReporting();
       }
    }
+   
 
    private final ConsoleServerOperations server_;
    private final EventBus eventBus_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/events/SuppressNextShellFocusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/events/SuppressNextShellFocusEvent.java
@@ -1,0 +1,75 @@
+/*
+ * SuppressNextShellFocusEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.shell.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class SuppressNextShellFocusEvent extends GwtEvent<SuppressNextShellFocusEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public static final Data create()
+      {
+         return JavaScriptObject.createObject().cast();
+      }
+   }
+
+   
+
+   public SuppressNextShellFocusEvent()
+   {
+      data_ = Data.create();
+   }
+
+   public SuppressNextShellFocusEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onSuppressNextShellFocus(SuppressNextShellFocusEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onSuppressNextShellFocus(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1735,10 +1735,12 @@ public class Source implements InsertSourceHandler,
                {
                   TextEditingTarget editingTarget = (TextEditingTarget)arg;
 
-                  if (event.getCursorPosition() != null)
+                  SourcePosition position = event.getCursorPosition();
+                  if (position != null &&
+                      position.getRow() > 0 &&
+                      position.getColumn() > 0)
                   {
-                     editingTarget.navigateToPosition(event.getCursorPosition(),
-                                                      false);
+                     editingTarget.navigateToPosition(position, false);
                   }
 
                   if (event.getExecute())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -88,6 +88,7 @@ import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.filetypes.EditableFileType;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
+import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.common.filetypes.events.OpenPresentationSourceFileEvent;
@@ -1719,14 +1720,17 @@ public class Source implements InsertSourceHandler,
       else
          docType = FileTypeRegistry.RMARKDOWN;
 
+      final ResultCallback<EditingTarget, ServerError> callback = event.getCallback();
+      
       // command to create and run the new doc
-      Command newDocCommand = new Command() {
+      Command newDocCommand = new Command()
+      {
          @Override
          public void execute()
          {
-            columnManager_.newDoc(docType,
-                   event.getCode(),
-                   new ResultCallback<EditingTarget, ServerError>() {
+            columnManager_.newDoc(docType, event.getCode(), new ResultCallback<EditingTarget, ServerError>()
+            {
+               @Override
                public void onSuccess(EditingTarget arg)
                {
                   TextEditingTarget editingTarget = (TextEditingTarget)arg;
@@ -1753,6 +1757,17 @@ public class Source implements InsertSourceHandler,
                         commands_.executePreviousChunks().execute();
                      }
                   }
+                  
+                  if (callback != null)
+                     callback.onSuccess(arg);
+               }
+               
+               @Override
+               public void onFailure(ServerError info)
+               {
+                  super.onFailure(info);
+                  if (callback != null)
+                     callback.onFailure(info);
                }
             });
          }
@@ -2996,6 +3011,44 @@ public class Source implements InsertSourceHandler,
             }
          });
          
+      }
+      else if (type == RStudioApiRequestEvent.TYPE_DOCUMENT_NEW)
+      {
+         RStudioApiRequestEvent.DocumentNewData data = requestEvent.getPayload().cast();
+         
+         SourcePosition position = SourcePosition.create(
+               data.getRow(),
+               data.getColumn());
+         
+         events_.fireEvent(new NewDocumentWithCodeEvent(
+               data.getType(),
+               data.getCode(),
+               position,
+               data.getExecute(),
+               new ResultCallback<EditingTarget, ServerError>()
+               {
+                  @Override
+                  public void onSuccess(final EditingTarget result)
+                  {
+                     // focus opened document (note that we may need to suppress
+                     // attempts by the shell widget to steal focus here)
+                     events_.fireEvent(new SuppressNextShellFocusEvent());
+                     result.focus();
+
+                     JsObject response = JsObject.createJsObject();
+                     response.setString("id", result.getId());
+                     server_.rstudioApiResponse(response, new VoidServerRequestCallback());
+                  }
+
+                  @Override
+                  public void onFailure(ServerError info)
+                  {
+                     super.onFailure(info);
+                     server_.rstudioApiResponse(
+                           JavaScriptObject.createObject(),
+                           new VoidServerRequestCallback());
+                  }
+               }));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -55,6 +55,7 @@ import org.rstudio.studio.client.rmarkdown.model.RmdChosenTemplate;
 import org.rstudio.studio.client.rmarkdown.model.RmdFrontMatter;
 import org.rstudio.studio.client.rmarkdown.model.RmdOutputFormat;
 import org.rstudio.studio.client.rmarkdown.model.RmdTemplateData;
+import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
@@ -1642,30 +1643,28 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          processOpenFileQueue();
    }
 
-   private void editFile(final String path)
+   public void editFile(String path,
+                        ResultCallback<EditingTarget, ServerError> callback)
    {
-      server_.ensureFileExists(
-         path,
-         new ServerRequestCallback<Boolean>()
+      server_.ensureFileExists(path, new ErrorLoggingServerRequestCallback<Boolean>()
+      {
+         @Override
+         public void onResponseReceived(Boolean success)
          {
-            @Override
-            public void onResponseReceived(Boolean success)
+            if (success)
             {
-               if (success)
-               {
-                  FileSystemItem file = FileSystemItem.createFile(path);
-                  openFile(file);
-               }
+               FileSystemItem file = FileSystemItem.createFile(path);
+               openFile(file, callback);
             }
-
-            @Override
-            public void onError(ServerError error)
-            {
-               Debug.logError(error);
-            }
-         });
+         }
+      });
    }
 
+   private void vimEditFile(String path)
+   {
+      editFile(path, new ResultCallback<EditingTarget, ServerError>() {});
+   }
+   
    public void openProjectDocs(final Session session, boolean mainColumn)
    {
       if (mainColumn && activeColumn_ != getByName(MAIN_SOURCE_NAME))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -120,7 +120,7 @@ public class SourceVimCommands
          // Handle other editing targets
          else if (params.args) {
             if (params.args.length === 1) {
-               source.getColumnManager()().@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::editFile(Ljava/lang/String;)(params.args[0]);
+               source.getColumnManager()().@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::vimEditFile(Ljava/lang/String;)(params.args[0]);
             }
             // TODO: on error?
          } else {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NewDocumentWithCodeEvent.java
@@ -15,6 +15,9 @@
  */
 package org.rstudio.studio.client.workbench.views.source.events;
 
+import org.rstudio.core.client.ResultCallback;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -66,6 +69,7 @@ public class NewDocumentWithCodeEvent
       code_ = data.code();
       cursorPosition_ = SourcePosition.create(data.row(), data.column());
       execute_ = data.execute();
+      callback_ = new ResultCallback<EditingTarget, ServerError>() {};
    }
 
    public NewDocumentWithCodeEvent(String type,
@@ -73,10 +77,24 @@ public class NewDocumentWithCodeEvent
                                    SourcePosition cursorPosition,
                                    boolean execute)
    {
+      this(
+            type,
+            code,
+            cursorPosition,
+            execute,
+            new ResultCallback<EditingTarget, ServerError>() {});
+   }
+   public NewDocumentWithCodeEvent(String type,
+                                   String code,
+                                   SourcePosition cursorPosition,
+                                   boolean execute,
+                                   ResultCallback<EditingTarget, ServerError> callback)
+   {
       type_ = type;
       code_ = code;
       cursorPosition_ = cursorPosition;
       execute_ = execute;
+      callback_ = callback;
    }
 
    public String getType()
@@ -98,6 +116,11 @@ public class NewDocumentWithCodeEvent
    {
       return execute_;
    }
+   
+   public ResultCallback<EditingTarget, ServerError> getCallback()
+   {
+      return callback_;
+   }
 
    @Override
    public Type<Handler> getAssociatedType()
@@ -115,6 +138,7 @@ public class NewDocumentWithCodeEvent
    private final String code_;
    private final SourcePosition cursorPosition_;
    private final boolean execute_;
+   private final ResultCallback<EditingTarget, ServerError> callback_;
 
    public static final Type<Handler> TYPE = new Type<>();
 


### PR DESCRIPTION
### Intent

Currently, there is no synchronous way for a user to open a document using RStudio. In particular, it is challenging to:

1. Create a new document in the IDE;
2. Receive an ID for that newly-created document;
3. Interact with that document.

This PR introduces an explicit API for opening a document on the user's filesystem. If that file does not already exist, then it will be created first.

### Approach

Nothing notable; implementation is mostly straightforward.

### QA Notes

Try opening various documents with `.rs.api.documentOpen()`, and see what happens when you specify "normal" paths, and perhaps also "weird" paths.