### PR TITLE
Fix Close All Except Current with unsaved files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -28,7 +28,6 @@ import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.CommandBinder;
-import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
@@ -311,7 +310,10 @@ public class SourceColumn implements BeforeShowEvent.Handler,
        // set and active editor
        activeEditor_ = target;
        if (activeEditor_ != null)
+       {
           activeEditor_.onActivate();
+          display_.selectTab(activeEditor_.asWidget());
+       }
    }
 
    void setActiveEditor()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1429,11 +1429,11 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                             boolean excludeMain,
                             Command onCompleted)
    {
-      columnList_.forEach((column) ->
-      {
-         closeAllTabs(column, excludeActive, excludeMain, onCompleted);
-      });
-         
+      // Columns may be deleted when all of their tabs are closed, so we iterate over the current
+      // names rather than the column list
+      ArrayList<String> columnNames = new ArrayList<>(getNames(false));
+      for (String name : columnNames)
+         closeAllTabs(getByName(name), excludeActive, excludeMain, onCompleted);
    }
 
    public void closeAllTabs(SourceColumn column,


### PR DESCRIPTION
### Intent

Fixes #8295 

Certain combinations of opening files with "dirty" files (requiring a prompt to save) prevent `Close All Except Current` from closing all columns. 

### Approach

Previously we set the active editor to keep track of the editor to leave open and reset it when a change was triggered by the prompt to save other editors. We were only resetting the variable tracking the active editor and not which editor was actually active in `DocTabLayoutPanel`. This fix selects the active editor when it is set manually.

There was also an issue with multiple columns that left all the tabs open when the current editor was in the left most column due to columns being removed while iterating the column list. We now iterate over the list of column names rather than the columns themselves to make sure we reach each one while closing tabs. This is a marginally slower approach but shouldn't be noticeable since the column list size should always be small (currently always less than 5).

### QA Notes

There are good examples in #8295 but we also need to make sure things work as expected with multiple columns open. 

