### PR TITLE
pull over small script tweaks from Qt 5.15 work

### DIFF
--- a/dependencies/osx/install-qt-macos
+++ b/dependencies/osx/install-qt-macos
@@ -36,6 +36,16 @@ fi
 if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]
 then
    command -v 7z >/dev/null 2>&1 || { echo >&2 "7z command required to install Qt but not found (brew install p7zip)."; exit 1; }
+   echo ----------------------------------------------------------------------
+   echo "                            *** Important ***"
+   echo ----------------------------------------------------------------------
+   echo " The minimal Qt installer should only be used on a build machine. For"
+   echo " a developer machine use the Qt online installer from qt.io or"
+   echo " MaintenanceTool.app from existing Qt folder to install $QT_VERSION."
+   echo ----------------------------------------------------------------------
+   echo " Pausing for 15 seconds... (Ctrl+C to interrupt)"
+   echo ----------------------------------------------------------------------
+   sleep 15
    echo "Installing minimal Qt $QT_VERSION SDK"
    ../common/install-qt.sh --version $QT_VERSION --directory ${QT_SDK_DIR} \
       qtbase \


### PR DESCRIPTION
### Intent

Pull over some generic improvements from the aborted Qt 5.15 branch. These are minor dependency installation script tweaks.

### Approach

- update install-qt.sh with latest from Qt (https://code.qt.io/cgit/qbs/qbs.git/tree/scripts/install-qt.sh); nothing new specific to our current usage but might as well update it so it's one less thing to worry about if we end up having to update Qt for some other reason
- install-qt-macos displays warning that the scripted Qt installer is only intended for build machines, not dev machines

### QA Notes

Nothing to test; purely dev-box/build-box impacting (and very minor at that).


