### PR TITLE
prevent navigation when hitting tab in visual mode

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/basekeys.ts
+++ b/src/gwt/panmirror/src/editor/src/api/basekeys.ts
@@ -82,6 +82,10 @@ export function baseKeysPlugin(keys: readonly BaseKeyBinding[]): Plugin {
     { key: BaseKey.Backspace, command: joinBackward },
     { key: BaseKey.Backspace, command: deleteSelection },
 
+    // base tab key behavior (ignore)
+    { key: BaseKey.Tab, command: ignoreKey },
+    { key: BaseKey.ShiftTab, command: ignoreKey },
+
     // base delete key behaviors
     { key: BaseKey.Delete, command: selectNodeForward },
     { key: BaseKey.Delete, command: joinForward },
@@ -152,6 +156,10 @@ interface Coords {
   right: number;
   top: number;
   bottom: number;
+}
+
+function ignoreKey(state: EditorState, dispatch?: (tr: Transaction) => void) {
+  return true;
 }
 
 function homeKey(state: EditorState, dispatch?: (tr: Transaction) => void, view?: EditorView) {


### PR DESCRIPTION
### Intent

Fix for https://github.com/rstudio/rstudio/issues/8474

### Approach

Note that this behavior was introduced in July in an attempt to enable keyboard navigation to the various text popups we have in the visual editor (e.g. the popup for links or the popup for cross references): https://github.com/rstudio/rstudio/commit/3bfe98a7287effb4d52bc6adeaa2ac284db40480#

We now ignore the tab key, but this also means that tab can't focus the text popups (at least w/o some additional custom keyboard handling that is too risky/complex at this stage of the release) so these are no longer keyboard accessible. I think we'd need to address this either in a patch release or in the next release depending on our view on the risks of the change required.

