### PR TITLE
check for null execContext when executing chunk

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -292,12 +292,12 @@ private:
          std::string prefix;
 
          bool isPythonActive = module_context::isPythonReplActive();
-         if (isPythonActive && execContext_->engine() != "python")
+         if (isPythonActive && (execContext_ == nullptr || execContext_->engine() != "python"))
          {
             // switching from Python -> R: deactivate the Python REPL
             prefix = "quit\n";
          }
-         else if (!isPythonActive && execContext_->engine() == "python")
+         else if (!isPythonActive && execContext_ && execContext_->engine() == "python")
          {
             // switching from R -> Python: activate the Python REPL
             prefix = "reticulate::repl_python()\n";


### PR DESCRIPTION
### Intent

Closes #8076.

### Approach

Validate `execContext_` is not `nullptr` when we use it.

### QA Notes

Test that execution of inline R chunks works.