### PR TITLE
Enable code commands when leaving visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -689,6 +689,7 @@ public class VisualMode implements VisualModeEditorSync,
    public void unmanageCommands()
    {
       restoreDisabledForVisualMode();
+      setCodeCommandsEnabled(true);
    }
    
    public void insertChunk(String chunkPlaceholder, int rowOffset, int colOffset)


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7991.

### Approach

Code-related commands (like Execute Selection) are disabled in visual mode (unless you're in an embedded editor), but were not always enabled immediately when switching back to source mode. This change ensures they're turned back on when re-entering source mode.

### QA Notes

This code runs on mode switch and when deactivating the edit surface entirely (e.g., for a tab switch), so ensure that code-related command state tracks those actions.


