### PR TITLE
fixups for C++ autoindent tests

### DIFF
--- a/src/gwt/test/autoindent_test_cpp.html
+++ b/src/gwt/test/autoindent_test_cpp.html
@@ -14,7 +14,6 @@
   <script type="text/javascript" src="../acesupport/acemode/r_matching_brace_outdent.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/r_scope_tree.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/r_code_model.js"></script>
-  <script type="text/javascript" src="../acesupport/acemode/background_highlighter.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/cpp_scope_tree.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/cpp_code_model.js"></script>
   <script type="text/javascript" src="../acesupport/acemode/c_cpp_fold_mode.js"></script>
@@ -117,7 +116,7 @@ template &lt;
     inline void foo() { return foo_; }
 </pre></li>
 
-<li><pre data-expected="8">
+<li><pre data-expected="8" open-brace-skip>
 void SomeFunction(
 </pre></li>
 
@@ -194,12 +193,12 @@ int foo
 struct bar{};
 </pre></li>
 
-<li><pre data-expected="2" open-brace-skip="true">
+<li><pre data-expected="2" open-brace-skip>
 class foo :
   A,
 </pre></li>
 
-<li><pre data-expected="4" data-expected-vertical-args="12" open-brace-skip="true">
+<li><pre data-expected="4" data-expected-vertical-args="12" open-brace-skip>
 class foo : A,
 </pre></li>
 
@@ -500,7 +499,7 @@ Foo(int a, int b):
     {
 </pre></li>
 
-<li><pre data-expected="4" data-expected-vertical-args="13">
+<li><pre data-expected="4" data-expected-vertical-args="13" open-brace-skip>
 std::find_if(x.begin(),
 </pre></li>
 
@@ -643,7 +642,7 @@ else {
 Param::Param(const std::string& paramText)
 </pre></li>
 
-<li><pre data-expected="8" data-expected-open-brace="4">
+<li><pre data-expected="4" data-expected-open-brace="4">
 class Foo {
 public:
     int foo(int a,
@@ -758,7 +757,6 @@ function doIndentTest(el, state) {
   );
 
   // Insert text + a newline (the editor will auto-insert after the newline)
-
   testEditor.insert((el.innerText || el.textContext).trimRight());
   testEditor.insert("\n");
 
@@ -774,38 +772,38 @@ function doIndentTest(el, state) {
   var symbol = state === "open-brace" ? "{" : "|";
 
   el.appendChild(document.createTextNode(indent + symbol));
-  var attrName = "data-expected"; 
-  if (state.length > 0 && 
-      el.getAttribute(attrName + "-" + state)) 
-  {
-    attrName += ("-" + state);
-  }
 
-  var skip = el.getAttribute(state + "-skip") !== null;
+  var attrName = "data-expected";
+  var override = "data-expected-" + state;
+  if (el.hasAttribute(override))
+    attrName = override;
+
+  var skipState = state + "-skip";
+  var skip = el.getAttribute(skipState) !== null;
   if (skip) {
     el.style.backgroundColor = "#DDD";
     return true;
-  } else {
+  }
     
-    var expected = el.getAttribute(attrName);
-    if (expected == indent.length + "")
-    {
-      el.style.backgroundColor = '#BFB';
-      return true;
-    }
-    else
-    {
-      el.style.backgroundColor = 'pink';
-      return false;
-    }
-
+  var expected = el.getAttribute(attrName);
+  if (expected == indent.length + "")
+  {
+    el.style.backgroundColor = '#BFB';
+    el.parentElement.appendChild(document.createTextNode("[PASS]"));
+    return true;
+  }
+  else
+  {
+    el.style.backgroundColor = 'pink';
+    el.parentElement.appendChild(document.createTextNode("[FAIL]"));
+    return false;
   }
 }
 
 var test = document.getElementById("runme");
 var container = document.getElementById("testcontainer");
 var passed = 0, failed = 0;
-var states = [ "", "vertical-args" , "open-brace"];
+var states = ["regular-indent", "vertical-args" , "open-brace"];
 for (var i = 0; i < states.length; i++) 
 {
 
@@ -816,10 +814,7 @@ for (var i = 0; i < states.length; i++)
   // Clone the tests for the new state
   var testnode = container.cloneNode(true);
   var header = document.createElement("h2");
-  header.innerText = "Test " + (i + 1) + (
-    states[i].length > 0 ? 
-                                          ": " + states[i] : 
-                                          "");
+  header.innerText = "Test " + (i + 1) + ": " + states[i];
   container.parentNode.appendChild(header);
   container.parentNode.appendChild(testnode);
   testnode.style.display = "block";


### PR DESCRIPTION
### Intent

Shake the dust off of the C++ auto-indent tests.

### Approach

- Don't try to include the now-removed `background_highlighter.js` (background highlighting is done in https://github.com/rstudio/rstudio/blob/bugfix/c++-autoindent-tests/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java, and is not relevant for these tests)

- Skip a couple more tests that aren't relevant for the open brace indentation tests.

- Make it easier to find failed tests by appending `[FAIL]` to broken tests (so once can then just search for `[FAIL]` in the document)

### QA Notes

Nothing for QA to test; this is mainly to ensure the C++ autoindent test suite runs without errors.

Closes https://github.com/rstudio/rstudio/issues/8229.