### PR TITLE
fix closeAllSourceBuffersWithoutSaving to silently close modified unsaved buffers

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1102,7 +1102,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    @Override
    public void onDocumentCloseAllNoSave(DocumentCloseAllNoSaveEvent event)
    {
-      revertUnsavedTargets(() -> commands_.closeAllSourceDocs().execute());
+      revertUnsavedTargets(() -> closeAllTabs(false, false, null));
    }
 
    public void nextTabWithWrap()


### PR DESCRIPTION


### Intent

- Fixes #8425
- Original fix didn't handle unsaved but modified buffers properly and would still prompt

### Approach

- use lower-level internal API that handles this case properly 

### QA Notes

- a fix to the original PR here: #8432
