### PR TITLE
ensure F1 works for Python help when triggered from console

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -377,10 +377,21 @@ options(help_type = "html")
 
 .rs.addJsonRpcHandler("show_custom_help_topic", function(helpHandler, topic, source) {
    
-   helpHandlerFunc <- tryCatch(eval(parse(text = helpHandler)), 
-                               error = function(e) NULL)
+   helpHandlerFunc <- tryCatch(
+      eval(parse(text = helpHandler)), 
+      error = function(e) NULL
+   )
+   
    if (!is.function(helpHandlerFunc))
       return()
+   
+   # workaround for broken help in reticulate 1.18
+   if (identical(helpHandler, "reticulate:::help_handler"))
+   {
+      text <- paste(source, topic, sep = ".")
+      .Call("rs_showPythonHelp", text, PACKAGE = "(embedding)")
+      return()
+   }
    
    url <- helpHandlerFunc("url", topic, source)
    if (!is.null(url) && nzchar(url)) # handlers return "" for no help topic

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -45,6 +45,12 @@
 
 .rs.addJsonRpcHandler("python_go_to_definition", function(line, offset)
 {
+   result <- .rs.python.goToDefinition(line, offset)
+   .rs.scalar(result)
+})
+
+.rs.addFunction("python.goToDefinition", function(line, offset)
+{
    # extract the line providing the object definition we're looking for
    text <- .rs.python.extractCurrentExpression(line, offset)
    if (!nzchar(text))
@@ -78,6 +84,12 @@
 })
 
 .rs.addJsonRpcHandler("python_go_to_help", function(line, offset)
+{
+   result <- .rs.python.goToHelp(line, offset)
+   .rs.scalar(result)
+})
+
+.rs.addFunction("python.goToHelp", function(line, offset)
 {
    text <- .rs.python.extractCurrentExpression(line, offset)
    if (!nzchar(text))

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/WebApplicationHeader.java
@@ -18,11 +18,13 @@ package org.rstudio.studio.client.application.ui.impl;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.ImageElement;
+import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Cursor;
 import com.google.gwt.dom.client.Style.Position;
 import com.google.gwt.dom.client.Style.TextDecoration;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Command;
@@ -533,15 +535,21 @@ public class WebApplicationHeader extends Composite
    // keystrokes (e.g. Help in Chrome)
    static
    {
-      Event.addNativePreviewHandler(event ->
+      Event.addNativePreviewHandler(preview ->
       {
-         if (event.getTypeInt() == Event.ONKEYDOWN)
+         if (preview.getTypeInt() == Event.ONKEYDOWN)
          {
-            int keyCode = event.getNativeEvent().getKeyCode();
-            int modifier = KeyboardShortcut.getModifierValue(event.getNativeEvent());
-            if (modifier == KeyboardShortcut.NONE && (keyCode == 112 || keyCode == 113))
+            NativeEvent event = preview.getNativeEvent();
+            int keyCode = event.getKeyCode();
+            int modifier = KeyboardShortcut.getModifierValue(event);
+            
+            if (modifier == KeyboardShortcut.NONE)
             {
-              event.getNativeEvent().preventDefault();
+               if (keyCode == KeyCodes.KEY_F1 ||
+                   keyCode == KeyCodes.KEY_F2)
+               {
+                  event.preventDefault();
+               }
             }
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -36,7 +36,6 @@ import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
-import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.CommandLineHistory;
@@ -50,7 +49,6 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.ConsoleEditorProvider;
 import org.rstudio.studio.client.workbench.commands.Commands;
-import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.model.ClientInitState;
 import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.ConsoleAction;
@@ -182,16 +180,17 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus.addHandler(SuppressNextShellFocusEvent.TYPE, this);
       eventBus.addHandler(RestartStatusEvent.TYPE, this);
 
-      final CompletionManager completionManager
-                  = new RCompletionManager(view_.getInputEditorDisplay(),
-                                          null,
-                                          new CompletionPopupPanel(),
-                                          server,
-                                          null,
-                                          null,
-                                          null,
-                                          (DocDisplay) view_.getInputEditorDisplay(),
-                                          EditorBehavior.AceBehaviorConsole);
+      final CompletionManager completionManager = new RCompletionManager(
+            view_.getInputEditorDisplay(),
+            null,
+            new CompletionPopupPanel(),
+            server,
+            null,
+            null,
+            null,
+            (DocDisplay) view_.getInputEditorDisplay(),
+            EditorBehavior.AceBehaviorConsole);
+      
       addKeyDownPreviewHandler(completionManager);
       addKeyPressPreviewHandler(completionManager);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -22,7 +22,6 @@ import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.Rectangle;
@@ -448,13 +447,13 @@ public class RCompletionManager implements CompletionManager
          {
             return snippets_.attemptSnippetInsertion(true);
          }
-         else if (keycode == 112 // F1
+         else if (keycode == KeyCodes.KEY_F1
                   && modifier == KeyboardShortcut.NONE)
          {
             goToHelp();
             return true;
          }
-         else if (keycode == 113 // F2
+         else if (keycode == KeyCodes.KEY_F2
                   && modifier == KeyboardShortcut.NONE)
          {
             goToDefinition();
@@ -533,12 +532,12 @@ public class RCompletionManager implements CompletionManager
                else if (keycode == KeyCodes.KEY_END)
                   return popup_.selectLast();
                
-               if (keycode == 112) // F1
+               if (keycode == KeyCodes.KEY_F1)
                {
                   context_.showHelpTopic();
                   return true;
                }
-               else if (keycode == 113) // F2
+               else if (keycode == KeyCodes.KEY_F2)
                {
                   goToDefinition();
                   return true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -19,6 +19,7 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.resources.client.ClientBundle;
@@ -154,11 +155,11 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
             int modifier = KeyboardShortcut.getModifierValue(event);
             if (modifier == KeyboardShortcut.NONE)
             {
-               if (event.getKeyCode() == 112) // F1
+               if (event.getKeyCode() == KeyCodes.KEY_F1)
                {
                   goToHelp();
                }
-               else if (event.getKeyCode() == 113) // F2
+               else if (event.getKeyCode() == KeyCodes.KEY_F2)
                {
                   goToDefinition();
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/cpp/CppCompletionManager.java
@@ -169,13 +169,13 @@ public class CppCompletionManager implements CompletionManager
          {
             return snippets_.attemptSnippetInsertion(true);
          }
-         else if (event.getKeyCode() == 112 // F1
+         else if (event.getKeyCode() == KeyCodes.KEY_F1
                   && modifier == KeyboardShortcut.NONE)
          {
             goToHelp();
             return true;
          }
-         else if (event.getKeyCode() == 113 // F2
+         else if (event.getKeyCode() == KeyCodes.KEY_F2
                   && modifier == KeyboardShortcut.NONE)
          {
             goToDefinition();


### PR DESCRIPTION
### Intent

<kbd>F1</kbd> was not properly triggered the 'go to help' command for Python code when triggered from the R console.

### Approach

Unfortunately, it seems like the underlying bug lives in `reticulate`, and may be somewhat hairy to fix (it involves different help handler code that I'm not super familiar with). Until we have that sorted out, the simplest way forward is to just have our own patch in RStudio.

### QA Notes

Verify that help for Python objects can be requested both in Python scripts and R scripts. For example, in R:

```
library(reticulate)
np <- import("numpy", convert = TRUE)
np$random
```

And in Python:

```
import numpy as np
np.random
```

Closes https://github.com/rstudio/rstudio/issues/5982.