### PR TITLE
mark UTF-8 encoding in package_skeleton

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -789,6 +789,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
                                                    sourceFiles,
                                                    usingRcpp)
 {
+   # mark encoding
+   Encoding(packageDirectory) <- "UTF-8"
+
    # sourceFiles is passed in as a list -- convert back to
    # character vector
    sourceFiles <- as.character(sourceFiles)


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8435.

### Approach

Mark UTF-8 string as UTF-8 in `.rs.rpc.package_skeleton` RPC method.

### QA Notes

Test via comment in https://github.com/rstudio/rstudio/issues/8435#issuecomment-731284135.