### PR TITLE
move Focus Terminal keyboard shortcut reference under Terminal group

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -724,7 +724,6 @@ well as menu structures (for main menu and popup menus).
 
          <shortcut refid="activateSource" value="Ctrl+1"/>
          <shortcut refid="activateConsole" value="Ctrl+2"/>
-         <shortcut refid="activateTerminal" value="Alt+Shift+M"/>
          <shortcut refid="activateHelp" value="Ctrl+3"/>
          <shortcut refid="activateHistory" value="Ctrl+4"/>
          <shortcut refid="activateFiles" value="Ctrl+5"/>
@@ -871,6 +870,7 @@ well as menu structures (for main menu and popup menus).
       </shortcutgroup>
       <shortcutgroup name="Terminal">
          <shortcut refid="newTerminal" value="Alt+Shift+R"/>
+         <shortcut refid="activateTerminal" value="Alt+Shift+M"/>
          <shortcut refid="previousTerminal" value="Shift+Alt+F11"/>
          <shortcut refid="nextTerminal" value="Shift+Alt+F12"/>
       </shortcutgroup>


### PR DESCRIPTION
### Intent

- Fixes #8230
- Make it easier to find the "Move Focus to Terminal" keyboard shortcut in the popup keyboard shortcut reference

### Approach

- Moved it to display under the Terminal group instead of the much larger "Panes" group; this is consistent with the location in the static `keyboard.htm` file

### QA Notes

Verify that the item has moved as described via Tools / Keyboard Shortcuts Help. Be sure screen-reader mode is OFF or you don't see this pane but instead the screen-reader friendly keyboard.htm.
