### PR TITLE
handle rainbow paren tokens in C++ outdent

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
@@ -157,7 +157,6 @@ var $alignCase                 = true; // case 'a':
       var prevLine = null;
       if (row > 0)
          prevLine = doc.getLine(row - 1);
-      var indent = this.$getIndent(line);
 
       // Check for '<<', '.'alignment
       if ($alignStreamOut && this.alignStartToken("<<", session, row, line, prevLine))
@@ -366,7 +365,7 @@ var $alignCase                 = true; // case 'a':
                row: row,
                column: line.length
             },
-            new RegExp(/paren\.keyword\.operator/)
+            new RegExp("(?:^|[.])paren(?:$|[.])", "")
          );
 
          if (openBracePos) {


### PR DESCRIPTION
### Intent

Fix https://github.com/rstudio/rstudio/issues/8165.

### Approach

The C++ outdent check tried to search for an opening bracket of type `paren.keyword.operator`; however, rainbow parentheses drop the `keyword.operator` types. In this case, we really should just look for a token with the `paren` type.

### QA Notes

Test that outdenting of C++ code works as expected, both with rainbow parentheses enabled and disabled.

Closes https://github.com/rstudio/rstudio/issues/8165.
