### PR TITLE
support updated ansi_console_mode pref value

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -720,9 +720,11 @@
    
 })
 
+# NOTE: we allow '1L' just in case for backwards compatibility
+# with older preferences not migrated to the newer string version
 .rs.addApiFunction("getConsoleHasColor", function(name) {
-   value <- .rs.readUiPref("ansi_console_mode")
-   if (is.null(value) || value != 1) FALSE else TRUE
+   mode <- .rs.readUiPref("ansi_console_mode")
+   mode %in% list(1L, "on")
 })
 
 .rs.addApiFunction("terminalSend", function(id, text) {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -724,7 +724,7 @@
 # with older preferences not migrated to the newer string version
 .rs.addApiFunction("getConsoleHasColor", function(name) {
    mode <- .rs.readUiPref("ansi_console_mode")
-   mode %in% list(1L, "on")
+   !is.null(mode) && mode %in% list(1L, "on")
 })
 
 .rs.addApiFunction("terminalSend", function(id, text) {


### PR DESCRIPTION
### Intent

The stored preference value for `ansi_console_mode` changed, but the R-level accessor did not. The R-level accessor should be updated.

### Approach

Handle both the old version of the preference (just in case) as well as the new, current version.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8323.

Closes https://github.com/rstudio/rstudio/issues/8323.