### PR TITLE
Prevent extra untitled doc

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -1059,14 +1059,17 @@ public class SourceColumn implements BeforeShowEvent.Handler,
             }
 
             @Override
-            public void onFailure(ServerError info)
+            public void onCancelled()
             {
+               super.onCancelled();
                newTabPending_--;
             }
 
             @Override
-            public void onCancelled()
+            public void onFailure(ServerError info)
             {
+               super.onFailure(info);
+               Debug.logError(info);
                newTabPending_--;
             }
          });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumn.java
@@ -1045,10 +1045,31 @@ public class SourceColumn implements BeforeShowEvent.Handler,
       // All columns aside from the main column should open with a document
       if (getTabCount() == 0 && newTabPending_ == 0)
       {
+         newTabPending_++;
+         
          // Avoid scenarios where the Source tab comes up but no tabs are
          // in it. (But also avoid creating an extra source tab when there
          // were already new tabs about to be created!)
-         newDoc(FileTypeRegistry.R, null);
+         newDoc(FileTypeRegistry.R, new ResultCallback<EditingTarget, ServerError>()
+         {
+            @Override
+            public void onSuccess(EditingTarget result)
+            {
+               newTabPending_--;
+            }
+
+            @Override
+            public void onFailure(ServerError info)
+            {
+               newTabPending_--;
+            }
+
+            @Override
+            public void onCancelled()
+            {
+               newTabPending_--;
+            }
+         });
       }
    }
 


### PR DESCRIPTION
### Intent

If an empty Source Pane is opened, it gets opened with an Untitled doc. There were some cases where two documents were being opened introduced with the multiple source column code. This fixes that issue.

### Approach

Increment and decrement`newTabPending_` when calling the method that checks if the document needs to be created. 

### QA Notes

See #8429 

Fixes #8429 
