### PR TITLE
Fix scroll/focus issue in visual editor in non-Chrome browsers

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -207,6 +207,16 @@ public class AceEditorNative extends JavaScriptObject
    }-*/;
 
    /**
+    * Forces the use of browser focus scrolling. This is the default on Chrome, but on other
+    * browsers, a complicated hack involving setting the 'ace_nocontext' attribute on all parent
+    * elements is used instead to avoid scroll jitter. This is not necessary in embedded editors,
+    * and causes ProseMirror to go nuts (see issue 8518), so this hook allows us to turn it off.
+    */
+   public final native void useBrowserInputFocus() /*-{
+      this.textInput.$focusScroll = "browser";
+   }-*/;
+
+   /**
     * Set an aria-label on the input element
     * @param label
     */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -231,6 +231,9 @@ public class VisualModeChunk
       // Prevent tab from advancing into editor
       chunkEditor.getTextInputElement().setTabIndex(-1);
 
+      // Force the use of browser APIs to set focus to the input element
+      chunkEditor.useBrowserInputFocus();
+
       // Allow the editor's size to be determined by its content (these
       // settings trigger an auto-growing behavior), up to a max of 1000
       // lines.


### PR DESCRIPTION
### Intent

Addresses an issue in which clicking into a code chunk causes wild behavior in the visual editor on browsers other than Chrome.

Fixes https://github.com/rstudio/rstudio/issues/8518. 

### Approach

The problem is that, on non-Chrome browsers, Ace has an epic hack it engages to keep the scroll position from jumping around when the editor is focused. This hack works by setting the property `ace_nocontext` on _every parent element_ of Ace's input element, setting focus, and then removing the property.

https://github.com/ajaxorg/ace/blob/e9f53ddf3c789f0042d83a0c9c3163021d028159/lib/ace/keyboard/textinput.js#L119-L135

Prosemirror picks up the DOM mutations created by all of these attribute additions, which happen on ~5 different elements under its surveillance. It doesn't recognize them, and winds up completely rebuilding (destroying and recreating) the Ace instance (node view) just to be on the safe side. 

Unfortunately, since focus is _in_ the Ace instance when it's destroyed, it has to go somewhere; what winds up happening is that focus goes all the way to the `<body>` tag, which has the side effect of scrolling the editor and causing other unpleasant side effects. 

The fix is pretty simple: Ace has an override flag that can be used to force the Chrome-style behavior in all browsers, so we just set that flag. This flag is never set in Ace's own code so it's quite possible it was created to address a situation not unlike this one. 

### QA Notes

The intent of all of this tomfoolery in Ace appears to be to keep scrolling from jumping when the editor gets focus, which is a real concern since the actual `<textarea>` that gets input is often not exactly where the cursor is located. So there's a possibility here that we have reintroduced unwanted behavior that was formerly suppressed by the `ace_nocontext` hack. Scrolling on focus worked fine in my testing, but would be worth scrutinizing to make sure it's reasonable (or at least no worse than it is on Chrome).
