### PR TITLE
avoid serializing cpp11 preserve env

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -170,28 +170,39 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 # save current state of options() to file
-.rs.addFunction( "saveOptions", function(filename)
+.rs.addFunction("saveOptions", function(filename)
 {
-   opt = options();
-   suppressWarnings(save(opt, file=filename))
+   # get reference to current options
+   opt <- options()
+   
+   # don't attempt to serialize cpp11 preserve env
+   opt$cpp11_preserve_env <- NULL
+   
+   # first write to sidecar file, and then rename that file
+   # (don't let failed serialization leave behind broken workspace)
+   sidecarFile <- paste(filename, "incomplete", sep = ".")
+   suppressWarnings(save(opt, file = sidecarFile))
+   
+   # now, try to rename it
+   file.rename(sidecarFile, filename)
 })
 
 # restore options() from file
-.rs.addFunction( "restoreOptions", function(filename)
+.rs.addFunction("restoreOptions", function(filename)
 {
    load(filename)
    options(opt)
 })
 
 # save current state of .libPaths() to file
-.rs.addFunction( "saveLibPaths", function(filename)
+.rs.addFunction("saveLibPaths", function(filename)
 {
-  libPaths = .libPaths();
-  save(libPaths, file=filename)
+  libPaths <- .libPaths()
+  save(libPaths, file = filename)
 })
 
 # restore .libPaths() from file
-.rs.addFunction( "restoreLibPaths", function(filename)
+.rs.addFunction("restoreLibPaths", function(filename)
 {
   load(filename)
   .libPaths(libPaths)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -181,9 +181,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # first write to sidecar file, and then rename that file
    # (don't let failed serialization leave behind broken workspace)
    sidecarFile <- paste(filename, "incomplete", sep = ".")
+   
+   # remove an old sidecar file if any -- these would be leftover from
+   # a previously-failed attempt to save the session
+   unlink(sidecarFile)
+   
+   # now, attempt to save
    suppressWarnings(save(opt, file = sidecarFile))
    
-   # now, try to rename it
+   # save completed -- rename sidecar file to final location
    file.rename(sidecarFile, filename)
 })
 


### PR DESCRIPTION
### Intent

When the `cpp11` package is loaded, it places an environment on the search path that causes a segfault when one attempts to serialize it.

### Approach

Don't serialize it.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2052.

Closes https://github.com/rstudio/rstudio-pro/issues/2052. Note that ultimately I believe this needs to be fixed in `cpp11` somehow, but this is at least an interim solution.