### PR TITLE
Improved status, no results, and cancellation of Datacite and Crossref Searches in Insert Citation

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -1418,16 +1418,13 @@ public:
       return Success();
    }
 
-   virtual core::Error show(const std::string& rev,
+   virtual core::Error show(const std::string& revision,
                             std::string* pOutput)
    {
       ShellArgs args = gitArgs()
             << "-c" << "core.quotepath=false"
-            << "show" << "--pretty=oneline" << "-M";
-      
-      if (s_gitVersion >= GIT_1_7_2)
-         args << "-c";
-      args << rev;
+            << "diff"
+            << (revision + "^!");
 
       return runGit(args, pOutput);
    }

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
@@ -357,9 +357,10 @@ export const InsertCitationPanel: React.FC<InsertCitationPanelProps> = props => 
   const panelHeight = props.height * .75;
 
   // In order to debounce typeahead search, we need to memoize the callback so the same debounce function will be
-  // used even when renders happen. 
-  const memoizedTypeaheadSearch = React.useCallback(debounce((searchTerm: string, selectedNode: NavigationTreeNode, existingIds: string[]) => {
-    const searchResult = selectedPanelProvider.typeAheadSearch(searchTerm, selectedNode, existingIds);
+  // used even when renders happen. Be sure to pass everything that need to reflect updated state since 
+  // otherwise the value will be captured when the callback is memoized.
+  const memoizedTypeaheadSearch = React.useCallback(debounce((searchTerm: string, panelProvider: CitationSourcePanelProvider, selectedNode: NavigationTreeNode, existingIds: string[]) => {
+    const searchResult = panelProvider.typeAheadSearch(searchTerm, selectedNode, existingIds);
     if (searchResult) {
       updateState({
         searchTerm,
@@ -383,7 +384,7 @@ export const InsertCitationPanel: React.FC<InsertCitationPanelProps> = props => 
     searchTerm: insertCitationPanelState.searchTerm,
     onSearchTermChanged: (term: string) => {
       updateState({ searchTerm: term });
-      memoizedTypeaheadSearch(term, insertCitationPanelState.selectedNode, existingCitationIds);
+      memoizedTypeaheadSearch(term, selectedPanelProvider, insertCitationPanelState.selectedNode, existingCitationIds);
     },
     onExecuteSearch: (searchTerm: string) => {
       updateState({ searchTerm, status: CitationSourceListStatus.inProgress, statusMessage: selectedPanelProvider.progressMessage });

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-crossref.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-crossref.tsx
@@ -70,8 +70,8 @@ export function crossrefSourcePanel(ui: EditorUI,
 
         return Promise.resolve({
           citations: citationEntries,
-          status: CitationSourceListStatus.default,
-          statusMessage: ''
+          status: citationEntries.length> 0 ? CitationSourceListStatus.default : CitationSourceListStatus.noResults,
+          statusMessage: citationEntries.length > 0 ? '' : ui.context.translateText('No results matching these search terms.')
         });
 
       } catch (e) {

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-datacite.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-datacite.tsx
@@ -55,6 +55,7 @@ export function dataciteSourcePanel(ui: EditorUI,
     search: async (searchTerm: string, _selectedNode: NavigationTreeNode, existingCitationIds: string[]) => {
       try {
         const dataciteResult = await server.search(searchTerm);
+        const noResultsMessage = ui.context.translateText('No results matching these search terms.');
         switch (dataciteResult.status) {
           case 'ok':
             if (dataciteResult.message !== null) {
@@ -70,15 +71,15 @@ export function dataciteSourcePanel(ui: EditorUI,
               });
               return Promise.resolve({
                 citations: citationEntries,
-                status: CitationSourceListStatus.default,
-                statusMessage: ''
+                status: citationEntries.length > 0 ? CitationSourceListStatus.default : CitationSourceListStatus.noResults,
+                statusMessage: citationEntries.length > 0 ? '' : noResultsMessage
               });
             } else {
               // No results
               return Promise.resolve({
                 citations: [],
-                status: CitationSourceListStatus.default,
-                statusMessage: ''
+                status: CitationSourceListStatus.noResults,
+                statusMessage: noResultsMessage
               });
             }
           default:


### PR DESCRIPTION
### Intent
When typing search terms in the crossers search, the search list would begin showing 'no items' prior to the user hitting the search button. The user has not yet searched, so the status should remain the default status.

In addition, both DataCite and Crossref didn't properly display the 'No Results' message when there were no matching results.

Finally, if the search was taking a long time and the user navigated away from a DataCite and Crossref search, we weren't ignoring the response/search results when they finally appeared.

### Approach
The selectedPanelProvider wasn’t being passed to a memoized callback, which means that the provider was captured at the time the callback was memoized. Instead, pass the provider so it reflects the current state.

(in this case, what this meant was that the wrong the provider was being queried for typeahead searches/status, though the bug didn’t appear that bad b/c there was only one typeahead provider).

### QA Notes
This bug would appear as incorrect status message in the crossref, pubmed, and data cite sections of the insert citation panel while the user was typing.

