### PR TITLE
Update package versions for new rmarkdown

### DIFF
--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -276,7 +276,7 @@
             "source": false
         },
         "xfun": {
-            "version": "0.3",
+            "version": "0.15",
             "location": "cran",
             "source": false
         },
@@ -291,7 +291,7 @@
             "source": false
         },
         "yaml": {
-            "version": "2.1.5",
+            "version": "2.1.19",
             "location": "cran",
             "source": false
         }


### PR DESCRIPTION
### Intent

We recently took a new drop of the rmarkdown package to get Pandoc 2.11 support. This release comes with some new supporting package version requirements, which we need to ask the IDE to install. 

Fixes https://github.com/rstudio/rstudio/issues/8063.

### Approach

Update the version these packages in the dependency installer and docs.

### QA Notes

The best way to test this is to start with an old version of xfun installed; ensure that RStudio prompts you to update it if you try to create/preview a notebook.