### PR TITLE
reset prompt on session restart

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -514,7 +514,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
       if (suspendingAndRestarting_) return;
       
       // set restart pending for desktop
-      setPendinqQuit(DesktopFrame.PENDING_QUIT_AND_RESTART);
+      setPendingQuit(DesktopFrame.PENDING_QUIT_AND_RESTART);
       
       final TimedProgressIndicator progress = new TimedProgressIndicator(
             globalDisplay_.getProgressIndicator("Error"));
@@ -536,11 +536,11 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
             onRestartComplete.execute();
          }, () -> { // failure
             onRestartComplete.execute();
-            setPendinqQuit(DesktopFrame.PENDING_QUIT_NONE);
+            setPendingQuit(DesktopFrame.PENDING_QUIT_NONE);
          });
    }
    
-   private void setPendinqQuit(int pendingQuit)
+   private void setPendingQuit(int pendingQuit)
    {
       if (Desktop.hasDesktopFrame())
          Desktop.getFrame().setPendingQuit(pendingQuit);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -58,6 +58,7 @@ public class SessionInfo extends JavaScriptObject
    public final native String getClientVersion() /*-{
       return this.client_version;
    }-*/;
+   
 
    public final native String getUserIdentity() /*-{
       return this.userIdentity;
@@ -75,6 +76,10 @@ public class SessionInfo extends JavaScriptObject
       return this.session_label;
    }-*/;
 
+   public final native String getPrompt() /*-{
+      return this.prompt;
+   }-*/;
+   
    public final native JsArray<RnwWeave> getRnwWeaveTypes() /*-{
       return this.rnw_weave_types;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -34,6 +34,7 @@ import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.SuspendAndRestartEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.ImageMenuItem;
@@ -79,7 +80,8 @@ public class EnvironmentPane extends WorkbenchPane
                              implements EnvironmentPresenter.Display,
                                         EnvironmentObjectsObserver,
                                         SessionInitEvent.Handler,
-                                        ReticulateEvent.Handler
+                                        ReticulateEvent.Handler,
+                                        SuspendAndRestartEvent.Handler
 {
    @Inject
    public EnvironmentPane(Commands commands,
@@ -122,6 +124,7 @@ public class EnvironmentPane extends WorkbenchPane
 
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(ReticulateEvent.TYPE, this);
+      events.addHandler(SuspendAndRestartEvent.TYPE, this);
 
       ensureWidget();
    }
@@ -708,6 +711,12 @@ public class EnvironmentPane extends WorkbenchPane
       {
          setActiveLanguage("R", true);
       }
+   }
+   
+   @Override
+   public void onSuspendAndRestart(SuspendAndRestartEvent event)
+   {
+      setActiveLanguage("R", false);
    }
 
    // An extension of the toolbar popup menu that gets environment names from


### PR DESCRIPTION
### Intent

When working in Python mode, the prompt is set to `>>> `. Upon restart, we return to "R" mode, but we don't reset the prompt, giving the indication that the user is still in Python mode.

### Approach

Allow the Shell widget to listen for restart events, and reset the prompt after a restart has occurred.

### QA Notes

Test by:

1. Activating Python mode, e.g. by running code in a Python script,
2. Restarting the session.

Closes https://github.com/rstudio/rstudio/issues/8011.