### PR TITLE
don't use virtual console for inline chunk output

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -87,7 +87,12 @@ var VirtualScroller;
       }
 
       // jump to latest button
-      if (this.scrollerEle.parentElement.getElementsByClassName("jump-to-latest-console").length < 1) {
+      var hasJumpToConsoleBtn =
+        this.scrollerEle &&
+        this.scrollerEle.parentElement &&
+        this.scrollerEle.parentElement.getElementsByClassName("jump-to-latest-console").length < 1;
+
+      if (hasJumpToConsoleBtn) {
         this.jumpToLatestButton = document.createElement("div");
         this.jumpToLatestButton.classList.add("jump-to-latest-console");
         this.jumpToLatestButton.innerText = "Latest";

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -86,13 +86,13 @@ var VirtualScroller;
         }
       }
 
-      // jump to latest button
-      var hasJumpToConsoleBtn =
-        this.scrollerEle &&
-        this.scrollerEle.parentElement &&
-        this.scrollerEle.parentElement.getElementsByClassName("jump-to-latest-console").length < 1;
+      // validate that we've successfully found ace_scroller
+      if (self.scrollerEle == null) {
+        throw "internal error: virtual scroller could not find ace_scroller element";
+      }
 
-      if (hasJumpToConsoleBtn) {
+      // jump to latest button
+      if (this.scrollerEle.parentElement.getElementsByClassName("jump-to-latest-console").length < 1) {
         this.jumpToLatestButton = document.createElement("div");
         this.jumpToLatestButton.classList.add("jump-to-latest-console");
         this.jumpToLatestButton.innerText = "Latest";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkInlineOutput.java
@@ -48,6 +48,7 @@ public class ChunkInlineOutput extends MiniPopupPanel
       
       console_ = new PreWidget();
       vconsole_ = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(console_.getElement());
+      vconsole_.setVirtualizedDisableOverride(true);
       chunkId_ = chunkId;
       selection_ = selection;
       state_ = State.Queued;


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8465.

### Approach

Disable virtualized console for outputs generated from inline code chunks. Also add a safety fix in virtualscroller.js to ensure we do have a scroller element to inspect when adding output.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8465.