### PR TITLE
Protect against attempting to format an empty array of authors

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/cite.ts
+++ b/src/gwt/panmirror/src/editor/src/api/cite.ts
@@ -194,7 +194,7 @@ function isValidDate(date: CSLDate): boolean {
 const kEtAl = 'et al.';
 export function formatAuthors(authors?: CSLName[], maxLength?: number): string {
   // No author(s) specified
-  if (!authors) {
+  if (!authors || authors.length === 0) {
     return '';
   }
 


### PR DESCRIPTION
Addresses @rstudio@#8576

### Intent

Formatting an empty array of authors into a string for display should be safe to call when the array of authors is empty (not just undefined).

### Approach

I was already checking for an undefined authors array before formatting, but I wasn't handling the case where the array was empty. Check that too.

### QA Notes


<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


