### PR TITLE
use UTF-8 strings in a few more places

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1341,6 +1341,11 @@ SEXP createUtf8(const std::string& data, Protect* pProtect)
    return strSEXP;
 }
 
+SEXP createUtf8(const FilePath& filePath, Protect* pProtect)
+{
+   return createUtf8(filePath.getAbsolutePath(), pProtect);
+}
+
 SEXP createRawVector(const std::string& data, Protect* pProtect)
 {
    SEXP rawSEXP;

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -159,7 +159,23 @@ public:
       params_.push_back(Param(name, paramSEXP));
       return *this;
    }
-                        
+   
+   template <typename T>
+   RFunction& addUtf8Param(const T& param)
+   {
+      return addUtf8Param(std::string(), param);
+   }
+   
+   template <typename T>
+   RFunction& addUtf8Param(const std::string& name, const T& param)
+   {
+      r::sexp::Protect protect;
+      SEXP paramSEXP = sexp::createUtf8(param, &protect);
+      preserver_.add(paramSEXP);
+      params_.push_back(Param(name, paramSEXP));
+      return *this;
+   }
+   
    core::Error call(SEXP evalNS = R_GlobalEnv, bool safely = true);
    core::Error callUnsafe();
 

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -116,82 +116,18 @@ core::Error evaluateString(const std::string& str, T* pValue)
 class RFunction : boost::noncopyable
 {
 public:
-   explicit RFunction(const std::string& name)
-      : functionSEXP_(R_UnboundValue)
-   {
-      commonInit(name);
-   }
    
-   template <typename ParamType>
-   RFunction(const std::string& name, const ParamType& param)
+   template <typename... T>
+   explicit RFunction(const std::string& name, const T&... params)
       : functionSEXP_(R_UnboundValue)
    {
       commonInit(name);
-      addParam(param);
-   }
-  
-   template <typename Param1Type, typename Param2Type>
-   RFunction(const std::string& name, 
-             const Param1Type& param1, 
-             const Param2Type& param2)
-      : functionSEXP_(R_UnboundValue)
-   {
-      commonInit(name);
-      addParam(param1);
-      addParam(param2);
-   }
-   
-   template <typename Param1Type, typename Param2Type, typename Param3Type>
-   RFunction(const std::string& name, 
-             const Param1Type& param1, 
-             const Param2Type& param2,
-             const Param3Type& param3)
-      : functionSEXP_(R_UnboundValue)
-   {
-      commonInit(name);
-      addParam(param1);
-      addParam(param2);
-      addParam(param3);
-   }
-
-   template <typename Param1Type, typename Param2Type,
-             typename Param3Type, typename Param4Type>
-   RFunction(const std::string& name,
-             const Param1Type& param1,
-             const Param2Type& param2,
-             const Param3Type& param3,
-             const Param4Type& param4)
-      : functionSEXP_(R_UnboundValue)
-   {
-      commonInit(name);
-      addParam(param1);
-      addParam(param2);
-      addParam(param3);
-      addParam(param4);
-   }
-   
-   template <typename Param1Type, typename Param2Type,
-             typename Param3Type, typename Param4Type,
-             typename Param5Type>
-   RFunction(const std::string& name,
-             const Param1Type& param1,
-             const Param2Type& param2,
-             const Param3Type& param3,
-             const Param4Type& param4,
-             const Param5Type& param5)
-      : functionSEXP_(R_UnboundValue)
-   {
-      commonInit(name);
-      addParam(param1);
-      addParam(param2);
-      addParam(param3);
-      addParam(param4);
-      addParam(param5);
+      initParams(params...);
    }
    
    explicit RFunction(SEXP functionSEXP);
    
-   virtual ~RFunction();
+   ~RFunction();
    
    // COPYING: boost::noncopyable
    
@@ -268,6 +204,17 @@ public:
    
 private:
    void commonInit(const std::string& functionName);
+   
+   void initParams()
+   {
+   }
+   
+   template <typename T, typename... Rest>
+   void initParams(const T& param, const Rest&... rest)
+   {
+      addParam(std::string(), param);
+      initParams(rest...);
+   }
    
 private:
    // preserve SEXPs

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -165,6 +165,7 @@ SEXP create(const std::map<std::string, SEXP> &value,
 
 // Create a UTF-8 encoded character vector
 SEXP createUtf8(const std::string& data, Protect* pProtect);
+SEXP createUtf8(const core::FilePath& filePath, Protect* pProtect);
 
 // Create a raw vector (binary data)
 SEXP createRawVector(const std::string& data, Protect* pProtect);

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -45,11 +45,6 @@ FilePath explorerCacheDir()
    return module_context::sessionScratchPath().completeChildPath(kExplorerCacheDir);
 }
 
-std::string explorerCacheDirSystem()
-{
-   return string_utils::utf8ToSystem(explorerCacheDir().getAbsolutePath());
-}
-
 void removeOrphanedCacheItems()
 {
    Error error;
@@ -125,7 +120,7 @@ void onShutdown(bool terminatedNormally)
    
    using namespace r::exec;
    Error error = RFunction(".rs.explorer.saveCache")
-         .addParam(explorerCacheDirSystem())
+         .addUtf8Param(explorerCacheDir())
          .call();
    
    if (error)
@@ -185,7 +180,7 @@ void onDeferredInit(bool)
    
    using namespace r::exec;
    error = RFunction(".rs.explorer.restoreCache")
-         .addParam(explorerCacheDirSystem())
+         .addUtf8Param(explorerCacheDir())
          .call();
    
    if (error)
@@ -254,7 +249,7 @@ SEXP rs_objectAttributes(SEXP objectSEXP)
 SEXP rs_explorerCacheDir()
 {
    r::sexp::Protect protect;
-   return r::sexp::create(explorerCacheDirSystem(), &protect);
+   return r::sexp::createUtf8(explorerCacheDir(), &protect);
 }
 
 } // end anonymous namespace

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -447,17 +447,16 @@
   return(.rs.getRmdOutputInfo(target))
 })
 
-.rs.addFunction("inputDirToIndexFile", function(input_dir) {
-   index <- file.path(input_dir, "index.Rmd")
-   if (file.exists(index))
-      index
-   else {
-      index <- file.path(input_dir, "index.md")
-      if (file.exists(index))
-         index
-      else
-         NULL
-   }
+.rs.addFunction("inputDirToIndexFile", function(input_dir)
+{
+   paths <- c(
+      file.path(input_dir, "index.Rmd"),
+      file.path(input_dir, "index.md")
+   )
+   
+   for (path in paths)
+      if (file.exists(path))
+         return(path)
 })
 
 .rs.addFunction("getAllOutputFormats", function(input_dir, encoding) {
@@ -566,10 +565,6 @@
 
 .rs.addFunction("bookdown.renderedOutputPath", function(websiteDir, outputPath)
 {
-   # set encoding
-   Encoding(websiteDir) <- "UTF-8"
-   Encoding(outputPath) <- "UTF-8"
-   
    # if we have a PDF for this file, use it
    if (tools::file_ext(outputPath) == "pdf")
       return(outputPath)

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -275,8 +275,8 @@ std::string assignOutputUrl(const std::string& outputFile)
    {
       std::string renderedPath;
       Error error = r::exec::RFunction(".rs.bookdown.renderedOutputPath")
-            .addParam(websiteDir.getAbsolutePath())
-            .addParam(outputPath.getAbsolutePath())
+            .addUtf8Param(websiteDir)
+            .addUtf8Param(outputPath)
             .callUtf8(&renderedPath);
       if (error)
          LOG_ERROR(error);

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -1081,14 +1081,16 @@ json::Array websiteOutputFormatsJson()
    json::Array formatsJson;
    if (projectContext().config().buildType == r_util::kBuildTypeWebsite)
    {
-      r::exec::RFunction getFormats(".rs.getAllOutputFormats");
-      getFormats.addParam(string_utils::utf8ToSystem(
-         projectContext().buildTargetPath().getAbsolutePath()));
-      getFormats.addParam(projectContext().defaultEncoding());
       std::vector<std::string> formats;
-      Error error = getFormats.call(&formats);
+      
+      Error error = r::exec::RFunction(".rs.getAllOutputFormats")
+            .addUtf8Param(projectContext().buildTargetPath())
+            .addParam(projectContext().defaultEncoding())
+            .call(&formats);
+      
       if (error)
          LOG_ERROR(error);
+      
       formatsJson = json::toJsonArray(formats);
    }
    return formatsJson;


### PR DESCRIPTION
### Intent

While testing on a Windows account with a user with non-English letters, I noticed a couple more issues with handling of filenames:

```
Error in file.exists(index) : 
  file name conversion problem -- name too long?
Error in file.exists(index) : 
  file name conversion problem -- name too long?
Error in file.exists(index) : 
  file name conversion problem -- name too long?
Warning message:
In list.files(cacheDir) :
  unable to translate 'C:/Users/Cr<e8>me Br<fb>l<e9>e/Desktop/renv/.Rproj.user/24A05536/explorer-cache' to native encoding
```

From what I understand, this is caused by (failed?) attempts to convert UTF-8 strings to the native encoding, as opposed to just using the UTF-8 strings as-is.

### Approach

Augment our `RFunction` class with a new `addUtf8Param()` function, which is used to add strings (or string-like things) which should be UTF-8 encoded.

### QA Notes

Testing this is somewhat broad: it would be worth checking that RStudio functions without issue on Windows, for a user whose user name has accented characters. (I tested with an account name Crème Brûlée.

Closes #8435.