### PR TITLE
Change visual mode key command from ctrl+shift+F12 to ctrl+shift+F4

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -707,8 +707,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="editLinesFromStart" value="Ctrl+Alt+Shift+A"/>
          <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim,sublime"/>
          <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim,sublime"/>
-         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+V" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+F4" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+F4" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>
          <shortcut value="Ctrl+Alt+Shift+Down" title="Move active cursor down"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -707,8 +707,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="editLinesFromStart" value="Ctrl+Alt+Shift+A"/>
          <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim,sublime"/>
          <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim,sublime"/>
-         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+F8" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+F8" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+V" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+V" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>
          <shortcut value="Ctrl+Alt+Shift+Down" title="Move active cursor down"/>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -707,8 +707,8 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="editLinesFromStart" value="Ctrl+Alt+Shift+A"/>
          <shortcut refid="goToStartOfCurrentScope" value="Ctrl+Alt+A" disableModes="default,vim,sublime"/>
          <shortcut refid="goToEndOfCurrentScope" value="Ctrl+Alt+E" disableModes="default,vim,sublime"/>
-         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+F12" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+F12" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Meta+Shift+F8" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="toggleRmdVisualMode" value="Ctrl+Shift+F8" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut value="Ctrl+Alt+Shift+Up" title="Move active cursor up"/>
          <shortcut value="Ctrl+Alt+Shift+Down" title="Move active cursor down"/>
 

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -152,8 +152,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Toggle visual markdown editor</td>
-      <td>Ctrl+Shift+F8</td>
-      <td>Ctrl+Shift+F8</td>
+      <td>Ctrl+Shift+V</td>
+      <td>Ctrl+Shift+V</td>
     </tr>
     <tr>
       <td>New document (except on Chrome/Windows)</td>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -152,8 +152,8 @@ References on default Ace shortcuts:
     </tr>
     <tr>
       <td>Toggle visual markdown editor</td>
-      <td>Ctrl+Shift+V</td>
-      <td>Ctrl+Shift+V</td>
+      <td>Ctrl+Shift+F4</td>
+      <td>Ctrl+Shift+F4</td>
     </tr>
     <tr>
       <td>New document (except on Chrome/Windows)</td>
@@ -567,6 +567,11 @@ References on default Ace shortcuts:
       <td>Paste</td>
       <td>Ctrl+V</td>
       <td>Command+V</td>
+    </tr>
+    <tr>
+      <td>Paste with Indent</td>
+      <td>Ctrl+Shift+V</td>
+      <td>Command+Shift+V</td>
     </tr>
     <tr>
       <td>Select All</td>


### PR DESCRIPTION
### Intent

Old key command had a conflict with nextTab.

Fixes https://github.com/rstudio/rstudio/issues/7717

### QA Notes

Ensure new key command Ctrl+Shift+F8 works correctly.

