### PR TITLE
mark R strings in RPC methods as UTF-8

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -58,6 +58,9 @@ if(MSVC)
   string(REGEX REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
   string(REGEX REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
 
+  string(REGEX REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+  string(REGEX REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+
   # ensure that we're using linker flags compatible with
   # the version of Boost that will be linked in
   if(NOT CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/src/cpp/r/RJsonRpc.cpp
+++ b/src/cpp/r/RJsonRpc.cpp
@@ -88,14 +88,34 @@ Error callRHandler(const std::string& functionName,
    
    // add params
    const core::json::Array& params = request.params;
-   for (size_t i=0; i < params.getSize(); i++)
-      rFunction.addParam(params[i]);
+   for (size_t i = 0; i < params.getSize(); i++)
+   {
+      const core::json::Value& param = params[i];
+      if (param.isString())
+      {
+         rFunction.addUtf8Param(param.getString());
+      }
+      else
+      {
+         rFunction.addParam(param);
+      }
+   }
    
    // add kwparams
    const core::json::Object& kwparams = request.kwparams;
    for (const core::json::Object::Member& member : kwparams)
    {
-      rFunction.addParam(member.getName(), member.getValue());
+      const std::string& name = member.getName();
+      const core::json::Value& value = member.getValue();
+
+      if (value.isString())
+      {
+         rFunction.addUtf8Param(name, value.getString());
+      }
+      else
+      {
+         rFunction.addParam(name, value);
+      }
    }
    
    // call the function
@@ -132,8 +152,7 @@ Error getRpcMethods(core::json::JsonRpcMethods* pMethods)
    // populate function map
    pMethods->clear();
    std::string rpcPrefix(".rs.rpc.");
-   for (std::vector<std::string>::const_iterator 
-        it = rpcHandlers.begin();
+   for (auto it = rpcHandlers.begin();
         it != rpcHandlers.end();
         ++it)
    {

--- a/src/cpp/session/modules/SessionProfiler.R
+++ b/src/cpp/session/modules/SessionProfiler.R
@@ -85,16 +85,20 @@
       resources <- .rs.profileResources()
       htmlFile <- normalizePath(tempfile(fileext = ".html", tmpdir = resources$tempPath), winslash = "/", mustWork = FALSE)
 
-      if (identical(profilerOptions$profvis, NULL)) {
-         if (identical(tools::file_ext(profilerOptions$fileName), "Rprof")) {
+      if (identical(profilerOptions$profvis, NULL))
+      {
+         if (identical(tools::file_ext(profilerOptions$fileName), "Rprof"))
+         {
             profvis <- profvis::profvis(prof_input = profilerOptions$fileName, split = "h")
             htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
          }
-         else {
+         else
+         {
             .rs.rpc.copy_profile(profilerOptions$fileName, htmlFile)
          }
       }
-      else {
+      else
+      {
          profvis <- profilerOptions$profvis
          htmlwidgets::saveWidget(profvis, htmlFile, selfcontained = TRUE)
       }

--- a/src/cpp/session/modules/SessionProfiler.cpp
+++ b/src/cpp/session/modules/SessionProfiler.cpp
@@ -89,11 +89,11 @@ void onDocPendingRemove(
    if (htmlLocalPath.empty() && path.empty())
       return;
 
-   r::exec::RFunction rFunction(".rs.rpc.clear_profile");
-   rFunction.addParam(path);
-   rFunction.addParam(htmlLocalPath);
+   Error error = r::exec::RFunction(".rs.rpc.clear_profile")
+         .addUtf8Param(path)
+         .addUtf8Param(htmlLocalPath)
+         .call();
 
-   Error error = rFunction.call();
    if (error)
    {
       LOG_ERROR(error);


### PR DESCRIPTION
### Intent

Whenever an RPC method is invoked, it's normally done with JSON data received from the client. Any such strings in that JSON are always UTF-8 encoded. However, when the associated R string is created from that JSON string, we were not marking the encoding. Hence, we ended up with data that was UTF-8 encoded, but interpreted as though it were in the native encoding.

This causes issues of this form on Windows:

https://github.com/rstudio/rstudio/issues/8435#issuecomment-731284135

A way to convince yourself is with something like the following:

```
 # take a UTF-8 string ...
> string <- enc2utf8("crème brûlée")
> 
> # but pretend it is latin1 encoded
> Encoding(string) <- "latin1"
> 
> string
[1] "crÃ¨me brÃ»lÃ©e"
```

And this is exactly the kind of mojibake seen in https://github.com/rstudio/rstudio/issues/8435#issuecomment-731284135.

### Approach

Use the associated UTF-8 APIs in `RFunction` when adding strings from JSON.

### QA Notes

On a Windows account with the name `Crème Brûlée`, confirm that you can create a new R package project.

Closes https://github.com/rstudio/rstudio/issues/8435.
Closes https://github.com/rstudio/rstudio/issues/8445.