### PR TITLE
Reset active column after a document pop out 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1343,8 +1343,14 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             Debug.logWarning("Warning: No column was provided to remove the doc from.");
          column = getActive();
       }
+      boolean setNewActiveEditor = false;
+      if (column == getActive() && column.getEditors().size() > 1)
+         setNewActiveEditor = true;
+      
       column.closeDoc(docId);
       column.cancelTabDrag();
+      if (setNewActiveEditor)
+         column.setActiveEditor();
    }
 
    public void selectTab(EditingTarget target)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocTabDragParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocTabDragParams.java
@@ -51,7 +51,7 @@ public class DocTabDragParams extends JavaScriptObject
         tab_width      : 0,
         cursor_offset  : 0,
         source_position: position,
-        display_name   : display_name
+        display_name   : displayName
      }
    }-*/;
    


### PR DESCRIPTION
### Intent

Fixes #6475 

Fixes issue where `Save / Save As...` was disabled after a viewer object was popped out from main source. Also fixes an issue that was found while testing that prevented data viewers from being returned to the source window.  

### Approach

When a document is popped out from the main column, reset the active editor to the next viewable one if one exists. 

### QA Notes

Issue #6475 has step-by-step repro instructions. Also make sure that the popped out data viewer can be returned to the main window. 


