### PR TITLE
improve yaml cursor position after omni-insert

### DIFF
--- a/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/yaml_metadata/yaml_metadata.ts
@@ -117,7 +117,7 @@ class YamlMetadataCommand extends ProsemirrorCommand {
         description: ui.context.translateText('YAML metadata block'),
         group: OmniInsertGroup.Blocks,
         priority: 3,
-        selectionOffset: 4,
+        selectionOffset: -4,
         image: () =>
           ui.prefs.darkMode() ? ui.images.omni_insert?.yaml_block_dark! : ui.images.omni_insert?.yaml_block!,
       },


### PR DESCRIPTION
This fixes a minor but nevertheless quite annoying defect: when creating front-matter in an empty document via omni-insert the cursor ended up positioned after the yaml block. This changes the offset to get it into the center of the block where it belongs.
