### PR TITLE
avoid dialog overflow via word-smithing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -1028,7 +1028,7 @@ public class Packages
             "Restarting R prior to install is highly recommended.\n\n" +
             "RStudio can restart R before installing the requested packages. " +
             "All work and data will be preserved during restart.\n\n" +
-            "Do you want to restart R?";
+            "Do you want to restart R prior to install?";
                   
       final boolean haveInstallCmd = installCmd.startsWith("install.packages");
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -1023,13 +1023,12 @@ public class Packages
    
    private void restartForInstallWithConfirmation(final String installCmd)
    {
-      String msg = "One or more of the packages that will be updated by this " +
-                   "installation are currently loaded. Restarting R prior " +
-                   "to updating these packages is strongly recommended.\n\n" +
-                   "RStudio can restart R and then automatically continue " +
-                   "the installation after restarting (all work and " +
-                   "data will be preserved during the restart).\n\n" +
-                   "Do you want to restart R prior to installing?";
+      String msg = 
+            "One or more of the packages to be updated are currently loaded. " +
+            "Restarting R prior to install is highly recommended.\n\n" +
+            "RStudio can restart R before installing the requested packages. " +
+            "All work and data will be preserved during restart.\n\n" +
+            "Do you want to restart R?";
                   
       final boolean haveInstallCmd = installCmd.startsWith("install.packages");
       
@@ -1038,13 +1037,12 @@ public class Packages
             "Updating Loaded Packages",
             msg,
             true,
-            new Operation() { public void execute()
+            () ->
             {
                events_.fireEvent(new SuspendAndRestartEvent(
                       SuspendOptions.createSaveAll(true), installCmd));  
-                  
-            }},
-            new Operation() { public void execute()
+            },
+            () ->
             {
                server_.ignoreNextLoadedPackageCheck(
                                             new VoidServerRequestCallback() {
@@ -1055,7 +1053,7 @@ public class Packages
                         executePkgCommand(installCmd);
                   }
                });
-            }},
+            },
             true);   
    }
 


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8524.

### Approach

Tweak wording to avoid overflowing dialog box used on Big Sur.

<img width="272" alt="Screen Shot 2020-12-03 at 11 18 35 AM" src="https://user-images.githubusercontent.com/1976582/101077177-50ddb280-3559-11eb-812d-9b63c9bfcee3.png">

### QA Notes

Test that the dialog box presented when running:

```
library(MASS)
install.packages("MASS")
```

does not overflow, as the one in https://github.com/rstudio/rstudio/issues/8524 does.