### PR TITLE
fix regression in completion of methods attached to list objects

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -665,15 +665,12 @@ assign(x = ".rs.acCompletionTypes",
       stripped <- .rs.stripSurrounding(string)
       envir <- .rs.resolveEnvironment(envir)
       
-      if (!grepl("(", stripped, fixed = TRUE))
-      {
-         object <- .rs.tryCatch(
-            .rs.getAnywhere(
-               name  = stripped,
-               envir = envir
-            )
+      object <- .rs.tryCatch(
+         .rs.getAnywhere(
+            name  = stripped,
+            envir = envir
          )
-      }
+      )
    }
    else if (length(splat) == 2)
    {

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -665,11 +665,11 @@ assign(x = ".rs.acCompletionTypes",
       stripped <- .rs.stripSurrounding(string)
       envir <- .rs.resolveEnvironment(envir)
       
-      if (!grepl("(", string, fixed = TRUE))
+      if (!grepl("(", stripped, fixed = TRUE))
       {
          object <- .rs.tryCatch(
-            eval(
-               expr = parse(text = string),
+            .rs.getAnywhere(
+               name  = stripped,
                envir = envir
             )
          )

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -664,7 +664,16 @@ assign(x = ".rs.acCompletionTypes",
    {
       stripped <- .rs.stripSurrounding(string)
       envir <- .rs.resolveEnvironment(envir)
-      object <- .rs.tryCatch(get(stripped, envir = envir, mode = "function"))
+      
+      if (!grepl("(", string, fixed = TRUE))
+      {
+         object <- .rs.tryCatch(
+            eval(
+               expr = parse(text = string),
+               envir = envir
+            )
+         )
+      }
    }
    else if (length(splat) == 2)
    {


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8423.

### Approach

A recent PR regressed this:

https://github.com/rstudio/rstudio/commit/7fd3ff2ba1b579952baceaddd6fcb2ca4c88d186#diff-f198a504f201904479c929e2e53ea3c82c2e83f60bad4dc7e518249fefc41938R598-R600

The `.rs.getAnywhere()` function actually does evaluate "safe" R statements; e.g. those of the form `foo$bar`, which is necessary when retrieving completions for e.g. R6 methods since we typically have calls of the form `object$method(...)`.

### QA Notes

With `|` indicating the cursor position, test that autocompletion results are shown as expected here:

```
test <- function(x, y, z) {}
callbacks <- list(f = test)
callbacks$f(|)
```

<img width="277" alt="Screen Shot 2020-11-18 at 9 50 11 AM" src="https://user-images.githubusercontent.com/1976582/99567801-75dffc00-2983-11eb-9e66-538ae25962f1.png">
