### PR TITLE
Always report startup configuration related errors to stderr, even if not connected to a terminal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,7 @@
 * **RETIRED:** The option `auth-proxy-require-hmac` is has been retired and it is no longer operational. RStudio will not start if enabled. See the documentation on [Proxy Security Considerations] for alternatives to secure RStudio. (Pro #2029)
 * Fix GetPass not working in remote sessions from Rstudio Desktop Pro (Pro #2218)
 * Fix issue with creating RSA key from remote sessions in RStudio Desktop Pro (Pro #2219)
+* Ensure error messages occurring during installation are displayed in the terminal (Pro #2214)
 
 ### Bugfixes
 

--- a/src/cpp/core/ProgramOptions.cpp
+++ b/src/cpp/core/ProgramOptions.cpp
@@ -57,23 +57,17 @@ bool validateOptionsProvided(const variables_map& vm,
 void reportError(const Error& error, const ErrorLocation& location, bool forceStderr)
 {
    std::string description = error.getProperty("description");
-   if (core::system::stderrIsTerminal() && !description.empty())
+
+   // in some cases, we may need to force stderr to be written
+   // for example, during installation on RedHat systems, stderr
+   // is not properly hooked up to a terminal when checking configuration during post install scripts
+   // which would cause error output to go only to syslog and be hidden from view during install
+   if ((forceStderr || core::system::stderrIsTerminal()) && !description.empty())
    {
       std::cerr << description << std::endl;
    }
-   else
-   {
-      // in some cases, we may need to force stderr to be written
-      // for example, during installation on RedHat systems, stderr
-      // is not properly hooked up to a terminal when checking configuration during post install scripts
-      // which would cause error output to go only to syslog and be hidden from view during install
-      if (forceStderr && !description.empty())
-         std::cerr << description << std::endl;
 
-      core::log::logError(error, location);
-   }
-
-
+   core::log::logError(error, location);
 }
 
 void reportError(const std::string& errorMessage, const ErrorLocation& location, bool forceStderr)

--- a/src/cpp/core/ProgramOptions.cpp
+++ b/src/cpp/core/ProgramOptions.cpp
@@ -43,7 +43,7 @@ bool validateOptionsProvided(const variables_map& vm,
          std::string msg = "Required option " + optionName + " not specified";
          if (!configFile.empty())
             msg += " in config file " + configFile;
-         reportError(msg, ERROR_LOCATION);
+         reportError(msg, ERROR_LOCATION, true);
          return false;
       }
    }
@@ -54,21 +54,42 @@ bool validateOptionsProvided(const variables_map& vm,
 
 }
 
-void reportError(const Error& error, const ErrorLocation& location)
+void reportError(const Error& error, const ErrorLocation& location, bool forceStderr)
 {
    std::string description = error.getProperty("description");
    if (core::system::stderrIsTerminal() && !description.empty())
+   {
       std::cerr << description << std::endl;
+   }
+   else
+   {
+      // in some cases, we may need to force stderr to be written
+      // for example, during installation on RedHat systems, stderr
+      // is not properly hooked up to a terminal when checking configuration during post install scripts
+      // which would cause error output to go only to syslog and be hidden from view during install
+      if (forceStderr && !description.empty())
+         std::cerr << description << std::endl;
 
-   core::log::logError(error, location);
+      core::log::logError(error, location);
+   }
+
+
 }
 
-void reportError(const std::string& errorMessage, const ErrorLocation& location)
+void reportError(const std::string& errorMessage, const ErrorLocation& location, bool forceStderr)
 {
    if (core::system::stderrIsTerminal())
+   {
       std::cerr << errorMessage << std::endl;
+   }
    else
+   {
+      // see above for rationale behind forceStderr
+      if (forceStderr)
+         std::cerr << errorMessage << std::endl;
+
       core::log::logErrorMessage(errorMessage, location);
+   }
 }
 
 void reportWarnings(const std::string& warningMessages,
@@ -118,7 +139,7 @@ bool parseConfigFile(variables_map& vm,
       if (error)
       {
          error.addProperty("description", "Unable to open config file: " + configFile);
-         reportError(error, ERROR_LOCATION);
+         reportError(error, ERROR_LOCATION, true);
 
          return false;
       }
@@ -133,7 +154,8 @@ bool parseConfigFile(variables_map& vm,
       {
          reportError(
            "Error reading " + configFile + ": " + std::string(e.what()),
-           ERROR_LOCATION);
+           ERROR_LOCATION,
+           true);
 
          return false;
       }
@@ -238,7 +260,7 @@ ProgramStatus read(const OptionsDescription& optionsDescription,
       std::string msg(e.what());
       if (!configFile.empty())
          msg += " in config file " + configFile;
-      reportError(msg, ERROR_LOCATION);
+      reportError(msg, ERROR_LOCATION, true);
       return ProgramStatus::exitFailure();
    }
    CATCH_UNEXPECTED_EXCEPTION

--- a/src/cpp/server/ServerOptions.cpp
+++ b/src/cpp/server/ServerOptions.cpp
@@ -220,7 +220,7 @@ ProgramStatus Options::read(int argc,
       sameSite != kSameSiteNoneOption &&
       sameSite != kSameSiteLaxOption)
    {
-      program_options::reportError("Invalid SameSite option: " + sameSite, ERROR_LOCATION);
+      program_options::reportError("Invalid SameSite option: " + sameSite, ERROR_LOCATION, true);
       return ProgramStatus::exitFailure();
    }
    if (sameSite == kSameSiteNoneOption)
@@ -235,7 +235,7 @@ ProgramStatus Options::read(int argc,
    std::string errMsg;
    if (!validateOverlayOptions(&errMsg, osWarnings))
    {
-      program_options::reportError(errMsg, ERROR_LOCATION);
+      program_options::reportError(errMsg, ERROR_LOCATION, true);
       return ProgramStatus::exitFailure();
    }
 


### PR DESCRIPTION

### Intent

When installing on CentOS, configuration related error messages do not display during the installation. This is because stderr (where we log this information) is not connected to a terminal, so it is only logged to syslog. However, if we force write these to stderr, they will properly show up.

### Approach

For these startup related errors, forcefully log them to both stderr and syslog even if stderr is not connected to a terminal. This ensures that the output can be seen by a user when starting the process via the installation.

For other code paths that report errors after startup (or daemonization), do not forcefully log to stderr - we want to make sure we aren't writing to a buffer that is never going to be read from (which could cause a hang).

(Also includes some code that should have been merged back to OS but was forgotten - the ostream and operator changes in ProgramOptions).

Fixes https://github.com/rstudio/rstudio-pro/issues/2214

### QA Notes

See https://github.com/rstudio/rstudio-pro/issues/2214


