### PR TITLE
Optional highlight around focused panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 * Accessibility preference to reduce focus rectangle display (#7242)
 * Multiple source panes can be opened in the main window via Global Options. (#2854)
 * Keyboard shortcut `F6` added to navigate focus to the next pane. (#7408)
+* Accessibility preference to show a highlight around focused panel (#7881)
 
 ### Configurable Paths
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -316,6 +316,7 @@ namespace prefs {
 #define kReducedMotion "reduced_motion"
 #define kTabKeyMoveFocus "tab_key_move_focus"
 #define kShowFocusRectangles "show_focus_rectangles"
+#define kShowPanelFocusRectangle "show_panel_focus_rectangle"
 #define kAutoSaveOnIdle "auto_save_on_idle"
 #define kAutoSaveOnIdleCommit "commit"
 #define kAutoSaveOnIdleBackup "backup"
@@ -1479,6 +1480,12 @@ public:
     */
    bool showFocusRectangles();
    core::Error setShowFocusRectangles(bool val);
+
+   /**
+    * Show which panel contains keyboard focus.
+    */
+   bool showPanelFocusRectangle();
+   core::Error setShowPanelFocusRectangle(bool val);
 
    /**
     * How to deal with changes to documents on idle.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2403,6 +2403,19 @@ core::Error UserPrefValues::setShowFocusRectangles(bool val)
 }
 
 /**
+ * Show which panel contains keyboard focus.
+ */
+bool UserPrefValues::showPanelFocusRectangle()
+{
+   return readPref<bool>("show_panel_focus_rectangle");
+}
+
+core::Error UserPrefValues::setShowPanelFocusRectangle(bool val)
+{
+   return writePref("show_panel_focus_rectangle", val);
+}
+
+/**
  * How to deal with changes to documents on idle.
  */
 std::string UserPrefValues::autoSaveOnIdle()
@@ -2952,6 +2965,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kReducedMotion,
       kTabKeyMoveFocus,
       kShowFocusRectangles,
+      kShowPanelFocusRectangle,
       kAutoSaveOnIdle,
       kAutoSaveIdleMs,
       kAutoSaveOnBlur,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1214,6 +1214,12 @@
             "title": "Always show focus outlines",
             "description": "Control with keyboard focus displays a visual focus indicator."
         },
+        "show_panel_focus_rectangle": {
+            "type": "boolean",
+            "default": false,
+            "title": "Show focus outline around focused panel",
+            "description": "Show which panel contains keyboard focus."
+        },
         "auto_save_on_idle": {
             "type": "string",
             "enum": ["commit", "backup", "none"],

--- a/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/LogicalWindow.java
@@ -61,6 +61,14 @@ public class LogicalWindow implements HasWindowStateChangeHandlers,
       normal_.focus();
    }
 
+   public void showWindowFocusIndicator(boolean showFocusIndicator)
+   {
+      if (normal_ != null)
+         normal_.showWindowFocusIndicator(showFocusIndicator);
+      if (minimized_ != null)
+         minimized_.showWindowFocusIndicator(showFocusIndicator);
+   }
+
    public boolean visible()
    {
       switch (state_)

--- a/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/MinimizedWindowFrame.java
@@ -124,6 +124,10 @@ public class MinimizedWindowFrame
       initWidget(layout_);
    }
 
+   public void showWindowFocusIndicator(boolean showFocusIndicator)
+   {
+   }
+
    protected Widget getExtraWidget()
    {
       return extraWidget_;

--- a/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/WindowFrame.java
@@ -42,12 +42,6 @@ public class WindowFrame extends Composite
               EnsureVisibleEvent.Handler,
               EnsureHeightEvent.Handler
 {
-   public WindowFrame(Widget mainWidget, String name)
-   {
-      this(name, name);
-      setMainWidget(mainWidget);
-   }
-
    public WindowFrame(String name, String accessibleName)
    {
       name_ = name;
@@ -338,6 +332,15 @@ public class WindowFrame extends Composite
          if (fill_ instanceof CanFocus)
             ((CanFocus)fill_).focus();
       }
+   }
+
+   public void showWindowFocusIndicator(boolean showFocusIndicator)
+   {
+      final ThemeStyles styles = ThemeResources.INSTANCE.themeStyles();
+      if (showFocusIndicator)
+         frame_.addStyleName(styles.focusedWindowFrameObject());
+      else
+         frame_.removeStyleName(styles.focusedWindowFrameObject());
    }
 
    public void onEnsureVisible(EnsureVisibleEvent event)

--- a/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/ThemeStyles.java
@@ -47,7 +47,7 @@ public interface ThemeStyles extends CssResource
    String docTabPanel();
    String docTabIcon();
    String docMenuScroll();
-          
+
    String closeTabButton();
 
    String visuallyHidden();
@@ -75,12 +75,12 @@ public interface ThemeStyles extends CssResource
    String menuItemSubtitle();
 
    String menuRightImage();
-   
+
    String scrollableMenuBar();
 
    String moduleTabPanel();
    String minimized();
-          
+
    String firstTabSelected();
 
    String toolbarSeparator();
@@ -92,10 +92,10 @@ public interface ThemeStyles extends CssResource
    String toolbarButtonLeftImage();
    String toolbarButtonRightImage();
    String toolbarFileLabel();
-   
+
    String toolbarButtonLatched();
    String toolbarButtonLatchable();
-   
+
    String windowFrameToolbarButton();
 
    String statusBarMenu();
@@ -122,11 +122,11 @@ public interface ThemeStyles extends CssResource
    String clearSearch();
 
    String dialogBottomPanel();
-   
+
    String dialogMessage();
    String sessionAbendMessage();
    String applicationHeaderStrong();
-   
+
    String environmentHierarchicalCol();
    String environmentDataFrameCol();
    String environmentFunctionCol();
@@ -134,16 +134,16 @@ public interface ThemeStyles extends CssResource
    String filterMatch();
 
    String odd();
-   
+
    String showFile();
    String showFileFixed();
    String showFilePreFixed();
-   
+
    String fileUploadPanel();
    String fileUploadField();
    String fileUploadLabel();
    String fileUploadTipLabel();
-   
+
    String fileList();
 
    String locatorPanel();
@@ -151,40 +151,41 @@ public interface ThemeStyles extends CssResource
    String multiPodUtilityArea();
    String rstheme_multiPodUtilityTabArea();
 
-   String tabOverflowPopup();   
-   
+   String tabOverflowPopup();
+
    String miniDialogPopupPanel();
    String miniDialogContainer();
    String miniDialogCaption();
    String miniDialogTools();
-   
+
    String selectWidget();
    String textBoxWithButton();
-   
+
    String selectableText();
    String forceMacScrollbars();
-   
+
    String adornedText();
-   
+
    String fullscreenCaptionIcon();
    String fullscreenCaptionLabel();
-   
+
    String presentationNavigatorLabel();
-   
+
    String notResizable();
-   
+
    String dialogTabPanel();
-   
+
    String handCursor();
-   
+
    String borderedIFrame();
-   
+
    String toolbarInfoLabel();
-   
+
    String displayNone();
    String logoAnchor();
 
    String windowFrameObject();
+   String focusedWindowFrameObject();
    String rstheme_minimizedWindowObject();
    String windowFrameWidget();
 
@@ -209,10 +210,10 @@ public interface ThemeStyles extends CssResource
    String dataTableColumnWidget();
 
    String tabIcon();
-   
+
    String menuCheckable();
-   
+
    String noLogo();
-   
+
    String launcherJobRunButton();
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -299,22 +299,22 @@ button, input[type="reset"], input[type="button"], input[type="submit"] {
 
 @if rstudio.desktop false {
 @if user.agent safari {
-.macintosh .forceMacScrollbars ::-webkit-scrollbar { 
-   -webkit-appearance: none; 
+.macintosh .forceMacScrollbars ::-webkit-scrollbar {
+   -webkit-appearance: none;
    -moz-appearance: none;
-   width: 12px; 
-   height: 12px; 
+   width: 12px;
+   height: 12px;
 }
-   
+
 .macintosh .forceMacScrollbars ::-webkit-scrollbar-track {
-   
+
    background: rgb(251,251,251);
    -webkit-box-shadow: 0 1px 0 0 rgba(255,255,255,0.35);
    -webkit-border-radius: 5px;
-}   
+}
 
 .macintosh .forceMacScrollbars ::-webkit-scrollbar-thumb {
-  
+
    border: 2px solid rgb(251,251,251);
    background: rgba(0,0,0,.22);
    -webkit-border-radius: 6px;
@@ -892,6 +892,18 @@ pre {
 
    /* overflow-hidden with border-radius degrades under windows */
    overflow: visible !important;
+}
+
+/* region focus indicator for classic theme and modern themes */
+.windowFrameObject.focusedWindowFrameObject > div:last-child {
+   outline: #8AA9DB dotted 2px !important;
+   outline-offset: -1px !important;
+}
+
+/* region focus indicator for sky theme */
+.rstudio-themes-flat .rstudio-themes-alternate .windowFrameObject.focusedWindowFrameObject > div:last-child {
+   outline: #2b75d8 dotted 2px !important;
+   outline-offset: -1px !important;
 }
 
 .gwt-SplitLayoutPanel-Workbench {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2587,6 +2587,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Show which panel contains keyboard focus.
+    */
+   public PrefValue<Boolean> showPanelFocusRectangle()
+   {
+      return bool(
+         "show_panel_focus_rectangle",
+         "Show focus outline around focused panel", 
+         "Show which panel contains keyboard focus.", 
+         false);
+   }
+
+   /**
     * How to deal with changes to documents on idle.
     */
    public PrefValue<String> autoSaveOnIdle()
@@ -3383,6 +3395,8 @@ public class UserPrefsAccessor extends Prefs
          tabKeyMoveFocus().setValue(layer, source.getBool("tab_key_move_focus"));
       if (source.hasKey("show_focus_rectangles"))
          showFocusRectangles().setValue(layer, source.getBool("show_focus_rectangles"));
+      if (source.hasKey("show_panel_focus_rectangle"))
+         showPanelFocusRectangle().setValue(layer, source.getBool("show_panel_focus_rectangle"));
       if (source.hasKey("auto_save_on_idle"))
          autoSaveOnIdle().setValue(layer, source.getString("auto_save_on_idle"));
       if (source.hasKey("auto_save_idle_ms"))
@@ -3626,6 +3640,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(reducedMotion());
       prefs.add(tabKeyMoveFocus());
       prefs.add(showFocusRectangles());
+      prefs.add(showPanelFocusRectangle());
       prefs.add(autoSaveOnIdle());
       prefs.add(autoSaveIdleMs());
       prefs.add(autoSaveOnBlur());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AccessibilityPreferencesPane.java
@@ -68,7 +68,8 @@ public class AccessibilityPreferencesPane extends PreferencesPane
       chkTabMovesFocus_ = new CheckBox("Tab key always moves focus");
       generalPanel.add(lessSpaced(chkTabMovesFocus_));
       chkShowFocusRectangles_ = new CheckBox("Always show focus outlines (requires restart)");
-      generalPanel.add(chkShowFocusRectangles_);
+      generalPanel.add(lessSpaced(chkShowFocusRectangles_));
+      generalPanel.add(checkboxPref("Highlight focused panel", prefs.showPanelFocusRectangle()));
 
       HelpLink helpLink = new HelpLink("RStudio accessibility help", "rstudio_a11y", false);
       nudgeRight(helpLink);


### PR DESCRIPTION
### Intent

- Fixes #6225

Provides optional support (off by default) for indicating which panel has keyboard focus via a dotted outline. Someone will presumably have a better visual treatment, but for 1.4 this seems sufficient. "Panel" in our terminology refers to the main regions of the page (formerly each of the 4 quadrants, but now also includes source columns).

Enable in accessibility options via new "Highlight focused panel" checkbox.

<img width="445" alt="screenshot of accessibility options showing highlight focused panel checkbox" src="https://user-images.githubusercontent.com/10569626/94223846-c6683b00-fea5-11ea-913a-1214bd54a073.png">

Screenshot showing source panel having focus:

<img width="756" alt="screenshot" src="https://user-images.githubusercontent.com/10569626/94223898-e7c92700-fea5-11ea-81bf-2f706f75cc47.png">

Screenshot showing console panel having focus:

<img width="318" alt="screenshot" src="https://user-images.githubusercontent.com/10569626/94223917-fca5ba80-fea5-11ea-99ac-f668d24d52af.png">


### Approach

Uses the `focusin` DOM event which is fired whenever focus changes in the page, then (if the option is enabled) checks if the currently focused element belongs to a panel and adds or removes the CSS style `focusedWindowFrameObject`. The CSS adds an outline.

So this indicator is truly representing keyboard focus being within a panel, not just a logical concept of focus, and is helpful in diagnosing focus issues in general. Many of our commands that show a specific pane do not actually move focus to it (#5652). Also some operations such as using the main menu in RStudio Server can leave focus nowhere (actually on the page body), which will cause none of the panels to show the focus outline (#6197).
 
### QA Notes

With option off, there should be no differences observable in the UI as you click/tab around the UI.

Then enable the option, and check that the dotted outline appears as you move focus around. Try F6 / Shift+F6 to move between panels via keyboard, or clicking or Tab key.

Check that you can see it with a variety of RStudio and Editor themes, and that is also works with source columns.

This mechanism is not active in secondary windows (popped out editor, Git, etc.).


