### PR TITLE
Disable Spellchecking on Emoji Marks

### DIFF
--- a/src/gwt/panmirror/src/editor/src/marks/emoji/emoji.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/emoji/emoji.ts
@@ -46,6 +46,7 @@ const extension = (context: ExtensionContext): Extension | null => {
     marks: [
       {
         name: 'emoji',
+        noSpelling: true,
         spec: {
           inclusive: false,
           noInputRules: true,


### PR DESCRIPTION
### Intent
There is no concept of a misspelling emoji (they are single character representations that are always considered properly spelled).

In addition, spellcheck can mutate the html inside the mark (e.g. adding a span to indicate the misspelling) which can transform the rendering of the emoji (e.g. the ✏️ emoji will be rendered differently with realtime spellcheck enabled vs disabled)

### Approach
Disable spellcheck for Emoji marks.

### QA Notes
I was able to reproduce the issue using the '✏️' emoji and enabling real time spell checking. In this case, the pencil would be rendered not as an emoji, but as the unicode pencil character. If you disable real time spell checking, the emoji is properly rendered. 

The fix should render the pencil properly no matter whether spell checking is enabled or not.

