### PR TITLE
Fix height for html chunk callbacks 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
@@ -212,7 +212,7 @@ public class ChunkOutputGallery extends Composite
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
-            int contentHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
+            int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             callbackContent.setHeight(contentHeight + "px");
             callbackContent.setWidth("100%");
             frame.getElement().getStyle().setWidth(100, Unit.PCT);
@@ -220,7 +220,7 @@ public class ChunkOutputGallery extends Composite
             host_.notifyHeightChanged();
             
             Command heightHandler = () -> {
-               int newHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
+               int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
                callbackContent.setHeight(newHeight + "px");
                frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
                host_.notifyHeightChanged();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -447,15 +447,13 @@ public class ChunkOutputStream extends FlowPanel
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
-            int contentHeight =
-               CALLBACK_BUFFER + frame.getWindow().getDocument().getBody().getOffsetHeight();
+            int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
             frame.getElement().getStyle().setWidth(100, Unit.PCT);
             onHeightChanged();
 
             Command handler = () -> {
-               int newHeight =
-                  CALLBACK_BUFFER + frame.getWindow().getDocument().getBody().getOffsetHeight();
+               int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
                frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
                onHeightChanged();
             };
@@ -778,7 +776,6 @@ public class ChunkOutputStream extends FlowPanel
    private int maxOrdinal_ = 0;
 
    private final static String ORDINAL_ATTRIBUTE = "data-ordinal";
-   private final static Integer CALLBACK_BUFFER = 10;
 
    private Command afterRender_;
    private Colors themeColors_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -447,13 +447,15 @@ public class ChunkOutputStream extends FlowPanel
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
-            int contentHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
+            int contentHeight =
+               CALLBACK_BUFFER + frame.getWindow().getDocument().getBody().getOffsetHeight();
             frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
             frame.getElement().getStyle().setWidth(100, Unit.PCT);
             onHeightChanged();
 
             Command handler = () -> {
-               int newHeight = frame.getWindow().getDocument().getBody().getOffsetHeight();
+               int newHeight =
+                  CALLBACK_BUFFER + frame.getWindow().getDocument().getBody().getOffsetHeight();
                frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
                onHeightChanged();
             };
@@ -776,6 +778,7 @@ public class ChunkOutputStream extends FlowPanel
    private int maxOrdinal_ = 0;
 
    private final static String ORDINAL_ATTRIBUTE = "data-ordinal";
+   private final static Integer CALLBACK_BUFFER = 10;
 
    private Command afterRender_;
    private Colors themeColors_;


### PR DESCRIPTION
### Intent

Fixes pro-issue #2007 https://github.com/rstudio/rstudio-pro/issues/2007

The height used for the iframe displaying html from a chunk callback should be based on the entire document.

### Approach

Previously this height was based on the html body which was leading to the callback displaying with too short of a height. 


