### PR TITLE
remove duplicate columns

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -1536,8 +1536,6 @@ public class PaneManager
 
       Widget panel = createSourceColumnWindow(name.getName(), name.getAccessibleName());
       panel_.addLeftWidget(panel);
-      leftList_.add(panel);
-      sourceColumnManager_.beforeShow(name.getName());
    }
 
    private Widget createSourceColumnWindow(String name, String accessibleName)


### PR DESCRIPTION
### Intent
Fixes #7809 

#7796 introduced an issue where column widgets were being double stored which led to columns not being fully removed until the user refreshed RStudio. It also caused new columns to open with two blank documents. 

### Approach

Remove duplicates. 

### QA Notes

Source columns should close completely when the last source doc is closed. They should also open with a single document. 
