### PR TITLE
increase the delay for syncing the pan theme with the editor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -333,7 +333,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
                   toolbar_.sync(true);
                   syncEditorTheme(event.getTheme());
                }
-            }.schedule(150);
+            }.schedule(500);
       }));
       
       registrations_.add(events_.addHandler(ChangeFontSizeEvent.TYPE, (event) -> {


### PR DESCRIPTION
### Intent

Increase the delay when changing themes so that visual mode doesn't try to sync before the main editor is finished loading. I noticed that the MathJax icons weren't showing up only when I changed themes. After increasing this delay I was no longer able to repro the issue. I would prefer if we weren't just setting arbitrary delays but this small tweak to what we have right now is the safest option.

~~Fixes https://github.com/rstudio/rstudio/issues/7947~~ Edit: I had a shower thought that this actually just fixes a different bug I found while investigating 7947. I'm going to request more information from the bug reporter to confirm. 

### QA Notes

Ensure that when switching from a light to a dark theme without a restart properly loads the colors with visual mode open and that you can see the inline math from the issue linked above.
