### PR TITLE
check for rstudio pam profile on load

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -516,6 +516,17 @@ int main(int argc, char * const argv[])
       // ignore SIGPIPE (don't log error because we should never call
       // syslog prior to daemonizing)
       core::system::ignoreSignal(core::system::SigPipe);
+      
+#ifdef __APPLE__
+      // warn if the rstudio pam profile does not exist
+      // (note that this only effects macOS development configurations)
+      FilePath pamProfilePath("/etc/pam.d/rstudio");
+      if (!pamProfilePath.exists())
+      {
+         std::cerr << "WARNING: /etc/pam.d/rstudio does not exist; authentication may fail!" << std::endl;
+         std::cerr << "Run 'sudo cp /etc/pam.d/cups /etc/pam.d/rstudio' to set a default PAM profile for RStudio." << std::endl;
+      }
+#endif
 
       // read program options 
       std::ostringstream osWarnings;


### PR DESCRIPTION
### Intent

Check that `/etc/pam.d/rstudio` exists on rserver startup, and notify the developer if it is not available.

<img width="965" alt="Screen Shot 2020-12-02 at 2 34 07 PM" src="https://user-images.githubusercontent.com/1976582/100939631-77ddab00-34ab-11eb-9003-d87b6f09aef8.png">

### Approach

Simple checking + writing to stderr.

### QA Notes

Developer only; no QA required.