### PR TITLE
handle UTF-8 paths when opening projects via API

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -985,7 +985,7 @@ Error readProjectFile(const FilePath& projectFilePath,
 Error writeProjectFile(const FilePath& projectFilePath,
                        const RProjectBuildDefaults& buildDefaults,
                        const RProjectConfig& config)
-{  
+{
    // build version field if necessary
    std::string rVersion;
    if (!config.rVersion.isDefault())

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -69,10 +69,16 @@
    # characters not representable in the current locale, so we instead
    # change to the requested directory, list files, and then build the
    # full paths
-   owd <- setwd(path)
-   rProjFiles <- list.files(pattern = "[.]Rproj$")
-   rProjFiles <- normalizePath(rProjFiles, winslash = "/", mustWork = TRUE)
-   setwd(owd)
+   rProjFiles <- (function() {
+      
+      # move to project path
+      owd <- setwd(path)
+      on.exit(setwd(owd), add = TRUE)
+      
+      # list files in path
+      file.path(path, list.files(pattern = "[.]Rproj$"))
+
+   })()
    
    # if we already have a .Rproj file, just return that
    if (length(rProjFiles))

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -65,11 +65,14 @@
    # attempt to initialize a project within that directory
    .rs.ensureDirectory(path)
    
-   # check to see if a .Rproj file already exists in that directory;
-   # if so, then we don't need to re-initialize
-   rProjFiles <- list.files(path, 
-                            pattern = "[.]Rproj$",
-                            full.names = TRUE)
+   # NOTE: list.files() will fail on Windows for paths containing
+   # characters not representable in the current locale, so we instead
+   # change to the requested directory, list files, and then build the
+   # full paths
+   owd <- setwd(path)
+   rProjFiles <- list.files(pattern = "[.]Rproj$")
+   rProjFiles <- normalizePath(rProjFiles, winslash = "/", mustWork = TRUE)
+   setwd(owd)
    
    # if we already have a .Rproj file, just return that
    if (length(rProjFiles))

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -961,18 +961,20 @@ void startup(const std::string& firstProjectPath)
 
 SEXP rs_writeProjectFile(SEXP projectFilePathSEXP)
 {
-   std::string absolutePath = r::sexp::asString(projectFilePathSEXP);
+   std::string absolutePath = r::sexp::asUtf8String(projectFilePathSEXP);
    FilePath projectFilePath(absolutePath);
    
    Error error = r_util::writeProjectFile(
             projectFilePath,
             ProjectContext::buildDefaults(),
             ProjectContext::defaultConfig());
-   
+
+   if (error)
+      r::exec::warning(error.asString());
+
+   bool succeeded = error == Success();
    r::sexp::Protect protect;
-   return error ?
-            r::sexp::create(false, &protect) :
-            r::sexp::create(true, &protect);
+   return r::sexp::create(succeeded, &protect);
 }
 
 SEXP rs_addFirstRunDoc(SEXP projectFileAbsolutePathSEXP, SEXP docRelativePathsSEXP)
@@ -995,7 +997,7 @@ SEXP rs_addFirstRunDoc(SEXP projectFileAbsolutePathSEXP, SEXP docRelativePathsSE
 
 SEXP rs_requestOpenProject(SEXP projectFileSEXP, SEXP newSessionSEXP)
 {
-   std::string projectFile = r::sexp::asString(projectFileSEXP);
+   std::string projectFile = r::sexp::asUtf8String(projectFileSEXP);
    bool newSession = r::sexp::asLogical(newSessionSEXP);
    
    // opening projects in a new session is only supported in desktop, RSP


### PR DESCRIPTION
### Intent

When creating projects, users might specify paths using characters not representable in the current locale. To properly handle such paths, we need to ensure the paths are UTF-8 encoded.

### Approach

Mostly straightforward `asString()` -> `asUtf8String()`, as well as a workaround for the behavior of `list.files()` with UTF-8 paths.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8225 and https://github.com/r-lib/usethis/issues/1231.

Closes https://github.com/rstudio/rstudio/issues/8225.