### PR TITLE
Properly note all instances of a single emoki (not just the first one)

### DIFF
--- a/src/gwt/panmirror/src/editor/src/marks/emoji/emoji.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/emoji/emoji.ts
@@ -172,11 +172,12 @@ const extension = (context: ExtensionContext): Extension | null => {
             const possibleMarks = new Map<number, Array<{ to: number; emoji: Emoji }>>();
             for (const emoji of emojis(ui.prefs.emojiSkinTone())) {
               emojiForAllSkinTones(emoji).forEach(skinToneEmoji => {
-                const charLoc = textNode.text.indexOf(skinToneEmoji.emoji);
-                if (charLoc !== -1) {
+                let charLoc = textNode.text.indexOf(skinToneEmoji.emoji);
+                while (charLoc !== -1) {
                   const from = textNode.pos + charLoc;
                   const to = from + skinToneEmoji.emoji.length;
                   possibleMarks.set(from, (possibleMarks.get(from) || []).concat({ to, emoji: skinToneEmoji }));
+                  charLoc = textNode.text.indexOf(skinToneEmoji.emoji, charLoc + 1);
                 }
               });
             }


### PR DESCRIPTION
This fixes rstudio/rstudio#7950


### Intent

Mark was being applied only to the first emoji in a string of identical emoji when fixups occurred.

### Approach

iterate through until all matching characters have proper mark applied

### QA Notes

Good catch, thanks!
