### PR TITLE
scroll cursor into view only after render

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -502,14 +502,13 @@ export class AceNodeView implements NodeView {
     // If the cursor moves and we're in focus, ensure that the cursor is
     // visible. Ace's own cursor visiblity mechanisms don't work in embedded
     // editors.
-    if (this.editSession) {
-      this.editSession.getSelection().on('changeCursor', () => {
-        if (this.dom.contains(document.activeElement)) {
-          this.cursorDirty = true;
-        }
-      });
-    }
-    this.aceEditor.on('beforeEndOperation', () => {
+    this.aceEditor.getSelection().on('changeCursor', () => {
+      if (this.dom.contains(document.activeElement)) {
+        this.cursorDirty = true;
+      }
+    });
+
+    this.aceEditor.renderer.on('afterRender', () => {
       if (this.cursorDirty) {
         this.scrollCursorIntoView();
         this.cursorDirty = false;


### PR DESCRIPTION
### Intent

When the Ace cursor is moved, we need to wait for Ace to render the updated cursor before it can be scrolled into view.

### Approach

Scroll the cursor into view after render, rather than after execution of a command.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8300.

Closes https://github.com/rstudio/rstudio/issues/8300.