### PR TITLE
Display overlay on emojis for macOS Big Sur desktop

### DIFF
--- a/src/gwt/panmirror/src/editor/src/editor/styles/styles.css
+++ b/src/gwt/panmirror/src/editor/src/editor/styles/styles.css
@@ -253,3 +253,22 @@ p.ProseMirror-selectednode {
   position: relative;
   left: 2px;
 }
+
+.macos-bigsur .pm-content .emoji {
+  position: relative;
+}
+
+.macos-bigsur .pm-content .emoji::before {
+  content: '?';
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: inline-block;
+  font-size: 10pt;
+  text-align: center;
+  width: 1.5em;
+  box-sizing: border-box;
+  border: 1px solid gray;
+  border-radius: 3px;
+  margin-top: -1px;
+}

--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -86,9 +86,13 @@ public class BrowseCap
    public static boolean isMacintoshDesktopMojave()
    {
       return isMacintoshDesktop() && isUserAgent("mac os x 10_14");
-            
    }
-  
+
+   public static boolean isMacintoshDesktopBigSur()
+   {
+      return isMacintoshDesktop() && isUserAgent("mac os x 10_16");
+   }
+
    public static boolean isWindows()
    {
       return OPERATING_SYSTEM.equals("windows");
@@ -258,6 +262,12 @@ public class BrowseCap
    static
    {
       Document.get().getBody().addClassName(OPERATING_SYSTEM);
+
+      // Support for scoping styles for macOS BigSur (10.16)
+      if (isMacintoshDesktopBigSur())
+      {
+         Document.get().getBody().addClassName("macos-bigsur");
+      }
 
       if (isWindowsDesktop())
       {


### PR DESCRIPTION
### Intent

This change mitigates (but does not fix) #7897. Since emoji do not render on macOS Big Sur, they show up blank. This change causes them to render in the visual editor as a boxed question mark with a tooltip indicating the name of the emoji.

![image](https://user-images.githubusercontent.com/470418/96639561-bbeb6680-12d6-11eb-9d88-8da030aed908.png)

This is a stop-gap measure intended to make emoji visible to Big Sur users while we sort out the underlying bug. 

### Approach

This change is implemented in (almost) pure CSS; we draw a pseudoelement with the ` ? ` over the emoji when we're specifically macOS Big Sur.

### QA Notes

Note that this affects *only* the rendered display of emoji in the visual editor's editing canvas. It does not address emojis anywhere else in the IDE, which will still be blank.