### PR TITLE
Do not attempt to continue logging session output dp fd writes if the read end of the pipe closes

### DIFF
--- a/src/cpp/core/system/PosixOutputCapture.cpp
+++ b/src/cpp/core/system/PosixOutputCapture.cpp
@@ -88,14 +88,12 @@ void standardStreamCaptureThread(
                 // mark that we should skip the write, and only log this error once
                 *pSkipWrite = true;
 
-                Error error = systemError(errno, ERROR_LOCATION);
                 std::string cause = errno == EBADF ? " closed" : "'s pipe read end closed";
                 std::string description =
                       descriptorType + " descriptor " + core::safe_convert::numberToString(dupFd) +
                       cause + ". Output will no longer be redirected.";
-                error.addProperty("description", description);
 
-                LOG_ERROR(systemError(errno, ERROR_LOCATION));
+                LOG_ERROR(systemError(errno, description, ERROR_LOCATION));
              }
              else if (errno != EAGAIN && errno != EINTR)
                 LOG_ERROR(systemError(errno, ERROR_LOCATION));

--- a/src/cpp/core/system/PosixOutputCapture.cpp
+++ b/src/cpp/core/system/PosixOutputCapture.cpp
@@ -23,6 +23,7 @@
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
+#include <shared_core/SafeConvert.hpp>
 #include <core/BoostThread.hpp>
 #include <core/BoostErrors.hpp>
 
@@ -71,21 +72,48 @@ void standardStreamCaptureThread(
    auto wrapHandler =
     [=](const boost::function<void(const std::string&)>& handler,
         int dupFd,
+        const std::string& descriptorType,
+        boost::shared_ptr<bool> pSkipWrite,
         const std::string& output)
     {
        handler(output);
-       if (::write(dupFd, output.c_str(), output.size()) == -1)
+
+       if (!*pSkipWrite)
        {
-          if (errno != EAGAIN && errno != EINTR)
-             LOG_ERROR(systemError(errno, ERROR_LOCATION));
+          if (::write(dupFd, output.c_str(), output.size()) == -1)
+          {
+             if (errno == EPIPE || errno == EBADF)
+             {
+                // the std stream was closed somehow, meaning this write call will never succeed again
+                // mark that we should skip the write, and only log this error once
+                *pSkipWrite = true;
+
+                Error error = systemError(errno, ERROR_LOCATION);
+                std::string cause = errno == EBADF ? " closed" : "'s pipe read end closed";
+                std::string description =
+                      descriptorType + " descriptor " + core::safe_convert::numberToString(dupFd) +
+                      cause + ". Output will no longer be redirected.";
+                error.addProperty("description", description);
+
+                LOG_ERROR(systemError(errno, ERROR_LOCATION));
+             }
+             else if (errno != EAGAIN && errno != EINTR)
+                LOG_ERROR(systemError(errno, ERROR_LOCATION));
+          }
        }
     };
 
    if (dupStdoutFd != -1)
-      outHandler = boost::bind<void>(wrapHandler, stdoutHandler, dupStdoutFd, _1);
+   {
+      boost::shared_ptr<bool> pSkipStdoutWrite = boost::make_shared<bool>(false);
+      outHandler = boost::bind<void>(wrapHandler, stdoutHandler, dupStdoutFd, "Stdout", pSkipStdoutWrite, _1);
+   }
 
    if (dupStderrFd != -1)
-      errHandler = boost::bind<void>(wrapHandler, stderrHandler, dupStderrFd, _1);
+   {
+      boost::shared_ptr<bool> pSkipStderrWrite = boost::make_shared<bool>(false);
+      errHandler = boost::bind<void>(wrapHandler, stderrHandler, dupStderrFd, "Stderr", pSkipStderrWrite, _1);
+   }
 
    try
    {


### PR DESCRIPTION




### Intent

Whenever the read end of the dup fd pipe closes, we continuously try to write to the pipe, but it will never succeed again. We should stop attempting to write in this case, and only log an error once.

It is currently unknown how this situation can occur, but it is happening for a user of Slurm sessions: see Zendesk ticket _53571_.

### Approach

If a pipe error (or FD is closed), stop trying to write to it. Only log the error once and explain that output will no longer be redirected.

Fixes #8082

### QA Notes

We are unable to reproduce this as of yet. We should ask the customer in the Zendesk ticket to verify the fix.


