### PR TITLE
defer setting of global mouse selection

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMixins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMixins.java
@@ -24,6 +24,7 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.AceSelectionChangedEvent;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.inject.Inject;
 
 public class AceEditorMixins
@@ -46,7 +47,12 @@ public class AceEditorMixins
             {
                String selection = editor_.getSelectedText();
                if (!StringUtil.isNullOrEmpty(selection))
-                  Desktop.getFrame().setGlobalMouseSelection(selection);
+               {
+                  Scheduler.get().scheduleDeferred(() ->
+                  {
+                     Desktop.getFrame().setGlobalMouseSelection(selection);
+                  });
+               }
             }
          });
       }


### PR DESCRIPTION
### Intent

On Linux, when a selection is made within an Ace editor instance, the "primary" clipboard selection (tracking the last-selected text in any application) typically receives a truncated copy of the selection, as per notes in https://github.com/rstudio/rstudio/issues/1667#issuecomment-708069511.

### Approach

We had a fix for this particular issue, but it attempted to set the clipboard selection too eagerly -- we would set the clipboard contents, and then get overwritten by the wrong / truncated version (likely by the window manager detecting and setting the clipboard selection itself). The fix, then, is to just defer setting the clipboard text.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/1667#issuecomment-708069511 -- in particular, try using middle-click pasting to select and paste text both within RStudio, from RStudio to another application, and other applications to RStudio.