### PR TITLE
file indexer ignores revdep, .noindex files / folders

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -498,11 +498,18 @@ std::vector<std::string> fileMonitorIgnoredComponents()
 
       // ignore things within a .git folder
       "/.git",
+      
+      // ignore some directories within the revdep folder
+      "/revdep/checks",
+      "/revdep/library",
 
       // ignore files within an renv or packrat library
       "/renv/library",
       "/renv/staging",
-      "/packrat/lib"
+      "/packrat/lib",
+      
+      // ignore things marked .noindex
+      ".noindex"
 
    };
    


### PR DESCRIPTION
### Intent

Instruct the file monitor to ignore the larger `revdep` folders, as well as files and folders marked as `.noindex`.

### Approach

Add these as ignored components for the set of ignores used when listing files.

### QA Notes

No testing required; this is a "Hadley feature".

Closes https://github.com/rstudio/rstudio/issues/8090.