### PR TITLE
Bugfixes/cite in cite redux

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/bibtex/bibtex.ts
+++ b/src/gwt/panmirror/src/editor/src/api/bibtex/bibtex.ts
@@ -151,7 +151,7 @@ const toBibtex = (entries: Entry[]): string => {
     bibTexStr = bibTexStr + `@${entry.type}{${entry.key}`;
 
     // The fields for this item
-    if (entry.values) {
+    if (entry.values && Object.keys(entry.values).length > 0) {
       sortedKeys(entry.values).forEach(key => {
         if (entry.values) {
           const rawValue = entry.values[key];
@@ -163,6 +163,10 @@ const toBibtex = (entries: Entry[]): string => {
           bibTexStr = bibTexStr + `,\n\t${key} = ${value}`;
         }
       });
+    } else {
+      // There are no values, we need to minimally place a ',' at the end of the id
+      // If we omit this, pandoc cannot parse the bibliography
+      bibTexStr = bibTexStr + ",";
     }
 
     // Close the entry

--- a/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
@@ -101,9 +101,9 @@ export class InsertCitationCommand extends ProsemirrorCommand {
 
                   // If the previous character is a part of a cite_id, advance to the end of the mark,
                   // insert a separator, and then proceed
-                  const citeIdRange = getMarkRange(tr.doc.resolve(start - 1), schema.marks.cite_id);
-                  if (citeIdRange) {
-                    setTextSelection(citeIdRange.to)(tr);
+                  const preCiteIdRange = getMarkRange(tr.doc.resolve(start - 1), schema.marks.cite_id);
+                  if (preCiteIdRange) {
+                    setTextSelection(preCiteIdRange.to)(tr);
                     const wrapperText = schema.text(`; `, []);
                     tr.insert(tr.selection.from, wrapperText);
                   }
@@ -117,6 +117,13 @@ export class InsertCitationCommand extends ProsemirrorCommand {
                       tr.insert(tr.selection.from, schema.text('; ', []));
                     }
                   });
+
+                  // If the next character is a part of a cite_id, insert a separator (that will appear after the current citeId)
+                  const postCiteIdRange = getMarkRange(tr.doc.resolve(tr.selection.from + 1), schema.marks.cite_id);
+                  if (postCiteIdRange) {
+                    const wrapperText = schema.text(`; `, []);
+                    tr.insert(tr.selection.from, wrapperText);
+                  }
 
                   // Enclose wrapper in the cite mark (if not already in a cite)
                   if (!alreadyInCite) {

--- a/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
@@ -92,7 +92,7 @@ export class InsertCitationCommand extends ProsemirrorCommand {
                   // always perform a 'note' style citation insert
                   // If we're already inside a cite including [], don't bother inserting wrapper
                   if (!alreadyInCite && includeWrapper) {
-                    const wrapperText = schema.text(`[]`, []);
+                    const wrapperText = schema.text('[]');
                     tr.insert(tr.selection.from, wrapperText);
 
                     // move the selection into the wrapper
@@ -104,8 +104,8 @@ export class InsertCitationCommand extends ProsemirrorCommand {
                   const preCiteIdRange = getMarkRange(tr.doc.resolve(start - 1), schema.marks.cite_id);
                   if (preCiteIdRange) {
                     setTextSelection(preCiteIdRange.to)(tr);
-                    const wrapperText = schema.text(`; `, []);
-                    tr.insert(tr.selection.from, wrapperText);
+                    const separator = schema.text('; ');
+                    tr.insert(tr.selection.from, separator);
                   }
 
                   // insert the CiteId marks and text
@@ -121,8 +121,8 @@ export class InsertCitationCommand extends ProsemirrorCommand {
                   // If the next character is a part of a cite_id, insert a separator (that will appear after the current citeId)
                   const postCiteIdRange = getMarkRange(tr.doc.resolve(tr.selection.from + 1), schema.marks.cite_id);
                   if (postCiteIdRange) {
-                    const wrapperText = schema.text(`; `, []);
-                    tr.insert(tr.selection.from, wrapperText);
+                    const separator = schema.text('; ');
+                    tr.insert(tr.selection.from, separator);
                   }
 
                   // Enclose wrapper in the cite mark (if not already in a cite)

--- a/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/cite/cite-commands.ts
@@ -28,7 +28,7 @@ import { BibliographyManager } from '../../api/bibliography/bibliography';
 
 import { ensureSourcesInBibliography } from './cite';
 import { showInsertCitationDialog, InsertCitationDialogResult } from '../../behaviors/insert_citation/insert_citation';
-import { markIsActive } from '../../api/mark';
+import { markIsActive, getMarkRange } from '../../api/mark';
 
 export class InsertCitationCommand extends ProsemirrorCommand {
   private initialSelectionKey: string | undefined;
@@ -97,6 +97,15 @@ export class InsertCitationCommand extends ProsemirrorCommand {
 
                     // move the selection into the wrapper
                     setTextSelection(tr.selection.from - 1)(tr);
+                  }
+
+                  // If the previous character is a part of a cite_id, advance to the end of the mark,
+                  // insert a separator, and then proceed
+                  const citeIdRange = getMarkRange(tr.doc.resolve(start - 1), schema.marks.cite_id);
+                  if (citeIdRange) {
+                    setTextSelection(citeIdRange.to)(tr);
+                    const wrapperText = schema.text(`; `, []);
+                    tr.insert(tr.selection.from, wrapperText);
                   }
 
                   // insert the CiteId marks and text


### PR DESCRIPTION
### Intent

Fix 2 citation issues identified in bug #8337.

1) When inserting a citation into or directly at the end of a citation, we should emit a separator and handle gracefully.

2) When inserting an empty entry into a bibtex bibliography, we should be sure we use the correct format to ensure the bibliography is valid.

### Approach

1) Check whether we are inserting into a citeId, and if so advance to the end of the mark, insert separator, and proceed with the insert.

2) When emiting any empty bibtex entry, include the comma.

### QA Notes

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


