### PR TITLE
support lambda, pipe in upcoming r-devel

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -139,7 +139,7 @@ public:
    {
       return type_ == type;
    }
-
+   
    // allow direct use in conditional statements (nullability)
    typedef void (*unspecified_bool_type)();
    static void unspecified_bool_true() {}
@@ -403,10 +403,11 @@ inline bool isNamespaceExtractionOperator(const RToken& rToken)
             rToken.contentEquals(L":::"));
 }
 
-inline bool isFunction(const RToken& rToken)
+inline bool isFunctionKeyword(const RToken& rToken)
 {
-   return rToken.isType(RToken::ID) &&
-          rToken.contentEquals(L"function");
+   return rToken.isType(RToken::ID) && (
+            rToken.contentEquals(L"function") ||
+            rToken.contentEquals(L"\\"));
 }
 
 inline bool isString(const RToken& rToken)

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -321,18 +321,6 @@ void addSourceItem(RSourceItem::Type type,
                             token.column() + 1));
 }
 
-void addSourceItem(RSourceItem::Type type,
-                   const RToken& token,
-                   const IndexStatus& status,
-                   RSourceIndex* pIndex)
-{
-   addSourceItem(type,
-                 std::vector<RS4MethodParam>(),
-                 token,
-                 status,
-                 pIndex);
-}
-
 typedef boost::function<void(const RTokenCursor&, const IndexStatus&, RSourceIndex*)> Indexer;
 
 void libraryCallIndexer(const RTokenCursor& cursor,
@@ -500,7 +488,7 @@ void variableAssignmentIndexer(const RTokenCursor& cursor,
    
    // determine index type (function or variable?)
    const RToken& nextToken = cursor.nextToken();
-   RSourceItem::Type type = nextToken.contentEquals(L"function")
+   RSourceItem::Type type = token_utils::isFunctionKeyword(nextToken)
          ? RSourceItem::Function
          : RSourceItem::Variable;
    

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -35,7 +35,7 @@ if(NOT WIN32)
          endif()
       endif()
 
-      set(QT_CANDIDATES 5.12.8)
+      set(QT_CANDIDATES 5.12.8 5.12.10)
 
       # find the newest installed Qt version among the versions we build
       # against

--- a/src/cpp/desktop/DesktopPosixDetectRHome.cpp
+++ b/src/cpp/desktop/DesktopPosixDetectRHome.cpp
@@ -67,6 +67,7 @@ bool prepareEnvironment(Options& options)
    if (!rLdScriptPath.exists())
       rLdScriptPath = supportingFilePath.completePath("session/r-ldpath");
 #endif
+   
    // attempt to detect R environment
    std::string rScriptPath, rVersion, errMsg;
    r_util::EnvironmentVars rEnvVars;

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -676,7 +676,7 @@ void lookAheadAndWarnOnUsagesOfSymbol(const RTokenCursor& startCursor,
       }
       
       // Skip over functions
-      if (clone.contentEquals(L"function"))
+      if (isFunctionKeyword(clone))
       {
          if (!clone.moveToNextSignificantToken())
             return;
@@ -1014,7 +1014,7 @@ bool extractInfoFromFunctionDefinition(
 {
    do
    {
-      if (cursor.contentEquals(L"function"))
+      if (isFunctionKeyword(cursor))
          break;
       
    } while (cursor.moveToNextSignificantToken());
@@ -1936,7 +1936,7 @@ void enterFunctionScope(RTokenCursor cursor,
    Position position = cursor.currentPosition();
    
    if (cursor.moveToPreviousSignificantToken() &&
-       cursor.contentEquals(L"function") &&
+       isFunctionKeyword(cursor) &&
        cursor.moveToPreviousSignificantToken() &&
        isLeftAssign(cursor) &&
        cursor.moveToPreviousSignificantToken())
@@ -2163,7 +2163,7 @@ START:
       }
       
       // Check for keywords.
-      if (cursor.contentEquals(L"function"))
+      if (isFunctionKeyword(cursor))
          goto FUNCTION_START;
       else if (cursor.contentEquals(L"for"))
          goto FOR_START;
@@ -2664,7 +2664,6 @@ ARGUMENT_LIST_END:
 FUNCTION_START:
       
       DEBUG("** Function start ** " << cursor);
-      ENSURE_CONTENT(cursor, status, L"function");
       MOVE_TO_NEXT_SIGNIFICANT_TOKEN_WARN_ON_BLANK(cursor, status);
       ENSURE_TYPE(cursor, status, RToken::LPAREN, true);
       status.pushBracket(cursor);

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -184,8 +184,15 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
 
   var RHighlightRules = function()
   {
+    // NOTE: The backslash character is an experimental alias
+    // for the 'function' symbol, and can be used for defining
+    // short-hand functions, e.g.
+    //
+    //     \(x) x + 1
+    //
     var keywords = lang.arrayToMap([
-      "function", "if", "else", "in", "break", "next", "repeat", "for", "while"
+      "\\", "function", "if", "else", "in",
+      "break", "next", "repeat", "for", "while"
     ]);
 
     var specialFunctions = lang.arrayToMap([
@@ -201,7 +208,9 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       "NA_complex_"
     ]);
 
-    var reIdentifier = "[a-zA-Z.][a-zA-Z0-9._]*";
+    // NOTE: We accept '\' as a standalone identifier here
+    // so that it can be parsed as the 'function' alias symbol
+    var reIdentifier = "(?:\\\\|[a-zA-Z.][a-zA-Z0-9._]*)";
 
     var $complements = {
       "{" : "}",


### PR DESCRIPTION
### Intent

The development builds of R include support for a couple new language items:

- The pipe operator, `|>`;
- Shorthand for anonymous functions, `\(x) x`.

This PR implements the support necessary for these in our tokenizers + diagnostics engines.

### Approach

Relatively straight-forward wiring of handling `\` the same way the `function` keyword would be handled, as well as handling `|>` in the tokenizer.

### QA Notes

Test that scripts using the function short-hand, as well as native pipes, do not produce false positives. For example:

```
foo <- \(x, y, z) {
  x |> y() |> z()
}
```