### PR TITLE
Escape chunk name and code before passing to executeChunkCallback

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -181,9 +181,18 @@ void onChunkExecCompleted(const std::string& docId,
    SEXP resultSEXP = R_NilValue;
    std::string callback;
 
+   std::string escapedLabel =
+      core::string_utils::jsLiteralEscape(
+        core::string_utils::htmlEscape(label, true));
+   std::string escapedCode =
+         core::string_utils::jsLiteralEscape(
+               core::string_utils::htmlEscape(code, true));
+   boost::algorithm::replace_all(escapedLabel, "-", "_");
+   boost::algorithm::replace_all(escapedCode, "-", "_");
+
    r::exec::RFunction func(".rs.executeChunkCallback");
-   func.addParam(label);
-   func.addParam(code);
+   func.addParam(escapedLabel);
+   func.addParam(escapedCode);
 
    core::Error error = func.call(&resultSEXP, &rProtect);
    if (error)


### PR DESCRIPTION
### Intent

`htmlCallback` was returned empty if the chunk name or code had unescaped characters. This update escapes the characters before they are passed to `executeChunkCallback`. 

### Approach

Escape the characters before the html callback is created.

### QA Notes

Register a callback function and then run chunks with various odd names include characters like `,<>&-\/`

