### PR TITLE
ensure focus set on file.edit call

### DIFF
--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -304,7 +304,7 @@
         args <- args[names(args) == ""]
 
       # call rstudio fileEdit function
-      invisible(.Call("rs_fileEdit", args))
+      invisible(.Call("rs_fileEdit", args, PACKAGE = "(embedding)"))
    })
 })
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1948,13 +1948,8 @@ public class Source implements InsertSourceHandler,
             // helper command to focus after navigation has completed
             final Command onNavigationCompleted = () ->
             {
-               if (file.focusOnNavigate())
-               {
-                  Scheduler.get().scheduleDeferred(() ->
-                  {
-                     target.focus();
-                  });
-               }
+               events_.fireEvent(new SuppressNextShellFocusEvent());
+               target.focus();
             };
 
 
@@ -2197,7 +2192,9 @@ public class Source implements InsertSourceHandler,
    {
       if (SourceWindowManager.isMainSourceWindow())
       {
-         fileTypeRegistry_.editFile(event.getFile());
+         FileSystemItem file = event.getFile();
+         file.setFocusOnNavigate(true);
+         fileTypeRegistry_.editFile(file);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1948,8 +1948,11 @@ public class Source implements InsertSourceHandler,
             // helper command to focus after navigation has completed
             final Command onNavigationCompleted = () ->
             {
-               events_.fireEvent(new SuppressNextShellFocusEvent());
-               target.focus();
+               if (file.focusOnNavigate())
+               {
+                  events_.fireEvent(new SuppressNextShellFocusEvent());
+                  target.focus();
+               }
             };
 
 


### PR DESCRIPTION
### Intent

Files navigated via `file.edit()` were no longer being focused after open. 

### Approach

Mark such files with the `focus_after_navigate` flag. Also provide a better fix for focus-after-navigate for visual mode.

### QA Notes

Test that `file.edit(<path>)` opens the file at `<path>`, and also focuses the source editor after the file has been opened. Verify this occurs both in regular source documents, as well as R Markdown documents open in visual mode.

Closes https://github.com/rstudio/rstudio/issues/7832.