### PR TITLE
allow digits after rcpp / cpp engine name

### DIFF
--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -199,7 +199,7 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
    this.$reChunkEndString =
       "^(?:[ ]{4})?`{3,}\\s*$";
 
-   this.$reCppChunkStartString        = engineRegex("(?:[rR][cC]pp|[cC](?:pp)?)");
+   this.$reCppChunkStartString        = engineRegex("(?:[rR][cC]pp|[cC](?:pp)?)\\d*");
    this.$reMarkdownChunkStartString   = engineRegex("block");
    this.$rePerlChunkStartString       = engineRegex("perl");
    this.$rePythonChunkStartString     = engineRegex("python");


### PR DESCRIPTION
### Intent

The [cpp11] package provides a new way to use C++ code within R packages. This PR allows us to support highlighting of `cpp11` chunks.

### Approach

Tweak the engine regex to allow for arbitrary digits after the engine name. (future-proof ourselves for the release of `cpp2050`)

### QA Notes

Test that R Markdown chunks of the form:

`````
```{cpp11}
#include <cpp11.hpp>
```
`````

are highlighted as though they are C++ code.