### PR TITLE
always enable save commands for new source docs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -982,7 +982,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
                   // toggle save commands after the editor has been opened,
                   // in case this action has created and focused a new editor
-                  if (activeEditor_ != null)
+                  if (SourceColumn.this == manager_.getActive())
                   {
                      target.forceSaveCommandActive();
                      manageSaveCommands(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -965,7 +965,6 @@ public class SourceColumn implements BeforeShowEvent.Handler,
                       final ResultCallback<EditingTarget, ServerError> resultCallback)
    {
       ensureVisible(false);
-      boolean active = activeEditor_ != null;
       server_.newDocument(
             fileType.getTypeId(),
             contents,
@@ -979,13 +978,14 @@ public class SourceColumn implements BeforeShowEvent.Handler,
                   // apply (dynamic) doc property defaults
                   SourceColumn.applyDocPropertyDefaults(newDoc, true, userPrefs_);
 
-                  EditingTarget target =
-                     addTab(newDoc, Source.OPEN_INTERACTIVE);
+                  EditingTarget target = addTab(newDoc, Source.OPEN_INTERACTIVE);
 
-                  if (contents != null)
+                  // toggle save commands after the editor has been opened,
+                  // in case this action has created and focused a new editor
+                  if (activeEditor_ != null)
                   {
                      target.forceSaveCommandActive();
-                     manageSaveCommands(active);
+                     manageSaveCommands(true);
                   }
 
                   if (resultCallback != null)


### PR DESCRIPTION
### Intent

Ensure that newly-opened R Markdown documents can be saved.

### Approach

The `newDoc()` function tried to enable / disable the Save command depending on whether the IDE already had an active editor. However, creation of a new document (usually) implies that a new editor will be created and become active, so we should check that state only after the document has been created.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8228.

Closes https://github.com/rstudio/rstudio/issues/8228.