### PR TITLE
fix navigation of console history with arrow keys

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
@@ -67,7 +67,7 @@ public class CommandLineHistory
             "");
       historyPos_ = newPos;
    }
-   
+
    public String getHistoryEntry(int offset)
    {
       int pos = getPositionAtOffset(offset);
@@ -79,11 +79,11 @@ public class CommandLineHistory
       historyPos_ = history_.size();
       historyTail_ = "";
    }
-   
+
    private int getPositionAtOffset(int offset)
    {
       int pos = historyPos_ + offset;
-      return Math.max(0, Math.min(pos, history_.size()) - 1);
+      return Math.max(0, Math.min(pos, history_.size()));
    }
 
    private final ArrayList<String> history_ = new ArrayList<String>();


### PR DESCRIPTION
### Intent

- Fixes #7945
- Caused by #7942, thus started with build 1.4.893 (any platform, desktop or server)

### Approach

Backed out one line of that change, a range-check on command line history that was added. Unclear to me why it was added though there was a comment saying "I also found an out of bounds error that would cause the traceback to be added to a floating element outside of the error message itself or, in the case where there was not later element to be found, throw a null pointer error and not display at all. This was unrelated to VirtualScroller."

### QA Notes

Validate scenarios in both issues (#7945 and #7928)

