### PR TITLE
don't quote option completions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1896,6 +1896,7 @@ public class RCompletionManager implements CompletionManager
          if (type == RCompletionType.ROXYGEN ||
              type == RCompletionType.PACKAGE ||
              type == RCompletionType.ARGUMENT ||
+             type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT)
          {
             return value;


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8538.

### Approach

Treat option completions as special, since options are returned with the format `<name> =` and so should not be quoted.

### QA Notes

Test that completions are appropriately inserted in `options(<TAB>`.