### PR TITLE
Prevent excessive set_client_state calls

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -93,7 +93,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
          if (a.hasSplitterPos() ^ b.hasSplitterPos())
             return false;
          if (a.hasSplitterPos() &&
-             Arrays.equals(a.getSplitterPos(), b.getSplitterPos()))
+             !Arrays.equals(a.getSplitterPos(), b.getSplitterPos()))
             return false;
 
          if (a.hasPanelWidth() ^ b.hasPanelWidth())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -423,16 +423,18 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       activeColumn_ = column;
 
       // If the active column changed, we need to update the active editor
-      if (prevColumn != null && prevColumn != activeColumn_)
+      if (prevColumn != activeColumn_)
       {
-         prevColumn.setActiveEditor("");
-         if (!hasActiveEditor())
-            activeColumn_.setActiveEditor();
-         manageCommands(true);
+         if (prevColumn != null)
+         {
+            prevColumn.setActiveEditor("");
+            if (!hasActiveEditor())
+               activeColumn_.setActiveEditor();
+            manageCommands(true);
+         }
+         columnState_ = State.createState(JsUtil.toJsArrayString(getNames(false)),
+            activeColumn_ == null ? "" : activeColumn_.getName());
       }
-
-      columnState_ = State.createState(JsUtil.toJsArrayString(getNames(false)),
-                                       activeColumn_ == null ? "" : activeColumn_.getName());
    }
 
    private void setActiveDocId(String docId)


### PR DESCRIPTION
### Intent

Fixes #7785 

We should only send `set_client_state` when a state has actually changed. This PR fixes two bugs where we were updating the workbench splitter position's state and the active source column's state when they hadn't actually changed. 

### Approach

One of the logic statements for checking the splitter position was reporting a change after it confirmed no change had occurred - it was missing a `!` in front of the check. 

`SourceColumnManager` was creating a new state every time it checked for a change in the active column, rather than when the active column changed. 

### QA Notes

See repro notes on original issue. 


