### PR TITLE
fix issue with removal of connection entry

### DIFF
--- a/src/cpp/session/modules/connections/ConnectionHistory.cpp
+++ b/src/cpp/session/modules/connections/ConnectionHistory.cpp
@@ -31,7 +31,7 @@ namespace connections {
 namespace {
 
 
-bool isConnection(const ConnectionId& id, json::Value valueJson)
+bool isConnection(const ConnectionId& id, const json::Value& valueJson)
 {
    if (!json::isType<json::Object>(valueJson))
    {


### PR DESCRIPTION
### Intent

Currently, attempting to remove a single connection from the Connections history actually removes _all_ connections from the Connections history. That seems bad. We should not do that.

### Approach

The issue appears to arise in the way we try to modify the JSON Array when removing a connection.

If I understand correctly, we were using the [erase-remove idiom](https://en.wikipedia.org/wiki/Erase%E2%80%93remove_idiom) here to remove a range of elements from the array, but this seems to not do what we expect here. A safe fix for 1.4 is to just create a brand new JSON array and add JSON elements to that, except for the connection to be removed.

### QA Notes

Follow @ronblum's excellent notes in https://github.com/rstudio/rstudio/issues/8204.

Closes https://github.com/rstudio/rstudio/issues/8204.