### PR TITLE
sync editing outline location before R Markdown render

### DIFF
--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -564,6 +564,10 @@ export class Editor {
     };
   }
 
+  public getEditingOutlineLocation(): EditingOutlineLocation {
+    return getEditingOutlineLocation(this.state);
+  }
+
   public getHTML(): string {
     return fragmentToHTML(this.state.schema, this.state.doc.content);
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorEditor.java
@@ -72,6 +72,8 @@ public class PanmirrorEditor
    public native PanmirrorMenus getMenus();
    
    public native PanmirrorOutlineItem[] getOutline();
+
+   public native PanmirrorEditingOutlineLocation getEditingOutlineLocation();
    
    public native PanmirrorFindReplace getFindReplace();
    

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -552,6 +552,11 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    {
       return editor_.getEditingLocation();
    }
+
+   public PanmirrorEditingOutlineLocation getEditingOutlineLocation()
+   {
+      return editor_.getEditingOutlineLocation();
+   }
    
    public PanmirrorOutlineItem[] getOutline()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6453,6 +6453,13 @@ public class TextEditingTarget implements
             String viewerType = RmdEditorOptions.getString(
                   getRmdFrontMatter(), RmdEditorOptions.PREVIEW_IN, null);
 
+            // if visual mode is active, move the cursor in source mode to match the its position in visual mode
+            // so that we pass the correct line number hint to render below
+            if (visualMode_.isVisualEditorActive())
+            {
+               visualMode_.syncSourceOutlineLocation();
+            }
+
             rmarkdownHelper_.renderRMarkdown(
                   docUpdateSentinel_.getPath(),
                   docDisplay_.getCursorPosition().getRow() + 1,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6453,9 +6453,10 @@ public class TextEditingTarget implements
             String viewerType = RmdEditorOptions.getString(
                   getRmdFrontMatter(), RmdEditorOptions.PREVIEW_IN, null);
 
-            // if visual mode is active, move the cursor in source mode to match the its position in visual mode
-            // so that we pass the correct line number hint to render below
-            if (visualMode_.isVisualEditorActive())
+            // if visual mode is active, move the cursor in source mode to
+            // match its position in visual mode, so that we pass the correct
+            // line number hint to render below
+            if (isVisualEditorActive())
             {
                visualMode_.syncSourceOutlineLocation();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -710,6 +710,16 @@ public class VisualMode implements VisualModeEditorSync,
       // Perform the command in the active code editor, if any.
       visualModeChunks_.performWithSelection(command);
    }
+
+   /**
+    * Moves the cursor in source mode to the currently active outline item in visual mode.
+    */
+   public void syncSourceOutlineLocation()
+   {
+      visualModeLocation_.setSourceOutlineLocation(
+              panmirror_.getEditingOutlineLocation());
+   }
+
    
    public DocDisplay getActiveEditor()
    {


### PR DESCRIPTION
### Intent

When we render R Markdown docs, we pass the location of the cursor, which is later used to infer a slide to navigate to when previewing presentations. However, the location of the cursor in source mode is used, so it doesn't reflect the user's cursor position if they're in visual mode, resulting in incorrect slide navigation. This change addresses that issue.

Fixes https://github.com/rstudio/rstudio/issues/8301. 

### Approach

This is a relatively scoped fix meant to address this specific issue. Prior to rendering R Markdown docs, we now move the cursor in source mode to an approximation of where it is in visual mode (same outline item, which is all we need for slide selection). 

### QA Notes

This change affects only R Markdown presentations (not R Presentations). 
