### PR TITLE
Redact Travis API keys

### DIFF
--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -26,7 +26,8 @@ redact_regex <- function() {
   
   words <- c(
     "API", "AUTH", "GITHUB", "HOST", "HOST", "KEY", "LOGNAME",
-    "PASSWORD", "PAT", "PWD", "SECRET", "TOKEN", "UID", "USERNAME"
+    "PASSWORD", "PAT", "PWD", "R TRAVIS (COM|ORG)", "SECRET", 
+    "TOKEN", "UID", "USERNAME"
   )
   
   fmt <- "\\b%s\\b"


### PR DESCRIPTION
### Intent

Travis API keys are currently not redacted in the diagnostics report. This fixes #8134 

### Approach

Add the TRAVIS to the list of key words. 

### QA Notes

As `_` are removed from the [contents](https://github.com/rstudio/rstudio/blob/291c992854e1c8372dfde650e2813aea5cd17699/src/cpp/r/R/Diagnostics.R#L75), I've removed `_` from the list of key words


<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
---
Agreement completed as requested.