### PR TITLE
infer appropriate encoding when reading HTML help documentation

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -507,7 +507,7 @@ options(help_type = "html")
    if (length(helpfiles) <= 0)
       return ()
    
-   file = helpfiles[[1]]
+   file <- helpfiles[[1]]
    path <- dirname(file)
    dirpath <- dirname(path)
    pkgname <- basename(dirpath)
@@ -516,18 +516,19 @@ options(help_type = "html")
    html <- suppressWarnings(tools:::httpd(query, NULL, NULL))$payload
    
    match <- suppressWarnings(regexpr('<body>.*</body>', html))
-   if (match >= 0)
+   if (match < 0)
    {
-      html = NULL
+      html <- NULL
    }
    else
    {
-      # first, assume that HTML documentation is in native encoding;
-      # if that fails, then try again with UTF-8 encoding
+      # assume UTF-8 encoding, and then fall back to native encoding
+      # if parsing in that encoding fails
+      Encoding(html) <- "UTF-8"
       html <- tryCatch(
          substring(html, match + 6, match + attr(match, 'match.length') - 1 - 7),
          error = function(e) {
-            Encoding(html) <- "UTF-8"
+            Encoding(html) <- "unknown"
             substring(html, match + 6, match + attr(match, 'match.length') - 1 - 7)
          }
       )


### PR DESCRIPTION
### Intent

Currently, UTF-8 encoded help is not displayed correctly in autocompletion tooltips. It would be neat if it did.

### Approach

Ensure that HTML help retrieved for a package is marked with the encoding declared in that package's DESCRIPTION file.

### QA Notes

Test with the package at https://github.com/kevinushey/nihao -- install it with:

```
remotes::install_github("kevinushey/nihao")
library(nihao)
nihao::
```

and confirm that Help documentation is displayed as expected. Note that this needs to be tested on Windows.

<img width="647" alt="Screen Shot 2020-10-07 at 10 04 08 PM" src="https://user-images.githubusercontent.com/1976582/95417094-09380300-08e9-11eb-9c91-66f877fca115.png">
