### PR TITLE
Ensure that VirtualConsole ranges don't write outside of VirtualScroller buckets

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -318,7 +318,7 @@ public class VirtualConsole
                insertions.add(range);
                haveInsertedRange = true;
                if (parent_ != null)
-                  parent_.insertAfter(range.element, overlap.element);
+                  overlap.element.getParentElement().insertAfter(range.element, overlap.element);
             }
          }
          else if (start <= l && end <= r && end > l)
@@ -334,6 +334,7 @@ public class VirtualConsole
                if (overlap.length == 0)
                {
                   deletions.add(l);
+
                   if (overlap.element.getParentElement() != null)
                      overlap.element.removeFromParent();
                }
@@ -394,7 +395,7 @@ public class VirtualConsole
                // insert the new range
                insertions.add(range);
                if (parent_ != null)
-                  parent_.insertAfter(range.element, overlap.element);
+                  overlap.element.getParentElement().insertAfter(range.element, overlap.element);
 
                // add back the remainder
                ClassRange remainder = new ClassRange(
@@ -403,7 +404,7 @@ public class VirtualConsole
                      text.substring((text.length() - (amountTrimmed - range.length))));
                insertions.add(remainder);
                if (parent_ != null)
-                  parent_.insertAfter(remainder.element, range.element);
+                  range.element.getParentElement().insertAfter(remainder.element, range.element);
             }
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/ConsolePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/ConsolePreferencesPane.java
@@ -38,7 +38,7 @@ public class ConsolePreferencesPane extends PreferencesPane
       add(headerLabel("Display"));
       add(checkboxPref("Show syntax highlighting in console input", prefs_.syntaxColorConsole()));
       add(checkboxPref("Different color for error or message output (requires restart)", prefs_.highlightConsoleErrors()));
-      add(checkboxPref("Limit console display to a subset of total content (requires restart)", prefs_.limitVisibleConsole()));
+      add(checkboxPref("Limit visible console output (requires restart)", prefs_.limitVisibleConsole()));
       NumericValueWidget limitLengthPref =
          numericPref("Limit output line length to:", prefs_.consoleLineLengthLimit());
       add(nudgeRightPlus(limitLengthPref));


### PR DESCRIPTION
### Intent

Fix https://github.com/rstudio/rstudio/issues/8511

### Approach

What was happening is VirtualConsole was doing in-range insertions based on the original parent instead of always relative to the original range element (that will be inside a VirtualScroller bucket). Change the `insertAfter` functions to always be relative to the original range.

### QA Notes

Make sure that the output in the test cases Kevin put in #8428 match with Limit Console Output turned on/off.


