### PR TITLE
Preserve visual editor widget when changing layouts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -240,8 +240,8 @@ public class PanmirrorWidget extends DockLayoutPanel implements
       events_ = events;
    }
    
-   private void attachEditor(PanmirrorEditor editor) {
-      
+   private void attachEditor(PanmirrorEditor editor)
+   {
       editor_ = editor;
        
       // initialize css
@@ -352,30 +352,21 @@ public class PanmirrorWidget extends DockLayoutPanel implements
       );   
    }
    
-   
-   @Override
-   public void onDetach()
+   public void destroy()
    {
-      try 
+      // detach registrations (outline events)
+      registrations_.removeHandler();
+      
+      if (editor_ != null) 
       {
-         // detach registrations (outline events)
-         registrations_.removeHandler();
-         
-         if (editor_ != null) 
-         {
-            // unsubscribe from editor events
-            for (JsVoidFunction unsubscribe : editorEventUnsubscribe_) 
-               unsubscribe.call();
-            editorEventUnsubscribe_.clear();
-              
-            // destroy editor
-            editor_.destroy();
-            editor_ = null;
-         }
-      }
-      finally
-      {
-         super.onDetach();
+         // unsubscribe from editor events
+         for (JsVoidFunction unsubscribe : editorEventUnsubscribe_) 
+            unsubscribe.call();
+         editorEventUnsubscribe_.clear();
+           
+         // destroy editor
+         editor_.destroy();
+         editor_ = null;
       }
    }
    
@@ -388,8 +379,6 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    {
       return editor_.getTitle();
    }
-   
-  
    
    public void setMarkdown(String code, 
                            PanmirrorWriterOptions options, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -925,6 +925,7 @@ public class VisualMode implements VisualModeEditorSync,
          syncOnIdle_.suspend();
       if (saveLocationOnIdle_ != null)
          saveLocationOnIdle_.suspend();
+      panmirror_.destroy();
    }
    
    public VisualModeChunk getChunkAtRow(int row)


### PR DESCRIPTION
### Intent

Addresses an issue in which the visual editor becomes blank when changing the pane layout. Fixes https://github.com/rstudio/rstudio/issues/7952.

### Approach

The problem is that the visual editor widget tears down the underlying Panmirror editor `onDetach` -- that is, when its widget is detached from the DOM by GWT, which happens during a re-layout. When the widget is later reattached, it no longer has any underlying editor.

The fix is to avoid doing anything special `onDetach`, as it may be temporary; instead, we only destroy the Panmirror editor instance when the tab is closed. 

### QA Notes

This is a slightly less robust way of ensuring that the editor gets cleaned up, so worth testing briefly around various switch/close scenarios to ensure that there isn't an obvious leak, esp. with larger documents.
