### PR TITLE
Fix chunk highlighting issue

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
@@ -268,9 +268,9 @@ public class AceBackgroundHighlighter
    @Override
    public void onAttachOrDetach(AttachEvent event)
    {
+      handlers_.removeHandler();
       if (!event.isAttached())
       {
-         handlers_.removeHandler();
          if (documentChangedHandler_ != null)
          {
             documentChangedHandler_.removeHandler();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
@@ -277,6 +277,18 @@ public class AceBackgroundHighlighter
             documentChangedHandler_ = null;
          }
       }
+      else
+      {
+         handlers_ = new HandlerRegistrations(
+            editor_.addEditorModeChangedHandler(this),
+            editor_.addAttachHandler(this));
+         
+         if (!highlightPatterns_.isEmpty())
+         {
+            documentChangedHandler_ = editor_.addDocumentChangedHandler(this);
+            synchronizeFrom(0);
+         }
+      }
    }
    
    // Private Methods ----
@@ -452,7 +464,7 @@ public class AceBackgroundHighlighter
    private final AceEditor editor_;
    private final EditSession session_;
    private final List<HighlightPattern> highlightPatterns_;
-   private final HandlerRegistrations handlers_;
+   private HandlerRegistrations handlers_;
    
    private HighlightPattern activeHighlightPattern_;
    private String activeModeId_;


### PR DESCRIPTION
### Intent

Fixes #8088 

When a document was created before a new source column and later had its mode changed, the highlighted background indicating a chunk was properly aligned with the chunk. 

### Approach

Layout changes for additional columns require existing source columns to detach and re-attach. Prior to this fix, the highlighter's event handlers were removed when detached but never added back since this wasn't necessary prior to 1.4. 

### QA Notes

See original ticket. 

