### PR TITLE
Use DOI to Not Insert Duplicate Citations

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
@@ -106,12 +106,12 @@ export async function showInsertCitationDialog(
       const providersForBibliography = (writable: boolean) => {
         return writable
           ? [
-              bibliographySourcePanel(doc, ui, bibliographyManager),
-              doiSourcePanel(ui, server.doi),
-              crossrefSourcePanel(ui, server.crossref, server.doi),
-              dataciteSourcePanel(ui, server.datacite, server.doi),
-              pubmedSourcePanel(ui, server.pubmed, server.doi),
-            ]
+            bibliographySourcePanel(doc, ui, bibliographyManager),
+            doiSourcePanel(ui, server.doi, bibliographyManager),
+            crossrefSourcePanel(ui, server.crossref, server.doi, bibliographyManager),
+            dataciteSourcePanel(ui, server.datacite, server.doi, bibliographyManager),
+            pubmedSourcePanel(ui, server.pubmed, server.doi, bibliographyManager),
+          ]
           : [bibliographySourcePanel(doc, ui, bibliographyManager)];
       };
 

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-crossref.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-crossref.tsx
@@ -29,13 +29,16 @@ import {
   CitationSourcePanelProvider,
   CitationListEntry,
   CitationSourceListStatus,
+  matchExistingSourceCitationListEntry,
 } from './insert_citation-source-panel';
 import { CitationSourceLatentSearchPanel } from './insert_citation-source-panel-latent-search';
+import { BibliographyManager } from '../../../api/bibliography/bibliography';
 
 export function crossrefSourcePanel(
   ui: EditorUI,
   server: CrossrefServer,
   doiServer: DOIServer,
+  bibliographyManager: BibliographyManager
 ): CitationSourcePanelProvider {
   const kCrossrefType = 'Crossref';
   return {
@@ -59,9 +62,11 @@ export function crossrefSourcePanel(
     search: async (searchTerm: string, _selectedNode: NavigationTreeNode, existingCitationIds: string[]) => {
       try {
         const works = await server.works(searchTerm);
+        const existingSources = bibliographyManager.localSources();
+
         const dedupeCitationIds = existingCitationIds;
         const citationEntries = works.items.map(work => {
-          const citationEntry = toCitationListEntry(work, dedupeCitationIds, ui, doiServer);
+          const citationEntry = matchExistingSourceCitationListEntry(work.DOI, dedupeCitationIds, ui, bibliographyManager) || toCitationListEntry(work, dedupeCitationIds, ui, doiServer);
           if (citationEntry) {
             // Add this id to the list of existing Ids so future ids will de-duplicate against this one
             dedupeCitationIds.push(citationEntry.id);

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-datacite.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-datacite.tsx
@@ -29,13 +29,16 @@ import {
   CitationListEntry,
   CitationSourceListStatus,
   errorForStatus,
+  matchExistingSourceCitationListEntry,
 } from './insert_citation-source-panel';
 import { CitationSourceLatentSearchPanel } from './insert_citation-source-panel-latent-search';
+import { BibliographyManager } from '../../../api/bibliography/bibliography';
 
 export function dataciteSourcePanel(
   ui: EditorUI,
   server: DataCiteServer,
   doiServer: DOIServer,
+  bibliographyManager: BibliographyManager
 ): CitationSourcePanelProvider {
   const kDataCiteType = 'Datacite';
   return {
@@ -66,7 +69,7 @@ export function dataciteSourcePanel(
               const records: DataCiteRecord[] = dataciteResult.message;
               const dedupeCitationIds = existingCitationIds;
               const citationEntries = records.map(record => {
-                const citationEntry = toCitationListEntry(record, dedupeCitationIds, ui, doiServer);
+                const citationEntry = matchExistingSourceCitationListEntry(record.doi, dedupeCitationIds, ui, bibliographyManager) || toCitationListEntry(record, dedupeCitationIds, ui, doiServer);
                 if (citationEntry) {
                   // Add this id to the list of existing Ids so future ids will de-duplicate against this one
                   dedupeCitationIds.push(citationEntry.id);

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-doi.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-doi.tsx
@@ -28,16 +28,19 @@ import {
   CitationListEntry,
   CitationSourceListStatus,
   errorForStatus,
+  matchExistingSourceCitationListEntry,
 } from './insert_citation-source-panel';
 import { CitationSourceLatentSearchPanel } from './insert_citation-source-panel-latent-search';
 
 import './insert_citation-source-panel-doi.css';
+import { BibliographyManager } from '../../../api/bibliography/bibliography';
 
 const kDOIType = 'DOI Search';
 
 export function doiSourcePanel(
   ui: EditorUI,
   server: DOIServer,
+  bibliographyManager: BibliographyManager
 ): CitationSourcePanelProvider {
   return {
     key: '76561E2A-8FB7-4D4B-B235-9DD8B8270EA1',
@@ -61,9 +64,11 @@ export function doiSourcePanel(
       try {
         const result = await server.fetchCSL(searchTerm, 1000);
         if (result.status === 'ok') {
+
           // Form the entry
+          const doi = searchTerm;
           const csl = result.message;
-          const citation = toCitationListEntry(csl, existingCitationIds, ui);
+          const citation = matchExistingSourceCitationListEntry(doi, existingCitationIds, ui, bibliographyManager) || toCitationListEntry(csl, existingCitationIds, ui);
 
           return Promise.resolve({
             citations: citation ? [citation] : [],

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-pubmed.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-pubmed.tsx
@@ -29,6 +29,7 @@ import {
   CitationListEntry,
   CitationSourceListStatus,
   errorForStatus,
+  matchExistingSourceCitationListEntry,
 } from './insert_citation-source-panel';
 import { CitationSourceLatentSearchPanel } from './insert_citation-source-panel-latent-search';
 
@@ -36,6 +37,7 @@ export function pubmedSourcePanel(
   ui: EditorUI,
   server: PubMedServer,
   doiServer: DOIServer,
+  bibliographyManager: BibliographyManager
 ): CitationSourcePanelProvider {
   const kPubmedType = 'Pubmed';
   return {
@@ -72,8 +74,8 @@ export function pubmedSourcePanel(
 
               // Create Citation List Entries for these PubMed docs
               const citationEntries = docs.map(doc => {
-                const citationEntry = toCitationListEntry(doc, dedupeCitationIds, ui, doiServer);
-                if (citationEntry) {
+                const citationEntry = matchExistingSourceCitationListEntry(doc.doi, dedupeCitationIds, ui, bibliographyManager) || toCitationListEntry(doc, dedupeCitationIds, ui, doiServer);
+                if (citationEntry && citationEntry.id) {
                   // Add this id to the list of existing Ids so future ids will de-duplicate against this one
                   dedupeCitationIds.push(citationEntry.id);
                 }
@@ -148,7 +150,7 @@ function toCitationListEntry(
   doiServer: DOIServer,
 ): CitationListEntry {
   const id = createUniqueCiteId(existingIds, suggestCiteId(doc));
-  const providerKey = 'crossref';
+  const providerKey = 'pubmed';
   return {
     id,
     isIdEditable: true,


### PR DESCRIPTION
When searching a third party resource, check the local bibligraphy to see whether we already have the item in the bibliography (using the DOI). If we do already have it, just return that item instead of the remote item.

Fixes @rstudio/rstudio#8335


### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


