### PR TITLE
Prune overflow data in Virtual Scroller

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -648,8 +648,11 @@ public class VirtualConsole
       }
 
       Entry<Integer, ClassRange> last = class_.lastEntry();
-      ClassRange range = last.getValue();
-      if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
+      if (last != null)
+      {
+         ClassRange range = last.getValue();
+         if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
+      }
 
       // If there was any plain text after the last control character, add it
       if (tail < data.length())

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -242,6 +242,8 @@ public class VirtualConsole
       {
          // just append to the existing output stream
          range.appendRight(text, 0);
+
+         if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
       }
       else
       {

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -238,12 +238,11 @@ public class VirtualConsole
    {
       Entry<Integer, ClassRange> last = class_.lastEntry();
       ClassRange range = last.getValue();
+
       if (!forceNewRange && StringUtil.equals(range.clazz, clazz))
       {
          // just append to the existing output stream
          range.appendRight(text, 0);
-
-         if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
       }
       else
       {
@@ -647,6 +646,10 @@ public class VirtualConsole
 
          match = match.nextMatch();
       }
+
+      Entry<Integer, ClassRange> last = class_.lastEntry();
+      ClassRange range = last.getValue();
+      if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
 
       // If there was any plain text after the last control character, add it
       if (tail < data.length())

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
@@ -75,11 +75,23 @@ public class VirtualScrollerManager
       scrollers_.get(parent.getAttribute(scrollerAttribute_)).append(content);
    }
 
+   public static void prune(Element parent, Element ele)
+   {
+      // if we don't have a connection to that parent there's nothing to clear
+      if (!initialized_ || parent == null ) return;
+
+      parent = getVirtualScrollerAncestor(parent);
+
+      if (scrollers_.get(parent.getAttribute(scrollerAttribute_)) == null)
+         return;
+
+      scrollers_.get(parent.getAttribute(scrollerAttribute_)).prune(ele);
+   }
+
    public static void clear(Element parent)
    {
       // if we don't have a connection to that parent there's nothing to clear
-      if (!initialized_ || parent == null )
-         return;
+      if (!initialized_ || parent == null ) return;
 
       parent = getVirtualScrollerAncestor(parent);
 

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
@@ -27,5 +27,6 @@ public class VirtualScrollerNative
    public native void append(Element ele);
    public native Element getCurBucket();
    public native void clear();
+   public native void prune(Element ele);
 }
 

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -289,12 +289,12 @@ var VirtualScroller;
       var indexToSlice = 0;
 
       while (newlinesToPrune > 0) {
-        indexToSlice = text.indexOf("\n", indexToSlice);
+        indexToSlice = text.indexOf("\n", indexToSlice + 1);
         newlinesToPrune -= 1;
       }
 
       if (indexToSlice > 0)
-        element.innerText = text.slice(indexToSlice);
+        element.innerText = element.innerText.substring(indexToSlice);
     },
 
     _createAndAddNewBucket: function() {


### PR DESCRIPTION
### Intent

Fixes #7712 

Currently, only in Desktop mode as far as I can tell, the server doesn't always accurately prune the data as per the 1000 line single element hard cap that it thinks it's doing. This difference can be observed by watching the `set_client_state` updates. Even when the server is being overzealous in Desktop mode the VirtualConsole will prune this information so it matches the server.

### Approach

The VirtualScroller will now prune elements as they're added as well as after a full submit loop in the VirtualConsole is run.

### QA Notes

Ensure that we're only seeing roughly 1000 lines within a single element as per the example in the issue above. This should match the functionality of having the VirtualConsole disabled as well ("Limit console output to a subset of content" setting). 


