### PR TITLE
Sanitize the CSL that we receive from Pubmed

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/csl.ts
+++ b/src/gwt/panmirror/src/editor/src/api/csl.ts
@@ -72,6 +72,7 @@ export interface CSL {
   subtitle?: string;
   subject?: string;
   archive?: string;
+  license?: [];
 }
 
 export interface CSLName {
@@ -103,6 +104,7 @@ export function sanitizeForCiteproc(csl: CSL): CSL {
     'subtitle',
     'container-title',
     'short-container-title',
+    'license'
   ];
   const cslAny: { [key: string]: any } = {
     ...csl,
@@ -119,19 +121,26 @@ export function sanitizeForCiteproc(csl: CSL): CSL {
           cslAny[property] = undefined;
         }
       }
-      return csl;
+      return cslAny;
     });
 
   // Strip any raw date representations
-  if (csl.issued?.raw) {
-    delete csl.issued.raw;
+  if (cslAny.issued?.raw) {
+    delete cslAny.issued.raw;
   }
+
+  // Pubmed and others may included license information (including date ranges and more)
+  // which will not be properly parsed by Pandoc (when writing to the bibiliography). Remove
+  if (cslAny.license) {
+    delete cslAny.license;
+  }
+
   // pandoc-citeproc performance is extremely poor with large abstracts. As a result, purge this property
   delete cslAny.abstract;
   delete cslAny.id;
 
   // Ensure only valid CSL types make it through
-  csl.type = ensureValidCSLType(csl.type);
+  cslAny.type = ensureValidCSLType(cslAny.type);
 
   return cslAny as CSL;
 }

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-pubmed.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-pubmed.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 
 import { BibliographyManager } from '../../../api/bibliography/bibliography';
 import { createUniqueCiteId } from '../../../api/cite';
-import { CSL } from '../../../api/csl';
+import { CSL, sanitizeForCiteproc } from '../../../api/csl';
 import { DOIServer } from '../../../api/doi';
 import { logException } from '../../../api/log';
 import { NavigationTreeNode } from '../../../api/widgets/navigation-tree';
@@ -167,7 +167,8 @@ function toCitationListEntry(
       // Generate CSL using the DOI
       const doiResult = await doiServer.fetchCSL(doc.doi, -1);
       const csl = doiResult.message as CSL;
-      return { ...csl, id: finalId, providerKey };
+      const sanitizedCSL = sanitizeForCiteproc(csl);
+      return { ...sanitizedCSL, id: finalId, providerKey };
     },
     isSlowGeneratingBibliographySource: true,
   };


### PR DESCRIPTION
fixes @rstudio#8625

-> we were previously not santizing the CSL
-> pubmed is sending a license field which pandoc is choking on (and doesn’t appear to be expected in well formed csl json, see https://github.com/citation-style-language/schema)
-> If present, we now sanitize that field out before we send the CSL to the bibliography


### Intent
Pubmed is including a 'license' field which doesn't appear to be an expected part of CSL Json. When we use Pandoc to read this CSL Json, it fails because of the presence of this field.

### Approach
We already sanitize the CSL that we receive from some providers (who don't always return well formed CSL). Add stripping of the license field to this sanitization and use the sanitizer when we receive CSL from Pubmed.

### QA Notes
Bug was a great catch. Because we generate CSL-JSON/CSL-YAML using Pandoc and generate Bibtex ourselves (or using better bibtex if that option is enabled), testing the variety of bibliography formats was a great idea. Good practice to continue including verifying that things work correctly with better bibtex.

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


