### PR TITLE
try reloading the IDE main page if the first attempts fail

### DIFF
--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -42,6 +42,12 @@ namespace desktop {
 
 namespace {
 
+// the number of times we've attempted to reload the main window
+int s_reloadCount = 0;
+
+// the maximum number of times we'll attempt to reload the page
+static const int s_maxReloadTries = 5;
+
 #ifdef _WIN32
 
 void CALLBACK onDialogStart(HWINEVENTHOOK hook, DWORD event, HWND hwnd,
@@ -65,7 +71,7 @@ MainWindow::MainWindow(QUrl url,
       pRemoteSessionLauncher_(nullptr),
       pLauncher_(new JobLauncher(this)),
       pCurrentSessionProcess_(nullptr),
-      loadTimer_(new QTimer(this)),
+      reloadTimer_(new QTimer(this)),
       isErrorDisplayed_(false)
 {
    RCommandEvaluator::setMainWindow(this);
@@ -112,8 +118,8 @@ MainWindow::MainWindow(QUrl url,
    setMenuBar(pMainMenuStub);
 #endif
    
-   connect(loadTimer_, &QTimer::timeout,
-           this, &MainWindow::onLoadFinishedImpl);
+   connect(reloadTimer_, &QTimer::timeout,
+           this, &MainWindow::onReloadPage);
    
    connect(&menuCallback_, SIGNAL(menuBarCompleted(QMenuBar*)),
            this, SLOT(setMenuBar(QMenuBar*)));
@@ -468,6 +474,11 @@ void MainWindow::onSessionQuit()
    }
 }
 
+void MainWindow::onReloadPage()
+{
+   webView()->reload();
+}
+
 void MainWindow::closeEvent(QCloseEvent* pEvent)
 {
 #ifdef _WIN32
@@ -671,36 +682,35 @@ void MainWindow::onLoadFinished(bool ok)
    {
       if (ok)
       {
-         // if this was a successful load, we're done
-         loadTimer_->stop();
-         loadedSuccessfully_ = true;
+         // we've loaded successfully; reset the reload count
+         // and stop the reload timer if it happens to be running
+         reloadTimer_->stop();
+         s_reloadCount = 0;
       }
-      else if (loadedSuccessfully_)
+      else if (s_reloadCount < s_maxReloadTries)
       {
-         // if the load was purportedly not successful, even
-         // though a prior load was successful, then ignore
-         // that (assume that this was a spurious / incorrect
-         // signal from Qt)
-         LOG_DEBUG_MESSAGE(
-                  "Discarding onLoadFinished(false) signal as we have "
-                  "already received onLoadFinished(true)");
+         // we failed to load; however, this load failure might be
+         // an intermittent failure. try again a couple times after
+         // a brief wait. note that we'll re-receive the onLoadFinished()
+         // signal after the webview has finished reloading
+         s_reloadCount += 1;
+         reloadTimer_->start(100);
       }
       else
       {
-         // schedule our load timer and allow a small buffer for
-         // incoming loadFinished() events which might report
-         // that the load was actually successful
-         loadTimer_->start(5000);
+         // we've failed too many times; give up and show an error page
+         reloadTimer_->stop();
+         onLoadFailed();
       }
    }
    END_LOCK_MUTEX
 }
 
-void MainWindow::onLoadFinishedImpl()
+void MainWindow::onLoadFailed()
 {
    LOCK_MUTEX(mutex_)
    {
-      if (loadedSuccessfully_ || pRemoteSessionLauncher_ || isErrorDisplayed_)
+      if (pRemoteSessionLauncher_ || isErrorDisplayed_)
          return;
 
       RS_CALL_ONCE();
@@ -708,7 +718,7 @@ void MainWindow::onLoadFinishedImpl()
       std::map<std::string, std::string> vars = {
          { "url",  webView()->url().url().toStdString() }
       };
-      
+
       std::ostringstream oss;
       Error error = text::renderTemplate(
                options().resourcesPath().completePath("html/connect.html"),
@@ -720,7 +730,7 @@ void MainWindow::onLoadFinishedImpl()
          LOG_ERROR(error);
          return;
       }
-      
+
       loadHtml(QString::fromStdString(oss.str()));
    }
    END_LOCK_MUTEX

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -46,7 +46,7 @@ namespace {
 int s_reloadCount = 0;
 
 // the maximum number of times we'll attempt to reload the page
-static const int s_maxReloadTries = 5;
+const int s_maxReloadTries = 5;
 
 #ifdef _WIN32
 

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -694,7 +694,7 @@ void MainWindow::onLoadFinished(bool ok)
          // a brief wait. note that we'll re-receive the onLoadFinished()
          // signal after the webview has finished reloading
          s_reloadCount += 1;
-         reloadTimer_->start(100);
+         reloadTimer_->start(200);
       }
       else
       {

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -75,7 +75,7 @@ public Q_SLOTS:
    void onPdfViewerSyncSource(QString srcFile, int line, int column);
    void onLicenseLost(QString licenseMessage);
    void onUpdateLicenseWarningBar(QString message);
-   void onLoadFinishedImpl();
+   void onLoadFailed();
 
    bool isRemoteDesktop() const;
 
@@ -86,6 +86,7 @@ Q_SIGNALS:
 protected Q_SLOTS:
    void onWorkbenchInitialized();
    void onSessionQuit();
+   void onReloadPage();
    void resetMargins();
    void commitDataRequest(QSessionManager &manager);
 
@@ -130,7 +131,6 @@ private:
    bool quitConfirmed_ = false;
    bool geometrySaved_ = false;
    bool workbenchInitialized_ = false;
-   bool loadedSuccessfully_ = false;
    MenuCallback menuCallback_;
    GwtCallback gwtCallback_;
    SessionLauncher* pSessionLauncher_;
@@ -138,7 +138,7 @@ private:
    boost::shared_ptr<JobLauncher> pLauncher_;
    ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
-   QTimer* loadTimer_;
+   QTimer* reloadTimer_;
 
    boost::mutex mutex_;
    bool isErrorDisplayed_;


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/8270.

### Approach

When the Desktop page fails to load, try to reload the page a couple times on the off-chance that the error occurred because the `rsession` was not quite ready yet.

### QA Notes

Unfortunately still not sure how to reproduce consistently; will rely on community feedback.