### PR TITLE
With Qt 5.15 ensure that closing Plumber or Shiny window stops the task in Console

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/plumber/PlumberAPIPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/plumber/PlumberAPIPresenter.java
@@ -58,6 +58,8 @@ public class PlumberAPIPresenter implements
       
       binder.bind(commands, this);  
       
+      satellite_.addCloseHandler(event -> onClose());
+
       initializeEvents();
    }     
 

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplicationPresenter.java
@@ -77,6 +77,8 @@ public class ShinyApplicationPresenter implements
          }
       };
 
+      satellite_.addCloseHandler(event -> onClose());
+
       binder.bind(commands, this);  
       
       initializeEvents();


### PR DESCRIPTION
### Intent

- When running a Plumber API or Shiny App in the IDE, with the results displayed in a window, closing that window should also stop the task in the Console
- Fixes #8176

### Approach

- The "unload" event isn't being fired with Qt 5.15.1, preventing notification being sent to the main window
- Fix by adding a close handler to fire the same code for both Plumber APIs and Shiny Applications

### QA Notes

- Test scenarios described in issue for macOS using Qt 5.15, plus also re-validate same scenario when run via RStudio Server, and on desktop platforms still using Qt 5.12


