### PR TITLE
use Ctrl + D to send EOF when readLines active

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@
 * Added basic editor support for Dockerfiles (#5141)
 * Markdown-style sub-sections are now rendered as nested sections in the document outline for R documents (#4124)
 * Update to Pandoc 2.11 (#7696)
+* `Ctrl + D` can now be used to send EOF when reading user input via `readLines()` (#3448)
 
 ### RStudio Server
 

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -219,6 +219,11 @@ SEXP RCntxt::call() const
    return pCntxt_ ? pCntxt_->call() : R_NilValue;
 }
 
+int RCntxt::evaldepth() const
+{
+   return pCntxt_ ? pCntxt_->evaldepth() : 0;
+}
+
 SEXP RCntxt::srcref() const
 {
    return pCntxt_ ? pCntxt_->srcref() : R_NilValue;

--- a/src/cpp/r/RCntxtUtils.cpp
+++ b/src/cpp/r/RCntxtUtils.cpp
@@ -48,7 +48,7 @@ RCntxtVersion contextVersion()
 
 RCntxt globalContext()
 {
-   return RCntxt(getGlobalContext());
+   return RCntxt(R_GlobalContext);
 }
 
 RCntxt firstFunctionContext()

--- a/src/cpp/r/include/r/RCntxt.hpp
+++ b/src/cpp/r/include/r/RCntxt.hpp
@@ -88,6 +88,7 @@ public:
    bool isNull() const;
    SEXP callfun() const;
    int callflag() const;
+   int evaldepth() const;
    SEXP call() const;
    SEXP srcref() const;
    SEXP cloenv() const;

--- a/src/cpp/r/include/r/RCntxtInterface.hpp
+++ b/src/cpp/r/include/r/RCntxtInterface.hpp
@@ -33,6 +33,7 @@ public:
    // accessors for RCNTXT entries
    virtual SEXP callfun() const       = 0;
    virtual int callflag() const       = 0;
+   virtual int evaldepth() const      = 0;
    virtual SEXP call() const          = 0;
    virtual SEXP srcref() const        = 0;
    virtual SEXP cloenv() const        = 0;

--- a/src/cpp/r/include/r/RIntCntxt.hpp
+++ b/src/cpp/r/include/r/RIntCntxt.hpp
@@ -41,6 +41,11 @@ public:
    {
       return pCntxt_->callflag;
    }
+   
+   int evaldepth() const
+   {
+      return pCntxt_->evaldepth;
+   }
 
    SEXP call() const
    {

--- a/src/cpp/r/include/r/RInterface.hpp
+++ b/src/cpp/r/include/r/RInterface.hpp
@@ -241,16 +241,5 @@ enum {
     CTXT_BUILTIN  = 64
 };
 
-namespace rstudio {
-namespace r {
-
-inline void* getGlobalContext()
-{
-   return R_GlobalContext;
-}
-
-} // namespace r
-} // namespace rstudio
-
 #endif // R_INTERFACE_HPP
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -27,6 +27,9 @@
 #include <R_ext/RStartup.h>
 #include <r/session/RSessionUtils.hpp>
 
+#define kConsoleInputCancel 1
+#define kConsoleInputEof    2
+
 #define EX_CONTINUE 100
 #define EX_FORCE    101
 
@@ -113,12 +116,46 @@ struct RInitInfo
       
 struct RConsoleInput
 {
-   explicit RConsoleInput(const std::string& console) : cancel(true), console(console) {}
-   explicit RConsoleInput(const std::string& text, const std::string& console) : 
-                          cancel(false), text(text), console(console) {}
-   bool cancel;
+   explicit RConsoleInput()
+      : flags(0)
+   {
+   }
+   
+   explicit RConsoleInput(int flags)
+      : flags(flags)
+   {
+   }
+   
+   explicit RConsoleInput(const std::string& text,
+                          const std::string& console)
+      : text(text),
+        console(console),
+        flags(0)
+   {
+   }
+   
+   explicit RConsoleInput(const std::string& text,
+                          const std::string& console,
+                          int flags)
+      : text(text),
+        console(console),
+        flags(flags)
+   {
+   }
+   
+   bool isCancel()
+   {
+      return (flags & kConsoleInputCancel) != 0;
+   }
+   
+   bool isEof()
+   {
+      return (flags & kConsoleInputEof) != 0;
+   }
+   
    std::string text;
    std::string console;
+   int flags;
 };
 
 // forward declare DisplayState

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -24,6 +24,7 @@
 #include <r/ROptions.hpp>
 #include <r/RSourceManager.hpp>
 #include <r/RUtil.hpp>
+#include <r/RCntxtUtils.hpp>
 #include <r/session/RClientState.hpp>
 #include <r/session/RConsoleActions.hpp>
 #include <r/session/RConsoleHistory.hpp>
@@ -312,15 +313,15 @@ int RReadConsole (const char *pmt,
 
       // get the next input
       bool addToHistory = (hist == 1);
-      RConsoleInput consoleInput("");
-      if (s_callbacks.consoleRead(promptString, addToHistory, &consoleInput) )
+      RConsoleInput consoleInput(kConsoleInputCancel);
+      if (s_callbacks.consoleRead(promptString, addToHistory, &consoleInput))
       {
          // add prompt to console actions (we do this after consoleRead
          // completes so that we don't send both a console prompt event
          // AND include the same prompt in the actions history)
          consoleActions().add(kConsoleActionPrompt, prompt);
 
-         if (consoleInput.cancel)
+         if (consoleInput.isCancel())
          {
             // notify of interrupt
             consoleActions().notifyInterrupt();
@@ -329,10 +330,20 @@ int RReadConsole (const char *pmt,
             // c++ stack unwinding to occur before jumping
             throw r::exec::InterruptException();
          }
+         
+         // handle EOF. note that we only want to return 0 here if we
+         // know that the session is waiting for input; otherwise we'll
+         // end up quitting R altogether! this effectively implies that
+         // EOF is a no-op at the top level, which seems to be fine
+         else if (consoleInput.isEof() &&
+                  r::context::globalContext().evaldepth() != 0)
+         {
+            return 0;
+         }
          else
          {
             // determine the input to return to R
-            std::string rInput = consoleInput.text;
+            std::string rInput(consoleInput.text);
 
             // refresh source if necessary (no-op in production)
             r::sourceManager().reloadIfNecessary();
@@ -356,9 +367,9 @@ int RReadConsole (const char *pmt,
                throw r::exec::InterruptException();
 
             // copy to buffer and add terminators
-            rInput.copy( (char*)buf, maxLen);
+            rInput.copy((char*)buf, maxLen);
             buf[inputLen] = '\n';
-            buf[inputLen+1] = '\0';
+            buf[inputLen + 1] = '\0';
          }
 
          return 1;

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -62,8 +62,10 @@ void setExecuting(bool executing)
 void enqueueConsoleInput(const rstudio::r::session::RConsoleInput& input)
 {
    json::Object data;
-   data[kConsoleText] = input.text + "\n";
-   data[kConsoleId]   = input.console;
+   data[kConsoleText]  = input.text + "\n";
+   data[kConsoleId]    = input.console;
+   data[kConsoleFlags] = input.flags;
+   
    ClientEvent inputEvent(client_events::kConsoleWriteInput, data);
    clientEventQueue().add(inputEvent);
 }
@@ -107,43 +109,23 @@ bool canSuspend(const std::string& prompt)
 // extract console input -- can be either null (user hit escape) or a string
 Error extractConsoleInput(const json::JsonRpcRequest& request)
 {
-   if (request.params.getSize() == 2)
-   {
-      // ensure the caller specified the requesting console
-      std::string console;
-      if (request.params[1].getType() == json::Type::STRING)
-      {
-         console = request.params[1].getString();
-      }
-      else
-      {
-         return Error(json::errc::ParamTypeMismatch, ERROR_LOCATION);
-      }
-
-      // extract the requesting console
-      if (request.params[0].isNull())
-      {
-         addToConsoleInputBuffer(rstudio::r::session::RConsoleInput(console));
-         return Success();
-      }
-      else if (request.params[0].getType() == json::Type::STRING)
-      {
-         // get console input to return to R
-         std::string text = request.params[0].getString();
-         addToConsoleInputBuffer(rstudio::r::session::RConsoleInput(text, console));
-
-         // return success
-         return Success();
-      }
-      else
-      {
-         return Error(json::errc::ParamTypeMismatch, ERROR_LOCATION);
-      }
-   }
-   else
-   {
-      return Error(json::errc::ParamMissing, ERROR_LOCATION);
-   }
+   std::string text;
+   std::string console;
+   int flags = 0;
+   
+   Error error = core::json::readParams(
+            request.params,
+            &text,
+            &console,
+            &flags);
+   
+   if (error)
+      return error;
+   
+   using namespace r::session;
+   addToConsoleInputBuffer(RConsoleInput(text, console, flags));
+   
+   return Success();
 }
 
 bool executing()
@@ -175,7 +157,7 @@ void fixupPendingConsoleInput()
    auto input = s_consoleInputBuffer.front();
    
    // nothing to do if this is a cancel
-   if (input.cancel)
+   if (input.isCancel() || input.isEof())
       return;
    
    // if this has no newlines, then nothing to do
@@ -279,7 +261,9 @@ void fixupPendingConsoleInput()
       }
    
       // add to buffer
-      s_consoleInputBuffer.push(rstudio::r::session::RConsoleInput(line, input.console));
+      using namespace r::session;
+      s_consoleInputBuffer.push(
+               RConsoleInput(line, input.console, input.flags));
       
    }
 }
@@ -342,7 +326,7 @@ bool rConsoleRead(const std::string& prompt,
       if (error)
       {
          LOG_ERROR(error);
-         *pConsoleInput = rstudio::r::session::RConsoleInput("", "");
+         *pConsoleInput = rstudio::r::session::RConsoleInput();
       }
       else
       {
@@ -351,7 +335,7 @@ bool rConsoleRead(const std::string& prompt,
    }
 
    // fire onBeforeExecute and onConsoleInput events if this isn't a cancel
-   if (!pConsoleInput->cancel)
+   if (!pConsoleInput->isCancel())
    {
       module_context::events().onBeforeExecute();
       module_context::events().onConsoleInput(pConsoleInput->text);
@@ -363,8 +347,9 @@ bool rConsoleRead(const std::string& prompt,
    // ensure that output resulting from this input goes to the correct console
    if (clientEventQueue().setActiveConsole(pConsoleInput->console))
    {
-      module_context::events().onActiveConsoleChanged(pConsoleInput->console,
-            pConsoleInput->text);
+      module_context::events().onActiveConsoleChanged(
+               pConsoleInput->console,
+               pConsoleInput->text);
    }
 
    ClientEvent promptEvent(client_events::kConsoleWritePrompt, prompt);

--- a/src/cpp/session/SessionConsoleInput.hpp
+++ b/src/cpp/session/SessionConsoleInput.hpp
@@ -21,10 +21,11 @@
 
 namespace rstudio {
 namespace r {
-   namespace session {
-      struct RConsoleInput;
-   }
+namespace session {
+struct RConsoleInput;
 }
+}
+
 namespace session {
 namespace console_input {
 

--- a/src/cpp/session/http/SessionHttpConnectionUtils.cpp
+++ b/src/cpp/session/http/SessionHttpConnectionUtils.cpp
@@ -241,6 +241,7 @@ bool checkForInterrupt(boost::shared_ptr<HttpConnection> ptrConnection)
    Error error = parseJsonRpcRequest(
             ptrConnection->request().body(),
             &request);
+   
    if (error)
    {
       ptrConnection->sendJsonRpcError(error);

--- a/src/cpp/session/modules/SessionConsole.hpp
+++ b/src/cpp/session/modules/SessionConsole.hpp
@@ -16,8 +16,9 @@
 #ifndef SESSION_CONSOLE_HPP
 #define SESSION_CONSOLE_HPP
 
-#define kConsoleText "text"
-#define kConsoleId   "console"
+#define kConsoleText  "text"
+#define kConsoleId    "console"
+#define kConsoleFlags "flags"
 
 namespace rstudio {
 namespace core {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -675,13 +675,15 @@ public class RemoteServer implements Server
 
    public void consoleInput(String consoleInput,
                             String consoleId,
+                            int flags,
                             ServerRequestCallback<Void> requestCallback)
    {
-      JSONArray params = new JSONArray();
-      params.set(0, consoleInput == null ? JSONNull.getInstance() :
-         new JSONString(consoleInput));
-      params.set(1, consoleId == null? JSONNull.getInstance() :
-         new JSONString(consoleId));
+      JSONArray params = new JSONArrayBuilder()
+            .add(consoleInput)
+            .add(consoleId)
+            .add(flags)
+            .get();
+      
       sendRequest(RPC_SCOPE, CONSOLE_INPUT, params, requestCallback);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleInputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleInputEvent.java
@@ -19,17 +19,29 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class ConsoleInputEvent extends GwtEvent<ConsoleInputEvent.Handler>
 {
-   public static final Type<Handler> TYPE = new Type<>();
-
-   public interface Handler extends EventHandler
-   {
-      void onConsoleInput(ConsoleInputEvent event);
-   }
-
-   public ConsoleInputEvent(String input, String console)
+   public static final int FLAG_CANCEL = 1;
+   public static final int FLAG_EOF    = 2;
+   
+   public ConsoleInputEvent(String input,
+                            String console,
+                            int flags)
    {
       input_ = input;
       console_ = console;
+      flags_ = flags;
+   }
+   
+   public ConsoleInputEvent(String input,
+                            String console)
+   {
+      input_ = input;
+      console_ = console;
+      flags_ = 0;
+   }
+   
+   public ConsoleInputEvent(int flags)
+   {
+      this("", "", flags);
    }
    
    public String getInput()
@@ -41,6 +53,15 @@ public class ConsoleInputEvent extends GwtEvent<ConsoleInputEvent.Handler>
    {
       return console_;
    }
+   
+   public int getFlags()
+   {
+      return flags_;
+   }
+   
+   private final String input_;
+   private final String console_;
+   private final int flags_;
    
    @Override
    protected void dispatch(Handler handler)
@@ -54,6 +75,11 @@ public class ConsoleInputEvent extends GwtEvent<ConsoleInputEvent.Handler>
       return TYPE;
    }
    
-   private final String input_;
-   private final String console_;
+   public interface Handler extends EventHandler
+   {
+      void onConsoleInput(ConsoleInputEvent event);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/model/ConsoleServerOperations.java
@@ -33,6 +33,7 @@ public interface ConsoleServerOperations extends CodeToolsServerOperations,
    // send console input
    void consoleInput(String consoleInput, 
                      String consoleId,
+                     int flags,
                      ServerRequestCallback<Void> requestCallback);
    
    void resetConsoleActions(ServerRequestCallback<Void> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -672,22 +672,19 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                   modifiers == KeyboardShortcut.CTRL &&
                   input_.getText().length() == 0)
          {
+            event.stopPropagation();
+            event.preventDefault();
+            
             eventBus_.fireEvent(
                   new ConsoleInputEvent(ConsoleInputEvent.FLAG_EOF));
          }
-         else
+         else if (keyCode == KeyCodes.KEY_L &&
+                  modifiers == KeyboardShortcut.CTRL)
          {
-            int mod = KeyboardShortcut.getModifierValue(event.getNativeEvent());
-            if (mod == KeyboardShortcut.CTRL)
-            {
-               switch (keyCode)
-               {
-                  case 'L':
-                     Shell.this.onConsoleClear();
-                     event.preventDefault();
-                     break;
-               }
-            }
+            event.stopPropagation();
+            event.preventDefault();
+            
+            Shell.this.onConsoleClear();
          }
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -304,6 +304,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       view_.clearLiveRegion();
       server_.consoleInput(event.getInput(),
                            event.getConsole(),
+                           event.getFlags(),
                            new ServerRequestCallback<Void>()
       {
          @Override
@@ -651,7 +652,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                      // send a console cancel
                      if (!busy)
                      {
-                        eventBus_.fireEvent(new ConsoleInputEvent(null, ""));
+                        eventBus_.fireEvent(
+                              new ConsoleInputEvent(ConsoleInputEvent.FLAG_CANCEL));
                      }
                         
                   }
@@ -665,6 +667,13 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
             }
 
             input_.clear();
+         }
+         else if (keyCode == KeyCodes.KEY_D &&
+                  modifiers == KeyboardShortcut.CTRL &&
+                  input_.getText().length() == 0)
+         {
+            eventBus_.fireEvent(
+                  new ConsoleInputEvent(ConsoleInputEvent.FLAG_EOF));
          }
          else
          {


### PR DESCRIPTION
### Intent

Currently, it is not possible for R scripts to read user input via `readLines()`, as RStudio doesn't provide any mechanism for sending an EOF.

### Approach

Make that possible, by:

- Allowing `Ctrl + D` in the console to send a special "EOF" console input,
- Refactor the various console input classes to accept a set of flags, rather than an implicit "cancel" action.

### QA Notes

Test that multi-line input can be read via `readLines()`, e.g. by executing the following:

```
readLines()
Hello!
Pleased to meet you.
<Ctrl + D>
```

<img width="391" alt="Screen Shot 2020-10-16 at 8 54 41 AM" src="https://user-images.githubusercontent.com/1976582/96280755-3d688f00-0f8d-11eb-8b20-c90d0cba037c.png">

---

Closes #3448.