### PR TITLE
specify formula switch in brew list invocations

### DIFF
--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -29,7 +29,7 @@ if ! command -v brew &> /dev/null; then
 fi
 
 # install postgres, needed by SOCI
-if brew list | grep postgresql &> /dev/null; then
+if brew list --formula | grep postgresql &> /dev/null; then
    echo "postgresql already installed"
 else
    brew install postgresql
@@ -41,7 +41,7 @@ if ! command -v gtimeout &> /dev/null; then
 fi
 
 # openssl needed to run rsession  (including unit tests)
-if brew list | grep openssl@1.1 &> /dev/null; then
+if brew list --formula | grep openssl@1.1 &> /dev/null; then
    echo "openssl already installed"
 else
    brew install openssl


### PR DESCRIPTION


### Intent

Eliminate warning messages from `install-dependencies-osx`:
```
"Warning: Calling `brew list` to only list formulae is deprecated! Use `brew list --formula` instead."
```

### Approach

Supply the switch suggested by the warning message.

### QA Notes

Purely a dev and build environment thing. Nothing to test.
