### PR TITLE
add API for navigating Files pane to path

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -23,7 +23,8 @@
    TYPE_SET_EDITOR_SELECTION = 2L,
    TYPE_DOCUMENT_ID          = 3L,
    TYPE_DOCUMENT_OPEN        = 4L,
-   TYPE_DOCUMENT_NEW         = 5L
+   TYPE_DOCUMENT_NEW         = 5L,
+   TYPE_FILES_PANE_NAVIGATE  = 6L
 ))
 
 # list of potential event targets
@@ -1104,4 +1105,27 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    
    # fire away
    .rs.api.sendRequest(request)
+})
+
+.rs.addApiFunction("filesPaneNavigate", function(path)
+{
+   info <- file.info(path, extra_cols = FALSE)
+   if (is.na(info$isdir))
+      stop("'", path, "' does not exist")
+   else if (identical(info$isdir, FALSE))
+      path <- dirname(path)
+   
+   payload <- list(
+      path  = .rs.scalar(.rs.createAliasedPath(path))
+   )
+   
+   request <- .rs.api.createRequest(
+      type    = .rs.api.eventTypes$TYPE_FILES_PANE_NAVIGATE,
+      sync    = FALSE,
+      target  = .rs.api.eventTargets$TYPE_UNKNOWN,
+      payload = payload
+   )
+   
+   .rs.api.sendRequest(request)
+   invisible(path)
 })

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -108,6 +108,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
    public static final int TYPE_DOCUMENT_ID          = 3;
    public static final int TYPE_DOCUMENT_OPEN        = 4;
    public static final int TYPE_DOCUMENT_NEW         = 5;
+   public static final int TYPE_FILES_PANE_NAVIGATE  = 6;
    
    // list of potential event targets (keep in sync with Api.R)
    public static final int TARGET_UNKNOWN       = 0;
@@ -162,6 +163,15 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       public final native int     getRow()        /*-{ return this["row"];     }-*/;
       public final native int     getColumn()     /*-{ return this["column"];  }-*/;
       public final native boolean getExecute()    /*-{ return this["execute"]; }-*/;
+   }
+   
+   public static class FilesPaneNavigateData extends JavaScriptObject
+   {
+      protected FilesPaneNavigateData()
+      {
+      }
+      
+      public final native String getPath() /*-{ return this["path"]; }-*/;
    }
    
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -39,6 +39,8 @@ import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserHandler;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
+import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperations;
+import org.rstudio.studio.client.events.RStudioApiRequestEvent;
 import org.rstudio.studio.client.server.*;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.WorkbenchView;
@@ -68,7 +70,8 @@ public class Files
       implements FileChangeHandler, 
                  OpenFileInBrowserHandler,
                  DirectoryNavigateHandler,
-                 RenameSourceFileEvent.Handler
+                 RenameSourceFileEvent.Handler,
+                 RStudioApiRequestEvent.Handler
 {
    interface Binder extends CommandBinder<Commands, Files> {}
  
@@ -175,6 +178,7 @@ public class Files
       
       eventBus_.addHandler(FileChangeEvent.TYPE, this);
       eventBus_.addHandler(RenameSourceFileEvent.TYPE, this);
+      eventBus_.addHandler(RStudioApiRequestEvent.TYPE, this);
 
       initSession();
    }
@@ -632,6 +636,20 @@ public class Files
    public void onRenameSourceFile(RenameSourceFileEvent event)
    {
       renameFile(FileSystemItem.createFile(event.getPath()));
+   }
+   
+   @Override
+   public void onRStudioApiRequest(RStudioApiRequestEvent requestEvent)
+   {
+      RStudioApiRequestEvent.Data requestData = requestEvent.getData();
+      
+      if (requestData.getType() == RStudioApiRequestEvent.TYPE_FILES_PANE_NAVIGATE)
+      {
+         RStudioApiRequestEvent.FilesPaneNavigateData data = requestData.getPayload().cast();
+         String path = data.getPath();
+         navigateToDirectory(FileSystemItem.createDir(path));
+      }
+      
    }
 
    private void navigateToDirectory(FileSystemItem directoryEntry)


### PR DESCRIPTION
### Intent

Make it possible for users / addin authors to use the Files pane to navigate to a particular path.

### Approach

Straightforward API implementation.

### QA Notes

Test navigation of specific paths, with e.g.

```
.rs.api.filesPaneNavigate("~/path/to/directory")
```

Play around a bit and make sure different "weird" paths are handled sanely.

RStudio side of https://github.com/rstudio/rstudioapi/issues/204.