### PR TITLE
properly resolve sourcerefs for bytecode contexts

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -77,7 +77,7 @@ bool RCntxt::isErrorHandler() const
 
 bool RCntxt::hasSourceRefs() const
 {
-   SEXP refs = sourceRefs();
+   SEXP refs = callFunSourceRefs();
    return refs && TYPEOF(refs) != NILSXP;
 }
 
@@ -92,19 +92,9 @@ SEXP RCntxt::contextSourceRefs() const
    {
       r::sexp::Protect protect;
    
-      // stuff context parameters into a list to avoid accidentally
-      // evaluating call objects prematurely
-      r::sexp::ListBuilder builder(&protect);
-      builder.add("call", call());
-      builder.add("callflag", callflag());
-      builder.add("callfun", callfun());
-      builder.add("srcref", srcref());
-      builder.add("cloenv", cloenv());
-      SEXP info = r::sexp::create(builder, &protect);
-   
       // attempt to resolve context
       Error error = r::exec::RFunction(".rs.resolveContextSourceRefs")
-            .addParam(info)
+            .addParam(callfun())
             .call(&ref, &protect);
       
       // errors are somewhat expected here, so don't log them and
@@ -116,7 +106,7 @@ SEXP RCntxt::contextSourceRefs() const
    return ref;
 }
 
-SEXP RCntxt::sourceRefs() const
+SEXP RCntxt::callFunSourceRefs() const
 {
    return r::sexp::getAttrib(originalFunctionCall(), "srcref");
 }

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -63,8 +63,16 @@ public:
    bool isDebugHidden() const;
    bool isErrorHandler() const;
 
+   // retrieve the source references associated with the context
+   // (the source reference where this context originated)
    SEXP contextSourceRefs() const;
-   SEXP sourceRefs() const;
+   
+   // retrieve source references associated with the calling function
+   // (where that calling function was actually defined in source)
+   SEXP callFunSourceRefs() const;
+   
+   // for traced functions, the 'real' function will be replaced by
+   // a wrapper function -- use this to find the original function
    SEXP originalFunctionCall() const;
 
    std::string shinyFunctionLabel() const;

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -63,6 +63,7 @@ public:
    bool isDebugHidden() const;
    bool isErrorHandler() const;
 
+   SEXP contextSourceRefs() const;
    SEXP sourceRefs() const;
    SEXP originalFunctionCall() const;
 
@@ -73,6 +74,9 @@ public:
    core::Error callSummary(std::string* pCallSummary) const;
 
    // implemented by R version specific internal context classes
+   //
+   // NOTE: 'srcref()' attribute may be set to <in-bc-interp>
+   // symbol for contexts associated with bytecode evaluation!
    bool isNull() const;
    SEXP callfun() const;
    int callflag() const;

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -743,7 +743,10 @@
    {
       fn <- sys.function(i)
       if (identical(fn, callfun))
-         return(attr(calls[[i]], "srcref"))
+      {
+         srcref <- attr(calls[[i]], "srcref", exact = TRUE)
+         return(srcref)
+      }
    }
    
    NULL

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -735,14 +735,14 @@
    .Call("rs_hasAltrep", var, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("resolveContextSourceRefs", function(info)
+.rs.addFunction("resolveContextSourceRefs", function(callfun)
 {
    calls <- sys.calls()
    
    for (i in seq_along(calls))
    {
       fn <- sys.function(i)
-      if (identical(fn, info$callfun))
+      if (identical(fn, callfun))
          return(attr(calls[[i]], "srcref"))
    }
    

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -735,3 +735,18 @@
    .Call("rs_hasAltrep", var, PACKAGE = "(embedding)")
 })
 
+.rs.addFunction("resolveContextSourceRefs", function(info)
+{
+   calls <- sys.calls()
+   
+   for (i in seq_along(calls))
+   {
+      fn <- sys.function(i)
+      if (identical(fn, info$callfun))
+         return(attr(calls[[i]], "srcref"))
+   }
+   
+   NULL
+   
+})
+

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -307,10 +307,14 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          else
             srcContext = *context;
 
+         // extract source reference associated with source context
+         SEXP srcref = srcContext.contextSourceRefs();
+         
          // mark this as a source-equivalent function if it's evaluating user
          // code into the global environment
-         varFrame["is_source_equiv"] = context->cloenv() == R_GlobalEnv &&
-            isValidSrcref(srcContext.contextSourceRefs());
+         varFrame["is_source_equiv"] =
+               context->cloenv() == R_GlobalEnv &&
+               isValidSrcref(srcref);
 
          std::string filename;
          error = srcContext.fileName(&filename);
@@ -321,7 +325,6 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          varFrame["aliased_file_name"] =
                module_context::createAliasedPath(FilePath(filename));
 
-         SEXP srcref = srcContext.contextSourceRefs();
          if (isValidSrcref(srcref))
          {
             varFrame["real_sourceref"] = true;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -582,7 +582,7 @@ bool functionIsOutOfSync(const r::context::RCntxt& context,
       return true;
    }
 
-   return functionDiffersFromSource(context.sourceRefs(), *pFunctionCode);
+   return functionDiffersFromSource(context.callFunSourceRefs(), *pFunctionCode);
 }
 
 // Returns a JSON array containing the names and associated call frame numbers

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -366,8 +366,8 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          // use this to compute the source location as an offset into the
          // function rather than as an absolute file position (useful when
          // we need to debug a copy of the function rather than the real deal).
-         SEXP srcRef = context->sourceRefs();
-         if (isValidSrcref(srcRef))
+         SEXP srcRef = context->callFunSourceRefs();
+         if (isValidSrcref(srcRef) && TYPEOF(srcRef) == INTSXP)
          {
             varFrame["function_line_number"] = INTEGER(srcRef)[0];
          }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -275,8 +275,7 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
       // debugging in the environment of the callee. note that there may be
       // multiple srcrefs on the stack for a given closure; in this case we
       // always want to take the first one as it's the most current/specific.
-      if (!r::context::isByteCodeContext(*context) &&
-          isValidSrcref(context->srcref()) &&
+      if (isValidSrcref(context->contextSourceRefs()) &&
           !context->nextcontext().isNull())
       {
          SEXP env = context->nextcontext().cloenv();
@@ -311,17 +310,18 @@ json::Array callFramesAsJson(LineDebugState* pLineDebugState)
          // mark this as a source-equivalent function if it's evaluating user
          // code into the global environment
          varFrame["is_source_equiv"] = context->cloenv() == R_GlobalEnv &&
-            isValidSrcref(srcContext.srcref());
+            isValidSrcref(srcContext.contextSourceRefs());
 
          std::string filename;
          error = srcContext.fileName(&filename);
          if (error)
             LOG_ERROR(error);
+         
          varFrame["file_name"] = filename;
          varFrame["aliased_file_name"] =
                module_context::createAliasedPath(FilePath(filename));
 
-         SEXP srcref = srcContext.srcref();
+         SEXP srcref = srcContext.contextSourceRefs();
          if (isValidSrcref(srcref))
          {
             varFrame["real_sourceref"] = true;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1215,6 +1215,31 @@ SEXP rs_isBrowserActive()
    return r::sexp::create(s_browserActive, &protect);
 }
 
+SEXP rs_dumpContexts()
+{
+   using namespace r::context;
+   
+   r::sexp::Protect protect;
+   r::sexp::ListBuilder contextList(&protect);
+   
+   for (auto it = RCntxt::begin();
+        it != RCntxt::end();
+        ++it)
+   {
+      r::sexp::ListBuilder builder(&protect);
+      builder.add("callfun", it->callfun());
+      builder.add("callflag", it->callflag());
+      builder.add("call", it->call());
+      builder.add("srcref", it->srcref());
+      builder.add("cloenv", it->cloenv());
+      
+      SEXP elt = r::sexp::create(builder, &protect);
+      contextList.add(elt);
+   }
+   
+   return r::sexp::create(contextList, &protect);
+}
+
 bool isSuspendable()
 {
    // suppress suspension if any object has a live external pointer; these can't be restored
@@ -1246,6 +1271,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_hasExternalPointer);
    RS_REGISTER_CALL_METHOD(rs_hasAltrep);
    RS_REGISTER_CALL_METHOD(rs_isAltrep);
+   RS_REGISTER_CALL_METHOD(rs_dumpContexts);
 
    // subscribe to events
    using boost::bind;


### PR DESCRIPTION
### Intent

When R byte-compiles a function, the context that is placed on the stack is slightly different in form. In particular, the `srcref` field associated with the context is replaced with an `<in-bc-interp>` marker, and the "true" source references need to be resolved separately.

### Approach

Detect byte-code contexts, and resolve their contexts by finding the associated R system call + function on the stack, and retrieve the source reference from the matching call object.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6922, but also worth running the "regular" debugger test suite to ensure this doesn't regress elsewhere.

Closes https://github.com/rstudio/rstudio/issues/6922.