### PR TITLE
Implement missing status/nav bar and chunk navigation in visual mode

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/navigation.ts
+++ b/src/gwt/panmirror/src/editor/src/api/navigation.ts
@@ -114,10 +114,18 @@ export function navigateToPos(view: EditorView, pos: number, animate = true): Na
       const editingRoot = editingRootNode(view.state.selection)!;
       const container = view.nodeDOM(editingRoot.pos) as HTMLElement;
       const scroller = zenscroll.createScroller(container, 700, 20);
+      // some nodes' DOM elements are grandchildren rather than direct children
+      // of the scroll container; move up a level if this is the case
+      let dest = node;
+      if (node.parentElement && 
+          node.parentElement.parentElement &&
+          node.parentElement.parentElement.parentElement === container) {
+         dest = node.parentElement;
+      }
       if (animate) {
-        scroller.to(node);
+        scroller.to(dest);
       } else {
-        scroller.to(node, 0);
+        scroller.to(dest, 0);
       }
     }, 200);
 

--- a/src/gwt/panmirror/src/editor/src/api/outline.ts
+++ b/src/gwt/panmirror/src/editor/src/api/outline.ts
@@ -104,7 +104,7 @@ export function getEditingOutlineLocation(state: EditorState): EditingOutlineLoc
 //  - yaml metadata blocks
 //  - top-level headings
 //  - rmd chunks at the top level or within a top-level list
-export function getDocumentOutline(state: EditorState) {
+export function getDocumentOutline(state: EditorState): NodeWithPos[] {
   // get top level body nodes
   const schema = state.schema;
   const bodyNodes = findTopLevelBodyNodes(state.doc, node => {

--- a/src/gwt/panmirror/src/editor/src/api/outline.ts
+++ b/src/gwt/panmirror/src/editor/src/api/outline.ts
@@ -26,6 +26,7 @@ export interface EditorOutlineItem {
   navigation_id: string;
   type: EditorOutlineItemType;
   level: number;
+  sequence: number;
   title: string;
   children: EditorOutlineItem[];
 }

--- a/src/gwt/panmirror/src/editor/src/api/rmd.ts
+++ b/src/gwt/panmirror/src/editor/src/api/rmd.ts
@@ -184,9 +184,23 @@ export function mergeRmdChunks(chunks: EditorRmdChunk[]) {
   }
 }
 
+/**
+ * Attempts to extract the engine name and label from a chunk header.
+ * 
+ * @param text The chunk header, e.g. {r foo}
+ * @returns An object with `engine` and `label` properties, or null.
+ */
 export function rmdChunkEngineAndLabel(text: string) {
-  const match = text.match(/^\{([a-zA-Z0-9_]+)[\s,]+([a-zA-Z0-9/-]+)/);
+  // Match the engine and label with a regex
+  const match = text.match(/^\{([a-zA-Z0-9_]+)[\s,]+([a-zA-Z0-9/._='"-]+)/);
   if (match) {
+    // The second capturing group in the regex matches the first string after
+    // the engine. This might be a label (e.g., {r label}), but could also be
+    // a chunk option (e.g., {r echo=FALSE}). If it has an =, presume that it's
+    // an option.
+    if (match[2].indexOf("=") !== -1) {
+      return null;
+    }
     return {
       engine: match[1],
       label: match[2]

--- a/src/gwt/panmirror/src/editor/src/behaviors/outline.ts
+++ b/src/gwt/panmirror/src/editor/src/behaviors/outline.ts
@@ -131,13 +131,27 @@ function editorOutline(state: EditorState): EditorOutline {
     return [];
   }
 
-  // function to create an outline node from a heading
+  // create mapping of node type names to their current sequence
+  const sequence = new Map<string, number>();
+
+  // function to create an outline item from a node
   const editorOutlineItem = (nodeWithPos: NodeWithPos, defaultLevel: number) => {
+    const typename = nodeWithPos.node.type.name;
+
+    // build sequence (ordinal of entry within node type)
+    let sequenceLast = sequence.get(typename);
+    if (sequenceLast === undefined) {
+      sequenceLast = 0;
+    }
+    const sequenceNext = sequenceLast + 1;
+    sequence.set(typename, sequenceNext);
+
     const item = {
       navigation_id: nodeWithPos.node.attrs.navigation_id,
       type: nodeWithPos.node.type.name as EditorOutlineItemType,
       level: nodeWithPos.node.attrs.level || defaultLevel,
       title: nodeWithPos.node.type.spec.code ? nodeWithPos.node.type.name : nodeWithPos.node.textContent,
+      sequence: sequenceNext,
       children: [],
     };
     

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -263,7 +263,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
          fireEvent(new PanmirrorUpdatedEvent());
       }));
       
-      // don't update outline eaglerly (wait for 500ms delay in typing)
+      // don't update outline eagerly (wait for 500ms delay in typing)
       DebouncedCommand updateOutineOnIdle = new DebouncedCommand(500)
       {
          @Override
@@ -552,6 +552,11 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    public PanmirrorEditingLocation getEditingLocation()
    {
       return editor_.getEditingLocation();
+   }
+   
+   public PanmirrorOutlineItem[] getOutline()
+   {
+      return editor_.getOutline();
    }
    
    public void setEditingLocation(

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -255,7 +255,6 @@ public class PanmirrorWidget extends DockLayoutPanel implements
          public void onPanmirrorOutlineNavigation(PanmirrorOutlineNavigationEvent event)
          {
             editor_.navigate(PanmirrorNavigationType.Id, event.getId(), true);
-            editor_.focus();
          }
       });
       

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineItem.java
@@ -23,6 +23,7 @@ public class PanmirrorOutlineItem
    public String navigation_id;
    public String type;
    public int level;
+   public int sequence;
    public String title;
    public PanmirrorOutlineItem[] children;
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
@@ -210,13 +210,13 @@ public class PanmirrorOutlineWidget extends Composite
             flattenedItems.add(item);
             doFlattenOutline(item.children, flattenedItems, chunkPref);
          }
-         else if (item.type == PanmirrorOutlineItemType.RmdChunk)
+         else if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
          {
             // Anonymous (unnamed) chunks have the generic title "rmd_chunk"; do
             // not show these chunks in the outline unless the user's opted to
             // show everything.
-            if (chunkPref == UserPrefs.DOC_OUTLINE_SHOW_ALL ||
-                item.title != PanmirrorOutlineItemType.RmdChunk)
+            if (StringUtil.equals(chunkPref, UserPrefs.DOC_OUTLINE_SHOW_ALL) ||
+                !StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
             {
                flattenedItems.add(item);
             }
@@ -240,8 +240,11 @@ public class PanmirrorOutlineWidget extends Composite
    {
       PanmirrorOutlineItem item = treeItem.getEntry().getItem();
       treeItem.addStyleName(outlineStyles_.node());
-      if (item.type == PanmirrorOutlineItemType.RmdChunk)
+      if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
+      {
+         // Apply chunk-specific styling
          treeItem.addStyleName(outlineStyles_.nodeLabelChunk());
+      }
       DomUtils.toggleClass(treeItem.getElement(), outlineStyles_.activeNode(), isActiveItem(item));
    }
    
@@ -331,12 +334,10 @@ public class PanmirrorOutlineWidget extends Composite
          String text = item.title;
          
          // Replace the title with sequence for anonymous chunks
-         if (item.type == PanmirrorOutlineItemType.RmdChunk)
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk) &&
+             StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
          {
-            if (item.title == PanmirrorOutlineItemType.RmdChunk)
-            {
-               text = "(chunk " + item.sequence + ")";
-            }
+            text = "(chunk " + item.sequence + ")";
          }
        
          if (label_ == null)

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
@@ -97,7 +97,7 @@ public class PanmirrorOutlineWidget extends Composite
          {
             if (outline_ != null)
             {
-               rebuildOutline();
+               updateOutline(items_);
             }
          });
       });
@@ -109,9 +109,13 @@ public class PanmirrorOutlineWidget extends Composite
       return handlers_.addHandler(PanmirrorOutlineNavigationEvent.getType(), handler);
    }
    
-   public void updateOutline(PanmirrorOutlineItem[] outline)
+   public void updateOutline(PanmirrorOutlineItem[] items)
    {
-      outline_ = flattenOutline(outline);
+      // save items so we can rebuild outline from the list later
+      items_ = items;
+      
+      // rebuild the outline from the items, flattening the tree into a list
+      outline_ = flattenOutline(items);
       rebuildOutline();
       updateActiveItem();
    }
@@ -216,7 +220,8 @@ public class PanmirrorOutlineWidget extends Composite
             // not show these chunks in the outline unless the user's opted to
             // show everything.
             if (StringUtil.equals(chunkPref, UserPrefs.DOC_OUTLINE_SHOW_ALL) ||
-                !StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
+                (StringUtil.equals(chunkPref, UserPrefs.DOC_OUTLINE_SHOW_SECTIONS_AND_CHUNKS) &&
+                 !StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk)))
             {
                flattenedItems.add(item);
             }
@@ -388,6 +393,7 @@ public class PanmirrorOutlineWidget extends Composite
   
    private final static DocumentOutlineWidget.Styles outlineStyles_ = DocumentOutlineWidget.RES.styles();
    
+   private PanmirrorOutlineItem[] items_ = null;
    private ArrayList<PanmirrorOutlineItem> outline_ = null;
    private int outlineMinLevel_ = 1;
    private PanmirrorSelection selection_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -2204,9 +2204,6 @@ public class TextEditingTarget implements
          {
             // Unlike the other status bar elements, the function outliner
             // needs its menu built on demand
-            JsArray<Scope> tree = docDisplay_.getScopeTree();
-            final StatusBarPopupMenu menu = new StatusBarPopupMenu();
-            MenuItem defaultItem = null;
             if (fileType_.isRpres())
             {
                String path = docUpdateSentinel_.getPath();
@@ -2226,9 +2223,15 @@ public class TextEditingTarget implements
                      });
                }
             }
+            else if (isVisualEditorActive())
+            {
+               showStatusBarPopupMenu(visualMode_.getStatusBarPopup());
+            }
             else
             {
-               defaultItem = addFunctionsToMenu(
+               final StatusBarPopupMenu menu = new StatusBarPopupMenu();
+               JsArray<Scope> tree = docDisplay_.getScopeTree();
+               MenuItem defaultItem = addFunctionsToMenu(
                   menu, tree, "", docDisplay_.getCurrentScope(), true);
 
                showStatusBarPopupMenu(new StatusBarPopupRequest(menu,
@@ -2363,7 +2366,7 @@ public class TextEditingTarget implements
    private void updateStatusBarLanguage()
    {
       statusBar_.getLanguage().setValue(fileType_.getLabel());
-      boolean canShowScope = fileType_.canShowScopeTree() && !isVisualModeActivated();
+      boolean canShowScope = fileType_.canShowScopeTree();
       statusBar_.setScopeVisible(canShowScope);
    }
 
@@ -2373,10 +2376,18 @@ public class TextEditingTarget implements
       statusBar_.getPosition().setValue((pos.getRow() + 1) + ":" +
                                         (pos.getColumn() + 1));
    }
+   
+   public void updateStatusBarLocation(String title, int type)
+   {
+      statusBar_.setScopeType(type);
+      statusBar_.getScope().setValue(title);
+   }
 
    private void updateCurrentScope()
    {
-      if (fileType_ == null || !fileType_.canShowScopeTree())
+      // don't sync scope if we can't show a scope tree or in visual mode (which
+      // is responsible for updating the scope visualization itself)
+      if (fileType_ == null || !fileType_.canShowScopeTree() || isVisualModeActivated())
          return;
 
       // special handing for presentations since we extract

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextPanmirrorUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextPanmirrorUi.java
@@ -38,7 +38,7 @@ public class ChunkContextPanmirrorUi extends ChunkContextUi
 
       // Position toolbar at top right of chunk
       Style style = toolbar_.getElement().getStyle();
-      style.setTop(20, Unit.PX);
+      style.setTop(15, Unit.PX);
       style.setRight(0, Unit.PX);
       style.setWidth(100, Unit.PX);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -981,15 +981,15 @@ public class VisualMode implements VisualModeEditorSync,
                StringUtil.repeat("&nbsp;&nbsp;", item.level));
          
          // Make headings bold
-         if (item.type == PanmirrorOutlineItemType.Heading)
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.Heading))
          {
             label.appendHtmlConstant("<strong>");
          }
          
-         if (item.type == PanmirrorOutlineItemType.RmdChunk)
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
          {
             label.appendEscaped("Chunk " + item.sequence);
-            if (item.title != PanmirrorOutlineItemType.RmdChunk)
+            if (!StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
             {
                label.appendEscaped(": " + item.title);
             }
@@ -1266,10 +1266,13 @@ public class VisualMode implements VisualModeEditorSync,
       
       // Find the selection and display it
       PanmirrorOutlineItem item = findNavigationId(items, targetId);
-      if (item == null)
+      if (item == null || item.type == PanmirrorOutlineItemType.YamlMetadata)
       {
          // If we didn't find the selection in the outline, we're at the top
          // level of the document.
+         //
+         // We also show this when beneath the top level YAML metadata region,
+         // if present.
          target_.updateStatusBarLocation("(Top Level)", StatusBar.SCOPE_TOP_LEVEL);
       }
       else
@@ -1281,7 +1284,7 @@ public class VisualMode implements VisualModeEditorSync,
          {
             type = StatusBar.SCOPE_SECTION;
          }
-         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
+         else if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
          {
             type = StatusBar.SCOPE_CHUNK;
             if (StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
@@ -1661,7 +1664,7 @@ public class VisualMode implements VisualModeEditorSync,
             new ArrayList<PanmirrorEditingOutlineLocationItem>();
       for (int j = 0; j < location.items.length; j++)
       {
-         if (location.items[j].type == PanmirrorOutlineItemType.RmdChunk)
+         if (StringUtil.equals(location.items[j].type, PanmirrorOutlineItemType.RmdChunk))
          {
             chunkItems.add(location.items[j]);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -953,8 +953,6 @@ public class VisualMode implements VisualModeEditorSync,
    {
       StatusBarPopupMenu menu = new StatusBarPopupMenu();
 
-      // Reset chunk counter
-      chunkCounter_ = 0;
       buildStatusBarMenu(panmirror_.getOutline(), menu);
       
       return new StatusBarPopupRequest(menu, null);
@@ -990,10 +988,7 @@ public class VisualMode implements VisualModeEditorSync,
          
          if (item.type == PanmirrorOutlineItemType.RmdChunk)
          {
-            // Format chunk names; use a counter and append the chunk label if
-            // it's supplied explicitly
-            chunkCounter_++;
-            label.appendEscaped("Chunk " + chunkCounter_);
+            label.appendEscaped("Chunk " + item.sequence);
             if (item.title != PanmirrorOutlineItemType.RmdChunk)
             {
                label.appendEscaped(": " + item.title);
@@ -1281,13 +1276,22 @@ public class VisualMode implements VisualModeEditorSync,
       {
          // Convert the outline type into a status bar type
          int type = StatusBar.SCOPE_ANON;
+         String title = item.title;
          if (StringUtil.equals(item.type, PanmirrorOutlineItemType.Heading))
+         {
             type = StatusBar.SCOPE_SECTION;
+         }
          if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
+         {
             type = StatusBar.SCOPE_CHUNK;
+            if (StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
+            {
+               title = "Chunk " + item.sequence;
+            }
+         }
          
          // Update the status bar and mark that we found an item
-         target_.updateStatusBarLocation(item.title, type);
+         target_.updateStatusBarLocation(title, type);
       }
    }
    
@@ -1693,7 +1697,6 @@ public class VisualMode implements VisualModeEditorSync,
    private UserPrefs prefs_;
    private SourceServerOperations source_;
    private DocDisplay activeEditor_;  // the current embedded editor
-   private int chunkCounter_ = 0; 
    
    private final TextEditingTarget target_;
    private final TextEditingTarget.Display view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -957,6 +957,8 @@ public class VisualMode implements VisualModeEditorSync,
    {
       StatusBarPopupMenu menu = new StatusBarPopupMenu();
 
+      // Reset chunk counter
+      chunkCounter_ = 0;
       buildStatusBarMenu(panmirror_.getOutline(), menu);
       
       return new StatusBarPopupRequest(menu, null);
@@ -990,8 +992,22 @@ public class VisualMode implements VisualModeEditorSync,
             label.appendHtmlConstant("<strong>");
          }
          
-         // Add the title of the item
-         label.appendEscaped(item.title);
+         if (item.type == PanmirrorOutlineItemType.RmdChunk)
+         {
+            // Format chunk names; use a counter and append the chunk label if
+            // it's supplied explicitly
+            chunkCounter_++;
+            label.appendEscaped("Chunk " + chunkCounter_);
+            if (item.title != PanmirrorOutlineItemType.RmdChunk)
+            {
+               label.appendEscaped(": " + item.title);
+            }
+         }
+         else
+         {
+            // For non-chunk outline items, use the title directly
+            label.appendEscaped(item.title);
+         }
 
          if (item.type == PanmirrorOutlineItemType.Heading)
          {
@@ -1681,6 +1697,7 @@ public class VisualMode implements VisualModeEditorSync,
    private UserPrefs prefs_;
    private SourceServerOperations source_;
    private DocDisplay activeEditor_;  // the current embedded editor
+   private int chunkCounter_ = 0; 
    
    private final TextEditingTarget target_;
    private final TextEditingTarget.Display view_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -969,7 +969,7 @@ public class VisualMode implements VisualModeEditorSync,
       for (PanmirrorOutlineItem item: items)
       {
          // Don't generate a menu entry for the YAML metadata
-         if (item.type == PanmirrorOutlineItemType.YamlMetadata)
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.YamlMetadata))
          {
             continue;
          }
@@ -1000,7 +1000,7 @@ public class VisualMode implements VisualModeEditorSync,
             label.appendEscaped(item.title);
          }
 
-         if (item.type == PanmirrorOutlineItemType.Heading)
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.Heading))
          {
             label.appendHtmlConstant("</strong>");
          }
@@ -1267,7 +1267,7 @@ public class VisualMode implements VisualModeEditorSync,
       
       // Find the selection and display it
       PanmirrorOutlineItem item = findNavigationId(items, targetId);
-      if (item == null || item.type == PanmirrorOutlineItemType.YamlMetadata)
+      if (item == null || StringUtil.equals(item.type, PanmirrorOutlineItemType.YamlMetadata))
       {
          // If we didn't find the selection in the outline, we're at the top
          // level of the document.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -658,10 +658,6 @@ public class VisualMode implements VisualModeEditorSync,
       
       // disable commands
       disableForVisualMode(
-        // Disabled since it just opens the scope tree widget (which doens't
-        // exist in visual mode)
-        commands_.jumpTo(),
-
         // Disabled since diagnostics aren't active in visual mode
         commands_.showDiagnosticsActiveDocument(),
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -1008,13 +1008,14 @@ public class VisualMode implements VisualModeEditorSync,
          // Create a menu item representing the item and add it to the menu
          final MenuItem menuItem = new MenuItem(
                label.toSafeHtml(),
-               new Command()
+               () ->
                {
-                  public void execute()
-                  {
-                     visualModeNavigation_.navigateToId(
-                           item.navigation_id, false);
-                  }
+                  // Navigate to the given ID
+                  visualModeNavigation_.navigateToId(item.navigation_id, false);
+                  
+                  // Immediately update the status bar with the new location
+                  // (this is usually done on idle so can lag a bit otherwise)
+                  syncStatusBarLocation();
                });
          
          menu.addItem(menuItem);
@@ -1287,9 +1288,10 @@ public class VisualMode implements VisualModeEditorSync,
          else if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
          {
             type = StatusBar.SCOPE_CHUNK;
-            if (StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
+            title = "Chunk " + item.sequence;
+            if (!StringUtil.equals(item.title, PanmirrorOutlineItemType.RmdChunk))
             {
-               title = "Chunk " + item.sequence;
+               title += ": " + item.title;
             }
          }
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -27,6 +27,7 @@ import org.rstudio.core.client.PreemptiveTaskQueue;
 import org.rstudio.core.client.Rendezvous;
 import org.rstudio.core.client.SerializedCommand;
 import org.rstudio.core.client.SerializedCommandQueue;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.patch.TextChange;
@@ -53,6 +54,7 @@ import org.rstudio.studio.client.panmirror.events.PanmirrorStateChangeEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorUpdatedEvent;
 import org.rstudio.studio.client.panmirror.location.PanmirrorEditingOutlineLocation;
 import org.rstudio.studio.client.panmirror.location.PanmirrorEditingOutlineLocationItem;
+import org.rstudio.studio.client.panmirror.outline.PanmirrorOutlineItem;
 import org.rstudio.studio.client.panmirror.outline.PanmirrorOutlineItemType;
 import org.rstudio.studio.client.panmirror.pandoc.PanmirrorPandocFormat;
 import org.rstudio.studio.client.panmirror.ui.PanmirrorUIDisplay;
@@ -71,6 +73,9 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditorContainer;
 import org.rstudio.studio.client.workbench.views.source.editors.text.findreplace.FindReplaceBar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
+import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar;
+import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarPopupMenu;
+import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBarPopupRequest;
 import org.rstudio.studio.client.workbench.views.source.editors.text.visualmode.events.VisualModeSpellingAddToDictionaryEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceDocAddedEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DirtyState;
@@ -84,7 +89,9 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.MenuItem;
 import com.google.inject.Inject;
 
 import elemental2.core.JsObject;
@@ -939,6 +946,79 @@ public class VisualMode implements VisualModeEditorSync,
          return null;
       return chunk.getDefinition();
    }
+   
+   /**
+    * Gets the document outline for the status bar popup; displayed when
+    * clicking on the status bar or using the Jump To command.
+    * 
+    * @return Menu of items in the outline
+    */
+   public StatusBarPopupRequest getStatusBarPopup()
+   {
+      StatusBarPopupMenu menu = new StatusBarPopupMenu();
+
+      buildStatusBarMenu(panmirror_.getOutline(), menu);
+      
+      return new StatusBarPopupRequest(menu, null);
+   }
+   
+   /**
+    * Recursively builds a status bar popup menu out of editor outline items.
+    * 
+    * @param items An array of items to add to the menu 
+    * @param menu The menu to add to
+    */
+   private void buildStatusBarMenu(PanmirrorOutlineItem[] items, StatusBarPopupMenu menu)
+   {
+      for (PanmirrorOutlineItem item: items)
+      {
+         // Don't generate a menu entry for the YAML metadata
+         if (item.type == PanmirrorOutlineItemType.YamlMetadata)
+         {
+            continue;
+         }
+
+         SafeHtmlBuilder label = new SafeHtmlBuilder();
+         
+         // Add non-breaking spaces to indent to the level of the item
+         label.appendHtmlConstant(
+               StringUtil.repeat("&nbsp;&nbsp;", item.level));
+         
+         // Make headings bold
+         if (item.type == PanmirrorOutlineItemType.Heading)
+         {
+            label.appendHtmlConstant("<strong>");
+         }
+         
+         // Add the title of the item
+         label.appendEscaped(item.title);
+
+         if (item.type == PanmirrorOutlineItemType.Heading)
+         {
+            label.appendHtmlConstant("</strong>");
+         }
+
+         // Create a menu item representing the item and add it to the menu
+         final MenuItem menuItem = new MenuItem(
+               label.toSafeHtml(),
+               new Command()
+               {
+                  public void execute()
+                  {
+                     visualModeNavigation_.navigateToId(
+                           item.navigation_id, false);
+                  }
+               });
+         
+         menu.addItem(menuItem);
+         
+         // If this item has children, add them recursively
+         if (item.children != null)
+         {
+            buildStatusBarMenu(item.children, menu);
+         }
+      }
+   }
 
    @Override
    public List<CommandPaletteItem> getCommandPaletteItems()
@@ -1039,9 +1119,13 @@ public class VisualMode implements VisualModeEditorSync,
                // activate widget
                editorContainer.activateWidget(panmirror_, focus);
                
-               // begin save-on-idle behavior
+               // begin idle behavior
                syncOnIdle_.resume();
                saveLocationOnIdle_.resume();
+               displayLocationOnIdle_.resume();
+               
+               // update status bar widget with current position
+               syncStatusBarLocation();
                
                // (re)inject notebook output from the editor
                target_.getNotebook().migrateCodeModeOutput();
@@ -1092,6 +1176,9 @@ public class VisualMode implements VisualModeEditorSync,
             
             if (saveLocationOnIdle_ != null)
                saveLocationOnIdle_.suspend();
+            
+            if (displayLocationOnIdle_ != null)
+               displayLocationOnIdle_.suspend();
             
             // move notebook outputs from visual mode
             target_.getNotebook().migrateVisualModeOutput();
@@ -1161,6 +1248,71 @@ public class VisualMode implements VisualModeEditorSync,
          panmirror_.activateDevTools();
    }
    
+   /**
+    * Updates the status bar with the name of the current location.
+    */
+   private void syncStatusBarLocation()
+   {
+      // Get the current outline so we can look up details of the selection
+      PanmirrorOutlineItem[] items = panmirror_.getOutline();
+      String targetId = panmirror_.getSelection().navigation_id;
+      
+      // Find the selection and display it
+      PanmirrorOutlineItem item = findNavigationId(items, targetId);
+      if (item == null)
+      {
+         // If we didn't find the selection in the outline, we're at the top
+         // level of the document.
+         target_.updateStatusBarLocation("(Top Level)", StatusBar.SCOPE_TOP_LEVEL);
+      }
+      else
+      {
+         // Convert the outline type into a status bar type
+         int type = StatusBar.SCOPE_ANON;
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.Heading))
+            type = StatusBar.SCOPE_SECTION;
+         if (StringUtil.equals(item.type, PanmirrorOutlineItemType.RmdChunk))
+            type = StatusBar.SCOPE_CHUNK;
+         
+         // Update the status bar and mark that we found an item
+         target_.updateStatusBarLocation(item.title, type);
+      }
+   }
+   
+   /**
+    * Recursively finds the outline item associated with a given navigation ID.
+    * 
+    * @param items An array of outline items.
+    * @param targetId The navigation ID to find.
+    * @return The outline item with the given ID, or null if no item was found.
+    */
+   private PanmirrorOutlineItem findNavigationId(
+       PanmirrorOutlineItem[] items, String targetId)
+   {
+      for (PanmirrorOutlineItem item: items)
+      {
+         // Check whether this is the item being sought
+         if (item.navigation_id == targetId)
+         {
+            return item;
+         }
+         
+         // If this item has children, check them recursively
+         if (item.children != null)
+         {
+            PanmirrorOutlineItem childItem = findNavigationId(
+                  item.children, targetId);
+            if (childItem != null)
+            {
+               return childItem;
+            }
+         }
+      }
+
+      // Item not found in this level
+      return null;
+   }
+   
    
    private void withPanmirror(Command ready)
    {
@@ -1204,6 +1356,16 @@ public class VisualMode implements VisualModeEditorSync,
                }
             };
             
+            // periodically display the selection in the status bar
+            displayLocationOnIdle_ = new DebouncedCommand(500)
+            {
+               @Override
+               protected void execute()
+               {
+                  syncStatusBarLocation();
+               }
+            };
+
             // set dirty flag + nudge idle sync on change
             panmirror_.addPanmirrorUpdatedHandler(new PanmirrorUpdatedEvent.Handler()
             {
@@ -1227,6 +1389,7 @@ public class VisualMode implements VisualModeEditorSync,
                public void onPanmirrorStateChange(PanmirrorStateChangeEvent event)
                {
                   saveLocationOnIdle_.nudge();
+                  displayLocationOnIdle_.nudge();
                }
             });
             
@@ -1538,6 +1701,7 @@ public class VisualMode implements VisualModeEditorSync,
    
    private DebouncedCommand syncOnIdle_; 
    private DebouncedCommand saveLocationOnIdle_;
+   private DebouncedCommand displayLocationOnIdle_;
    
    private boolean isDirty_ = false;
    private boolean loadingFromSource_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeNavigation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeNavigation.java
@@ -73,6 +73,11 @@ public class VisualModeNavigation
    {
       context_.panmirror().navigate(PanmirrorNavigationType.XRef, xref, recordCurrentPosition);
    }
+
+   public void navigateToId(String id, boolean recordCurrentPosition)
+   {
+      context_.panmirror().navigate(PanmirrorNavigationType.Id, id, recordCurrentPosition);
+   }
    
    public void recordCurrentNavigationPosition()
    {


### PR DESCRIPTION
### Intent

This change does a couple of things.

First, it provides a visual mode implementation of the status/navigation bar in visual mode, and the accompanying *Jump To* command. This makes it possible to jump quickly to different parts of the document without using the outline. 

![image](https://user-images.githubusercontent.com/470418/95232276-1f46a600-07b9-11eb-84de-85dcadc3a41a.png)

It also makes the document outline chunk-aware in visual mode. Prior to this change, the document outline only showed headings in visual mode. It now respects the same preference that source mode does, and can show headings only, headings and named chunks, or everything.

![image](https://user-images.githubusercontent.com/470418/95232472-646ad800-07b9-11eb-92de-4472806adff9.png)

Closes https://github.com/rstudio/rstudio/issues/7891.

### Approach

Most of the work here is on the GWT side, where we use the VisualMode to supply an outline for the navigation widget. There's also a new `sequence` property on navigation items over on the panmirror side, which is used assign a sequential number to each chunk. 

### QA Notes

This represents a wholly different way of calculating the document outline than what's used in source mode, yet we generally want them to look and feel the same, so checking against source mode is a good way to validate that we're doing the right thing. There are a couple of known differences:

- Visual mode does not have the same interpretation of the current position; for example, outside of chunks and headings the position is considered to be the nearest/last chunk or heading rather than (Top Level). 
- Visual mode does not treat the document title as a heading. 

Also worth testing a little around other navigation methods (to xref, via Find file/function, etc) as these codepaths were touched. 