### PR TITLE
Activate the active source column with activateSource()

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1350,7 +1350,7 @@ public class Source implements InsertSourceHandler,
    @Handler
    public void onActivateSource()
    {
-      onActivateSource(SourceColumnManager.MAIN_SOURCE_NAME, null);
+      onActivateSource(columnManager_.getActive().getName(), null);
    }
 
    public void onActivateSource(String columnName, final Command afterActivation)


### PR DESCRIPTION
### Intent

Fixes #8235 
Fixes #8236 

When we call `activateSource` it should activate the active source column instead of defaulting to the main source pane. This is called when we exit a modal and need to reactivate a source element, run the commands `switchToTab`, `switchFocusSourceConsole`, and `activateSource`, and when an API call is received to open a new document with code. 

### Approach

Retrieve the active column from the `SourceColumnManager` on activation instead of defaulting to the main source pane. 

### QA Notes

We should test that the active source column remains the same when the events above happen.

Exit a modal
- Follow repro steps in #8235 

Run `switchToTab`
- Open several documents in a column. Navigate to the View Menu and select "Switch to Tab", then select a tab. 

Run `switchFocusSourceConsole`
- Navigate to Global Options >> Code >> Keybindings and select Emacs. Focus a source column and press `Ctrl + X Ctrl + O`, to run the command which should switch focus to the Console. When pressed a second time focus should move to the original column. 

Run `activateSource`
- See repro in #8236 

Open New Document with API 
- Run the following in the console:
` > rstudioapi::documentNew("hello", type = "r")`
