### PR TITLE
Implement previous/following chunk execution commands outside chunks

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -28,5 +28,7 @@
 * Fixed issue where C++ compilation database was not invalidated when compiler was updated (#8588)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
+* The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)
+
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1923,7 +1923,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="executeSubsequentChunks"
         menuLabel="Run All C_hunks Below"
-        desc="Run all chunks after the current one"
+        desc="Run all chunks below the current one"
         context="r"/>
 
    <cmd id="executeCurrentChunk"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1918,7 +1918,7 @@ well as menu structures (for main menu and popup menus).
 
    <cmd id="executePreviousChunks"
         menuLabel="_Run All Chunks Above"
-        desc="Run all above the current one"
+        desc="Run all chunks above the current one"
         context="r"/>
 
    <cmd id="executeSubsequentChunks"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5001,7 +5001,7 @@ public class TextEditingTarget implements
    
    /**
     * Performs a command after synchronizing the document and selection state
-    * from visual mode (useful for executing code). The command is not executed
+    * from visual mode (useful for executing code). The command is not executed if
     * there is no active code editor in visual mode (e.g., the cursor is outside
     * a code chunk)
     * 
@@ -5011,7 +5011,14 @@ public class TextEditingTarget implements
    {
       if (isVisualEditorActive())
       {
-         visualMode_.performWithSelection((pos) -> command.execute());
+         visualMode_.performWithSelection((pos) ->
+         {
+            // A null position indicates that the cursor is outside a code chunk.
+            if (pos != null)
+            {
+               command.execute();
+            }
+         });
       }
       else
       {
@@ -5650,7 +5657,7 @@ public class TextEditingTarget implements
          Scope nextChunk = null;
          if (pos == null)
          {
-            // We are outside a chunk in visual mode, so
+            // We are outside a chunk in visual mode, so get the nearest chunk below
             nextChunk = visualMode_.getNearestChunkScope(TextEditingTargetScopeHelper.FOLLOWING_CHUNKS);
             if (nextChunk == null)
             {
@@ -5660,6 +5667,7 @@ public class TextEditingTarget implements
          }
          else
          {
+            // Force scope tree rebuild and get chunk from source mode
             docDisplay_.getScopeTree();
             nextChunk = scopeHelper_.getNextSweaveChunk();
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -5710,7 +5710,23 @@ public class TextEditingTarget implements
                // any previous/next chunks to run)
                return;
             }
-            pos = scope.getBodyStart();
+            if (dir == TextEditingTargetScopeHelper.FOLLOWING_CHUNKS)
+            {
+               // Going down: start at beginning of next chunk
+               pos = scope.getBodyStart();
+            }
+            else
+            {
+               // Going up: start *just beneath* chunk if we can (so chunk itself is included)
+
+               // Clone position so we can update it without affecting the chunk scope
+               pos = Position.create(scope.getEnd().getRow(), scope.getEnd().getColumn());
+               if (pos.getRow() < docDisplay_.getRowCount())
+               {
+                  pos.setRow(pos.getRow() + 1);
+                  pos.setColumn(1);
+               }
+            }
          }
          executeChunks(pos, dir);
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -1341,6 +1341,8 @@ public class TextEditingTargetNotebook
    
    public static boolean isSetupChunkScope(Scope scope)
    {
+      if (scope == null)
+         return false;
       if (!scope.isChunk())
          return false;
       if (scope.getChunkLabel() == null)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -53,6 +53,7 @@ import org.rstudio.studio.client.panmirror.events.PanmirrorFocusEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorNavigationEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorStateChangeEvent;
 import org.rstudio.studio.client.panmirror.events.PanmirrorUpdatedEvent;
+import org.rstudio.studio.client.panmirror.location.PanmirrorEditingLocation;
 import org.rstudio.studio.client.panmirror.location.PanmirrorEditingOutlineLocation;
 import org.rstudio.studio.client.panmirror.location.PanmirrorEditingOutlineLocationItem;
 import org.rstudio.studio.client.panmirror.outline.PanmirrorOutlineItem;
@@ -981,10 +982,16 @@ public class VisualMode implements VisualModeEditorSync,
     */
    public Scope getNearestChunkScope(int dir)
    {
-      int pos = panmirror_.getEditingLocation().pos;
-      VisualModeChunk chunk = visualModeChunks_.getNearestChunk(pos, dir);
+      PanmirrorEditingLocation loc = panmirror_.getEditingLocation();
+      if (loc == null)
+      {
+         // No current location, so can't find nearest chunk
+         return null;
+      }
+      VisualModeChunk chunk = visualModeChunks_.getNearestChunk(loc.pos, dir);
       if (chunk == null)
       {
+         // No nearest chunk
          return null;
       }
       return chunk.getScope();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -72,6 +72,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ScopeList;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditingTargetRMarkdownHelper;
 import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditorContainer;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 import org.rstudio.studio.client.workbench.views.source.editors.text.findreplace.FindReplaceBar;
 import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkDefinition;
 import org.rstudio.studio.client.workbench.views.source.editors.text.status.StatusBar;
@@ -708,12 +709,13 @@ public class VisualMode implements VisualModeEditorSync,
 
    /**
     * Perform a command after synchronizing the selection state of the visual
-    * editor. Note that the command will not be performed unless focus is in a
-    * code editor (as otherwise we can't map selection 1-1).
-    * 
-    * @param command
+    * editor. Note that the command will be passed a null position if focus is
+    * not in a code editor (outside a code editor we can't map selection 1-1).
+    *
+    * @param command The command to perform; will be passed the exact cursor
+    *    position if available.
     */
-   public void performWithSelection(Command command)
+   public void performWithSelection(CommandWithArg<Position> command)
    {
       // Drive focus to the editing surface. This is necessary so we correctly
       // identify the active (focused) editor on which to perform the command.
@@ -967,6 +969,25 @@ public class VisualMode implements VisualModeEditorSync,
       if (chunk == null)
          return null;
       return chunk.getDefinition();
+   }
+
+
+   /**
+    * Gets the Scope of the nearest visual mode chunk.
+    *
+    * @param dir The direction in which to look
+    *
+    * @return The scope of the nearest chunk, or null if no chunk was found.
+    */
+   public Scope getNearestChunkScope(int dir)
+   {
+      int pos = panmirror_.getEditingLocation().pos;
+      VisualModeChunk chunk = visualModeChunks_.getNearestChunk(pos, dir);
+      if (chunk == null)
+      {
+         return null;
+      }
+      return chunk.getScope();
    }
    
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -23,7 +23,6 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.regex.Pattern;
-import org.rstudio.studio.client.RStudio;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
@@ -562,7 +561,7 @@ public class VisualModeChunk
     */
    public void executeSelection()
    {
-      performWithSelection(() ->
+      performWithSelection((pos) ->
       {
          codeExecution_.executeSelection(false);
       });
@@ -572,9 +571,10 @@ public class VisualModeChunk
     * Performs an arbitrary command after synchronizing the selection state of
     * the child editor to the parent.
     * 
-    * @param command The command to perform.
+    * @param command The command to perform. The new position of the cursor in
+    *    source mode is passed as an argument.
     */
-   public void performWithSelection(Command command)
+   public void performWithSelection(CommandWithArg<Position> command)
    {
       sync_.syncToEditor(SyncType.SyncTypeExecution, () ->
       {
@@ -582,7 +582,7 @@ public class VisualModeChunk
       });
    }
    
-   private void performWithSyncedSelection(Command command)
+   private void performWithSyncedSelection(CommandWithArg<Position> command)
    {
       // Ensure we have a scope. This should always exist since we sync the
       // scope outline prior to executing code.
@@ -611,7 +611,7 @@ public class VisualModeChunk
       // Execute selection in the parent
       parent_.setSelectionRange(selectionRange);
 
-      command.execute();
+      command.execute(selectionRange.getStart());
       
       // After the event loop, forward the parent selection back to the child if
       // it's changed (this allows us to advance the cursor after running a line)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -165,7 +165,8 @@ public class VisualModeChunks implements ChunkDefinition.Provider
     * Performs an arbitrary command after synchronizing the selection state of
     * the child editor to the parent.
     * 
-    * @param command The command to perform.
+    * @param command The command to perform. The new position of the cursor in
+    *    source mode is passed as an argument.
     */
    public void performWithSelection(CommandWithArg<Position> command)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -98,6 +98,47 @@ public class VisualModeChunks implements ChunkDefinition.Provider
       }
       return null;
    }
+
+   /**
+    * Gets the visual mode chunk nearest to the given position.
+    *
+    * @param pos The position in visual mode (usually of the cursor)
+    * @param dir The direction in which to look
+    *
+    * @return The nearest chunk, or null if no chunks are found.
+    */
+   public VisualModeChunk getNearestChunk(int pos, int dir)
+   {
+      // Candidate for nearest chunk
+      VisualModeChunk nearest = null;
+
+      // Distance of nearest chunk from the given position
+      int best = 0;
+
+      for (VisualModeChunk chunk: chunks_)
+      {
+         // Check distance from position
+         int chunkPos = chunk.getVisualPosition();
+         int offset = dir == TextEditingTargetScopeHelper.PREVIOUS_CHUNKS ?
+            pos - chunkPos : chunkPos - pos;
+         if (offset < 0)
+         {
+            // Skip if past target
+            continue;
+         }
+
+         if (nearest == null || offset < best)
+         {
+            // Record this chunk if it's the nearest we've found so far
+            nearest = chunk;
+            best = offset;
+         }
+      }
+
+      // Return nearest chunk; could be null if e.g., there are no chunks after the cursor
+      // and FOLLOWING_CHUNKS was specified
+      return nearest;
+   }
    
    /**
     * Find the visual mode chunk editor corresponding to the given visual
@@ -121,61 +162,23 @@ public class VisualModeChunks implements ChunkDefinition.Provider
    }
    
    /**
-    * Executes the currently active chunk
-    */
-   public void executeCurrentChunk()
-   {
-      withActiveChunk((chunk) ->
-      {
-         chunk.execute();
-      });
-   }
-   
-   /**
-    * Executes all previous chunks
-    */
-   public void executePreviousChunks()
-   {
-      withActiveChunk((chunk) ->
-      {
-         target_.executeChunks(
-               Position.create(chunk.getScope().getBodyStart().getRow(), 0),
-               TextEditingTargetScopeHelper.PREVIOUS_CHUNKS);
-      });
-   }
-   
-   /**
-    * Executes the next chunk
-    */
-   public void executeNextChunk()
-   {
-      boolean next = false;
-      for (VisualModeChunk chunk: chunks_)
-      {
-         if (next)
-         {
-            chunk.focus();
-            chunk.execute();
-            break;
-         }
-         if (chunk.isActive())
-         {
-            next = true;
-         }
-      }
-   }
-   
-   /**
     * Performs an arbitrary command after synchronizing the selection state of
     * the child editor to the parent.
     * 
     * @param command The command to perform.
     */
-   public void performWithSelection(Command command)
+   public void performWithSelection(CommandWithArg<Position> command)
    {
       withActiveChunk((chunk) ->
       {
-         chunk.performWithSelection(command);
+         if (chunk == null)
+         {
+            command.execute(null);
+         }
+         else
+         {
+            chunk.performWithSelection(command);
+         }
       });
    }
    
@@ -248,7 +251,12 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          }
       }
    }
-   
+
+   /**
+    * Executes a command with the currently active visual chunk (or null if no chunk is active)
+    *
+    * @param command The command to execute.
+    */
    private void withActiveChunk(CommandWithArg<VisualModeChunk> command)
    {
       for (VisualModeChunk chunk: chunks_)
@@ -256,9 +264,12 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          if (chunk.isActive())
          {
             command.execute(chunk);
-            break;
+            return;
          }
       }
+
+      // No chunk found; execute without one
+      command.execute(null);
    }
 
    private final VisualModeEditorSync sync_;


### PR DESCRIPTION
### Intent

Makes the "Execute Previous Chunks" and "Execute Subsequent Chunks" commands work correctly in visual mode when the cursor is outside a code chunk. 

Fixes https://github.com/rstudio/rstudio/issues/8500
Fixes https://github.com/rstudio/rstudio/issues/8275

### Approach

This fix is not trivial since a good deal of plumbing is required. In particular, these (and most other) code execution commands currently presume you're already in a code editor. So here's what we do now:

1. The code that synchronizes the current code editor position has been plumbed so that it now returns the position it found, or `null` when the position isn't inside a code editor.
2. If the Execute Next or Execute Previous commands are run when the position isn't inside a code editor, we find the nearest code editor (in the requested direction), and use it as a virtual position for executing the command. 

### QA Notes

This one is worth testing lots of edge cases on: top/bottom of document, when there are no chunks at all, when all the chunks are below/above the cursor, when the cursor is actually inside a chunk, when the cursor is just before/after one, etc. 