### PR TITLE
Ensure line widget for toolbar in source mode always has a host

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextCodeUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextCodeUi.java
@@ -50,9 +50,31 @@ public class ChunkContextCodeUi extends ChunkContextUi
    protected void createToolbar(int row)
    {
       super.createToolbar(row);
+
+      // Create a new pinned line widget; ensure it always has a host by
+      // providing our own host wrapper
       lineWidget_ = new PinnedLineWidget(
             ChunkContextToolbar.LINE_WIDGET_TYPE, outerEditor_.getDocDisplay(), 
-            toolbar_, row, null, host_);
+            toolbar_, row, null, new PinnedLineWidget.Host()
+            {
+               @Override
+               public void onLineWidgetRemoved(LineWidget widget)
+               {
+                  if (host_ != null)
+                  {
+                     host_.onLineWidgetRemoved(widget);
+                  }
+               }
+               
+               @Override
+               public void onLineWidgetAdded(LineWidget widget)
+               {
+                  if (host_ != null)
+                  {
+                     host_.onLineWidgetAdded(widget);
+                  }
+               }
+            });
    }
    
    @Override


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7936. 

### Approach

Ensure that the pinned line widget (which is how we get Ace to draw the toolbars on chunks in source mode) always has a host.

### QA Notes

Low-risk change. Note that the repro is fairly sensitive to initial conditions; I was able to reproduce reliably with the exact steps in #7936, but not when I altered the steps even a little (e.g., had more than one chunk or if I ran the chunk). 
