### PR TITLE
convert condition messages to UTF-8 when handling in notebook

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -23,4 +23,6 @@
 * Fixed issue where restoring R workspace could fail when project path contained non-ASCII characters (#8321)
 * Fixed issue where forked R sessions could hang after a package was loaded or unloaded (#8361)
 * Fixed issue where attempting to profile lines ending in comment would fail (#8407)
+* Fixed issue where warnings + messages were mis-encoded in chunk outputs on Windows (#8565)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
+

--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -264,6 +264,18 @@ core::Error executeSafely(boost::function<SEXP()> function, SEXP* pSEXP)
    }
 }
 
+Error executeCallUnsafe(SEXP callSEXP,
+                        SEXP envirSEXP,
+                        SEXP *pResultSEXP,
+                        sexp::Protect *pProtect)
+{
+   return evaluateExpressionsUnsafe(callSEXP,
+                                    envirSEXP,
+                                    pResultSEXP,
+                                    pProtect,
+                                    EvalDirect);
+}
+
 Error executeStringUnsafe(const std::string& str,
                           SEXP envirSEXP,
                           SEXP* pSEXP, 

--- a/src/cpp/r/RSourceManager.cpp
+++ b/src/cpp/r/RSourceManager.cpp
@@ -40,6 +40,9 @@ SourceManager& sourceManager()
    
 Error SourceManager::sourceTools(const core::FilePath& filePath)
 {
+   if (!filePath.exists())
+      return fileNotFoundError(filePath, ERROR_LOCATION);
+   
    Error error = sourceLocal(filePath);
    if (error)
       return error;

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -140,25 +140,14 @@ std::string rconsole2utf8(const std::string& encoded)
 #endif
 }
 
-core::Error iconvstr(const std::string& value,
-                     const std::string& from,
-                     const std::string& to,
-                     bool allowSubstitution,
-                     std::string* pResult)
+namespace {
+
+core::Error iconvstrImpl(const std::string& value,
+                         const std::string& from,
+                         const std::string& to,
+                         bool allowSubstitution,
+                         std::string* pResult)
 {
-   std::string effectiveFrom = from;
-   if (effectiveFrom.empty())
-      effectiveFrom = "UTF-8";
-   std::string effectiveTo = to;
-   if (effectiveTo.empty())
-      effectiveTo = "UTF-8";
-
-   if (effectiveFrom == effectiveTo)
-   {
-      *pResult = value;
-      return Success();
-   }
-
    std::vector<char> output;
    output.reserve(value.length());
 
@@ -209,6 +198,46 @@ core::Error iconvstr(const std::string& value,
    *pResult = std::string(output.begin(), output.end());
    return Success();
 }
+
+} // end anonymous namespace
+
+core::Error nativeToUtf8(const std::string& value,
+                         bool allowSubstitution,
+                         std::string *pResult)
+{
+   return iconvstrImpl(value, "", "UTF-8", allowSubstitution, pResult);
+}
+
+core::Error utf8ToNative(const std::string& value,
+                         bool allowSubstitution,
+                         std::string* pResult)
+{
+   return iconvstrImpl(value, "UTF-8", "", allowSubstitution, pResult);
+}
+
+core::Error iconvstr(const std::string& value,
+                     const std::string& from,
+                     const std::string& to,
+                     bool allowSubstitution,
+                     std::string* pResult)
+{
+   std::string effectiveFrom = from;
+   if (effectiveFrom.empty())
+      effectiveFrom = "UTF-8";
+
+   std::string effectiveTo = to;
+   if (effectiveTo.empty())
+      effectiveTo = "UTF-8";
+
+   if (effectiveFrom == effectiveTo)
+   {
+      *pResult = value;
+      return Success();
+   }
+
+   return iconvstrImpl(value, from, to, allowSubstitution, pResult);
+}
+
 
 std::set<std::string> makeRKeywords()
 {

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -85,16 +85,23 @@ inline EvalFlags operator|(EvalFlags lhs, EvalFlags rhs)
    return static_cast<EvalFlags>(static_cast<int>(lhs) | static_cast<int>(rhs));
 }
 
-// parse and evaluate expressions  
+// parse and evaluate expressions
+core::Error executeCallUnsafe(SEXP callSEXP,
+                              SEXP envirSEXP,
+                              SEXP* pResultSEXP,
+                              sexp::Protect* pProtect);
+
 core::Error executeStringUnsafe(const std::string& str, 
                                 SEXP* pSEXP, 
                                 sexp::Protect* pProtect);
+
 core::Error executeStringUnsafe(const std::string& str,
                                 SEXP envirSEXP,
                                 SEXP* pSEXP,
                                 sexp::Protect* pProtect);
 
 core::Error executeString(const std::string& str);
+
 core::Error evaluateString(const std::string& str,
                            SEXP* pSEXP,
                            sexp::Protect* pProtect,

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -48,11 +48,20 @@ bool hasCapability(const std::string& capability);
 
 std::string rconsole2utf8(const std::string& encoded);
 
+core::Error nativeToUtf8(const std::string& value,
+                         bool allowSubstitution,
+                         std::string* pResult);
+
+core::Error utf8ToNative(const std::string& value,
+                         bool allowSubstitution,
+                         std::string* pResult);
+
 core::Error iconvstr(const std::string& value,
                      const std::string& from,
                      const std::string& to,
                      bool allowSubstitution,
                      std::string* result);
+
 
 bool isRKeyword(const std::string& name);
 bool isWindowsOnlyFunction(const std::string& name);

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -31,8 +31,10 @@
 
 # NOTE: we need to add condition handlers to the top level, but cannot
 # actually do so if there is an R function context on the stack.
-# To circumvent this, we use R funcitons to just provide the call object
-# that needs to be executed, and then execute that call at the top level.
+#
+# To circumvent this, we define R functions with the code we need to run,
+# but explicitly extract the body of that function, and then execute that
+# at the top level.
 .rs.addFunction("notebookConditions.connectCall", function()
 {
    body(.rs.notebookConditions.connectImpl)

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -52,7 +52,7 @@
    ))
    
    envir <- as.environment("tools:rstudio")
-   assign(".rs.notebook.handlerStack", handlers, envir = envir)
+   assign(".rs.notebookConditions.handlerStack", handlers, envir = envir)
    
    handlers
 })
@@ -65,7 +65,7 @@
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
    envir <- as.environment("tools:rstudio")
-   handlers <- get(".rs.notebook.handlerStack", envir = envir)
-   rm(".rs.notebook.handlerStack", envir = envir)
+   handlers <- get(".rs.notebookConditions.handlerStack", envir = envir)
+   rm(".rs.notebookConditions.handlerStack", envir = envir)
    .Internal(.resetCondHands(handlers))
 })

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -1,0 +1,71 @@
+#
+# NotebookConditions.R
+#
+# Copyright (C) 2020 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("notebookConditions.onWarning", function(condition)
+{
+   prefix <- gettext("Warning:", domain = "R")
+   message <- paste(condition$message, collapse = "\n")
+   full <- paste(prefix, message)
+   .Call("rs_signalNotebookCondition", 1L, full, PACKAGE = "(embedding)")
+   invokeRestart("muffleWarning")
+})
+
+.rs.addFunction("notebookConditions.onMessage", function(condition)
+{
+   full <- paste(condition$message, collapse = "\n")
+   .Call("rs_signalNotebookCondition", 0L, full, PACKAGE = "(embedding)")
+   invokeRestart("muffleMessage")
+})
+
+# NOTE: we need to add condition handlers to the top level, but cannot
+# actually do so if there is an R function context on the stack.
+# To circumvent this, we use R funcitons to just provide the call object
+# that needs to be executed, and then execute that call at the top level.
+.rs.addFunction("notebookConditions.connectCall", function()
+{
+   body(.rs.notebookConditions.connectImpl)
+})
+
+.rs.addFunction("notebookConditions.connectImpl", function()
+{
+   handlers <- .Internal(.addCondHands(
+      c("warning", "message"),
+      list(
+         warning = .rs.notebookConditions.onWarning,
+         message = .rs.notebookConditions.onMessage
+      ),
+      globalenv(),
+      NULL,
+      TRUE
+   ))
+   
+   envir <- as.environment("tools:rstudio")
+   assign(".rs.notebook.handlerStack", handlers, envir = envir)
+   
+   handlers
+})
+
+.rs.addFunction("notebookConditions.disconnectCall", function()
+{
+   body(.rs.notebookConditions.disconnectImpl)
+})
+
+.rs.addFunction("notebookConditions.disconnectImpl", function()
+{
+   envir <- as.environment("tools:rstudio")
+   handlers <- get(".rs.notebook.handlerStack", envir = envir)
+   rm(".rs.notebook.handlerStack", envir = envir)
+   .Internal(.resetCondHands(handlers))
+})

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -25,6 +25,7 @@
 #include <r/RExec.hpp>
 #include <r/RRoutines.hpp>
 #include <r/RSexp.hpp>
+#include <r/RUtil.hpp>
 
 #include <session/SessionAsyncRProcess.hpp>
 #include <session/SessionModuleContext.hpp>

--- a/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
@@ -63,7 +63,7 @@ void ConditionCapture::connect()
       return;
    }
    
-   SEXP resultSEXP;
+   SEXP resultSEXP = R_NilValue;
    error = r::exec::executeCallUnsafe(connectCall, R_GlobalEnv, &resultSEXP, &protect);
    if (error)
    {
@@ -78,7 +78,15 @@ void ConditionCapture::disconnect()
 {
    if (connected())
    {
-      Error error = r::exec::RFunction(".rs.notebookConditions.disconnect").call();
+      r::sexp::Protect protect;
+      
+      SEXP disconnectCall = R_NilValue;
+      Error error = r::exec::RFunction(".rs.notebookConditions.disconnectCall").call(&disconnectCall, &protect);
+      if (error)
+         LOG_ERROR(error);
+      
+      SEXP resultSEXP = R_NilValue;
+      error = r::exec::executeCallUnsafe(disconnectCall, R_GlobalEnv, &resultSEXP, &protect);
       if (error)
          LOG_ERROR(error);
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookConditions.cpp
@@ -34,7 +34,7 @@ namespace {
 SEXP rs_signalNotebookCondition(SEXP condition, SEXP message)
 {
    // extract message (make sure we got one)
-   std::string msg = r::sexp::safeAsString(message, "");
+   std::string msg = r::sexp::asUtf8String(message);
    if (msg.empty())
       return R_NilValue;
 
@@ -51,18 +51,18 @@ void ConditionCapture::connect()
 {
    // create a parsed expression which will disable messages; this is 
    // effectively identical to suppressConditions() but we need to evaluate it
-   // at the top level so we can influence the global handler stack.   
+   // at the top level so we can influence the global handler stack.
    r::sexp::Protect protect;
    SEXP retSEXP = R_NilValue;
    Error error = r::exec::executeStringUnsafe(
          ".Internal(.addCondHands(c(\"warning\", \"message\"), "
          " list(warning = function(m) { "
-         "   .Call(\"rs_signalNotebookCondition\", " + 
+         "   .Call(\"rs_signalNotebookCondition\", " +
                       safe_convert::numberToString(ConditionWarning) + "L, "
          "          m$message, PACKAGE = '(embedding)'); "
          "   invokeRestart(\"muffleWarning\") "
          " }, message = function(m) { "
-         "   .Call(\"rs_signalNotebookCondition\", " + 
+         "   .Call(\"rs_signalNotebookCondition\", " +
                       safe_convert::numberToString(ConditionMessage) + "L, "
          "          m$message, PACKAGE = '(embedding)'); "
          "   invokeRestart(\"muffleMessage\") "

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -294,33 +294,16 @@ bool ChunkExecContext::onCondition(Condition condition,
       return false;
    }
 
-   // condition messages are typically converted to the native
-   // encoding so we'll have to convert back to UTF-8 here.
-   //
-   // note that systemToUtf8() is not appropriate here as
-   // the configured locale + language used for translations
-   // does not necessarily match the active system codepage!
-   std::string utf8Message = message;
-
-#ifdef _WIN32
-   Error error = r::util::nativeToUtf8(message, true, &utf8Message);
-   if (error)
-   {
-      LOG_ERROR(error);
-      utf8Message = message;
-   }
-#endif
-
    // give each capturing module a chance to handle the condition
    for (boost::shared_ptr<NotebookCapture> pCapture : captures_)
    {
-      if (pCapture->onCondition(condition, utf8Message))
+      if (pCapture->onCondition(condition, message))
          return true;
    }
 
-   onConsoleOutput(module_context::ConsoleOutputError, utf8Message);
+   onConsoleOutput(module_context::ConsoleOutputError, message);
    module_context::enqueClientEvent(
-      ClientEvent(client_events::kConsoleWriteError, utf8Message));
+      ClientEvent(client_events::kConsoleWriteError, message));
 
    return true;
 }


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/8546.

### Approach

Ensure that condition messages, as captured when notebook mode is active, are converted to UTF-8.

Also refactor some of the global condition handling code. Rather than build a string to be executed at the top level, we instead use a regular R function to define the associated call, and then extract the body of that function and execute that at the top level. IMHO, this makes the implementation much easier to maintain and tweak.

Also add some helper functions, `nativeToUtf8()` + `utf8ToNative()`, to be used in the future when explicit conversion is required.

### QA Notes

This should be tested on Windows, in an R Markdown document. First, instruct RStudio to translate messages to Korean with:

```
Sys.setlocale(locale = "Korean")
Sys.setenv(LANGUAGE = "ko")
```

Then, try loading a package and confirm that the output is properly encoded and displayed as Korean:

<img width="602" alt="Screen Shot 2020-12-08 at 9 44 26 AM" src="https://user-images.githubusercontent.com/1976582/101520914-f7e79300-3939-11eb-8be8-d1094914d906.png">

Note that it is expected here that part of the message is not translated here, as no translation is defined for this part of the message output.

You can also test explicitly with message / warning output:

```
msg <- gettextf("Attaching package: %s", "dplyr")
message(msg)
warning(msg)
```

<img width="468" alt="Screen Shot 2020-12-08 at 9 45 56 AM" src="https://user-images.githubusercontent.com/1976582/101521084-2ebda900-393a-11eb-8b98-e71f35820ab0.png">
