### PR TITLE
use more robust test for writable library

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -681,9 +681,31 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 
-.rs.addFunction( "isLibraryWriteable", function(lib)
+.rs.addFunction("isLibraryWriteable", function(lib)
 {
-   file.exists(lib) && (file.access(lib, 2) == 0)
+   # file.access() can be unreliable here, as it's
+   # possible for a directory to be un-writable despite
+   # having writable permissions set. the best way to
+   # be sure is to try to create and remove a file in
+   # that directory
+   file <- tempfile(pattern = ".rstudio-", tmpdir = lib)
+   status <- tryCatch(file.create(file), condition = identity)
+   
+   # treat any conditions as errors, since R will emit a
+   # warning (rather than error) if file creation fails
+   if (inherits(status, "condition"))
+      return(FALSE)
+   
+   # now, try to remove the temporary file (it would stink
+   # if we could create files but not remove them ...)
+   status <- tryCatch(file.remove(file), condition = identity)
+   if (inherits(status, "condition"))
+      return(FALSE)
+   
+   # we successfully created and removed a file in the library
+   # directory; treat it as writable
+   TRUE
+   
 })
 
 .rs.addFunction( "defaultLibPathIsWriteable", function()


### PR DESCRIPTION
### Intent

In some cases, RStudio might mis-detect a non-writable R library as writable. This PR intends to be a bit more robust to those cases.

### Approach

Rather than trust the POSIX permissions, check that we can explicitly create and remove a dummy file within the library directory. (This is necessary since, in some cases, POSIX permissions might report that a directory is writable even if the user doesn't actually have write access to that directory.)

### QA Notes

Unfortunately, not sure how to reproduce, but this was reported as occurring with an installation of R living on a NFS.

Closes https://github.com/rstudio/rstudio-pro/issues/2184.