### PR TITLE
Remove superfluous R Markdown package deps

### DIFF
--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -225,11 +225,6 @@
             "location": "cran",
             "source": false
         },
-        "rprojroot": {
-            "version": "1.0",
-            "location": "cran",
-            "source": false
-        },
         "rsconnect": {
             "version": "0.8.16",
             "location": "cran",
@@ -361,7 +356,6 @@
         "rmarkdown": {
             "description": "R Markdown",
             "packages": [
-                "Rcpp",
                 "base64enc",
                 "digest",
                 "evaluate",
@@ -374,7 +368,6 @@
                 "markdown",
                 "mime",
                 "rmarkdown",
-                "rprojroot",
                 "stringi",
                 "stringr",
                 "tinytex",


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7935.

### Approach

Removes packages that are no longer dependencies of R Markdown.

### QA Notes

The primary use of this package list is to ensure everything is installed correctly for R Markdown to work correctly, so a good test would be to start with an empty R package library, create a new R Markdown doc, and make sure it can knit after all the packages are auto-installed. 
