### PR TITLE
Fast-forward past orphaned items in Ace render queue

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace-render-queue.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace-render-queue.ts
@@ -206,16 +206,18 @@ export class AceRenderQueue {
       this.needsSort = false;
     }
 
-    // Pop the next view (editor instance) to be rendered off the stack
-    const view = this.renderQueue.shift();
+    // Pop the next view (editor instance) to be rendered off the stack.
+    // Fast-forward past instances that no longer have a position; these can
+    // accumulate when NodeViews are added to the render queue but replaced
+    // (by a document rebuild) before they have a chance to render.
+    let view: AceNodeView | undefined;
+    while (view === null || view === undefined || view.getPos() === undefined) {
+      view = this.renderQueue.shift();
+    }
 
     // Render this view
     if (view) {
-      // Don't render if the view no longer has a position (this can happen if
-      // the view was moved or deleted before it got a chance to render)
-      if (view.getPos() !== undefined) {
-        view.initEditor();
-      }
+      view.initEditor();
     }
 
     if (this.renderQueue.length > 0) {


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7852, in which chunks sometimes don't highlight immediately after the user scrolls to them.

### Approach

This can happen when the render queue contains a lot of orphaned chunks (i.e. NodeViews which are no longer part of the document). We don't try to render orphaned chunks, but they do consume a work unit, and because they are perpetually at the "top" of the document, they often get priority over chunks that actually do need to render. The result is that the render queue doesn't do anything for a long time until these orphaned chunks have trickled out of the queue.

The fix is to skip past orphaned NodeViews when we are doing a unit of render work. 

### QA Notes

This bug doesn't repro 100% of the time; you need a fairly long document (so the render queue takes time to process), and you also need to scroll relatively quickly after launch. 

Note that even after the fix it can take a second or two for the chunks to highlight after you scroll, but it shouldn't take > 5s. 