### PR TITLE
hardcode location for POSTGRES librarys on macOS

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -41,8 +41,8 @@ add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 # they currently do not work with our source
 add_definitions(-D_WEBSOCKETPP_NO_CPP11_MEMORY_=1)
 
-# the non-strict masking option was identified as a potentially crashing 
-# issue due to reliance on undefined C++ behavior, and was removed entirely in 
+# the non-strict masking option was identified as a potentially crashing
+# issue due to reliance on undefined C++ behavior, and was removed entirely in
 # websocketpp 0.7 (RStudio is using 0.5.1 at this time)
 add_definitions(-DWEBSOCKETPP_STRICT_MASKING)
 
@@ -115,7 +115,7 @@ if(UNIX)
          message(STATUS "Set CMAKE_OSX_DEPLOYMENT_TARGET to ${CMAKE_OSX_DEPLOYMENT_TARGET}")
       endif()
 
-      # Figure out what version of Mac OS X this is. Unfortunately 
+      # Figure out what version of Mac OS X this is. Unfortunately
       # CMAKE_SYSTEM_VERSION does not match uname -r, so get the Mac OS
       # version number another way.
       execute_process(COMMAND /usr/bin/sw_vers -productVersion OUTPUT_VARIABLE MACOSX_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -415,7 +415,11 @@ if(UNIX)
    find_library(DL_LIB "dl")
    find_library(SQLITE_LIB "sqlite3")
    get_filename_component(SQLITE_LIB "${SQLITE_LIB}" REALPATH)
-   find_library(PQ_LIB "pq")
+   if (APPLE)
+      set(PQ_LIB "/usr/local/lib/libpq.dylib")
+    else()
+      find_library(PQ_LIB "pq")
+   endif()
    get_filename_component(PQ_LIB "${PQ_LIB}" REALPATH)
    list(APPEND SOCI_DEPENDENCIES ${SQLITE_LIB} ${PQ_LIB})
    list(APPEND SOCI_LIBRARIES ${SOCI_SQLITE_LIB} ${SOCI_POSTGRESQL_LIB} ${SQLITE_LIB} ${PQ_LIB} ${SOCI_CORE_LIB} ${DL_LIB})

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -416,6 +416,8 @@ if(UNIX)
    find_library(SQLITE_LIB "sqlite3")
    get_filename_component(SQLITE_LIB "${SQLITE_LIB}" REALPATH)
    if (APPLE)
+      # macdeployqt will only bundle dylibs, and find_library may resolve an xcode library spec file
+      # which won't get included in the bundle; hardcode path to ensure this doesn't happen
       set(PQ_LIB "/usr/local/lib/libpq.dylib")
     else()
       find_library(PQ_LIB "pq")


### PR DESCRIPTION
# Intent

Mac package builds should include the postgreql dependencies in the generated bundle, otherwise the application may not run on a non-developer machine.

On some configurations this was not happening, and cmake was deciding these libraries are part of the system and not including them. Specifically, find_library was resolving to:

`PQ_LIB:FILEPATH=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/usr/lib/libpq.tbd`

### Approach

Hardcode path to library on macOS only. Confirmed with a local build that this results in all dependencies going into the resulting package build.

### QA Notes

Dev / build thing, nothing to test
