### PR TITLE
Windows: Reset active column after document pop-out

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1459,7 +1459,7 @@ public class Source implements InsertSourceHandler,
       }
       if (e.getOldWindowId().equals(SourceWindowManager.getSourceWindowId()))
       {
-         columnManager_.disownDocOnDrag(e.getDocId(), oldDisplay);
+         columnManager_.disownDoc(e.getDocId(), oldDisplay, true);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1344,16 +1344,17 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       getActive().newDoc(fileType, contents, resultCallback);
    }
 
+   
    public void disownDoc(String docId)
    {
       SourceColumn column = findByDocument(docId);
-      column.closeDoc(docId);
+      disownDoc(docId, column, false);
    }
 
    // When dragging between columns/windows, we need to be specific about which column we're
    // removing the document from as it may exist in more than one column. If the column is null,
    // it is assumed that we are a satellite window and do not have multiple displays.
-   public void disownDocOnDrag(String docId, SourceColumn column)
+   public void disownDoc(String docId, SourceColumn column, boolean isDrag)
    {
       if (column == null)
       {
@@ -1366,7 +1367,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          setNewActiveEditor = true;
       
       column.closeDoc(docId);
-      column.cancelTabDrag();
+      if (isDrag)
+         column.cancelTabDrag();
       if (setNewActiveEditor)
          column.setActiveEditor();
    }


### PR DESCRIPTION
### Intent

Fixes #6475 

The continuation of #7861, containing the fix for Windows. Fixes issue where `Save / Save As` could be disabled after popping out a document. 

### Approach

Consolidated similar `disownDoc` functions so that they both reassign the active editor after a document is disowned. This resets which commands are enabled based on the active editor's type.

### QA Notes

Repro steps are in #6475 - behavior should be consistent across all OSs. 


