### PR TITLE
revert to creating strings in native encoding by default

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1035,10 +1035,18 @@ SEXP create(const char* value, Protect* pProtect)
    return create(std::string(value), pProtect);
 }
 
+// NOTE: by default, we create strings in the _native_ encoding,
+// not as UTF-8 strings. this is primarily because in a number of
+// places we explicitly convert strings from UTF-8 to the native
+// encoding, and so those code paths rely on the 'value' parameter
+// here really being in the native encoding. we should change this
+// to CE_UTF8 in the future but that will require auditing all
+// usages of create(), of which there are many (especially through
+// e.g. the RFunction class)
 SEXP create(const std::string& value, Protect* pProtect)
 {
    SEXP charSEXP;
-   pProtect->add(charSEXP = Rf_mkCharLenCE(value.c_str(), value.size(), CE_UTF8));
+   pProtect->add(charSEXP = Rf_mkCharLenCE(value.c_str(), value.size(), CE_NATIVE));
    
    SEXP valueSEXP;
    pProtect->add(valueSEXP = Rf_allocVector(STRSXP, 1));

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -154,8 +154,9 @@ Error NotebookQueueUnit::parseOptions(json::Object* pOptions)
    // evaluate this chunk's options in R
    r::sexp::Protect protect;
    SEXP sexpOptions = R_NilValue;
-   Error error = r::exec::RFunction(".rs.evaluateChunkOptions", 
-               string_utils::wideToUtf8(code_)).call(&sexpOptions, &protect);
+   Error error = r::exec::RFunction(".rs.evaluateChunkOptions")
+         .addUtf8Param(string_utils::wideToUtf8(code_))
+         .call(&sexpOptions, &protect);
    if (error)
       return error;
 
@@ -183,7 +184,7 @@ Error NotebookQueueUnit::parseOptions(json::Object* pOptions)
 Error NotebookQueueUnit::innerCode(std::string* pCode)
 {
    return r::exec::RFunction(".rs.extractChunkInnerCode")
-       .addParam(string_utils::wideToUtf8(code_))
+       .addUtf8Param(string_utils::wideToUtf8(code_))
        .callUtf8(pCode);
 }
 


### PR DESCRIPTION
### Intent

This was discovered as part of fixing https://github.com/rstudio/rstudio/issues/8435, and reverts part of an older PR: https://github.com/rstudio/rstudio/pull/7263

In particular, as part of that PR, we made a change so that strings were ~converted~ marked as UTF-8 by default here:

https://github.com/rstudio/rstudio/commit/d1289249b11e0d12d2be12b3ceb701c41f110cec#diff-1c101207d4078bdd9f5c46490672cf8b04cbbad2db4b10671ab88906af5aee26R1041

In hindsight, this isn't a great choice because it breaks our own usages of the form:

```
RFunction(".rs.foo")
    .addParam(string_utils::utf8ToSystem("string")))
```

because we effectively end up with a string in the native encoding, but we mark it as though it were UTF-8.

### Approach

Until we can take the time to audit usages of `RFunction` + `systemToUtf8()` (and other usages of `r::sexp::create(<string>)`), we should revert the default behavior to treating strings as though they are in the native encoding, since we do that intentionally in a number of places.

In the meantime, we can (as we did in my prior PR) explicitly use `addUtf8Param()` when we want to pass in UTF-8 strings, and `callUtf8()` when we want to ensure the returned string is UTF-8 encoded.

### QA Notes

Nothing specific to test; any issues would hopefully be caught in a normal certification pass on Windows.