### PR TITLE
Fix issues with Save All command

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1521,7 +1521,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       {
          // The active editor may have been changed during the save process so may need to be 
          // reset so it isn't closed
-         if (excludeEditor != activeColumn_.getActiveEditor())
+         if (excludeEditor != null &&
+             excludeEditor != activeColumn_.getActiveEditor())
             setActive(excludeEditor);
 
          if (sourceColumn == null) 


### PR DESCRIPTION
### Intent

Fixes #8102 , #8103 
 
#8095 broke the `Close All` command by accessing a variable the could be null. This PR adds the null check. 

### Approach

Only check the variable when it is null; in this case we do not want to exclude any editors from being closed. 

### QA Notes

Clear steps to reproduce are on tickets mentioned.


