### PR TITLE
Fix default folder for per-user install on WIndows

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -15,6 +15,7 @@
 * Update Windows Desktop to openSSL 1.1.1i (#8574)
 * Improve ordering of items in Command Palette list and search results (#7567, #7956)
 * Update embedded Pandoc to v2.11.3
+* Change default per-user install folder to %LocalAppData%\Programs on Windows (#8598)
 
 ### RStudio Server
 

--- a/package/win32/cmake/modules/NSIS.template.in
+++ b/package/win32/cmake/modules/NSIS.template.in
@@ -973,7 +973,7 @@ SectionEnd
 ; This custom page does not show up visibly, but it executes prior to the
 ; first visible page and sets up $INSTDIR properly...
 ; Choose different default installation folder based on SV_ALLUSERS...
-; "Program Files" for AllUsers, "My Documents" for JustMe...
+; "Program Files" for AllUsers, "%localappdata%\Programs" for JustMe...
 
 Function .onInit
 
@@ -1038,7 +1038,7 @@ Function .onInit
   ; if default install dir then change the default
   ; if it is installed for JustMe
   StrCmp "$IS_DEFAULT_INSTALLDIR" "1" 0 +2
-    StrCpy $INSTDIR "$DOCUMENTS\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
+    StrCpy $INSTDIR "$LOCALAPPDATA\Programs\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
 
   ClearErrors
   UserInfo::GetName


### PR DESCRIPTION
### Intent

- Fixes #8598
- On Windows, a non-elevated (per-user) install can be triggered via group policy or by running the installer as follows:

`cmd.exe /c "set __COMPAT_LAYER=RunAsInvoker && RStudio-1.4.1100.exe"`

- The installer chooses user's documents folder as the default location; this goes against modern Windows recommendation for a per-user install (and causes problems with sync clients)

### Approach

- Use the %LocalAppData%\Programs folder as the default for a per-user install

### QA Notes

- On a Windows machine without an existing RStudio install, run the installer as shown above to trigger a per-user install
- The default folder should now be in user's %appdata%\Local\Programs folder, not in Documents
- Note to uninstall a per-user install performed this way, you must run the uninstall.exe using the same trick or it will mess up and leave a phantom entry in add-remove programs; this wouldn't happen on a system where group policy was used to force this behavior
- Also try a regular install to ensure an elevated (all-users) install goes to program files as before