### PR TITLE
handle more pipe styles in "execute current statement" heuristics

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3652,7 +3652,7 @@ public class AceEditor implements DocDisplay,
       return cursor.getRow();
    }
    
-   private boolean rowEndsInBinaryOp(int row)
+   private boolean rowEndsInBinaryOperatorOrOpenParen(int row)
    {
       // move to the last interesting token on this line 
       JsArray<Token> tokens = getSession().getTokens(row);
@@ -3663,7 +3663,8 @@ public class AceEditor implements DocDisplay,
             continue;
          if (t.getType()  == "keyword.operator" ||
              t.getType()  == "keyword.operator.infix" ||
-             t.getValue() == ",")
+             t.getValue() == "," ||
+             t.getValue() == "(")
             return true;
          break;
       } 
@@ -3843,7 +3844,7 @@ public class AceEditor implements DocDisplay,
       while (false);
       
       // check for binary operator on start line
-      if (rowEndsInBinaryOp(startRow))
+      if (rowEndsInBinaryOperatorOrOpenParen(startRow))
       {
          // move token cursor to that row
          c.moveToEndOfRow(startRow);
@@ -3890,7 +3891,7 @@ public class AceEditor implements DocDisplay,
          
          // check for binary operator on previous line
          int prevRow = startRow - 1;
-         if (rowEndsInBinaryOp(prevRow))
+         if (rowEndsInBinaryOperatorOrOpenParen(prevRow))
          {
             // move token cursor to that row
             c.moveToEndOfRow(prevRow);
@@ -3982,7 +3983,7 @@ public class AceEditor implements DocDisplay,
          }
          
          // continue search if line ends with binary operator
-         if (rowEndsInBinaryOp(endRow) || rowIsEmptyOrComment(endRow))
+         if (rowEndsInBinaryOperatorOrOpenParen(endRow) || rowIsEmptyOrComment(endRow))
          {
             endRow++;
             continue;

--- a/src/gwt/test/test-multiline-expr.R
+++ b/src/gwt/test/test-multiline-expr.R
@@ -109,6 +109,17 @@ mtcars %>%
       mpg > 20) %>%
    select(everything())
 
+# 17: more pipes
+mtcars %>%
+   filter(
+      mpg > 20) %>% select(everything())
+
+# 18: more pipes
+mtcars %>% 
+   mutate(
+      x1 = "ok here") %>% 
+   mutate(
+      x2 = "not ok") # use Ctrl + Enter in this line
 
 # cursor should end here after executing all lines
 EOF


### PR DESCRIPTION
### Intent

Fixes an edge case in RStudio's "find current expression" heuristics. Closes https://github.com/rstudio/rstudio/issues/6248.

### Approach

Treat lines ending with `(`s as continuations (and so they should be included as part of the "current" expression).

### QA Notes

Test via cases in https://github.com/rstudio/rstudio/issues/6248.