### PR TITLE
Hide cursor position in visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBar.java
@@ -40,6 +40,7 @@ public interface StatusBar
    StatusBarElement getPosition();
    StatusBarElement getScope();
    StatusBarElement getLanguage();
+   void setPositionVisible(boolean visible);
    void setScopeVisible(boolean visible);
    void setScopeType(int type);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/StatusBarWidget.java
@@ -132,6 +132,12 @@ public class StatusBarWidget extends Composite
       scopeIcon_.setVisible(visible);
    }
 
+   public void setPositionVisible(boolean visible)
+   {
+      position_.setClicksEnabled(visible);
+      position_.setVisible(visible);
+   }
+
    public void setScopeType(int type)
    {
       scopeType_ = type;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -1138,6 +1138,12 @@ public class VisualMode implements VisualModeEditorSync,
                
                // update status bar widget with current position
                syncStatusBarLocation();
+
+               // hide cursor position widget (doesn't update in visual mode)
+               if (target_.getStatusBar() != null)
+               {
+                  target_.getStatusBar().setPositionVisible(false);
+               }
                
                // (re)inject notebook output from the editor
                target_.getNotebook().migrateCodeModeOutput();
@@ -1194,7 +1200,13 @@ public class VisualMode implements VisualModeEditorSync,
             
             // move notebook outputs from visual mode
             target_.getNotebook().migrateVisualModeOutput();
-            
+
+            // bring the cursor position indicator back
+            if (target_.getStatusBar() != null)
+            {
+               target_.getStatusBar().setPositionVisible(true);
+            }
+
             // execute completed hook
             Scheduler.get().scheduleDeferred(completed);
          };


### PR DESCRIPTION
### Intent

Hides the cursor position when visual mode is active. Fixes https://github.com/rstudio/rstudio/issues/8174.

### Approach

Hide the cursor position widget when entering visual mode, and restore it on exit.

### QA Notes

Test switching modes as well as documents that open initially in each mode.