### PR TITLE
use timer to collate multiple loadFinished calls

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -669,11 +669,28 @@ void MainWindow::onLoadFinished(bool ok)
 {
    LOCK_MUTEX(mutex_)
    {
-      loadTimer_->start(1000);
-      
       if (ok)
       {
+         // if this was a successful load, we're done
+         loadTimer_->stop();
          loadedSuccessfully_ = true;
+      }
+      else if (loadedSuccessfully_)
+      {
+         // if the load was purportedly not successful, even
+         // though a prior load was successful, then ignore
+         // that (assume that this was a spurious / incorrect
+         // signal from Qt)
+         LOG_DEBUG_MESSAGE(
+                  "Discarding onLoadFinished(false) signal as we have "
+                  "already received onLoadFinished(true)");
+      }
+      else
+      {
+         // schedule our load timer and allow a 1s buffer for
+         // incoming loadFinished() events which might report
+         // that the load was actually successful
+         loadTimer_->start(1000);
       }
    }
    END_LOCK_MUTEX

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -65,6 +65,7 @@ MainWindow::MainWindow(QUrl url,
       pRemoteSessionLauncher_(nullptr),
       pLauncher_(new JobLauncher(this)),
       pCurrentSessionProcess_(nullptr),
+      loadTimer_(new QTimer(this)),
       isErrorDisplayed_(false)
 {
    RCommandEvaluator::setMainWindow(this);
@@ -110,6 +111,9 @@ MainWindow::MainWindow(QUrl url,
    pMainMenuStub->addMenu(QString::fromUtf8("Help"));
    setMenuBar(pMainMenuStub);
 #endif
+   
+   connect(loadTimer_, &QTimer::timeout,
+           this, &MainWindow::onLoadFinishedImpl);
    
    connect(&menuCallback_, SIGNAL(menuBarCompleted(QMenuBar*)),
            this, SLOT(setMenuBar(QMenuBar*)));
@@ -665,21 +669,42 @@ void MainWindow::onLoadFinished(bool ok)
 {
    LOCK_MUTEX(mutex_)
    {
-      if (ok || pRemoteSessionLauncher_ || isErrorDisplayed_)
+      loadTimer_->start(1000);
+      
+      if (ok)
+      {
+         loadedSuccessfully_ = true;
+      }
+   }
+   END_LOCK_MUTEX
+}
+
+void MainWindow::onLoadFinishedImpl()
+{
+   LOCK_MUTEX(mutex_)
+   {
+      if (loadedSuccessfully_ || pRemoteSessionLauncher_ || isErrorDisplayed_)
          return;
 
       RS_CALL_ONCE();
+
+      std::map<std::string, std::string> vars = {
+         { "url",  webView()->url().url().toStdString() }
+      };
       
-      std::map<std::string,std::string> vars;
-      vars["url"] = webView()->url().url().toStdString();
       std::ostringstream oss;
-      Error error = text::renderTemplate(options().resourcesPath().completePath("html/connect.html"),
-                                       vars, oss);
+      Error error = text::renderTemplate(
+               options().resourcesPath().completePath("html/connect.html"),
+               vars,
+               oss);
 
       if (error)
+      {
          LOG_ERROR(error);
-      else
-         loadHtml(QString::fromStdString(oss.str()));
+         return;
+      }
+      
+      loadHtml(QString::fromStdString(oss.str()));
    }
    END_LOCK_MUTEX
 }

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -75,6 +75,7 @@ public Q_SLOTS:
    void onPdfViewerSyncSource(QString srcFile, int line, int column);
    void onLicenseLost(QString licenseMessage);
    void onUpdateLicenseWarningBar(QString message);
+   void onLoadFinishedImpl();
 
    bool isRemoteDesktop() const;
 
@@ -129,6 +130,7 @@ private:
    bool quitConfirmed_ = false;
    bool geometrySaved_ = false;
    bool workbenchInitialized_ = false;
+   bool loadedSuccessfully_ = false;
    MenuCallback menuCallback_;
    GwtCallback gwtCallback_;
    SessionLauncher* pSessionLauncher_;
@@ -136,6 +138,7 @@ private:
    boost::shared_ptr<JobLauncher> pLauncher_;
    ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
+   QTimer* loadTimer_;
 
    boost::mutex mutex_;
    bool isErrorDisplayed_;


### PR DESCRIPTION
### Intent

On rare occasions, multiple `loadFinished()` signals will be sent to the main window when attempting to load RStudio, with the first of those signal(s) setting `ok = false` with the final setting `ok = true`. This causes issues for us on load as we expect to only ever receive a single `loadFinished()` signal.

### Approach

Use a timer to collect and wait for other incoming `loadFinished()` signals, to see if we eventually receive a "success" signal.

### QA Notes

Unfortunately not sure how to reproduce consistently, but users encountering this issue will hopefully be able to report back.

Closes https://github.com/rstudio/rstudio/issues/8270.