### PR TITLE
fix autocompletion of formals for piped-to S3 generics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,7 @@
 * Fixed issue where diagnostics system surface "Unknown or uninitialized column" warnings in some cases. (#7372)
 * Fixed issue where hovering mouse cursor over C++ completion popup would steal focus. (#5941)
 * Fixed issue where autocompletion could fail for functions masked by objects in global environments. (#6942)
+* Fixed issue where autocompletion could fail to provide argument names for piped-to S3 generics. (#7060)
 * Fixed issue where UTF-8 output from Python chunks was mis-encoded on Windows. (#6254)
 * Git integration now works properly for project names containing the '!' character. (#6160)
 * Fixed issue where loading the Rfast package could lead to session hangs. (#6645)


### PR DESCRIPTION
### Intent

Autocompletion of function argument names could fail when piping in an object to an S3 generic function.

### Approach

We normally try to retrieve function arguments from two locations:

1. The S3 method that would normally be dispatched to, if we can determine which method that is;
2. The S3 generic itself.

However, in the case where our attempts to find a method in (1). fail, we would end up with no completion results at all. This PR alleviates that by falling back to (2) when (1) fails.

### QA Notes

Test via example described in https://github.com/rstudio/rstudio/issues/7060. Be sure that the `tidyr` package is installed and loaded when testing.