### PR TITLE
osx underline shortcut: display in menu and toggle off

### DIFF
--- a/src/gwt/panmirror/src/editor/src/marks/underline.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/underline.ts
@@ -20,6 +20,7 @@ import { Extension, extensionIfEnabled } from '../api/extension';
 import { PandocOutput, PandocTokenType } from '../api/pandoc';
 
 import './underline-styles.css';
+import { kPlatformMac } from '../api/platform';
 
 const extension: Extension = {
   marks: [
@@ -54,7 +55,7 @@ const extension: Extension = {
   ],
 
   commands: (schema: Schema) => {
-    return [new MarkCommand(EditorCommandId.Underline, [], schema.marks.underline)];
+    return [new MarkCommand(EditorCommandId.Underline, kPlatformMac ? ['Mod-u'] : [], schema.marks.underline)];
   },
 };
 


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/8656

Note that this keyboard shortcut had been disabled entirely (due to conflicts with the Ctrl+U shortcut for yank before cursor) however it continued working (to a point) on OS X desktop (presumably because the contentEditable implementation in WebKit chromium or base ProseMirror was handling the shortcut?).

Since the shortcut *sort of* works on the Mac even when we don't enable it, it's better to just explicitly enabled it (on Mac only, as the other platforms still have the Ctrl+U conflict). This makes the menu paint correctly and provides the expected toggle off behavior.

We could argue that we should introduce yet another shortcut key that doesn't conflict with Ctrl+U however I don't even think underline warrants a keyboard shortcut in the first place (as it was just added to Pandoc a couple of months ago and is considered bad form compared to using bold or italics).
