### PR TITLE
Stop using Ctrl+FKey shortcuts on macOS

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -736,7 +736,7 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateBuild" value="Meta+F2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateBuild" value="Ctrl+F2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
-         <!-- Not using Cmd+F5 on Mac, it is the standard shortcut for toggling VoiceOver -->
+         <!-- Not using Cmd+F5 (aka Meta+F5) on Mac, it is the standard shortcut for toggling VoiceOver -->
          <shortcut refid="activateConnections" value="Ctrl+F5" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          
          <shortcut refid="activateFindInFiles" value="Meta+F6" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -731,11 +731,15 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activatePackages" value="Ctrl+7"/>
          <shortcut refid="activateEnvironment" value="Ctrl+8"/>
          <shortcut refid="activateViewer" value="Ctrl+9"/>
-         <shortcut refid="activateVcs" value="Ctrl+F1"/>
-         <shortcut refid="activateBuild" value="Ctrl+F2"/>
-         <shortcut refid="activateConnections" value="Ctrl+F5"/>
-         <shortcut refid="activateFindInFiles" value="Ctrl+F6"/>
-         <shortcut refid="newSourceColumn" value="Ctrl+F7"/>
+         <shortcut refid="activateVcs" value="Meta+F1" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateVcs" value="Ctrl+F1" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateBuild" value="Meta+F2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateBuild" value="Ctrl+F2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateConnections" value="Ctrl+F5" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateFindInFiles" value="Meta+F6" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="activateFindInFiles" value="Ctrl+F6" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="newSourceColumn" value="Meta+F7" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         <shortcut refid="newSourceColumn" value="Ctrl+F7" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
 
          <!-- Windows masks Ctrl+Shift+0 for IME input -->
          <shortcut refid="layoutEndZoom" value="Ctrl+Shift+0" if="!org.rstudio.core.client.BrowseCap.isWindowsDesktop()" />

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -735,7 +735,10 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateVcs" value="Ctrl+F1" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateBuild" value="Meta+F2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateBuild" value="Ctrl+F2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         
+         <!-- Not using Cmd+F5 on Mac, it is the standard shortcut for toggling VoiceOver -->
          <shortcut refid="activateConnections" value="Ctrl+F5" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
+         
          <shortcut refid="activateFindInFiles" value="Meta+F6" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateFindInFiles" value="Ctrl+F6" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="newSourceColumn" value="Meta+F7" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -827,7 +827,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Git/SVN</td>
       <td>Ctrl+F1</td>
-      <td>Cmd+F1</td>
+      <td>Command+F1</td>
     </tr>
     <tr>
       <td>Zoom Git/SVN</td>
@@ -836,7 +836,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Build</td>
       <td>Ctrl+F2</td>
-      <td>Cmd+F2</td>
+      <td>Command+F2</td>
     </tr>
     <tr>
       <td>Zoom Build</td>
@@ -861,7 +861,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Find in Files Results</td>
       <td>Ctrl+F6</td>
-      <td>Cmd+F6</td>
+      <td>Command+F6</td>
     </tr>
     <tr>
       <td>Sync Editor &amp; PDF Preview</td>

--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -827,7 +827,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Git/SVN</td>
       <td>Ctrl+F1</td>
-      <td>Ctrl+F1</td>
+      <td>Cmd+F1</td>
     </tr>
     <tr>
       <td>Zoom Git/SVN</td>
@@ -836,7 +836,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Build</td>
       <td>Ctrl+F2</td>
-      <td>Ctrl+F2</td>
+      <td>Cmd+F2</td>
     </tr>
     <tr>
       <td>Zoom Build</td>
@@ -846,7 +846,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Connections</td>
       <td>Ctrl+F5</td>
-      <td>Ctrl+F5</td>
+      <td>No shortcut</td>
     </tr>
     <tr>
       <td>Zoom Connections</td>
@@ -861,7 +861,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Show Find in Files Results</td>
       <td>Ctrl+F6</td>
-      <td>Ctrl+F6</td>
+      <td>Cmd+F6</td>
     </tr>
     <tr>
       <td>Sync Editor &amp; PDF Preview</td>
@@ -886,7 +886,7 @@ References on default Ace shortcuts:
     <tr>
       <td>Add source column</td>
       <td>Ctrl+F7</td>
-      <td>Ctrl+F7</td>
+      <td>Command+F7</td>
     </tr>
     <tr>
       <td>Global Options</td>


### PR DESCRIPTION
### Intent

- The Ctrl+F1 through Ctrl+F8 shortcuts have existing meanings on macOS and shouldn't be used by applications
- They are either not passed through to the application at all, or come through inconsistently especially in RStudio Desktop
- Fixes #8401

### Approach

- On Mac change following shortcuts from Ctrl+FKey to Cmd+FKey:
    - Cmd+F1 - activate VCS pane
    - Cmd+F2 - activate Build pane
    - Cmd+F6 - activate Find in Files pane
    - Cmd+F7 - new source column
- On Mac, get rid of shortcut for Activate Connections altogether (was Ctrl+F5 which is reserved but Cmd+F5 is used for VoiceOver on macOS; given nobody has cared don't think eliminating it will be a big problem and users can always add their own mapping)

### QA Notes

Test that these shortcuts now work on Mac and are unchanged on Windows/Linux.
