### PR TITLE
set abend flag before running R

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -711,11 +711,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       }
    }
 
-   // set flag indicating we had an abnormal end (if this doesn't get
-   // unset by the time we launch again then we didn't terminate normally
-   // i.e. either the process dying unexpectedly or a call to R_Suicide)
-   rsession::persistentState().setAbend(true);
-
    // begin session
    using namespace module_context;
    activeSession().beginSession(rVersion(), rHomeDir(), rVersionLabel());
@@ -2157,6 +2152,11 @@ int main (int argc, char * const argv[])
       rCallbacks.showHelp = rShowHelp;
       rCallbacks.showMessage = rShowMessage;
       rCallbacks.serialization = rSerialization;
+
+      // set flag indicating we had an abnormal end (if this doesn't get
+      // unset by the time we launch again then we didn't terminate normally
+      // i.e. either the process dying unexpectedly or a call to R_Suicide)
+      rsession::persistentState().setAbend(true);
 
       // run r (does not return, terminates process using exit)
       error = rstudio::r::session::run(rOptions, rCallbacks);


### PR DESCRIPTION
### Intent

Currently, the "abnormal end" (abend) flag is set somewhat late in the process, and so doesn't catch all cases wherein the R session might fail to start. Notably, it doesn't catch failures to launch that occur while attempting to deserialize session state, or load RStudio's own session modules.

### Approach

Set the abend flag just before running R.

### QA Notes

Not quite sure how to test this with QA...

Closes https://github.com/rstudio/rstudio/issues/7983. Note that we don't necessarily need to take this for 1.4.