### PR TITLE
Fix cross-device global replace

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -576,7 +576,8 @@ private:
             error = setPermissions(tempReplaceFile_.getAbsolutePath(), filePermissions_);
 #endif
             if (!error)
-               error = tempReplaceFile_.move(FilePath(currentFile_));
+               error = tempReplaceFile_.move(FilePath(currentFile_), FilePath::MoveType::MoveCrossDevice, true);
+
             currentFile_.clear();
             if (error)
             {


### PR DESCRIPTION
### Intent

Global replace was silently failing when the file was on a different machine than RStudio. This was reported in #7736 which I'm leaving open until we can get confirmation from the user that it is fixed as there has been lots of back and forth. 

### Approach

Pass the `overwrite` flag to the move command when performing the replace; otherwise cross-machine moves that overwrite a file are prevented. 


### QA Notes

Perform find and replace where the file containing the replace is not on the same machine as the IDE. 

