### PR TITLE
markdown headers should not close chunks

### DIFF
--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -424,7 +424,7 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
          for (var i = children.length - 1; i >= 0; i--)
          {
             var child = children[i];
-            if (child.isFunction())
+            if (child.isFunction() || child.isChunk())
                return;
 
             if (child.isSection() && child.attributes.depth >= depth)


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8495.

### Approach

Don't let Markdown-style headers close chunks. This is necessary since Markdown-style headers (through R sections) can now be present within R Markdown chunks.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8495.