### PR TITLE
don't display help for file completion items

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -577,7 +577,7 @@ options(help_type = "html")
    if (length(package) && nzchar(package))
    {
       packagePath <- system.file(package = package)
-      if (file.exists(packagePath))
+      if (nzchar(packagePath))
       {
          encoding <- .rs.packageHelpEncoding(packagePath)
          if (identical(encoding, "UTF-8"))

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -555,7 +555,7 @@ options(help_type = "html")
    #    <libpath>/<package>/help/<...>
    #
    # so we look for the 'help' component and parse from there
-   if (!length(package))
+   if (!length(package) || package == "")
    {
       parts <- strsplit(file, "/", fixed = TRUE)[[1L]]
       
@@ -574,12 +574,15 @@ options(help_type = "html")
    }
    
    # try to figure out the encoding for the provided HTML
-   if (length(package))
+   if (length(package) && nzchar(package))
    {
       packagePath <- system.file(package = package)
-      encoding <- .rs.packageHelpEncoding(packagePath)
-      if (identical(encoding, "UTF-8"))
-         Encoding(html) <- "UTF-8"
+      if (file.exists(packagePath))
+      {
+         encoding <- .rs.packageHelpEncoding(packagePath)
+         if (identical(encoding, "UTF-8"))
+            Encoding(html) <- "UTF-8"
+      }
    }
    
    # try to extract HTML body

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
@@ -71,6 +71,10 @@ public class HelpStrategy
          case RCompletionType.OPTION:
             showParameterHelp(item, display);
             break;
+         case RCompletionType.FILE:
+         case RCompletionType.DIRECTORY:
+         case RCompletionType.STRING:
+            break;
          default:
             showDefaultHelp(item, display);
             break;


### PR DESCRIPTION
### Intent

When scrolling through an autocompletion list, RStudio always attempts to display help for a completion item. However, some completion types (e.g. files and directories) do not have any relevant completion items. Still, we request help for these as though they were R objects, and so sometimes we ended up providing irrelevant help. For example, from RStudio 1.2:

<img width="755" alt="Screen Shot 2020-11-02 at 11 49 12 AM" src="https://user-images.githubusercontent.com/1976582/97912271-6f098600-1d01-11eb-8101-329d18f1777b.png">

In older versions of RStudio, we "successfully" provided the wrong help topic; in the 1.4 dailies, we erred when reading this help.

### Approach

Fix the underlying issue causing the R error to appear when requesting help, and disallow help requests for file / directory / string completion items.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8260#issuecomment-720673265. In particular, with `|` denoting the cursor position:

```
dir.create("data")
"|"
```

Try to request completions. You should see the error as RStudio erroneously attempts to display help for the directory completion item.


Closes https://github.com/rstudio/rstudio/issues/8260.