### PR TITLE
don't enque client events from forked sessions

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -16,4 +16,5 @@
 * Fixed issue where reinstalling an already-loaded package could cause errors (#8265)
 * Fixed issue where right-assignment with multi-line strings gave false-positive diagnostic errors (#8307)
 * Fixed issue where restoring R workspace could fail when project path contained non-ASCII characters (#8321)
+* Fixed issue where forked R sessions could hang after a package was loaded or unloaded (#8361)
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -160,6 +160,10 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
 {
    try
    {
+      // ignore forked sessions
+      if (main_process::wasForked())
+         return R_NilValue;
+      
       // extract name
       std::string name = r::sexp::asString(nameSEXP);
       


### PR DESCRIPTION
### Intent

Avoid attempts to enque client callbacks from forked sessions. (Most commonly, these are package events from forked processes.)

### Approach

Simple check of `wasForked()` flag.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8361.

Closes https://github.com/rstudio/rstudio/issues/8361.

