### PR TITLE
make it possible to interrupt readLines(stdin())

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,4 +121,4 @@
 * Added option for clickable links in Terminal pane (#6621)
 * Fixed issue where R scripts containing non-ASCII characters in their path could not be sourced as a local job on Windows (#6701)
 * Fixed issue where French (AZERTY) keyboards inserted '/' rather than ':' in some cases (#7932)
-
+* `readline()` and `readLines()` can now be interrupted, even when reading from `stdin()`. (#3448)

--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -48,6 +48,8 @@ namespace exec {
    
 namespace {
 
+bool s_wasInterrupted;
+
 // create a scope for disabling any installed error handlers (e.g. recover)
 // we need to do this so that recover isn't invoked while we are running
 // R code within an r::exec scope -- when the user presses 0 to exit
@@ -531,6 +533,8 @@ bool interruptsPending()
    
 void setInterruptsPending(bool pending)
 {
+   setWasInterrupted(pending);
+   
 #ifdef _WIN32
    UserBreak = pending ? 1 : 0;
 #else
@@ -609,6 +613,15 @@ DisableDebugScope::~DisableDebugScope()
    }
 }
 
+bool getWasInterrupted()
+{
+   return s_wasInterrupted;
+}
+
+void setWasInterrupted(bool wasInterrupted)
+{
+   s_wasInterrupted = wasInterrupted;
+}
 
 } // namespace exec   
 } // namespace r

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -365,6 +365,10 @@ private:
 
 class InterruptException {};
 
+// track whether the session was interrupted
+bool getWasInterrupted();
+void setWasInterrupted(bool wasInterrupted);
+
 } // namespace exec   
 } // namespace r
 } // namespace rstudio

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -76,9 +76,6 @@ InternalCallbacks s_internalCallbacks;
 // temporarily suppress output
 bool s_suppressOutput = false;
 
-// temporarily suppress interrupt output
-bool s_suppressNextInterruptOutput = false;
-
 class JumpToTopException
 {
 };
@@ -392,7 +389,6 @@ int RReadConsole (const char *pmt,
       // handle the interrupt as we noticed calling Rf_onintr() in that
       // environment could cause a crash
 #ifndef _WIN32
-      s_suppressNextInterruptOutput = true;
       Rf_onintr();
 #endif
 
@@ -433,15 +429,6 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
          // get output
          std::string output = std::string(buf, buflen);
          output = util::rconsole2utf8(output);
-         
-         // ignore newline from interrupt if requested
-         if (s_suppressNextInterruptOutput &&
-             output == "\n" &&
-             otype == 1)
-         {
-            s_suppressNextInterruptOutput = false;
-            return;
-         }
          
          // add to console actions
          int type = otype == 1 ? kConsoleActionOutputError :

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -426,6 +426,18 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
    {
       if (!s_suppressOutput)
       {
+         bool isInterruptOutput =
+               r::exec::getWasInterrupted() &&
+               otype == 1 &&
+               buflen == 1 &&
+               buf[0] == '\n';
+         
+         if (isInterruptOutput)
+         {
+            r::exec::setWasInterrupted(false);
+            return;
+         }
+         
          // get output
          std::string output = std::string(buf, buflen);
          output = util::rconsole2utf8(output);

--- a/src/cpp/session/http/SessionHttpConnectionUtils.cpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.cpp
@@ -258,6 +258,13 @@ bool checkForInterrupt(boost::shared_ptr<HttpConnection> ptrConnection)
       // to ensure that the R session always receives an interrupt, we explicitly
       // set the interrupt flag even though the normal interrupt handler would do
       // the same.
+      //
+      // NOTE: if the R session is currently waiting for input via stdin, then
+      // a plain interrupt will not be sufficient to stop the read. it's not
+      // immediately clear why this is the case, but if we detect this case then
+      // we avoid sending an interrupt, and instead tell the client that R is not
+      // busy and it should instead send an explicit request to canncel the current
+      // console read request.
       bool busy = session::console_input::executing();
       if (busy)
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationInterrupt.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationInterrupt.java
@@ -89,18 +89,21 @@ public class ApplicationInterrupt
          
          eventBus_.fireEvent(new InterruptStatusEvent(
                InterruptStatusEvent.INTERRUPT_INITIATED));
-         server_.interrupt(new VoidServerRequestCallback() {
+         
+         server_.interrupt(new ServerRequestCallback<Boolean>()
+         {
             @Override
-            public void onSuccess()
+            public void onResponseReceived(Boolean response)
             {
                eventBus_.fireEvent(new InterruptStatusEvent(
                      InterruptStatusEvent.INTERRUPT_COMPLETED));
                finishInterrupt(handler);
             }
-            
+
             @Override
-            public void onFailure()
+            public void onError(ServerError error)
             {
+               Debug.logError(error);
                finishInterrupt(handler);
             }
          });

--- a/src/gwt/src/org/rstudio/studio/client/application/model/ApplicationServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/model/ApplicationServerOperations.java
@@ -34,7 +34,7 @@ public interface ApplicationServerOperations extends PrefsServerOperations
    void getJobConnectionStatus(ServerRequestCallback<String> requestCallback);
 
    // interrupt the current session
-   void interrupt(ServerRequestCallback<Void> requestCallback);
+   void interrupt(ServerRequestCallback<Boolean> requestCallback);
    
    // abort the current session
    void abort(String nextSessionProject,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -825,7 +825,7 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, PROCESS_NOTIFY_VISIBLE, params, requestCallback);
    }
 
-   public void interrupt(ServerRequestCallback<Void> requestCallback)
+   public void interrupt(ServerRequestCallback<Boolean> requestCallback)
    {
       sendRequest(RPC_SCOPE, INTERRUPT, requestCallback);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.java
@@ -125,21 +125,24 @@ public class NewConnectionInstallOdbcHost extends Composite
    }
 
    private void terminateOdbcInstall(final Operation operation) {
-      if (consoleProcess_ != null) {
-         consoleProcess_.interrupt(new VoidServerRequestCallback() {
-            @Override
-            public void onSuccess()
-            {
-               reapOdbcInstall(operation);
-            }
-            
-            @Override
-            public void onFailure()
-            {
-               reapOdbcInstall(operation);
-            }
-         });
-      }
+      
+      if (consoleProcess_ == null)
+         return;
+      
+      consoleProcess_.interrupt(new VoidServerRequestCallback()
+      {
+         @Override
+         public void onSuccess()
+         {
+            reapOdbcInstall(operation);
+         }
+
+         @Override
+         public void onFailure()
+         {
+            reapOdbcInstall(operation);
+         }
+      });
    }
 
    protected void addHandlerRegistration(HandlerRegistration reg)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionInstallOdbcHost.java
@@ -124,8 +124,8 @@ public class NewConnectionInstallOdbcHost extends Composite
       }
    }
 
-   private void terminateOdbcInstall(final Operation operation) {
-      
+   private void terminateOdbcInstall(final Operation operation)
+   {
       if (consoleProcess_ == null)
          return;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -28,7 +28,7 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
                         ServerRequestCallback<Void> requestCallback);
    
    // interrupt the current session
-   void interrupt(ServerRequestCallback<Void> requestCallback);
+   void interrupt(ServerRequestCallback<Boolean> requestCallback);
 
    // send console input
    void consoleInput(String consoleInput, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/model/DataImportServerOperations.java
@@ -34,7 +34,7 @@ public interface DataImportServerOperations
                                int maxFactors,
                                ServerRequestCallback<DataImportPreviewResponse> requestCallback);
    
-   void interrupt(ServerRequestCallback<Void> requestCallback);
+   void interrupt(ServerRequestCallback<Boolean> requestCallback);
    
    void previewDataImportAsyncAbort(ServerRequestCallback<Void> requestCallback);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ConsoleProgressDialog.java
@@ -280,7 +280,8 @@ public class ConsoleProgressDialog extends ProgressDialog
    {
       if (running_)
       {
-         consoleProcess_.interrupt(new SimpleRequestCallback<Void>() {
+         consoleProcess_.interrupt(new SimpleRequestCallback<Void>()
+         {
             @Override
             public void onResponseReceived(Void response)
             {
@@ -294,6 +295,7 @@ public class ConsoleProgressDialog extends ProgressDialog
                super.onError(error);
             }
          });
+         
          stopButton().setEnabled(false);
       }
       else


### PR DESCRIPTION
### Intent

Currently, when R requests input from the user via `readline()` or `readLines(stdin())`, there is no way to interrupt the read -- the R session is effectively stuck and the user is forced to restart the session.

This PR makes it possible to exit that state.

Closes https://github.com/rstudio/rstudio/issues/3448.

### Approach

Previously, we tried to "guess" whether the appropriate action was to send a "true" process interrupt, or to try and send a "console" interrupt, based on the state of the prompt. This fails when R attempts to read input from the user without setting a prompt, as in `readLines(stdin())`.

To properly handle this, we now:

1. Always send a so-called "interrupt" RPC;
2. If the R session appears to be busy, then we interrupt it; if not, then we send a console-level interrupt.

### QA Notes

Test that the following states can all be interrupted (by pressing <kbd>Escape</kbd> while the Console has focus) on different platforms:

```
Sys.sleep(10)
system("sleep 10")
readLines(stdin())
readline()
readline("Enter input: ")
```