### PR TITLE
Fix installation from Windows path containing multibyte chars not from system codepage

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -14,6 +14,7 @@
 
 ### Bugfixes
 
+* Fix Windows Desktop installer to support running from path with characters from other codepages (#8421)
 * Fixed issue where reinstalling an already-loaded package could cause errors (#8265)
 * Fixed issue where right-assignment with multi-line strings gave false-positive diagnostic errors (#8307)
 * Fixed issue where restoring R workspace could fail when project path contained non-ASCII characters (#8321)

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -7,6 +7,8 @@
   !define PATCH  "@CPACK_PACKAGE_VERSION_PATCH@"
   !define INST_DIR "@CPACK_TEMPORARY_DIRECTORY@"
 
+  Unicode true
+
 ;--------------------------------
 ;Variables
 


### PR DESCRIPTION
### Intent

- Fixes #8421
- Targeting Juliet-Rose since this issue has been around forever

### Approach

- Turn on NSIS Unicode support

### QA Notes

- Try installing on Windows with the setup package in a folder containing characters not in the current system language (e.g. a folder named 鬼 on an English system)
- Can do this by creating a user with that username, but also simply by creating a folder with that name and moving the setup .exe into it before running
