### PR TITLE
Copy code to temporary file during Source as Local Job

### DIFF
--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -148,8 +148,7 @@ void ScriptJob::start()
             session::options().modulesRSourcePath()
                               .completePath("SourceWithProgress.R").getAbsolutePath())) +
                      "'); sourceWithProgress(script = '" +
-                     string_utils::utf8ToSystem(
-            string_utils::singleQuotedStrEscape(path)) + "', "
+            string_utils::singleQuotedStrEscape(path) + "', "
       "encoding = '" + encoding + "', "
       "con = stdout(), "
       "importRdata = " + importRdata + ", "


### PR DESCRIPTION
### Intent

Fixes #6701 

`Source as Local Job` was failing on Windows when the file's path had a non ASCII character in it on Windows. This PR executes the source as it does on other operating systems today. 

### Approach

Rather than attempting to source from the file the user is working in, copy the contents of that file to a temporary file. This avoids us needing to encode and re-encode files paths.

### QA Notes

The original ticket gives a good repro. We should also make sure functionality hasn't regressed on other OSes. We should also ensure that non-ascii encoded characters run without issue (they may produce a warning which is ok).


