### PR TITLE
fix by-hand construction of 'console_input' RPC

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -20,6 +20,7 @@
 
 #include <boost/function.hpp>
 
+#include <shared_core/json/Json.hpp>
 #include <shared_core/FilePath.hpp>
 
 #include <core/r_util/RSessionContext.hpp>
@@ -127,16 +128,8 @@ struct RConsoleInput
    }
    
    explicit RConsoleInput(const std::string& text,
-                          const std::string& console)
-      : text(text),
-        console(console),
-        flags(0)
-   {
-   }
-   
-   explicit RConsoleInput(const std::string& text,
-                          const std::string& console,
-                          int flags)
+                          const std::string& console = "",
+                          int flags = 0)
       : text(text),
         console(console),
         flags(flags)
@@ -151,6 +144,16 @@ struct RConsoleInput
    bool isEof()
    {
       return (flags & kConsoleInputEof) != 0;
+   }
+   
+   // typically used for hand-constructed RPC requests
+   core::json::Array toJsonArray()
+   {
+      core::json::Array jsonArray;
+      jsonArray.push_back(text);
+      jsonArray.push_back(console);
+      jsonArray.push_back(flags);
+      return jsonArray;
    }
    
    std::string text;

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2025,10 +2025,10 @@ void enqueFileChangedEvents(const core::FilePath& vcsStatusRoot,
 
 Error enqueueConsoleInput(const std::string& consoleInput)
 {
+   using namespace r::session;
+   
    // construct our JSON RPC
-   json::Array jsonParams;
-   jsonParams.push_back(consoleInput);
-   jsonParams.push_back("");
+   json::Array jsonParams = RConsoleInput(consoleInput).toJsonArray();
    
    json::Object jsonRpc;
    jsonRpc["method"] = "console_input";
@@ -2817,26 +2817,21 @@ Error adaptToLanguage(const std::string& language)
          conn.disconnect();
       });
       
-      if (activeLanguage == "R")
+      Error error;
+
+      if (activeLanguage == "R" && language == "Python")
       {
-         if (language == "Python")
-         {
-            // r -> python: activate the reticulate REPL
-            Error error =
-                  module_context::enqueueConsoleInput("reticulate::repl_python()");
-            if (error)
-               LOG_ERROR(error);
-         }
+         // r -> python: activate the reticulate REPL
+         error = module_context::enqueueConsoleInput("reticulate::repl_python()");
       }
-      else if (activeLanguage == "Python")
+      else if (activeLanguage == "Python" && language == "R")
       {
-         if (language == "R")
-         {
-            // python -> r: deactivate the reticulate REPL
-            Error error =
-                  module_context::enqueueConsoleInput("quit");
-         }
+         // python -> r: deactivate the reticulate REPL
+         error = module_context::enqueueConsoleInput("quit");
       }
+
+      if (error)
+         LOG_ERROR(error);
    }
    
    return Success();

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -35,6 +35,7 @@
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
 #include <r/RSexp.hpp>
+#include <r/session/RSession.hpp>
 
 #include <core/Exec.hpp>
 #include <core/Thread.hpp>
@@ -320,13 +321,15 @@ private:
       return Success();
    }
 
-   void sendConsoleInput(const std::string& chunkId, const json::Value& input)
+   void sendConsoleInput(const std::string& chunkId, const json::Value& jsonInput)
    {
-      json::Array arr;
-      ExecRange range(0, 0);
-      arr.push_back(input);
-      arr.push_back(chunkId);
-      arr.push_back(0); // console input type (not cancel/eof)
+      using namespace r::session;
+      
+      std::string input = jsonInput.isString()
+            ? jsonInput.getString()
+            : std::string();
+      
+      json::Array arr = RConsoleInput(input, chunkId).toJsonArray();
 
       // formulate request body
       json::Object rpc;


### PR DESCRIPTION
### Intent

A previous PR (https://github.com/rstudio/rstudio/pull/8089/files) refactored the way console input RPCs are constructed; notably adding a "flag" argument to the JSON array. Unfortunately, there are a couple cases where we construct console input RPCs by hand, and those usages were not including the new flag, causing those requests to fail.

### Approach

Ensure that the `console_input` RPCs constructed "by hand" include the flag. Make that code part of the `RConsoleInput` object so it's easier to re-use.

### QA Notes

Test that, when executing code in R scripts and Python scripts, the console automagically adapts to the appropriate language.

Closes https://github.com/rstudio/rstudio/issues/8243.