### PR TITLE
allow R completion manager in inline R code chunks

### DIFF
--- a/src/gwt/acesupport/acemode/rmarkdown.js
+++ b/src/gwt/acesupport/acemode/rmarkdown.js
@@ -219,6 +219,9 @@ oop.inherits(Mode, MarkdownMode);
             var line = session.getLine(pos.row);
             var token = session.getTokenAt(pos.row, pos.column - 1);
 
+            // validate that we're not already working within an inline chunk --
+            // check the token at cursor position for 'support.function' type
+            // to confirm
             if (token !== null &&
                 token.type.indexOf("support.function") === -1 &&
                 line[pos.column - 1] === "`")
@@ -236,6 +239,8 @@ oop.inherits(Mode, MarkdownMode);
             var pos = editor.getCursorPosition();
             var token = session.getTokenAt(pos.row, pos.column + 1);
 
+            // validate that we are working within an inline chunk --
+            // only skip '`' if that appears to be the case
             if (token != null &&
                 token.value === "`" &&
                 token.type.indexOf("support.function") !== -1)

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -66,7 +66,7 @@ var RMarkdownHighlightRules = function() {
    Utils.embedRules(
       this,
       RHighlightRules,
-      "r",
+      "r-inline",
       "`r",
       "`",
       ["start", "listblock", "allowBlock"]

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -63,6 +63,16 @@ var RMarkdownHighlightRules = function() {
       ["start", "listblock", "allowBlock"]
    );
 
+   Utils.embedRules(
+      this,
+      RHighlightRules,
+      "r",
+      "`r",
+      "`",
+      ["start", "listblock", "allowBlock"]
+   );
+
+
    // Embed C++ highlight rules
    Utils.embedRules(
       this,


### PR DESCRIPTION
### Intent

Older versions of RStudio allowed the R completer to provide completions within inline R code chunks. Losing that functionality was not intentional; this PR brings it back.

### Approach

Properly delegate to the R completion manager if we detect the cursor is within an inline R code chunk.

### QA Notes

Create an R Markdown document, and then test that R code completions are popped up for text of the form:

```
`r st|`
```

### Notes

Also comes with R highlighting of inline R code chunks, because ... why not.

<img width="477" alt="Screen Shot 2020-10-08 at 2 13 24 PM" src="https://user-images.githubusercontent.com/1976582/95514228-717df780-0970-11eb-839c-2b098e2eb2b1.png">

Closes https://github.com/rstudio/rstudio/issues/8013.