### PR TITLE
Disable virtualized console for chunk output in markdown files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -740,7 +740,10 @@ public class ChunkOutputStream extends FlowPanel
          console_.getElement().setInnerHTML("");
       }
       if (vconsole_ == null)
+      {
          vconsole_ = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(console_.getElement());
+         vconsole_.setVirtualizedDisableOverride(true);
+      }
       else
          vconsole_.clear();
 


### PR DESCRIPTION
### Intent

Fix chunk output throwing errors in markdown files with virtualized console turned on.

Fixes #8418 
Fixes #8416 

### Approach

Just had to disable Virtualization in the ChunkOutput.

### QA Notes

Very simple change. Should stop errors being thrown when running a simple chunk in Rmd files.


