### PR TITLE
Avoid migrating ODBC drivers from scratch path

### DIFF
--- a/src/cpp/core/r_util/RUserData.cpp
+++ b/src/cpp/core/r_util/RUserData.cpp
@@ -117,6 +117,16 @@ Error migrateUserStateIfNecessary(SessionType sessionType)
    std::vector<std::string> failures;
    for (const auto& f: files)
    {
+      // RStudio Desktop Pro encourages users to install ODBC drivers to the user scratch folder
+      // e.g., ~/.rstudio-desktop/odbc/drivers (in RStudio 1.3 and prior); see
+      // .rs.connectionOdbcInstallerPath for details. These driver paths then become part of user
+      // content such as R scripts, so they can't be moved without breaking user code. Skip this
+      // directory when migrating to avoid this breakage.
+      if (f.isDirectory() && f.getFilename() == "odbc")
+      {
+         continue;
+      }
+
       FilePath target = newPath.completeChildPath(f.getFilename());
       Error moveError = f.move(target);
       if (moveError)


### PR DESCRIPTION
### Intent

RStudio Desktop Pro defaults cause users to install our professional ODBC drivers into the user scratch path (`~/.rstudio-desktop/odbc` in prior versions). When we migrate those drivers to the new user scratch path in RStudio 1.4, it can break user code that contains references to the full path of the drivers in the old scratch path. The intent of this change is to avoid that problem.

### Approach

This changes takes the conservative approach of excluding that specific folder (`odbc`) from migration. 

### QA Notes

Ensure that the `odbc` folder is not migrated to the new scratch path (e.g. `~/.local/share/rstudio`) and that professional drivers installed by previous version of RStudio continue to work. 

Fixes https://github.com/rstudio/rstudio-pro/issues/2065. 


