### PR TITLE
Fix stale daily build links for MacOS

### DIFF
--- a/docker/jenkins/publish-daily-binary.sh
+++ b/docker/jenkins/publish-daily-binary.sh
@@ -39,6 +39,11 @@ if [ "$FLAVOR" != "desktop" ] && [ "$FLAVOR" != "server" ]; then
     exit 1
 fi
 
+# macOS => mac for URL
+if [ "$OS" == "macos" ];  then
+    OS="mac"
+fi
+
 # figure out the "latest" package name by replacing the version number with "latest"; for example
 # for "rstudio-server-pro-1.3.413-4.deb", we want "rstudio-server-pro-latest.deb"
 LATEST=$(echo "$FILENAME" | sed -e 's/[[:digit:]]\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\(-[[:digit:]][[:digit:]]*\)*/latest/')


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/8633.

### Approach

The macOS daily build links were not being updated since the S3 URL identifies the platform as `macos`, but the redirect URLs refer to the platform as `mac`, so the fix is to correct this mismatch in the script.

### QA Notes

No product change; test via notes in #8633.

