### PR TITLE
Add preference governing pipe operator style

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -5,6 +5,7 @@
 ### Misc
 
 * Added support for the `|>` pipe operator, and `\(x)` function shorthand syntax (#8543)
+* Added preference toggle for inserting the |> pipe operator when the Insert Pipe Operator command is used (#8534)
 * Improve detection for crashes that occur early in session initialization (#7983)
 * The mouse back / forward buttons can now be used to navigate within the Help pane (#8338)
 * Right-click on document tab provides menu with close, close all, close others (#1664)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -380,6 +380,7 @@ namespace prefs {
 #define kPythonVersion "python_version"
 #define kPythonPath "python_path"
 #define kSaveRetryTimeout "save_retry_timeout"
+#define kInsertNativePipeOperator "insert_native_pipe_operator"
 
 class UserPrefValues: public Preferences
 {
@@ -1668,6 +1669,12 @@ public:
     */
    int saveRetryTimeout();
    core::Error setSaveRetryTimeout(int val);
+
+   /**
+    * Whether the Insert Pipe Operator command should insert the native R pipe operator, |>
+    */
+   bool insertNativePipeOperator();
+   core::Error setInsertNativePipeOperator(bool val);
 
 };
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2805,6 +2805,19 @@ core::Error UserPrefValues::setSaveRetryTimeout(int val)
    return writePref("save_retry_timeout", val);
 }
 
+/**
+ * Whether the Insert Pipe Operator command should insert the native R pipe operator, |>
+ */
+bool UserPrefValues::insertNativePipeOperator()
+{
+   return readPref<bool>("insert_native_pipe_operator");
+}
+
+core::Error UserPrefValues::setInsertNativePipeOperator(bool val)
+{
+   return writePref("insert_native_pipe_operator", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3022,6 +3035,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kPythonVersion,
       kPythonPath,
       kSaveRetryTimeout,
+      kInsertNativePipeOperator,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1438,6 +1438,12 @@
             "default": 15,
             "title": "Save Retry Timeout",
             "description": "The maximum amount of seconds of retry for save operations."
+        },
+        "insert_native_pipe_operator": {
+            "description": "Whether the Insert Pipe Operator command should insert the native R pipe operator, |>",
+            "title": "Use R's native pipe operator, |>",
+            "type": "boolean",
+            "default": false 
         }
     }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3051,6 +3051,18 @@ public class UserPrefsAccessor extends Prefs
          15);
    }
 
+   /**
+    * Whether the Insert Pipe Operator command should insert the native R pipe operator, |>
+    */
+   public PrefValue<Boolean> insertNativePipeOperator()
+   {
+      return bool(
+         "insert_native_pipe_operator",
+         "Use R's native pipe operator, |>", 
+         "Whether the Insert Pipe Operator command should insert the native R pipe operator, |>", 
+         false);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -3481,6 +3493,8 @@ public class UserPrefsAccessor extends Prefs
          pythonPath().setValue(layer, source.getString("python_path"));
       if (source.hasKey("save_retry_timeout"))
          saveRetryTimeout().setValue(layer, source.getInteger("save_retry_timeout"));
+      if (source.hasKey("insert_native_pipe_operator"))
+         insertNativePipeOperator().setValue(layer, source.getBool("insert_native_pipe_operator"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -3699,6 +3713,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(pythonVersion());
       prefs.add(pythonPath());
       prefs.add(saveRetryTimeout());
+      prefs.add(insertNativePipeOperator());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -77,6 +77,8 @@ public class EditingPreferencesPane extends PreferencesPane
             "When enabled, the indentation for documents not part of an RStudio project " +
             "will be automatically detected."));
       editingPanel.add(checkboxPref("Insert matching parens/quotes", prefs_.insertMatching()));
+      editingPanel.add(checkboxPref("Use native pipe operator, |> (requires R 4.1+)",
+         prefs_.insertNativePipeOperator()));
       editingPanel.add(checkboxPref("Auto-indent code after paste", prefs_.reindentOnPaste()));
       editingPanel.add(checkboxPref("Vertically align arguments in auto-indent", prefs_.verticallyAlignArgumentsIndent()));
       editingPanel.add(checkboxPref("Soft-wrap R source files", prefs_.softWrapRFiles()));
@@ -146,7 +148,6 @@ public class EditingPreferencesPane extends PreferencesPane
       Label executionLabel = headerLabel("Execution");
       editingPanel.add(executionLabel);
       executionLabel.getElement().getStyle().setMarginTop(8, Unit.PX);
-      editingPanel.add(checkboxPref("Always save R scripts before sourcing", prefs.saveBeforeSourcing()));
       editingPanel.add(checkboxPref("Focus console after executing from source", prefs_.focusConsoleAfterExec()));
 
       executionBehavior_ = new SelectWidget(
@@ -287,6 +288,7 @@ public class EditingPreferencesPane extends PreferencesPane
       setEncoding(prefs.defaultEncoding().getGlobalValue());
 
       savePanel.add(spacedBefore(headerLabel("Auto-save")));
+      savePanel.add(checkboxPref("Always save R scripts before sourcing", prefs.saveBeforeSourcing()));
       savePanel.add(checkboxPref("Automatically save when editor loses focus", prefs_.autoSaveOnBlur()));
       autoSaveOnIdle_ = new SelectWidget(
             "When editor is idle: ",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -659,11 +659,14 @@ public class AceEditor implements DocDisplay,
       boolean hasWhitespaceBefore =
             Character.isSpace(getCharacterBeforeCursor()) ||
             (!hasSelection() && getCursorPosition().getColumn() == 0);
-      
+
+      // Use magrittr style pipes unless user has opted into new native pipe syntax in R 4.1+
+      String pipe = userPrefs_.insertNativePipeOperator().getValue() ? "|>" : "%>%";
+
       if (hasWhitespaceBefore)
-         insertCode("%>% ", false);
+         insertCode(pipe + " ", false);
       else
-         insertCode(" %>% ", false);
+         insertCode(" " + pipe + " ", false);
    }
    
    private boolean shouldIndentOnPaste()


### PR DESCRIPTION
### Intent

Adds a new user preference which can be used to make the *Insert Pipe Operator* command insert an R 4.1 native pipe, `|>`, rather than a magrittr style pipe, `%>%`. 

![image](https://user-images.githubusercontent.com/470418/101965273-e831ae00-3bc8-11eb-8972-143ec15885f0.png)

Closes https://github.com/rstudio/rstudio/issues/8534.

### Approach

Add the pref and consult it before inserting a pipe. 

As usual, dialog space is an issue; there was no room for this in its natural location (under Editing), so the "Save when sourcing" pref was moved to the Saving tab (arguably a more natural home) to make room. 

At some point, we may want to add this pref to the computed layer, such that instead of always defaulting to magrittr style pipes, we automatically default to `|>` when R supports it. However, since compatibility with the tidyverse (and exact R version support) are still murky, this preference is currently only for early adopters and defaults to off. 

### QA Notes

Test via notes in #8534. 