### PR TITLE
avoid stomping on rainbow parens state with raw strings

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -253,13 +253,12 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
           
           // initialize stack
           stack = stack || [];
-          stack.length = 2;
 
           // save current state in stack
           stack[0] = state;
 
           // save the expected suffix for exit
-          stack[1] =
+          stack[2] =
             $complements[value[value.length - 1]] +
             value.substring(2, value.length - 1) +
             value[1];
@@ -464,7 +463,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         token : "string",
         regex : "[\\]})][-]*['\"]",
         onMatch: function(value, state, stack, line) {
-          this.next = (value === stack[1]) ? stack[0] : "rawstring";
+          this.next = (value === stack[2]) ? stack[0] : "rawstring";
           return this.token;
         }
       },

--- a/src/gwt/acesupport/acemode/rainbow_paren_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rainbow_paren_highlight_rules.js
@@ -39,30 +39,26 @@ define("mode/rainbow_paren_highlight_rules", ["require", "exports", "module"], f
       merge : false,
       onMatch: function(val, state, stack) {
 
-      if (!$rainbowParentheses) {
-        this.token = "paren.keyword.operator.nomatch";
-        return this.token;
-      }
+        if (!$rainbowParentheses) {
+          this.token = "paren.keyword.operator.nomatch";
+          return this.token;
+        }
 
-      if (stack.length !== 2) {
-        stack.length = 2;
+        stack = stack || [];
         stack[0] = state;
-        stack[1] = 0;
-      }
+        stack[1] = stack[1] || 0;
 
-      switch(val) {
-        case "[":
-        case "{":
-        case "(":
+        switch(val) {
+
+        case "[": case "{": case "(":
           this.token = "paren.paren_color_" + (stack[1] % $numParenColors);
           stack[1] = stack[1] + 1;
           break;
-        default:
-          if (stack.length > 1 && stack[1] > 0) {
-            stack[1] = stack[1] - 1;
-            this.token = "paren.paren_color_" + (stack[1] % $numParenColors);
-          }
-      }
+        case "]": case "}": case ")":
+          stack[1] = Math.max(0, stack[1] - 1);
+          this.token = "paren.paren_color_" + (stack[1] % $numParenColors);
+          break;
+        }
 
       return this.token;
     },


### PR DESCRIPTION
### Intent

In our tokenizer, we keep track of both the rainbow parentheses count as well as the complement for a raw string (if any). Those were using the same indices into the state array, and so could stomp on each other in some cases.

(Note: I experimented with both using an object to keep track of this state, as well as a "named" array, but both seemed to have problems; likely based on how Ace uses + manipulates that array. We could fix it with an Ace patch, but that's definitely out of scope for 1.4)

### Approach

Use a different index for raw strings.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8302.

Closes https://github.com/rstudio/rstudio/issues/8302.