### PR TITLE
Fix null reference in Find in Files pane 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -425,7 +425,7 @@ public class FindOutputPresenter extends BasePresenter
          @Override
          protected JsObject getValue()
          {
-            if (dialogState_ != null)
+            if (dialogState_ == null)
                return dialogState_.cast();
 
             JsObject object = dialogState_.<JsObject>cast().clone();


### PR DESCRIPTION
### Intent

Fixes #7864 

When `Find in Files` was performed in a project on any OS errors would appear in the console "Cannot read property 'path' of null". Instead, we now return from `getValue()` if a state hasn't been set.

### Approach

It looks like at one point I accidentally changed a `!=` to `==` which caused this issue. 

### QA Notes

See repro steps in original ticket. Note this was happening with all OSes, not exclusively Linux.