### PR TITLE
try reloading main window if R not yet ready

### DIFF
--- a/src/cpp/conf/rdesktop-dev.conf
+++ b/src/cpp/conf/rdesktop-dev.conf
@@ -31,12 +31,6 @@ r-resources-path=${CMAKE_CURRENT_SOURCE_DIR}/session/resources
 r-session-library=${CMAKE_CURRENT_BINARY_DIR}/r/R/packages/library
 r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 
-# override r home and doc dir (to ensure we always run against the version
-# we built against and so we can pick them up even when we are launched
-# standalone in the debugger)
-r-home-dir-override=${LIBR_HOME}
-r-doc-dir-override=${LIBR_DOC_DIR}
-
 external-rpostback-path=${CMAKE_CURRENT_BINARY_DIR}/session/postback/postback/rpostback
 external-consoleio-path=${CMAKE_CURRENT_BINARY_DIR}/session/consoleio/consoleio.exe
 external-gnudiff-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/gnudiff

--- a/src/cpp/desktop/DesktopMainWindow.cpp
+++ b/src/cpp/desktop/DesktopMainWindow.cpp
@@ -17,6 +17,7 @@
 
 #include <QToolBar>
 #include <QWebChannel>
+#include <QWebEngineSettings>
 
 #include <boost/bind.hpp>
 #include <boost/format.hpp>
@@ -53,6 +54,15 @@ void CALLBACK onDialogStart(HWINEVENTHOOK hook, DWORD event, HWND hwnd,
 
 #endif
 
+// number of times we've tried to reload in startup
+int s_reloadCount = 0;
+
+// maximum number of times to try reloading
+const int s_maxReloadCount = 5;
+
+// amount of time to wait before each reload, in milliseconds
+const int s_reloadWaitDuration = 200;
+
 } // end anonymous namespace
 
 MainWindow::MainWindow(QUrl url,
@@ -65,7 +75,6 @@ MainWindow::MainWindow(QUrl url,
       pRemoteSessionLauncher_(nullptr),
       pLauncher_(new JobLauncher(this)),
       pCurrentSessionProcess_(nullptr),
-      loadTimer_(new QTimer(this)),
       isErrorDisplayed_(false)
 {
    RCommandEvaluator::setMainWindow(this);
@@ -92,6 +101,10 @@ MainWindow::MainWindow(QUrl url,
       channel->registerObject(QStringLiteral("remoteDesktop"), &gwtCallback_);
    }
    channel->registerObject(QStringLiteral("desktopMenuCallback"), &menuCallback_);
+   
+   // disable error page on main window -- we don't want to show the default 404 page
+   // on failure as we show our own error / loading page instead
+   webPage()->settings()->setAttribute(QWebEngineSettings::ErrorPageEnabled, false);
 
    // Dummy menu bar to deal with the fact that
    // the real menu bar isn't ready until well
@@ -111,9 +124,6 @@ MainWindow::MainWindow(QUrl url,
    pMainMenuStub->addMenu(QString::fromUtf8("Help"));
    setMenuBar(pMainMenuStub);
 #endif
-   
-   connect(loadTimer_, &QTimer::timeout,
-           this, &MainWindow::onLoadFinishedImpl);
    
    connect(&menuCallback_, SIGNAL(menuBarCompleted(QMenuBar*)),
            this, SLOT(setMenuBar(QMenuBar*)));
@@ -136,7 +146,7 @@ MainWindow::MainWindow(QUrl url,
 
    connect(webView(), &WebView::urlChanged,
            this, &MainWindow::onUrlChanged);
-
+   
    connect(webView(), &WebView::loadFinished,
            this, &MainWindow::onLoadFinished);
 
@@ -671,59 +681,73 @@ void MainWindow::onLoadFinished(bool ok)
    {
       if (ok)
       {
-         // if this was a successful load, we're done
-         loadTimer_->stop();
-         loadedSuccessfully_ = true;
+         // hurray!
+         s_reloadCount = 0;
       }
-      else if (loadedSuccessfully_)
+      else if (isErrorDisplayed_)
       {
-         // if the load was purportedly not successful, even
-         // though a prior load was successful, then ignore
-         // that (assume that this was a spurious / incorrect
-         // signal from Qt)
-         LOG_DEBUG_MESSAGE(
-                  "Discarding onLoadFinished(false) signal as we have "
-                  "already received onLoadFinished(true)");
+         // the session failed to launch and we're already showing
+         // an error page to the user; nothing else to do here.
       }
       else
       {
-         // schedule our load timer and allow a small buffer for
-         // incoming loadFinished() events which might report
-         // that the load was actually successful
-         loadTimer_->start(5000);
+         // the load failed, but we haven't yet received word that the
+         // session has failed to load. let the user know that the R
+         // session is still initializing, and then reload the page.
+         std::map<std::string, std::string> vars = {};
+
+         std::ostringstream oss;
+         Error error = text::renderTemplate(
+                  options().resourcesPath().completePath("html/loading.html"),
+                  vars,
+                  oss);
+
+         if (error)
+            LOG_ERROR(error);
+
+         loadHtml(QString::fromStdString(oss.str()));
+
+         if (s_reloadCount < s_maxReloadCount)
+         {
+            s_reloadCount++;
+            QTimer::singleShot(
+                     s_reloadWaitDuration * s_reloadCount,
+                     [&]() { loadUrl(webView()->baseUrl()); });
+         }
+         else
+         {
+            s_reloadCount = 0;
+            onLoadFailed();
+         }
       }
    }
    END_LOCK_MUTEX
 }
 
-void MainWindow::onLoadFinishedImpl()
+void MainWindow::onLoadFailed()
 {
-   LOCK_MUTEX(mutex_)
+   if (pRemoteSessionLauncher_ || isErrorDisplayed_)
+      return;
+
+   RS_CALL_ONCE();
+
+   std::map<std::string, std::string> vars = {
+      { "url",  webView()->url().url().toStdString() }
+   };
+
+   std::ostringstream oss;
+   Error error = text::renderTemplate(
+            options().resourcesPath().completePath("html/connect.html"),
+            vars,
+            oss);
+
+   if (error)
    {
-      if (loadedSuccessfully_ || pRemoteSessionLauncher_ || isErrorDisplayed_)
-         return;
-
-      RS_CALL_ONCE();
-
-      std::map<std::string, std::string> vars = {
-         { "url",  webView()->url().url().toStdString() }
-      };
-      
-      std::ostringstream oss;
-      Error error = text::renderTemplate(
-               options().resourcesPath().completePath("html/connect.html"),
-               vars,
-               oss);
-
-      if (error)
-      {
-         LOG_ERROR(error);
-         return;
-      }
-      
-      loadHtml(QString::fromStdString(oss.str()));
+      LOG_ERROR(error);
+      return;
    }
-   END_LOCK_MUTEX
+
+   loadHtml(QString::fromStdString(oss.str()));
 }
 
 WebView* MainWindow::getWebView()

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -118,6 +118,7 @@ private:
    void onActivated() override;
 
    void onUrlChanged(QUrl url);
+   void reload();
    void onLoadFinished(bool ok);
    void onLoadFailed();
 

--- a/src/cpp/desktop/DesktopMainWindow.hpp
+++ b/src/cpp/desktop/DesktopMainWindow.hpp
@@ -75,7 +75,6 @@ public Q_SLOTS:
    void onPdfViewerSyncSource(QString srcFile, int line, int column);
    void onLicenseLost(QString licenseMessage);
    void onUpdateLicenseWarningBar(QString message);
-   void onLoadFinishedImpl();
 
    bool isRemoteDesktop() const;
 
@@ -120,6 +119,7 @@ private:
 
    void onUrlChanged(QUrl url);
    void onLoadFinished(bool ok);
+   void onLoadFailed();
 
    void saveRemoteAuthCookies(const boost::function<QList<QNetworkCookie>()>& loadCookies,
                               const boost::function<void(QList<QNetworkCookie>)>& saveCookies,
@@ -130,7 +130,6 @@ private:
    bool quitConfirmed_ = false;
    bool geometrySaved_ = false;
    bool workbenchInitialized_ = false;
-   bool loadedSuccessfully_ = false;
    MenuCallback menuCallback_;
    GwtCallback gwtCallback_;
    SessionLauncher* pSessionLauncher_;
@@ -138,7 +137,6 @@ private:
    boost::shared_ptr<JobLauncher> pLauncher_;
    ApplicationLaunch *pAppLauncher_;
    QProcess* pCurrentSessionProcess_;
-   QTimer* loadTimer_;
 
    boost::mutex mutex_;
    bool isErrorDisplayed_;

--- a/src/cpp/desktop/DesktopPosixDetectRHome.cpp
+++ b/src/cpp/desktop/DesktopPosixDetectRHome.cpp
@@ -51,6 +51,7 @@ bool prepareEnvironment(Options& options)
       rWhichRPath = FilePath(whichROverride);
 
 #ifdef Q_OS_MAC
+# ifdef RSTUDIO_PACKAGE_BUILD
    FilePath rLdScriptPath = options.scriptsPath().completePath("session/r-ldpath");
    if (!rLdScriptPath.exists())
    {
@@ -60,6 +61,9 @@ bool prepareEnvironment(Options& options)
          LOG_ERROR(error);
       rLdScriptPath = executablePath.getParent().completePath("r-ldpath");
    }
+# else
+   FilePath rLdScriptPath = options.scriptsPath().completePath("../session/r-ldpath");
+# endif
 #else
    // determine rLdPaths script location
    FilePath supportingFilePath = options.supportingFilePath();

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -68,9 +68,11 @@ void launchProcess(const std::string& absPath,
    if (rLib.exists())
    {
       QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
+      
       environment.insert(
                QStringLiteral("DYLD_INSERT_LIBRARIES"),
                QString::fromStdString(rLib.getAbsolutePathNative()));
+      
       process->setProcessEnvironment(environment);
    }
 #endif
@@ -135,6 +137,7 @@ Error SessionLauncher::launchFirstSession()
    logEnvVar("R_LIBS");
    logEnvVar("R_LIBS_USER");
    logEnvVar("DYLD_LIBRARY_PATH");
+   logEnvVar("DYLD_FALLBACK_LIBRARY_PATH");
    logEnvVar("LD_LIBRARY_PATH");
    logEnvVar("PATH");
    logEnvVar("HOME");
@@ -201,6 +204,7 @@ Error SessionLauncher::launchFirstSession()
       pAppLaunch_->activateWindow();
       pMainWindow_->loadUrl(url);
    }
+   
    qApp->setQuitOnLastWindowClosed(true);
    return Success();
 }

--- a/src/cpp/desktop/html/loading.html
+++ b/src/cpp/desktop/html/loading.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+    <head>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
+        <title>Initializing R</title>
+        <style>
+            h1 {
+                margin-left: auto;
+                margin-right: auto;
+            }
+
+            body {
+                font-family: Helvetica, sans-serif;
+                margin-left: 100px;
+                margin-right: 100px;
+                margin-top: 50px;
+                margin-bottom: 50px;
+            }
+
+            .reload {
+                padding-top: 10px;
+                padding-bottom: 10px;
+                padding-left: 30px;
+                padding-right: 30px;
+                text-transform: uppercase;
+                font-family: Helvetica, sans-serif;
+                display: inline-block;
+                margin-left: auto;
+                margin-right: auto;
+                background-color: #2268BC;
+                color: white;
+                border: 0;
+                border-radius: 3px;
+                font-size: 12pt;
+                cursor: pointer;
+                text-decoration: none;
+            }
+        </style>
+    </head>
+
+    <body>
+        <div style="float: right; width: 144px; height: 112px; position: relative; margin-left: 20px;">
+
+            <!-- R logo -->
+            <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="144" height="112" viewBox="0 0 724 561" style="position: absolute; top: 0; left: 0;">
+              <title>R Logo</title>
+              <defs>
+                <linearGradient id="gradientFill-1" x1="0" x2="1" y1="0" y2="1" gradientUnits="objectBoundingBox" spreadMethod="pad">
+                  <stop offset="0" stop-color="rgb(203,206,208)" stop-opacity="1"/>
+                  <stop offset="1" stop-color="rgb(132,131,139)" stop-opacity="1"/>
+                </linearGradient>
+                <linearGradient id="gradientFill-2" x1="0" x2="1" y1="0" y2="1" gradientUnits="objectBoundingBox" spreadMethod="pad">
+                  <stop offset="0" stop-color="rgb(39,109,195)" stop-opacity="1"/>
+                  <stop offset="1" stop-color="rgb(22,92,170)" stop-opacity="1"/>
+                </linearGradient>
+              </defs>
+              <path d="M361.453,485.937 C162.329,485.937 0.906,377.828 0.906,244.469 C0.906,111.109 162.329,3.000 361.453,3.000 C560.578,3.000 722.000,111.109 722.000,244.469 C722.000,377.828 560.578,485.937 361.453,485.937 ZM416.641,97.406 C265.289,97.406 142.594,171.314 142.594,262.484 C142.594,353.654 265.289,427.562 416.641,427.562 C567.992,427.562 679.687,377.033 679.687,262.484 C679.687,147.971 567.992,97.406 416.641,97.406 Z" fill="url(#gradientFill-1)" fill-rule="evenodd"/>
+              <path d="M550.000,377.000 C550.000,377.000 571.822,383.585 584.500,390.000 C588.899,392.226 596.510,396.668 602.000,402.500 C607.378,408.212 610.000,414.000 610.000,414.000 L696.000,559.000 L557.000,559.062 L492.000,437.000 C492.000,437.000 478.690,414.131 470.500,407.500 C463.668,401.969 460.755,400.000 454.000,400.000 C449.298,400.000 420.974,400.000 420.974,400.000 L421.000,558.974 L298.000,559.026 L298.000,152.938 L545.000,152.938 C545.000,152.938 657.500,154.967 657.500,262.000 C657.500,369.033 550.000,377.000 550.000,377.000 ZM496.500,241.024 L422.037,240.976 L422.000,310.026 L496.500,310.002 C496.500,310.002 531.000,309.895 531.000,274.877 C531.000,239.155 496.500,241.024 496.500,241.024 Z" fill="url(#gradientFill-2)" fill-rule="evenodd"/>
+            </svg>
+
+        </div>
+
+        <h1>Initializing R</h1>
+
+        <p>
+            RStudio is initializing the R session -- please wait a moment...
+        </p>
+
+    </body>
+</html>

--- a/src/cpp/desktop/html/loading.html
+++ b/src/cpp/desktop/html/loading.html
@@ -64,7 +64,7 @@
         <h1>Initializing R</h1>
 
         <p>
-            RStudio is initializing the R session -- please wait a moment...
+            The R session is initializing -- please wait a moment...
         </p>
 
     </body>

--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -96,7 +96,7 @@ define_source_file_names(rstudio-r)
 # link dependencies
 target_link_libraries(rstudio-r rstudio-core)
 
-if(RSTUDIO_PACKAGE_BUILD AND APPLE)
+if(APPLE)
    target_link_libraries(rstudio-r "-undefined dynamic_lookup")
 else()
    target_link_libraries(rstudio-r "${LIBR_LIBRARIES}")

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -444,7 +444,7 @@ target_link_libraries(rsession
    ${CRASHPAD_LIBRARIES}
 )
 
-if(RSTUDIO_PACKAGE_BUILD AND APPLE)
+if(APPLE)
    target_link_libraries(rsession "-undefined dynamic_lookup")
 else()
    target_link_libraries(rsession "${LIBR_LIBRARIES}")

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -442,13 +442,13 @@ bool waitForMethod(const std::string& method,
                                    boost::posix_time::milliseconds(50);
 
    // wait until we get the method we are looking for
-   while(true)
+   while (true)
    {
       // suspend if necessary (does not return if a suspend occurs)
       suspend::suspendIfRequested(allowSuspend);
 
       // check for timeout
-      if ( isTimedOut(timeoutTime) )
+      if (isTimedOut(timeoutTime))
       {
          if (allowSuspend())
          {
@@ -509,13 +509,13 @@ bool waitForMethod(const std::string& method,
          }
 
          // check for client_init
-         if ( isMethod(ptrConnection, kClientInit) )
+         if (isMethod(ptrConnection, kClientInit))
          {
             client_init::handleClientInit(initFunction, ptrConnection);
          }
 
          // check for the method we are waiting on
-         else if ( isMethod(ptrConnection, method) )
+         else if (isMethod(ptrConnection, method))
          {
             // parse and validate request then proceed
             if (parseAndValidateJsonRpcConnection(ptrConnection, pRequest))

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1726,6 +1726,15 @@ int main (int argc, char * const argv[])
 {
    try
    {
+      // sleep on startup if requested (mainly for debugging)
+      std::string sleepOnStartup = core::system::getenv("RSTUDIO_SESSION_SLEEP_ON_STARTUP");
+      if (!sleepOnStartup.empty())
+      {
+         int sleepDuration = core::safe_convert::stringTo<int>(sleepOnStartup, 0);
+         if (sleepDuration > 0)
+            ::sleep(sleepDuration);
+      }
+      
       // initialize log so we capture all errors including ones which occur
       // reading the config file (if we are in desktop mode then the log
       // will get re-initialized below)


### PR DESCRIPTION
### Intent

Fix an issue where the Desktop client would be ready and attempting to connect to R before R itself was ready to receive connections.

### Approach

Similar to the last approach, retry attempts to connect to the R session a couple times. This PR also makes it easier to test this case, by allowing one to instruct the R session to sleep on startup for a brief period of time (effectively simulating a "slow" session startup).

### QA Notes

On macOS, test with the following:

```
export RSTUDIO_SESSION_SLEEP_ON_STARTUP=5
/Applications/RStudio.app/Contents/MacOS/RStudio
```

You should see a temporary "initializing R" window first:

<img width="774" alt="Screen Shot 2020-12-14 at 11 32 35 AM" src="https://user-images.githubusercontent.com/1976582/102126600-2238c500-3e00-11eb-8066-552ff71cf6a0.png">

The session should later load successfully after a brief pause.

You can also test the extreme case, with:

```
export RSTUDIO_SESSION_SLEEP_ON_STARTUP=60
/Applications/RStudio.app/Contents/MacOS/RStudio
```

In this case, you should eventually see the "cannot connect to R" error page, but if you wait 60 seconds you should be able to retry and successfully connect.

Closes https://github.com/rstudio/rstudio/issues/8270.