### PR TITLE
Verify connection state of PostgreSQL connection pooled connection and re-establish if necessary

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -583,6 +583,9 @@ void ConnectionPool::testAndReconnect(boost::shared_ptr<Connection>& connection)
    if (!error)
       return;
 
+   error.addProperty("description", "Connection check query failed when getting connection from the pool");
+   LOG_ERROR(error);
+
    // a connection error has occurred - attempt to reopen the connection by throwing this one away
    // and replacing it with a new one
    boost::shared_ptr<IConnection> newConnection;

--- a/src/cpp/core/include/core/Database.hpp
+++ b/src/cpp/core/include/core/Database.hpp
@@ -218,6 +218,8 @@ private:
 class ConnectionPool : public boost::enable_shared_from_this<ConnectionPool>
 {
 public:
+   ConnectionPool(const ConnectionOptions& options);
+
    // get a connection from the connection pool, blocking until one becomes available
    boost::shared_ptr<IConnection> getConnection();
 
@@ -234,8 +236,10 @@ private:
                                      boost::shared_ptr<ConnectionPool>* pPool);
 
    void returnConnection(const boost::shared_ptr<Connection>& connection);
+   void testAndReconnect(boost::shared_ptr<Connection>& connection);
 
    thread::ThreadsafeQueue<boost::shared_ptr<Connection>> connections_;
+   ConnectionOptions connectionOptions_;
 };
 
 class Transaction


### PR DESCRIPTION

### Intent

Currently, database connections are not re-established if they go defunct, such as if the upstream PostgreSQL database stops or due to transient network failure. We should restart these connections automatically.

See #8266 for more detail.

### Approach

Whenever a connection is requested from the pool, quickly check to see if the state is open by running a very simple efficient query. If not, attempt to re-establish this connection, but only once. If we do re-establish the connection, use it instead of the old connection.

Fixes #8266

### QA Notes

See #8266 


