### PR TITLE
Hide selected word outline when not focused

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.css
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.css
@@ -54,7 +54,8 @@
  * invisible cursor position.
  */
 .pm-ace-editor-inactive .ace_marker-layer .ace_bracket,
-.pm-ace-editor-inactive .ace_marker-layer .ace_selection {
+.pm-ace-editor-inactive .ace_marker-layer .ace_selection,
+.pm-ace-editor-inactive .ace_marker-layer .ace_selected-word {
   display: none;
 }
 


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7925.

### Approach

We can't actually unselect content in Ace when it blurs (we may need to act on the selection later), but we do need to hide it, which we do here with CSS. 

### QA Notes

CSS-only change, visual impact only.