### PR TITLE
update format list after loading visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1920,13 +1920,6 @@ public class TextEditingTarget implements
          docDisplay_.addOrUpdateBreakpoint(breakpoint);
       }
       
-      if (extendedType_.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
-      {
-         // populate the popup menu with a list of available formats
-         updateRmdFormatList();
-         setRMarkdownBehaviorEnabled(true);
-      }
-
       view_.addRmdFormatChangedHandler(new RmdOutputFormatChangedEvent.Handler()
       {
          @Override
@@ -1977,6 +1970,13 @@ public class TextEditingTarget implements
          events_,
          releaseOnDismiss_
       );
+
+      // populate the popup menu with a list of available formats
+      if (extendedType_.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX))
+      {
+         updateRmdFormatList();
+         setRMarkdownBehaviorEnabled(true);
+      }
 
       // provide find replace button to view
       view_.addVisualModeFindReplaceButton(visualMode_.getFindReplaceButton());


### PR DESCRIPTION
### Intent

Normally, when the editing toolbar is initialized, changes are sequenced roughly as:

- manage UI elements
- do Shiny-specific things

When the `visualMode_` object is initialized, it also calls performs the 'manage UI elements' step, so we effectively have:

- manage UI elements
- do Shiny-specific things
- manage UI elements

and that extraneous attempt to manage UI elements stomps on the Shiny-specific actions we had taken.

### Approach

Re-arrange initialization so that visual mode is initialized before we update the R Markdown format list.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8213. It may also be worth verifying that other R Markdown runtimes (e.g. from https://rmarkdown.rstudio.com/authoring_shiny_prerendered.html; `runtime: shiny_prerendered`) are handled properly.

Closes https://github.com/rstudio/rstudio/issues/8213.