### PR TITLE
set default cursor color for visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/panmirror/theme/PanmirrorThemeCreator.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/theme/PanmirrorThemeCreator.java
@@ -16,8 +16,8 @@
 package org.rstudio.studio.client.panmirror.theme;
 
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.ColorUtil.RGBColor;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.ColorUtil.RGBColor;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.ThemeColors;
 import org.rstudio.core.client.theme.ThemeFonts;
@@ -38,12 +38,12 @@ public class PanmirrorThemeCreator
       theme.darkMode = aceTheme.isDark();
       theme.solarizedMode = aceTheme.isSolarizedLight();
       
-      // get cursor color (guard against themes that don't set ace_cursor color)
-      String defaultCursorColor = aceTheme.isDark() ? "white" : "black";
+      // get cursor color (work around themes that don't set the ace_cursor color
+      // but instead style the cursor via a border styling)
       String cursorColor = DomUtils.extractCssValue("ace_cursor", "color");
-      theme.cursorColor = StringUtil.isNullOrEmpty(cursorColor)
-            ? cursorColor
-            : defaultCursorColor;
+      if (aceTheme.isDark() && StringUtil.equals(cursorColor, "rgb(0, 0, 0)"))
+         cursorColor = "white";
+      theme.cursorColor = cursorColor;
       
       // selection color
       if (aceTheme.isDark())

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/theme/PanmirrorThemeCreator.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/theme/PanmirrorThemeCreator.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.panmirror.theme;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ColorUtil.RGBColor;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.theme.ThemeColors;
 import org.rstudio.core.client.theme.ThemeFonts;
@@ -37,7 +38,12 @@ public class PanmirrorThemeCreator
       theme.darkMode = aceTheme.isDark();
       theme.solarizedMode = aceTheme.isSolarizedLight();
       
-      theme.cursorColor = DomUtils.extractCssValue("ace_cursor", "color");
+      // get cursor color (guard against themes that don't set ace_cursor color)
+      String defaultCursorColor = aceTheme.isDark() ? "white" : "black";
+      String cursorColor = DomUtils.extractCssValue("ace_cursor", "color");
+      theme.cursorColor = StringUtil.isNullOrEmpty(cursorColor)
+            ? cursorColor
+            : defaultCursorColor;
       
       // selection color
       if (aceTheme.isDark())


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8409.

### Approach

Not all Ace themes define a `color:` for the `ace_cursor` CSS style. Some themes style the cursor by instead coloring the cursor element's border, or via other means.

For such cases, it suffices just to use a better default cursor color (white for dark themes; black for light themes).

### QA Notes

Test that the themes enumerated in https://github.com/rstudio/rstudio/issues/8409#issuecomment-729080945 have a visible cursor in visual mode.