### PR TITLE
Fix issues with global replace on long lines

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -65,7 +65,7 @@ namespace {
 // This must be the same as MAX_COUNT in FindOutputPane.java
 const size_t MAX_COUNT = 1000;
 
-const size_t MAX_LINE_LENGTH = 1000;
+const size_t MAX_LINE_LENGTH = 3000;
 
 // Reflects the estimated current progress made in performing a replace
 class LocalProgress : public boost::noncopyable
@@ -1028,7 +1028,7 @@ private:
                                   &replaceMatchOn, &replaceMatchOff,
                                   &errorMessage);
                   lineInfo.decodedPreview = lineInfo.decodedContents;
-                  adjustForPreview(&lineInfo.decodedPreview, &matchOn, &matchOff);
+                  adjustForPreview(&lineInfo.decodedPreview, &replaceMatchOn, &replaceMatchOff);
                }
             }
 


### PR DESCRIPTION
### Intent & Approach

Closes #7736 

We received a request to increase the length of lines we'll perform a replace on so I've increased it from 1000 to 3000. While increasing this I realized an issue affecting how the replaced word gets highlighted in the IDE so this includes that fix as well. 

### QA Notes

Perform a global search and replace on a line between 1000 and 3000 characters. 


