### PR TITLE
default to RStudio PDF viewer on macOS

### DIFF
--- a/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsComputedLayer.cpp
@@ -76,9 +76,15 @@ Error UserPrefsComputedLayer::readPrefs()
    layer[kDefaultRVersion] = defaultRVersionJson;
 
    // Synctex viewer ----------------------------------------------------------
-
-   layer[kPdfPreviewer] =  session::options().programMode() == kSessionProgramModeDesktop ?
-      kPdfPreviewerDesktopSynctex : kPdfPreviewerRstudio;
+#ifdef __APPLE__
+# define kDefaultDesktopPdfPreviewer kPdfPreviewerRstudio
+#else
+# define kDefaultDesktopPdfPreviewer kPdfPreviewerDesktopSynctex
+#endif
+   
+   layer[kPdfPreviewer] = (session::options().programMode() == kSessionProgramModeDesktop)
+         ? kDefaultDesktopPdfPreviewer
+         : kPdfPreviewerRstudio;
 
    // Spelling ----------------------------------------------------------------
    layer["spelling"] =

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefUtils.java
@@ -1,5 +1,5 @@
 /*
- * UserPrefsUtils.java
+ * UserPrefUtils.java
  *
  * Copyright (C) 2020 by RStudio, PBC
  *


### PR DESCRIPTION
### Intent

The default PDF previewer had unintentionally been set to (No preview) with RStudio 1.4 on macOS. This was actually caused by us attempting to request a desktop synctex viewer; however, we do not bundle any such viewer on macOS.

### Approach

When computing the PDF previewer preference, choose the RStudio viewer on macOS, and the default synctex viewer otherwise.

### QA Notes

Test that, for a brand new RStudio 1.4 on macOS, that the default previewer is not set to (No preview).

Closes https://github.com/rstudio/rstudio/issues/8124.