### PR TITLE
enable auto save on blur for visual mode

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/event-types.ts
+++ b/src/gwt/panmirror/src/editor/src/api/event-types.ts
@@ -25,6 +25,7 @@ export const StateChangeEvent = makeEventType('StateChange');
 export const ResizeEvent = makeEventType('Resize');
 export const LayoutEvent = makeEventType('Layout');
 export const ScrollEvent = makeEventType('Scroll');
+export const BlurEvent = makeEventType('Blur');
 export const FocusEvent = makeEventType<ProsemirrorNode>('Focus');
 export const DispatchEvent = makeEventType<Transaction>('Dispatch');
 export const NavigateEvent = makeEventType<Navigation>('Navigate');

--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -50,6 +50,7 @@ import {
   FocusEvent,
   DispatchEvent,
   NavigateEvent,
+  BlurEvent,
 } from '../api/event-types';
 import {
   PandocFormat,
@@ -897,6 +898,10 @@ export class Editor {
       key: new PluginKey('domevents'),
       props: {
         handleDOMEvents: {
+          blur: (view: EditorView, event: Event) => {
+            this.emitEvent(BlurEvent);
+            return false;
+          },
           focus: (view: EditorView, event: Event) => {
             this.emitEvent(FocusEvent, view.state.doc);
             return false;

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorEvent.java
@@ -23,6 +23,7 @@ public class PanmirrorEvent
    public static String Resize = "panmirrorResize";
    public static String Layout = "panmirrorLayout";
    public static String Scroll = "panmirrorScroll";
+   public static String Blur = "panmirrorBlur";
    public static String Focus = "panmirrorFocus";
    public static String Navigate = "panmirrorNavigate";
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.panmirror.command.PanmirrorToolbarCommands;
 import org.rstudio.studio.client.panmirror.command.PanmirrorToolbarMenu;
 import org.rstudio.studio.client.panmirror.events.PanmirrorOutlineNavigationEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorOutlineVisibleEvent;
+import org.rstudio.studio.client.panmirror.events.PanmirrorBlurEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorFindReplaceVisibleEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorFindReplaceVisibleEvent.Handler;
 import org.rstudio.studio.client.panmirror.events.PanmirrorOutlineWidthEvent;
@@ -100,6 +101,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    PanmirrorOutlineWidthEvent.HasPanmirrorOutlineWidthHandlers,
    PanmirrorFindReplaceVisibleEvent.HasPanmirrorFindReplaceVisibleHandlers,
    PanmirrorNavigationEvent.HasPanmirrorNavigationHandlers,
+   PanmirrorBlurEvent.HasPanmirrorBlurHandlers,
    PanmirrorFocusEvent.HasPanmirrorFocusHandlers
    
 {
@@ -311,6 +313,10 @@ public class PanmirrorWidget extends DockLayoutPanel implements
          
          PanmirrorNavigation nav = Js.uncheckedCast(data);
          fireEvent(new PanmirrorNavigationEvent(nav));  
+      }));
+      
+      editorEventUnsubscribe_.add(editor_.subscribe(PanmirrorEvent.Blur, (data) -> {
+         fireEvent(new PanmirrorBlurEvent());
       }));
       
       editorEventUnsubscribe_.add(editor_.subscribe(PanmirrorEvent.Focus, (data) -> {
@@ -650,6 +656,12 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    public HandlerRegistration addPanmirrorNavigationHandler(PanmirrorNavigationEvent.Handler handler)
    {
       return handlers_.addHandler(PanmirrorNavigationEvent.getType(), handler);
+   }
+   
+   @Override
+   public HandlerRegistration addPanmirrorBlurHandler(org.rstudio.studio.client.panmirror.events.PanmirrorBlurEvent.Handler handler)
+   {
+      return handlers_.addHandler(PanmirrorBlurEvent.getType(), handler);
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorBlurEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorBlurEvent.java
@@ -1,0 +1,65 @@
+/*
+ * PanmirrorBlurEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.panmirror.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.event.shared.HasHandlers;
+
+public class PanmirrorBlurEvent extends
+    GwtEvent<PanmirrorBlurEvent.Handler> {
+
+  public static interface Handler extends EventHandler {
+    void onPanmirrorBlur(PanmirrorBlurEvent event);
+  }
+
+  public interface HasPanmirrorBlurHandlers extends HasHandlers {
+    HandlerRegistration addPanmirrorBlurHandler(Handler handler);
+  }
+
+
+  private static Type<PanmirrorBlurEvent.Handler> TYPE;
+
+
+  public static void fire(HasPanmirrorBlurHandlers source) {
+    if (TYPE != null) {
+      PanmirrorBlurEvent event = new PanmirrorBlurEvent();
+      source.fireEvent(event);
+    }
+  }
+
+  public static Type<PanmirrorBlurEvent.Handler> getType() {
+    if (TYPE == null) {
+      TYPE = new Type<PanmirrorBlurEvent.Handler>();
+    }
+    return TYPE;
+  }
+
+  
+  public PanmirrorBlurEvent() {}
+  
+  @Override
+  public final Type<PanmirrorBlurEvent.Handler> getAssociatedType() {
+    return TYPE;
+  }
+
+  @Override
+  protected void dispatch(PanmirrorBlurEvent.Handler handler) {
+    handler.onPanmirrorBlur(new PanmirrorBlurEvent());
+  }
+  
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -128,7 +128,6 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
-import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
@@ -698,23 +697,7 @@ public class TextEditingTarget implements
 
       docDisplay_.addEditorBlurHandler((BlurEvent evt) ->
       {
-         // When the editor loses focus, perform an autosave if enabled, the
-         // buffer is dirty, and we have a file to save to
-         if (prefs.autoSaveOnBlur().getValue() &&
-             dirtyState_.getValue() &&
-             getPath() != null &&
-             !docDisplay_.hasActiveCollabSession())
-         {
-            try
-            {
-               save();
-            }
-            catch(Exception e)
-            {
-               // Autosave exceptions are logged rather than displayed
-               Debug.logException(e);
-            }
-         }
+         maybeAutoSaveOnBlur();
       });
 
       events_.addHandler(
@@ -1165,6 +1148,11 @@ public class TextEditingTarget implements
    public void ensureVisualModeActive(Command command)
    {
       visualMode_.activate(command);
+   }
+   
+   public void onVisualEditorBlur()
+   {
+      maybeAutoSaveOnBlur();
    }
    
    public void navigateToXRef(String xref)
@@ -3230,6 +3218,26 @@ public class TextEditingTarget implements
       else
       {
          onComplete.execute();
+      }
+   }
+   
+   // When the editor loses focus, perform an autosave if enabled, the
+   // buffer is dirty, and we have a file to save to
+   private void maybeAutoSaveOnBlur() {
+      if (prefs_.autoSaveOnBlur().getValue() &&
+          dirtyState_.getValue() &&
+          getPath() != null &&
+          !docDisplay_.hasActiveCollabSession())
+      {
+         try
+         {
+            save();
+         }
+         catch(Exception e)
+         {
+            // Autosave exceptions are logged rather than displayed
+            Debug.logException(e);
+         }
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -48,6 +48,7 @@ import org.rstudio.studio.client.panmirror.PanmirrorOptions;
 import org.rstudio.studio.client.panmirror.PanmirrorSetMarkdownResult;
 import org.rstudio.studio.client.panmirror.PanmirrorWidget;
 import org.rstudio.studio.client.panmirror.command.PanmirrorCommands;
+import org.rstudio.studio.client.panmirror.events.PanmirrorBlurEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorFocusEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorNavigationEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorStateChangeEvent;
@@ -1423,6 +1424,17 @@ public class VisualMode implements VisualModeEditorSync,
                   visualModeNavigation_.onNavigated(event.getNavigation());
                }
             });
+            
+            // propagate blur to text editing target
+            panmirror_.addPanmirrorBlurHandler(new PanmirrorBlurEvent.Handler()
+            {
+               @Override
+               public void onPanmirrorBlur(PanmirrorBlurEvent event)
+               {
+                  target_.onVisualEditorBlur();
+               }
+            });
+            
             
             // check for external edit on focus
             panmirror_.addPanmirrorFocusHandler(new PanmirrorFocusEvent.Handler()


### PR DESCRIPTION
Note that moving focus into an embedded code chunk counts as "blur". While this is mildly inconsistent I don't think it's objectionable and removing this inconsistency would be IMO not be worth the time/effort/added complexity..
