### PR TITLE
Use normal font size for chunk outputs in visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.core.client.widget.ProgressSpinner;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
@@ -594,11 +595,13 @@ public class ChunkOutputWidget extends Composite
       if (embedded)
       {
          addStyleName(style.embedded());
+         addStyleName(FontSizer.getNormalFontSizeClass());
          chunkOutputSize_ = ChunkOutputSize.Natural;
       }
       else
       {
          removeStyleName(style.embedded());
+         removeStyleName(FontSizer.getNormalFontSizeClass());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
@@ -136,7 +136,7 @@
       right: 71px;
    }
    
-   .embedded {
+   div.outer.embedded {
 	  line-height: 0;
 	  top: 3px;
    }


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7984.

### Approach

In source mode, the font size is set in chunk outputs via a `FontSizer` CSS class applied to the outer editor. No such class is applied in visual mode, so we apply this class to each individual chunk output to ensure it gets the correct font size.

### QA Notes

This change only affects CSS styles used in visual mode, so verification of correct appearance is all that's needed here.