### PR TITLE
Ensure files moved to Source Pane are visible

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -192,7 +192,9 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
       additionalColumnCount_ = paneConfig.getAdditionalSourceColumns();
 
       add(new Label("Choose the layout of the panels in RStudio by selecting from the controls in" +
-         " each panel. Add up to three additional Source Columns to the left side of the layout.",
+         " each panel. Add up to three additional Source Columns to the left side of the layout. " +
+         "When a column is removed, all saved files within the column are closed and any unsaved " +
+         "files are moved to the main Source Pane.",
          true));
 
       Toolbar columnToolbar = new Toolbar("Manage Column Display");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1602,6 +1602,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                      public void onResponseReceived(final SourceDocument doc)
                      {
                         mainColumn.addTab(doc, Source.OPEN_INTERACTIVE);
+                        mainColumn.ensureVisible(true);
                      }
 
                      @Override


### PR DESCRIPTION
### Intent

Closes #8353 

If a source columns with unsaved files is closed, the files are moved to the main source area. However, if the main source pane was minimized this wasn't apparent so we now pop it open. 

### Approach

When a file is added to a pane, ensure the pane is visible. Also added text to the Global Options pane so that the behavior is clear to the user. Depending on feedback, we may change this behavior in 1.5.

### QA Notes

Open several files in a new column and minimized the main source pane. Add text without saving to one of the files. Remove the column from the Global Options pane and confirm the unsaved file is now visible in the source pane. 


