### PR TITLE
Show debug traceback while VirtualScroller is turned on

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -488,7 +488,7 @@ public class VirtualConsole
    public void submit(String data, String clazz, boolean forceNewRange, boolean ariaLiveAnnounce)
    {
       // Only capture new elements when dealing with error output, which
-      // is only place that sets forceNewRange to true. This is just an
+      // is the only place that sets forceNewRange to true. This is just an
       // optimization to avoid unnecessary overhead for large (non-error)
       // output.
       captureNewElements_ = forceNewRange;
@@ -686,9 +686,7 @@ public class VirtualConsole
          element.setInnerText(text);
 
          if (captureNewElements_)
-         {
             newElements_.add(element);
-         }
       }
 
       public void trimLeft(int delta)

--- a/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
@@ -83,7 +83,7 @@ public class CommandLineHistory
    private int getPositionAtOffset(int offset)
    {
       int pos = historyPos_ + offset;
-      return Math.max(0, Math.min(pos, history_.size()));
+      return Math.max(0, Math.min(pos, history_.size()) - 1);
    }
 
    private final ArrayList<String> history_ = new ArrayList<String>();

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.java
@@ -58,6 +58,7 @@ public class ConsoleError extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       
       VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(errorMessage.getElement());
+      vc.setVirtualizedDisableOverride(true);
       vc.submit(err.getErrorMessage().trim());
       errorMessage.addStyleName(errorClass);
       


### PR DESCRIPTION
### Intent

Fix traceback showing up while the VirtualScroller is turned on. Also fix an out of bounds error that existed before the VirtualScroller was added.

Fixes #7928 

### Approach

The ConsoleError element is its own VirtualConsole that cannot and should not be virtualized. Luckily the flag that I added for disabling that functionality came through in a pinch here. 

I also found an out of bounds error that would cause the traceback to be added to a floating element outside of the error message itself or, in the case where there was not later element to be found, throw a null pointer error and not display at all. This was unrelated to VirtualScroller.

### QA Notes

Ensure that the traceback shows properly when the VirtualScroller is both on and off, as shown in the issue linked above.


