### PR TITLE
Feature/visual chunk option completion

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -67,6 +67,7 @@ import org.rstudio.studio.client.workbench.views.environment.events.DebugModeCha
 import org.rstudio.studio.client.workbench.views.source.SourceSatellite;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
+import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor.EditorBehavior;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 
@@ -182,7 +183,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                                           null,
                                           null,
                                           (DocDisplay) view_.getInputEditorDisplay(),
-                                          true);
+                                          EditorBehavior.AceBehaviorConsole);
       addKeyDownPreviewHandler(completionManager);
       addKeyPressPreviewHandler(completionManager);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -7509,6 +7509,11 @@ public class TextEditingTarget implements
    {
       return rContext_;
    }
+   
+   public RnwCompletionContext getRnwCompletionContext()
+   {
+      return compilePdfHelper_;
+   }
 
    public static void syncFontSize(
                               ArrayList<HandlerRegistration> releaseOnDismiss,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
@@ -321,19 +321,26 @@ public class TextEditingTargetCompilePdfHelper
    @Override
    public int getRnwOptionsStart(String line, int cursorPos)
    {
-      Pattern pattern = docDisplay_.getFileType().getRnwStartPatternBegin();
-      if (pattern == null)
+      return getRnwOptionsStart(line, 
+            cursorPos, 
+            docDisplay_.getFileType().getRnwStartPatternBegin(),
+            docDisplay_.getFileType().getRnwStartPatternEnd());
+   }
+   
+   public static int getRnwOptionsStart(String line, int cursorPos, 
+         Pattern startPattern, Pattern endPattern)
+   {
+      if (startPattern == null)
          return -1;
-
+      
       String linePart = line.substring(0, cursorPos);
-      Match match = pattern.match(linePart, 0);
+      Match match = startPattern.match(linePart, 0);
       if (match == null)
          return -1;
 
       // See if the cursor is already past the end of the chunk header,
       // for example <<foo>>=[CURSOR].
-      Pattern patternEnd = docDisplay_.getFileType().getRnwStartPatternEnd();
-      if (patternEnd != null && patternEnd.match(linePart, 0) != null)
+      if (endPattern != null && endPattern.match(linePart, 0) != null)
          return -1;
 
       return match.getValue().length();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
@@ -170,11 +170,6 @@ public class TextEditingTargetPrefsHelper
             {
                docDisplay.forceImmediateRender();
             }));
-      releaseOnDismiss.add(prefs.foldStyle().bind(
-            (arg) ->
-            {
-               docDisplay.setFoldStyle(FoldStyle.fromPref(arg));
-            }));
       releaseOnDismiss.add(prefs.surroundSelection().bind(
             (arg) ->
             {
@@ -213,6 +208,11 @@ public class TextEditingTargetPrefsHelper
                (arg) ->
                {
                   docDisplay.setUseEmacsKeybindings(arg == UserPrefs.EDITOR_KEYBINDINGS_EMACS);
+               }));
+         releaseOnDismiss.add(prefs.foldStyle().bind(
+               (arg) ->
+               {
+                  docDisplay.setFoldStyle(FoldStyle.fromPref(arg));
                }));
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -33,6 +33,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ChunkOutputWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ChunkRowExecState;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
+import org.rstudio.studio.client.workbench.views.source.editors.text.FoldStyle;
 import org.rstudio.studio.client.workbench.views.source.editors.text.Scope;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetCompilePdfHelper;
@@ -172,6 +173,11 @@ public class VisualModeChunk
       chunk.setMode = (String mode) ->
       {
          setMode(editor_, mode);
+
+         // Disable code folding, since we don't have a gutter (must be done
+         // after setting the mode)
+         editor_.setFoldStyle(FoldStyle.FOLD_MARK_MANUAL);
+      
       };
       
       // Provide a callback to have the code at the cursor executed


### PR DESCRIPTION
### Intent

This change makes code completion for chunk options work inside the visual editor. 

![image](https://user-images.githubusercontent.com/470418/94587348-4fc99580-0237-11eb-9ca3-7cba1c98b527.png)

Fixes https://github.com/rstudio/rstudio/issues/7697.

### Approach

This is a little tricky to hook up since the embedded Ace instances think they are editing R code, not an R Markdown chunk. The change accomplishes this by adding a new enum indicating the kind of editor behavior we want (embedded vs default), and wrapping the chunk options completer from the parent Ace instance in one that finds the chunk options text in the first line of the embedded editor. 

### QA Notes

This should now work the same way it does in source mode. 

