### PR TITLE
fix precedence in null check

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -1748,8 +1748,7 @@ public class Source implements InsertSourceHandler,
 
                   SourcePosition position = event.getCursorPosition();
                   if (position != null &&
-                      position.getRow() > 0 ||
-                      position.getColumn() > 0)
+                      (position.getRow() > 0 || position.getColumn() > 0))
                   {
                      editingTarget.navigateToPosition(position, false);
                   }


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8198.

### Approach

Use parentheses to properly guard against `null` position when accessing its values. (🤦 )

### QA Notes

Test via @R-Hannibal's notes in https://github.com/rstudio/rstudio/issues/8198.