### PR TITLE
provide an internal API for closing all source tabs without saving

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -720,6 +720,10 @@
    
 })
 
+.rs.addApiFunction("closeAllSourceBuffersWithoutSaving", function() {
+   .Call("rs_documentCloseAllNoSave", PACKAGE = "(embedding)")
+})
+
 # NOTE: we allow '1L' just in case for backwards compatibility
 # with older preferences not migrated to the newer string version
 .rs.addApiFunction("getConsoleHasColor", function(name) {

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -201,6 +201,7 @@ const int kTutorialLaunch = 186;
 const int kReticulateEvent = 187;
 const int kEnvironmentChanged = 188;
 const int kRStudioApiRequest = 189;
+const int kDocumentCloseAllNoSave = 190;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -558,6 +559,8 @@ std::string ClientEvent::typeName() const
          return "environment_changed";
       case client_events::kRStudioApiRequest:
          return "rstudioapi_request";
+      case client_events::kDocumentCloseAllNoSave:
+         return "document_close_all_no_save";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -202,6 +202,7 @@ extern const int kTutorialLaunch;
 extern const int kReticulateEvent;
 extern const int kEnvironmentChanged;
 extern const int kRStudioApiRequest;
+extern const int kDocumentCloseAllNoSave;
 }
 
 class ClientEvent

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1416,6 +1416,12 @@ SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP) {
    return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentClose), &protect);
 }
 
+SEXP rs_documentCloseAllNoSave() {
+   ClientEvent event(client_events::kDocumentCloseAllNoSave);
+   module_context::enqueClientEvent(event);
+   return R_NilValue;
+}
+
 SEXP rs_readSourceDocument(SEXP idSEXP)
 {
    std::string id = r::sexp::asString(idSEXP);
@@ -1492,6 +1498,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_requestDocumentSave, 1);
    RS_REGISTER_CALL_METHOD(rs_readSourceDocument, 1);
    RS_REGISTER_CALL_METHOD(rs_requestDocumentClose, 2);
+   RS_REGISTER_CALL_METHOD(rs_documentCloseAllNoSave, 0);
 
    // install rpc methods
    using boost::bind;

--- a/src/gwt/src/org/rstudio/studio/client/server/model/DocumentCloseAllNoSaveEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/model/DocumentCloseAllNoSaveEvent.java
@@ -1,0 +1,43 @@
+/*
+ * DocumentCloseAllNoSaveEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.server.model;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/**
+ * Close all documents, in all windows, discarding any unsaved changes.
+ */
+public class DocumentCloseAllNoSaveEvent extends GwtEvent<DocumentCloseAllNoSaveEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onDocumentCloseAllNoSave(DocumentCloseAllNoSaveEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onDocumentCloseAllNoSave(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -192,6 +192,7 @@ class ClientEvent extends JavaScriptObject
    public static final String TutorialLaunch = "tutorial_launch";
    public static final String ReticulateEvent = "reticulate_event";
    public static final String RStudioApiRequest = "rstudioapi_request";
+   public static final String DocumentCloseAllNoSave = "document_close_all_no_save";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -97,6 +97,7 @@ import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentCompletedEv
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentFailedEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentOutputEvent;
 import org.rstudio.studio.client.server.Bool;
+import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.server.model.RequestDocumentCloseEvent;
 import org.rstudio.studio.client.server.model.RequestDocumentSaveEvent;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
@@ -1063,6 +1064,10 @@ public class ClientEventDispatcher
          {
             RStudioApiRequestEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new RStudioApiRequestEvent(data));
+         }
+         else if (type == ClientEvent.DocumentCloseAllNoSave)
+         {
+            eventBus_.dispatchEvent(new DocumentCloseAllNoSaveEvent());
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -63,6 +63,7 @@ import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
+import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
 import org.rstudio.studio.client.workbench.FileMRUList;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.ClientState;
@@ -100,6 +101,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Singleton
 public class SourceColumnManager implements CommandPaletteEntrySource,
                                             SourceExtendedTypeDetectedEvent.Handler,
+                                            DocumentCloseAllNoSaveEvent.Handler,
                                             DebugModeChangedEvent.Handler
 {
    public interface CPSEditingTargetCommand
@@ -207,6 +209,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
       events_.addHandler(SourceExtendedTypeDetectedEvent.TYPE, this);
       events_.addHandler(DebugModeChangedEvent.TYPE, this);
+      events_.addHandler(DocumentCloseAllNoSaveEvent.TYPE, this);
 
       WindowEx.addFocusHandler(new FocusHandler()
       {
@@ -1094,6 +1097,12 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       EditingTarget target = findEditor(e.getDocId());
       if (target != null)
          target.adaptToExtendedFileType(e.getExtendedType());
+   }
+
+   @Override
+   public void onDocumentCloseAllNoSave(DocumentCloseAllNoSaveEvent event)
+   {
+      revertUnsavedTargets(() -> commands_.closeAllSourceDocs().execute());
    }
 
    public void nextTabWithWrap()


### PR DESCRIPTION

### Intent

- When authoring Selenium automation it can be helpful to close all existing sources tabs without worrying about saving
- Fixes #8425

### Approach

- Invoke from console via `.rs.api.closeAllSourceBuffersWithoutSaving()`
- Made the name intentionally long and cumbersome to reduce likelihood of accidentally invoking it

### QA Notes

- All code added will only be hit if this internal API is invoked from Console, so very safe

