### PR TITLE
Visual Mode Insert Citation Fixes

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography.ts
+++ b/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography.ts
@@ -117,11 +117,11 @@ export interface BibliographySourceWithCollections extends BibliographySource {
 // when searching bibliographic sources
 const kFields: Fuse.FuseOptionKeyObject[] = [
   { name: 'id', weight: 30 },
-  { name: 'author.family', weight: 40 },
-  { name: 'author.literal', weight: 40 },
-  { name: 'author.given', weight: 10 },
-  { name: 'title', weight: 10 },
+  { name: 'author.family', weight: 15 },
+  { name: 'author.literal', weight: 15 },
   { name: 'issued', weight: 15 },
+  { name: 'title', weight: 15 },
+  { name: 'author.given', weight: 10 },
   { name: 'providerKey', weight: 0.01 },
   { name: 'collectionKeys', weight: 0.01 },
 ];


### PR DESCRIPTION
### Intent

Addresses 2 issues with insert citation. 

1) Fuzzy search weighting - we elevate the weight of the citation key and move other less important fields into a secondary bucket. This results in better search matches in most scenarios.

2) Fix a bug whereby empty brackets could be inserted into document when user doesn't select a citation and presses 'insert' in the insert citation dialog.

### Approach

Adjust weights, wrap the actual insert work of the insert citation dialog with a conditional that requires a selection.

### QA Notes

I was only able to reproduce the bug in desktop, the steps to repro are outlined in the commit message.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


