### PR TITLE
don't raise History pane on console reset

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
@@ -219,8 +219,6 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
          @Override
          public void onConsoleResetHistory(ConsoleResetHistoryEvent event)
          {
-            view_.bringToFront();
-
             // convert to HistoryEntry
             ArrayList<HistoryEntry> commands = toRecentCommandsList(
                                                          event.getHistory());


### PR DESCRIPTION
### Intent

When a console history file is loaded, we automatically raise + focus the History pane. This is a bit too aggressive, especially in the context of reticulate since we need to switch + maintain separate history files for R + Python.

### Approach

Don't raise the History pane.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5984.

Closes https://github.com/rstudio/rstudio/issues/5984.