### PR TITLE
implement parser for testthat 3.0.0 message output

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1405,8 +1405,10 @@ bool isMinimumRoxygenInstalled()
 std::string packageVersion(const std::string& packageName)
 {
    std::string version;
-   Error error = r::exec::RFunction(".rs.packageVersionString", packageName)
-                                                               .call(&version);
+   Error error = r::exec::RFunction(".rs.packageVersionString")
+         .addParam(packageName)
+         .call(&version);
+   
    if (error)
    {
       LOG_ERROR(error);
@@ -1418,7 +1420,22 @@ std::string packageVersion(const std::string& packageName)
    }
 }
 
-bool hasMinimumRVersion(const std::string &version)
+Error packageVersion(const std::string& packageName,
+                     core::Version* pVersion)
+{
+   std::string version;
+   Error error = r::exec::RFunction(".rs.packageVersionString")
+         .addParam(packageName)
+         .call(&version);
+   
+   if (error)
+      return error;
+   
+   *pVersion = Version(version);
+   return Success();
+}
+
+bool hasMinimumRVersion(const std::string& version)
 {
    bool hasVersion = false;
    boost::format fmt("getRversion() >= '%1%'");

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -25,6 +25,7 @@
 
 #include <core/BoostSignals.hpp>
 #include <core/HtmlUtils.hpp>
+#include <core/Version.hpp>
 #include <core/system/System.hpp>
 #include <core/system/ShellUtils.hpp>
 #include <core/system/FileChangeEvent.hpp>
@@ -150,6 +151,8 @@ bool isMinimumDevtoolsInstalled();
 bool isMinimumRoxygenInstalled();
 
 std::string packageVersion(const std::string& packageName);
+core::Error packageVersion(const std::string& packageName,
+                           core::Version* pVersion);
 
 bool hasMinimumRVersion(const std::string& version);
 

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -671,8 +671,8 @@ private:
       type_ = type;
 
       // add testthat and shinytest result parsers
-      std::string testthatVersionString = module_context::packageVersion("testthat");
-      core::Version testthatVersion(testthatVersionString);
+      core::Version testthatVersion;
+      module_context::packageVersion("testthat", &testthatVersion);
       
       if (type == kTestFile)
       {

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -29,6 +29,7 @@
 
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
+#include <core/Version.hpp>
 #include <core/text/DcfParser.hpp>
 #include <core/system/Process.hpp>
 #include <core/system/Environment.hpp>
@@ -670,13 +671,18 @@ private:
       type_ = type;
 
       // add testthat and shinytest result parsers
-      if (type == kTestFile) {
+      std::string testthatVersionString = module_context::packageVersion("testthat");
+      core::Version testthatVersion(testthatVersionString);
+      
+      if (type == kTestFile)
+      {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.getParent()));
+         parsers.add(testthatErrorParser(packagePath.getParent(), testthatVersion));
       }
-      else if (type == kTestPackage) {
+      else if (type == kTestPackage)
+      {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat")));
+         parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat"), testthatVersion));
       }
 
       initErrorParser(packagePath, parsers);

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -33,7 +33,7 @@
 #include <session/SessionModuleContext.hpp>
 #include <session/projects/SessionProjects.hpp>
 
-#define kAnsiEscapeRegex "(?:\033\\[[0-9]+m)*"
+#define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
 
 using namespace rstudio::core;
 
@@ -298,7 +298,7 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "\\)"            // closing paren
                   ":"              // colon separator
                   "\\s+"           // separating space
-                  "([^\033\\n]*)"  // error message       (5)
+                  "([:print:]+)"   // error message       (5)
                   kAnsiEscapeRegex // color
                   );
       }
@@ -313,7 +313,7 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "([^:\\n]+)"     // error type          (3)
                   kAnsiEscapeRegex // color
                   ":\\s*"          // spaces
-                  "([^\033\\n]*)"  // error message       (4)
+                  "([:print:]+)"   // error message       (4)
                   kAnsiEscapeRegex // color
                   );
       }

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -298,7 +298,7 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "\\)"            // closing paren
                   ":"              // colon separator
                   "\\s+"           // separating space
-                  "([^\033\\n]*)"  // error message       (5)
+                  "([[:print:]]*)" // error message       (5)
                   kAnsiEscapeRegex // color
                   );
       }
@@ -312,8 +312,9 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   kAnsiEscapeRegex // color
                   "([^:\\n]+)"     // error type          (3)
                   kAnsiEscapeRegex // color
-                  ":\\s*"          // spaces
-                  "([^\033\\n]*)"  // error message       (4)
+                  ":"              // separating colon
+                  "\\s*"           // spaces
+                  "([[:print:]]*)" // error message       (4)
                   kAnsiEscapeRegex // color
                   );
       }

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -298,7 +298,7 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "\\)"            // closing paren
                   ":"              // colon separator
                   "\\s+"           // separating space
-                  "([:print:]+)"   // error message       (5)
+                  "([^\033\\n]*)"  // error message       (5)
                   kAnsiEscapeRegex // color
                   );
       }
@@ -313,7 +313,7 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "([^:\\n]+)"     // error type          (3)
                   kAnsiEscapeRegex // color
                   ":\\s*"          // spaces
-                  "([:print:]+)"   // error message       (4)
+                  "([^\033\\n]*)"  // error message       (4)
                   kAnsiEscapeRegex // color
                   );
       }

--- a/src/cpp/session/modules/build/SessionBuildErrors.hpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.hpp
@@ -24,6 +24,8 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/json/Json.hpp>
 
+#include <core/Version.hpp>
+
 #include <session/SessionModuleContext.hpp>
 
 namespace rstudio {
@@ -31,8 +33,8 @@ namespace session {
 namespace modules {
 namespace build {
 
-typedef boost::function<std::vector<module_context::SourceMarker>(const std::string&)>
-                                                         CompileErrorParser;
+using CompileErrorParserSignature = std::vector<module_context::SourceMarker>(const std::string&);
+using CompileErrorParser = boost::function<CompileErrorParserSignature>;
 
 class CompileErrorParsers
 {
@@ -68,7 +70,8 @@ CompileErrorParser gccErrorParser(const core::FilePath& basePath);
 
 CompileErrorParser rErrorParser(const core::FilePath& basePath);
 
-CompileErrorParser testthatErrorParser(const core::FilePath& basePath);
+CompileErrorParser testthatErrorParser(const core::FilePath& basePath,
+                                       const rstudio::core::Version& testthatVersion);
 
 CompileErrorParser shinytestErrorParser(const core::FilePath& basePath, const core::FilePath& rdsPath);
 


### PR DESCRIPTION
### Intent

Parse messages generated by testthat 3.0.0, and populate the Issues view with the parsed error messages.

### Approach

Create and use an appropriate regular expression, matching lines of output emitted by testthat when errors occur. Also fix up handling of ANSI escapes from the prior implementation -- the `\033` escape code was not properly captured, leading it to be included as part of the error message. (Since it's just rendered as an invisible character, there wasn't any actual user-facing issue -- this just makes the parser itself more "correct".)

### QA Notes

Testing this requires you to think like an R package author, using `devtools` + `testthat` while authoring your package + tests. For an R package using testthat, containing tests + errors in those tests, from the Build pane, use More -> Test Package to run the tests in the package.

<img width="395" alt="Screen Shot 2020-12-02 at 1 44 14 PM" src="https://user-images.githubusercontent.com/1976582/100935071-79f03b80-34a4-11eb-82c0-2144bac86fc7.png">

Note that a couple permutations need to be tested:

1. Handling of ANSI escapes enabled vs. disabled:

<img width="606" alt="Screen Shot 2020-12-02 at 2 09 15 PM" src="https://user-images.githubusercontent.com/1976582/100937522-f7697b00-34a7-11eb-991c-82b2a4b0408c.png">

2. `testthat 2.3.2` versus `testthat 3.0.0`. You can install the different versions of `testthat` with:

```
# install renv if you don't have it
install.packages("renv")

# install devtools
install.packages("devtools")

# run tests with testthat 3.0.0
renv::install("testthat@3.0.0")

# run tests with testthat 2.3.2
renv::install("testthat@2.3.2")
```

You can test with the dummy R package here:

https://github.com/kevinushey/rstudio.testthat.tests

or experiment and try to create your own R package with failing testthat tests.

Closes https://github.com/rstudio/rstudio/issues/8505.