### PR TITLE
Remove public facing use of "quadrants"

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -67,11 +67,11 @@ public class ClassIds
    public final static String SOURCE_PANEL = "source_panel";
    public final static String DOC_OUTLINE_CONTAINER = "doc_outline_container";
 
-   // WindowFrameButton (combined with unique suffix for each quadrant)
+   // WindowFrameButton (combined with unique suffix for each panel)
    public final static String PANEL_MIN_BTN = "panel_min_btn";
    public final static String PANEL_MAX_BTN = "panel_max_btn";
 
-   // Chunk Context (combined with unique suffix for each quadrant)
+   // Chunk Context (combined with unique suffix for each panel)
    public final static String CHUNK = "chunk";
    public final static String CHUNK_OUTPUT = "chunk_output";
    public final static String MODIFY_CHUNK = "modify_chunk";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -191,7 +191,9 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
       PaneConfig paneConfig = userPrefs.panes().getGlobalValue().cast();
       additionalColumnCount_ = paneConfig.getAdditionalSourceColumns();
 
-      add(new Label("Choose the layout of the panes in RStudio by selecting from the controls in each quadrant.", true));
+      add(new Label("Choose the layout of the panels in RStudio by selecting from the controls in" +
+         " each panel. Add up to three additional Source Columns to the left side of the layout.",
+         true));
 
       Toolbar columnToolbar = new Toolbar("Manage Column Display");
       columnToolbar.setStyleName(res_.styles().newSection());
@@ -241,13 +243,13 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
       String[] visiblePanes = PaneConfig.getVisiblePanes();
 
       leftTop_ = new ListBox();
-      Roles.getListboxRole().setAriaLabelProperty(leftTop_.getElement(), "Top left quadrant");
+      Roles.getListboxRole().setAriaLabelProperty(leftTop_.getElement(), "Top left panel");
       leftBottom_ = new ListBox();
-      Roles.getListboxRole().setAriaLabelProperty(leftBottom_.getElement(), "Bottom left quadrant");
+      Roles.getListboxRole().setAriaLabelProperty(leftBottom_.getElement(), "Bottom left panel");
       rightTop_ = new ListBox();
-      Roles.getListboxRole().setAriaLabelProperty(rightTop_.getElement(), "Top right quadrant");
+      Roles.getListboxRole().setAriaLabelProperty(rightTop_.getElement(), "Top right panel");
       rightBottom_ = new ListBox();
-      Roles.getListboxRole().setAriaLabelProperty(rightBottom_.getElement(), "Bottom right quadrant");
+      Roles.getListboxRole().setAriaLabelProperty(rightBottom_.getElement(), "Bottom right panel");
       visiblePanes_ = new ListBox[]{leftTop_, leftBottom_, rightTop_, rightBottom_};
       for (ListBox lb : visiblePanes_)
       {


### PR DESCRIPTION
### Intent

The term quadrant is now out-dated because users can have multiple source columns. 

### Approach

Functions, variables, ect. including the word `quadrant` will remain as is. We agreed to use "panel" as the public facing word, but this word is already heavily used behind the scenes. 



