### PR TITLE
exclude context completions when retrieving chunk option completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -703,7 +703,7 @@ public class CompletionRequester
                   JsUtil.toJsArrayInteger(new ArrayList<>(result.completions.length())),
                   JsUtil.toJsArrayString(new ArrayList<>(result.completions.length())),
                   "",
-                  false,
+                  true,
                   false,
                   true,
                   null,


### PR DESCRIPTION
### Intent

When retrieving chunk option completions, we allowed for context-related completions as well. These completions aren't relevant / useful.

### Approach

Don't use context completions for chunk option completions.

### QA Notes

Validate that chunk option completions are the same regardless of source / visual mode. Compare with screencast in https://github.com/rstudio/rstudio/issues/7697#issuecomment-727040458.

Closes https://github.com/rstudio/rstudio/issues/7697.