### PR TITLE
load focus-visible polyfill in satellite windows

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
@@ -69,6 +69,9 @@ public class Satellite implements HasCloseHandlers<Satellite>
       // load MathJax
       MathJaxLoader.ensureMathJaxLoaded();
 
+      // load focus-visible polyfill
+      RStudioGinjector.INSTANCE.getFocusVisiblePolyfill().load(null);
+
       // NOTE: Desktop doesn't seem to get onWindowClosing events in Qt 4.8
       // so we instead rely on an explicit callback from the desktop frame
       // to notifyRStudioSatelliteClosing


### PR DESCRIPTION
### Intent

- Fixes #7882
- Shows focus rectangles in satellite windows, not just main window (via focus-visible polyfill)

### Approach

When I implemented #7351 I made loading of the focus-visible polyfill conditional on the "Always show focus outlines" user preference and moved the load call to Workbench.java since it required user preferences to be available. This path isn't hit when loading satellite windows, so added the same call in Satellite.java.

### QA Notes

Test as described in #7882.
