### PR TITLE
allow Qt 5.15.x redirects

### DIFF
--- a/src/cpp/desktop/DesktopWebPage.cpp
+++ b/src/cpp/desktop/DesktopWebPage.cpp
@@ -470,6 +470,14 @@ bool WebPage::acceptNavigationRequest(const QUrl &url,
       {
          return true;
       }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+      else if (navType == NavigationTypeRedirect)
+      {
+         return
+               this->url().authority() == url.authority() ||
+               isSafeHost(host);
+      }
+#endif
       else
       {
          // when not allowing external navigation, open an external browser


### PR DESCRIPTION
### Intent

Qt 5.14 added a new type of navigation, [NavigationTypeRedirect](https://doc.qt.io/qt-5/qwebenginepage.html#NavigationType-enum), which we were disallowing in requests to `acceptNavigationRequest()`. This PR allows us to accept redirects.

In addition, prior releases of RStudio needed to work around a Qt bug in `acceptNavigationRequest()`, which basically required us to infer the navigation type in a roundabout way. That workaround is no longer required.

**NOTE**: We should consider whether we want to always allow redirects. If a host is considered "safe", do we also want to consider their redirects (even to a separate host / origin) as safe? Or is the right fix here to just disallow the `marketo` redirect altogether? Or do we whitelist `marketo` but disallow other redirects?

### Approach

Straightforward removal of old workaround + handling of new navigation type.

### QA Notes

Closes https://github.com/rstudio/rstudio/issues/8187. Test via notes in https://github.com/rstudio/rstudio/issues/8187.