### PR TITLE
Avoid intermittent hang on visual editor close

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace-render-queue.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace-render-queue.ts
@@ -217,7 +217,8 @@ export class AceRenderQueue {
     // accumulate when NodeViews are added to the render queue but replaced
     // (by a document rebuild) before they have a chance to render.
     let view: AceNodeView | undefined;
-    while (view === null || view === undefined || view.getPos() === undefined) {
+    while ((view === null || view === undefined || view.getPos() === undefined) &&
+           this.renderQueue.length > 0) {
       view = this.renderQueue.shift();
     }
 
@@ -277,6 +278,11 @@ export class AceRenderQueue {
   private destroy() {
     // Cancel any pending renders
     this.cancelTimer();
+
+    // Clear any pending update timer
+    if (this.updateTimer !== 0) {
+      window.clearTimeout(this.updateTimer);
+    }
 
     // Remove event subscriptions
     this.subscriptions.forEach(unsub => unsub());


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/8291.

The source of this bug is a while loop that is intended to skip past editors that don't need to be rendered. In some pathological (and timing-dependent) situations, the entire remainder of the render queue consists of defunct editors. When this happens, the loop spins endlessly since `shift()` returns `undefined` on an empty array.

### Approach

Ensure that there are items left in the render queue before we try to skip them. 

### QA Notes

Reproducing this bug usually requires a number of tries. 