### PR TITLE
check that we didn't step off row when building range for multiline expr

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3882,26 +3882,40 @@ public class AceEditor implements DocDisplay,
       }
       while (false);
       
-      // check for binary operator on start line
+      // check for lines of the form:
+      //
+      //     ) foo +
+      //
+      // that is, the line ends in a binary operator, but also
+      // starts with a right bracket. in that case, we want to
+      // move the cursor to the associated left bracket.
       if (rowEndsInBinaryOperatorOrOpenParen(startRow))
       {
          // move token cursor to that row
          c.moveToEndOfRow(startRow);
 
          // skip comments, operators, etc.
+         boolean foundBracket = false;
          while (c.hasType("text", "comment", "virtual-comment", "keyword.operator"))
          {
             if (c.isRightBracket())
+            {
+               foundBracket = true;
                break;
+            }
 
             if (!c.moveToPreviousToken())
+               break;
+          
+            // if we moved back off the start row, break
+            if (c.getRow() != startRow)
                break;
          }
 
          // if we landed on a closing bracket, look for its match
          // and then continue search from that row. otherwise,
          // just look back a single row
-         if (c.valueEquals(")") || c.valueEquals("]"))
+         if (foundBracket && (c.valueEquals(")") || c.valueEquals("]")))
          {
             if (c.bwdToMatchingToken())
             {


### PR DESCRIPTION
### Intent

Fix multine expr case documented in https://github.com/rstudio/rstudio/issues/8156.

### Approach

When finding the 'start' of the current expression, don't step back off the current row when looking for a right bracket.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8156. See also test cases in https://github.com/rstudio/rstudio/blob/master/src/gwt/test/test-multiline-expr.R.

Closes #8156.