### PR TITLE
Added LSApplicationCategoryType key to Info.plist.in

### DIFF
--- a/src/cpp/desktop/Info.plist.in
+++ b/src/cpp/desktop/Info.plist.in
@@ -272,6 +272,8 @@
 	<string>Rstd</string>
 	<key>CFBundleVersion</key>
 	<string>${CPACK_PACKAGE_VERSION}</string>
+  	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>LSRequiresCarbon</key>


### PR DESCRIPTION
Added LSApplicationCategoryType key to Info.plist.in so RStudio Desktop is identified in the Developer Tools category (e.g. for Screen Time reports)
