### PR TITLE
visual editor: correctly handle finding words w/ punctuation

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/find.ts
+++ b/src/gwt/panmirror/src/editor/src/behaviors/find.ts
@@ -482,7 +482,7 @@ class FindPlugin extends Plugin<DecorationSet> {
   private findRegEx() {
     try {
       return new RegExp(this.term, !this.options.caseSensitive ? 'gui' : 'gu');
-    } catch(e) {
+    } catch {
       return null;
     }
   }

--- a/src/gwt/panmirror/src/editor/src/behaviors/find.ts
+++ b/src/gwt/panmirror/src/editor/src/behaviors/find.ts
@@ -75,7 +75,9 @@ class FindPlugin extends Plugin<DecorationSet> {
   public find(term: string, options: FindOptions) {
     return (state: EditorState<any>, dispatch?: (tr: Transaction<any>) => void) => {
       if (dispatch) {
-        this.term = !options.regex ? term.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&') : term;
+        this.term = !options.regex ? term.replace(/[-/\\^$*+?.()|[\]{}]/g, (escape: string) => {
+          return '\\u' + ('0000' + escape.charCodeAt(0).toString(16)).slice(-4);
+        }) : term;
         this.options = options;
         this.updateResults(state, dispatch);
       }
@@ -480,7 +482,7 @@ class FindPlugin extends Plugin<DecorationSet> {
   private findRegEx() {
     try {
       return new RegExp(this.term, !this.options.caseSensitive ? 'gui' : 'gu');
-    } catch {
+    } catch(e) {
       return null;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/rstudio/rstudio/issues/8655

The cause of the problem was using normal regex character escapes (e.g. `\-`) in a unicode regex. See discussion here: https://esdiscuss.org/topic/why-is-regexp-u-a-syntax-error

The fix is to use full unicode escape sequences (e.g. `\u002d`) rather than simple ascii character based escapes.

@jmcphers Could you review to make sure there aren't any hidden gotchas w/ this approach?
