### PR TITLE
Use Lucida Grande as a fallback on macOS

### DIFF
--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -268,11 +268,14 @@ QString Options::proportionalFont() const
    if (selectedFont == sansSerif)
    {
 #if defined(__APPLE__)
-      // Qt 5.15 has a known issue on MacOS in which it can't detect any fonts; if this happens,
-      // fall back to Lucida Grande in that case as it's almost certainly installed and the
-      // sans-serif default (Helvetica) doesn't line up as nicely with our UI elements.
+      // Qt 5.15 has a known issue in which it does not match any fonts (so we can't tell if any of
+      // our preferred fonts are installed).
+      //
+      // https://bugreports.qt.io/browse/QTBUG-87267
+      //
+      // Fall back to Lucida Grande in that case as it's almost certainly installed and the
+      // sans-serif default (Helvetica) doesn't line up very nicely with our UI elements.
       return QStringLiteral("\"Lucida Grande\"");
-
 #else
       return sansSerif;
 #endif

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -266,7 +266,17 @@ QString Options::proportionalFont() const
    // quotes; e.g. "sans-serif" is a signal to look for a font called sans-serif
    // rather than use the default sans-serif font!
    if (selectedFont == sansSerif)
+   {
+#if defined(__APPLE__)
+      // Qt 5.15 has a known issue on MacOS in which it can't detect any fonts; if this happens,
+      // fall back to Lucida Grande in that case as it's almost certainly installed and the
+      // sans-serif default (Helvetica) doesn't line up as nicely with our UI elements.
+      return QStringLiteral("\"Lucida Grande\"");
+
+#else
       return sansSerif;
+#endif
+   }
    else
       return QStringLiteral("\"%1\"").arg(selectedFont);
 }


### PR DESCRIPTION
### Intent

Restore RStudio's appearance on MacOS + Qt 5.15. Fixes https://github.com/rstudio/rstudio/issues/8157. 

### Approach

This appears to be broken because Qt isn't detecting any fonts on MacOS (no known cause). When we detect no fonts, we fall back on `sans-serif`, which renders poorly with our UI. As a temporary measure, this change allows us to use Lucida Grande (our preferred font) even if it isn't detected. 

### QA Notes

You could uninstall Lucida Grande if you really want to be evil with this one. This should result in the display of a system sans-serif font like Helvetica (as it did before the change). 