### PR TITLE
fix offset check when reading history

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
@@ -15,6 +15,8 @@
 package org.rstudio.studio.client.common;
 
 import com.google.gwt.user.client.ui.HasText;
+
+import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.StringUtil;
 
 import java.util.ArrayList;
@@ -70,7 +72,7 @@ public class CommandLineHistory
 
    public String getHistoryEntry(int offset)
    {
-      int pos = getPositionAtOffset(offset);
+      int pos = MathUtil.clamp(getPositionAtOffset(offset), 0, history_.size() - 1);
       return history_.get(pos);
    }
 


### PR DESCRIPTION
### Intent

When attempting to access the most recent item in the command line history, we would (on occasion) read out of bounds of our history list, leading to a JS exception.

### Approach

Clamp the history offset to the range of the history list.

### QA Notes

Reproduce via notes in https://github.com/rstudio/rstudio/issues/8293.

Closes https://github.com/rstudio/rstudio/issues/8293.