### PR TITLE
adapt test script to changes in #8614

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -131,6 +131,16 @@ else
     RSTUDIO_SESSION_BIN="rsession"
 fi
 
+# set R environment variables needed by rsession tests
+export R_HOME=$(R --slave --vanilla -e "cat(paste(R.home('home'),sep=':'))")
+export R_DOC_DIR=$(R --slave --vanilla -e "cat(paste(R.home('doc'),sep=':'))")
+export R_LIB_DIR=$(R --slave --vanilla -e "cat(paste(R.home('lib'),sep=':'))")
+
+# On macOS, we need to tell the rsession executable where to look for libR.dylib
+if [ "$(uname)" = "Darwin" ]; then
+   export DYLD_INSERT_LIBRARIES="$R_LIB_DIR/libR.dylib"
+fi
+
 # Run core tests
 if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "core" ]; then
     echo Running 'core' tests...
@@ -146,10 +156,6 @@ fi
 
 # Setup for rsession tests
 if [ -e ${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf ]; then
-   # set R environment variables needed by rsession tests
-   export R_HOME=$(R --slave --vanilla -e "cat(paste(R.home('home'),sep=':'))")
-   export R_DOC_DIR=$(R --slave --vanilla -e "cat(paste(R.home('doc'),sep=':'))")
-
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf
 else
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf


### PR DESCRIPTION
### Intent

Ensure that `rsession` tests can still run even with the changes in #8614.

### Approach

Make sure `R_HOME`, `R_DOC_DIR` and `R_LIB_DIR` are always defined. In addition, force `rsession` to use a version of `libR.dylib`, since we explicitly don't link directly to the R library (so users can choose different versions of R at runtime).

### QA Notes

No QA; this is just to get tests up and running again.