### PR TITLE
use 'git diff' rather than 'git show' when showing diff

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1418,16 +1418,13 @@ public:
       return Success();
    }
 
-   virtual core::Error show(const std::string& rev,
+   virtual core::Error show(const std::string& revision,
                             std::string* pOutput)
    {
       ShellArgs args = gitArgs()
             << "-c" << "core.quotepath=false"
-            << "show" << "--pretty=oneline" << "-M";
-      
-      if (s_gitVersion >= GIT_1_7_2)
-         args << "-c";
-      args << rev;
+            << "diff"
+            << (revision + "^!");
 
       return runGit(args, pOutput);
    }


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/7912.

### Approach

`git show` doesn't show a diff in some cases. Since we ultimately just want a diff, let's ask for a diff.

### QA Notes

Check the Git History tab (as described in https://github.com/rstudio/rstudio/issues/7912) to confirm that changes files (and those changes) are properly shown.