### PR TITLE
forward C++ completion context to embedded editor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -7620,7 +7620,12 @@ public class TextEditingTarget implements
    {
       return rContext_;
    }
-   
+
+   public CppCompletionContext getCppCompletionContext()
+   {
+      return cppCompletionContext_;
+   }
+
    public RnwCompletionContext getRnwCompletionContext()
    {
       return compilePdfHelper_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -112,8 +112,9 @@ public class VisualModeChunk
       final AceEditorNative chunkEditor = editor_.getWidget().getEditor();
       chunk.editor = Js.uncheckedCast(chunkEditor);
 
-      // Forward the R completion context from the parent editing session
+      // Forward the R and C++ completion contexts from the parent editing session
       editor_.setRCompletionContext(target_.getRCompletionContext());
+      editor_.setCppCompletionContext(target_.getCppCompletionContext());
       
       // Forward the Rnw completion context with a wrapper to adjust for the
       // position in our display; this is what allows the completion engine to


### PR DESCRIPTION
### Intent

Fix https://github.com/rstudio/rstudio/issues/8618, in which C/C++ code blocks don't work in the visual editor.

### Approach

This happens because the completion context for C/C++ isn't initialized inside the code chunks in the visual editor. The fix is to forward the parent editor's completion context, which gives the completion manager access to information such as the path to the file being edited that isn't available in embedded editors. 

### QA Notes

Test via notes in #8618. 
