### PR TITLE
don't remove reticulate hooks on REPL teardown

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -269,18 +269,6 @@
 
 .rs.addFunction("reticulate.replTeardown", function()
 {
-   # restore old help method
-   builtins <- reticulate::import_builtins(convert = FALSE)
-   builtins$help <- .rs.getVar("reticulate.help")
-   
-   # restore matplotlib method
-   show <- .rs.getVar("reticulate.matplotlib.show")
-   if (!is.null(show)) {
-      matplotlib <- reticulate::import("matplotlib", convert = TRUE)
-      plt <- matplotlib$pyplot
-      plt$show <- show
-   }
-   
    # client event
    .rs.reticulate.enqueueClientEvent(
       .rs.reticulateEvents$REPL_TEARDOWN,


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8413.

### Approach

Previous versions of the IDE tried to ensure that our help + matplotlib hooks were only active with the Python REPL was active. This was considered confusing, since it meant those hooks were not active when interacting with the Python session from R via the `reticulate` functions directly.

Unfortunately, when that change was made I forgot to remove the old code that cleaned up the hooks in REPL teardown, which meant quitting the REPL implied clearing hooks that were set when Python was initialized.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8413.