### PR TITLE
use new-style remotes format for embedded packages

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -50,10 +50,12 @@ git checkout $PACKAGE_VERSION
 # append GitHub fields to DESCRIPTION
 PACKAGE_SHA1=`git rev-parse $PACKAGE_VERSION`
 cat <<EOF >> DESCRIPTION
-GithubRepo: $PACKAGE
-GithubUsername: rstudio
-GithubRef: $PACKAGE_VERSION
-GithubSHA1: $PACKAGE_SHA1
+RemoteType: github
+RemoteHost: api.github.com
+RemoteRepo: $PACKAGE
+RemoteUsername: rstudio
+RemoteRef: $PACKAGE_VERSION
+RemoteSha: $PACKAGE_SHA1
 Origin: RStudioIDE
 EOF
 

--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -48,8 +48,14 @@ git pull
 git checkout $PACKAGE_VERSION
 
 # append GitHub fields to DESCRIPTION
+# NOTE: older-style Github prefix required by Packrat 0.5.0;
+#       newer-style Remote prefix required by renv.
 PACKAGE_SHA1=`git rev-parse $PACKAGE_VERSION`
 cat <<EOF >> DESCRIPTION
+GithubRepo: $PACKAGE
+GithubUsername: rstudio
+GithubRef: $PACKAGE_VERSION
+GithubSHA1: $PACKAGE_SHA1
 RemoteType: github
 RemoteHost: api.github.com
 RemoteRepo: $PACKAGE

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -45,10 +45,12 @@ REM append GitHub fields to DESCRIPTION
 git rev-parse "%PACKAGE_VERSION%" > PACKAGE_SHA1
 set /p PACKAGE_SHA1= < PACKAGE_SHA1
 del PACKAGE_SHA1
-echo GithubRepo: %PACKAGE% >> DESCRIPTION
-echo GithubUsername: rstudio >> DESCRIPTION
-echo GithubRef: %PACKAGE_VERSION% >> DESCRIPTION
-echo GithubSHA1: %PACKAGE_SHA1% >> DESCRIPTION
+echo RemoteType: github >> DESCRIPTION
+echo RemoteHost: api.github.com >> DESCRIPTION
+echo RemoteRepo: %PACKAGE% >> DESCRIPTION
+echo RemoteUsername: rstudio >> DESCRIPTION
+echo RemoteRef: %PACKAGE_VERSION% >> DESCRIPTION
+echo RemoteSha: %PACKAGE_SHA1% >> DESCRIPTION
 echo Origin: RStudioIDE >> DESCRIPTION
 
 REM create source package

--- a/dependencies/common/install-packages.cmd
+++ b/dependencies/common/install-packages.cmd
@@ -42,9 +42,15 @@ git checkout "%PACKAGE_VERSION%"
 
 
 REM append GitHub fields to DESCRIPTION
+REM NOTE: older-style Github prefix required by Packrat 0.5.0;
+REM       newer-style Remote prefix required by renv.
 git rev-parse "%PACKAGE_VERSION%" > PACKAGE_SHA1
 set /p PACKAGE_SHA1= < PACKAGE_SHA1
 del PACKAGE_SHA1
+echo GithubRepo: %PACKAGE% >> DESCRIPTION
+echo GithubUsername: rstudio >> DESCRIPTION
+echo GithubRef: %PACKAGE_VERSION% >> DESCRIPTION
+echo GithubSHA1: %PACKAGE_SHA1% >> DESCRIPTION
 echo RemoteType: github >> DESCRIPTION
 echo RemoteHost: api.github.com >> DESCRIPTION
 echo RemoteRepo: %PACKAGE% >> DESCRIPTION


### PR DESCRIPTION
### Intent

When embedding R packages, we use the old-style `Github*` fields for indicating the package source. Those are not supported by `renv`, and `devtools` and friends have supported the `Remotes*` syntax for some time now, so use that instead.

### Approach

Straightforward use of new `Remotes*` syntax.

### QA Notes

No test required.