### PR TITLE
fix building with boost 1.75

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -35,7 +35,6 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeGlobals.txt")
 
 # global directives
 add_definitions(-DBOOST_ENABLE_ASSERT_HANDLER)
-add_definitions(-DBOOST_BIND_GLOBAL_PLACEHOLDERS)
 
 # explicitly do not use new c++ 11 features for websocketpp
 # they currently do not work with our source

--- a/src/cpp/core/ConfigUtils.cpp
+++ b/src/cpp/core/ConfigUtils.cpp
@@ -18,13 +18,15 @@
 #include <algorithm>
 
 #include <boost/regex.hpp>
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/FileLockTests.cpp
+++ b/src/cpp/core/FileLockTests.cpp
@@ -23,10 +23,12 @@
 #include <shared_core/FilePath.hpp>
 
 #include <boost/thread.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #define RSTUDIO_NO_TESTTHAT_ALIASES
 #include <tests/TestThat.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/FileUtils.cpp
+++ b/src/cpp/core/FileUtils.cpp
@@ -16,7 +16,7 @@
 #include <fstream>
 #include <iostream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/FileUtils.hpp>
 #include <core/FileSerializer.hpp>
@@ -28,6 +28,8 @@
 #ifndef _WIN32
 #include <core/system/PosixUser.hpp>
 #endif
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/HtmlUtils.cpp
+++ b/src/cpp/core/HtmlUtils.cpp
@@ -19,12 +19,15 @@
 
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Base64.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/RegexUtils.hpp>
 
 #include <core/http/Util.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/file_lock/FileLock.cpp
+++ b/src/cpp/core/file_lock/FileLock.cpp
@@ -27,9 +27,12 @@
 #include <core/system/Xdg.hpp>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
 
 // borrowed from SessionConstants.hpp
 #define kRStudioSessionRoute "RSTUDIO_SESSION_ROUTE"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/gwt/GwtSymbolMaps.cpp
+++ b/src/cpp/core/gwt/GwtSymbolMaps.cpp
@@ -20,15 +20,17 @@
 #include <set>
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Thread.hpp>
 #include <core/RegexUtils.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <core/FileSerializer.hpp>
+
+using namespace boost::placeholders;
 
 // NOTE: this is a port of the following GWT class:
 // (our rev was 11565, we should track to future changes)

--- a/src/cpp/core/http/SocketProxy.cpp
+++ b/src/cpp/core/http/SocketProxy.cpp
@@ -27,9 +27,8 @@
 
 #include <iostream>
 
-#include <boost/bind.hpp>
-
 #include <boost/asio/placeholders.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
@@ -37,6 +36,7 @@
 #include <core/http/SocketUtils.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/http/UriHandler.cpp
+++ b/src/cpp/core/http/UriHandler.cpp
@@ -17,10 +17,12 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/http/Request.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/Predicate.hpp
+++ b/src/cpp/core/include/core/Predicate.hpp
@@ -16,8 +16,10 @@
 #ifndef CORE_PREDICATE_HPP
 #define CORE_PREDICATE_HPP
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/http/AsyncUriHandler.hpp
+++ b/src/cpp/core/include/core/http/AsyncUriHandler.hpp
@@ -20,14 +20,16 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/variant.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/http/UriHandler.hpp>
 #include <core/http/AsyncConnection.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/http/Message.hpp
+++ b/src/cpp/core/include/core/http/Message.hpp
@@ -20,8 +20,10 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/utility.hpp>
+
+using namespace boost::placeholders;
 
 namespace RSTUDIO_BOOST_NAMESPACE {
 namespace asio {

--- a/src/cpp/core/include/core/json/JsonRpc.hpp
+++ b/src/cpp/core/include/core/json/JsonRpc.hpp
@@ -91,13 +91,15 @@ struct is_error_code_enum<rstudio::core::json::errc::errc_t>
 
 #include <string>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/json/Json.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -19,12 +19,12 @@
 #include <string>
 #include <vector>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/utility.hpp>
 #include <boost/regex.hpp>
 #include <boost/range/adaptors.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <shared_core/SafeConvert.hpp>
@@ -33,6 +33,8 @@
 
 #include <core/r_util/RTokenizer.hpp>
 #include <core/r_util/RFunctionInformation.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/text/TemplateFilter.hpp
+++ b/src/cpp/core/include/core/text/TemplateFilter.hpp
@@ -21,12 +21,14 @@
 #include <string>
 #include <map>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <boost/iostreams/filter/regex.hpp>
 
 #include <core/StringUtils.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/markdown/MathJax.cpp
+++ b/src/cpp/core/markdown/MathJax.cpp
@@ -17,12 +17,14 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/algorithm/string.hpp>
 
 #include <core/RegexUtils.hpp>
 #include <core/system/System.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -15,7 +15,7 @@
 
 #include <core/r_util/RActiveSessions.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include <core/StringUtils.hpp>
@@ -27,6 +27,8 @@
 #include <core/r_util/RSessionContext.hpp>
 
 #define kSessionDirPrefix "session-"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -25,8 +25,10 @@
 #include <core/r_util/RTokenizer.hpp>
 #include <core/r_util/RTokenCursor.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/r_util/RVersionsPosix.cpp
+++ b/src/cpp/core/r_util/RVersionsPosix.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <algorithm>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/FileSerializer.hpp>
@@ -32,6 +32,8 @@
 #define kRFrameworkVersions "/Library/Frameworks/R.framework/Versions"
 #define kRScriptPath "Resources/bin/R"
 #endif
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/spelling/HunspellCustomDictionaries.cpp
+++ b/src/cpp/core/spelling/HunspellCustomDictionaries.cpp
@@ -15,10 +15,12 @@
 
 #include <core/spelling/HunspellCustomDictionaries.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Log.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/spelling/HunspellDictionaryManager.cpp
+++ b/src/cpp/core/spelling/HunspellDictionaryManager.cpp
@@ -16,10 +16,12 @@
 #include <core/spelling/HunspellDictionaryManager.hpp>
 #include <core/system/Xdg.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <core/Log.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
+++ b/src/cpp/core/system/ChildProcessSubprocPollTests.cpp
@@ -15,10 +15,12 @@
 
 #include "ChildProcessSubprocPoll.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/thread.hpp>
 
 #include <tests/TestThat.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/Environment.cpp
+++ b/src/cpp/core/system/Environment.cpp
@@ -20,13 +20,15 @@
 
 #include <core/Algorithm.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #ifdef _WIN32
 #define kPathSeparator ";"
 #else
 #define kPathSeparator ":"
 #endif
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -33,7 +33,7 @@
 #include <sys/types.h>
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
@@ -45,6 +45,8 @@
 #include <core/Thread.hpp>
 
 #include <core/PerformanceTimer.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -18,7 +18,9 @@
 #include <sys/wait.h>
 
 #include <boost/format.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixOutputCapture.cpp
+++ b/src/cpp/core/system/PosixOutputCapture.cpp
@@ -29,7 +29,9 @@
 
 #include <core/system/System.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixProcess.cpp
+++ b/src/cpp/core/system/PosixProcess.cpp
@@ -16,12 +16,14 @@
 #include <core/system/PosixProcess.hpp>
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/BoostThread.hpp>
 #include <core/Thread.hpp>
 
 #include <core/system/PosixSystem.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -23,7 +23,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/range/as_array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <signal.h>
 #include <fcntl.h>
@@ -89,6 +89,8 @@
 #include <shared_core/system/User.hpp>
 
 #include "config.h"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 
 #include <boost/algorithm/cxx11/any_of.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Scope.hpp>
 #include <shared_core/Error.hpp>
@@ -27,6 +27,8 @@
 
 #include <core/PerformanceTimer.hpp>
 #include <core/system/ChildProcess.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/ProcessTests.cpp
+++ b/src/cpp/core/system/ProcessTests.cpp
@@ -17,7 +17,7 @@
 
 #include <atomic>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread.hpp>
 
 #include <shared_core/SafeConvert.hpp>
@@ -27,6 +27,8 @@
 #include <core/Thread.hpp>
 
 #include <tests/TestThat.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -29,12 +29,12 @@
 #include <tlhelp32.h>
 #include <VersionHelpers.h>
 
-#include <boost/bind.hpp>
 #include <boost/system/windows_error.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/range.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <core/Log.hpp>
@@ -54,6 +54,8 @@
 #ifndef JOB_OBJECT_LIMIT_BREAKAWAY_OK
 #define JOB_OBJECT_LIMIT_BREAKAWAY_OK 0x00000800
 #endif
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -18,8 +18,8 @@
 
 #include <list>
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -35,6 +35,8 @@
 // in theory cause us to lose notifications on Win32 and OS X however in
 // practice we can't think of an easy way for the user to specify the
 // non case-sensitive variant of a file
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/system/file_monitor/FileMonitorImpl.hpp
+++ b/src/cpp/core/system/file_monitor/FileMonitorImpl.hpp
@@ -20,7 +20,7 @@
 #include <algorithm>
 #include <list>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/FilePath.hpp>
 #include <core/collection/Tree.hpp>
@@ -28,6 +28,8 @@
 #include <core/system/FileChangeEvent.hpp>
 
 #include <core/system/FileMonitor.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {   

--- a/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/MacFileMonitor.cpp
@@ -19,7 +19,7 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/classification.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -30,6 +30,8 @@
 #include <core/system/System.hpp>
 
 #include "FileMonitorImpl.hpp"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/text/DcfParser.cpp
+++ b/src/cpp/core/text/DcfParser.cpp
@@ -22,17 +22,18 @@
 #include <map>
 
 #include <boost/format.hpp>
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/regex.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/split.hpp>
-#include <boost/regex.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/RegexUtils.hpp>
 
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -18,9 +18,9 @@
 #include <QPushButton>
 #include <QQuickWindow>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/scoped_ptr.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/CrashHandler.hpp>
 #include <core/FileSerializer.hpp>
@@ -58,6 +58,8 @@
 
 QProcess* pRSessionProcess;
 QString sharedSecret;
+
+using namespace boost::placeholders;
 
 using namespace rstudio;
 using namespace rstudio::core;

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -19,8 +19,8 @@
 #include <QWebChannel>
 #include <QWebEngineSettings>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/FileSerializer.hpp>
 #include <core/Macros.hpp>
@@ -37,6 +37,7 @@
 #include "DesktopRCommandEvaluator.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace desktop {

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -17,7 +17,7 @@
 
 #include <iostream>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Macros.hpp>
 #include <core/http/Request.hpp>
@@ -42,6 +42,7 @@
              std::cout << (message) << std::endl;
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace desktop {

--- a/src/cpp/desktop/DesktopWin32DetectRHome.cpp
+++ b/src/cpp/desktop/DesktopWin32DetectRHome.cpp
@@ -21,7 +21,7 @@
 
 #include <windows.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/system/System.hpp>
 #include <core/system/Environment.hpp>
@@ -29,6 +29,7 @@
 #include "DesktopRVersion.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace desktop {

--- a/src/cpp/ext/websocketpp/common/functional.hpp
+++ b/src/cpp/ext/websocketpp/common/functional.hpp
@@ -52,9 +52,11 @@
 #ifdef _WEBSOCKETPP_CPP11_FUNCTIONAL_
     #include <functional>
 #else
-    #include <boost/bind.hpp>
     #include <boost/function.hpp>
     #include <boost/ref.hpp>
+    #include <boost/bind/bind.hpp>
+
+    using namespace boost::placeholders;
 #endif
 
 

--- a/src/cpp/ext/websocketpp/transport/asio/endpoint.hpp
+++ b/src/cpp/ext/websocketpp/transport/asio/endpoint.hpp
@@ -38,11 +38,13 @@
 #include <websocketpp/common/functional.hpp>
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/system/error_code.hpp>
 
 #include <sstream>
 #include <string>
+
+using namespace boost::placeholders;
 
 namespace websocketpp {
 namespace transport {

--- a/src/cpp/r/RJsonRpc.cpp
+++ b/src/cpp/r/RJsonRpc.cpp
@@ -47,7 +47,7 @@
 #define R_INTERNAL_FUNCTIONS
 #include <r/RJsonRpc.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -58,6 +58,7 @@
 #include <r/RJson.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -25,10 +25,10 @@
 
 #include <core/Algorithm.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 #include <boost/optional.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Macros.hpp>
 #include <core/Log.hpp>
@@ -43,6 +43,7 @@
 #undef FALSE
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/RSourceManager.cpp
+++ b/src/cpp/r/RSourceManager.cpp
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -27,6 +27,7 @@
 #include <r/RExec.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RClientState.cpp
+++ b/src/cpp/r/session/RClientState.cpp
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -26,6 +26,7 @@
 #include <core/FileSerializer.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RConsoleHistory.cpp
+++ b/src/cpp/r/session/RConsoleHistory.cpp
@@ -15,9 +15,9 @@
 
 #include <r/session/RConsoleHistory.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/tokenizer.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -28,6 +28,7 @@
 #include <gsl/gsl>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -28,8 +28,8 @@
 
 #include <stdio.h>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 
 #include <shared_core/FilePath.hpp>
@@ -54,6 +54,7 @@ extern "C" {
 }
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -13,7 +13,7 @@
  *
  */
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/system/Environment.hpp>
 
@@ -37,6 +37,7 @@
 #define kGraphicsPath "graphics"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RQuit.cpp
+++ b/src/cpp/r/session/RQuit.cpp
@@ -15,7 +15,7 @@
 
 #define R_INTERNAL_FUNCTIONS
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <gsl/gsl>
 
 #include <r/RErrorCategory.hpp>
@@ -28,6 +28,7 @@
 #include "RStdCallbacks.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -26,11 +26,11 @@
 #include <algorithm>
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -46,6 +46,7 @@
 #include <r/session/RSessionUtils.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/function.hpp>
 #include <boost/regex.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
@@ -60,6 +61,7 @@ __declspec(dllimport) SA_TYPE SaveAction;
 }
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -17,8 +17,8 @@
 
 #include <cstdlib>
 
-#include <boost/bind.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -53,6 +53,7 @@
 
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -18,10 +18,10 @@
 #include <algorithm>
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -39,6 +39,7 @@
 #include "RGraphicsPlotManipulatorManager.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManipulatorManager.cpp
@@ -18,8 +18,8 @@
 #include <string>
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -32,6 +32,7 @@
 #include "RGraphicsPlotManager.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
+++ b/src/cpp/r/session/graphics/RShadowPngGraphicsHandler.cpp
@@ -18,8 +18,8 @@
 #include <iostream>
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/system/System.hpp>
 #include <core/StringUtils.hpp>
@@ -38,6 +38,7 @@
 #include <Rembedded.h>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace r {

--- a/src/cpp/session/SessionConsoleProcessSocketTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketTests.cpp
@@ -16,11 +16,11 @@
 #include <session/SessionConsoleProcessSocket.hpp>
 #include <session/SessionConsoleProcessSocketPacket.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/lexical_cast.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <websocketpp/config/asio_no_tls_client.hpp>
 #include <websocketpp/client.hpp>
@@ -32,6 +32,7 @@ namespace session {
 namespace console_process {
 
 using namespace console_process;
+using namespace boost::placeholders;
 
 namespace {
 

--- a/src/cpp/session/SessionSourceDatabase.cpp
+++ b/src/cpp/session/SessionSourceDatabase.cpp
@@ -19,8 +19,8 @@
 #include <vector>
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/regex.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <core/Log.hpp>
@@ -63,6 +63,7 @@
 // properties rather than a side-database
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/include/session/IncrementalFileChangeHandler.hpp
+++ b/src/cpp/session/include/session/IncrementalFileChangeHandler.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/noncopyable.hpp>
 #include <boost/function.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <boost/date_time/posix_time/posix_time.hpp>
 
@@ -31,6 +31,8 @@
 #include <session/SessionModuleContext.hpp>
 
 #include <session/projects/SessionProjects.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/include/session/SessionScopes.hpp
+++ b/src/cpp/session/include/session/SessionScopes.hpp
@@ -19,8 +19,8 @@
 #ifndef SESSION_SCOPES_HPP
 #define SESSION_SCOPES_HPP
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 
 #include <shared_core/FilePath.hpp>
@@ -38,6 +38,9 @@
 
 #include <session/projects/ProjectsSettings.hpp>
 #include <session/projects/SessionProjectSharing.hpp>
+
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionAskPass.cpp
+++ b/src/cpp/session/modules/SessionAskPass.cpp
@@ -15,7 +15,7 @@
 
 #include "SessionAskPass.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
 #include <core/Log.hpp>
@@ -35,6 +35,7 @@
 
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionAskSecret.cpp
+++ b/src/cpp/session/modules/SessionAskSecret.cpp
@@ -15,7 +15,7 @@
 
 #include "SessionAskSecret.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
 #include <core/Log.hpp>
@@ -36,6 +36,7 @@
 
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -17,9 +17,9 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/utility.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
@@ -42,6 +42,7 @@
 using namespace rstudio::core;
 using namespace rstudio::r::sexp;
 using namespace rstudio::r::exec;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionCRANMirrors.cpp
+++ b/src/cpp/session/modules/SessionCRANMirrors.cpp
@@ -15,7 +15,7 @@
 
 #include "SessionCRANMirrors.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/http/URL.hpp>
 #include <core/http/TcpIpBlockingClient.hpp>
@@ -29,6 +29,7 @@
 #include <session/prefs/UserPrefs.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -23,13 +23,13 @@
 #include <set>
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/foreach.hpp>
 #include <boost/format.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/split.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -63,6 +63,7 @@
 #include <core/Macros.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {  

--- a/src/cpp/session/modules/SessionCrypto.cpp
+++ b/src/cpp/session/modules/SessionCrypto.cpp
@@ -17,7 +17,7 @@
 
 #include <string>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -33,6 +33,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -16,8 +16,8 @@
 #include "SessionDependencies.hpp"
 #include "SessionPackages.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/join.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -36,6 +36,7 @@
 #include "jobs/ScriptJob.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -41,7 +41,7 @@
 #include "shiny/SessionShiny.hpp"
 
 #include <boost/shared_ptr.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 
 #include <r/RSexp.hpp>
@@ -54,6 +54,8 @@
 #include <core/text/CsvParser.hpp>
 #include <core/collection/Tree.hpp>
 #include <core/collection/Stack.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -25,10 +25,12 @@
 #include <core/FileUtils.hpp>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <session/SessionOptions.hpp>
 #include "SessionRParser.hpp"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionDirty.cpp
+++ b/src/cpp/session/modules/SessionDirty.cpp
@@ -17,9 +17,9 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/utility.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
@@ -39,6 +39,7 @@
 using namespace rstudio::core;
 using namespace rstudio::r::sexp;
 using namespace rstudio::r::exec;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionErrors.cpp
+++ b/src/cpp/session/modules/SessionErrors.cpp
@@ -22,7 +22,7 @@
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/prefs/UserPrefs.hpp>
 #include <session/prefs/UserState.hpp>
@@ -30,6 +30,7 @@
 #include "SessionBreakpoints.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionFilesListingMonitor.cpp
+++ b/src/cpp/session/modules/SessionFilesListingMonitor.cpp
@@ -17,7 +17,7 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
@@ -36,6 +36,7 @@
 #include "SessionVCS.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -18,10 +18,10 @@
 #include <algorithm>
 #include <gsl/gsl>
 
-#include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
 #include <core/StringUtils.hpp>
@@ -37,6 +37,7 @@
 #include <session/prefs/UserPrefs.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionGraphics.cpp
+++ b/src/cpp/session/modules/SessionGraphics.cpp
@@ -15,7 +15,7 @@
 
 #include "SessionGraphics.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
@@ -29,6 +29,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -16,17 +16,15 @@
 
 #include "SessionHTMLPreview.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/enable_shared_from_this.hpp>
-
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/iostreams/copy.hpp>
 #include <boost/iostreams/concepts.hpp>
 #include <boost/iostreams/filter/regex.hpp>
 #include <boost/iostreams/filtering_stream.hpp>
-
-#include <boost/algorithm/string/join.hpp>
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -57,6 +55,7 @@
 #define kHTMLPreviewLocation "/" kHTMLPreview "/"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionHistory.cpp
+++ b/src/cpp/session/modules/SessionHistory.cpp
@@ -22,12 +22,12 @@
 #include <gsl/gsl>
 
 #include <boost/utility.hpp>
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
 #include <boost/format.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -45,6 +45,7 @@
 #include "SessionHistoryArchive.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionLimits.cpp
+++ b/src/cpp/session/modules/SessionLimits.cpp
@@ -17,8 +17,8 @@
 #include "SessionLimits.hpp"
 
 #include <boost/format.hpp>
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -29,6 +29,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionLists.cpp
+++ b/src/cpp/session/modules/SessionLists.cpp
@@ -18,9 +18,9 @@
 
 #include <map>
 
-#include <boost/bind.hpp>
 #include <boost/utility.hpp>
 #include <boost/circular_buffer.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
@@ -29,6 +29,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -17,7 +17,7 @@
 
 #include "SessionObjectExplorer.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <shared_core/Error.hpp>
@@ -30,6 +30,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -20,9 +20,9 @@
 
 #include "SessionPackages.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/regex.hpp>
 #include <boost/format.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -43,6 +43,7 @@
 #include "session-config.h"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -18,7 +18,7 @@
 #include <string>
 #include <vector>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Algorithm.hpp>
 #include <shared_core/Error.hpp>
@@ -32,6 +32,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionProjectTemplate.cpp
+++ b/src/cpp/session/modules/SessionProjectTemplate.cpp
@@ -14,8 +14,8 @@
  */
 #include <session/SessionProjectTemplate.hpp>
 
-#include <boost/bind.hpp>
 #include <boost/function.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/adaptors.hpp>
 
 #include <core/Algorithm.hpp>
@@ -37,6 +37,7 @@
 #define kRStudioProjectTemplatesPath "rstudio/templates/project"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -27,7 +27,7 @@
 #include <core/text/DcfParser.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -40,6 +40,7 @@
 #include <session/SessionPackageProvidedExtension.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionRHooks.cpp
+++ b/src/cpp/session/modules/SessionRHooks.cpp
@@ -20,7 +20,7 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include "SessionRHooks.hpp"
 
@@ -30,6 +30,7 @@ namespace modules {
 namespace rhooks {
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 Error initialize()
 {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -42,8 +42,10 @@
 
 #include <r/session/RSessionUtils.hpp>
 
+#include <boost/bind/bind.hpp>
 #include <boost/container/flat_set.hpp>
-#include <boost/bind.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -40,12 +40,14 @@
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
 
-#include <boost/bind.hpp>
-#include <boost/container/flat_set.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
+#include <boost/container/flat_set.hpp>
 
 #include <core/Macros.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionRPubs.cpp
+++ b/src/cpp/session/modules/SessionRPubs.cpp
@@ -15,11 +15,11 @@
 
 #include "SessionRPubs.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/utility.hpp>
 #include <boost/format.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -39,6 +39,7 @@
 #include <session/projects/SessionProjects.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -17,7 +17,7 @@
 
 #include "SessionThemes.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -28,6 +28,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -22,10 +22,10 @@
 #endif
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
 #include <boost/date_time.hpp>
 #include <boost/regex.hpp>
 #include <core/BoostLamda.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/FileSerializer.hpp>
 #include <core/rapidxml/rapidxml.hpp>
@@ -55,6 +55,7 @@ using namespace rstudio::core;
 using namespace rstudio::core::shell_utils;
 using namespace rstudio::session::modules::vcs_utils;
 using namespace rstudio::session::console_process;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionSnippets.cpp
+++ b/src/cpp/session/modules/SessionSnippets.cpp
@@ -21,9 +21,11 @@
 #include <shared_core/json/Json.hpp>
 #include <core/system/Xdg.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <session/SessionModuleContext.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -22,8 +22,8 @@
 
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/utility.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/r_util/RSourceIndex.hpp>
 
@@ -61,6 +61,7 @@ extern "C" const char *locale2charset(const char *);
 #include <session/prefs/Preferences.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -15,12 +15,12 @@
 
 #include "SessionThemes.hpp"
 
+#include <boost/lexical_cast.hpp>
+#include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/algorithm.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/bind.hpp>
-#include <boost/regex.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -45,6 +45,7 @@
 #include <string>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionUpdates.cpp
+++ b/src/cpp/session/modules/SessionUpdates.cpp
@@ -20,7 +20,7 @@
 #include <core/system/Process.hpp>
 #include <core/system/Environment.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -31,6 +31,7 @@
 #include "session-config.h"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/SessionUserCommands.cpp
+++ b/src/cpp/session/modules/SessionUserCommands.cpp
@@ -19,7 +19,7 @@
 
 #include "SessionUserCommands.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Exec.hpp>
@@ -38,6 +38,7 @@ namespace modules {
 namespace user_commands {
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace {
 

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -17,10 +17,10 @@
 
 #include <algorithm>
 
-#include <boost/bind.hpp>
 #include <boost/regex.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/SafeConvert.hpp>
@@ -32,6 +32,7 @@
 #include <session/projects/SessionProjects.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {  

--- a/src/cpp/session/modules/clang/RSourceIndex.cpp
+++ b/src/cpp/session/modules/clang/RSourceIndex.cpp
@@ -15,8 +15,8 @@
 
 #include "RSourceIndex.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/FileInfo.hpp>
 #include <shared_core/FilePath.hpp>
@@ -29,6 +29,7 @@
 
 using namespace rstudio::core;
 using namespace rstudio::core::libclang;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
+++ b/src/cpp/session/modules/connections/ConnectionsIndexer.cpp
@@ -23,7 +23,7 @@
 #include <core/text/DcfParser.hpp>
 
 #include <boost/regex.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/system/error_code.hpp>
 
@@ -38,6 +38,7 @@
 #include <session/SessionPackageProvidedExtension.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -20,9 +20,9 @@
 #include <sstream>
 #include <gsl/gsl>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Log.hpp>
 #include <shared_core/Error.hpp>
@@ -66,6 +66,7 @@
 #define MAX_COLUMNS 50
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/panmirror/SessionPanmirrorBibliography.cpp
+++ b/src/cpp/session/modules/panmirror/SessionPanmirrorBibliography.cpp
@@ -15,7 +15,7 @@
 
 #include "SessionPanmirrorBibliography.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <core/Hash.hpp>
@@ -30,6 +30,7 @@
 #include <session/SessionModuleContext.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/presentation/PresentationLog.cpp
+++ b/src/cpp/session/modules/presentation/PresentationLog.cpp
@@ -16,9 +16,9 @@
 
 #include "PresentationLog.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <shared_core/Error.hpp>
@@ -34,6 +34,7 @@
 #include "PresentationState.hpp"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/presentation/SessionPresentation.cpp
+++ b/src/cpp/session/modules/presentation/SessionPresentation.cpp
@@ -19,7 +19,7 @@
 #include "SessionPresentation.hpp"
 
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/Exec.hpp>
 #include <core/http/Util.hpp>
@@ -40,6 +40,7 @@
 
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/presentation/SlideQuizRenderer.cpp
+++ b/src/cpp/session/modules/presentation/SlideQuizRenderer.cpp
@@ -17,15 +17,16 @@
 
 #include <iostream>
 
-#include <boost/bind.hpp>
 #include <boost/format.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/trim.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/SafeConvert.hpp>
 #include <core/RegexUtils.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -21,8 +21,8 @@
 #include "NotebookWorkingDir.hpp"
 #include "NotebookHtmlWidgets.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/StringUtils.hpp>
 #include <core/Algorithm.hpp>
@@ -33,6 +33,7 @@
 #include <r/RSexp.hpp>
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -20,7 +20,7 @@
 #include "NotebookOutput.hpp"
 #include "NotebookHtmlWidgets.hpp"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSourceDatabase.hpp>
@@ -41,6 +41,7 @@
 #define kCacheAgeThresholdMs 1000 * 60 * 60 * 24 * 2
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -20,7 +20,7 @@
 #include "NotebookOutput.hpp"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/StringUtils.hpp>
 #include <core/Exec.hpp>
@@ -35,6 +35,7 @@
 
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionExecuteChunkOperation.hpp
@@ -15,10 +15,10 @@
 #ifndef SESSION_MODULES_RMARKDOWN_SESSION_EXECUTE_CHUNK_OPERATIONR_HPP
 #define SESSION_MODULES_RMARKDOWN_SESSION_EXECUTE_CHUNK_OPERATIONR_HPP
 
-#include <boost/bind.hpp>
 #include <boost/enable_shared_from_this.hpp>
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
@@ -30,6 +30,8 @@
 #include "NotebookOutput.hpp"
 #include "NotebookExec.hpp"
 #include "SessionRmdNotebook.hpp"
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
@@ -15,8 +15,8 @@
 
 #include "ZoteroCollectionsLocal.hpp"
 
-#include <boost/bind.hpp>
 #include <boost/algorithm/algorithm.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/json/Json.hpp>
@@ -38,6 +38,7 @@
 #include "session-config.h"
 
 using namespace rstudio::core;
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -45,10 +45,10 @@
 #include <boost/filesystem.hpp>
 #undef BOOST_NO_CXX11_SCOPED_ENUMS
 
+#include <boost/bind/bind.hpp>
+#include <boost/make_shared.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/bind.hpp>
-#include <boost/make_shared.hpp>
 
 #include <shared_core/Logger.hpp>
 #include <shared_core/Error.hpp>
@@ -56,6 +56,8 @@
 #include <shared_core/system/User.hpp>
 
 typedef boost::filesystem::path path_t;
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/shared_core/system/Win32User.cpp
+++ b/src/cpp/shared_core/system/Win32User.cpp
@@ -18,12 +18,14 @@
 #include <shlobj.h>
 
 #include <boost/algorithm/string.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <shared_core/FilePath.hpp>
 #include <shared_core/Logger.hpp>
 #include <shared_core/SafeConvert.hpp>
 #include <shared_core/system/Win32StringUtils.hpp>
+
+using namespace boost::placeholders;
 
 namespace rstudio {
 namespace core {


### PR DESCRIPTION
### Intent

This pull requests solves building rstudio with boost 1.75 which recently dropped in Arch Linux.

### Approach

The required header files were included as well as the required namespace. 

### QA Notes

This builds with my rstudio [PKGBUILD](https://github.com/JanMarvin/rstudio-archlinuxpkg) (this PKGBUILD includes another boost patch, though I am not sure what that was fixing [lost track of rstudios development a while ago]). 

I expect this to be backward compatible if the included header files exist in previous boost releases, but I have not tested this. I have also not tested this with the included rstudio boost.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

I have signed a contributor agreement a long time ago.
