### PR TITLE
fixups for rs_addFirstRunDoc

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1181,10 +1181,17 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    
    cat(Rproj, file = RprojPath, sep = "\n")
    
+   # compute scratch paths
+   scratchPaths <- .Call("rs_computeScratchPaths", RprojPath, PACKAGE = "(embedding)")
+   scratchPath <- scratchPaths$scratch_path
+   
    # NOTE: this file is not always generated (e.g. people who have implicitly opted
    # into using devtools won't need the template file)
-   if (file.exists(file.path(packageDirectory, "R", "hello.R")))
-      .Call("rs_addFirstRunDoc", RprojPath, "R/hello.R", PACKAGE = "(embedding)")
+   if (!is.null(scratchPath) &&
+       file.exists(file.path(packageDirectory, "R", "hello.R")))
+   {
+      .Call("rs_addFirstRunDoc", scratchPath, "R/hello.R", PACKAGE = "(embedding)")
+   }
 
    ## NOTE: This must come last to ensure the other package
    ## infrastructure bits have been generated; otherwise
@@ -1194,8 +1201,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
        require(Rcpp, quietly = TRUE))
    {
       Rcpp::compileAttributes(packageDirectory)
-      if (file.exists(file.path(packageDirectory, "src/rcpp_hello.cpp")))
-         .Call("rs_addFirstRunDoc", RprojPath, "src/rcpp_hello.cpp", PACKAGE = "(embedding)")
+      if (!is.null(scratchPath) &&
+          file.exists(file.path(packageDirectory, "src/rcpp_hello.cpp")))
+      {
+         .Call("rs_addFirstRunDoc", scratchPath, "src/rcpp_hello.cpp", PACKAGE = "(embedding)")
+      }
    }
    
    .rs.success()

--- a/src/cpp/session/modules/SessionProjectTemplate.R
+++ b/src/cpp/session/modules/SessionProjectTemplate.R
@@ -15,7 +15,7 @@
 
 .rs.addFunction("getProjectTemplateRegistry", function()
 {
-   .Call("rs_getProjectTemplateRegistry")
+   .Call("rs_getProjectTemplateRegistry", PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("initializeProjectFromTemplate", function(projectFilePath,
@@ -72,7 +72,11 @@
       grep(regex, projectFiles, value = TRUE)
    }))
    
+   # compute scratch path
+   scratchPaths <- .Call("rs_computeScratchPaths", projectFilePath, PACKAGE = "(embedding)")
+   scratchPath <- scratchPaths$scratch_path
+   
    # add these as first-run documents
-   .Call("rs_addFirstRunDoc", projectFilePath, files)
+   .Call("rs_addFirstRunDoc", scratchPath, files, PACKAGE = "(embedding)")
 })
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -1019,9 +1019,9 @@ SEXP rs_requestOpenProject(SEXP projectFileSEXP, SEXP newSessionSEXP)
 Error initialize()
 {
    // register R methods
-   RS_REGISTER_CALL_METHOD(rs_writeProjectFile, 1);
-   RS_REGISTER_CALL_METHOD(rs_addFirstRunDoc, 2);
-   RS_REGISTER_CALL_METHOD(rs_requestOpenProject, 2);
+   RS_REGISTER_CALL_METHOD(rs_writeProjectFile);
+   RS_REGISTER_CALL_METHOD(rs_addFirstRunDoc);
+   RS_REGISTER_CALL_METHOD(rs_requestOpenProject);
    
    // call project-context initialize
    Error error = s_projectContext.initialize();


### PR DESCRIPTION
### Intent

A previous PR (https://github.com/rstudio/rstudio/commit/05f2af6940f12df057f0094690c35ebdecff810a) refactored the way first-run documents were added, but the associated changes did not propagate to the R-level API usages of those functions.

### Approach

Adapt the R methods to the recent refactor.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/7940.

Closes https://github.com/rstudio/rstudio/issues/7940.