### PR TITLE
properly extract symbol names from quoted symbols

### DIFF
--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -281,6 +281,8 @@ test_context("Diagnostics")
       EXPECT_ERRORS("%a\nb%");
       
       EXPECT_ERRORS("local({ if (TRUE) })");
+
+      EXPECT_NO_ERRORS("phi = function(`arg 1`) 1 + 1\nph(`arg 1` = 1)");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -959,7 +959,7 @@ void extractFormal(
    std::wstring::const_iterator defaultValueStart;
    
    if (cursor.isType(RToken::ID))
-      formalName = cursor.contentAsUtf8();
+      formalName = getSymbolName(cursor);
    
    if (!cursor.moveToNextSignificantToken())
       return;

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -604,23 +604,21 @@ public:
                          int column,
                          const std::string& name)
    {
-      DEBUG("--- Adding defined variable '" << name << "' (" << row << ", " << column << ")");
       definedSymbols_[name].push_back(Position(row, column));
-   }
-
-   void addDefinedSymbol(const RToken& rToken)
-   {
-      DEBUG("--- Adding defined variable '" << rToken.contentAsUtf8() << "'");
-      definedSymbols_[rToken.contentAsUtf8()].push_back(
-            Position(rToken.row(), rToken.column()));
    }
    
    void addDefinedSymbol(const RToken& rToken,
                          const Position& position)
    {
-      definedSymbols_[rToken.contentAsUtf8()].push_back(position);
+      std::string name = token_utils::getSymbolName(rToken);
+      definedSymbols_[name].push_back(position);
    }
    
+   void addDefinedSymbol(const RToken& rToken)
+   {
+      addDefinedSymbol(rToken, rToken.position());
+   }
+
    void addReferencedSymbol(int row,
                             int column,
                             const std::string& name)
@@ -630,14 +628,14 @@ public:
 
    void addReferencedSymbol(const RToken& rToken)
    {
-      referencedSymbols_[rToken.contentAsUtf8()].push_back(
-            Position(rToken.row(), rToken.column()));
+      std::string name = token_utils::getSymbolName(rToken);
+      referencedSymbols_[name].push_back(rToken.position());
    }
    
    void addNseReferencedSymbol(const RToken& rToken)
    {
-      nseReferencedSymbols_[rToken.contentAsUtf8()].push_back(
-               Position(rToken.row(), rToken.column()));
+      std::string name = token_utils::getSymbolName(rToken);
+      nseReferencedSymbols_[name].push_back(rToken.position());
    }
    
    void addInternalPackageSymbol(const std::string& package,


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/6886.

### Approach

Quoted tokens were not being properly de-quoted in some of the diagnostics system's parse routines.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6886.