### PR TITLE
Add null check to prevent overwriting file with 'NULL'

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -446,7 +446,7 @@
 {
    # if 'name' is missing, we're likely being invoked by
    # 'utils::file.edit()', so just edit the requested file
-   if (missing(name))
+   if (missing(name) || is.null(name))
       return(.Call("rs_editFile", file, PACKAGE = "(embedding)"))
    
    # otherwise, we're more likely being invoked by 'edit()', which


### PR DESCRIPTION
### Intent

Fixed #8209 

Fix the `edit` call so it doesn't overwrite files when writing to a file on Windows.

### Approach

We need to recognize the user is requesting to edit a file by the name being missing **or** null. Previously, we were only checking if name was missing and interpreting NULL as a string to write to the file.

### QA Notes

See original ticket. 

