### PR TITLE
Increase Better BibTeX Timeout

### DIFF
--- a/src/cpp/session/modules/zotero/ZoteroBetterBibTeX.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroBetterBibTeX.cpp
@@ -57,7 +57,7 @@ bool betterBibtexJsonRpcRequest(const std::string& method, const json::Array& pa
    request.setBody(rpcRequest.writeFormatted());
 
    http::Response response;
-   Error error = http::sendRequest("localhost", "23119", boost::posix_time::milliseconds(1000), request, &response);
+   Error error = http::sendRequest("localhost", "23119", boost::posix_time::milliseconds(10000), request, &response);
    if (!error)
    {
       if (response.statusCode() == http::status::Ok)


### PR DESCRIPTION
On windows, the short connection timeout could be triggered, causing the Better BibTex integration to fail. Increase the timeout.

fixes @rstudio/issues#8241

### Intent

Resolve failure to connect to Better BixTeX on Windows.

### Approach

The connection to the Better BibTeX localhost server was timing out. Increase the timeout.

### QA Notes

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


