### PR TITLE
disable JS / CSS diagnostics by default

### DIFF
--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -383,7 +383,7 @@
         },
         "show_diagnostics_other": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "title": "Show diagnostics in other languages",
             "description": "Whether to show diagnostic messages for other types of code (not R or C++)."
         },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -791,7 +791,7 @@ public class UserPrefsAccessor extends Prefs
          "show_diagnostics_other",
          "Show diagnostics in other languages", 
          "Whether to show diagnostic messages for other types of code (not R or C++).", 
-         true);
+         false);
    }
 
    /**


### PR DESCRIPTION
### Intent

The JS + CSS diagnostics systems bundled with RStudio are fairly old at this point, and provide false positives when using more modern idioms. Since we're too late in the release cycle to update these components, we should just disable them.

### Approach

Flip the default preference for these settings from `true` to `false`.

### QA Notes

Validate that 'Show diagnostics for Javascript HTML, and CSS' is off by default:

<img width="602" alt="Screen Shot 2020-10-07 at 3 45 15 PM" src="https://user-images.githubusercontent.com/1976582/95395714-1981bb00-08b4-11eb-9cbf-4b90b16885c6.png">

and that diagnostics are not shown in JS / CSS / HTML files.