### PR TITLE
fix issues with completion insertion in high-latency environments

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -129,6 +129,9 @@ public abstract class CompletionManagerBase
       if (positionChanged)
          return;
       
+      // cache context data (to be used by popup during active completion session)
+      contextData_ = data;
+      
       String line = data.getLine();
       if (completions.isCacheable())
          completionCache_.store(line, completions);
@@ -244,7 +247,7 @@ public abstract class CompletionManagerBase
    @Override
    public void onCompletionRequestError(String message)
    {
-      
+      contextData_ = null;
    }
    
    public void onCompletionCommit()
@@ -294,11 +297,11 @@ public abstract class CompletionManagerBase
             isTabTriggered,
             canAutoAccept);
             
-      context_ = new CompletionRequestContext(this, data);
-      if (completionCache_.satisfyRequest(line, context_))
+      CompletionRequestContext context = new CompletionRequestContext(this, data);
+      if (completionCache_.satisfyRequest(line, context))
          return true;
       
-      boolean canComplete = getCompletions(line, context_);
+      boolean canComplete = getCompletions(line, context);
       
       // if tab was used to trigger the completion, but no completions
       // are available in that context, then insert a literal tab
@@ -402,12 +405,12 @@ public abstract class CompletionManagerBase
    
    public void onPaste(PasteEvent event)
    {
-      popup_.hide();
+      invalidatePendingRequests();
    }
    
    public void close()
    {
-      popup_.hide();
+      invalidatePendingRequests();
    }
    
    public void detach()
@@ -415,8 +418,7 @@ public abstract class CompletionManagerBase
       removeHandlers();
       suggestTimer_.cancel();
       snippets_.detach();
-      invalidation_.invalidate();
-      popup_.hide();
+      invalidatePendingRequests();
    }
    
    public boolean previewKeyDown(NativeEvent event)
@@ -433,6 +435,16 @@ public abstract class CompletionManagerBase
       
       if (popup_.isShowing())
       {
+         // attempts to move the cursor left or right should be treated
+         // as requests to cancel the current completion session
+         switch (keyCode)
+         {
+         case KeyCodes.KEY_LEFT:
+         case KeyCodes.KEY_RIGHT:
+            invalidatePendingRequests();
+            return false;
+         }
+         
          switch (modifier)
          {
          
@@ -451,27 +463,52 @@ public abstract class CompletionManagerBase
          {
             switch (keyCode)
             {
-            case KeyCodes.KEY_UP:        popup_.selectPrev();         return true;
-            case KeyCodes.KEY_DOWN:      popup_.selectNext();         return true;
-            case KeyCodes.KEY_PAGEUP:    popup_.selectPrevPage();     return true;
-            case KeyCodes.KEY_PAGEDOWN:  popup_.selectNextPage();     return true;
-            case KeyCodes.KEY_HOME:      popup_.selectFirst();        return true;
-            case KeyCodes.KEY_END:       popup_.selectLast();         return true;
-            case KeyCodes.KEY_ESCAPE:    invalidatePendingRequests(); return true;
+            case KeyCodes.KEY_UP:        popup_.selectPrev();               return true;
+            case KeyCodes.KEY_DOWN:      popup_.selectNext();               return true;
+            case KeyCodes.KEY_PAGEUP:    popup_.selectPrevPage();           return true;
+            case KeyCodes.KEY_PAGEDOWN:  popup_.selectNextPage();           return true;
+            case KeyCodes.KEY_HOME:      popup_.selectFirst();              return true;
+            case KeyCodes.KEY_END:       popup_.selectLast();               return true;
+            case KeyCodes.KEY_ESCAPE:    invalidatePendingRequests();       return true;
             case KeyCodes.KEY_ENTER:     return onPopupEnter();
             case KeyCodes.KEY_TAB:       return onPopupTab();
             case KeyCodes.KEY_F1:        return onPopupAdditionalHelp();
             }
             
+            // cancel the current completion session if the cursor
+            // has been moved before the completion start position,
+            // or to a new line. this ensures that backspace can
+            if (contextData_ != null)
+            {
+               Position cursorPos = docDisplay_.getCursorPosition();
+               Position completionPos = contextData_.getPosition();
+
+               boolean dismiss =
+                     cursorPos.getRow() != completionPos.getRow() ||
+                     cursorPos.getColumn() < completionPos.getColumn();
+
+               if (dismiss)
+               {
+                  invalidatePendingRequests();
+                  return false;
+               }
+            }
+            
+            // handle backspace specially -- allow it to continue
+            // the current completion session after taking its
+            // associated action
+            if (keyCode == KeyCodes.KEY_BACKSPACE)
+            {
+               Scheduler.get().scheduleDeferred(() ->
+               {
+                  beginSuggest(false, false, false);
+               });
+               
+               return false;
+            }
+            
             break;
          }
-         }
-         
-         switch (keyCode)
-         {
-         case KeyCodes.KEY_LEFT:
-         case KeyCodes.KEY_RIGHT:
-            invalidatePendingRequests();
          }
          
          return false;
@@ -540,7 +577,10 @@ public abstract class CompletionManagerBase
       else
       {
          if (canAutoPopup(charCode, userPrefs_.codeCompletionCharacters().getValue() - 1))
+         {
+            invalidatePendingRequests();
             suggestTimer_.schedule(true, false);
+         }
       }
       
       return false;
@@ -632,9 +672,9 @@ public abstract class CompletionManagerBase
    private void onSelection(String completionToken,
                             QualifiedName completion)
    {
+      invalidatePendingRequests();
       suggestTimer_.cancel();
       
-      popup_.hide();
       popup_.clearHelp(false);
       popup_.setHelpVisible(false);
       
@@ -646,11 +686,26 @@ public abstract class CompletionManagerBase
       else
       {
          String value = onCompletionSelected(completion);
+         
+         // compute an appropriate offset for completion --
+         // this is necessary in case the user has typed in the interval
+         // between when completions were requested, and the completion
+         // RPC response was received.
+         int offset = 0;
+         if (contextData_ != null)
+         {
+            Position cursorPos = docDisplay_.getCursorPosition();
+            Position completionPos = contextData_.getPosition();
+            offset =
+                  completionToken.length() +
+                  cursorPos.getColumn() -
+                  completionPos.getColumn();
+         }
 
          Range[] ranges = docDisplay_.getNativeSelection().getAllRanges();
          for (Range range : ranges)
          {
-            Position replaceStart = range.getEnd().movedLeft(completionToken.length());
+            Position replaceStart = range.getEnd().movedLeft(offset);
             Position replaceEnd = range.getEnd();
             docDisplay_.replaceRange(Range.fromPoints(replaceStart, replaceEnd), value);
          }
@@ -941,7 +996,7 @@ public abstract class CompletionManagerBase
    private String snippetToken_;
    private boolean ignoreNextBlur_;
    
-   private CompletionRequestContext context_;
+   private CompletionRequestContext.Data contextData_;
    private HelpStrategy helpStrategy_;
    
    protected EventBus events_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -121,6 +121,14 @@ public abstract class CompletionManagerBase
    public void onCompletionResponseReceived(CompletionRequestContext.Data data,
                                             Completions completions)
    {
+      // if the cursor has moved to a different line, discard this completion request
+      boolean positionChanged =
+            docDisplay_.getCursorPosition().getRow() !=
+            data.getPosition().getRow();
+      
+      if (positionChanged)
+         return;
+      
       String line = data.getLine();
       if (completions.isCacheable())
          completionCache_.store(line, completions);
@@ -282,6 +290,7 @@ public abstract class CompletionManagerBase
       
       CompletionRequestContext.Data data = new CompletionRequestContext.Data(
             line,
+            docDisplay_.getCursorPosition(),
             isTabTriggered,
             canAutoAccept);
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequestContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequestContext.java
@@ -74,6 +74,11 @@ public class CompletionRequestContext extends ServerRequestCallback<Completions>
       token_ = host.getInvalidationToken();
       data_ = data;
    }
+   
+   public Data getData()
+   {
+      return data_;
+   }
 
    @Override
    public void onError(ServerError error)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequestContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequestContext.java
@@ -18,16 +18,19 @@ import org.rstudio.core.client.Invalidation;
 import org.rstudio.studio.client.common.codetools.Completions;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
 public class CompletionRequestContext extends ServerRequestCallback<Completions>
 {
    public static class Data
    {
       public Data(String line,
+                  Position position,
                   boolean isTabTriggeredCompletion,
                   boolean autoAcceptSingleCompletionResult)
       {
          line_ = line;
+         position_ = position;
          isTabTriggeredCompletion_ = isTabTriggeredCompletion;
          autoAcceptSingleCompletionResult_ = autoAcceptSingleCompletionResult;
       }
@@ -35,6 +38,11 @@ public class CompletionRequestContext extends ServerRequestCallback<Completions>
       public String getLine()
       {
          return line_;
+      }
+      
+      public Position getPosition()
+      {
+         return position_;
       }
       
       public boolean isTabTriggeredCompletion()
@@ -48,6 +56,7 @@ public class CompletionRequestContext extends ServerRequestCallback<Completions>
       }
       
       private final String line_;
+      private final Position position_;
       private final boolean isTabTriggeredCompletion_;
       private final boolean autoAcceptSingleCompletionResult_;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1149,9 +1149,10 @@ public class RCompletionManager implements CompletionManager
       if (context.getToken() == "'@")
          context.setToken(context.getToken().substring(1));
       
-      context_ = new CompletionRequestContext(invalidation_.getInvalidationToken(),
-                                              selection,
-                                              canAutoInsert);
+      context_ = new CompletionRequestContext(
+            invalidation_.getInvalidationToken(),
+            selection,
+            canAutoInsert);
       
       RInfixData infixData = RInfixData.create();
       AceEditor editor = (AceEditor) docDisplay_;


### PR DESCRIPTION
### Intent

In some cases (especially in high-latency environments), attempts to insert completions would produce a "wrong" completion result. For example:

- The text would be duplicated; producing `stats::ac` -> `stats::acacf()` rather than `stats::acf()`;
- The wrong portion of text would be replaced; e.g. `stats::rn` -> `stats:rnorm()` rather than `stats::rnorm()`.

In particular, the issue normally occurs when:

1. The user requests completions (either automatically, or explicitly via TAB);
2. The user immediately begins typing new characters,
3. The completion response is received, and the popup is shown.

In particular, the completion engine was not handling the new characters added (or removed) in (2) cleanly.

### Approach

The issue was caused by some incongruences in the autocompletion context being used. New completion requests are triggered somewhat aggressively as the user types, and the completion manager tracks a single "active" completion context. Unfortunately, the "active" completion context was being updated too soon, so in the case where:

1. The user is being presented with completion results (in a popup) as part of the current set of completions,
2. A new completion request has been sent off,
3. The response from completion request (2) has not yet been received.

the "active" completion context would represent the state from (2) rather than (1), and so the completion insertion would be incorrect.

### QA Notes

Test via cases in https://github.com/rstudio/rstudio/issues/5979. Note that both R and Python scripts should be tested independently, as they use different completion manager implementations. (Hopefully that will change in the future.)

Closes https://github.com/rstudio/rstudio/issues/5979.