### PR TITLE
properly convert line ending pref on read

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectEditingPreferencesPane.java
@@ -135,7 +135,7 @@ public class ProjectEditingPreferencesPane extends ProjectPreferencesPane
       numSpacesForTab_.setValue(initialConfig_.getNumSpacesForTab() + "");
       chkAutoAppendNewline_.setValue(initialConfig_.getAutoAppendNewline());
       chkStripTrailingWhitespace_.setValue(initialConfig_.getStripTrailingWhitespace());
-      lineEndings_.setIntValue(initialConfig_.getLineEndings());
+      lineEndings_.setValue(ProjectPrefs.prefFromLineEndings(initialConfig_.getLineEndings()));
       setEncoding(initialConfig_.getEncoding());
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/ProjectPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/ProjectPrefs.java
@@ -22,6 +22,25 @@ public class ProjectPrefs
    public static final int LINEENDINGS_NATIVE = 2;
    public static final int LINEENDINGS_PASSTHROUGH = 3;
    
+   public static final String prefFromLineEndings(int prefValue)
+   {
+      switch (prefValue)
+      {
+      case LINEENDINGS_DEFAULT:
+         return UserPrefs.LINE_ENDING_CONVERSION_DEFAULT;
+      case LINEENDINGS_WINDOWS:
+         return UserPrefs.LINE_ENDING_CONVERSION_WINDOWS;
+      case LINEENDINGS_POSIX:
+         return UserPrefs.LINE_ENDING_CONVERSION_POSIX;
+      case LINEENDINGS_NATIVE:
+         return UserPrefs.LINE_ENDING_CONVERSION_NATIVE;
+      case LINEENDINGS_PASSTHROUGH:
+         return UserPrefs.LINE_ENDING_CONVERSION_PASSTHROUGH;
+      default:
+         return UserPrefs.LINE_ENDING_CONVERSION_DEFAULT;
+      }
+   }
+   
    public static final int lineEndingsFromPref(String pref)
    {
       switch(pref)


### PR DESCRIPTION
### Intent

The line ending preference was not properly converted from its internal integer code to the front-end string value on load.

### Approach

Implement the (mirror) mapping for these integer values to String preference values.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8169.

Closes #8169.