### PR TITLE
Handle multibyte characters in long global replace previews

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -517,7 +517,13 @@ private:
       {
          if (firstMatchOn > maxPreviewLength)
          {
-            *contents = contents->erase(0, firstMatchOn - 30);
+            std::string::iterator pos = contents->begin();
+            Error error = string_utils::utf8Advance(contents->begin(),
+                                                    firstMatchOn - 30,
+                                                    contents->end(),
+                                                    &pos);
+
+            contents->assign(&*pos);
             contents->insert(0, "...");
             int leadingCharactersErased = gsl::narrow_cast<int>(firstMatchOn - 33);
             json::Array newMatchOnArray;


### PR DESCRIPTION
### Intent

When determining which characters to highlight in the Find in Files pane we need to account for multibyte characters. 

### Approach

When adjusting the output of long strings we determine which characters to remove from the front based on the utf8 character values rather than bytes. 

### QA Notes

This issue only happens with search and replaces performed on lines with over 3000 characters that include a multibyte utf8 character e.g. Я


