### PR TITLE
support sub-sections in R documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,11 +45,12 @@
 * Add support for navigating source history with mouse forward/back buttons (#7272)
 * Add ability to go directly to various Global Option panes via Command Palette (#7678)
 * R6Class method definitions are now indexed and accessible by the fuzzy finder (Ctrl + .)
-* The 'Preview' command for R documentation files now passes along RdMacros declared from the package DESCRIPTION file. (#6871)
+* The 'Preview' command for R documentation files now passes along RdMacros declared from the package DESCRIPTION file (#6871)
 * Some panes didn't have commands for making them visible, now they do (#5775)
 * Show correct symbol for Return key in Mac menus (#6524)
 * Added command and button for clearing Build pane output (#6636)
 * Added option to disable clickable hyperlinks in the editor (#6689, thanks to Paul Kaefer)
+* Markdown-style sub-sections are now rendered as nested sections in the document outline for R documents (#4124)
 
 ### RStudio Server
 

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -932,10 +932,20 @@ var RCodeModel = function(session, tokenizer,
             var match = /^\s*([#]+)\s*\w/.exec(value);
             if (match != null)
             {
-               var labelStartPos = {row: position.row, column: 0};
-               var labelEndPos = {row: position.row, column: Infinity};
+               // compute depth -- if the depth seems unlikely / large,
+               // then treat it as just a plain section (similar to how
+               // HTML only provides <h1> through <h6>)
                var depth = match[1].length;
-               this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, false);
+               if (depth > 6)
+               {
+                  this.$scopes.onSectionStart(label, position);
+               }
+               else
+               {
+                  var labelStartPos = {row: position.row, column: 0};
+                  var labelEndPos = {row: position.row, column: Infinity};
+                  this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, false);
+               }
             }
             else
             {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -896,7 +896,7 @@ var RCodeModel = function(session, tokenizer,
             var reBraces = /{.*}\s*$/;
             label = label.replace(reBraces, "");
 
-            this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth);
+            this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, true);
          }
 
          // Add R-comment sections; e.g.
@@ -924,7 +924,24 @@ var RCodeModel = function(session, tokenizer,
                label = label.replace(/\s*[#=-]+\s*$/, "");
             }
 
-            this.$scopes.onSectionStart(label, position);
+            // Detect Markdown-style headers, of the form
+            // 
+            //   ## Header 2 ----
+            //
+            // When we have such a header, we can provide a depth.
+            var match = /^\s*([#]+)\s*\w/.exec(value);
+            if (match != null)
+            {
+               var labelStartPos = {row: position.row, column: 0};
+               var labelEndPos = {row: position.row, column: Infinity};
+               var depth = match[1].length;
+               this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, false);
+            }
+            else
+            {
+               this.$scopes.onSectionStart(label, position);
+            }
+
          }
 
          // Sweave
@@ -965,7 +982,7 @@ var RCodeModel = function(session, tokenizer,
             var labelStartPos = {row: position.row, column: 0};
             var labelEndPos = {row: position.row, column: Infinity};
 
-            this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth);
+            this.$scopes.onMarkdownHead(label, labelStartPos, labelEndPos, depth, true);
          }
 
          // Check specifically for YAML header boundaries ('---')

--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -424,6 +424,9 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
          for (var i = children.length - 1; i >= 0; i--)
          {
             var child = children[i];
+            if (child.isFunction())
+               return;
+
             if (child.isSection() && child.attributes.depth >= depth)
             {
                debuglog("Closing Markdown scope: '" + child.label + "'");
@@ -444,7 +447,7 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
          this.closeMarkdownHeaderScopes(node.parentScope, position, depth);
       };
 
-      this.onMarkdownHead = function(label, labelStartPos, labelEndPos, depth)
+      this.onMarkdownHead = function(label, labelStartPos, labelEndPos, depth, isMarkdown)
       {
          debuglog("Adding Markdown header: '" + label + "' [" + depth + "]");
          var scopes = this.getActiveScopes(labelStartPos);
@@ -456,7 +459,7 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
             labelEndPos,
             labelStartPos,
             ScopeNode.TYPE_SECTION,
-            {depth: depth, isMarkdown: true}
+            {depth: depth, isMarkdown: isMarkdown}
          ));
       };
 


### PR DESCRIPTION
### Intent

In Markdown documents, the document outline indents headers based on their nested-ness in the document itself. This brings that behavior to regular R documents as well, for Markdow-style sections.

### Approach

We can re-use the same "Markdown"-style sections for R here, and allow sections of the form:

```
## Header 2 ----
```

to be parsed just as a regular `## Header 2` section might be in a Markdown document.

### QA Notes

Test by mixing sections + functions in the same R script. For example, with:

```

# Section 1 ----

## Section 1.a ----
## Section 1.b ----

### Section 1.a.1 ----
### Section 1.a.2 ----

# Functions ----

top_level_fn <- function() {
   
   ## Sub-section 1 ----
   ## Sub-section 2 ----
}

top_level_fn_2 <- function() {
   
}
```

I see:

<img width="398" alt="Screen Shot 2020-10-09 at 2 19 28 PM" src="https://user-images.githubusercontent.com/1976582/95632442-7effb400-0a3a-11eb-9fe3-7d14b542c4e1.png">


---

Closes #4124.