### PR TITLE
use UTF-8 path when restoring global environment

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -148,6 +148,8 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 # the error message
 .rs.addFunction("restoreGlobalEnvFromFile", function(path)
 {
+   Encoding(path) <- "UTF-8"
+
    status <- try(load(path, envir = .GlobalEnv), silent = TRUE)
    if (!inherits(status, "try-error"))
       return("")

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -73,9 +73,9 @@ std::string createAliasedPath(const FilePath& filePath)
    
 Error restoreGlobalEnvFromFile(const std::string& path, std::string* pErrMessage)
 {
-   r::exec::RFunction fn(".rs.restoreGlobalEnvFromFile");
-   fn.addParam(path);
-   return fn.call(pErrMessage);
+   return r::exec::RFunction(".rs.restoreGlobalEnvFromFile")
+         .addParam(path)
+         .call(pErrMessage);
 }
 
 void completeDeferredSessionInit(bool newSession)
@@ -129,7 +129,7 @@ void deferredRestoreNewSession()
       // what they intended
       r::exec::IgnoreInterruptsScope ignoreInterrupts;
 
-      std::string path = string_utils::utf8ToSystem(globalEnvPath.getAbsolutePath());
+      std::string path = globalEnvPath.getAbsolutePath();
       std::string aliasedPath = createAliasedPath(globalEnvPath);
       
       std::string errMessage;


### PR DESCRIPTION
### Intent

On Windows, users might be working within paths / projects that cannot actually be represented in the current locale. This can cause various issues.

### Approach

Use UTF-8 paths instead.

### QA Notes

Test that RStudio functions as expected (and you can save + load an R workspace) on Windows when the path contains non-ASCII characters; e.g. letters or words from a language not using the Latin alphabet.

Closes https://github.com/rstudio/rstudio/issues/8321.