### PR TITLE
Fix jumpy scroll/cursor/selection action with large code chunks

### DIFF
--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -128,6 +128,7 @@ export class AceNodeView implements NodeView {
   private updating: boolean;
   private escaping: boolean;
   private gapCursorPending: boolean;
+  private mouseDown: boolean;
   private mode: string;
   private findMarkers: number[];
   private selectionMarker: number | null;
@@ -171,8 +172,9 @@ export class AceNodeView implements NodeView {
     this.subscriptions = [];
     this.resizeTimer = 0;
     this.renderedWidth = 0;
-    this.scrollRow = 0;
+    this.scrollRow = -1;
     this.cursorDirty = false;
+    this.mouseDown = false;
 
     // options
     this.editorOptions = editorOptions;
@@ -503,13 +505,16 @@ export class AceNodeView implements NodeView {
     // visible. Ace's own cursor visiblity mechanisms don't work in embedded
     // editors.
     this.aceEditor.getSelection().on('changeCursor', () => {
-      if (this.dom.contains(document.activeElement)) {
+      if (this.dom.contains(document.activeElement) && !this.mouseDown) {
         this.cursorDirty = true;
       }
     });
 
     this.aceEditor.renderer.on('afterRender', () => {
-      if (this.cursorDirty) {
+      // If the cursor position is dirty and the mouse is not down, scroll the
+      // cursor into view. Don't scroll while the mouse is down, as it will be
+      // treated as a click-and-drag by Ace.
+      if (this.cursorDirty && !this.mouseDown) {
         this.scrollCursorIntoView();
         this.cursorDirty = false;
       }
@@ -711,6 +716,15 @@ export class AceNodeView implements NodeView {
         this.scrollRow = -1;
       }),
     );
+
+    // Keep track of mouse state so we can avoid e.g., autoscrolling while the
+    // mouse is down
+    this.dom.addEventListener("mousedown", (evt) => {
+      this.mouseDown = true;
+    });
+    this.dom.addEventListener("mouseup", (evt) => {
+      this.mouseDown = false;
+    });
   }
 
   /**
@@ -824,7 +838,12 @@ export class AceNodeView implements NodeView {
 
     // Ensure we still have focus before proceeding
     if (this.dom.contains(document.activeElement)) {
-      const cursor = document.activeElement as HTMLElement;
+
+      // Find the element containing the rendered virtual cursor 
+      const cursor = this.dom.querySelector(".ace_cursor");
+      if (cursor === null) {
+        return;
+      }
 
       // Ace doesn't actually move the cursor but uses CSS translations to
       // make it appear in the right place, so we need to use the somewhat
@@ -837,12 +856,12 @@ export class AceNodeView implements NodeView {
       const cursorRect = cursor.getBoundingClientRect();
 
       // Scrolling down?
-      const down = cursorRect.bottom + cursorRect.height + 20 - containerRect.bottom;
+      const down = cursorRect.bottom + 10 - containerRect.bottom;
       if (down > 0) {
         container.scrollTop += down;
       } else {
         // Scrolling up?
-        const up = containerRect.top + cursorRect.height + 35 - cursorRect.top;
+        const up = containerRect.top + 10 - cursorRect.top;
         if (up > 0) {
           container.scrollTop -= up;
         }

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -725,6 +725,10 @@ export class AceNodeView implements NodeView {
     this.dom.addEventListener("mouseup", (evt) => {
       this.mouseDown = false;
     });
+    this.dom.addEventListener("mouseleave", (evt) => {
+      // Treat mouse exit as an up since it will cause us to miss the up event
+      this.mouseDown = false;
+    });
   }
 
   /**


### PR DESCRIPTION
### Intent

This change addresses an issue in which clicking inside a large code chunk (when the cursor is offscreen) in the visual editor can generate unwanted scroll jumping/selection.

Fixes https://github.com/rstudio/rstudio/issues/8332. 

### Approach

There are two small changes necessary to resolve this issue:

1. First, we were formerly obtaining the cursor geometry from the focused element, a hidden `<textarea>`. However, the cursor the user actually sees is a painted-on `ace_cursor` element, so now we get more accurate geometry from there.
2. Second, we were scrolling the document while Ace considered the mouse to be down. Ace treats this as a selection-generating event. We now avoid trying to auto-scroll the cursor into view while the mouse is down.

### QA Notes

The code affected here is intended to help keep the cursor in view when navigating with the keyboard, so ensure that still works correctly. 