### PR TITLE
Enable code commands only when a code editor is focused

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -671,6 +671,10 @@ public class VisualMode implements VisualModeEditorSync,
         // Disabled since we don't have line numbers in the visual editor
         commands_.goToLine()
       );
+      
+      // initially disable code commands (they will be re-enabled later when an
+      // editor has focus)
+      setCodeCommandsEnabled(false);
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -668,10 +668,6 @@ public class VisualMode implements VisualModeEditorSync,
         commands_.unfold(),
         commands_.unfoldAll(),
 
-        // Temporarily disabled since keybinding conflicts with Panmirrors'
-        // Italicize command
-        commands_.reindent(),
-        
         // Disabled since we don't have line numbers in the visual editor
         commands_.goToLine()
       );
@@ -710,9 +706,67 @@ public class VisualMode implements VisualModeEditorSync,
       return activeEditor_;
    }
    
+   /**
+    * Sets the active (currently focused) code chunk editor.
+    * 
+    * @param editor The current code chunk editor, or null if no code chunk
+    *   editor has focus.
+    */
    public void setActiveEditor(DocDisplay editor)
    {
       activeEditor_ = editor;
+      
+      if (editor != null)
+      {
+         // A code chunk has focus; enable code commands
+         setCodeCommandsEnabled(true);
+      }
+   }
+   
+   /**
+    * Sets the enabled state for code commands -- i.e. those that require
+    * selection to be inside a chunk of code. We disable these outside code
+    * chunks.
+    * 
+    * @param enabled Whether to enable code commands
+    */
+   private void setCodeCommandsEnabled(boolean enabled)
+   {
+      AppCommand[] commands = {
+         commands_.commentUncomment(),
+         commands_.executeCode(),
+         commands_.executeCodeWithoutFocus(),
+         commands_.executeCodeWithoutMovingCursor(),
+         commands_.executeCurrentFunction(),
+         commands_.executeCurrentLine(),
+         commands_.executeCurrentParagraph(),
+         commands_.executeCurrentSection(),
+         commands_.executeCurrentStatement(),
+         commands_.executeFromCurrentLine(),
+         commands_.executeToCurrentLine(),
+         commands_.extractFunction(),
+         commands_.extractLocalVariable(),
+         commands_.goToDefinition(),
+         commands_.insertRoxygenSkeleton(),
+         commands_.profileCode(),
+         commands_.profileCodeWithoutFocus(),
+         commands_.reflowComment(),
+         commands_.reformatCode(),
+         commands_.reindent(),
+         commands_.renameInScope(),
+         commands_.runSelectionAsJob(),
+         commands_.runSelectionAsLauncherJob(),
+         commands_.sendToTerminal(),
+      };
+
+      for (AppCommand command : commands)
+      {
+         if (command.isVisible())
+         {
+            command.setEnabled(enabled);
+         }
+      }
+      
    }
 
    public void goToNextSection()
@@ -808,7 +862,6 @@ public class VisualMode implements VisualModeEditorSync,
       {
          return false;
       }
-            
    }
    
    @Override
@@ -1186,6 +1239,16 @@ public class VisualMode implements VisualModeEditorSync,
                public void onPanmirrorFocus(PanmirrorFocusEvent event)
                {
                   target_.checkForExternalEdit(100);
+                  
+                  // Disable code-related commands, on the presumption that we
+                  // are in a prose region of the document. These commands will
+                  // be re-enabled shortly if focus is sent to a code chunk, and
+                  // will remain disabled if we aren't.
+                  //
+                  // Note that the PanmirrorFocusEvent is fired when selection
+                  // exits a code chunk as well as when the entire widget loses
+                  // focus.
+                  setCodeCommandsEnabled(false);
                }
             });
              


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7886, in which code-related commands are enabled even when outside a code editor. This change allows the same shortcut to do different things inside a code editor and the prose editor; e.g., Cmd+I will now reindent inside a code editor *and* italicize inside the prose editor.

### Approach

The idea here is pretty simple:

1. We disable code-related commands by default in the visual editor.
2. When focus enters a code editor, the commands are enabled.
3. When focus re-enters the prose region, the commands are disabled again.

### QA Notes

This affects a lot of commands (the PR diff has an easy to read list). Of particular interest is commands that have bindings that overlap with the visual editor's. 