### PR TITLE
fix running rsession unit tests on macos

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -57,9 +57,9 @@ runWatchdogProcess()
       fi
    else
       if [ "$privileged" = true ]; then
-         sudo $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         sudo $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       else
-         $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT  DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
       fi
    fi
 


### PR DESCRIPTION
### Intent

- Fixes #8685
- Purely dev environment tweak, no impact on end-user code

### Approach

- Have to pass along DYLD_INSERT_LIBRARIES when running rsession via the timeout command
- This worked as-is for at least one person, theory being that having SIP disabled is a factor

### QA Notes

- Move along. Nothing to see here.
