### PR TITLE
update from Qt 5.12.8 to 5.12.10

### DIFF
--- a/dependencies/linux/README
+++ b/dependencies/linux/README
@@ -9,7 +9,7 @@ systems. Specific version requirements for various components include:
 - R 3.0.1
 - CMake 3.4.3 or newer
 - Boost 1.69
-- Qt 5.12.8 [Required only for Desktop]
+- Qt 5.12.10 [Required only for Desktop]
 - patchelf 0.9 [Required only for Desktop]
 
 Installation of Qt SDK

--- a/dependencies/osx/README
+++ b/dependencies/osx/README
@@ -17,7 +17,7 @@ xcode-select --install
 Installing Qt SDK
 =============================================================================
 
-Building RStudio Desktop requires installation of Qt 5.12.8, including
+Building RStudio Desktop requires installation of Qt 5.12.10, including
 the macOS and QtWebEngine components.
 
 - https://www.qt.io/

--- a/dependencies/osx/install-qt-macos
+++ b/dependencies/osx/install-qt-macos
@@ -21,7 +21,7 @@
 set -e
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.12.8
+    QT_VERSION=5.12.10
 fi
 if [ -z "$QT_SDK_DIR" ]; then
 

--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -83,7 +83,7 @@ Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
 
 Write-Host "-----------------------------------------------------------"
 Write-Host "Core dependencies successfully installed. Next steps:"
-Write-Host "(1) Install Qt 5.12.8 from https://qt.io for MSVC 2017 64-bit with QtWebEngine"
+Write-Host "(1) Install Qt 5.12.10 from https://qt.io for MSVC 2017 64-bit with QtWebEngine"
 Write-Host "(2) Start a non-administrator Command Prompt"
 Write-Host "(3) git clone https://github.com/rstudio/rstudio"
 Write-Host "(4) change working dir to rstudio\src\dependencies\windows"

--- a/dependencies/windows/README.md
+++ b/dependencies/windows/README.md
@@ -13,7 +13,7 @@ Bootstrap
 
 Install Qt SDK
 =============================================================================
-Install Qt 5.12.8 SDK for Windows from https://qt.io, selecting 
+Install Qt 5.12.10 SDK for Windows from https://qt.io, selecting 
 following components:
 
 - MSVC 2017 64-bit
@@ -26,7 +26,7 @@ to include older versions.
 
 Alternatively, the offline installer may be used:
 
-http://download.qt.io/official_releases/qt/5.12/5.12.8/qt-opensource-windows-x86-5.12.8.exe
+http://download.qt.io/official_releases/qt/5.12/5.12.10/qt-opensource-windows-x86-5.12.10.exe
 
 Clone the Repo and Run Batch File
 =============================================================================

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -105,7 +105,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -101,7 +101,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # remove any previous users with conflicting IDs

--- a/docker/jenkins/Dockerfile.centos8-x86_64
+++ b/docker/jenkins/Dockerfile.centos8-x86_64
@@ -88,7 +88,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # get libuser header files (libuser-devel not currently available on centos8)

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -91,7 +91,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -83,7 +83,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # install GnuPG 1.4 from source (needed for release signing)

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -53,9 +53,9 @@ RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
 
 # install qt (note that we are using the current directory's context)
 RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.8-msvc2017_64.7z', 'c:\QtSDK-5.12.8-msvc2017_64.7z'); `
-  7z x c:\QtSDK-5.12.8-msvc2017_64.7z -oc:\ ; `
-  Remove-Item c:\QtSDK-5.12.8-msvc2017_64.7z -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.10-msvc2017_64.7z', 'c:\QtSDK-5.12.10-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.10-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.10-msvc2017_64.7z -Force
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/docker/jenkins/Dockerfile.xenial-amd64
+++ b/docker/jenkins/Dockerfile.xenial-amd64
@@ -106,7 +106,7 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
-RUN export QT_VERSION=5.12.8 && \
+RUN export QT_VERSION=5.12.10 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT WIN32)
          endif()
       endif()
 
-      set(QT_CANDIDATES 5.12.8)
+      set(QT_CANDIDATES 5.12.10)
 
       # find the newest installed Qt version among the versions we build
       # against
@@ -68,7 +68,7 @@ if(NOT WIN32)
    endif()
 else()
    # Windows
-   set(QT_VERSION "5.12.8")
+   set(QT_VERSION "5.12.10")
    set(QT_VERSION_SUBDIR "${QT_VERSION}")   
    if(NOT QT_QMAKE_EXECUTABLE)
 


### PR DESCRIPTION
Draft, still need to build on Windows and Linux (have done Mac so far) and see if any of the fixes actually help us.

### Intent

- Update to latest 5.12 LTS release (5.12.10)
- Fixes #8359

### Approach

- Update cmake files, dependency scripts. readme files

### QA Notes

- General usage of Desktop IDE to look for new excitement; this is a minor Qt update which (in theory) only includes a handful of fixes to Chromium and QtWebEngine
- Qt 5.12.10: https://www.qt.io/blog/qt-5.12.10-released
- Qt 5.12.9: https://www.qt.io/blog/qt-5.12.9-released

