### PR TITLE
register Enter handler only on textbox

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -121,7 +121,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          updateDescription();
       });
       
-      tbPythonInterpreter_.addDomHandler((KeyDownEvent event) ->
+      tbPythonInterpreter_.getTextBox().addDomHandler((KeyDownEvent event) ->
       {
          if (event.getNativeKeyCode() == KeyCodes.KEY_ENTER)
          {


### PR DESCRIPTION
### Intent

The handler here was being registered on the entire widget, making it active for both the textbox and the Select button. This was preventing the Select button from reacting to Enter keypresses. 

### Approach

Scope the handler to the textbox only.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8331.

Closes https://github.com/rstudio/rstudio/issues/8331.