### PR TITLE
fix insertion of ':' when completion popup showing w/AZERTY keyboards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -119,3 +119,5 @@
 * Fixed issue causing C++ diagnostics to fail when Xcode developer tools were active (#7824)
 * Added option for clickable links in Terminal pane (#6621)
 * Fixed issue where R scripts containing non-ASCII characters in their path could not be sourced as a local job on Windows (#6701)
+* Fixed issue where French (AZERTY) keyboards inserted '/' rather than ':' in some cases (#7932)
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.RegexUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardHelper;
 import org.rstudio.core.client.command.KeyboardShortcut;
+import org.rstudio.core.client.dom.EventProperty;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -550,7 +551,8 @@ public class RCompletionManager implements CompletionManager
          
          // if we insert a '/', we're probably forming a directory --
          // pop up completions
-         if (keycode == 191 && modifier == KeyboardShortcut.NONE)
+         if (modifier == KeyboardShortcut.NONE &&
+             StringUtil.equals(EventProperty.key(event), "/"))
          {
             input_.insertCode("/");
             return beginSuggest(true, true, false);


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/7932.

### Approach

Avoid using the integer key code property, as the actual underlying key may differ depending on the user's selected keyboard layout.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/7932.