### PR TITLE
Ignore range errors that occur when switching to visual mode

### DIFF
--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -498,7 +498,7 @@ export class Editor {
       this.view.updateState(this.state);
     } else {
       // note current editing location
-      const location = this.getEditingLocation();
+      const loc = this.getEditingLocation();
 
       // replace the top level nodes in the doc
       const tr = this.state.tr;
@@ -511,8 +511,14 @@ export class Editor {
         return false;
       });
       // set selection to previous location if it's still valid
-      if (location.pos < tr.doc.nodeSize) {
-        setTextSelection(location.pos)(tr);
+      if (loc.pos < tr.doc.nodeSize) {
+        // eat exceptions that might result from an invalid position
+        try {
+          setTextSelection(loc.pos)(tr);
+        } catch(e) {
+          // do-nothing, this error can happen and shouldn't result in 
+          // a failure to setMarkdown
+        }
       }
       // dispatch
       this.view.dispatch(tr);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -550,11 +550,23 @@ public class VisualMode implements VisualModeEditorSync,
                               // case sync our editing location to what it is in source 
                               if (focus)
                               { 
-                                 panmirror_.focus();
-                                 panmirror_.setEditingLocation(
-                                       visualModeLocation_.getSourceOutlineLocation(), 
-                                       visualModeLocation_.savedEditingLocation()
-                                       ); 
+                                 // catch exceptions which occur here (can result from attempting to restore
+                                 // an invalid position). generally we'd like to diagnose and fix instances
+                                 // of this error in a more targeted fashion, however we are now at the point
+                                 // of v1.4 release and the error results in an inability to switch to visual
+                                 // mode, so we do more coarse grained error handling here
+                                 try
+                                 {
+                                    panmirror_.focus();
+                                    panmirror_.setEditingLocation(
+                                          visualModeLocation_.getSourceOutlineLocation(), 
+                                          visualModeLocation_.savedEditingLocation()
+                                          ); 
+                                 }
+                                 catch(Exception e)
+                                 {
+                                    Debug.logException(e);
+                                 }
                               }
                               
                               // show any warnings


### PR DESCRIPTION
### Intent

Fix https://github.com/rstudio/rstudio/issues/8513

### Approach

Catch exceptions which occur when restoring positions in visual mode (can result from attempting to restore an invalid position). Generally we'd like to diagnose and fix instances of this error in a more targeted fashion, however we are now at the point of v1.4 release and the error results in an inability to switch to visual mode, so we do more coarse grained error handling here


