### PR TITLE
Add support for shift click

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-list-item.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-list-item.tsx
@@ -51,8 +51,12 @@ export const CitationSourcePanelListItem = (props: ListChildComponentProps) => {
     }
   };
 
-  const onItemClick = () => {
-    citationListData.onSelectedIndexChanged(props.index);
+  const onItemClick = (e: React.MouseEvent) => {
+    if (e.shiftKey) {
+      citationListData.onAddCitation(citationEntry);
+    } else {
+      citationListData.onSelectedIndexChanged(props.index);
+    }
   };
 
   const onDoubleClick = () => {


### PR DESCRIPTION
### Intent

A user reported that they expected shift+click to result in adding a citation to the basket (which makes sense given that this is a frequently a multiselect gesture). This change will make that happen.

### Approach

A small change to check the shift on the click event and use that to determine what to do.

### QA Notes

This change is low risk as the code path for adding an item to the basket it already used extensively, so this is just calling that code path when shift clicking.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


