### PR TITLE
clear history search offset on new search requests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -124,7 +124,7 @@
 * Reduced difference in font size and spacing between Terminal and Console (#6382)
 * Fixed issue where path autocompletion in R Markdown documents did not respect Knit Directory preference (#5412)
 * Fixed issue where Job Launcher streams could remain open longer than expected when viewing the job details page (Pro #1855)
-* Fixed issue where `rstudioapi::askForPassword()` did not mask user input in some cases.
+* Fixed issue where `rstudioapi::askForPassword()` did not mask user input in some cases
 * Fixed issue where Job Launcher admin users would have `gid=0` in Slurm Launcher Sessions (Pro #1935)
 * Fixed issue where Slurm Job Launcher jobs would not post updated resource utilization without browser refresh (Pro #2177)
 * Fixed issue causing script errors when reloading Shiny applications from the editor toolbar (#7762)
@@ -135,6 +135,8 @@
 * Fixed issue where non-ASCII characters in Subversion commit comments were incorrect encoded on Windows (#7959)
 * Prevent Discard button from being hidden in Subversion diff viewer (#6031)
 * Fixed issue where French (AZERTY) keyboards inserted '/' rather than ':' in some cases (#7932)
-* `readline()` and `readLines()` can now be interrupted, even when reading from `stdin()`. (#3448)
+* `readline()` and `readLines()` can now be interrupted, even when reading from `stdin()` (#3448)
 * Fixed issue causing Knit button to show old formats after editing the YAML header (#7833)
 * Fixed issue wherein the Python prompt would continue to be shown after an R restart (#8011)
+* Fixed issue where searches in the console history could inappropriately preserve search position (#7682)
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -110,6 +110,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                 AriaLiveService ariaLive,
                 Display display,
                 Session session,
+                EventBus events,
                 Commands commands,
                 UserPrefs uiPrefs,
                 ErrorManager errorManager,
@@ -195,7 +196,9 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       addKeyPressPreviewHandler(completionManager);
 
       historyCompletion_ = new HistoryCompletionManager(
-            view_.getInputEditorDisplay(), server);
+            view_.getInputEditorDisplay(),
+            server);
+      
       addKeyDownPreviewHandler(historyCompletion_);
 
       // we need to explicitly connect a paste handler on Desktop
@@ -356,6 +359,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    public void onConsolePrompt(ConsolePromptEvent event)
    {
+      historyCompletion_.resetOffset();
       String prompt = event.getPrompt().getPromptText();
       boolean addToHistory = event.getPrompt().getAddToHistory();
       consolePrompt(prompt, addToHistory);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
@@ -61,6 +61,11 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
       // Current offset when navigating through search results
       offset_ = -1;
    }
+   
+   public void resetOffset()
+   {
+      offset_ = -1;
+   }
 
    public boolean previewKeyDown(NativeEvent event)
    {
@@ -229,13 +234,8 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
    {
       public HistoryCallback(String text, PopupMode desiredMode)
       {
-         // clear offset if initiating empty search, or if the new search
-         // text doesn't match the last search text
-         boolean resetOffset =
-               StringUtil.isNullOrEmpty(text) ||
-               !StringUtil.equals(text, lastSearch_);
-         
-         if (resetOffset)
+         // reset offset if initiating a new search
+         if (!StringUtil.equals(text, lastSearch_))
             offset_ = -1;
          
          // set associated class members

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
@@ -229,16 +229,21 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
    {
       public HistoryCallback(String text, PopupMode desiredMode)
       {
+         // clear offset if initiating empty search, or if the new search
+         // text doesn't match the last search text
+         boolean resetOffset =
+               StringUtil.isNullOrEmpty(text) ||
+               !StringUtil.equals(text, lastSearch_);
+         
+         if (resetOffset)
+            offset_ = -1;
+         
+         // set associated class members
          historyRequestInvalidation_.invalidate();
          token_ = historyRequestInvalidation_.getInvalidationToken();
          text_ = text;
          lastSearch_ = text;
          desiredMode_ = desiredMode;
-
-         // If we aren't re-initiating a previous search, clear the offset
-         // selection
-         if (lastSearch_ != text)
-            offset_ = -1;
       }
 
       @Override


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/7682.

### Approach

The history search offset was not being properly reset. Ensure we check for a search term change before updating `lastSearch_`.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/7682.