### PR TITLE
force promises in S3 methods table on unload

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -58,7 +58,8 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # will now have invalid pointers to the old lazy-load database.
    #
    # note that we iterate over all loaded packages here because loading a
-   # package might entail registering S3 methods in the method owner's namespace
+   # package might entail registering S3 methods in the namespace of the
+   # package owning the generic, which typically is a separate package
    #
    # https://bugs.r-project.org/bugzilla/show_bug.cgi?id=16644
    # https://github.com/rstudio/rstudio/issues/8265


### PR DESCRIPTION
### Intent

When a package is unloaded and later re-installed, sometimes older pieces of the previously-loaded package can stick around. For registered S3 methods, these might be promises holding data relevant only to the previously-installed copy of that package. This can cause strange errors to be emitted to the R console, and that package to fail to load, when later loading that package.

### Approach

Before unloading the package, force any existing promises, so they can evaluate in the right context (and be properly re-registered / replaced when the namespace is later reloaded).

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8265.

Closes https://github.com/rstudio/rstudio/issues/8265.