### PR TITLE
require restart after changing spelling language

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -88,7 +88,8 @@ public class SpellingPreferencesPane extends PreferencesPane
 
       add(blacklistWarning_);
 
-      languageWidget_.addChangeHandler((event) -> {
+      languageWidget_.addChangeHandler((event) ->
+      {
          boolean canRealtimeCheck = TypoSpellChecker.canRealtimeSpellcheckDict(languageWidget_.getSelectedLanguage());
          blacklistWarning_.setVisible(!canRealtimeCheck);
          realtimeSpellcheckingCheckbox_.setValue(realtimeSpellcheckingCheckbox_.getValue() && canRealtimeCheck);
@@ -172,11 +173,18 @@ public class SpellingPreferencesPane extends PreferencesPane
    @Override
    public RestartRequirement onApply(UserPrefs rPrefs)
    {
-      uiPrefs_.spellingDictionaryLanguage().setGlobalValue(
-                                       languageWidget_.getSelectedLanguage());
-
       RestartRequirement restart = super.onApply(rPrefs);
-      restart.setDesktopRestartRequired(restart.getDesktopRestartRequired() || customDictsWidget_.getCustomDictsModified());
+      
+      uiPrefs_.spellingDictionaryLanguage().setGlobalValue(
+            languageWidget_.getSelectedLanguage());
+
+      restart.setDesktopRestartRequired(
+            restart.getDesktopRestartRequired() ||
+            customDictsWidget_.getCustomDictsModified() ||
+            !StringUtil.equals(
+                  rPrefs.spellingDictionaryLanguage().getValue(),
+                  languageWidget_.getSelectedLanguage()));
+      
       return restart;
    }
 


### PR DESCRIPTION
### Intent

When the dictionary language is changed (particularly, if new languages are downloaded and installed), one can get into a state where the set of dictionaries available on the client are then out-of-sync with what is actually available to the session.

The simplest fix to this is to just request the user restart their session if they've changed the spellchecker language.

Fixes part of https://github.com/rstudio/rstudio/issues/7218#issuecomment-713770620.

### Approach

Request that the user restarts after changing the dictionary language.

### QA Notes

Check that you are prompted to restart after changing the dictionary language.