### PR TITLE
avoid running pandoc when we have empty .Rmd file

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionBookdownXRefs.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionBookdownXRefs.cpp
@@ -137,11 +137,15 @@ XRefFileIndex indexForDoc(const std::string& file, const std::string& contents)
       }
    }
    std::string indexContents = boost::algorithm::join(indexLines, "\n");
-
+   
    // build index
    XRefFileIndex index(file);
 
-   // run pandoc w/ custom lua filter to capture index
+   // if we have no lines, bail early
+   if (indexContents.empty())
+      return index;
+
+   // otherwise, run pandoc w/ custom lua filter to capture index
    std::vector<std::string> args;
    args.push_back("--from");
    args.push_back("markdown");


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8453.

### Approach

Pandoc will hang if we try to run it and give an empty string as input.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8453.