### PR TITLE
Unsync source column count 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -450,11 +450,6 @@ public class PaneManager
          @Override
          public void onUserPrefsChanged(UserPrefsChangedEvent e)
          {
-            if (additionalSourceCount_ != userPrefs_.panes().getGlobalValue().getAdditionalSourceColumns())
-            {
-               syncAdditionalColumnCount(
-                  userPrefs_.panes().getGlobalValue().getAdditionalSourceColumns(), true);
-            }
             if (!userPrefs_.showPanelFocusRectangle().getValue())
             {
                clearFocusIndicator();


### PR DESCRIPTION
### Intent

Closes #8107 

Adding or removing a column should not affect other instances of RStudio the user is running. Previously any changes made to the `additional_column_count` in `global-prefs.json` were made immediately, but now changes are only made on startup and when the IDE is writing to the preference file. This allows the column state to be saved between sessions, while preventing columns being added/removed in an active session without user prompt.

### Approach

I removed the `panes` user preference handler that was syncing the two instances. Now the column count is only updated when requested by the user in that session.

### QA Notes

If the user ends a session with three columns, their next session should start with three columns. However, when running two instances of RStudio, the column counts should not be in sync.

Original ticket has good repo notes.

