### PR TITLE
bump up wait time for desktop load

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -687,10 +687,10 @@ void MainWindow::onLoadFinished(bool ok)
       }
       else
       {
-         // schedule our load timer and allow a 1s buffer for
+         // schedule our load timer and allow a small buffer for
          // incoming loadFinished() events which might report
          // that the load was actually successful
-         loadTimer_->start(1000);
+         loadTimer_->start(5000);
       }
    }
    END_LOCK_MUTEX


### PR DESCRIPTION
### Intent

Potential fix for https://github.com/rstudio/rstudio/issues/8270.

### Approach

Wait a little longer for a successful loadFinished() signal.

### QA Notes

Unfortunately still not sure how to reproduce; will request further community testing.