### PR TITLE
handle state arrays in getState() method

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/EditSession.java
@@ -29,7 +29,34 @@ public class EditSession extends JavaScriptObject
    }-*/;
    
    public native final String getState(int row) /*-{
-      return this.getState(row);
+      
+      var state = this.getState(row);
+      
+      // handle array states -- necessary for cases where
+      // rainbow parentheses are enabled, as we may see a
+      // '#tmp' temporary state at the front of the state
+      // array.
+      if (Array.isArray(state))
+      {
+         for (var i = 0; i < state.length; i++)
+         {
+            // skip the '#tmp' state
+            if (state[i] === "#tmp")
+            {
+               continue;
+            }
+            
+            return state[i] || "start";
+         }
+         
+         // if we have an empty state array, or if that
+         // array only contains the '#tmp' state, then
+         // just return the default 'start' state
+         return "start";
+      }
+      
+      return state || "start";
+      
    }-*/;
    
    public native final String getTabString() /*-{

--- a/src/gwt/test/test-multiline-expr.R
+++ b/src/gwt/test/test-multiline-expr.R
@@ -79,7 +79,8 @@ x <- f(a = 1,
        # d = 4
 )
 
-# 12: data.table style
+# 12: data.table style (note: two separate statements)
+dt <- data.table(mtcars)
 dt[ , sequence := seq_len( nrow( dt ) )
 
     ][ , normal := rnorm( nrow( dt ) )


### PR DESCRIPTION
### Intent

For each line in the document, Ace tracks the current "state" for highlight rules. This is either a string for a single state, or an array giving the set of states that are active for that line. This is typically used for e.g. multi-line strings, where the state tells us that we are (for example) in a double-quoted multiline string, identified by the `qqstring` state.

When rainbow parentheses are activated, we see two main issues:

1. getState() returns an array rather than a string;
2. A dummy `#tmp` state is placed at the front of the state array.

### Approach

This PR handles the two above cases, by ensuring that `getState(row)` returns whatever the "primary" state is.

### QA Notes

Test manually with the test cases in https://github.com/rstudio/rstudio/blob/master/src/gwt/test/test-multiline-expr.R, and ensure each case works with rainbow parentheses enabled / disabled.

Closes https://github.com/rstudio/rstudio/issues/8156. (thanks @melissa-barca for catching that!)

