### PR TITLE
fix svn commit message encoding issue

### DIFF
--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -1029,6 +1029,7 @@ Error svnCommit(const json::JsonRpcRequest& request,
 
    ShellArgs args;
    args << "commit" << globalArgs();
+   args << "--encoding" << "UTF-8";
    args << "-F" << tempFile;
 
    args << "--";


### PR DESCRIPTION
### Intent

- Fixes #7959
- On Windows, an SVN commit message containing non-ASCII characters was being mangled by a Windows encoding conversion.
- NOTE: this appears to have always been broken, so if we have any concerns about risk (or testing cost) we could consider punting this to 1.5

### Approach

- svn works internally in utf-8, and we don't do any conversion of the (utf-8) string we get from the user, so make sure it doesn't get converted to another locale on Windows by specifying that it is already utf-8

### QA Notes

Test scenario described in issue. I used https://tortoisesvn.net/ to install svn on Windows (be sure to include the command-line tools, which aren't installed by default).

Note that this change doesn't fix previously mangled commit messages, only new ones. Try a variety of characters in commit messages and make sure they show up correctly when viewing svn history from the UI and from command-line.
