### PR TITLE
Default to pre-built macOS binaries on dev machines

### DIFF
--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -30,9 +30,15 @@ set -e
 # via sudo; however, this causes problems if used when building a Dockerfile
 if [ "$1" != "--install-crashpad-sudo" ]
 then
-   ./install-crashpad
+  if [[ "$OSTYPE" == "darwin"* ]]; then 
+    # use pre-built binaries on macos as compilation environment is difficult
+    # to configure there
+    ./install-crashpad osx
+  else 
+    ./install-crashpad
+  fi
 else
-   sudo ./install-crashpad
+  sudo ./install-crashpad
 fi
 
 if [ -e install-overlay ]


### PR DESCRIPTION
### Intent

Makes it easier to bootstrap macOS dev machines by defaulting to installation of pre-built Crashpad binaries.

### Approach

On MacOS, modify the common bootstrap script so that it uses pre-built binaries by default.

### QA Notes

Dev-only change, no product impact.