### PR TITLE
Forward scrolling from chunk callback to editor

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -902,6 +902,24 @@ public class DomUtils
       doc.close();
    }-*/;
 
+   /**
+    * Forwards wheel events between a document and element. Originally written to pass wheel 
+    * events up from an iframe.
+    * @param fromDoc The document that first receives the wheel event.
+    * @param toElement The element the event is forwarded to.
+    */
+   public static final native void forwardWheelEvent(Document fromDoc, Element toElement) /*-{
+
+       function forward(event) {
+           toElement.dispatchEvent(new event.constructor(event.type, event));
+       }
+       // While "wheel" is the current standard, Ace will not handle the event if "mousewheel" is 
+       // supported by the browser. Older browsers require "DomMouseScroll".
+       var wheelEvent = $wnd.document.onmousewheel !== undefined ? "mousewheel" :
+           "onwheel" in toElement ? "wheel" : "DomMouseScroll";
+       fromDoc.addEventListener(wheelEvent, forward);
+   }-*/;
+
    public static native final Element getElementById(String id) /*-{
       return $doc.getElementById(id);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.ArrayList;
 
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.rstudio.core.client.ColorUtil;
@@ -193,7 +194,7 @@ public class ChunkOutputGallery extends Composite
    }
 
    @Override
-   public void showCallbackHtml(String htmlOutput)
+   public void showCallbackHtml(String htmlOutput, Element parentElement)
    {
       VerticalPanel callbackContent = new VerticalPanel();
       callback_.add(callbackContent);
@@ -213,6 +214,7 @@ public class ChunkOutputGallery extends Composite
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
+            DomUtils.forwardWheelEvent(frame.getIFrame().getContentDocument(), parentElement);
             int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             callbackContent.setHeight(contentHeight + "px");
             callbackContent.setWidth("100%");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
@@ -16,6 +16,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import java.util.ArrayList;
 
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import org.rstudio.core.client.ColorUtil;
 import org.rstudio.core.client.StringUtil;
@@ -220,10 +221,21 @@ public class ChunkOutputGallery extends Composite
             host_.notifyHeightChanged();
             
             Command heightHandler = () -> {
-               int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
-               callbackContent.setHeight(newHeight + "px");
-               frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
-               host_.notifyHeightChanged();
+               // reset height so we can shrink it if necessary
+               frame.getElement().getStyle().setHeight(0, Unit.PX);
+
+               // delay calculating the height so any images can load
+               new Timer()
+               {
+                  @Override
+                  public void run()
+                  {
+                     int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
+                     callbackContent.setHeight(newHeight + "px");
+                     frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
+                     host_.notifyHeightChanged();
+                  }
+               }.schedule(50);
             };
 
             MutationObserver.Builder builder = new MutationObserver.Builder(heightHandler);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputPresenter.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
+import com.google.gwt.dom.client.Element;
 import org.rstudio.core.client.js.JsArrayEx;
 import org.rstudio.studio.client.common.debugging.model.UnhandledError;
 import org.rstudio.studio.client.rmarkdown.model.NotebookFrameMetadata;
@@ -52,7 +53,7 @@ public interface ChunkOutputPresenter extends IsWidget, EditorThemeListener
    void updatePlot(String plotUrl, String pendingStyle);
 
    // Handles html that can be appended to end of the chunk.
-   void showCallbackHtml(String htmlOutput);
+   void showCallbackHtml(String htmlOutput, Element parentElement);
 
    // clear output or indicate that interactive output (or playback) is complete
    void clearOutput();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -19,7 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.VirtualConsole;
@@ -426,8 +425,6 @@ public class ChunkOutputStream extends FlowPanel
       }
    }
 
-   
-
    @Override
    public void showCallbackHtml(String htmlOutput, Element parentElement)
    {
@@ -453,7 +450,6 @@ public class ChunkOutputStream extends FlowPanel
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
             DomUtils.forwardWheelEvent(frame.getIFrame().getContentDocument(), parentElement);
             
-            Document anotherDoc = frame.getWindow().getDocument().getOwnerDocument();
             int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
             frame.getElement().getStyle().setWidth(100, Unit.PCT);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.dom.DomUtils;
@@ -447,15 +448,27 @@ public class ChunkOutputStream extends FlowPanel
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
+            
             int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
             frame.getElement().getStyle().setWidth(100, Unit.PCT);
             onHeightChanged();
 
             Command handler = () -> {
-               int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
-               frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
-               onHeightChanged();
+               // reset height so we can shrink it if necessary
+               frame.getElement().getStyle().setHeight(0, Unit.PX);
+  
+               // delay calculating the height so any images can load
+               new Timer()
+               {
+                  @Override
+                  public void run()
+                  {
+                     int newHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
+                     frame.getElement().getStyle().setHeight(newHeight, Unit.PX);
+                     onHeightChanged();
+                  }
+               }.schedule(50);
             };
             
             MutationObserver.Builder builder = new MutationObserver.Builder(handler);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Timer;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.VirtualConsole;
@@ -425,8 +426,10 @@ public class ChunkOutputStream extends FlowPanel
       }
    }
 
+   
+
    @Override
-   public void showCallbackHtml(String htmlOutput)
+   public void showCallbackHtml(String htmlOutput, Element parentElement)
    {
       // flush any queued errors
       initializeOutput(RmdChunkOutputUnit.TYPE_HTML);
@@ -448,7 +451,9 @@ public class ChunkOutputStream extends FlowPanel
          public void execute()
          {
             DomUtils.fillIFrame(frame.getIFrame(), htmlOutput);
+            DomUtils.forwardWheelEvent(frame.getIFrame().getContentDocument(), parentElement);
             
+            Document anotherDoc = frame.getWindow().getDocument().getOwnerDocument();
             int contentHeight = frame.getWindow().getDocument().getDocumentElement().getOffsetHeight();
             frame.getElement().getStyle().setHeight(contentHeight, Unit.PX);
             frame.getElement().getStyle().setWidth(100, Unit.PCT);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -263,11 +263,11 @@ public class ChunkOutputWidget extends Composite
       return expansionState_.addValueChangeHandler(handler);
    }
 
-   public void renderHtml(String htmlOutput)
+   public void renderHtml(String htmlOutput, Element parentElement)
    {
       if (StringUtil.isNullOrEmpty(htmlOutput))
          return;
-      presenter_.showCallbackHtml(htmlOutput);
+      presenter_.showCallbackHtml(htmlOutput, parentElement);
    }
 
    public void showChunkOutput(RmdChunkOutput output, int mode, int scope,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import com.google.gwt.dom.client.Element;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
@@ -811,7 +812,8 @@ public class TextEditingTargetNotebook
       if (chunkHasOutput(data.getChunkId()) &&
           !StringUtil.isNullOrEmpty(data.getHtmlCallback()))
       {
-         outputs().get(data.getChunkId()).getOutputWidget().renderHtml(data.getHtmlCallback());
+         outputs().get(data.getChunkId()).getOutputWidget().renderHtml(data.getHtmlCallback(),
+            docDisplay_.asWidget().getElement());
       }
    }
 


### PR DESCRIPTION
### Intent

Fixes #8008 

Prior to this fix scrolling over chunk callback output would do nothing and interrupt scrolling occuring on the editor. Now the iframe will forward `mousewheel` or `wheel` events to the editor so it can handle the scrolling.

### Approach

Since the iframe was not triggering the scroll event, the iframe forwards wheel events to the editor -- ace editor was coded to trigger scroll events from these. Due to browsers handling the wheel events differently, we need to check which event is supported to set the listener. I ran into an issue with Chrome where if listeners were set for `wheel` or `wheel` and `mousewheel` the scroll wasn't triggered so `mousewheel` is used as the preferred event.

A similar approach can be used to fix #2202 but since that would require some additional logic I didn't implement it with this PR. 

I also included a fix to set the height of the output to 0 whenever the output is mutated. Without this the frame was not resized if its content shrunk.

### QA Notes

We need to make sure this is working for all supported browsers. 

