### PR TITLE
Keep VCS context menu visible

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.java
@@ -99,6 +99,11 @@ public class ThemedPopupPanel extends DecoratedPopupPanel
          sizeToWindow(top, Style.Overflow.AUTO);
    }
 
+   public void setAutoConstrain(boolean autoConstrain)
+   {
+      autoConstrain_ = autoConstrain;
+   }
+
    // Size the table to the window
    private void sizeToWindow(int top, Style.Overflow overflowY)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -27,6 +27,7 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
@@ -79,6 +80,45 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    {
       this();
       parent_ = parent;
+   }
+
+   /**
+    * Position popup relative to a point, typically for a right-click context menu
+    * @param clientX
+    * @param clientY
+    */
+   public void showRelativeTo(int clientX, int clientY)
+   {
+      setPopupPositionAndShow((offsetWidth, offsetHeight) ->
+      {
+         // Calculate top position for the popup; normally we expand "down" from where user
+         // right-clicked but if there isn't room them expand "up"
+         int top = clientY;
+
+         // Make sure scrolling is taken into account, since
+         // box.getAbsoluteTop() takes scrolling into account. We don't normally
+         // allow the main window to be scrolled, but just in case.
+         int windowTop = Window.getScrollTop();
+         int windowBottom = Window.getScrollTop() + Window.getClientHeight();
+
+         // Distance from the top edge of the window to the clicked location
+         int distanceFromWindowTop = top - windowTop;
+
+         // Distance from the bottom edge of the window to the clicked location
+         int distanceToWindowBottom = windowBottom - top;
+
+         // If there is not enough space for the popup's height below the clicked
+         // location and there IS enough space for the popup's height above the
+         // clicked location, then position the popup above the location. However, if there
+         // is not enough space on either side, then stick with displaying the
+         // popup below the clicked location.
+         if (distanceToWindowBottom < offsetHeight && distanceFromWindowTop >= offsetHeight)
+         {
+            top -= offsetHeight;
+         }
+         setAutoConstrain(false);
+         setPopupPosition(clientX, top);
+      });
    }
 
    protected ToolbarMenuBar createMenuBar()

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -91,6 +91,32 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    {
       setPopupPositionAndShow((offsetWidth, offsetHeight) ->
       {
+         // Calculate left position for the popup; normally the clicked location but
+         // if it doesn't fix horizontally nudge it to the left
+         int left = clientX;
+
+         // Make sure scrolling is taken into account, since
+         // box.getAbsoluteLeft() takes scrolling into account.
+         int windowRight = Window.getClientWidth() + Window.getScrollLeft();
+         int windowLeft = Window.getScrollLeft();
+
+         // Distance from the clicked location to the right edge of the window
+         int distanceToWindowRight = windowRight - clientX;
+
+         // Distance from the clicked location to the left edge of the window
+         int distanceFromWindowLeft = clientX - windowLeft;
+
+         // If there is not enough space for the overflow of the popup's
+         // width to the right, and there IS enough space for the
+         // overflow to the left, then right-align the popup.
+         // However, if there is not enough space on either side, then stick with
+         // left-alignment.
+         if (distanceToWindowRight < offsetWidth && distanceFromWindowLeft >= offsetWidth)
+         {
+            // Align the right edge of popup with clicked location
+            left -= offsetWidth;
+         }
+
          // Calculate top position for the popup; normally we expand "down" from where user
          // right-clicked but if there isn't room them expand "up"
          int top = clientY;
@@ -117,7 +143,7 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
             top -= offsetHeight;
          }
          setAutoConstrain(false);
-         setPopupPosition(clientX, top);
+         setPopupPosition(left, top);
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -23,7 +23,6 @@ import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.user.client.ui.MenuItem;
-import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 import com.google.gwt.view.client.SelectionChangeEvent.Handler;
 import com.google.inject.Inject;
 
@@ -286,13 +285,7 @@ public class GitPane extends WorkbenchPane implements Display
       menu.addSeparator();
       menu.addItem(commands_.vcsOpen().createMenuItem(false));
 
-      menu.setPopupPositionAndShow(new PositionCallback() {
-         @Override
-         public void setPosition(int offsetWidth, int offsetHeight)
-         {
-            menu.setPopupPosition(clientX, clientY);
-         }
-      });
+      menu.showRelativeTo(clientX, clientY);
    }
 
    private ToolbarButton historyButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
@@ -15,7 +15,6 @@
 package org.rstudio.studio.client.workbench.views.vcs.svn;
 
 import com.google.gwt.user.client.ui.Widget;
-import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 import com.google.inject.Inject;
 
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -132,13 +131,7 @@ public class SVNPane extends WorkbenchPane implements Display
       menu.addSeparator();
       menu.addItem(commands_.vcsOpen().createMenuItem(false));
 
-      menu.setPopupPositionAndShow(new PositionCallback() {
-         @Override
-         public void setPosition(int offsetWidth, int offsetHeight)
-         {
-            menu.setPopupPosition(clientX, clientY);
-         }
-      });
+      menu.showRelativeTo(clientX, clientY);
    }
 
    @Override


### PR DESCRIPTION
### Intent

- Fixes #7859 for both Git and SVN panes

### Approach

Created a helper method to calculate position of context menu so it displays above the clicked location if there isn't enough room below it. Same with left/right, if you click close to the right edge of window, it will now display to the left instead of being pushed out of the visible window.

### QA Notes

Follow steps in issue, confirm the menu now fully appears even when Git or SVN pane is in bottom region, and you are clicking close to the bottom of it.