### PR TITLE
update save commands on window focus

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -219,7 +219,12 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
 
    public void setEnabled(boolean enabled)
    {
-      if (enabled != enabled_)
+      setEnabled(enabled, false);
+   }
+   
+   public void setEnabled(boolean enabled, boolean force)
+   {
+      if (force || enabled != enabled_)
       {
          enabled_ = enabled;
          handlers_.fireEvent(new EnabledChangedEvent(this));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceAppCommand.java
@@ -177,15 +177,25 @@ public class SourceAppCommand
 
    public void setEnabled(boolean enabled)
    {
-      setEnabled(true, enabled, enabled);
+      setEnabled(true, enabled, enabled, false);
+   }
+   
+   public void setEnabled(boolean setCommand,
+                          boolean commandEnabled,
+                          boolean buttonEnabled)
+   {
+      setEnabled(setCommand, commandEnabled, buttonEnabled, false);
    }
 
-   public void setEnabled(boolean setCommand, boolean commandEnabled, boolean buttonEnabled)
+   public void setEnabled(boolean setCommand,
+                          boolean commandEnabled,
+                          boolean buttonEnabled,
+                          boolean force)
    {
       buttonEnabled_ = buttonEnabled;
       if (setCommand)
-         command_.setEnabled(commandEnabled);
-      handlers_.fireEvent((new EnabledChangedEvent(command_, column_, buttonEnabled)));
+         command_.setEnabled(commandEnabled, force);
+      handlers_.fireEvent(new EnabledChangedEvent(command_, column_, buttonEnabled));
    }
 
    private ToolbarButton createToolbarButton(boolean synced)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.workbench.views.source;
 
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.user.client.Command;
@@ -24,10 +26,12 @@ import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
+import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
@@ -35,6 +39,7 @@ import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.theme.DocTabSelectionEvent;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.EditableFileType;
@@ -120,11 +125,10 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       display_.addTabClosedHandler(this);
       display_.addTabReorderHandler(this);
 
-      // these handlers cannot be added earlier because they rely on manager_
       events_.addHandler(FileTypeChangedEvent.TYPE, event -> manageCommands(false));
-      boolean active = this == manager_.getActive();
-      events_.addHandler(SourceOnSaveChangedEvent.TYPE, event -> manageSaveCommands(active));
-      events_.addHandler(SynctexStatusChangedEvent.TYPE, event -> manageSaveCommands(active));
+      events_.addHandler(SourceOnSaveChangedEvent.TYPE, event -> manageSaveCommands(isActive()));
+      events_.addHandler(SynctexStatusChangedEvent.TYPE, event -> manageSaveCommands(isActive()));
+      
       initialized_ = true;
    }
 
@@ -814,8 +818,21 @@ public class SourceColumn implements BeforeShowEvent.Handler,
    {
       boolean saveEnabled = getNextActiveEditor() != null &&
                             getNextActiveEditor().isSaveCommandActive();
-      getSourceCommand(commands_.saveSourceDoc())
-         .setEnabled(active, active && saveEnabled, saveEnabled);
+      
+      AppCommand[] saveCommands = new AppCommand[] {
+            commands_.saveSourceDoc(),
+            commands_.saveSourceDocAs()
+      };
+      
+      for (AppCommand command : saveCommands)
+      {
+         SourceAppCommand appCommand = getSourceCommand(command);
+         appCommand.setEnabled(
+               active,
+               active && saveEnabled,
+               saveEnabled,
+               true);
+      }
    }
 
    private void manageRSConnectCommands(boolean active)
@@ -982,7 +999,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
 
                   // toggle save commands after the editor has been opened,
                   // in case this action has created and focused a new editor
-                  if (SourceColumn.this == manager_.getActive())
+                  if (isActive())
                   {
                      target.forceSaveCommandActive();
                      manageSaveCommands(true);
@@ -1221,6 +1238,11 @@ public class SourceColumn implements BeforeShowEvent.Handler,
          manager_.clearSourceNavigationHistory();
          events_.fireEvent(new LastSourceDocClosedEvent(name_));
       }
+   }
+   
+   private boolean isActive()
+   {
+	   return manager_.getActive() == this;
    }
 
    private Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -824,6 +824,24 @@ public class SourceColumn implements BeforeShowEvent.Handler,
             commands_.saveSourceDocAs()
       };
       
+      // NOTE: The save commands themselves are global, but multiple
+      // different SourceColumns may want to manage the state of those
+      // commands. The general idea here is that:
+      //
+      //    1. Only the active source column should be able to toggle the
+      //       Save command's enabled-ness itself;
+      //
+      //    2. Other source columns should be able to enabled / disable
+      //       their save buttons regardless, since the associated Save
+      //       command would become "active" immediately after click.
+      //
+      // In addition, as per https://github.com/rstudio/rstudio/issues/6475,
+      // in some cases the client-side + desktop-side state for these commands
+      // can get out-of-sync in some cases (notably, when popping out windows).
+      //
+      // We did not have time to explore the underlying issue in time for the
+      // 1.4 release, so the safer fix here was to just set 'force = true' to
+      // ensure that save command state is synchronized with desktop.
       for (AppCommand command : saveCommands)
       {
          SourceAppCommand appCommand = getSourceCommand(command);
@@ -831,7 +849,7 @@ public class SourceColumn implements BeforeShowEvent.Handler,
                active,
                active && saveEnabled,
                saveEnabled,
-               true);
+               Desktop.isDesktop());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -18,7 +18,10 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
 import com.google.gwt.json.client.JSONString;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.user.client.Command;
@@ -32,6 +35,7 @@ import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
@@ -203,6 +207,18 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
       events_.addHandler(SourceExtendedTypeDetectedEvent.TYPE, this);
       events_.addHandler(DebugModeChangedEvent.TYPE, this);
+
+      WindowEx.addFocusHandler(new FocusHandler()
+      {
+         @Override
+         public void onFocus(FocusEvent event)
+         {
+            Scheduler.get().scheduleDeferred(() ->
+            {
+               getActive().manageSaveCommands(true);
+            });
+         }
+      });
 
       events_.addHandler(EditingTargetSelectedEvent.TYPE,
          new EditingTargetSelectedEvent.Handler()


### PR DESCRIPTION
### Intent

When focus is transferred between different source windows, the state for certain commands is not always updated. This PR ensures that save commands are enabled / disabled as appropriate when an RStudio window gains focus.

### Approach

Use a Window focus handler to update save commands as appropriate.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6475.

Closes https://github.com/rstudio/rstudio/issues/6475.