### PR TITLE
Ensure that console clear command always cleans up everything

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -162,13 +162,8 @@ public class ConsoleOutputWriter
    {
       if (virtualConsole_ != null)
       {
-         Node child = virtualConsole_.getParent().getLastChild();
-         if (child != null &&
-             child.getNodeType() == Node.ELEMENT_NODE &&
-             !Element.as(child).getInnerText().endsWith("\n"))
-         {
-            virtualConsole_.submit("\n");
-         }
+          virtualConsole_.ensureStartingOnNewLine();
+
          // clear the virtual console so we start with a fresh slate
          virtualConsole_ = null;
       }

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -23,6 +23,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.TreeSet;
 
+import com.google.gwt.dom.client.Node;
 import com.google.inject.Provider;
 import com.google.inject.assistedinject.Assisted;
 import org.rstudio.core.client.regex.Match;
@@ -363,7 +364,7 @@ public class VirtualConsole
                moves.put(l, overlap.start);
 
                if (parent_ != null && !range.text().isEmpty())
-                  parent_.insertBefore(range.element, overlap.element);
+                  overlap.element.getParentElement().insertBefore(range.element, overlap.element);
 
             }
          }
@@ -647,13 +648,6 @@ public class VirtualConsole
          match = match.nextMatch();
       }
 
-      Entry<Integer, ClassRange> last = class_.lastEntry();
-      if (last != null)
-      {
-         ClassRange range = last.getValue();
-         if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
-      }
-
       // If there was any plain text after the last control character, add it
       if (tail < data.length())
          text(data.substring(tail), currentClazz, forceNewRange);
@@ -673,6 +667,19 @@ public class VirtualConsole
       return newText_ == null ? "" : newText_.toString();
    }
 
+   public void ensureStartingOnNewLine()
+   {
+      if (isVirtualized())
+         VirtualScrollerManager.ensureStartingOnNewLine(parent_.getParentElement());
+      else
+      {
+         Node child = getParent().getLastChild();
+         if (child != null &&
+                 child.getNodeType() == Node.ELEMENT_NODE &&
+                 !Element.as(child).getInnerText().endsWith("\n"))
+            submit("\n");
+      }
+   }
    private class ClassRange
    {
       public ClassRange(int pos, String className, String text)

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.JavaScriptException;
 
 import java.util.Date;
 import java.util.HashMap;
+
 import com.google.gwt.dom.client.Element;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
@@ -99,6 +100,18 @@ public class VirtualScrollerManager
          return;
 
       scrollers_.get(parent.getAttribute(scrollerAttribute_)).clear();
+   }
+
+   public static void ensureStartingOnNewLine(Element parent)
+   {
+      if (!initialized_ || parent == null ) return;
+
+      parent = getVirtualScrollerAncestor(parent);
+
+      if (scrollers_.get(parent.getAttribute(scrollerAttribute_)) == null)
+         return;
+
+      scrollerForElement(parent).ensureStartingOnNewLine();
    }
 
    public static Element getCurBucket(Element parent)

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
@@ -28,5 +28,6 @@ public class VirtualScrollerNative
    public native Element getCurBucket();
    public native void clear();
    public native void prune(Element ele);
+   public native void ensureStartingOnNewLine();
 }
 

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -269,9 +269,18 @@ var VirtualScroller;
     },
 
     clear: function() {
+      var i = 0;
+
       // remove all buckets from the DOM
-      for (var i = 0; i < this.buckets.length; i++) {
+      for (i = 0; i < this.buckets.length; i++) {
         this.buckets[i].remove();
+      }
+
+      // remove possible vestigial contents of the parent element that
+      // may have snuck in before the VirtualScroller was initialized
+      var eleChildren = this.consoleEle.children;
+      while (this.consoleEle.children.length > 0) {
+          this.consoleEle.removeChild(this.consoleEle.children[0]);
       }
 
       this._setJumpToLatestVisible(false);
@@ -300,6 +309,16 @@ var VirtualScroller;
 
       if (indexToSlice > 0)
         element.innerText = element.innerText.substring(indexToSlice);
+    },
+
+    ensureStartingOnNewLine: function() {
+      if (this.getCurBucket().children < 1)
+        return;
+
+      // get the last element from the last bucket
+      var lastText = this.getCurBucket().lastElementChild.innerHTML;
+      if (!lastText.endsWith("\n"))
+        this.getCurBucket().lastElementChild.innerHTML = lastText + "\n";
     },
 
     _createAndAddNewBucket: function() {


### PR DESCRIPTION
### Intent

Fixes #8428 

Most specifically, the original spirit of 8428 and not what it turned into further down the line: When hitting console clear ensure that everything is cleared.

### Approach

This fixes some, but not all of the causes of 8428. There are some issues that can cause items to get added outside of the VirtualScroller buckets so the old "delete items in buckets" clear wasn't sufficient. I made the cleanup much more thorough to ensure that this doesn't happen again.

I also found a couple items that could cause this issue, specifically the over-aggressive pruning and the fact that `ensureStartingOnNewLine` was not compatible with the VirtualScroller by directly modifying the DOM outside of VirtualConsole so I didn't know what was even happening.

### QA Notes

Ensure that clear console (Ctrl+L) always clears everything in the console, particularly in the cases in 8428.


