### PR TITLE
Fix various virtualscroller autoscrolling bugs

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -131,6 +131,16 @@ else
     RSTUDIO_SESSION_BIN="rsession"
 fi
 
+# set R environment variables needed by rsession tests
+export R_HOME=$(R --slave --vanilla -e "cat(paste(R.home('home'),sep=':'))")
+export R_DOC_DIR=$(R --slave --vanilla -e "cat(paste(R.home('doc'),sep=':'))")
+export R_LIB_DIR=$(R --slave --vanilla -e "cat(paste(R.home('lib'),sep=':'))")
+
+# On macOS, we need to tell the rsession executable where to look for libR.dylib
+if [ "$(uname)" = "Darwin" ]; then
+   export DYLD_INSERT_LIBRARIES="$R_LIB_DIR/libR.dylib"
+fi
+
 # Run core tests
 if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "core" ]; then
     echo Running 'core' tests...
@@ -146,10 +156,6 @@ fi
 
 # Setup for rsession tests
 if [ -e ${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf ]; then
-   # set R environment variables needed by rsession tests
-   export R_HOME=$(R --slave --vanilla -e "cat(paste(R.home('home'),sep=':'))")
-   export R_DOC_DIR=$(R --slave --vanilla -e "cat(paste(R.home('doc'),sep=':'))")
-
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf
 else
    SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -27,7 +27,7 @@ var VirtualScroller;
       //  *** _CONSTANTS ***
       this._DEBUG = false;
       this._SCROLL_DEBOUNCE_MS = 500;
-      this._BUCKET_MAX_SIZE = 50;
+      this._BUCKET_MAX_HEIGHT = 50;
       this._MAX_VISIBLE_BUCKETS = 10;
       this._MAX_NEWLINES = 1000;
 
@@ -52,6 +52,7 @@ var VirtualScroller;
       self._isAtBottomBucket = self._isAtBottomBucket.bind(self);
       self._isAtTopBucket = self._isAtTopBucket.bind(self);
       self._isBucketHidden = self._isBucketHidden.bind(self);
+      self._isBucketFull = self._isBucketFull.bind(self);
       self._jumpToBottom = self._jumpToBottom.bind(self);
       self._moveWindow = self._moveWindow.bind(self);
       self._onParentScroll = self._onParentScroll.bind(self);
@@ -155,6 +156,16 @@ var VirtualScroller;
       }
     },
 
+    _isBucketFull: function(bucket) {
+      var height = 0;
+      var contents = bucket.innerText;
+
+      // add height for each new line
+      height += contents.split(/\n/).length - 1;
+
+      return height >= this._BUCKET_MAX_HEIGHT;
+    },
+
     _hideBucket: function(index) {
       if (!!this.buckets[index] && !this._isBucketHidden(index))
         this.buckets[index].classList.add(this._HIDDEN_STYLE);
@@ -178,11 +189,11 @@ var VirtualScroller;
     },
 
     _scrolledToTop: function() {
-      return this.scrollerEle.scrollTop < 1;
+      return this.scrollerEle.scrollTop < 4;
     },
 
     _scrolledToBottom: function() {
-      return Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 1;
+      return Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 4;
     },
 
     // this BOUND callback function
@@ -260,12 +271,17 @@ var VirtualScroller;
       if (element === null)
         return;
 
-      if (this.getCurBucket().childElementCount >= this._BUCKET_MAX_SIZE) {
+      var keepScrolled = !!this.scrollerEle && this._scrolledToBottom();
+
+      if (this._isBucketFull(this.getCurBucket())) {
         this._createAndAddNewBucket();
       }
       this.prune(element);
       this.getCurBucket().appendChild(element);
       this._jumpToBottom();
+      if (keepScrolled && !!this.scrollerEle)  {
+        this.scrollerEle.scrollTop = this.scrollerEle.scrollHeight;
+      }
     },
 
     clear: function() {

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -229,7 +229,8 @@ public class ShellWidget extends Composite implements ShellDisplay,
       verticalPanel_.add(inputLine_);
       verticalPanel_.setWidth("100%");
 
-      scrollPanel_ = new ClickableScrollPanel();
+      // dont use the autoscroll timer if we're controlling the content externally
+      scrollPanel_ = new ClickableScrollPanel(!prefs_.limitVisibleConsole().getValue());
       scrollPanel_.setWidget(verticalPanel_);
       scrollPanel_.addStyleName("ace_editor");
       scrollPanel_.addStyleName("ace_scroller");
@@ -727,6 +728,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
       private ClickableScrollPanel()
       {
          super();
+      }
+
+      private ClickableScrollPanel(boolean useTimer)
+      {
+         super(useTimer);
       }
 
       public HandlerRegistration addClickHandler(ClickHandler handler)


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/8544
Fixes https://github.com/rstudio/rstudio/issues/8504
Fixes https://github.com/rstudio/rstudio/issues/8529
Fixes https://github.com/rstudio/rstudio/issues/8552

Wanted to get #8568 also in here but there's some weirdness related to GWT going on 😢 

### Approach

The weird Tibble related bugs were due to how I was counting the number of items in a bucket. A super wide Tibble is a ton of unique `span` elements that can all be on a single line. This caused the calculation of how large a bucket is to be wildly inaccurate so it didn't know if it was scrolled all the way up or down. The `isBucketFull` function in `virtualscroller.js` solves this by just counting newlines in the `innerText` which seems to work pretty well for now, though I did notice a performance hit which might need some attention.

The console always scrolling to the bottom is a...more complex issue. It happens in a lot of places based on a whole bunch of different events and there are a few different `scrollToBottom` insertion points that are hard to grab in a catch all. The `BottomScrollPane` makes a lot of assumptions based on events that happen entirely within GWT and the state doesn't seem to update cleanly between pure JS and the GWT event loop. I refactored out some of the built in autoscrolling and conditionally moved that to virtualscroller.js but there is still more work to be done. This [comment](https://github.com/rstudio/rstudio/issues/8568#issuecomment-745748922) in #8568 shows some of the complexity inherent in having the content and scrolling managed in multiple places.

### QA Notes

The most important thing in testing this will be to ensure that nothing with the Limit Console Output feature turned off is broken. Always good to be a little extra cautious when changing rerouting old code.