### PR TITLE
Fix layout of Subversion diff viewer secondary toolbar

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -121,5 +121,6 @@
 * Added option for clickable links in Terminal pane (#6621)
 * Fixed issue where R scripts containing non-ASCII characters in their path could not be sourced as a local job on Windows (#6701)
 * Fixed issue where non-ASCII characters in Subversion commit comments were incorrect encoded on Windows (#7959)
+* Prevent Discard button from being hidden in Subversion diff viewer (#6031)
 * Fixed issue where French (AZERTY) keyboards inserted '/' rather than ':' in some cases (#7932)
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.css
@@ -51,12 +51,20 @@
    border: none;
 }
 
+.diffToolbarInnerWrapper {
+   float: right;
+}
+
+.diffContextLines {
+   padding-top: 4px;
+}
+
 .rstudio-themes-flat .diffToolbarInnerWrapper {
    border: none;
 }
 
 .rstudio-themes-flat .diffToolbarWrapper {
-   height: 28px; 
+   height: 28px;
 }
 
 .rstudio-themes-flat .splitPanel .gwt-SplitLayoutPanel-VDragger {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPanel.java
@@ -98,6 +98,7 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       String contextLabel();
       String diffToolbar();
       String diffViewOptions();
+      String diffContextLines();
    }
 
    @SuppressWarnings("unused")
@@ -227,9 +228,9 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       switchViewButton_ = new LeftRightToggleButton("Changes", "History", true);
       switchViewButton_.getElement().getStyle().setMarginRight(8, Unit.PX);
       topToolbar_.addLeftWidget(switchViewButton_);
-      
+
       topToolbar_.addLeftSeparator();
-      
+
       topToolbar_.addLeftWidget(new ToolbarButton(
             "Refresh", ToolbarButton.NoTitle, commands.vcsRefresh().getImageResource(),
             new ClickHandler() {
@@ -240,9 +241,9 @@ public class SVNReviewPanel extends ResizeComposite implements Display
                   commands_.vcsRefresh().execute();
                }
             }));
-      
+
       topToolbar_.addLeftSeparator();
-      
+
       topToolbar_.addLeftWidget(commands.vcsAddFiles().createToolbarButton());
       topToolbar_.addLeftWidget(commands.vcsRemoveFiles().createToolbarButton());
       topToolbar_.addLeftSeparator();
@@ -252,8 +253,8 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       topToolbar_.addLeftWidget(commands.vcsResolve().createToolbarButton());
       topToolbar_.addLeftSeparator();
       topToolbar_.addLeftWidget(commands.vcsCommit().createToolbarButton());
-      
-      
+
+
       commands.vcsPull().setButtonLabel("Update");
       commands.vcsPull().setMenuLabel("Update");
       topToolbar_.addRightWidget(commands.vcsPull().createToolbarButton());
@@ -266,6 +267,7 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       discardAllButton_ = diffToolbar_.addLeftWidget(new ToolbarButton(
             "Discard All", ToolbarButton.NoTitle,  new ImageResource2x(RES.discard2x())));
 
+      contextLines_.addStyleName(RES.styles().diffContextLines());
       lblContext_.setFor(contextLines_);
       listBoxAdapter_ = new ListBoxAdapter(contextLines_);
 
@@ -372,7 +374,7 @@ public class SVNReviewPanel extends ResizeComposite implements Display
    {
       return changelist_.getSelectedPaths();
    }
-   
+
    @Override
    public ArrayList<StatusAndPath> getSelectedItems()
    {
@@ -423,11 +425,11 @@ public class SVNReviewPanel extends ResizeComposite implements Display
    }
 
    @Override
-   public void showContextMenu(final int clientX, 
+   public void showContextMenu(final int clientX,
                                final int clientY)
    {
       final ToolbarPopupMenu menu = new ToolbarPopupMenu();
-      
+
       menu.addItem(commands_.vcsAddFiles().createMenuItem(false));
       menu.addItem(commands_.vcsRemoveFiles().createMenuItem(false));
       menu.addSeparator();
@@ -437,12 +439,12 @@ public class SVNReviewPanel extends ResizeComposite implements Display
       menu.addItem(commands_.vcsResolve().createMenuItem(false));
       menu.addSeparator();
       menu.addItem(commands_.vcsOpen().createMenuItem(false));
-    
+
       menu.setPopupPositionAndShow(new PositionCallback() {
          @Override
          public void setPosition(int offsetWidth, int offsetHeight)
          {
-            menu.setPopupPosition(clientX, clientY);     
+            menu.setPopupPosition(clientX, clientY);
          }
       });
    }
@@ -478,7 +480,7 @@ public class SVNReviewPanel extends ResizeComposite implements Display
    ScrollPanel diffScroll_;
 
    private final Commands commands_;
-   
+
    private ListBoxAdapter listBoxAdapter_;
 
    private ToolbarButton discardAllButton_;


### PR DESCRIPTION
### Intent

- Fixes #6031
- The "Discard All" button on the Subversion diff view was almost completely hidden and only reachable if you used Tab key to move focus to it
- Has been broken this way since RStudio 1.1

### Approach

- Tweaked CSS layout to match how this was displayed in RStudio 1.0

### QA Notes

- As per the issue, you'll need an RStudio project using Subversion for source control, then in the SVN tab click on "Diff" and look at the toolbar area between the upper and lower panes
- Should now look like this with the Discard All button to the right of the Context dropdown

<img width="247" alt="screenshot of subversion diff view showing fixed toolbar" src="https://user-images.githubusercontent.com/10569626/95547844-af9f0980-09b8-11eb-9edb-3f6ed30a4985.png">
