### PR TITLE
fix vim close-all command

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1424,7 +1424,21 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       findByDocument(target.getId()).closeTab(
          target.asWidget(), interactive, onClosed);
    }
-   
+
+   private void closeAllTabs(boolean interactive, Command onCompleted)
+   {
+      if (interactive)
+      {
+         // call into the interactive tab closer
+         commands_.closeAllSourceDocs().execute();
+      }
+      else
+      {
+         // revert unsaved targets and close tabs
+         revertUnsavedTargets(() -> closeAllTabs(false, false, onCompleted));
+      }
+   }
+
    public void closeAllTabs(boolean excludeActive,
                             boolean excludeMain,
                             Command onCompleted)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceVimCommands.java
@@ -101,9 +101,9 @@ public class SourceVimCommands
       
          var interactive = true;
          if (params.argString && params.argString === "!")
-            interactive = false;
+            interactive = false; // close unsaved files without saving them (or prompting)
          
-         source.@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::closeAllTabs(ZZLcom/google/gwt/user/client/Command;)(interactive, false, onCompleted);
+         source.@org.rstudio.studio.client.workbench.views.source.SourceColumnManager::closeAllTabs(ZLcom/google/gwt/user/client/Command;)(interactive, onCompleted);
       });
        
       $wnd.require("ace/keyboard/vim").CodeMirror.Vim.defineEx("qall", "qa", callback);


### PR DESCRIPTION
### Intent

- Fixes #8388

### Approach

- Refactoring during addition of source columns removed handling of the "interactive" flag (and accidentally interpreted it as the "don't close active file" flag
- Now "interactive" once again means a :qa or :qall vim command will prompt about unsaved changes, and ultimately close all files
- The original code that got removed can be seen here: https://github.com/rstudio/rstudio/blob/a865ba2b2e5b4daee39d0e94d0e42c7b6088054d/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java#L892-L923

### QA Notes

Validate scenario described in issue.
