### PR TITLE
Fix 'Close All Except Current' command

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1517,10 +1517,19 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          dirtyTargets.addAll(sourceColumn.getDirtyEditors(excludeEditor));
 
       // create a command used to close all tabs
-      final Command closeAllTabsCommand = sourceColumn == null
-            ? () -> closeAllTabs(excludeActive, false, null)
-            : () -> closeAllTabs(sourceColumn, excludeActive, false, null);
+      final Command closeAllTabsCommand = () ->
+      {
+         // The active editor may have been changed during the save process so may need to be 
+         // reset so it isn't closed
+         if (excludeEditor != activeColumn_.getActiveEditor())
+            setActive(excludeEditor);
 
+         if (sourceColumn == null) 
+            closeAllTabs(excludeActive, false, null);
+         else
+            closeAllTabs(sourceColumn, excludeActive, false, null);
+      };
+      
       saveEditingTargetsWithPrompt(caption,
          dirtyTargets,
          CommandUtil.join(closeAllTabsCommand, onCompleted),


### PR DESCRIPTION
### Intent

Fixes #7861 

The `Close Other Documents` command was broken by the multiple columns code -- if the user was prompted to save any other document prior to closing, the wrong document was left open.

### Approach

The code existed to save the editor prior to executing commands that could reset the active editor, but it wasn't actually being used.

### QA Notes

See original ticket. 

