### PR TITLE
Ensure log file gets reopened if needed

### DIFF
--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -208,18 +208,36 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
       return;
 
    // Lock the mutex before attempting to write.
-   boost::unique_lock<boost::mutex> lock(m_impl->Mutex);
+   try
+   {
+      boost::lock_guard<boost::mutex> lock(m_impl->Mutex);
 
-   // Open the log file if it's not open. If it fails to open, log nothing.
-   if (!m_impl->LogOutputStream && !m_impl->openLogFile())
-      return;
+      // Open the log file if it's not open. If it fails to open, log nothing.
+      if (!m_impl->openLogFile())
+         return;
 
-   // Rotate the log file if necessary. If it fails to rotate, log nothing.
-   if (!m_impl->rotateLogFile())
-      return;
+      // Rotate the log file if necessary. If it fails to rotate, log nothing.
+      if (!m_impl->rotateLogFile())
+         return;
 
-   (*m_impl->LogOutputStream) << in_message;
-   m_impl->LogOutputStream->flush();
+      (*m_impl->LogOutputStream) << in_message;
+      m_impl->LogOutputStream->flush();
+
+      // If the output stream has bad state after writing, it might have been closed. Try re-opening it and writing the
+      // message again. Often it is not possible to tell that a stream has failed until a write is attempted.
+      if (!m_impl->LogOutputStream->good())
+      {
+         if (!m_impl->openLogFile())
+            return;
+
+         (*m_impl->LogOutputStream) << in_message;
+         m_impl->LogOutputStream->flush();
+      }
+   }
+   catch (...)
+   {
+      // Swallow exceptions because we'd trigger recursive logging otherwise.
+   }
 }
 
 } // namespace log


### PR DESCRIPTION
### Intent

Fixes #7898.

Ensure that we are able to log to a file from the server even after we daemonize.

### Approach

It's not enough to test the goodbit/state of the output stream because even it doesn't know it's in a bad state until a real write has been attempted. Writing an empty string is not sufficient.

To resolve this, each time we write a log to the stream, we check the goodbit on the stream. If the goodbit is not set, we re-open the stream and re-attempt the write operation. Most of the time, the goodbit is good and the stream will not be re-opened.

### QA Notes

This issue only affects the rserver process. If the logger for the rserver process is configured as described in #7898, the log should contain more messages than just `20 Oct 2020 00:16:28 [rserver] INFO Reading rserver configuration from /etc/rstudio/rserver.conf`, which is the only entry I get prior to the fix. The output you see in the file should be the same (excepting times and barring confguration changes) as the logs you get in syslog when the file logger is not enabled.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


