### PR TITLE
Always adapt to extended type when not autosaving

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3353,9 +3353,15 @@ public class TextEditingTarget implements
       // hasn't changed as the path may have changed
       syncPublishPath(docUpdateSentinel_.getPath());
 
-      // ignore if unchanged
-      if (StringUtil.equals(extendedType, extendedType_))
+      // if autosaves are enabled and the extended type hasn't changed, then
+      // don't do any further work as adapting to the extended type can cause
+      // disruptive side effects during autosave (e.g., knocking down
+      // autocomplete dialogs, resetting vim mode)
+      if (StringUtil.equals(extendedType, extendedType_) &&
+          prefs_.autoSaveEnabled())
+      {
          return;
+      }
 
       view_.adaptToExtendedFileType(extendedType);
       if (extendedType.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/7833, in which the editor toolbar does not update fully when changing the output format of an R Markdown document.

### Approach

We avoid reloading the editor toolbar every time you save because when that happens during autosave it's very disruptive (due to side effects, not the toolbar itself). However this also means that the editor toolbar doesn't adapt to the finer points of the current document without being reloaded; only big changes in file types (e.g. R to Shiny R or Rmd to Notebook) are detected.

However, there's no need to run in this lean mode when autosave is disabled (and anecdotally autosave is popular with only a small minority of users), so this change re-introduces the full reload as long as autosave is off. 

There is still a scenario where this problem reproduces (i.e., you're changing the YAML header _and_ you have autosave on), but it is likely rare and would require a larger fix than we can take for 1.4.

### QA Notes

This code change is only active when neither of the autosave options are on (Save on Blur or Save on Idle).