### PR TITLE
Respect "tab key always moves focus" pref in visual editor

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -27,4 +27,6 @@
 * Fixed issue where warnings + messages were mis-encoded in chunk outputs on Windows (#8565)
 * Fixed issue where C++ compilation database was not invalidated when compiler was updated (#8588)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
+* Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
+
 


### PR DESCRIPTION
### Intent

Respect the accessibility setting "Tab Key Always Moves Focus" in visual mode chunks. Fixes https://github.com/rstudio/rstudio/issues/8584.

### Approach

This wasn't working because the code that tracks this pref is in the `AceEditorWidget` class. The Ace instance used in the visual editor is not wrapped in an `AceEditorWidget` and so it does not track the pref.

The fix is pretty simple: we just track the pref ourselves in the visual mode chunk. 

### QA Notes

This should track the preference not only at startup but also as the preference is changed in real time (e.g., try changing the setting in Global Options and confirm that the open editors are affected).