### PR TITLE
Synchronize scope tree after setting canonical source

### DIFF
--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -136,6 +136,9 @@ export interface EditorSetMarkdownResult {
 
   // unparsed meta
   unparsed_meta: { [key: string]: any };
+
+  // updated outline 
+  location: EditingOutlineLocation;
 }
 
 export interface EditorContext {
@@ -529,6 +532,7 @@ export class Editor {
     // current 'view' of the doc as markdown looks like
     const getMarkdownTr = this.state.tr;
     const canonical = await this.getMarkdownCode(getMarkdownTr, options);
+    const location = getEditingOutlineLocation(this.state);
 
     // return
     return {
@@ -536,6 +540,7 @@ export class Editor {
       line_wrapping,
       unrecognized,
       unparsed_meta,
+      location
     };
   }
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorSetMarkdownResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorSetMarkdownResult.java
@@ -18,6 +18,7 @@ package org.rstudio.studio.client.panmirror;
 
 import elemental2.core.JsObject;
 import jsinterop.annotations.JsType;
+import org.rstudio.studio.client.panmirror.location.PanmirrorEditingOutlineLocation;
 
 @JsType
 public class PanmirrorSetMarkdownResult
@@ -26,6 +27,7 @@ public class PanmirrorSetMarkdownResult
    public String line_wrapping;
    public String[] unrecognized;
    public JsObject unparsed_meta;
+   public PanmirrorEditingOutlineLocation location;
    
    public static final String kLineWrappingNone = "none";
    public static final String kLineWrappingColumn= "column";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -334,19 +334,14 @@ public class VisualMode implements VisualModeEditorSync,
                         // note that ready.execute() is never called in the error case
                         return;
                      }
-                     
+
                      // we are about to mutate the document, so create a single
                      // shot handler that will adjust the known position of
                      // items in the outline (we do this opportunistically
                      // unless executing code)
                      if (markdown.location != null && syncType != SyncType.SyncTypeExecution)
                      {
-                        final Value<HandlerRegistration> handler = new Value<HandlerRegistration>(null);
-                        handler.setValue(docDisplay_.addScopeTreeReadyHandler((evt) ->
-                        {
-                           alignScopeOutline(markdown.location);
-                           handler.getValue().removeHandler();
-                        }));
+                         alignScopeTreeAfterUpdate(markdown.location);
                      }
                      
                      // apply diffs unless the wrap column changed (too expensive)
@@ -540,8 +535,10 @@ public class VisualMode implements VisualModeEditorSync,
                            // so that diffs are efficient)
                            if (result.canonical != editorCode)
                            {
-                              getSourceEditor().setCode(result.canonical);
-                              markDirty();
+                               // ensure we realign the scope tree after changing the code
+                               alignScopeTreeAfterUpdate(result.location);
+                               getSourceEditor().setCode(result.canonical);
+                               markDirty();
                            }
                            
                            // completed
@@ -1715,7 +1712,26 @@ public class VisualMode implements VisualModeEditorSync,
          chunk.setScope(chunkScopes.get(k));
       }
    }
-   
+
+   /**
+    * Aligns the scope tree with chunks in visual mode; intended to be called when code
+    * has been mutated in the editor.
+    *
+    * @param location An outline of editing locations
+    */
+   private void alignScopeTreeAfterUpdate(PanmirrorEditingOutlineLocation location)
+   {
+      final Value<HandlerRegistration> handler = new Value<HandlerRegistration>(null);
+      handler.setValue(docDisplay_.addScopeTreeReadyHandler((evt) ->
+      {
+         if (location != null)
+         {
+            alignScopeOutline(location);
+         }
+         handler.getValue().removeHandler();
+      }));
+   }
+
    private Commands commands_;
    private UserPrefs prefs_;
    private SourceServerOperations source_;


### PR DESCRIPTION
### Intent

Addresses a variety of intermittent off-by-one errors reported when executing code in visual mode. Fixes https://github.com/rstudio/rstudio/issues/7946.

The underlying problem is that when switching to the visual editor, we create the visual editor's contents from the source editor's markdown as-is.... then we re-write the source editor's markdown to be canonical. This can move chunks to different lines, and as we don't do another AST -> markdown conversion on execution (technically it's unnecessary) the usual method used to enforce sync before execute doesn't run. 

### Approach

When changing the contents of the source editor into canonical format, perform the work that's usually done when we change the markdown in the source editor: get the outline from Panmirror and synchronize it with the new scope tree.

### QA Notes

The original bug has some pretty reliable repros; if you're having trouble note that most things you do in visual mode (even typing a few characters, saving, or switching modes) will make the problem go away, so you need to reproduce it immediately after switching modes.