### PR TITLE
Fix issue with daily build links

### DIFF
--- a/docker/jenkins/publish-daily-binary.sh
+++ b/docker/jenkins/publish-daily-binary.sh
@@ -15,10 +15,34 @@ URL=$1
 IDENTITY=$2
 FILENAME="${URL##*/}"
 
+# parse the URL into components; save/restore IFS (field separator)
+OLDIFS="$IFS"
+IFS='/'
+read -ra COMPONENTS <<< "$URL"
+IFS="$OLDIFS"
+
+# ensure sufficient components
+if [[ ${#COMPONENTS[@]} -lt 7 ]]; then
+    echo "Unexpected URL format '$URL'"
+    exit 1
+fi
+
+# parse URL components to extract flavor/OS/platform
+FLAVOR=${COMPONENTS[4]}
+OS=${COMPONENTS[5]}
+PLATFORM=${COMPONENTS[6]}
+
+# sanity check a URL component to fail faster if the URL is not in the format
+# we expect
+if [ "$FLAVOR" != "desktop" ] && [ "$FLAVOR" != "server" ]; then
+    echo "Unsupported flavor '$FLAVOR' (expected 'desktop' or 'server')"
+    exit 1
+fi
+
 # figure out the "latest" package name by replacing the version number with "latest"; for example
 # for "rstudio-server-pro-1.3.413-4.deb", we want "rstudio-server-pro-latest.deb"
 LATEST=$(echo "$FILENAME" | sed -e 's/[[:digit:]]\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\(-[[:digit:]][[:digit:]]*\)*/latest/')
-echo "Publishing $FILENAME as daily build $LATEST..."
+echo "Publishing $FILENAME as daily $FLAVOR build for $OS ($PLATFORM): $LATEST..."
 
 # download the current .htaccess file to a temporary location
 HTACCESS=$(mktemp)
@@ -26,7 +50,7 @@ echo "Fetching .htaccess for update..."
 scp -o StrictHostKeyChecking=no -i $IDENTITY www-data@rstudio.org:/srv/www/rstudio.org/public_html/download/latest/daily/.htaccess $HTACCESS
 
 # remove existing redirect
-sed -i.bak "s/$LATEST .*/$LATEST ${URL//\//\\/}/" $HTACCESS
+sed -i.bak "s/${FLAVOR}\/${OS}\/${LATEST} .*/${FLAVOR}\/${OS}\/${LATEST} ${URL//\//\\/}/" $HTACCESS
 
 # copy it back up
 echo "Uploading new .htaccess..."
@@ -35,3 +59,4 @@ scp -o StrictHostKeyChecking=no -i $IDENTITY $HTACCESS www-data@rstudio.org:/srv
 # clean up
 rm -f $HTACCESS
 rm -f $HTACCESS.bak
+


### PR DESCRIPTION
### Intent

This change addresses an issue that could cause the daily build redirects (`/latest/`) to point to the wrong build. 

Fixes https://github.com/rstudio/rstudio/issues/8105.

### Approach

The underlying problem is that the regex used to match the URL to update the `.htaccess` file isn't restrictive enough. This can cause an updated link for one platform to be applied to other platforms, and the fix is simply to amend the regex with some pieces of the download link so that doesn't happen.

As a side note, careful scrutiny will reveal that there's a potential for a variety of other problems with this way of updating the daily build links (e.g. race conditions when two concurrent builds finish at once). This system is old and should be replaced, but doing so is out of scope for 1.4

### QA Notes

Test via notes in #8105. There is is a tooling change, not a product change.
