### PR TITLE
Fix a race condition when displaying the R error page

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -663,22 +663,22 @@ void MainWindow::onUrlChanged(QUrl url)
 
 void MainWindow::onLoadFinished(bool ok)
 {
-   if (ok || pRemoteSessionLauncher_)
-      return;
-
-   RS_CALL_ONCE();
-   
-   std::map<std::string,std::string> vars;
-   vars["url"] = webView()->url().url().toStdString();
-   std::ostringstream oss;
-   Error error = text::renderTemplate(options().resourcesPath().completePath("html/connect.html"),
-                                      vars, oss);
-
    LOCK_MUTEX(mutex_)
    {
+      if (ok || pRemoteSessionLauncher_ || isErrorDisplayed_)
+         return;
+
+      RS_CALL_ONCE();
+      
+      std::map<std::string,std::string> vars;
+      vars["url"] = webView()->url().url().toStdString();
+      std::ostringstream oss;
+      Error error = text::renderTemplate(options().resourcesPath().completePath("html/connect.html"),
+                                       vars, oss);
+
       if (error)
          LOG_ERROR(error);
-      else if (!isErrorDisplayed_)
+      else
          loadHtml(QString::fromStdString(oss.str()));
    }
    END_LOCK_MUTEX

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -22,6 +22,8 @@
 #include <QtGui>
 #include <QSessionManager>
 
+#include <core/Thread.hpp>
+
 #include "DesktopInfo.hpp"
 #include "DesktopGwtCallback.hpp"
 #include "DesktopGwtWindow.hpp"
@@ -57,6 +59,8 @@ public:
    QWebEngineProfile* getPageProfile();
    WebView* getWebView();
    bool workbenchInitialized();
+
+   void setErrorDisplayed();
 
 public Q_SLOTS:
    void quit();
@@ -132,6 +136,9 @@ private:
    boost::shared_ptr<JobLauncher> pLauncher_;
    ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
+
+   boost::mutex mutex_;
+   bool isErrorDisplayed_;
 
 #ifdef _WIN32
    HWINEVENTHOOK eventHook_;

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -311,7 +311,10 @@ void SessionLauncher::showLaunchErrorPage()
    if (error)
        LOG_ERROR(error);
    else
+   {
+      pMainWindow_->setErrorDisplayed();
       pMainWindow_->loadHtml(QString::fromStdString(oss.str()));
+   }
 }
 
 void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -17,6 +17,8 @@
 
 #include <gsl/gsl>
 
+#include <iostream>
+
 #include <boost/function.hpp>
 #include <boost/regex.hpp>
 
@@ -613,6 +615,7 @@ void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env)
 // NOTE: Win32 doesn't receive this callback
 void RSuicide(const char* s)
 {
+   std::cerr << s << std::endl;
    s_callbacks.suicide(s);
    s_internalCallbacks.suicide(s);
 }

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -615,6 +615,8 @@ void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env)
 // NOTE: Win32 doesn't receive this callback
 void RSuicide(const char* s)
 {
+   // We need to write this to stderr so the parent process (rstudio) can pick up the error message and display it 
+   // to the user in case the session log file is not accessbile.
    std::cerr << s << std::endl;
    s_callbacks.suicide(s);
    s_internalCallbacks.suicide(s);


### PR DESCRIPTION
### Intent
 
Fix the issue that @kfeinauer raised when verifying #7742, as well as a second issue that we found while diagnosing the first.

1st issue: The "Cannot connect to R" page is displayed instead of "Error Starting R" because the session exits before the "Cannot connect to R" page has been displayed.

2nd issue: The R Suicide message is not sent to stderr, which means the real reason that the session failed (cannot access `~/.local/share/rstudio`) is not displayed on the "Error Starting R" page.

### Approach

* Use a mutex and a flag to ensure the race condition always resolves as we desire (once the Error page is displayed, don't load another over top of it).

* Write the R exit reason string to `std::cerr` before exiting the session so the `rstudio` process can retrieve and display the message.

This is what a failure to access `~/.local/share/rstudio` should look like now:
![image](https://user-images.githubusercontent.com/37987486/96808233-4dd59b00-13cd-11eb-9c59-d8a20ad7a463.png)

### QA Notes

See QA notes on #7742.


