### PR TITLE
encrypt passwords for remote desktop sessions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/crypto/RSAEncrypt.java
@@ -35,9 +35,9 @@ public class RSAEncrypt
          final String input,
          final ResponseCallback callback)
    {
-      if (Desktop.hasDesktopFrame())
+      if (Desktop.isDesktop())
       {
-         // Don't encrypt for desktop, Windows can't decrypt it.
+         // Don't encrypt for desktop sessions, Windows can't decrypt it.
          callback.onSuccess(input);
          return;
       }


### PR DESCRIPTION

### Intent

- Fixes https://github.com/rstudio/rstudio-pro/issues/2218
- Fixes https://github.com/rstudio/rstudio-pro/issues/2219

### Approach

When deciding when to encrypt input for passwords, secrets, and RSA keys, only disable for desktop sessions, not for server-based remote sessions.

### QA Notes

Test following operations both locally (desktop), pure server (RSP or open source), and remote session (RDP -> RSP):

1. `x <- rstudioapi::askForPassword()`
2. `y <- rstudioapi::askForSecret("tell me something")`
3. Create an RSA key with a passphrase from Global Options / Git/SVN / Create RSA Key, then verify you can use the resulting key with the passphrase (e.g. try `ssh-keygen -y`)

