### PR TITLE
handle multiline tokens with binary ops

### DIFF
--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -303,6 +303,13 @@ test_context("RTokenizer")
       expect_true(rTokens.at(3).isType(RToken::RPAREN));
    }
    
+   test_that("multiline strings are tokenized as strings")
+   {
+      RTokens rTokens(L"'abc\ndef'");
+      expect_true(rTokens.size() == 1);
+      expect_true(rTokens.at(0).isType(RToken::STRING));
+   }
+   
 }
 
 } // namespace r_util

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -283,6 +283,8 @@ test_context("Diagnostics")
       EXPECT_ERRORS("local({ if (TRUE) })");
 
       EXPECT_NO_ERRORS("phi = function(`arg 1`) 1 + 1\nph(`arg 1` = 1)");
+      EXPECT_NO_ERRORS("'a\nb' <- 1");
+      EXPECT_NO_ERRORS("`a\nb` <- 1");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -2430,7 +2430,12 @@ START:
          // parses with '-' as a binary operator.
          if (isBinaryOp(next))
          {
-            if (!status.isInParentheticalScope() && (next.row() > cursor.row()))
+            // handle '\n' within the token
+            int row =
+                  cursor.row() +
+                  std::count(cursor.begin(), cursor.end(), '\n');
+            
+            if (!status.isInParentheticalScope() && next.row() > row)
             {
                DEBUG("----- Not binding binary operator to statement" << next);
                MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);


### PR DESCRIPTION
### Intent

Certain tokens (strings, quoted identifiers) can span multiple lines. This can cause issues in some cases where our R parser fails to properly bind the binary operator to that token.

### Approach

Properly handle multi-line tokens.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8307.
Closes https://github.com/rstudio/rstudio/issues/8307.