### PR TITLE
attempt to reload Viewer page on refresh

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -261,9 +261,16 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public void refresh()
    {
-      String url = frame_.getUrl();
-      if (url != null)
-         frame_.setUrl(url);
+      try
+      {
+         frame_.getWindow().reload();
+      }
+      catch (Exception e)
+      {
+         String url = frame_.getUrl();
+         if (url != null)
+            frame_.setUrl(url);
+      }
    }
 
 


### PR DESCRIPTION
### Intent

Packages which display content in the Viewer pane might want to be able to refresh the current page being shown by the viewer. Currently, a refresh implies reloading the initially-opened page, which means navigation done within the Viewer is lost.

### Approach

Attempt to reload the page as-is, and fall back to setting the frame URL if that fails (e.g. because of CORS).

### QA Notes

I believe @yihui and @cderv will be able to verify this independently. Note that this will only work on RStudio Server, and this works because we use proxy URLs (and so don't fall victim to CORS restrictions there).

Note that if this PR is accepted, you should be able to test via `rstudioapi::executeCommand("viewerRefresh")`.