### PR TITLE
detect newer plumber tags

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -18,6 +18,7 @@
 * Change default per-user install folder to %LocalAppData%\Programs on Windows (#8598)
 * Cmd+U now toggles underlining in the visual editor on macOS (#8656)
 * Improve YAML cursor position after omni-insert in the visual editor (#8670)
+* Detect newer plumber tags when enabling plumber integration (#8118)
 
 ### RStudio Server
 

--- a/src/cpp/session/modules/plumber/SessionPlumber.cpp
+++ b/src/cpp/session/modules/plumber/SessionPlumber.cpp
@@ -44,7 +44,7 @@ PlumberFileType getPlumberFileType(const std::string& contents)
    // this to be a plumber file. We don't care about details or fully checking syntax, just enough
    // to enable plumber-specific functionality.
    static const boost::regex rePlumberAnnotation(
-         R"(^#\*\s*@(get|put|post|filter|assets|use|delete|head|options|patch)\s)");
+         R"(^#\*\s*@(get|put|post|filter|assets|use|delete|head|options|patch|plumber|serializer|parser|preempt|response|tag|apiTitle|apiDescription|apiTOS|apiContact|apiLicense|apiVersion|apiTag)\s)");
    return regex_utils::search(contents, rePlumberAnnotation) ? 
           PlumberFileType::PlumberApi : PlumberFileType::PlumberNone;
 }


### PR DESCRIPTION
- Fixes #8118

### Intent

Light-up IDE plumber integration when newer tags are seen, not just the original plumber tags.

### Approach

Updated the regex based on list from plumber team.

### QA Notes

Validate scenario as described in #8118

