### PR TITLE
fix usage of addHistory flag

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -360,7 +360,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       boolean addToHistory = event.getPrompt().getAddToHistory();
       consolePrompt(prompt, addToHistory);
    }
-
+   
    private void consolePrompt(String prompt, boolean addToHistory)
    {
       view_.consolePrompt(prompt, true);
@@ -743,7 +743,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       {
          SessionInfo info = session_.getSessionInfo();
          String prompt = info.getPrompt();
-         consolePrompt(prompt, false);
+         consolePrompt(prompt, true);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -361,6 +361,10 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       consolePrompt(prompt, addToHistory);
    }
    
+   // NOTE: 'addToHistory()' flag controls whether the next-processed
+   // command entry should be added to the console history; normally,
+   // it's only set to false for commands synthesized by the IDE (and
+   // so not explicitly entered by the user)
    private void consolePrompt(String prompt, boolean addToHistory)
    {
       view_.consolePrompt(prompt, true);


### PR DESCRIPTION
### Intent

A recent PR (https://github.com/rstudio/rstudio/pull/8053) made some changes to ensure the console prompt was properly reset after a session restart, to avoid the case where e.g. a Python prompt was preserved even after the session restart returned to R mode.

This had the unintended side effect of causing the next-executed command to be omitted from the console history. This was due to my misunderstanding of the `addHistory` flag; I thought "surely we do not want to add the prompt to the console history" but this actually sets a flag that controls whether the next-processed command is added to the console history.

### Approach

We _do_ want the next-executed command to be added to the console history, so add it!

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8391.

Closes https://github.com/rstudio/rstudio/issues/8391.