### PR TITLE
ensure profiler resources path is UTF-8

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1329,6 +1329,18 @@ SEXP create(const std::map<std::string, std::string>& map, Protect* pProtect)
    return listSEXP;
 }
 
+SEXP createUtf8(const std::string& data, Protect* pProtect)
+{
+   SEXP strSEXP;
+   pProtect->add(strSEXP = Rf_allocVector(STRSXP, 1));
+
+   SEXP charSEXP;
+   pProtect->add(charSEXP = Rf_mkCharLenCE(data.c_str(), data.size(), CE_UTF8));
+
+   SET_STRING_ELT(strSEXP, 0, charSEXP);
+   return strSEXP;
+}
+
 SEXP createRawVector(const std::string& data, Protect* pProtect)
 {
    SEXP rawSEXP;

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -163,6 +163,9 @@ SEXP create(const std::map<std::string, std::string>& value, Protect* pProtect);
 SEXP create(const std::map<std::string, SEXP> &value,
             Protect *pProtect);
 
+// Create a UTF-8 encoded character vector
+SEXP createUtf8(const std::string& data, Protect* pProtect);
+
 // Create a raw vector (binary data)
 SEXP createRawVector(const std::string& data, Protect* pProtect);
 

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -31,9 +31,16 @@
       "profvis.prof_output",
       default = .rs.profilesPath()
    )
-   
-   if (!.rs.dirExists(tempPath))
-      dir.create(tempPath, recursive = TRUE)
+
+   # NOTE: this code runs on IDE startup, and so errors can cause
+   # session initialization to fail. for that reason, we catch and
+   # log errors as warnings just so we avoid taking down the session
+   #
+   # https://github.com/rstudio/rstudio/issues/8256
+   tryCatch(
+      dir.create(tempPath, recursive = TRUE, showWarnings = FALSE),
+      error = warning
+   )
 
    list(tempPath = tempPath)
 })

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -45,21 +45,21 @@ namespace {
 
 std::string profilesCacheDir() 
 {
-   return module_context::scopedScratchPath().completeChildPath(kProfilesCacheDir)
-      .getAbsolutePath();
+   return module_context::scopedScratchPath()
+       .completeChildPath(kProfilesCacheDir)
+       .getAbsolutePath();
 }
 
 SEXP rs_profilesPath()
 {
    r::sexp::Protect rProtect;
-   std::string cacheDir = core::string_utils::utf8ToSystem(profilesCacheDir());
-   return r::sexp::create(cacheDir, &rProtect);
+   return r::sexp::create(profilesCacheDir(), &rProtect);
 }
 
 } // anonymous namespace
 
 void handleProfilerResReq(const http::Request& request,
-                            http::Response* pResponse)
+                          http::Response* pResponse)
 {
    std::string resourceName = http::util::pathAfterPrefix(request, "/" kProfilesUrlPath "/");
 
@@ -102,17 +102,21 @@ void onDocPendingRemove(
 }
 
 Error initialize()
-{  
+{
    ExecBlock initBlock;
    
    source_database::events().onDocPendingRemove.connect(onDocPendingRemove);
 
    RS_REGISTER_CALL_METHOD(rs_profilesPath);
-   
-   r::options::setOptionDefault(
-            "profvis.prof_output",
-            string_utils::utf8ToSystem(profilesCacheDir()));
-   
+
+   // set up profiles path (be careful to mark as UTF-8)
+   r::sexp::Protect protect;
+   SEXP cacheDir = r::sexp::createUtf8(profilesCacheDir(), &protect);
+   Error error = r::exec::RFunction(".rs.setOptionDefault")
+               .addParam("profvis.prof_output")
+               .addParam(cacheDir)
+               .call();
+
    initBlock.addFunctions()
       (boost::bind(module_context::sourceModuleRFile, "SessionProfiler.R"))
       (boost::bind(module_context::registerUriHandler, "/" kProfilesUrlPath "/", handleProfilerResReq))


### PR DESCRIPTION
### Intent

Attempts to open projects with non-ASCII characters in the pathname could fail in some cases. This was caused by an attempt to create a directory associated with a mis-encoded path on startup, which (in some cases) could be an error rather than a warning.

### Approach

Ensure that the profiler path is UTF-8 encoded, and also treat errors as warnings so they don't prohibit session start.

### QA Notes

On Windows: test that projects with multibyte characters can be created / opened.

Closes https://github.com/rstudio/rstudio/issues/8256.