### PR TITLE
Check saved cache for notebook output

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookOutput.cpp
@@ -293,8 +293,26 @@ Error handleChunkOutputRequest(const http::Request& request,
 
    if (!target.exists())
    {
-      pResponse->setNotFoundError(request);
-      return Success();
+      // if this path refers to a file in an unsaved cache, it's possible that it does not exist
+      // because the document has now been saved, and the file was consequently moved to the saved
+      // context. we are likely seeing this request because the front end has a stale reference to
+      // the file in its previous unsaved location (see issue 8227).
+      if (ctxId != kSavedCtx)
+      {
+         FilePath savedTarget = chunkCacheFolder(path, docId, kSavedCtx).completePath(
+            algorithm::join(parts, "/"));
+         if (savedTarget.exists())
+         {
+            target = savedTarget;
+         }
+      }
+
+      // if we're still unable to find a viable copy of the file, fail the request
+      if (!target.exists())
+      {
+         pResponse->setNotFoundError(request);
+         return Success();
+      }
    }
 
    bool isHtml = target.hasExtensionLowerCase(".htm") ||


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/8227, an issue in which newly created HTML widgets in R Notebooks break when switching from source to visual mode.

This problem arises from the fact that R Notebooks have separated "saved" and "unsaved" notebook caches (which is necessary so that any changes you make can discarded if you choose not to save). Switching into visual mode triggers a save as a side effect, which moves HTML widgets from the unsaved cache to the saved cache. The URL of the iframe, however, still refers to the unsaved cache.

### Approach

This is the simplest fix I could find for the problem; the idea is that when an HTTP request arrives for a resource in the unsaved cache, we first check to see if it's in the saved cache before giving up. If it is, we serve it from the saved cache. This allows the client's stale URLs to continue to work. There is little risk of serving stale content since document, context, and chunk IDs ensure uniqueness. 

If we weren't close to shipping 1.4 we might undertake a more ambitious fix such as forming these URLs in a cache-agnostic way, or attempting to refresh the URLs on the client when the notebook is saved.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8227.


