### PR TITLE
allow forward / back in Help pane with mouse side buttons

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
@@ -34,7 +34,7 @@ import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.LauncherServerEvent;
-import org.rstudio.studio.client.application.events.MouseNavigateSourceHistoryEvent;
+import org.rstudio.studio.client.application.events.MouseNavigateEvent;
 import org.rstudio.studio.client.application.events.SaveActionChangedEvent;
 import org.rstudio.studio.client.application.events.SuicideEvent;
 import org.rstudio.studio.client.application.model.ProductEditionInfo;
@@ -257,7 +257,7 @@ public class DesktopHooks
 
    void mouseNavigateButtonClick(boolean forward, int x, int y)
    {
-      events_.fireEvent(new MouseNavigateSourceHistoryEvent(forward, x, y));
+      events_.fireEvent(new MouseNavigateEvent(forward, x, y));
    }
    
    void onDragStart()

--- a/src/gwt/src/org/rstudio/studio/client/application/events/MouseNavigateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/MouseNavigateEvent.java
@@ -17,9 +17,9 @@ package org.rstudio.studio.client.application.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
-public class MouseNavigateSourceHistoryEvent extends GwtEvent<MouseNavigateSourceHistoryEvent.Handler>
+public class MouseNavigateEvent extends GwtEvent<MouseNavigateEvent.Handler>
 {
-   public MouseNavigateSourceHistoryEvent(boolean forward, int mouseX, int mouseY)
+   public MouseNavigateEvent(boolean forward, int mouseX, int mouseY)
    {
       forward_ = forward;
       mouseX_ = mouseX;
@@ -28,7 +28,7 @@ public class MouseNavigateSourceHistoryEvent extends GwtEvent<MouseNavigateSourc
 
    public interface Handler extends EventHandler
    {
-      void onMouseNavigateSourceHistory(MouseNavigateSourceHistoryEvent event);
+      void onMouseNavigate(MouseNavigateEvent event);
    }
 
    @Override
@@ -40,7 +40,7 @@ public class MouseNavigateSourceHistoryEvent extends GwtEvent<MouseNavigateSourc
    @Override
    protected void dispatch(Handler handler)
    {
-      handler.onMouseNavigateSourceHistory(this);
+      handler.onMouseNavigate(this);
    }
 
    public boolean getForward()

--- a/src/gwt/src/org/rstudio/studio/client/application/events/MouseNavigateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/MouseNavigateEvent.java
@@ -17,6 +17,12 @@ package org.rstudio.studio.client.application.events;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
+// This event is primarily used to paper over issues with QtWebEngine;
+// it appears that Qt 5.12.x does not propagate side mouse buttons to the
+// associated WebEngine view, and so we are instead forced to synthesize
+// a synthetic navigation event that gets handled specially on the GWT side.
+//
+// https://github.com/rstudio/rstudio/pull/7272
 public class MouseNavigateEvent extends GwtEvent<MouseNavigateEvent.Handler>
 {
    public MouseNavigateEvent(boolean forward, int mouseX, int mouseY)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -44,7 +44,6 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
@@ -69,6 +68,7 @@ import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.MouseNavigateEvent;
 import org.rstudio.studio.client.application.ui.RStudioThemes;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -152,11 +152,18 @@ public class HelpPane extends WorkbenchPane
          }
       };
 
-      prefs_.helpFontSizePoints().bind(new CommandWithArg<Double>()
+      prefs_.helpFontSizePoints().bind((Double value) -> refresh());
+      
+      events_.addHandler(MouseNavigateEvent.TYPE, (MouseNavigateEvent event) ->
       {
-         public void execute(Double value)
+         // check to see if we're targeting the Help pane
+         Element el = DomUtils.elementFromPoint(event.getMouseX(), event.getMouseY());
+         if (StringUtil.equals(el.getId(), ElementIds.getElementId(ElementIds.HELP_FRAME)))
          {
-            refresh();
+            if (event.getForward())
+               forward();
+            else
+               back();
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -79,7 +79,7 @@ import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.events.MouseNavigateSourceHistoryEvent;
+import org.rstudio.studio.client.application.events.MouseNavigateEvent;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
@@ -220,7 +220,7 @@ public class Source implements InsertSourceHandler,
                                EditPresentationSourceEvent.Handler,
                                XRefNavigationEvent.Handler,
                                NewDocumentWithCodeEvent.Handler,
-                               MouseNavigateSourceHistoryEvent.Handler,
+                               MouseNavigateEvent.Handler,
                                RStudioApiRequestEvent.Handler
 {
    interface Binder extends CommandBinder<Commands, Source>
@@ -336,7 +336,7 @@ public class Source implements InsertSourceHandler,
       events_.addHandler(NewDocumentWithCodeEvent.TYPE, this);
       events_.addHandler(XRefNavigationEvent.TYPE, this);
       if (Desktop.hasDesktopFrame())
-         events_.addHandler(MouseNavigateSourceHistoryEvent.TYPE, this);
+         events_.addHandler(MouseNavigateEvent.TYPE, this);
 
       events_.addHandler(SourcePathChangedEvent.TYPE,
             new SourcePathChangedEvent.Handler()
@@ -1800,7 +1800,7 @@ public class Source implements InsertSourceHandler,
    }
 
    @Override
-   public void onMouseNavigateSourceHistory(MouseNavigateSourceHistoryEvent event)
+   public void onMouseNavigate(MouseNavigateEvent event)
    {
       if (isPointInSourcePane(event.getMouseX(), event.getMouseY()))
       {


### PR DESCRIPTION
### Intent

Make it possible to navigate backwards / forwards using mouse buttons.

### Approach

Fairly straightforward implementation of mouse handlers + JS callbacks to power the feature.

### QA Notes

Test that your mouse's side buttons allow you to navigate forwards / backwards within the Help pane.

Closes https://github.com/rstudio/rstudio/issues/8338.
Closes #7462.