### PR TITLE
End previous mathjax renders before starting a new one

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -218,6 +218,9 @@ public class MathJax
                            final boolean background,
                            final MathJaxTypeset.Callback callback)
    {
+      // always clean up any ongoing renders before starting a new one
+      endRender();
+
       MathJaxLoader.withMathJaxLoaded(new MathJaxLoader.Callback()
       {
          @Override


### PR DESCRIPTION
### Intent

Fix #7947 

### Approach

Make sure that `MathJax.endRender` is called before `MathJax.renderLatex` executes. The issue was pretty easy to track down once I had a good repro, thanks Karl!

### QA Notes

Make sure that #7947 doesn't occur anymore using the repro that Karl posted at the bottom of the ticket.

