### PR TITLE
unset isSaving_ flag on save cancel

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3015,8 +3015,12 @@ public class TextEditingTarget implements
                public void execute(final FileSystemItem saveItem,
                                    ProgressIndicator indicator)
                {
+                  // null here implies the user cancelled the save
                   if (saveItem == null)
+                  {
+                     isSaving_ = false;
                      return;
+                  }
 
                   try
                   {


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8186.

### Approach

Ensures the `isSaving_` flag is set to `false` when a save is canceled.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8186.