### PR TITLE
fix opening external files on Big Sur with spaces in filename or path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,8 @@
 * Markdown-style sub-sections are now rendered as nested sections in the document outline for R documents (#4124)
 * Update to Pandoc 2.11 (#7696)
 * `Ctrl + D` can now be used to send EOF when reading user input via `readLines()` (#3448)
+* External files with spaces in their path or filename are now openable on Big Sur from Files pane (#8506)
+* PDF files opened from Files pane on macOS will open in registered application, not always Preview.app (#8506)
 
 ### RStudio Server
 

--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -204,36 +204,6 @@ void GwtCallback::printFinished(int result)
 void GwtCallback::browseUrl(QString url)
 {
    QUrl qurl = QUrl::fromEncoded(url.toUtf8());
-
-#ifdef Q_OS_MAC
-   if (qurl.scheme() == QString::fromUtf8("file"))
-   {
-      QProcess open;
-      QStringList args;
-      // force use of Preview for PDFs (Adobe Reader 10.01 crashes)
-      if (url.toLower().endsWith(QString::fromUtf8(".pdf")))
-      {
-         args.append(QString::fromUtf8("-a"));
-         args.append(QString::fromUtf8("Preview"));
-         args.append(url);
-      }
-      else
-      {
-         args.append(url);
-      }
-      open.start(QString::fromUtf8("open"), args);
-      open.waitForFinished(5000);
-      if (open.exitCode() != 0)
-      {
-         // Probably means that the file doesn't have a registered
-         // application or something.
-         QProcess reveal;
-         reveal.startDetached(QString::fromUtf8("open"), QStringList() << QString::fromUtf8("-R") << url);
-      }
-      return;
-   }
-#endif
-
    desktop::openUrl(qurl);
 }
 


### PR DESCRIPTION
### Intent

- RStudio fails to open external files with spaces in their filesnames and/or paths (PDFs, Word Docs, etc.) when clicked on in the Files pane on RStudio Desktop running on Big Sur
- Fixes #8506

### Approach

- The fix was to have Mac desktop use the same code as other desktop platforms for opening files; namely, `QDesktopServices::openUrl()`
- This changes how PDFs are opening; instead of forcing them to always use Preview, they will now use whatever is registered in the system (e.g. Acrobat); there was a comment about problems with Acrobat 10, but Acrobat 10 is from 2010 and current version of Acrobat works fine

More details:

- On Mac desktop only, when opening an external file, RStudio has been creating a process to run "open filename"; other desktop platforms instead use QDesktopServices::openUrl()
- Based on comments, the reason was to work around a problem with Acrobat 10 crashing when it was registered as PDF file app, so the code was forcing use of Preview
- On Big Sur only, for reasons I couldn't quite figure out, this failed if there were spaces in the path or filename and the files wouldn't open (any files including Word Docs, etc., not just PDFs)
- I tried various combinations of escaping the path, including wrapping in single quote, double quotes, using URL encoding of the spaces (%20), putting a backslash before the spaces, and none of these helped

### QA Notes

- macOS desktop-specific fix, no code changes for Server or desktop for Linux or Windows
- Primarily, try opening various files from the Files pane including files in folders with spaces in the name, and files with spaces in their filenames
- For files that RStudio doesn't support editing, the externally registered program should open
- Test on both Big Sur, and on down-level macOS (I did sanity test on Big Sur 11.0.1 and most recent Catalina)
- Try with and without Adobe Acrobat installed (ideally with some older versions if you can track them down)

