### PR TITLE
fixup C++ multi-line comment behaviors

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
+++ b/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
@@ -127,16 +127,17 @@ var CStyleBehaviour = function(codeModel) {
 
       if (text === "\n") {
 
-         // Get some needed variables
-         var row = editor.selection.getCursor().row;
-         var col = editor.selection.getCursor().column;
-
-         var tab = session.getTabString();
-
+         // Get some needed variables.
          var cursor = editor.getCursorPosition();
-         var line = session.doc.getLine(cursor.row);
+         var row = cursor.row;
+         var col = cursor.col;
+         var tab = session.getTabString();
+         var lines = session.doc.$lines;
+         var line = lines[row];
 
-         if (this.codeModel.inMacro(session.getDocument().$lines, row - 1)) {
+         // If we're editing within a multi-line macro definition,
+         // don't try to apply any custom behavior rules.
+         if (this.codeModel.inMacro(lines, row - 1)) {
             return;
          }
 
@@ -149,13 +150,22 @@ var CStyleBehaviour = function(codeModel) {
             };
          }
 
-         // If we're inserting a newline within a newly constructed comment
-         // block, insert a '*'.
-         if (/^\s*\/\*/.test(line))
+         // If the user has started a multi-line comment block,
+         // with text of the form:
+         // 
+         //     /**
+         //
+         // then fill in the rest of the comment with
+         //
+         //     /**
+         //      * |
+         //      */
+         //
+         if (/^\s*[/][*]+\s*$/.test(line))
          {
-            // Double-check that we haven't already closed this comment,
-            // or that this comment is continued on the next line.
-            if (line.indexOf("*/") !== -1 || !/^\s*\*/.test(session.getLine(row + 1)))
+            // Check if this comment block has already been continued.
+            var nextLine = lines[row + 1] || "";
+            if (!/^\s*[*]/.test(nextLine))
             {
                var indent = this.$getIndent(line);
                var newIndent = indent + " * ";


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8489.

### Approach

Tweak the way we detect whether `/**` is "incomplete" and so we should complete the comment with `*/`. We now perform detection based on whether the next line already has a `*` comment marker on the next line.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8489.