### PR TITLE
Treat odbc migration skip as a failure

### DIFF
--- a/src/cpp/core/r_util/RUserData.cpp
+++ b/src/cpp/core/r_util/RUserData.cpp
@@ -124,6 +124,9 @@ Error migrateUserStateIfNecessary(SessionType sessionType)
       // directory when migrating to avoid this breakage.
       if (f.isDirectory() && f.getFilename() == "odbc")
       {
+         // Log as a failure so we don't clean up the ~/.rstudio-desktop folder (will generate an
+         // ignorable but accurate warning in the logs)
+         failures.push_back(f.getFilename());
          continue;
       }
 


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio-pro/issues/2065. 

### Approach

The previous fix https://github.com/rstudio/rstudio/pull/8305 didn't work in all circumstances; we remove the entire `~/.rstudio-desktop` folder if we detect a fully successful migration. This fix treats the `odbc` folder skip as a failure so that the `odbc` and its parent are left behind after migration.

### QA Notes

Test via notes in #2065
