### PR TITLE
mechanical refactor, replace explicit type with <>

### DIFF
--- a/src/gwt/src/com/google/gwt/widgetideas/client/ResizableWidgetCollection.java
+++ b/src/gwt/src/com/google/gwt/widgetideas/client/ResizableWidgetCollection.java
@@ -135,7 +135,7 @@ public class ResizableWidgetCollection implements WindowResizeListener,
   /**
    * A hash map of the resizable widgets this collection is checking.
    */
-  private Map<ResizableWidget, ResizableWidgetInfo> widgets = new HashMap<ResizableWidget, ResizableWidgetInfo>();
+  private Map<ResizableWidget, ResizableWidgetInfo> widgets = new HashMap<>();
 
   /**
    * The current window height.

--- a/src/gwt/src/com/google/gwt/widgetideas/client/SliderBar.java
+++ b/src/gwt/src/com/google/gwt/widgetideas/client/SliderBar.java
@@ -195,7 +195,7 @@ public class SliderBar extends FocusPanel implements ResizableWidget,
   /**
    * The elements used to display labels above the ticks.
    */
-  private List<Element> labelElements = new ArrayList<Element>();
+  private List<Element> labelElements = new ArrayList<>();
 
   /**
    * The formatter used to generate label text.
@@ -263,7 +263,7 @@ public class SliderBar extends FocusPanel implements ResizableWidget,
    * The elements used to display tick marks, which are the vertical lines along
    * the slider bar.
    */
-  private List<Element> tickElements = new ArrayList<Element>();
+  private List<Element> tickElements = new ArrayList<>();
 
   /**
    * Create a slider bar.

--- a/src/gwt/src/com/sksamuel/gwt/websockets/Websocket.java
+++ b/src/gwt/src/com/sksamuel/gwt/websockets/Websocket.java
@@ -33,7 +33,7 @@ public class Websocket {
         return _isWebsocket();
     }
 
-    private final Set<WebsocketListener> listeners = new HashSet<WebsocketListener>();
+    private final Set<WebsocketListener> listeners = new HashSet<>();
 
     private final String varName;
     private final String url;

--- a/src/gwt/src/org/rstudio/core/client/CsvReader.java
+++ b/src/gwt/src/org/rstudio/core/client/CsvReader.java
@@ -37,7 +37,7 @@ public class CsvReader implements Iterable<String[]>
 
          public String[] next()
          {
-            ArrayList<String> list = new ArrayList<String>();
+            ArrayList<String> list = new ArrayList<>();
             StringBuilder chunk = new StringBuilder();
 
             final int START = 0;

--- a/src/gwt/src/org/rstudio/core/client/DirectedGraph.java
+++ b/src/gwt/src/org/rstudio/core/client/DirectedGraph.java
@@ -69,7 +69,7 @@ public class DirectedGraph<K, V>
    private DirectedGraph(DirectedGraph<K, V> parent, K key, V value, DefaultConstructor<V> constructor)
    {
       parent_ = parent;
-      children_ = new SafeMap<K, DirectedGraph<K, V>>();
+      children_ = new SafeMap<>();
       
       key_ = key;
       
@@ -117,7 +117,7 @@ public class DirectedGraph<K, V>
    
    private DirectedGraph<K, V> addChild(K key)
    {
-      DirectedGraph<K, V> child = new DirectedGraph<K, V>(this, key, null, constructor_);
+      DirectedGraph<K, V> child = new DirectedGraph<>(this, key, null, constructor_);
       children_.put(key, child);
       return child;
    }
@@ -142,8 +142,8 @@ public class DirectedGraph<K, V>
    
    public List<Pair<List<K>, V>> flatten()
    {
-      List<Pair<List<K>, V>> list = new ArrayList<Pair<List<K>, V>>();
-      List<K> keys = new ArrayList<K>();
+      List<Pair<List<K>, V>> list = new ArrayList<>();
+      List<K> keys = new ArrayList<>();
       fillRecursive(list, keys, this);
       return list;
    }
@@ -153,7 +153,7 @@ public class DirectedGraph<K, V>
                                             DirectedGraph<K, V> node)
    {
       keys.add(node.getKey());
-      list.add(new Pair<List<K>, V>(new ArrayList<K>(keys), node.getValue()));
+      list.add(new Pair<>(new ArrayList<>(keys), node.getValue()));
       
       for (Map.Entry<K, DirectedGraph<K, V>> entry : node.getChildren().entrySet())
          fillRecursive(list, keys, entry.getValue());
@@ -161,7 +161,7 @@ public class DirectedGraph<K, V>
    
    public List<K> getKeyChain()
    {
-      List<K> chain = new ArrayList<K>();
+      List<K> chain = new ArrayList<>();
       DirectedGraph<K, V> node = this;
       while (!node.isRoot())
       {

--- a/src/gwt/src/org/rstudio/core/client/DuplicateHelper.java
+++ b/src/gwt/src/org/rstudio/core/client/DuplicateHelper.java
@@ -58,16 +58,14 @@ public class DuplicateHelper
 
       void addDupeInfo(T value, ArrayList<Integer> indices)
       {
-         valueCounts_.add(new Pair<T, Integer>(value, indices.size()));
+         valueCounts_.add(new Pair<>(value, indices.size()));
          if (indices.size() > 1)
             dupes_.add(indices);
       }
 
       private final Comparator<T> comparator_;
-      private ArrayList<ArrayList<Integer>> dupes_ =
-            new ArrayList<ArrayList<Integer>>();
-      private ArrayList<Pair<T, Integer>> valueCounts_ =
-            new ArrayList<Pair<T, Integer>>();
+      private ArrayList<ArrayList<Integer>> dupes_ = new ArrayList<>();
+      private ArrayList<Pair<T, Integer>> valueCounts_ = new ArrayList<>();
    }
 
    private static class CaseInsensitiveStringComparator implements Comparator<String>
@@ -106,10 +104,10 @@ public class DuplicateHelper
    public static <T> DuplicationInfo<T> detectDupes(List<T> list,
                                                     final Comparator<T> comparator)
    {
-      ArrayList<Pair<Integer, T>> sorted = new ArrayList<Pair<Integer, T>>();
+      ArrayList<Pair<Integer, T>> sorted = new ArrayList<>();
       for (int i = 0; i < list.size(); i++)
       {
-         sorted.add(new Pair<Integer, T>(i, list.get(i)));
+         sorted.add(new Pair<>(i, list.get(i)));
       }
 
       // Sort our copy of the list, so dupes are right next to each other
@@ -122,8 +120,8 @@ public class DuplicateHelper
          }
       });
 
-      DuplicationInfo<T> dupeInfo = new DuplicationInfo<T>(comparator);
-      ArrayList<Integer> currentDupes = new ArrayList<Integer>();
+      DuplicationInfo<T> dupeInfo = new DuplicationInfo<>(comparator);
+      ArrayList<Integer> currentDupes = new ArrayList<>();
       T lastSeenValue = null;
       for (Pair<Integer, T> value : sorted)
       {
@@ -135,7 +133,7 @@ public class DuplicateHelper
             // a new list.
             if (currentDupes.size() > 0)
                dupeInfo.addDupeInfo(lastSeenValue, currentDupes);
-            currentDupes = new ArrayList<Integer>();
+            currentDupes = new ArrayList<>();
          }
 
          // Add ourselves to the current list
@@ -157,7 +155,7 @@ public class DuplicateHelper
    public static ArrayList<String> getPathLabels(ArrayList<String> paths,
                                                  boolean includeExtension)
    {
-      ArrayList<String> labels = new ArrayList<String>();
+      ArrayList<String> labels = new ArrayList<>();
       for (String entry : paths)
       {
          if (includeExtension)
@@ -204,15 +202,14 @@ public class DuplicateHelper
                            ArrayList<Integer> indices,
                            ArrayList<String> labels)
    {
-      ArrayList<ArrayList<String>> pathElementListList =
-            new ArrayList<ArrayList<String>>();
+      ArrayList<ArrayList<String>> pathElementListList = new ArrayList<>();
 
       for (Integer index : indices)
          pathElementListList.add(toPathElements(fullPaths.get(index)));
 
       while (indices.size() > 0)
       {
-         ArrayList<String> lastPathElements = new ArrayList<String>();
+         ArrayList<String> lastPathElements = new ArrayList<>();
 
          for (int i = 0; i < pathElementListList.size(); i++)
          {
@@ -269,7 +266,6 @@ public class DuplicateHelper
    private static ArrayList<String> toPathElements(String path)
    {
       FileSystemItem fsi = FileSystemItem.createFile(path);
-      return new ArrayList<String>(
-            Arrays.asList(fsi.getParentPathString().split("/")));
+      return new ArrayList<>(Arrays.asList(fsi.getParentPathString().split("/")));
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/ExternalJavaScriptLoader.java
+++ b/src/gwt/src/org/rstudio/core/client/ExternalJavaScriptLoader.java
@@ -39,8 +39,7 @@ public class ExternalJavaScriptLoader
 
    public static void loadSequentially(String[] urls, final Callback callback)
    {
-      final LinkedList<ExternalJavaScriptLoader> loaders =
-            new LinkedList<ExternalJavaScriptLoader>();
+      final LinkedList<ExternalJavaScriptLoader> loaders = new LinkedList<>();
 
       for (String url : urls)
          loaders.add(new ExternalJavaScriptLoader(url));
@@ -131,7 +130,7 @@ public class ExternalJavaScriptLoader
       });
    }
 
-   private LinkedList<Callback> callbacks_ = new LinkedList<Callback>();
+   private LinkedList<Callback> callbacks_ = new LinkedList<>();
    private State state_ = State.Start;
    private final String url_;
    private final Document document_;

--- a/src/gwt/src/org/rstudio/core/client/ExternalStyleSheetLoader.java
+++ b/src/gwt/src/org/rstudio/core/client/ExternalStyleSheetLoader.java
@@ -105,7 +105,7 @@ public class ExternalStyleSheetLoader
       });
    }
 
-   private LinkedList<Callback> callbacks_ = new LinkedList<Callback>();
+   private LinkedList<Callback> callbacks_ = new LinkedList<>();
    private State state_ = State.Start;
    private final String url_;
    private final Document document_;

--- a/src/gwt/src/org/rstudio/core/client/HtmlMessageListener.java
+++ b/src/gwt/src/org/rstudio/core/client/HtmlMessageListener.java
@@ -44,7 +44,7 @@ public class HtmlMessageListener
       htmlMessageListener_ = this;
       fileTypeRegistry_ = fileTypeRegistry;
       pUserPrefs_ = pUIPrefs;
-      themeSources_ = new ArrayList<JavaScriptObject>();
+      themeSources_ = new ArrayList<>();
       
       initializeMessageListeners();
 

--- a/src/gwt/src/org/rstudio/core/client/JsArrayUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/JsArrayUtil.java
@@ -58,7 +58,7 @@ public class JsArrayUtil
    public static <T extends JavaScriptObject> ArrayList<T> toArrayList(
          JsArray<T> jsArray)
    {
-      ArrayList<T> list = new ArrayList<T>();
+      ArrayList<T> list = new ArrayList<>();
       fillList(jsArray, list);
       return list;
    }
@@ -86,7 +86,7 @@ public class JsArrayUtil
    
    public static ArrayList<String> fromJsArrayString(JsArrayString in)
    {
-      ArrayList<String> out = new ArrayList<String>();
+      ArrayList<String> out = new ArrayList<>();
       for (int i = 0; i < in.length(); i++)
       {
          out.add(in.get(i));

--- a/src/gwt/src/org/rstudio/core/client/ListUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/ListUtil.java
@@ -35,7 +35,7 @@ public class ListUtil
    
    public static <T> List<T> filter(List<T> list, FilterPredicate<T> predicate)
    {
-      List<T> filtered = new ArrayList<T>();
+      List<T> filtered = new ArrayList<>();
       for (T object : list)
          if (predicate.test(object))
             filtered.add(object);
@@ -53,14 +53,14 @@ public class ListUtil
    @SuppressWarnings("unchecked")
    public static <T> List<T> create(T... ts)
    {
-      List<T> result = new ArrayList<T>(ts.length);
+      List<T> result = new ArrayList<>(ts.length);
       for (T t : ts) result.add(t);
       return result;
    }
    
    public static List<String> create(JsArrayString array)
    {
-      List<String> list = new ArrayList<String>();
+      List<String> list = new ArrayList<>();
       for (int i = 0, n = array.length(); i < n; i++)
          list.add(array.get(i));
       return list;
@@ -68,7 +68,7 @@ public class ListUtil
    
    public static <T extends JavaScriptObject> List<T> create(JsArray<T> array)
    {
-      List<T> list = new ArrayList<T>();
+      List<T> list = new ArrayList<>();
       for (int i = 0, n = array.length(); i < n; i++)
          list.add(array.get(i));
       return list;

--- a/src/gwt/src/org/rstudio/core/client/PreemptiveTaskQueue.java
+++ b/src/gwt/src/org/rstudio/core/client/PreemptiveTaskQueue.java
@@ -141,7 +141,7 @@ public class PreemptiveTaskQueue
    }
    
    
-   private Queue<Task> taskQueue_ = new LinkedList<Task>();
+   private Queue<Task> taskQueue_ = new LinkedList<>();
    private boolean processing_ = false;
    private final boolean log_;
    private final boolean safe_;

--- a/src/gwt/src/org/rstudio/core/client/Rendezvous.java
+++ b/src/gwt/src/org/rstudio/core/client/Rendezvous.java
@@ -41,7 +41,7 @@ public class Rendezvous
    public Rendezvous(int count)
    {
       this.remainingArrivals = count;
-      this.joined = new ArrayList<Command>();
+      this.joined = new ArrayList<>();
    }
 
    /**

--- a/src/gwt/src/org/rstudio/core/client/SafeHtmlUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/SafeHtmlUtil.java
@@ -198,7 +198,7 @@ public class SafeHtmlUtil
       
       // Store matches in a tree set ordered by the index at which the match was
       // found.
-      Set<SearchMatch> matches = new TreeSet<SearchMatch>(
+      Set<SearchMatch> matches = new TreeSet<>(
             (SearchMatch o1, SearchMatch o2) -> {
                   return o1.index.compareTo(o2.index);
             });

--- a/src/gwt/src/org/rstudio/core/client/cellview/TriStateCheckboxCell.java
+++ b/src/gwt/src/org/rstudio/core/client/cellview/TriStateCheckboxCell.java
@@ -51,7 +51,7 @@ public class TriStateCheckboxCell<TKey> implements Cell<Boolean>
    public TriStateCheckboxCell(SelectionModel<TKey> selectionModel)
    {
       selectionModel_ = selectionModel;
-      consumedEvents_ = new HashSet<String>();
+      consumedEvents_ = new HashSet<>();
       consumedEvents_.add("click");
       consumedEvents_.add("keydown");
       consumedEvents_.add("mouseover");

--- a/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
@@ -42,7 +42,7 @@ public class ApplicationCommandManager
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
 
-      bindings_ = new ConfigFileBacked<EditorKeyBindings>(
+      bindings_ = new ConfigFileBacked<>(
             server_,
             KEYBINDINGS_PATH,
             false,
@@ -145,7 +145,7 @@ public class ApplicationCommandManager
                              final CommandWithArg<EditorKeyBindings> afterLoad)
    {
       List<Pair<List<KeySequence>, AppCommand>> resolvedBindings;
-      resolvedBindings = new ArrayList<Pair<List<KeySequence>, AppCommand>>();
+      resolvedBindings = new ArrayList<>();
 
       for (String id : bindings.iterableKeys())
       {
@@ -153,7 +153,7 @@ public class ApplicationCommandManager
          if (command == null)
             continue;
          List<KeySequence> keys = bindings.get(id).getKeyBindings();
-         resolvedBindings.add(new Pair<List<KeySequence>, AppCommand>(keys, command));
+         resolvedBindings.add(new Pair<>(keys, command));
       }
 
       KeyMap map = ShortcutManager.INSTANCE.getKeyMap(KeyMapType.APPLICATION);

--- a/src/gwt/src/org/rstudio/core/client/command/CommandBundle.java
+++ b/src/gwt/src/org/rstudio/core/client/command/CommandBundle.java
@@ -39,6 +39,5 @@ public abstract class CommandBundle
       return commandsById_;
    }
 
-   private final HashMap<String, AppCommand> commandsById_ =
-         new HashMap<String, AppCommand>();
+   private final HashMap<String, AppCommand> commandsById_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/core/client/command/CommandEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/command/CommandEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class CommandEvent extends GwtEvent<CommandHandler>
 {
-   public static final Type<CommandHandler> TYPE = new Type<CommandHandler>();
+   public static final Type<CommandHandler> TYPE = new Type<>();
 
    public CommandEvent(AppCommand command)
    {

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -60,7 +60,7 @@ public class EditorCommandManager
 
       public final void setBindings(String key, List<KeySequence> ksList)
       {
-         List<String> bindings = new ArrayList<String>();
+         List<String> bindings = new ArrayList<>();
          for (KeySequence ks : ksList)
             bindings.add(ks.toString());
 
@@ -77,7 +77,7 @@ public class EditorCommandManager
       public final List<KeySequence> getKeyBindings()
       {
          JsArrayString bindings = getBindingsInternal();
-         Set<KeySequence> keys = new HashSet<KeySequence>();
+         Set<KeySequence> keys = new HashSet<>();
          for (String binding : JsUtil.asIterable(bindings))
          {
             String[] splat = binding.split("\\|");
@@ -87,7 +87,7 @@ public class EditorCommandManager
             }
          }
 
-         List<KeySequence> keyList = new ArrayList<KeySequence>();
+         List<KeySequence> keyList = new ArrayList<>();
          keyList.addAll(keys);
          return keyList;
       }
@@ -112,7 +112,7 @@ public class EditorCommandManager
 
       manager_ = AceCommandManager.create();
 
-      bindings_ = new ConfigFileBacked<EditorKeyBindings>(
+      bindings_ = new ConfigFileBacked<>(
             files_,
             KEYBINDINGS_PATH,
             false,

--- a/src/gwt/src/org/rstudio/core/client/command/EnabledChangedEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EnabledChangedEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class EnabledChangedEvent extends GwtEvent<EnabledChangedHandler>
 {
-   public static final Type<EnabledChangedHandler> TYPE = new Type<EnabledChangedHandler>();
+   public static final Type<EnabledChangedHandler> TYPE = new Type<>();
 
    public EnabledChangedEvent(AppCommand command)
    {

--- a/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
@@ -44,16 +44,16 @@ public class KeyMap
 
    public KeyMap()
    {
-      graph_ = new DirectedGraph<KeyCombination, List<CommandBinding>>(new DefaultConstructor<List<CommandBinding>>()
+      graph_ = new DirectedGraph<>(new DefaultConstructor<List<CommandBinding>>()
       {
          @Override
          public List<CommandBinding> create()
          {
-            return new ArrayList<CommandBinding>();
+            return new ArrayList<>();
          }
       });
 
-      idToNodeMap_ = new SafeMap<String, List<DirectedGraph<KeyCombination, List<CommandBinding>>>>();
+      idToNodeMap_ = new SafeMap<>();
    }
 
    public void addBinding(KeySequence keys, CommandBinding command)
@@ -61,11 +61,11 @@ public class KeyMap
       DirectedGraph<KeyCombination, List<CommandBinding>> node = graph_.ensureNode(keys.getData());
 
       if (node.getValue() == null)
-         node.setValue(new ArrayList<CommandBinding>());
+         node.setValue(new ArrayList<>());
       node.getValue().add(0, command);
 
       if (!idToNodeMap_.containsKey(command.getId()))
-         idToNodeMap_.put(command.getId(), new ArrayList<DirectedGraph<KeyCombination, List<CommandBinding>>>());
+         idToNodeMap_.put(command.getId(), new ArrayList<>());
       idToNodeMap_.get(command.getId()).add(node);
    }
 
@@ -94,7 +94,7 @@ public class KeyMap
          if (bindings == null || bindings.isEmpty())
             continue;
 
-         List<CommandBinding> filtered = new ArrayList<CommandBinding>();
+         List<CommandBinding> filtered = new ArrayList<>();
          for (CommandBinding binding : bindings)
             if (binding.getId() != command.getId())
                filtered.add(binding);
@@ -121,7 +121,7 @@ public class KeyMap
 
    public List<KeySequence> getBindings(String id)
    {
-      List<KeySequence> keys = new ArrayList<KeySequence>();
+      List<KeySequence> keys = new ArrayList<>();
       List<DirectedGraph<KeyCombination, List<CommandBinding>>> bindings = idToNodeMap_.get(id);
       if (bindings == null)
          return keys;
@@ -152,7 +152,7 @@ public class KeyMap
       if (node == null)
          return false;
 
-      final Mutable<Boolean> pending = new Mutable<Boolean>(false);
+      final Mutable<Boolean> pending = new Mutable<>(false);
       node.forEachNode(new ForEachNodeCommand<KeyCombination, List<CommandBinding>>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeySequence.java
@@ -25,12 +25,12 @@ public class KeySequence
 {
    public KeySequence()
    {
-      keyCombinations_ = new ArrayList<KeyCombination>();
+      keyCombinations_ = new ArrayList<>();
    }
 
    public KeySequence(List<KeyCombination> keyList)
    {
-      keyCombinations_ = new ArrayList<KeyCombination>(keyList);
+      keyCombinations_ = new ArrayList<>(keyList);
    }
 
    public static KeySequence fromShortcutString(String shortcut)

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
@@ -22,7 +22,7 @@ public class ShortcutInfo
 {
    public ShortcutInfo (KeyboardShortcut shortcut, AppCommand command)
    {
-      shortcuts_ = new ArrayList<String>();
+      shortcuts_ = new ArrayList<>();
       description_ = shortcut.getTitle().length() > 0 ?
                         shortcut.getTitle() :
                         command != null ?

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutManager.java
@@ -33,7 +33,6 @@ import org.rstudio.core.client.command.KeyMap.KeyMapType;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.events.NativeKeyDownEvent;
 import org.rstudio.studio.client.RStudioGinjector;
-import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.WarningBarClosedEvent;
 import org.rstudio.studio.client.events.EditEvent;
@@ -75,7 +74,7 @@ public class ShortcutManager implements NativePreviewHandler,
    private ShortcutManager()
    {
       keyBuffer_ = new KeySequence();
-      ignoredKeys_ = new IgnoredKeysMap<KeyCombination>();
+      ignoredKeys_ = new IgnoredKeysMap<>();
       keyTimer_ = new Timer()
       {
          @Override
@@ -85,12 +84,12 @@ public class ShortcutManager implements NativePreviewHandler,
          }
       };
 
-      shortcutInfo_ = new ArrayList<ShortcutInfo>();
-      defaultBindings_ = new ArrayList<Pair<KeySequence, AppCommandBinding>>();
+      shortcutInfo_ = new ArrayList<>();
+      defaultBindings_ = new ArrayList<>();
 
       // Initialize the key maps. We use a LinkedHashMap so that insertion
       // order can be preserved.
-      keyMaps_ = new LinkedHashMap<KeyMapType, KeyMap>();
+      keyMaps_ = new LinkedHashMap<>();
       for (KeyMapType type : KeyMapType.values())
          keyMaps_.put(type, new KeyMap());
 
@@ -271,7 +270,7 @@ public class ShortcutManager implements NativePreviewHandler,
          appKeyMap.addBinding(keys, binding);
 
          // Cache the binding (so we can reset later if required)
-         defaultBindings_.add(new Pair<KeySequence, AppCommandBinding>(keys, binding));
+         defaultBindings_.add(new Pair<>(keys, binding));
       }
    }
 
@@ -351,9 +350,9 @@ public class ShortcutManager implements NativePreviewHandler,
    {
       // Filter out commands disabled due to the current editor mode.
       // Also only retain the first discovered binding for a particular command.
-      final Set<String> encounteredShortcuts = new HashSet<String>();
+      final Set<String> encounteredShortcuts = new HashSet<>();
 
-      List<ShortcutInfo> filtered = new ArrayList<ShortcutInfo>();
+      List<ShortcutInfo> filtered = new ArrayList<>();
       for (int i = 0, n = shortcutInfo_.size(); i < n; i++)
       {
          ShortcutInfo object = shortcutInfo_.get(n - i - 1);
@@ -702,13 +701,13 @@ public class ShortcutManager implements NativePreviewHandler,
    {
       public IgnoredKeysMap()
       {
-         ignoredKeys_ = new HashMap<Integer, Set<T>>();
+         ignoredKeys_ = new HashMap<>();
          count_ = 0;
       }
 
       public Handle addIgnoredKeys(T keys)
       {
-         Set<T> keySet = new HashSet<T>();
+         Set<T> keySet = new HashSet<>();
          keySet.add(keys);
          return addIgnoredKeys(keySet);
       }

--- a/src/gwt/src/org/rstudio/core/client/command/SubMenuVisibleChangedEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/command/SubMenuVisibleChangedEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class SubMenuVisibleChangedEvent extends GwtEvent<SubMenuVisibleChangedHandler>
 {
-   public static final Type<SubMenuVisibleChangedHandler> TYPE = new Type<SubMenuVisibleChangedHandler>();
+   public static final Type<SubMenuVisibleChangedHandler> TYPE = new Type<>();
    @Override
    public Type<SubMenuVisibleChangedHandler> getAssociatedType()
    {

--- a/src/gwt/src/org/rstudio/core/client/command/UserCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/UserCommandManager.java
@@ -35,7 +35,7 @@ public class UserCommandManager
    public UserCommandManager()
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
-      commandMap_ = new HashMap<KeyboardShortcut, UserCommand>();
+      commandMap_ = new HashMap<>();
 
       events_.addHandler(
             RegisterUserCommandEvent.TYPE,

--- a/src/gwt/src/org/rstudio/core/client/command/VisibleChangedEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/command/VisibleChangedEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class VisibleChangedEvent extends GwtEvent<VisibleChangedHandler>
 {
-   public static final Type<VisibleChangedHandler> TYPE = new Type<VisibleChangedHandler>();
+   public static final Type<VisibleChangedHandler> TYPE = new Type<>();
 
    public VisibleChangedEvent(AppCommand command)
    {

--- a/src/gwt/src/org/rstudio/core/client/command/impl/WebMenuCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/command/impl/WebMenuCallback.java
@@ -104,6 +104,6 @@ public class WebMenuCallback implements MenuCallback
       return menuStack_.peek();
    }
 
-   private final Stack<AppMenuBar> menuStack_ = new Stack<AppMenuBar>();
+   private final Stack<AppMenuBar> menuStack_ = new Stack<>();
    private AppMenuBar result_;
 }

--- a/src/gwt/src/org/rstudio/core/client/container/SafeMap.java
+++ b/src/gwt/src/org/rstudio/core/client/container/SafeMap.java
@@ -25,7 +25,7 @@ public class SafeMap<K, V>
 {
    public SafeMap()
    {
-      data_ = new HashMap<K, V>();
+      data_ = new HashMap<>();
    }
 
    public V get(K key)

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -697,7 +697,7 @@ public class DomUtils
                                       boolean siblings,
                                       NodePredicate filter)
    {
-      List<Node> results = new ArrayList<Node>();
+      List<Node> results = new ArrayList<>();
       int remaining = 0;
 
       if (start == null)

--- a/src/gwt/src/org/rstudio/core/client/events/SelectionCommitEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/events/SelectionCommitEvent.java
@@ -25,7 +25,7 @@ public class SelectionCommitEvent<I> extends GwtEvent<SelectionCommitEvent.Handl
    {
      if (TYPE != null)
      {
-       SelectionCommitEvent<I> event = new SelectionCommitEvent<I>(selectedItem);
+       SelectionCommitEvent<I> event = new SelectionCommitEvent<>(selectedItem);
        source.fireEvent(event);
      }
    }

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -343,8 +343,7 @@ public class FileSystemItem extends JavaScriptObject
    }-*/;
 
    // NOTE: should be synced with mime type database in FilePath.cpp
-   private final static HashMap<String,String> MIME_TYPES =
-                                             new HashMap<String,String>();
+   private final static HashMap<String,String> MIME_TYPES = new HashMap<>();
    static
    {
       MIME_TYPES.put( "htm",   "text/html" );

--- a/src/gwt/src/org/rstudio/core/client/files/PosixFileSystemContext.java
+++ b/src/gwt/src/org/rstudio/core/client/files/PosixFileSystemContext.java
@@ -51,7 +51,7 @@ public abstract class PosixFileSystemContext implements FileSystemContext
 
    public FileSystemItem[] parseDir(String dirPath)
    {
-      ArrayList<FileSystemItem> results = new ArrayList<FileSystemItem>();
+      ArrayList<FileSystemItem> results = new ArrayList<>();
 
       if (dirPath.startsWith("/"))
          results.add(FileSystemItem.createDir("/"));

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/ChooseFolderDialog2.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/ChooseFolderDialog2.java
@@ -53,7 +53,7 @@ public class ChooseFolderDialog2 extends FileSystemDialog
    public FileSystemItem[] ls()
    {
       FileSystemItem[] items = super.ls();
-      ArrayList<FileSystemItem> dirs = new ArrayList<FileSystemItem>();
+      ArrayList<FileSystemItem> dirs = new ArrayList<>();
       for (FileSystemItem item : items)
          if (item.isDirectory())
             dirs.add(item);

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileSystemDialog.java
@@ -325,7 +325,7 @@ public abstract class FileSystemDialog extends ModalDialogBase
       if (items == null)
          return new FileSystemItem[0];
 
-      ArrayList<FileSystemItem> filtered = new ArrayList<FileSystemItem>();
+      ArrayList<FileSystemItem> filtered = new ArrayList<>();
       for (int i = 0; i < items.length; i++)
       {
          if (items[i].isDirectory())

--- a/src/gwt/src/org/rstudio/core/client/html/HTMLAttributesParser.java
+++ b/src/gwt/src/org/rstudio/core/client/html/HTMLAttributesParser.java
@@ -63,9 +63,9 @@ public class HTMLAttributesParser
       public Parser(String attributes)
       {
          attributes_ = StringUtil.notNull(attributes).trim();
-         map_ = new HashMap<String, String>();
+         map_ = new HashMap<>();
          identifier_ = "";
-         classes_ = new ArrayList<String>();
+         classes_ = new ArrayList<>();
          
          index_ = 0;
          n_ = attributes.length();

--- a/src/gwt/src/org/rstudio/core/client/js/JsUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/js/JsUtil.java
@@ -230,7 +230,7 @@ public class JsUtil
    
    public static List<String> toList(JsArrayString array)
    {
-      List<String> list = new ArrayList<String>();
+      List<String> list = new ArrayList<>();
       for (int i = 0, n = array.length(); i < n; i++)
          list.add(array.get(i));
       return list;

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RequestLog.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RequestLog.java
@@ -45,8 +45,7 @@ public class RequestLog
       return entries;
    }
 
-   private static final ArrayList<RequestLogEntry> entries_ =
-         new ArrayList<RequestLogEntry>();
+   private static final ArrayList<RequestLogEntry> entries_ = new ArrayList<>();
 
    private static final int MAX_ENTRIES = 50;
 }

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcObjectList.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcObjectList.java
@@ -42,7 +42,7 @@ public class RpcObjectList<T extends JavaScriptObject> extends JavaScriptObject
 
    public final ArrayList<T> toArrayList()
    {
-      ArrayList<T> result = new ArrayList<T>(length());
+      ArrayList<T> result = new ArrayList<>(length());
       for (int i = 0; i < length(); i++)
          result.add(get(i));
       return result;

--- a/src/gwt/src/org/rstudio/core/client/layout/FadeOutAnimation.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/FadeOutAnimation.java
@@ -26,7 +26,7 @@ public class FadeOutAnimation extends Animation
 {
    public FadeOutAnimation(Widget widget, Command callback)
    {
-      List<Widget> widgets = new ArrayList<Widget>();
+      List<Widget> widgets = new ArrayList<>();
       widgets.add(widget);
       widgets_ = widgets;
       callback_ = callback;

--- a/src/gwt/src/org/rstudio/core/client/patch/SubstringDiff.java
+++ b/src/gwt/src/org/rstudio/core/client/patch/SubstringDiff.java
@@ -47,7 +47,7 @@ public class SubstringDiff
    
    public TextChange[] asTextChanges() 
    {
-      ArrayList<TextChange> changes = new ArrayList<TextChange>();
+      ArrayList<TextChange> changes = new ArrayList<>();
       if (valid_)
       {
          if (offset_ > 0)

--- a/src/gwt/src/org/rstudio/core/client/tex/TexMagicComment.java
+++ b/src/gwt/src/org/rstudio/core/client/tex/TexMagicComment.java
@@ -24,7 +24,7 @@ public class TexMagicComment
 {
    public static ArrayList<TexMagicComment> parseComments(String code)
    {
-      ArrayList<TexMagicComment> comments = new ArrayList<TexMagicComment>();
+      ArrayList<TexMagicComment> comments = new ArrayList<>();
       
       Iterable<String> lines = StringUtil.getLineIterator(code);
       

--- a/src/gwt/src/org/rstudio/core/client/widget/AutocompleteSuggestionDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/AutocompleteSuggestionDisplay.java
@@ -35,7 +35,7 @@ public class AutocompleteSuggestionDisplay
    
    public AutocompleteSuggestionDisplay()
    {
-      showHandlers_ = new ArrayList<ShowSuggestionsHandler>();
+      showHandlers_ = new ArrayList<>();
       PopupPanel panel = getPopupPanel();
       if (panel != null)
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/DocPropMenuItem.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/DocPropMenuItem.java
@@ -72,7 +72,7 @@ public class DocPropMenuItem extends CheckableMenuItem
    @Override
    public void onInvoked()
    {
-      HashMap<String, String> props = new HashMap<String, String>();
+      HashMap<String, String> props = new HashMap<>();
       String target = targetValue_;
       
       // toggle behavior for boolean values: if our target was true but the

--- a/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FastSelectTable.java
@@ -395,7 +395,7 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
    {
       sortSelectedRows();
 
-      ArrayList<Integer> results = new ArrayList<Integer>();
+      ArrayList<Integer> results = new ArrayList<>();
       for (TableRowElement row : selectedRows_)
          results.add(codec_.physicalOffsetToLogicalOffset(table_,
                                                           row.getRowIndex()));
@@ -488,7 +488,7 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
    {
       sortSelectedRows();
 
-      ArrayList<TItemOutput> results = new ArrayList<TItemOutput>();
+      ArrayList<TItemOutput> results = new ArrayList<>();
       for (TableRowElement row : selectedRows_)
          results.add(codec_.getOutputForRow(row));
       return results;
@@ -509,7 +509,7 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
    {
       sortSelectedRows();
 
-      ArrayList<TItemOutput2> results = new ArrayList<TItemOutput2>();
+      ArrayList<TItemOutput2> results = new ArrayList<>();
       for (TableRowElement row : selectedRows_)
          results.add(codec_.getOutputForRow2(row));
       return results;
@@ -584,7 +584,7 @@ public class FastSelectTable<TItemInput, TItemOutput, TItemOutput2> extends Widg
 
    public ArrayList<TableRowElement> getSelectedRows()
    {
-      return new ArrayList<TableRowElement>(selectedRows_);
+      return new ArrayList<>(selectedRows_);
    }
 
    public Rectangle getSelectionRect()

--- a/src/gwt/src/org/rstudio/core/client/widget/LocalRepositoriesWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/LocalRepositoriesWidget.java
@@ -80,7 +80,7 @@ public class LocalRepositoriesWidget extends Composite
    }
    
    public ArrayList<String> getItems() {
-      ArrayList<String> items = new ArrayList<String>();
+      ArrayList<String> items = new ArrayList<>();
       int numItems = listBox_.getItemCount();
       for (int i = 0; i < numItems; ++i) {
          items.add(listBox_.getItemText(i));

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -232,10 +232,10 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       initialFilterText_ = filterText;
       shortcuts_ = ShortcutManager.INSTANCE;
       
-      changes_ = new HashMap<KeyboardShortcutEntry, KeyboardShortcutEntry>();
+      changes_ = new HashMap<>();
       buffer_ = new KeySequence();
       
-      table_ = new RStudioDataGrid<KeyboardShortcutEntry>(1000, RES, KEY_PROVIDER);
+      table_ = new RStudioDataGrid<>(1000, RES, KEY_PROVIDER);
       
       FlowPanel emptyWidget = new FlowPanel();
       Label emptyLabel = new Label("No bindings available");
@@ -285,7 +285,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       table_.setKeyboardSelectionHandler(new CellPreviewEvent.Handler<KeyboardShortcutEntry>()
       {
          private final AbstractCellTable.CellTableKeyboardSelectionHandler<KeyboardShortcutEntry> handler_ =
-               new AbstractCellTable.CellTableKeyboardSelectionHandler<KeyboardShortcutEntry>(table_);
+               new AbstractCellTable.CellTableKeyboardSelectionHandler<>(table_);
          
          @Override
          public void onCellPreview(CellPreviewEvent<KeyboardShortcutEntry> preview)
@@ -318,7 +318,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          }
       });
       
-      dataProvider_ = new ListDataProvider<KeyboardShortcutEntry>();
+      dataProvider_ = new ListDataProvider<>();
       dataProvider_.addDataDisplay(table_);
       
       addColumns();
@@ -361,7 +361,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          {
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
          
       });
@@ -438,13 +438,13 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          String id = newBinding.getId();
          
          // Get all commands with this ID.
-         List<KeyboardShortcutEntry> bindingsWithId = new ArrayList<KeyboardShortcutEntry>();
+         List<KeyboardShortcutEntry> bindingsWithId = new ArrayList<>();
          for (KeyboardShortcutEntry binding : originalBindings_)
             if (binding.getId() == id)
                bindingsWithId.add(binding);
          
          // Collect all shortcuts.
-         List<KeySequence> keys = new ArrayList<KeySequence>();
+         List<KeySequence> keys = new ArrayList<>();
          for (KeyboardShortcutEntry binding : bindingsWithId)
             keys.add(binding.getKeySequence());
             
@@ -735,7 +735,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       boolean isEmptyQuery = StringUtil.isNullOrEmpty(query);
       boolean customOnly = radioCustomized_.getValue();
       
-      List<KeyboardShortcutEntry> filtered = new ArrayList<KeyboardShortcutEntry>();
+      List<KeyboardShortcutEntry> filtered = new ArrayList<>();
       for (int i = 0; i < originalBindings_.size(); i++)
       {
          KeyboardShortcutEntry binding = originalBindings_.get(i);
@@ -1019,7 +1019,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
    
    private void collectShortcuts()
    {
-      final List<KeyboardShortcutEntry> bindings = new ArrayList<KeyboardShortcutEntry>();
+      final List<KeyboardShortcutEntry> bindings = new ArrayList<>();
       SerializedCommandQueue queue = new SerializedCommandQueue();
       
       // Load addins discovered as part of package exports. This registers
@@ -1150,7 +1150,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
                      int type = KeyboardShortcutEntry.TYPE_RSTUDIO_COMMAND;
                      boolean isCustom = customBindings.hasKey(id);
                      
-                     List<KeySequence> keySequences = new ArrayList<KeySequence>();
+                     List<KeySequence> keySequences = new ArrayList<>();
                      if (isCustom)
                         keySequences = customBindings.get(id).getKeyBindings();
                      else

--- a/src/gwt/src/org/rstudio/core/client/widget/MultipleItemSuggestTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MultipleItemSuggestTextBox.java
@@ -36,7 +36,7 @@ public class MultipleItemSuggestTextBox extends TextBoxBase
    
    public List<String> getItems()
    {
-      ArrayList<String> items = new ArrayList<String>();
+      ArrayList<String> items = new ArrayList<>();
       String text = super.getText();
       if (!StringUtil.isNullOrEmpty(text))
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WidgetListBox.java
@@ -328,8 +328,8 @@ public class WidgetListBox<T extends Widget>
    private VerticalPanel panel_;
    private VerticalPanel emptyTextBox_;
    private Label emptyTextLabel_;
-   private List<HTMLPanel> options_ = new ArrayList<HTMLPanel>();
-   private List<T> items_ = new ArrayList<T>();
+   private List<HTMLPanel> options_ = new ArrayList<>();
+   private List<T> items_ = new ArrayList<>();
 
    private Resources resources_;
    private ListStyle style_;

--- a/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Wizard.java
@@ -497,7 +497,7 @@ public class Wizard<I,T> extends ModalDialog<T>
     
    protected ArrayList<String> getWizardBodyStyles()
    {
-      ArrayList<String> classes = new ArrayList<String>();
+      ArrayList<String> classes = new ArrayList<>();
       classes.add(WizardResources.INSTANCE.styles().wizardBodyPanel());
       return classes;
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/WizardIntermediatePage.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardIntermediatePage.java
@@ -53,7 +53,7 @@ public abstract class WizardIntermediatePage<I,T> extends WizardPage<I,T>
    {
       // we have a single subpage, which is the next page we were initialized
       // with
-      ArrayList<WizardPage<I, T>> subPage = new ArrayList<WizardPage<I, T>>();
+      ArrayList<WizardPage<I, T>> subPage = new ArrayList<>();
       subPage.add(nextPage_);
       return subPage;
    }

--- a/src/gwt/src/org/rstudio/core/client/widget/WizardNavigationPage.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WizardNavigationPage.java
@@ -40,7 +40,7 @@ public class WizardNavigationPage<I,T> extends WizardPage<I,T>
            image,
            largeImage,
            pages,
-           pages1 -> new WizardPageSelector<I, T>(pages1));
+           pages1 -> new WizardPageSelector<>(pages1));
    }
 
    public WizardNavigationPage(String title,

--- a/src/gwt/src/org/rstudio/core/rebind/JavaScriptSerializerGenerator.java
+++ b/src/gwt/src/org/rstudio/core/rebind/JavaScriptSerializerGenerator.java
@@ -40,7 +40,7 @@ public class JavaScriptSerializerGenerator extends Generator
                             String typeName) throws UnableToCompleteException
     {
        TypeOracle oracle = context.getTypeOracle();
-       List<JClassType> classes = new ArrayList<JClassType>();
+       List<JClassType> classes = new ArrayList<>();
        
        // locate all the types annotated with JavaScriptSerializable
        for (JClassType classType : oracle.getTypes())

--- a/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
+++ b/src/gwt/src/org/rstudio/core/rebind/command/ShortcutsEmitter.java
@@ -92,7 +92,7 @@ public class ShortcutsEmitter
    
    private static List<String> preprocessShortcutValue(String shortcutValue)
    {
-      List<String> shortcuts = new ArrayList<String>();
+      List<String> shortcuts = new ArrayList<>();
       
       for (String keySequence : shortcutValue.split("\\|"))
       {
@@ -118,7 +118,7 @@ public class ShortcutsEmitter
                               String title,
                               String disableModes) throws UnableToCompleteException
    {
-      List<ShortcutKeyCombination> keys = new ArrayList<ShortcutKeyCombination>();
+      List<ShortcutKeyCombination> keys = new ArrayList<>();
       
       for (String keyCombination : shortcut.split("\\s+"))
       {

--- a/src/gwt/src/org/rstudio/studio/client/JavaScriptEventHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/JavaScriptEventHistory.java
@@ -62,7 +62,7 @@ public class JavaScriptEventHistory
    
    public JavaScriptEventHistory()
    {
-      queue_ = new LinkedList<EventData>();
+      queue_ = new LinkedList<>();
       registerEventListeners();
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/ResizableHeader.java
@@ -86,7 +86,7 @@ public class ResizableHeader extends Header<String>
    
    public ResizableHeader(AbstractCellTable<?> table, String text)
    {
-      super(new ResizableHeaderCell<String>(table));
+      super(new ResizableHeaderCell<>(table));
       
       table_ = table;
       text_ = text;
@@ -94,7 +94,7 @@ public class ResizableHeader extends Header<String>
       
       MouseDragHandler.addHandler(table_, new MouseDragHandler()
       {
-         List<Integer> columnWidths_ = new ArrayList<Integer>();
+         List<Integer> columnWidths_ = new ArrayList<>();
          
          @Override
          public boolean beginDrag(MouseDownEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationQuit.java
@@ -304,8 +304,7 @@ public class ApplicationQuit implements SaveActionChangedEvent.Handler,
       // multiple save targets
       else
       {
-         ArrayList<UnsavedChangesTarget> unsaved = 
-                                      new ArrayList<UnsavedChangesTarget>();
+         ArrayList<UnsavedChangesTarget> unsaved = new ArrayList<>();
          if (saveAction == SaveAction.SAVEASK && globalEnvTarget != null)
             unsaved.add(globalEnvTarget);
          unsaved.addAll(unsavedSourceDocs);

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -85,7 +85,7 @@ public class ApplicationUtils
    
    public static void removeQueryParam(String param)
    {
-      ArrayList<String> params = new ArrayList<String>();
+      ArrayList<String> params = new ArrayList<>();
       params.add(param);
       removeQueryParams(params);
    }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RVersionSelectWidget.java
@@ -68,7 +68,7 @@ public class RVersionSelectWidget extends SelectWidget
       boolean disambiguate = RVersionSpec.hasDuplicates(rVersions);
 
       // build list of choices
-      ArrayList<String> choices = new ArrayList<String>();
+      ArrayList<String> choices = new ArrayList<>();
 
       // include "default" label if requested
       if (includeSystemDefault)
@@ -91,7 +91,7 @@ public class RVersionSelectWidget extends SelectWidget
    private static String[] rVersionValues(JsArray<RVersionSpec> rVersions,
                                           boolean includeSystemDefault)
    {
-      ArrayList<String> values = new ArrayList<String>();
+      ArrayList<String> values = new ArrayList<>();
 
       if (includeSystemDefault)
          values.add(rVersionSpecToString(RVersionSpec.createEmpty()));

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogVisualization.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/RequestLogVisualization.java
@@ -306,7 +306,7 @@ public class RequestLogVisualization extends Composite
                      public void execute(String input)
                      {
                         CsvReader reader = new CsvReader(input);
-                        ArrayList<RequestLogEntry> entries = new ArrayList<RequestLogEntry>();
+                        ArrayList<RequestLogEntry> entries = new ArrayList<>();
                         Iterator<String[]> it = reader.iterator();
                         String now = it.next()[0];
                         while (it.hasNext())

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/addins/AddinsToolbarButton.java
@@ -241,7 +241,7 @@ public class AddinsToolbarButton extends ToolbarMenuButton
    
    private Map<String, List<RAddin>> organizeAddins()
    {
-      Map<String, List<RAddin>> organized = new HashMap<String, List<RAddin>>();
+      Map<String, List<RAddin>> organized = new HashMap<>();
       
       String query = searchWidget_.getValue().toLowerCase().trim();
       
@@ -260,7 +260,7 @@ public class AddinsToolbarButton extends ToolbarMenuButton
          String pkg = splat[0];
          
          if (!organized.containsKey(pkg))
-            organized.put(pkg, new ArrayList<RAddin>());
+            organized.put(pkg, new ArrayList<>());
          
          List<RAddin> addinList = organized.get(pkg);
          addinList.add(addin);

--- a/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/CommandLineHistory.java
@@ -88,7 +88,7 @@ public class CommandLineHistory
       return Math.max(0, Math.min(pos, history_.size()));
    }
 
-   private final ArrayList<String> history_ = new ArrayList<String>();
+   private final ArrayList<String> history_ = new ArrayList<>();
    private int historyPos_;
    // If you start typing a command, then go up in history, then go down,
    // then what you had previously typed should still be there. This is

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/BreakpointManager.java
@@ -149,7 +149,7 @@ public class BreakpointManager
 
       notifyServer(breakpoint, true, true);
 
-      ArrayList<Breakpoint> bps = new ArrayList<Breakpoint>();
+      ArrayList<Breakpoint> bps = new ArrayList<>();
       bps.add(breakpoint);
       return breakpoint;
    }
@@ -265,7 +265,7 @@ public class BreakpointManager
 
    public ArrayList<Breakpoint> getBreakpointsInFile(String fileName)
    {
-      ArrayList<Breakpoint> breakpoints = new ArrayList<Breakpoint>();
+      ArrayList<Breakpoint> breakpoints = new ArrayList<>();
       for (Breakpoint breakpoint: breakpoints_)
       {
          if (breakpoint.isInFile(fileName))
@@ -381,7 +381,7 @@ public class BreakpointManager
       // past to begin actually evaluating the function. Step past it
       // immediately.
       JsArray<CallFrame> frames = event.getCallFrames();
-      Set<FileFunction> activeFunctions = new TreeSet<FileFunction>();
+      Set<FileFunction> activeFunctions = new TreeSet<>();
       boolean hasSourceEquiv = false;
       for (int idx = 0; idx < frames.length(); idx++)
       {
@@ -409,7 +409,7 @@ public class BreakpointManager
       // For any functions that were previously active in the callstack but
       // are no longer active, enable any pending breakpoints for those
       // functions.
-      Set<FileFunction> enableFunctions = new TreeSet<FileFunction>();
+      Set<FileFunction> enableFunctions = new TreeSet<>();
       for (FileFunction function: activeFunctions_)
       {
          if (!activeFunctions.contains(function))
@@ -480,7 +480,7 @@ public class BreakpointManager
       {
          // Restarting R unloads all the packages, so mark all active package
          // breakpoints as inactive when this happens.
-         ArrayList<Breakpoint> breakpoints = new ArrayList<Breakpoint>();
+         ArrayList<Breakpoint> breakpoints = new ArrayList<>();
          for (Breakpoint breakpoint: breakpoints_)
          {
             if (breakpoint.isPackageBreakpoint())
@@ -497,8 +497,8 @@ public class BreakpointManager
 
    private void setFunctionBreakpoints(FileFunction function)
    {
-      ArrayList<String> steps = new ArrayList<String>();
-      final ArrayList<Breakpoint> breakpoints = new ArrayList<Breakpoint>();
+      ArrayList<String> steps = new ArrayList<>();
+      final ArrayList<Breakpoint> breakpoints = new ArrayList<>();
       for (Breakpoint breakpoint: breakpoints_)
       {
          if (function.containsBreakpoint(breakpoint))
@@ -537,8 +537,7 @@ public class BreakpointManager
       // look over the list of breakpoints in this function and see if any are
       // marked inactive, or if they need their steps refreshed (necessary
       // when a function has had steps added or removed in the editor)
-      final ArrayList<Breakpoint> inactiveBreakpoints =
-            new ArrayList<Breakpoint>();
+      final ArrayList<Breakpoint> inactiveBreakpoints = new ArrayList<>();
       int[] inactiveLines = new int[]{};
       int numLines = 0;
       for (Breakpoint breakpoint: breakpoints_)
@@ -609,7 +608,7 @@ public class BreakpointManager
 
    private void resetBreakpointsInPath(String path, boolean isFile)
    {
-      Set<FileFunction> functionsToBreak = new TreeSet<FileFunction>();
+      Set<FileFunction> functionsToBreak = new TreeSet<>();
       for (Breakpoint breakpoint: breakpoints_)
       {
          // set this breakpoint if it's a function breakpoint in the file
@@ -633,7 +632,7 @@ public class BreakpointManager
    private void markInactiveBreakpoint(Breakpoint breakpoint)
    {
       breakpoint.setState(Breakpoint.STATE_INACTIVE);
-      ArrayList<Breakpoint> breakpoints = new ArrayList<Breakpoint>();
+      ArrayList<Breakpoint> breakpoints = new ArrayList<>();
       breakpoints.add(breakpoint);
       notifyBreakpointsSaved(breakpoints, true);
    }
@@ -642,8 +641,7 @@ public class BreakpointManager
          ArrayList<Breakpoint> breakpoints,
          JsArray<FunctionSteps> stepList)
    {
-      ArrayList<Breakpoint> unSettableBreakpoints =
-            new ArrayList<Breakpoint>();
+      ArrayList<Breakpoint> unSettableBreakpoints = new ArrayList<>();
 
       // Walk through the array of breakpoints for which we requested function
       // steps and the array of results from the server in lock-step, populating
@@ -716,8 +714,8 @@ public class BreakpointManager
 
    private void updatePackageBreakpoints(String packageName, boolean enable)
    {
-      Set<FileFunction> functionsToBreak = new TreeSet<FileFunction>();
-      ArrayList<Breakpoint> breakpointsToDisable = new ArrayList<Breakpoint>();
+      Set<FileFunction> functionsToBreak = new TreeSet<>();
+      ArrayList<Breakpoint> breakpointsToDisable = new ArrayList<>();
       for (Breakpoint breakpoint: breakpoints_)
       {
          if (breakpoint.isPackageBreakpoint() &&
@@ -749,7 +747,7 @@ public class BreakpointManager
 
    private void clearAllBreakpoints()
    {
-      Set<FileFunction> functions = new TreeSet<FileFunction>();
+      Set<FileFunction> functions = new TreeSet<>();
       for (Breakpoint breakpoint: breakpoints_)
       {
          breakpoint.setState(Breakpoint.STATE_REMOVING);
@@ -768,12 +766,12 @@ public class BreakpointManager
                function.functionName,
                function.fileName,
                function.packageName,
-               new ArrayList<String>(),
-               new QuietServerRequestCallback<Void>());
+               new ArrayList<>(),
+               new QuietServerRequestCallback<>());
       }
 
       server_.removeAllBreakpoints(new VoidServerRequestCallback());
-      notifyBreakpointsSaved(new ArrayList<Breakpoint>(breakpoints_), false);
+      notifyBreakpointsSaved(new ArrayList<>(breakpoints_), false);
       breakpoints_.clear();
       onBreakpointAddOrRemove();
    }
@@ -786,7 +784,7 @@ public class BreakpointManager
 
    private void notifyServer(Breakpoint breakpoint, boolean added, boolean arm)
    {
-      ArrayList<Breakpoint> bps = new ArrayList<Breakpoint>();
+      ArrayList<Breakpoint> bps = new ArrayList<>();
       bps.add(breakpoint);
       server_.updateBreakpoints(bps, added, arm,
                                 new VoidServerRequestCallback());
@@ -796,8 +794,7 @@ public class BreakpointManager
    {
       for (Breakpoint breakpoint: breakpoints_)
       {
-         ArrayList<Breakpoint> activatedBreakpoints =
-               new ArrayList<Breakpoint>();
+         ArrayList<Breakpoint> activatedBreakpoints = new ArrayList<>();
          if (breakpoint.isPendingDebugCompletion() &&
              breakpoint.getState() == Breakpoint.STATE_INACTIVE &&
              breakpoint.getType() == Breakpoint.TYPE_TOPLEVEL &&
@@ -886,8 +883,8 @@ public class BreakpointManager
    private final GlobalDisplay globalDisplay_;
    private final Commands commands_;
 
-   private ArrayList<Breakpoint> breakpoints_ = new ArrayList<Breakpoint>();
-   private Set<FileFunction> activeFunctions_ = new TreeSet<FileFunction>();
+   private ArrayList<Breakpoint> breakpoints_ = new ArrayList<>();
+   private Set<FileFunction> activeFunctions_ = new TreeSet<>();
    private String activeSource_;
 
    private boolean breakpointStateDirty_ = false;

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ErrorManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ErrorManager.java
@@ -171,7 +171,7 @@ public class ErrorManager
 
    private void setErrorManagementType(String type)
    {
-      setErrorManagementType(type, new QuietServerRequestCallback<Void>());
+      setErrorManagementType(type, new QuietServerRequestCallback<>());
    }
 
    private void syncHandlerCommandsCheckedState()

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/DependencyManager.java
@@ -93,8 +93,8 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    {
       globalDisplay_ = globalDisplay;
       server_ = server;
-      satisfied_ = new ArrayList<Dependency>();
-      requestQueue_ = new LinkedList<DependencyRequest>();
+      satisfied_ = new ArrayList<>();
+      requestQueue_ = new LinkedList<>();
       session_ = session;
       commands_ = commands;
       events_ = eventBus;
@@ -674,7 +674,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
 
    public void withTestPackage(final Command command, boolean useTestThat)
    {
-      List<Dependency> dependencies = new ArrayList<Dependency>();
+      List<Dependency> dependencies = new ArrayList<>();
       String message;
       if (useTestThat)
       {
@@ -776,7 +776,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
               String packageName,
               String packageVersion)
    {
-    ArrayList<Dependency> deps = new ArrayList<Dependency>();
+    ArrayList<Dependency> deps = new ArrayList<>();
       deps.add(Dependency.cranPackage(packageName, packageVersion));
 
       return deps;
@@ -1001,7 +1001,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
             public void onResponseReceived(String jobId)
             {   
                // Hold handler registration so we can clean it up when finished
-               final Value<HandlerRegistration> reg = new Value<HandlerRegistration>(null);
+               final Value<HandlerRegistration> reg = new Value<>(null);
                reg.setValue(events_.addHandler(JobUpdatedEvent.TYPE, event ->
                {
                   // Ensure the update is for this job
@@ -1124,7 +1124,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    
    private String describeDepPkgs(JsArray<Dependency> dependencies)
    {
-      ArrayList<String> deps = new ArrayList<String>();
+      ArrayList<String> deps = new ArrayList<>();
       for (int i = 0; i < dependencies.length(); i++)
          deps.add(dependencies.get(i).getName());
       return StringUtil.join(deps, ", ");
@@ -1144,7 +1144,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
          }
       }
 
-      List<Dependency> dependencies = new ArrayList<Dependency>();
+      List<Dependency> dependencies = new ArrayList<>();
       dependencies.add(dependency);
       withUnsatisfiedDependencies(dependencies, requestCallback);
    }
@@ -1226,7 +1226,7 @@ public class DependencyManager implements InstallShinyEvent.Handler,
    private ArrayList<Dependency> getFeatureDependencies(String feature)
    {
       // The list of R package dependencies to return
-      ArrayList<Dependency> dependencies = new ArrayList<Dependency>();
+      ArrayList<Dependency> dependencies = new ArrayList<>();
 
       // Read a list of package dependencies for this feature
       DependencyList list = session_.getSessionInfo().getPackageDependencies();

--- a/src/gwt/src/org/rstudio/studio/client/common/fileexport/FileExport.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/fileexport/FileExport.java
@@ -43,7 +43,7 @@ public class FileExport
    
    public void export(String caption, String description, FileSystemItem file)
    {
-      ArrayList<FileSystemItem> files = new ArrayList<FileSystemItem>();
+      ArrayList<FileSystemItem> files = new ArrayList<>();
       files.add(file);
       export(caption, description, null, files);
    }
@@ -111,7 +111,7 @@ public class FileExport
                   archiveName += ZIP;
                
                // build list of filenames
-               ArrayList<String> filenames = new ArrayList<String>();
+               ArrayList<String> filenames = new ArrayList<>();
                for (FileSystemItem file : files)
                   filenames.add(file.getName());
                

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/NewFileMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/NewFileMenu.java
@@ -42,7 +42,6 @@ public abstract class NewFileMenu
    protected abstract ArrayList<FileTypeCommands.CommandWithId> 
       getFileTypeCommands(FileTypeCommands fileTypeCommands);
    
-   private ArrayList<FileTypeCommands.CommandWithId> fileTypeCommands_ =
-         new ArrayList<FileTypeCommands.CommandWithId>();
+   private ArrayList<FileTypeCommands.CommandWithId> fileTypeCommands_ = new ArrayList<>();
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/ProfilerType.java
@@ -51,7 +51,7 @@ public class ProfilerType extends EditableFileType
 
    public HashSet<AppCommand> getSupportedCommands(Commands commands)
    {
-      HashSet<AppCommand> results = new HashSet<AppCommand>();
+      HashSet<AppCommand> results = new HashSet<>();
       results.add(commands.saveSourceDoc());
       results.add(commands.saveSourceDocAs());
       results.add(commands.saveProfileAs());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -299,7 +299,7 @@ public class TextFileType extends EditableFileType
 
    public HashSet<AppCommand> getSupportedCommands(Commands commands)
    {
-      HashSet<AppCommand> results = new HashSet<AppCommand>();
+      HashSet<AppCommand> results = new HashSet<>();
       results.add(commands.saveSourceDoc());
       results.add(commands.reopenSourceDocWithEncoding());
       results.add(commands.saveSourceDocAs());

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenDataFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenDataFileEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 public class OpenDataFileEvent extends GwtEvent<OpenDataFileHandler>
 {
-   public static final GwtEvent.Type<OpenDataFileHandler> TYPE =
-      new GwtEvent.Type<OpenDataFileHandler>();
+   public static final GwtEvent.Type<OpenDataFileHandler> TYPE = new GwtEvent.Type<>();
    
    public OpenDataFileEvent(FileSystemItem file)
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenFileInBrowserEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenFileInBrowserEvent.java
@@ -19,7 +19,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 public class OpenFileInBrowserEvent extends GwtEvent<OpenFileInBrowserHandler>
 {
-   public static Type<OpenFileInBrowserHandler> TYPE = new Type<OpenFileInBrowserHandler>();
+   public static Type<OpenFileInBrowserHandler> TYPE = new Type<>();
 
    public OpenFileInBrowserEvent(FileSystemItem file)
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenPresentationSourceFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenPresentationSourceFileEvent.java
@@ -22,8 +22,7 @@ import org.rstudio.studio.client.common.filetypes.TextFileType;
 
 public class OpenPresentationSourceFileEvent extends GwtEvent<OpenPresentationSourceFileHandler>
 {
-   public static final GwtEvent.Type<OpenPresentationSourceFileHandler> TYPE =
-      new GwtEvent.Type<OpenPresentationSourceFileHandler>();
+   public static final GwtEvent.Type<OpenPresentationSourceFileHandler> TYPE = new GwtEvent.Type<>();
 
    public OpenPresentationSourceFileEvent(FileSystemItem file, 
                                           TextFileType fileType,

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/OpenSourceFileEvent.java
@@ -27,8 +27,7 @@ import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 @JavaScriptSerializable
 public class OpenSourceFileEvent extends CrossWindowEvent<OpenSourceFileHandler>
 {
-   public static final GwtEvent.Type<OpenSourceFileHandler> TYPE =
-      new GwtEvent.Type<OpenSourceFileHandler>();
+   public static final GwtEvent.Type<OpenSourceFileHandler> TYPE = new GwtEvent.Type<>();
 
    public OpenSourceFileEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/WebTextInput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/WebTextInput.java
@@ -69,7 +69,7 @@ public class WebTextInput implements TextInput
       // This variable introduces a level of pointer indirection that lets us
       // get around passing TextEntryModalDialog a reference to itself in its
       // own constructor.
-      final Value<TextEntryModalDialog> pDialog = new Value<TextEntryModalDialog>(null);
+      final Value<TextEntryModalDialog> pDialog = new Value<>(null);
 
       final TextEntryModalDialog dialog = new TextEntryModalDialog(
             title,

--- a/src/gwt/src/org/rstudio/studio/client/common/latex/LatexProgramRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/latex/LatexProgramRegistry.java
@@ -73,7 +73,7 @@ public class LatexProgramRegistry
          JsArrayString types = 
                 pSession_.get().getSessionInfo().getLatexProgramTypes();
        
-         latexProgramTypes_ = new ArrayList<String>();
+         latexProgramTypes_ = new ArrayList<>();
          for (int i=0; i<types.length(); i++)
             latexProgramTypes_.add(types.get(i));
       }

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJax.java
@@ -77,9 +77,9 @@ public class MathJax
       prefs_ = prefs;
       popup_ = new MathJaxPopupPanel(this);
       renderQueue_ = new MathJaxRenderQueue(this);
-      handlers_ = new ArrayList<HandlerRegistration>();
-      cowToPlwMap_ = new SafeMap<ChunkOutputWidget, PinnedLineWidget>();
-      lwToPlwMap_ = new SafeMap<LineWidget, ChunkOutputWidget>();
+      handlers_ = new ArrayList<>();
+      cowToPlwMap_ = new SafeMap<>();
+      lwToPlwMap_ = new SafeMap<>();
 
       handlers_.add(popup_.addAttachHandler(new AttachEvent.Handler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxLoader.java
@@ -137,7 +137,7 @@ public class MathJaxLoader
       return el;
    }
    
-   private static List<Callback> MATHJAX_CALLBACKS = new ArrayList<Callback>();
+   private static List<Callback> MATHJAX_CALLBACKS = new ArrayList<>();
    private static boolean MATHJAX_LOADED = false;
    private static int RETRY_COUNT = 0;
    

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxRenderQueue.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxRenderQueue.java
@@ -26,7 +26,7 @@ public class MathJaxRenderQueue
    {
       mathjax_ = mathjax;
       
-      ranges_ = new LinkedList<Range>();
+      ranges_ = new LinkedList<>();
       callback_ = new MathJaxTypeset.Callback()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxUtil.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mathjax/MathJaxUtil.java
@@ -107,7 +107,7 @@ public class MathJaxUtil
    public static List<Range> findLatexChunks(DocDisplay docDisplay)
    {
       docDisplay.tokenizeDocument();
-      List<Range> ranges = new ArrayList<Range>();
+      List<Range> ranges = new ArrayList<>();
       
       Position startPos = null;
       for (int i = 0, n = docDisplay.getRowCount(); i < n; i++)

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
@@ -186,7 +186,7 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
          public void onResponseReceived(JsArray<CRANMirror> mirrors)
          {   
             // keep internal list of mirrors 
-            mirrors_ = new ArrayList<CRANMirror>(mirrors.length());
+            mirrors_ = new ArrayList<>(mirrors.length());
             
             // create list box and select default item
             listBox_ = new ListBox();

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -70,7 +70,7 @@ public class CRANMirror extends UserPrefs.CranMirror
    {
       setURL(cran);
 
-      ArrayList<String> entries = new ArrayList<String>();
+      ArrayList<String> entries = new ArrayList<>();
       for (CRANMirror repo : repos)
       {
          if (!repo.getName().toLowerCase().equals("cran"))
@@ -89,7 +89,7 @@ public class CRANMirror extends UserPrefs.CranMirror
 
    public final ArrayList<CRANMirror> getSecondaryRepos()
    {
-      ArrayList<CRANMirror> repos = new ArrayList<CRANMirror>();
+      ArrayList<CRANMirror> repos = new ArrayList<>();
 
       String secondary = getSecondary();
       if (StringUtil.isNullOrEmpty(secondary))

--- a/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/RTokenizer.java
@@ -30,7 +30,7 @@ public class RTokenizer
    
    public static ArrayList<RToken> asTokens(String code)
    {
-      ArrayList<RToken> results = new ArrayList<RToken>();
+      ArrayList<RToken> results = new ArrayList<>();
       RTokenizer rt = new RTokenizer(code);
       RToken t;
       while (null != (t = rt.nextToken()))

--- a/src/gwt/src/org/rstudio/studio/client/common/r/roxygen/RoxygenHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/r/roxygen/RoxygenHelper.java
@@ -796,7 +796,7 @@ public class RoxygenHelper
          Pattern.create("^\\s*#+'\\s*@[^@]", "");
    
    private static final ArrayList<String> ROXYGEN_ANNOTATABLE_CALLS =
-      new ArrayList<String>(
+      new ArrayList<>(
             Arrays.asList(new String[] {
             "setClass",
             "setRefClass",

--- a/src/gwt/src/org/rstudio/studio/client/common/rnw/RnwWeaveRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rnw/RnwWeaveRegistry.java
@@ -68,7 +68,7 @@ public class RnwWeaveRegistry
          JsArray<RnwWeave> types = 
                            pSession_.get().getSessionInfo().getRnwWeaveTypes();
        
-         weaveTypes_ = new ArrayList<RnwWeave>();
+         weaveTypes_ = new ArrayList<>();
          for (int i=0; i<types.length(); i++)
             weaveTypes_.add(types.get(i));
       }

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/AskSecretManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/AskSecretManager.java
@@ -31,7 +31,6 @@ import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.server.ServerError;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 
 import com.google.gwt.user.client.Window;
@@ -118,7 +117,7 @@ public class AskSecretManager
                               Debug.logError(error);
                               server.askSecretCompleted(
                                  null, false, false,
-                                 new SimpleRequestCallback<Void>());
+                                 new SimpleRequestCallback<>());
                            }
                         });
                   }
@@ -132,7 +131,7 @@ public class AskSecretManager
                      
                      server.askSecretCompleted(
                         null, false, false,
-                        new SimpleRequestCallback<Void>());
+                        new SimpleRequestCallback<>());
                   }
                }
             );
@@ -155,7 +154,7 @@ public class AskSecretManager
                   null, 
                   false,
                   false,
-                  new SimpleRequestCallback<Void>());
+                  new SimpleRequestCallback<>());
             }
             
          } 

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/DialogHtmlSanitizer.java
@@ -26,7 +26,7 @@ import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 
 public final class DialogHtmlSanitizer implements HtmlSanitizer {
-   private static final Set<String> TAG_WHITELIST = new HashSet<String>(
+   private static final Set<String> TAG_WHITELIST = new HashSet<>(
       Arrays.asList(
          "p", "em", "strong", "b", "i", "a"
       )

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/RStudioAPI.java
@@ -41,8 +41,6 @@ import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
-import org.rstudio.studio.client.server.Void;
-
 @Singleton
 public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
 {
@@ -110,7 +108,7 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
          @Override
          public void execute()
          {
-            server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+            server_.showDialogCompleted(null, false, new SimpleRequestCallback<>());
          }
       }, true, false);
       dlg.showModal();
@@ -136,14 +134,14 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
             {
                indicator.onCompleted();
                
-               server_.showDialogCompleted(input.input, false, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(input.input, false, new SimpleRequestCallback<>());
             }        
          }, 
          new Operation() {
             @Override
             public void execute()
             {
-               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<>());
             }
          });
    }
@@ -163,17 +161,17 @@ public class RStudioAPI implements RStudioAPIShowDialogEvent.Handler
          false,
          new Operation() {
             public void execute() {
-               server_.showDialogCompleted(null, true, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(null, true, new SimpleRequestCallback<>());
             }
          },
          new Operation() {
             public void execute() {
-               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<>());
             }
          },
          new Operation() {
             public void execute() {
-               server_.showDialogCompleted(null, false, new SimpleRequestCallback<Void>());
+               server_.showDialogCompleted(null, false, new SimpleRequestCallback<>());
             }
          },
          ok,

--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/SatelliteManager.java
@@ -187,7 +187,7 @@ public class SatelliteManager implements CloseHandler<Window>
       if (!pendingEventsBySatelliteName_.containsKey(name))
       {
          pendingEventsBySatelliteName_.put(name,
-                                           new ArrayList<JavaScriptObject>());
+                                           new ArrayList<>());
       }
 
       // record satellite params for subsequent setting (this value is read
@@ -367,7 +367,7 @@ public class SatelliteManager implements CloseHandler<Window>
             if (satelliteWnd.isClosed())
             {
                if (removeWindows == null)
-                  removeWindows = new ArrayList<ActiveSatellite>();
+                  removeWindows = new ArrayList<>();
                removeWindows.add(satellite);
             }
             else
@@ -510,7 +510,7 @@ public class SatelliteManager implements CloseHandler<Window>
          return;
 
       for (ActiveSatellite satellite :
-                                    new ArrayList<ActiveSatellite>(satellites_))
+                                    new ArrayList<>(satellites_))
       {
          if (satellite.getName() == name
              && !satellite.getWindow().isClosed())
@@ -659,14 +659,12 @@ public class SatelliteManager implements CloseHandler<Window>
    private final EventBus events_;
    private final Provider<SourceWindowManager> pSourceWindowManager_;
    private final Provider<ApplicationUncaughtExceptionHandler> pUncaughtExceptionHandler_;
-   private final ArrayList<ActiveSatellite> satellites_ = 
-                                          new ArrayList<ActiveSatellite>();
+   private final ArrayList<ActiveSatellite> satellites_ = new ArrayList<>();
    
-   private final HashMap<String,JavaScriptObject> satelliteParams_ = 
-                                new HashMap<String,JavaScriptObject>();
+   private final HashMap<String,JavaScriptObject> satelliteParams_ = new HashMap<>();
 
    private final HashMap<String, ArrayList<JavaScriptObject>>
-         pendingEventsBySatelliteName_ = new HashMap<String, ArrayList<JavaScriptObject>>();
+         pendingEventsBySatelliteName_ = new HashMap<>();
 
    private class ActiveSatellite
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerList.java
@@ -51,7 +51,7 @@ public class SourceMarkerList extends Composite
    {
       codec_ = new SourceMarkerItemCodec(res_, false);
 
-      errorTable_ = new FastSelectTable<SourceMarker, CodeNavigationTarget, CodeNavigationTarget>(
+      errorTable_ = new FastSelectTable<>(
             codec_,
             res_.styles().selectedRow(),
             true,
@@ -121,7 +121,7 @@ public class SourceMarkerList extends Composite
                            int autoSelect)
    {
       boolean showFileHeaders = false;
-      ArrayList<SourceMarker> errorList = new ArrayList<SourceMarker>();
+      ArrayList<SourceMarker> errorList = new ArrayList<>();
       int firstErrorIndex = -1;
       for (int i=0; i<errors.length(); i++)
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/SpellingService.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/SpellingService.java
@@ -79,7 +79,7 @@ public class SpellingService implements HasChangeHandlers
       final SpellCheckerResult spellCheckerResult = new SpellCheckerResult();
       
       // only send words to the server that aren't in the cache
-      final ArrayList<String> wordsToCheck = new ArrayList<String>();
+      final ArrayList<String> wordsToCheck = new ArrayList<>();
       for (int i = 0; i<words.size(); i++)
       {
          String word = words.get(i);
@@ -112,7 +112,7 @@ public class SpellingService implements HasChangeHandlers
          public void onResponseReceived(JsArrayInteger result)
          {
             // get misspelled indexes
-            ArrayList<Integer> misspelledIndexes = new ArrayList<Integer>();
+            ArrayList<Integer> misspelledIndexes = new ArrayList<>();
             for (int i=0; i<result.length(); i++)
                misspelledIndexes.add(result.get(i));
             
@@ -225,8 +225,7 @@ public class SpellingService implements HasChangeHandlers
    private final SpellingServerOperations server_;
    private final UserPrefs uiPrefs_;
    
-   private HashMap<String,Boolean> previousResults_ = 
-                                             new HashMap<String,Boolean>();
+   private HashMap<String,Boolean> previousResults_ = new HashMap<>();
    
    HandlerManager handlerManager_ = new HandlerManager(this);
    

--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/TypoSpellChecker.java
@@ -66,8 +66,8 @@ public class TypoSpellChecker
       {
          String path = GWT.getHostPageBaseURL() + "dictionaries/" + language_ + "/" + language_;
 
-         final Mutable<String> aff = new Mutable<String>();
-         final Mutable<String> dic = new Mutable<String>();
+         final Mutable<String> aff = new Mutable<>();
+         final Mutable<String> dic = new Mutable<>();
          final Command onReady = () -> {
 
             if (cancelled_ || aff.get() == null || dic.get() == null)

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/AskPassManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/AskPassManager.java
@@ -28,7 +28,6 @@ import org.rstudio.studio.client.common.crypto.RSAEncrypt;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.server.ServerError;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.AskPassEvent;
 
@@ -138,7 +137,7 @@ public class AskPassManager
 
                                     server.askpassCompleted(
                                        null, false,
-                                       new SimpleRequestCallback<Void>());
+                                       new SimpleRequestCallback<>());
                                  }
                               });
                      }
@@ -152,7 +151,7 @@ public class AskPassManager
                         
                         server.askpassCompleted(
                                            null, false,
-                                           new SimpleRequestCallback<Void>());
+                                           new SimpleRequestCallback<>());
                      }
                   });
          }
@@ -170,8 +169,8 @@ public class AskPassManager
                askpassPending_ = false;
                
                server.askpassCompleted(null, 
-                                        false,
-                                        new SimpleRequestCallback<Void>());
+                                       false,
+                                       new SimpleRequestCallback<>());
             }
             
          } 

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/StatusAndPath.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/StatusAndPath.java
@@ -54,7 +54,7 @@ public class StatusAndPath
       if (infos == null)
          return null;
 
-      ArrayList<StatusAndPath> result = new ArrayList<StatusAndPath>();
+      ArrayList<StatusAndPath> result = new ArrayList<>();
       for (int i = 0; i < infos.length(); i++)
       {
          result.add(new StatusAndPath(infos.get(i)));

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/Ignore.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/ignore/Ignore.java
@@ -230,7 +230,7 @@ public class Ignore
       // special case for empty path list -- make the project root the 
       // parent path and return an empty list
       if (paths.size() == 0)
-         return new IgnoreList("", new ArrayList<String>());
+         return new IgnoreList("", new ArrayList<>());
        
       // get the parent path of the first element
       FileSystemItem firstPath = FileSystemItem.createFile(paths.get(0));
@@ -238,7 +238,7 @@ public class Ignore
       
       // confirm that all of the elements start with that path and take the
       // remainder of their paths for our list
-      ArrayList<String> ignored = new ArrayList<String>();
+      ArrayList<String> ignored = new ArrayList<>();
       for (String path : paths)
       {
          String thisParent = 
@@ -278,7 +278,7 @@ public class Ignore
    private String getIgnored(IgnoreList ignoreList, String existingIgnored)
    {
       // split existing ignored into list
-      ArrayList<String> ignored = new ArrayList<String>();
+      ArrayList<String> ignored = new ArrayList<>();
       Iterable<String> existing = StringUtil.getLineIterator(existingIgnored);
       for (String item : existing)
       {

--- a/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/viewfile/ViewFilePanel.java
@@ -418,6 +418,5 @@ public class ViewFilePanel extends Composite implements TextDisplay
    
    private SaveFileAsHandler saveFileAsHandler_ = null;
    
-   private final ArrayList<HandlerRegistration> releaseOnDismiss_ =
-         new ArrayList<HandlerRegistration>();
+   private final ArrayList<HandlerRegistration> releaseOnDismiss_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -83,7 +83,7 @@ public class DataTable
             // no suggestions
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
       searchWidget_.addValueChangeHandler(new ValueChangeHandler<String>() {

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -96,7 +96,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       handler.onRStudioApiRequest(this);
    }
 
-   public static final Type<Handler> TYPE = new Type<Handler>();
+   public static final Type<Handler> TYPE = new Type<>();
    
    
    // Event Data ----

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/HTMLPreviewPresenter.java
@@ -327,8 +327,7 @@ public class HTMLPreviewPresenter implements IsWidget
    {
       if (lastSuccessfulPreview_.getEnableReexecute())
       {
-         server_.previewHTML(lastPreviewParams_, 
-                             new SimpleRequestCallback<Boolean>());
+         server_.previewHTML(lastPreviewParams_, new SimpleRequestCallback<>());
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowHTMLPreviewEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/htmlpreview/events/ShowHTMLPreviewEvent.java
@@ -20,8 +20,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class ShowHTMLPreviewEvent extends GwtEvent<ShowHTMLPreviewHandler>
 { 
-   public static final GwtEvent.Type<ShowHTMLPreviewHandler> TYPE =
-      new GwtEvent.Type<ShowHTMLPreviewHandler>();
+   public static final GwtEvent.Type<ShowHTMLPreviewHandler> TYPE = new GwtEvent.Type<>();
    
    public ShowHTMLPreviewEvent(HTMLPreviewParams params)
    {

--- a/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratActionDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratActionDialogContents.java
@@ -43,11 +43,11 @@ public class PackratActionDialogContents extends Composite {
          JsArray<PackratPackageAction> prRestoreActionsArray)
    {
       
-      prRestoreActionsList_ = new ArrayList<PackratPackageAction>();
+      prRestoreActionsList_ = new ArrayList<>();
       JsArrayUtil.fillList(prRestoreActionsArray, prRestoreActionsList_);
       
-      table_ = new RStudioDataGrid<PackratPackageAction>(prRestoreActionsList_.size(),
-            (PackagesDataGridCommon)GWT.create(PackagesDataGridCommon.class));
+      table_ = new RStudioDataGrid<>(prRestoreActionsList_.size(),
+            (PackagesDataGridCommon) GWT.create(PackagesDataGridCommon.class));
       table_.setRowData(prRestoreActionsList_);
       
       initTableColumns();
@@ -77,10 +77,10 @@ public class PackratActionDialogContents extends Composite {
    
    private void initTableColumns()
    {      
-      addColumn(table_, new SortableColumnWithHeader<PackratPackageAction>(prRestoreActionsList_, "package", "Package"));
-      addColumn(table_, new SortableColumnWithHeader<PackratPackageAction>(prRestoreActionsList_, "packrat.version", "Packrat"));
-      addColumn(table_, new SortableColumnWithHeader<PackratPackageAction>(prRestoreActionsList_, "library.version", "Library"));
-      addColumn(table_, new SortableColumnWithHeader<PackratPackageAction>(prRestoreActionsList_, "message", "Action"));
+      addColumn(table_, new SortableColumnWithHeader<>(prRestoreActionsList_, "package", "Package"));
+      addColumn(table_, new SortableColumnWithHeader<>(prRestoreActionsList_, "packrat.version", "Packrat"));
+      addColumn(table_, new SortableColumnWithHeader<>(prRestoreActionsList_, "library.version", "Library"));
+      addColumn(table_, new SortableColumnWithHeader<>(prRestoreActionsList_, "message", "Action"));
       
       table_.setColumnWidth(0, "15%");
       table_.setColumnWidth(1, "15%");

--- a/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratResolveConflictDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/packrat/ui/PackratResolveConflictDialog.java
@@ -72,7 +72,7 @@ public class PackratResolveConflictDialog
       mainWidget_.add(label);
             
       // table
-      table_ = new RStudioDataGrid<PackratConflictActions>(conflictActions.size(),
+      table_ = new RStudioDataGrid<>(conflictActions.size(),
             (PackagesDataGridCommon)GWT.create(PackagesDataGridCommon.class));
       StyleUtils.forceMacScrollbars(table_);
       table_.addStyleName(RESOURCES.styles().conflictsTable());

--- a/src/gwt/src/org/rstudio/studio/client/palette/AppCommandPaletteSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/AppCommandPaletteSource.java
@@ -42,9 +42,9 @@ public class AppCommandPaletteSource implements CommandPaletteEntryProvider
    @Override
    public List<CommandPaletteItem> getCommandPaletteItems()
    {
-      List<CommandPaletteItem> items = new ArrayList<CommandPaletteItem>();
-      List<String> sorted = new ArrayList<String>();
-      Set<String> unsorted = new HashSet<String>();
+      List<CommandPaletteItem> items = new ArrayList<>();
+      List<String> sorted = new ArrayList<>();
+      Set<String> unsorted = new HashSet<>();
       unsorted.addAll(commands_.getCommands().keySet());
 
       // Front-load the first page of results with some useful commands; we don't attempt to sort

--- a/src/gwt/src/org/rstudio/studio/client/palette/CommandPaletteLauncher.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/CommandPaletteLauncher.java
@@ -81,7 +81,7 @@ public class CommandPaletteLauncher implements CommandPalette.Host
          // to use the Command Palette as a quick "run last command again" tool
          if (mru_ == null)
          {
-            mru_ = new ArrayList<CommandPaletteMruEntry>();
+            mru_ = new ArrayList<>();
          }
          mru_.removeIf(entry -> entry.equals(evt.getMruEntry()));
          mru_.add(0, evt.getMruEntry());
@@ -124,7 +124,7 @@ public class CommandPaletteLauncher implements CommandPalette.Host
    private void createPanel()
    {
       // Extra sources (currently only the source tab)
-      List<CommandPaletteEntryProvider> providers = new ArrayList<CommandPaletteEntryProvider>();
+      List<CommandPaletteEntryProvider> providers = new ArrayList<>();
       
       // Create sources
       providers.add(new AppCommandPaletteSource(ShortcutManager.INSTANCE, commands_));
@@ -144,7 +144,7 @@ public class CommandPaletteLauncher implements CommandPalette.Host
             ArrayList<String> mru = evt.getList();
 
             // After the first time the palette is shown, the MRU is updated by this event handler.
-            mru_ = new ArrayList<CommandPaletteMruEntry>();
+            mru_ = new ArrayList<>();
             for (String entry: mru)
             {
                CommandPaletteMruEntry mruEntry = CommandPaletteMruEntry.fromString(entry);

--- a/src/gwt/src/org/rstudio/studio/client/palette/RAddinPaletteSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/RAddinPaletteSource.java
@@ -26,7 +26,6 @@ import org.rstudio.core.client.command.KeySequence;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
-import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
 import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.palette.ui.CommandPalette;
 import org.rstudio.studio.client.workbench.addins.Addins.AddinExecutor;
@@ -49,7 +48,7 @@ public class RAddinPaletteSource implements CommandPaletteEntryProvider
    @Override
    public List<CommandPaletteItem> getCommandPaletteItems()
    {
-      List<CommandPaletteItem> items = new ArrayList<CommandPaletteItem>();
+      List<CommandPaletteItem> items = new ArrayList<>();
       for (String id: JsUtil.asIterable(addins_.keys()))
       {
          RAddin addin = addins_.get(id);

--- a/src/gwt/src/org/rstudio/studio/client/palette/UserPrefPaletteSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/UserPrefPaletteSource.java
@@ -40,7 +40,7 @@ public class UserPrefPaletteSource implements CommandPaletteEntryProvider
    @Override
    public List<CommandPaletteItem> getCommandPaletteItems()
    {
-      List<CommandPaletteItem> items = new ArrayList<CommandPaletteItem>();
+      List<CommandPaletteItem> items = new ArrayList<>();
       for (PrefValue<?> val: prefs_.allPrefs())
       {
          if (StringUtil.isNullOrEmpty(val.getTitle()))

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWidget.java
@@ -133,7 +133,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
          PanmirrorFormat format = formatSource.getFormat(new PanmirrorUITools().format);
                
          // create the editor
-         new PromiseWithProgress<PanmirrorEditor>(
+         new PromiseWithProgress<>(
             PanmirrorEditor.create(editorWidget.editorParent_.getElement(), context, format, options),
             null,
             progressDelay,
@@ -390,7 +390,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
                            int progressDelay,
                            CommandWithArg<JsObject> completed) 
    {
-      new PromiseWithProgress<JsObject>(
+      new PromiseWithProgress<>(
          editor_.setMarkdown(code, options, emitUpdate),
          null,
          progressDelay,
@@ -399,7 +399,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    }
    
    public void getMarkdown(PanmirrorWriterOptions options, int progressDelay, CommandWithArg<JsObject> completed) {
-      new PromiseWithProgress<JsObject>(
+      new PromiseWithProgress<>(
          editor_.getMarkdown(options),
          null,
          progressDelay,
@@ -409,7 +409,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    
    public void getCanonical(String code, PanmirrorWriterOptions options, int progressDelay, CommandWithArg<String> completed)
    {
-      new PromiseWithProgress<String>(
+      new PromiseWithProgress<>(
          editor_.getCanonical(code, options),
          null,
          progressDelay,
@@ -581,7 +581,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    
    public Promise<Boolean> showContextMenu(PanmirrorMenuItem[] items, int clientX, int clientY)
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          
          final PanmirrorToolbarMenu menu = new PanmirrorToolbarMenu(commands_);
          menu.addCloseHandler((event) -> {
@@ -744,7 +744,7 @@ public class PanmirrorWidget extends DockLayoutPanel implements
    
    private final HandlerManager handlers_ = new HandlerManager(this);
    private final HandlerRegistrations registrations_ = new HandlerRegistrations();
-   private final ArrayList<JsVoidFunction> editorEventUnsubscribe_ = new ArrayList<JsVoidFunction>();
+   private final ArrayList<JsVoidFunction> editorEventUnsubscribe_ = new ArrayList<>();
 }
 
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommandIcons.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommandIcons.java
@@ -88,6 +88,6 @@ public class PanmirrorCommandIcons
    
    public static PanmirrorCommandIcons INSTANCE = new PanmirrorCommandIcons();
    
-   private HashMap<String,ImageResource> icons_ = new HashMap<String,ImageResource>();
+   private HashMap<String,ImageResource> icons_ = new HashMap<>();
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommandPaletteEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommandPaletteEntry.java
@@ -59,7 +59,7 @@ public class PanmirrorCommandPaletteEntry extends CommandPaletteCommand
 
    private static List<KeySequence> keySequence(PanmirrorCommandUI command)
    {
-      List<KeySequence> keys = new ArrayList<KeySequence>();
+      List<KeySequence> keys = new ArrayList<>();
       KeySequence keySequence = command.getKeySequence();
       if (keySequence != null)
          keys.add(keySequence);

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbar.java
@@ -230,5 +230,5 @@ public class PanmirrorToolbar extends SecondaryToolbar implements RequiresResize
    
    private PanmirrorToolbarCommands commands_ = null;
    private PanmirrorMenus menus_ = null;
-   private ArrayList<PanmirrorCommandUIObject> commandObjects_ = new ArrayList<PanmirrorCommandUIObject>();
+   private ArrayList<PanmirrorCommandUIObject> commandObjects_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
@@ -22,7 +22,6 @@ import java.util.List;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
-import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
 import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 
 import com.google.gwt.aria.client.MenuitemRole;
@@ -170,7 +169,7 @@ public class PanmirrorToolbarCommands implements CommandPaletteEntryProvider
    @Override
    public List<CommandPaletteItem> getCommandPaletteItems()
    {
-      List<CommandPaletteItem> items = new ArrayList<CommandPaletteItem>();
+      List<CommandPaletteItem> items = new ArrayList<>();
       for (PanmirrorCommandUI cmd: commandsUI_.values())
       {
          if (cmd != null && cmd.isVisible())
@@ -245,5 +244,5 @@ public class PanmirrorToolbarCommands implements CommandPaletteEntryProvider
    }
    
    private PanmirrorCommand[] commands_ = null;
-   private final HashMap<String,PanmirrorCommandUI> commandsUI_ = new HashMap<String,PanmirrorCommandUI>();
+   private final HashMap<String,PanmirrorCommandUI> commandsUI_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarRadioMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarRadioMenu.java
@@ -83,6 +83,6 @@ public class PanmirrorToolbarRadioMenu extends ToolbarMenuButton implements Panm
    private final String defaultText_;
    private int minWidth_ = 0;
    private final PanmirrorToolbarMenu menu_;
-   private final ArrayList<String> commandIds_ = new ArrayList<String>();
+   private final ArrayList<String> commandIds_ = new ArrayList<>();
    private final PanmirrorToolbarCommands commands_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorDialogs.java
@@ -71,7 +71,7 @@ public class PanmirrorDialogs {
    
    public Promise<Boolean> alert(String message, String title, int type) 
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          int alertType = MessageDisplay.MSG_INFO;
          switch(type) {
             case AlertType.Info:
@@ -98,7 +98,7 @@ public class PanmirrorDialogs {
    
    public Promise<Boolean> yesNoMessage(String message, String title, int type, String yesLabel, String noLabel) 
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          int alertType = MessageDisplay.MSG_INFO;
          switch(type) {
             case AlertType.Info:
@@ -147,7 +147,7 @@ public class PanmirrorDialogs {
    public Promise<PanmirrorLinkEditResult> editLink(
       PanmirrorLinkProps link, PanmirrorLinkTargets targets, PanmirrorLinkCapabilities capabilities)
    {
-      return new Promise<PanmirrorLinkEditResult>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorLinkEditResult> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditLinkDialog dialog = new PanmirrorEditLinkDialog(link, targets, capabilities,
                (result) -> { resolve.onInvoke(result); }
@@ -159,7 +159,7 @@ public class PanmirrorDialogs {
    
    public Promise<PanmirrorImageProps> editImage(PanmirrorImageProps image, PanmirrorImageDimensions dims, boolean editAttributes)
    {
-      return new Promise<PanmirrorImageProps>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorImageProps> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditImageDialog dialog = new PanmirrorEditImageDialog(image, dims, editAttributes, uiContext_,
                (result) -> { resolve.onInvoke(result); }
@@ -171,7 +171,7 @@ public class PanmirrorDialogs {
    
    public Promise<PanmirrorCodeBlockProps> editCodeBlock(PanmirrorCodeBlockProps codeBlock, boolean attributes, String[] languages)
    {
-      return new Promise<PanmirrorCodeBlockProps>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorCodeBlockProps> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditCodeBlockDialog dialog = new PanmirrorEditCodeBlockDialog(codeBlock, attributes, languages,
                (result) -> { resolve.onInvoke(result); }
@@ -184,7 +184,7 @@ public class PanmirrorDialogs {
    public Promise<PanmirrorListProps> editList(PanmirrorListProps props, 
                                                PanmirrorListCapabilities capabilities)
    {
-      return new Promise<PanmirrorListProps>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorListProps> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditListDialog dialog = new PanmirrorEditListDialog(props, capabilities,
                (result) -> { resolve.onInvoke(result); }
@@ -213,7 +213,7 @@ public class PanmirrorDialogs {
 
    private Promise<PanmirrorAttrEditResult> editPanmirrorAttr(String caption, String removeButtonCaption, String idHint, PanmirrorAttrProps attr) 
    {
-      return new Promise<PanmirrorAttrEditResult>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorAttrEditResult> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditAttrDialog dialog = new PanmirrorEditAttrDialog(caption, removeButtonCaption, idHint, attr, 
                (result) -> { resolve.onInvoke(result); }
@@ -237,7 +237,7 @@ public class PanmirrorDialogs {
 
    private Promise<PanmirrorRawFormatResult> editRaw(PanmirrorRawFormatProps raw, String[] outputFormats, boolean inline)
    {
-      return new Promise<PanmirrorRawFormatResult>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorRawFormatResult> resolve, RejectCallbackFn reject) -> {  
             PanmirrorEditRawDialog dialog = new PanmirrorEditRawDialog(raw, outputFormats, inline, 
                (result) -> { resolve.onInvoke(result); }
@@ -249,7 +249,7 @@ public class PanmirrorDialogs {
    
    public Promise<PanmirrorInsertTableResult> insertTable(PanmirrorTableCapabilities capabilities)
    {
-      return new Promise<PanmirrorInsertTableResult>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorInsertTableResult> resolve, RejectCallbackFn reject) -> {  
             PanmirrorInsertTableDialog dialog = new PanmirrorInsertTableDialog(capabilities, (result) -> {
                resolve.onInvoke(result);
@@ -261,7 +261,7 @@ public class PanmirrorDialogs {
    
    public Promise<PanmirrorInsertCiteResult> insertCite(PanmirrorInsertCiteProps citeProps)
    {
-      return new Promise<PanmirrorInsertCiteResult>(
+      return new Promise<>(
          (ResolveCallbackFn<PanmirrorInsertCiteResult> resolve, RejectCallbackFn reject) -> {  
             PanmirrorInsertCiteDialog dialog = new PanmirrorInsertCiteDialog(citeProps, (result) -> {
                resolve.onInvoke(result);
@@ -276,7 +276,7 @@ public class PanmirrorDialogs {
                                       JsVoidFunction focus,
                                       PanmirrorHTMLDialog.ValidateFn validate)
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          PanmirrorHTMLDialog dialog = new PanmirrorHTMLDialog(title, okText, create, focus, validate, (result) -> {
             resolve.onInvoke(result);
          });

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.java
@@ -70,7 +70,7 @@ public class PanmirrorEditListDialog extends ModalDialog<PanmirrorListProps>
       numberStyle_.setVisible(capabilities.fancy);
       numberDelimiter_.setVisible(capabilities.fancy);
       
-      List<String> numberStyleChoices = new ArrayList<String>();
+      List<String> numberStyleChoices = new ArrayList<>();
       numberStyleChoices.add("DefaultStyle");
       numberStyleChoices.add("Decimal");
       numberStyleChoices.add("LowerRoman");

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorLangSuggestBox.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorLangSuggestBox.java
@@ -59,7 +59,7 @@ public class PanmirrorLangSuggestBox extends SuggestBox
          {
             String query = request.getQuery();
             
-            ArrayList<Suggestion> suggestions = new ArrayList<Suggestion>();
+            ArrayList<Suggestion> suggestions = new ArrayList<>();
             for (int i=0; i<languages.length; i++)
             {
                String language = languages[i];

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorRawFormatSelect.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorRawFormatSelect.java
@@ -37,7 +37,7 @@ public class PanmirrorRawFormatSelect extends SelectWidget
    
    private static String[] getFormatList(String firstItem, String[] formats, String value)
    {
-      ArrayList<String> options = new ArrayList<String>();
+      ArrayList<String> options = new ArrayList<>();
       options.add(firstItem);
       options.addAll(Arrays.asList(formats));
       if (!options.contains(value))

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorBlurEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorBlurEvent.java
@@ -44,7 +44,7 @@ public class PanmirrorBlurEvent extends
 
   public static Type<PanmirrorBlurEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorBlurEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorFindReplaceVisibleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorFindReplaceVisibleEvent.java
@@ -78,7 +78,7 @@ public class PanmirrorFindReplaceVisibleEvent extends
    */
   public static Type<PanmirrorFindReplaceVisibleEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorFindReplaceVisibleEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorFocusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorFocusEvent.java
@@ -44,7 +44,7 @@ public class PanmirrorFocusEvent extends
 
   public static Type<PanmirrorFocusEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorFocusEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorNavigationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorNavigationEvent.java
@@ -80,7 +80,7 @@ public class PanmirrorNavigationEvent extends
    */
   public static Type<PanmirrorNavigationEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorNavigationEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineNavigationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineNavigationEvent.java
@@ -78,7 +78,7 @@ public class PanmirrorOutlineNavigationEvent extends
    */
   public static Type<PanmirrorOutlineNavigationEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorOutlineNavigationEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineVisibleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineVisibleEvent.java
@@ -78,7 +78,7 @@ public class PanmirrorOutlineVisibleEvent extends
    */
   public static Type<PanmirrorOutlineVisibleEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorOutlineVisibleEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineWidthEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorOutlineWidthEvent.java
@@ -78,7 +78,7 @@ public class PanmirrorOutlineWidthEvent extends
    */
   public static Type<PanmirrorOutlineWidthEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorOutlineWidthEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorStateChangeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorStateChangeEvent.java
@@ -44,7 +44,7 @@ public class PanmirrorStateChangeEvent extends
 
   public static Type<PanmirrorStateChangeEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorStateChangeEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorUpdatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/events/PanmirrorUpdatedEvent.java
@@ -44,7 +44,7 @@ public class PanmirrorUpdatedEvent extends
 
   public static Type<PanmirrorUpdatedEvent.Handler> getType() {
     if (TYPE == null) {
-      TYPE = new Type<PanmirrorUpdatedEvent.Handler>();
+      TYPE = new Type<>();
     }
     return TYPE;
   }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/outline/PanmirrorOutlineWidget.java
@@ -195,7 +195,7 @@ public class PanmirrorOutlineWidget extends Composite
    
    private ArrayList<PanmirrorOutlineItem> flattenOutline(PanmirrorOutlineItem[] items)
    {
-      ArrayList<PanmirrorOutlineItem> flattenedItems = new ArrayList<PanmirrorOutlineItem>();
+      ArrayList<PanmirrorOutlineItem> flattenedItems = new ArrayList<>();
       String chunkPref = pPrefs_.get().docOutlineShow().getValue();
       doFlattenOutline(items, flattenedItems, chunkPref);
       return flattenedItems;

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/pandoc/PanmirrorPandocServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/pandoc/PanmirrorPandocServer.java
@@ -46,9 +46,9 @@ public class PanmirrorPandocServer {
    
    public Promise<JavaScriptObject> getCapabilities()
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.pandocGetCapabilities(
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }
@@ -59,58 +59,58 @@ public class PanmirrorPandocServer {
       // ever write stdin if it's empty)
       final String input = !StringUtil.isNullOrEmpty(markdown) ? markdown : " ";
       
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          
          server_.pandocMarkdownToAst(
             input, format, options, 
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }
    
    public Promise<String> astToMarkdown(JavaScriptObject ast, String format, JsArrayString options)
    {
-      return new Promise<String>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
          server_.pandocAstToMarkdown(
             ast, format, options, 
-            new PromiseServerRequestCallback<String>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }
    
    public Promise<JavaScriptObject> getBibliography(String file, JsArrayString bibliographies, String refBlock, String etag)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {       
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {       
           server_.pandocGetBibliography(
             file,
             bibliographies,
             refBlock,
             etag,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject, "Reading bibliography...", 1500)
+            new PromiseServerRequestCallback<>(resolve, reject, "Reading bibliography...", 1500)
          );
       });
    }
    
    public Promise<Boolean> addToBibliography(String bibliography, boolean project, String id, String sourceAsJson, String sourceAsBibTeX)
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {       
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {       
          server_.pandocAddToBibliography(
            bibliography,
            project,
            id,
            sourceAsJson,
            sourceAsBibTeX,
-           new PromiseServerRequestCallback<Boolean>(resolve, reject, "Saving biliography...", 1500)
+           new PromiseServerRequestCallback<>(resolve, reject, "Saving biliography...", 1500)
         );
      }); 
    }
    
    public Promise<String> citationHTML(String file, String sourceAsJson, String csl)
    {
-      return new Promise<String>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
          server_.pandocCitationHTML(
             file, sourceAsJson, csl,
-            new PromiseServerRequestCallback<String>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }
@@ -118,8 +118,8 @@ public class PanmirrorPandocServer {
 
    public Promise<String> listExtensions(String format)
    {
-      return new Promise<String>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
-         server_.pandocListExtensions(format, new PromiseServerRequestCallback<String>(resolve, reject));
+      return new Promise<>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
+         server_.pandocListExtensions(format, new PromiseServerRequestCallback<>(resolve, reject));
       });
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorCrossrefServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorCrossrefServer.java
@@ -42,10 +42,10 @@ public class PanmirrorCrossrefServer
    
    public Promise<JavaScriptObject> works(String query)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.crossrefWorks(
             query,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorDOIServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorDOIServer.java
@@ -43,10 +43,10 @@ public class PanmirrorDOIServer
    
    public Promise<JavaScriptObject> fetchCSL(String doi, int delayMs)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.doiFetchCSL(
         		doi,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject, "Looking up DOI...", delayMs)
+            new PromiseServerRequestCallback<>(resolve, reject, "Looking up DOI...", delayMs)
          );
       });
    }   

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorDataCiteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorDataCiteServer.java
@@ -42,10 +42,10 @@ public class PanmirrorDataCiteServer
    
    public Promise<JavaScriptObject> search(String query)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.dataciteSearch(
             query,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorPubMedServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorPubMedServer.java
@@ -42,10 +42,10 @@ public class PanmirrorPubMedServer
    
    public Promise<JavaScriptObject> search(String query)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.pubmedSearch(
             query,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorXRefServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorXRefServer.java
@@ -42,21 +42,21 @@ public class PanmirrorXRefServer
    
    public Promise<JavaScriptObject> indexForFile(String file)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.xrefIndexForFile(
             file,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }
    
    public Promise<JavaScriptObject> xrefForId(String file, String id)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.xrefForId(
             file,
             id,
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorZoteroServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/server/PanmirrorZoteroServer.java
@@ -44,9 +44,9 @@ public class PanmirrorZoteroServer
 
    public Promise<Boolean> validateWebAPIKey(String key)
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          server_.zoteroValidateWebAPIKey(key,
-               new PromiseServerRequestCallback<Boolean>(resolve, reject));
+               new PromiseServerRequestCallback<>(resolve, reject));
       });
    }
 
@@ -54,28 +54,28 @@ public class PanmirrorZoteroServer
                                                    JsArray<PanmirrorZoteroCollectionSpec> cached,
                                                    boolean useCache)
    {
-      return new Promise<JavaScriptObject>(
+      return new Promise<>(
             (ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
                server_.zoteroGetCollections(file, collections, cached, useCache,
-                     new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject, "Loading Collections...", 2000));
+                     new PromiseServerRequestCallback<>(resolve, reject, "Loading Collections...", 2000));
             });
    }
 
    public Promise<JavaScriptObject> getLibraryNames()
    {
-      return new Promise<JavaScriptObject>(
+      return new Promise<>(
             (ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
                server_.zoteroGetLibraryNames(
-                     new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject));
+                     new PromiseServerRequestCallback<>(resolve, reject));
             });
    }
    
    public Promise<JavaScriptObject> getActiveCollectionSpecs(String file, JsArrayString collections)
    {
-      return new Promise<JavaScriptObject>(
+      return new Promise<>(
             (ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
                server_.zoteroGetActiveCollectionSpecs(file, collections,
-                  new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject, "Reading Collections...", 2000));
+                  new PromiseServerRequestCallback<>(resolve, reject, "Reading Collections...", 2000));
             });
    }
    
@@ -85,12 +85,12 @@ public class PanmirrorZoteroServer
                                                        String translatorId, 
                                                        int libraryID)
    {
-      return new Promise<JavaScriptObject>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<JavaScriptObject> resolve, RejectCallbackFn reject) -> {
          server_.zoteroBetterBibtexExport(
             itemKeys, 
             translatorId, 
             libraryID, 
-            new PromiseServerRequestCallback<JavaScriptObject>(resolve, reject)
+            new PromiseServerRequestCallback<>(resolve, reject)
          );
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIMath.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIMath.java
@@ -31,7 +31,7 @@ public class PanmirrorUIMath {
    
    public Promise<Boolean> typeset(Element el, String text, boolean priority)
    {
-      return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+      return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
          MathJaxLoader.withMathJaxLoaded((alreadyLoaded) -> {
             MathJaxTypeset.typeset(el, text, priority, (error) -> {
                resolve.onInvoke(error);

--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
@@ -374,7 +374,7 @@ public class PdfJsWindow extends WindowEx
       final double w = pdfLocation.getWidth() * factor;
       final double h = pdfLocation.getHeight() * factor;
       
-      final Value<Integer> retries = new Value<Integer>(0);
+      final Value<Integer> retries = new Value<>(0);
 
       // Sometimes pageContainer is null during load, so retry every 100ms
       // until it's not, or we've tried 40 times.

--- a/src/gwt/src/org/rstudio/studio/client/plumber/events/LaunchPlumberAPIEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/plumber/events/LaunchPlumberAPIEvent.java
@@ -30,7 +30,7 @@ public class LaunchPlumberAPIEvent
    }
 
    public static final GwtEvent.Type<LaunchPlumberAPIEvent.Handler> TYPE =
-      new GwtEvent.Type<LaunchPlumberAPIEvent.Handler>();
+      new GwtEvent.Type<>();
    
    public LaunchPlumberAPIEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/plumber/events/PlumberAPIStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/plumber/events/PlumberAPIStatusEvent.java
@@ -30,8 +30,7 @@ public class PlumberAPIStatusEvent
       void onPlumberAPIStatus(PlumberAPIStatusEvent event);
    }
 
-   public static final GwtEvent.Type<PlumberAPIStatusEvent.Handler> TYPE =
-      new GwtEvent.Type<PlumberAPIStatusEvent.Handler>();
+   public static final GwtEvent.Type<PlumberAPIStatusEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public PlumberAPIStatusEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -560,7 +560,7 @@ public class Projects implements OpenProjectFileHandler,
                   // not be currently installed; in those cases, verify that the package is
                   // installed and if not attempt installation from CRAN first
                   String pkg = newProject.getProjectTemplateOptions().getDescription().getPackage();
-                  ArrayList<Dependency> deps = new ArrayList<Dependency>();
+                  ArrayList<Dependency> deps = new ArrayList<>();
                   deps.add(Dependency.cranPackage(pkg));
                   RStudioGinjector.INSTANCE.getDependencyManager().withDependencies(
                         "Creating project",

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectErrorEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectErrorEvent.java
@@ -20,8 +20,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class OpenProjectErrorEvent extends GwtEvent<OpenProjectErrorHandler>
 {
-   public static final GwtEvent.Type<OpenProjectErrorHandler> TYPE =
-      new GwtEvent.Type<OpenProjectErrorHandler>();
+   public static final GwtEvent.Type<OpenProjectErrorHandler> TYPE = new GwtEvent.Type<>();
    
    public OpenProjectErrorEvent(OpenProjectError error)
    {

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectFileEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 public class OpenProjectFileEvent extends GwtEvent<OpenProjectFileHandler>
 {
-   public static final GwtEvent.Type<OpenProjectFileHandler> TYPE =
-      new GwtEvent.Type<OpenProjectFileHandler>();
+   public static final GwtEvent.Type<OpenProjectFileHandler> TYPE = new GwtEvent.Type<>();
    
    public OpenProjectFileEvent(FileSystemItem file)
    {

--- a/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectNewWindowEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/events/OpenProjectNewWindowEvent.java
@@ -20,8 +20,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class OpenProjectNewWindowEvent extends GwtEvent<OpenProjectNewWindowHandler>
 {
-   public static final GwtEvent.Type<OpenProjectNewWindowHandler> TYPE =
-      new GwtEvent.Type<OpenProjectNewWindowHandler>();
+   public static final GwtEvent.Type<OpenProjectNewWindowHandler> TYPE = new GwtEvent.Type<>();
    
    public OpenProjectNewWindowEvent(String project, RVersionSpec rVersion)
    {

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateRegistryProvider.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/ProjectTemplateRegistryProvider.java
@@ -40,7 +40,7 @@ public class ProjectTemplateRegistryProvider
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
-      pendingCallbacks_ = new ArrayList<Callback>();
+      pendingCallbacks_ = new ArrayList<>();
       
       events_.addHandler(ProjectTemplateRegistryUpdatedEvent.TYPE, this);
       

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -264,7 +264,7 @@ public class RProjectConfig extends JavaScriptObject
                                           boolean namespace,
                                           boolean vignette)
    {
-      ArrayList<String> roclets = new ArrayList<String>();
+      ArrayList<String> roclets = new ArrayList<>();
       if (rd)
          roclets.add(ROXYGENIZE_RD);
       if (collate)

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/CodeFilesList.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/CodeFilesList.java
@@ -81,7 +81,7 @@ public class CodeFilesList extends Composite
    
    public ArrayList<String> getCodeFiles()
    {
-      ArrayList<String> codeFiles = new ArrayList<String>();
+      ArrayList<String> codeFiles = new ArrayList<>();
       for (int i=0; i<listBox_.getItemCount(); i++)
          codeFiles.add(listBox_.getItemText(i));
       return codeFiles;

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryNavigationPage.java
@@ -75,8 +75,8 @@ public class NewDirectoryNavigationPage
    private static ArrayList<WizardPage<NewProjectInput, NewProjectResult>>
                                          createPages(SessionInfo sessionInfo)
    {
-      ArrayList<WizardPage<NewProjectInput, NewProjectResult>> pages = 
-            new ArrayList<WizardPage<NewProjectInput, NewProjectResult>>();
+      ArrayList<WizardPage<NewProjectInput, NewProjectResult>> pages =
+            new ArrayList<>();
       
       // add default RStudio dialogs
       pages.add(new NewDirectoryPage());

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPackratPreferencesPane.java
@@ -211,7 +211,7 @@ public class ProjectPackratPreferencesPane extends ProjectPreferencesPane
       List<String> values = Arrays.asList(value.split("\\s*,\\s*"));
 
       // remove entries that are only whitespace
-      ArrayList<String> result = new ArrayList<String>();
+      ArrayList<String> result = new ArrayList<>();
       for (String s : values)
       {
          if (!StringUtil.isNullOrEmpty(s))

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsWebsitePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/BuildToolsWebsitePanel.java
@@ -74,8 +74,8 @@ public class BuildToolsWebsitePanel extends BuildToolsPanel
          
          // get all available output formats
          JsArrayString formatsJson = buildContext.getWebsiteOutputFormats();
-         ArrayList<String> formatNames = new ArrayList<String>();
-         ArrayList<String> formats = new ArrayList<String>();
+         ArrayList<String> formatNames = new ArrayList<>();
+         ArrayList<String> formats = new ArrayList<>();
         
          // always include "All Formats"
          formatNames.add("(All Formats)");

--- a/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/renv/ui/RenvActionDialogContents.java
@@ -43,10 +43,10 @@ public class RenvActionDialogContents extends Composite
    public RenvActionDialogContents(String action, JsArray<RenvAction> actions)
    {
       action_ = action;
-      actions_ = new ArrayList<RenvAction>();
+      actions_ = new ArrayList<>();
       JsArrayUtil.fillList(actions, actions_);
       
-      table_ = new RStudioDataGrid<RenvAction>(actions.length(), RES);
+      table_ = new RStudioDataGrid<>(actions.length(), RES);
       
       table_.setHeight("500px");
       table_.setWidth("600px");

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/RmdOutput.java
@@ -431,7 +431,7 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
          public void execute()
          {
             server_.renderRmdSource(event.getSource(),
-                                    new SimpleRequestCallback<Boolean>()); 
+                                    new SimpleRequestCallback<>()); 
          }
       });
    }
@@ -860,10 +860,8 @@ public class RmdOutput implements RmdRenderStartedEvent.Handler,
 
    // stores the last scroll position of each document we know about: map
    // of path to position
-   private final Map<String, Integer> scrollPositions_ = 
-         new HashMap<String, Integer>();
-   private final Map<String, String> anchors_ = 
-         new HashMap<String, String>();
+   private final Map<String, Integer> scrollPositions_ = new HashMap<>();
+   private final Map<String, String> anchors_ = new HashMap<>();
    private RmdRenderResult result_;
    private RmdShinyDocInfo shinyDoc_;
    private Operation onRenderCompleted_;

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookQueueUnit.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookQueueUnit.java
@@ -130,7 +130,7 @@ public class NotebookQueueUnit extends JavaScriptObject
    private final List<Integer> linesFromRanges(
          JsArray<NotebookExecRange> ranges)
    {
-      List<Integer> lines = new ArrayList<Integer>();
+      List<Integer> lines = new ArrayList<>();
       final String code = getCode();
       int line = 0, last = -1;
       for (int i = 0; i < code.length(); i++)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlTree.java
@@ -121,7 +121,7 @@ public class YamlTree
       public String key;
       public int indentLevel = 0;
       public YamlTreeNode parent = null;
-      public List<YamlTreeNode> children = new ArrayList<YamlTreeNode>();
+      public List<YamlTreeNode> children = new ArrayList<>();
       
       private String getKey(String line)
       {
@@ -142,7 +142,7 @@ public class YamlTree
    public YamlTree(String yaml)
    {
       root_ = createYamlTree(yaml);
-      keyMap_ = new HashMap<String, YamlTreeNode>();
+      keyMap_ = new HashMap<>();
       createKeyMap(root_, keyMap_);
    }
    
@@ -182,7 +182,7 @@ public class YamlTree
          if (!keyMap_.containsKey(parentKey))
             return null;
          YamlTreeNode parent = keyMap_.get(parentKey);
-         ArrayList<String> result = new ArrayList<String>();
+         ArrayList<String> result = new ArrayList<>();
          for (YamlTreeNode child: parent.children)
          {
             result.add(child.key);

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdTemplateOptionsWidget.java
@@ -170,7 +170,7 @@ public class RmdTemplateOptionsWidget extends Composite
    
    private void updateFormatOptions(String format)
    {
-      tabs_ = new HashMap<String, FlowPanel>();
+      tabs_ = new HashMap<>();
       optionsTabs_.clear();
       for (int i = 0; i < formats_.length(); i++)
       {
@@ -193,7 +193,7 @@ public class RmdTemplateOptionsWidget extends Composite
       {
          labelFormatNotes_.setVisible(false);
       }
-      optionWidgets_ = new ArrayList<RmdFormatOption>();
+      optionWidgets_ = new ArrayList<>();
       JsArrayString options = format.getOptions();
       for (int i = 0; i < options.length(); i++)
       {
@@ -320,7 +320,7 @@ public class RmdTemplateOptionsWidget extends Composite
    private void applyFrontMatter(RmdFrontMatter frontMatter)
    {
       frontMatter_ = frontMatter;
-      frontMatterCache_ = new HashMap<String, String>();
+      frontMatterCache_ = new HashMap<>();
       ensureOptionsCache();
       JsArrayString formats = frontMatter.getFormatList();
       for (int i = 0; i < formats.length(); i++)
@@ -379,7 +379,7 @@ public class RmdTemplateOptionsWidget extends Composite
    {
       if (optionCache_ != null)
          return;
-      optionCache_ = new HashMap<String, RmdTemplateFormatOption>();
+      optionCache_ = new HashMap<>();
       for (int i = 0; i < options_.length(); i++)
       {
          RmdTemplateFormatOption option = options_.get(i);

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -1017,8 +1017,7 @@ public class RSConnect implements SessionInitEvent.Handler,
 
       // If we know the most recent deployment of the directory, act on that
       // deployment by default
-      final ArrayList<RSConnectDeploymentRecord> recordList =
-            new ArrayList<RSConnectDeploymentRecord>();
+      final ArrayList<RSConnectDeploymentRecord> recordList = new ArrayList<>();
       RSConnectDeploymentRecord lastRecord = dirState_.getLastDeployment(dir);
       if (lastRecord != null)
       {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/EnableRStudioConnectUIEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/EnableRStudioConnectUIEvent.java
@@ -37,8 +37,7 @@ public class EnableRStudioConnectUIEvent
       void onEnableRStudioConnectUI(EnableRStudioConnectUIEvent event);
    }
 
-   public static final GwtEvent.Type<EnableRStudioConnectUIEvent.Handler> TYPE =
-      new GwtEvent.Type<EnableRStudioConnectUIEvent.Handler>();
+   public static final GwtEvent.Type<EnableRStudioConnectUIEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public EnableRStudioConnectUIEvent(Data enable)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectActionEvent.java
@@ -28,8 +28,7 @@ public class RSConnectActionEvent extends GwtEvent<RSConnectActionEvent.Handler>
       void onRSConnectAction(RSConnectActionEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectActionEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectActionEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectActionEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public static RSConnectActionEvent ConfigureAppEvent(String path)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeployInitiatedEvent.java
@@ -28,8 +28,7 @@ public class RSConnectDeployInitiatedEvent extends GwtEvent<RSConnectDeployIniti
       void onRSConnectDeployInitiated(RSConnectDeployInitiatedEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectDeployInitiatedEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeployInitiatedEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeployInitiatedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeployInitiatedEvent(RSConnectPublishSource source,
                                         RSConnectPublishSettings settings,

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCancelledEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCancelledEvent.java
@@ -24,8 +24,7 @@ public class RSConnectDeploymentCancelledEvent extends GwtEvent<RSConnectDeploym
       void onRSConnectDeploymentCancelled(RSConnectDeploymentCancelledEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeploymentCancelledEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeploymentCancelledEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentCompletedEvent.java
@@ -24,8 +24,7 @@ public class RSConnectDeploymentCompletedEvent extends GwtEvent<RSConnectDeploym
       void onRSConnectDeploymentCompleted(RSConnectDeploymentCompletedEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectDeploymentCompletedEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeploymentCompletedEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeploymentCompletedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeploymentCompletedEvent(String url)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentFailedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentFailedEvent.java
@@ -40,8 +40,7 @@ public class RSConnectDeploymentFailedEvent extends GwtEvent<RSConnectDeployment
       }-*/;
    }
 
-   public static final GwtEvent.Type<RSConnectDeploymentFailedEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeploymentFailedEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeploymentFailedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeploymentFailedEvent(Data data)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentOutputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentOutputEvent.java
@@ -26,8 +26,7 @@ public class RSConnectDeploymentOutputEvent extends GwtEvent<RSConnectDeployment
       void onRSConnectDeploymentOutput(RSConnectDeploymentOutputEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectDeploymentOutputEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeploymentOutputEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeploymentOutputEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeploymentOutputEvent(CompileOutput output)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentStartedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/events/RSConnectDeploymentStartedEvent.java
@@ -24,8 +24,7 @@ public class RSConnectDeploymentStartedEvent extends GwtEvent<RSConnectDeploymen
       void onRSConnectDeploymentStarted(RSConnectDeploymentStartedEvent event);
    }
 
-   public static final GwtEvent.Type<RSConnectDeploymentStartedEvent.Handler> TYPE =
-      new GwtEvent.Type<RSConnectDeploymentStartedEvent.Handler>();
+   public static final GwtEvent.Type<RSConnectDeploymentStartedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public RSConnectDeploymentStartedEvent(String path, String title)
    {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/PlotPublishMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/PlotPublishMRUList.java
@@ -109,5 +109,5 @@ public class PlotPublishMRUList
    }
 
    private final WorkbenchList plotMru_;
-   private ArrayList<String> plotMruList_ = new ArrayList<String>();
+   private ArrayList<String> plotMruList_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishResult.java
@@ -20,7 +20,7 @@ public class RSConnectPublishResult
 {
    public RSConnectPublishResult(RSConnectPublishSource source)
    {
-      ArrayList<String> deployFiles = new ArrayList<String>();
+      ArrayList<String> deployFiles = new ArrayList<>();
       deployFiles.add(source.getDeployFile());
       publishType_ = PUBLISH_RPUBS;
       appName_     = ""; 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/NewRSConnectAuthPage.java
@@ -372,7 +372,7 @@ public class NewRSConnectAuthPage
    private RSConnectServerOperations server_;
    private GlobalDisplay display_;
    private RSConnectAuthWait contents_;
-   private Value<Boolean> waitingForAuth_ = new Value<Boolean>(false);
+   private Value<Boolean> waitingForAuth_ = new Value<>(false);
    private boolean runningAuthCompleteCheck_ = false;
    private ProgressIndicator wizardIndicator_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
@@ -38,9 +38,7 @@ public class PublishDocServicePage
            createPages(RSConnectPublishInput input)
    {
       ArrayList<WizardPage<RSConnectPublishInput, 
-                           RSConnectPublishResult>> pages =
-                           new ArrayList<WizardPage<RSConnectPublishInput, 
-                                                    RSConnectPublishResult>>();
+                           RSConnectPublishResult>> pages = new ArrayList<>();
       String rscTitle = RSConnectAccountWizard.SERVICE_NAME;
       String rscDesc = RSConnectAccountWizard.SERVICE_DESCRIPTION;
            

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishMultiplePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishMultiplePage.java
@@ -39,9 +39,7 @@ public class PublishMultiplePage
            createPages(RSConnectPublishInput input)
    {
       ArrayList<WizardPage<RSConnectPublishInput, 
-                           RSConnectPublishResult>> pages =
-                           new ArrayList<WizardPage<RSConnectPublishInput, 
-                                                    RSConnectPublishResult>>();
+                           RSConnectPublishResult>> pages = new ArrayList<>();
       String singleTitle = "Publish just this document";
       String singleSubtitle = "Only the document " + 
                               input.getSourceRmd().getName() + 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
@@ -44,9 +44,7 @@ public class PublishReportSourcePage
            createPages(RSConnectPublishInput input, boolean asMultiple)
    {
       ArrayList<WizardPage<RSConnectPublishInput, 
-                           RSConnectPublishResult>> pages =
-                           new ArrayList<WizardPage<RSConnectPublishInput, 
-                                                    RSConnectPublishResult>>();
+                           RSConnectPublishResult>> pages = new ArrayList<>();
       
       String descriptor = "document";
       if (asMultiple)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountWizard.java
@@ -94,9 +94,7 @@ public class RSConnectAccountWizard
    {
       if (showCloudPage)
       {
-         return new WizardNavigationPage<
-            NewRSConnectAccountInput,
-            NewRSConnectAccountResult>(
+         return new WizardNavigationPage<>(
                   "Choose Account Type", 
                   "Choose Account Type", 
                   "Connect Account", 
@@ -111,9 +109,7 @@ public class RSConnectAccountWizard
                                          NewRSConnectAccountResult>> createPages()
    {
       ArrayList<WizardPage<NewRSConnectAccountInput, 
-                           NewRSConnectAccountResult>> pages =
-           new ArrayList<WizardPage<NewRSConnectAccountInput, 
-                                    NewRSConnectAccountResult>>();
+                           NewRSConnectAccountResult>> pages = new ArrayList<>();
 
       pages.add(new NewRSConnectCloudPage());
       pages.add(new NewRSConnectLocalPage());

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -178,6 +178,5 @@ public class RSConnectDeployDialog
    private RSConnectAccount defaultAccount_;
    
    // Map of app URL to the deployment made to that URL
-   private Map<String, RSConnectDeploymentRecord> deployments_ = 
-         new HashMap<String, RSConnectDeploymentRecord>();
+   private Map<String, RSConnectDeploymentRecord> deployments_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -666,13 +666,13 @@ public class RSConnectPublishButton extends Composite
                      RSConnectPublishSource source = 
                            new RSConnectPublishSource(htmlFile, null, 
                                  true, true, false, "Plot", contentType_);
-                     ArrayList<String> deployFiles = new ArrayList<String>();
+                     ArrayList<String> deployFiles = new ArrayList<>();
                      deployFiles.add(FilePathUtils.friendlyFileName(htmlFile));
                      RSConnectPublishSettings settings = 
                            new RSConnectPublishSettings(
                                  deployFiles, 
-                                 new ArrayList<String>(), 
-                                 new ArrayList<String>(), 
+                                 new ArrayList<>(), 
+                                 new ArrayList<>(), 
                                  false, true);
                      events_.fireEvent(
                            new RSConnectDeployInitiatedEvent(source, settings,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1083,7 +1083,7 @@ public class ClientEventDispatcher
 
    private final EventBus eventBus_;
 
-   private final ArrayList<ClientEvent> pendingEvents_ = new ArrayList<ClientEvent>();
+   private final ArrayList<ClientEvent> pendingEvents_ = new ArrayList<>();
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerAuth.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerAuth.java
@@ -127,8 +127,7 @@ class RemoteServerAuth
 
    // save previous form as a precaution against forms which are not
    // cleaned up due to the submit handler not being called
-   private static ArrayList<FormPanel> previousUpdateCredentialsForms_ =
-                                            new ArrayList<FormPanel>();
+   private static ArrayList<FormPanel> previousUpdateCredentialsForms_ = new ArrayList<>();
 
    private void safeCleanupPreviousUpdateCredentials()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -486,12 +486,10 @@ class RemoteServerEventListener
    private Watchdog watchdog_ = new Watchdog();
 
    // Stores async requests that expect to be completed later.
-   private final HashMap<String, AsyncRequestInfo> asyncRequests_
-         = new HashMap<String, AsyncRequestInfo>();
+   private final HashMap<String, AsyncRequestInfo> asyncRequests_ = new HashMap<>();
 
    // Stores any async responses that didn't have matching requests at the
    // time they were received. This is to deal with any race conditions where
    // the completion occurs before we even finished making the request.
-   private final HashMap<String, RpcResponse> asyncResponses_
-         = new HashMap<String, RpcResponse>();
+   private final HashMap<String, RpcResponse> asyncResponses_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -90,7 +90,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       currentViewType_ = UserPrefs.SHINY_VIEWER_TYPE_NONE;
       dependencyManager_ = dependencyManager;
       interrupt_ = interrupt;
-      params_ = new ArrayList<ShinyApplicationParams>();
+      params_ = new ArrayList<>();
       
       eventBus_.addHandler(ShinyApplicationStatusEvent.TYPE, this);
       eventBus_.addHandler(LaunchShinyApplicationEvent.TYPE, this);

--- a/src/gwt/src/org/rstudio/studio/client/shiny/events/LaunchShinyApplicationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/events/LaunchShinyApplicationEvent.java
@@ -30,7 +30,7 @@ public class LaunchShinyApplicationEvent
    }
 
    public static final GwtEvent.Type<LaunchShinyApplicationEvent.Handler> TYPE =
-      new GwtEvent.Type<LaunchShinyApplicationEvent.Handler>();
+      new GwtEvent.Type<>();
    
    public LaunchShinyApplicationEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/shiny/events/ShinyApplicationStatusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/events/ShinyApplicationStatusEvent.java
@@ -30,8 +30,7 @@ public class ShinyApplicationStatusEvent
       void onShinyApplicationStatus(ShinyApplicationStatusEvent event);
    }
 
-   public static final GwtEvent.Type<ShinyApplicationStatusEvent.Handler> TYPE =
-      new GwtEvent.Type<ShinyApplicationStatusEvent.Handler>();
+   public static final GwtEvent.Type<ShinyApplicationStatusEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public ShinyApplicationStatusEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyViewerTypePopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ui/ShinyViewerTypePopupMenu.java
@@ -41,9 +41,9 @@ public class ShinyViewerTypePopupMenu extends ToolbarPopupMenu
       addSeparator();
       addItem(commands.shinyRunInBrowser().createMenuItem(false));
       addSeparator();
-      addItem(new UserPrefMenuItem<Boolean>(prefs.shinyBackgroundJobs(), 
+      addItem(new UserPrefMenuItem<>(prefs.shinyBackgroundJobs(), 
             false, "In R Console", prefs));
-      addItem(new UserPrefMenuItem<Boolean>(prefs.shinyBackgroundJobs(), 
+      addItem(new UserPrefMenuItem<>(prefs.shinyBackgroundJobs(), 
             true, "In Background Job", prefs));
       addSeparator();
       addItem(commands.shinyRecordTest().createMenuItem(false));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/BrowseAddinsDialog.java
@@ -102,11 +102,11 @@ public class BrowseAddinsDialog extends ModalDialog<Command>
          }
       };
       
-      table_ = new RStudioDataGrid<RAddin>(1000, RES, keyProvider_);
+      table_ = new RStudioDataGrid<>(1000, RES, keyProvider_);
       table_.setWidth("500px");
       table_.setHeight("400px");
       
-      selectionModel_ = new SingleSelectionModel<RAddin>();
+      selectionModel_ = new SingleSelectionModel<>();
       selectionModel_.addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
@@ -133,7 +133,7 @@ public class MRUList
    protected void manageCommands(List<String> entries, AppCommand[] commands)
    {
       // optionally transform paths
-      ArrayList<String> transformed = new ArrayList<String>();
+      ArrayList<String> transformed = new ArrayList<>();
       for (String entry : entries)
          transformed.add(transformMruEntryPath(entry));
 
@@ -169,7 +169,7 @@ public class MRUList
       return mruCmds_;
    }
 
-   private final ArrayList<String> mruEntries_ = new ArrayList<String>();
+   private final ArrayList<String> mruEntries_ = new ArrayList<>();
    private final AppCommand[] mruCmds_;
    private final AppCommand clearCommand_;
    private final WorkbenchList mruList_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MainWindowObject.java
@@ -93,7 +93,7 @@ public class MainWindowObject<T>
    
    public static final MainWindowObject<Window> lastFocusedWindow()
    {
-      return new MainWindowObject<Window>(LAST_FOCUSED_WINDOW, new DefaultProvider<Window>()
+      return new MainWindowObject<>(LAST_FOCUSED_WINDOW, new DefaultProvider<Window>()
       {
          @Override
          public Window defaultValue()
@@ -105,7 +105,7 @@ public class MainWindowObject<T>
    
    public static final MainWindowObject<String> lastFocusedEditorId()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_EDITOR_ID, new DefaultProvider<String>()
+      return new MainWindowObject<>(LAST_FOCUSED_EDITOR_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -117,7 +117,7 @@ public class MainWindowObject<T>
    
    public static final MainWindowObject<String> lastFocusedWindowId()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_WINDOW_ID, new DefaultProvider<String>()
+      return new MainWindowObject<>(LAST_FOCUSED_WINDOW_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -129,7 +129,7 @@ public class MainWindowObject<T>
    
    public static final MainWindowObject<String> lastFocusedSourceWindowId()
    {
-      return new MainWindowObject<String>(LAST_FOCUSED_SOURCE_WINDOW_ID, new DefaultProvider<String>()
+      return new MainWindowObject<>(LAST_FOCUSED_SOURCE_WINDOW_ID, new DefaultProvider<String>()
       {
          @Override
          public String defaultValue()
@@ -141,7 +141,7 @@ public class MainWindowObject<T>
    
    public static final MainWindowObject<RAddins> rAddins()
    {
-      return new MainWindowObject<RAddins>(R_ADDINS, new DefaultProvider<RAddins>()
+      return new MainWindowObject<>(R_ADDINS, new DefaultProvider<RAddins>()
       {
          @Override
          public RAddins defaultValue()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -64,7 +64,6 @@ import org.rstudio.studio.client.rmarkdown.events.ShinyGadgetDialogEvent;
 import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.server.remote.ExecuteUserCommandEvent;
 import org.rstudio.studio.client.shiny.ShinyApplication;
@@ -601,13 +600,13 @@ public class Workbench implements BusyEvent.Handler,
                new Operation() {
                   @Override
                   public void execute() {
-                     server_.setUserCrashHandlerPrompted(true, new SimpleRequestCallback<Void>());
+                     server_.setUserCrashHandlerPrompted(true, new SimpleRequestCallback<>());
                   }
                },
                new Operation() {
                   @Override
                   public void execute() {
-                     server_.setUserCrashHandlerPrompted(false, new SimpleRequestCallback<Void>());
+                     server_.setUserCrashHandlerPrompted(false, new SimpleRequestCallback<>());
                   }
                },
                true);
@@ -648,7 +647,7 @@ public class Workbench implements BusyEvent.Handler,
          public void execute()
          {
             server_.userPromptCompleted(response,
-                                        new SimpleRequestCallback<Void>());
+                                        new SimpleRequestCallback<>());
 
          }
       };
@@ -739,7 +738,7 @@ public class Workbench implements BusyEvent.Handler,
       return new Operation() {
          public void execute()
          {
-            server_.adminNotificationAcknowledged(id, new SimpleRequestCallback<Void>());
+            server_.adminNotificationAcknowledged(id, new SimpleRequestCallback<>());
          }
       };
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/Addins.java
@@ -179,7 +179,7 @@ public class Addins
          {
             server_.executeRAddinNonInteractively(
                   addin.getId(),
-                  new SimpleRequestCallback<Void>("Error Executing Addin", true));
+                  new SimpleRequestCallback<>("Error Executing Addin", true));
          }
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/addins/AddinsCommandManager.java
@@ -37,7 +37,7 @@ public class AddinsCommandManager
    {
       events_ = events;
 
-      bindings_ = new ConfigFileBacked<EditorKeyBindings>(
+      bindings_ = new ConfigFileBacked<>(
             server,
             KEYBINDINGS_PATH,
             false,
@@ -120,8 +120,7 @@ public class AddinsCommandManager
    private void registerBindings(final EditorKeyBindings bindings,
                                  final CommandWithArg<EditorKeyBindings> afterLoad)
    {
-      List<Pair<List<KeySequence>, CommandBinding>> commands =
-            new ArrayList<Pair<List<KeySequence>, CommandBinding>>();
+      List<Pair<List<KeySequence>, CommandBinding>> commands = new ArrayList<>();
 
       RAddins rAddins = MainWindowObject.rAddins().get();
       for (String id : bindings.iterableKeys())
@@ -131,7 +130,7 @@ public class AddinsCommandManager
          if (addin == null)
             continue;
          CommandBinding binding = new AddinCommandBinding(addin);
-         commands.add(new Pair<List<KeySequence>, CommandBinding>(keyList, binding));
+         commands.add(new Pair<>(keyList, binding));
       }
 
       KeyMap map = ShortcutManager.INSTANCE.getKeyMap(KeyMapType.ADDIN);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearch.java
@@ -227,6 +227,5 @@ public class CodeSearch
    private final EventBus events_;
    
    private Observer observer_ = null;
-   private ArrayList<HandlerRegistration> eventBusHandlers_ = 
-                                 new ArrayList<HandlerRegistration>();
+   private ArrayList<HandlerRegistration> eventBusHandlers_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -150,8 +150,7 @@ public class CodeSearchOracle extends SuggestOracle
             if (queryLower.indexOf('*') != -1)
                pattern = patternForTerm(queryLower);
             
-            ArrayList<CodeSearchSuggestion> suggestions =
-                                       new ArrayList<CodeSearchSuggestion>();
+            ArrayList<CodeSearchSuggestion> suggestions = new ArrayList<>();
             for (int s=0; s<res.getSuggestions().size(); s++)
             {
                CodeSearchSuggestion sugg = res.getSuggestions().get(s);
@@ -297,8 +296,7 @@ public class CodeSearchOracle extends SuggestOracle
             @Override
             public void onResponseReceived(CodeSearchResults response)
             {  
-               ArrayList<CodeSearchSuggestion> suggestions = 
-                                       new ArrayList<CodeSearchSuggestion>();
+               ArrayList<CodeSearchSuggestion> suggestions = new ArrayList<>();
                
                // file results
                ArrayList<FileItem> fileResults = 
@@ -397,7 +395,7 @@ public class CodeSearchOracle extends SuggestOracle
                                    boolean moreAvailable)
    {
       // get file paths for file targets (which are always at the beginning)
-      ArrayList<String> filePaths = new ArrayList<String>();
+      ArrayList<String> filePaths = new ArrayList<>();
       for(CodeSearchSuggestion suggestion : suggestions)
       {
          if (!suggestion.isFileTarget())
@@ -410,8 +408,7 @@ public class CodeSearchOracle extends SuggestOracle
       ArrayList<String> displayLabels =
             DuplicateHelper.getPathLabels(filePaths, true);
       
-      ArrayList<CodeSearchSuggestion> newSuggestions =
-            new ArrayList<CodeSearchSuggestion>(suggestions);
+      ArrayList<CodeSearchSuggestion> newSuggestions = new ArrayList<>(suggestions);
       
       for (int i = 0; i < displayLabels.size(); i++)
       {
@@ -439,8 +436,7 @@ public class CodeSearchOracle extends SuggestOracle
    private final WorkbenchContext workbenchContext_;
    private final CodeSearchCommand codeSearch_ = new CodeSearchCommand();
    
-   private final ArrayList<SearchResult> resultCache_ = 
-                                             new ArrayList<SearchResult>();
+   private final ArrayList<SearchResult> resultCache_ = new ArrayList<>();
    
    private class SearchResult
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/events/ListChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/events/ListChangedEvent.java
@@ -42,7 +42,7 @@ public class ListChangedEvent extends GwtEvent<ListChangedEvent.Handler>
       name_ = eventData.getString("name");
 
       JsArrayString list = eventData.getObject("list");
-      list_ = new ArrayList<String>();
+      list_ = new ArrayList<>();
       for (int i=0; i<list.length(); i++)
          list_.add(list.get(i));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/EventBasedChangeTracker.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/EventBasedChangeTracker.java
@@ -44,7 +44,7 @@ public class EventBasedChangeTracker<T> implements ChangeTracker
 
    public ChangeTracker fork()
    {
-      EventBasedChangeTracker<T> ebct = new EventBasedChangeTracker<T>(source_);
+      EventBasedChangeTracker<T> ebct = new EventBasedChangeTracker<>(source_);
       ebct.changed_ = changed_;
       return ebct;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
@@ -79,7 +79,7 @@ public class RemoteFileSystemContext extends PosixFileSystemContext
 
       final FileSystemItem newPathEntry = FileSystemItem.createDir(newPath);
       
-      final ArrayList<FileSystemItem> fsi = new ArrayList<FileSystemItem>();
+      final ArrayList<FileSystemItem> fsi = new ArrayList<>();
 
       server_.listFiles(
             newPathEntry,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchLists.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchLists.java
@@ -39,7 +39,7 @@ public class WorkbenchLists extends JavaScriptObject
    
    private ArrayList<String> convertList(JsArrayString jsList)
    {
-      ArrayList<String> list = new ArrayList<String>();
+      ArrayList<String> list = new ArrayList<>();
       for (int i=0; i<jsList.length(); i++)
          list.add(jsList.get(i));
       return list;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
@@ -67,7 +67,7 @@ public abstract class ClientStateValue<T> implements SaveClientStateEvent.Handle
    {
       JsObject grp = state.peek(group_);
       T obj = doGet(grp, name_);
-      valueTracker_ = new ValueChangeTracker<T>(obj);
+      valueTracker_ = new ValueChangeTracker<>(obj);
       onInit(obj);
 
       EventBus evt = RStudioGinjector.INSTANCE.getEventBus();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/UserPrefsChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/UserPrefsChangedEvent.java
@@ -22,7 +22,7 @@ import org.rstudio.studio.client.workbench.prefs.model.PrefLayer;
 @JavaScriptSerializable
 public class UserPrefsChangedEvent extends CrossWindowEvent<UserPrefsChangedHandler>
 {
-   public static final Type<UserPrefsChangedHandler> TYPE = new Type<UserPrefsChangedHandler>();
+   public static final Type<UserPrefsChangedHandler> TYPE = new Type<>();
    
    public UserPrefsChangedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/UserStateChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/events/UserStateChangedEvent.java
@@ -24,7 +24,7 @@ import com.google.gwt.event.shared.EventHandler;
 @JavaScriptSerializable
 public class UserStateChangedEvent extends CrossWindowEvent<UserStateChangedEvent.Handler>
 {
-   public static final Type<UserStateChangedEvent.Handler> TYPE = new Type<UserStateChangedEvent.Handler>();
+   public static final Type<UserStateChangedEvent.Handler> TYPE = new Type<>();
    
    public UserStateChangedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/Prefs.java
@@ -512,7 +512,7 @@ public abstract class Prefs
       PrefValue<T> val = (PrefValue<T>) values_.get(name);
       if (val == null)
       {
-         val = new ObjectValue<T>(name, title, description, defaultValue);
+         val = new ObjectValue<>(name, title, description, defaultValue);
          values_.put(name, val);
       }
       return val;
@@ -525,6 +525,5 @@ public abstract class Prefs
    }
    
    private JsArray<PrefLayer> layers_;
-   private final HashMap<String, PrefValue<?>> values_ =
-         new HashMap<String, PrefValue<?>>();
+   private final HashMap<String, PrefValue<?>> values_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3512,7 +3512,7 @@ public class UserPrefsAccessor extends Prefs
    }
    public List<PrefValue<?>> allPrefs()
    {
-      ArrayList<PrefValue<?>> prefs = new ArrayList<PrefValue<?>>();
+      ArrayList<PrefValue<?>> prefs = new ArrayList<>();
       prefs.add(runRprofileOnResume());
       prefs.add(saveWorkspace());
       prefs.add(loadWorkspace());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -566,7 +566,7 @@ public class UserStateAccessor extends Prefs
    }
    public List<PrefValue<?>> allPrefs()
    {
-      ArrayList<PrefValue<?>> prefs = new ArrayList<PrefValue<?>>();
+      ArrayList<PrefValue<?>> prefs = new ArrayList<>();
       prefs.add(contextId());
       prefs.add(autoCreatedProfile());
       prefs.add(theme());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -571,7 +571,7 @@ public class GeneralPreferencesPane extends PreferencesPane
 
    private void initializeGraphicsBackendWidget()
    {
-      Map<String, String> valuesToLabelsMap = new HashMap<String, String>();
+      Map<String, String> valuesToLabelsMap = new HashMap<>();
       valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_DEFAULT, " (Default)");
       valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_QUARTZ,    "Quartz");
       valuesToLabelsMap.put(UserPrefs.GRAPHICS_BACKEND_WINDOWS,   "Windows");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/LineEndingsSelectWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/LineEndingsSelectWidget.java
@@ -39,7 +39,7 @@ public class LineEndingsSelectWidget extends SelectWidget
 
    private static String[] getLineEndingsCaptions(boolean includeDefault)
    {
-      ArrayList<String> captions = new ArrayList<String>();
+      ArrayList<String> captions = new ArrayList<>();
       if (includeDefault)
          captions.add("(Use Default)");
       captions.add("None");
@@ -52,7 +52,7 @@ public class LineEndingsSelectWidget extends SelectWidget
    
    private static String[] getLineEndingsValues(boolean includeDefault)
    {
-      ArrayList<String> values = new ArrayList<String>();
+      ArrayList<String> values = new ArrayList<>();
       if (includeDefault)
          values.add(UserPrefs.LINE_ENDING_CONVERSION_DEFAULT);
       values.add(UserPrefs.LINE_ENDING_CONVERSION_PASSTHROUGH);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/SpellingPreferencesPane.java
@@ -106,7 +106,7 @@ public class SpellingPreferencesPane extends PreferencesPane
          userDictLabel.setText(kUserDictionary + StringUtil.formatGeneralNumber(entries) + " words");
       };
       
-      final ArrayList<String> userDictWords = new ArrayList<String>();
+      final ArrayList<String> userDictWords = new ArrayList<>();
       WorkbenchList userDict = workbenchListManager.getUserDictionaryList();
       userDict.addListChangedHandler((e) -> {
          userDictWords.clear();
@@ -133,7 +133,7 @@ public class SpellingPreferencesPane extends PreferencesPane
                if (dictionary != null)
                {
                   List<String> dictSplitItems = Arrays.asList(dictionary.split("\n"));
-                  ArrayList<String> dictWords = new ArrayList<String>();
+                  ArrayList<String> dictWords = new ArrayList<>();
                   for (String item : dictSplitItems)
                   {
                      item = item.trim();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -32,7 +32,7 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
       super("Python Interpreters", Roles.getDialogRole(), operation);
       setOkButtonCaption("Select");
       
-      widgets_ = new WidgetListBox<PythonInterpreterListEntryUi>();
+      widgets_ = new WidgetListBox<>();
       widgets_.setHeight("420px");
       widgets_.setAriaLabel("Python Interpreters");
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/zotero/ZoteroConnectionWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/zotero/ZoteroConnectionWidget.java
@@ -36,13 +36,13 @@ public class ZoteroConnectionWidget extends Composite
    
       HorizontalPanel panel = new HorizontalPanel();
       
-      ArrayList<String> options = new ArrayList<String>();
+      ArrayList<String> options = new ArrayList<>();
       options.add("(None)");
       if (!webOnly())
          options.add("Local");
       options.add("Web");
       
-      ArrayList<String> values = new ArrayList<String>();
+      ArrayList<String> values = new ArrayList<>();
       values.add(UserStateAccessor.ZOTERO_CONNECTION_TYPE_NONE);
       if (!webOnly())
          values.add(UserStateAccessor.ZOTERO_CONNECTION_TYPE_LOCAL);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/zotero/ZoteroLibrariesWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/zotero/ZoteroLibrariesWidget.java
@@ -47,7 +47,7 @@ public class ZoteroLibrariesWidget extends Composite
       VerticalPanel panel = new VerticalPanel();
       panel.addStyleName(RES.styles().librariesWidget());
       
-      ArrayList<String> options = new ArrayList<String>();
+      ArrayList<String> options = new ArrayList<>();
       
       if (includeUseDefault)
          options.add(USE_DEFAULT);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/ui/EditSnippetsDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/ui/EditSnippetsDialog.java
@@ -113,7 +113,7 @@ public class EditSnippetsDialog extends ModalDialogBase implements TextDisplay
       panel_.setHeight(size.height + "px");
       
       // snippet types
-      snippetTypes_ = new WidgetListBox<EditableSnippets>();
+      snippetTypes_ = new WidgetListBox<>();
       snippetTypes_.addChangeHandler(new ChangeHandler() {
          @Override
          public void onChange(ChangeEvent event)
@@ -306,8 +306,7 @@ public class EditSnippetsDialog extends ModalDialogBase implements TextDisplay
    private boolean editorDirty_ = false;
    private EditableSnippets activeSnippets_ = null;
    
-   private final ArrayList<HandlerRegistration> releaseOnDismiss_ =
-         new ArrayList<HandlerRegistration>();
+   private final ArrayList<HandlerRegistration> releaseOnDismiss_ = new ArrayList<>();
    
    private EventBus events_;
    private GlobalDisplay globalDisplay_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -614,8 +614,8 @@ public class ConnectionsPresenter extends BasePresenter
    private Connection exploredConnection_;
    private Connection lastExploredConnection_;
    
-   private ArrayList<Connection> allConnections_ = new ArrayList<Connection>();
-   private ArrayList<ConnectionId> activeConnections_ = new ArrayList<ConnectionId>();
+   private ArrayList<Connection> allConnections_ = new ArrayList<>();
+   private ArrayList<ConnectionId> activeConnections_ = new ArrayList<>();
    
    private static boolean installersUpdated_ = false;
    private static String installersWarning_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionObjectSpecifier.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/ConnectionObjectSpecifier.java
@@ -24,7 +24,7 @@ public class ConnectionObjectSpecifier
 {
    public ConnectionObjectSpecifier()
    {
-      containers_ = new ArrayList<ConnectionPathEntry>();
+      containers_ = new ArrayList<>();
    }
    
    public ConnectionObjectSpecifier(String name, String type)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/model/NewConnectionContext.java
@@ -36,7 +36,7 @@ public class NewConnectionContext extends JavaScriptObject
 
    public final ArrayList<NewConnectionInfo> getConnectionsList()
    {
-      ArrayList<NewConnectionInfo> result = new ArrayList<NewConnectionInfo>(getConnectionsLength());
+      ArrayList<NewConnectionInfo> result = new ArrayList<>(getConnectionsLength());
       for (int i = 0; i < getConnectionsLength(); i++)
          result.add(getConnectionsItem(i));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ConnectionsPane.java
@@ -104,8 +104,8 @@ public class ConnectionsPane extends WorkbenchPane
          }
       };
       
-      selectionModel_ = new SingleSelectionModel<Connection>();
-      connectionsDataGrid_ = new RStudioDataGrid<Connection>(1000, RES, keyProvider_);
+      selectionModel_ = new SingleSelectionModel<>();
+      connectionsDataGrid_ = new RStudioDataGrid<>(1000, RES, keyProvider_);
       connectionsDataGrid_.setSelectionModel(selectionModel_);
       selectionModel_.addSelectionChangeHandler(new SelectionChangeEvent.Handler()
       {
@@ -177,7 +177,7 @@ public class ConnectionsPane extends WorkbenchPane
       connectionsDataGrid_.setColumnWidth(exploreColumn, 30, Unit.PX);
       
       // data provider
-      dataProvider_ = new ListDataProvider<Connection>();
+      dataProvider_ = new ListDataProvider<>();
       dataProvider_.addDataDisplay(connectionsDataGrid_);
       
       // create connection explorer, add it, and hide it
@@ -346,7 +346,7 @@ public class ConnectionsPane extends WorkbenchPane
             // no suggestions
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
 
@@ -357,7 +357,7 @@ public class ConnectionsPane extends WorkbenchPane
             // no suggestions
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
 
@@ -591,7 +591,7 @@ public class ConnectionsPane extends WorkbenchPane
   
    private final ProvidesKey<Connection> keyProvider_;
    private final ListDataProvider<Connection> dataProvider_;
-   private List<ConnectionId> activeConnections_ = new ArrayList<ConnectionId>();
+   private List<ConnectionId> activeConnections_ = new ArrayList<>();
    
    private SearchWidget searchWidget_;
    private SearchWidget objectSearchWidget_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetDialog.java
@@ -144,5 +144,5 @@ public class NewConnectionSnippetDialog extends ModalDialog<HashMap<String, Stri
    
    private NewConnectionInfo newConnectionInfo_;
    private ArrayList<NewConnectionSnippetParts> initialConfig_;
-   HashMap<String, String> partsKeyValues_ = new HashMap<String, String>();
+   HashMap<String, String> partsKeyValues_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/NewConnectionSnippetHost.java
@@ -145,7 +145,7 @@ public class NewConnectionSnippetHost extends Composite
    }
 
    private ArrayList<NewConnectionSnippetParts> parseSnippet(String input) {
-      ArrayList<NewConnectionSnippetParts> parts = new ArrayList<NewConnectionSnippetParts>();
+      ArrayList<NewConnectionSnippetParts> parts = new ArrayList<>();
 
       RegExp regExp = RegExp.compile(pattern_, "g");
 
@@ -248,8 +248,8 @@ public class NewConnectionSnippetHost extends Composite
       visibleRows = Math.min(visibleRows, maxRows);
 
       visibleParams = Math.min(visibleParams, snippetParts.size());
-      final ArrayList<NewConnectionSnippetParts> secondarySnippetParts = 
-            new ArrayList<NewConnectionSnippetParts>(snippetParts.subList(visibleParams, snippetParts.size()));
+      final ArrayList<NewConnectionSnippetParts> secondarySnippetParts =
+            new ArrayList<>(snippetParts.subList(visibleParams, snippetParts.size()));
 
       final LayoutGrid connGrid = new LayoutGrid(visibleRows + 1, 4);
       connGrid.addStyleName(RES.styles().grid());
@@ -653,7 +653,7 @@ public class NewConnectionSnippetHost extends Composite
 
    NewConnectionInfo info_;
    ArrayList<NewConnectionSnippetParts> snippetParts_;
-   HashMap<String, String> partsKeyValues_ = new HashMap<String, String>();
+   HashMap<String, String> partsKeyValues_ = new HashMap<>();
 
    static final String pattern_ = "\\$\\{([0-9]+):([^:=}]+)(=([^:}]*))?(:([^}]+))?\\}";
    static final String patternRandNumber_ = "\\$\\{#\\}";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowser.java
@@ -124,8 +124,7 @@ public class ObjectBrowser extends Composite implements RequiresResize
          
          // if we got here, the user has clicked Show More, so scroll to the
          // bottom when they're done
-         final Value<HandlerRegistration> registration = 
-               new Value<HandlerRegistration>(null);
+         final Value<HandlerRegistration> registration = new Value<>(null);
          registration.setValue(scrollPanel_.addScrollHandler(e -> 
          {
             scrollPanel_.scrollToBottom();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowserModel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ui/ObjectBrowserModel.java
@@ -112,9 +112,9 @@ public class ObjectBrowserModel implements TreeViewModel
 
       if (value == null || rootData)
       {
-         return new DefaultNodeInfo<DatabaseObject>(
+         return new DefaultNodeInfo<>(
                   objectProvider_,
-                   new ContainerCell(),
+                  new ContainerCell(),
                   noObjectSelectionModel_,
                   null);
       }
@@ -127,17 +127,17 @@ public class ObjectBrowserModel implements TreeViewModel
          {
             FieldProvider fieldProvider = new FieldProvider((DatabaseObject)value);
             fieldProviders_.put(val, fieldProvider);
-            return new DefaultNodeInfo<Field>(fieldProvider, 
-                                              new FieldCell(),
-                                              noFieldSelectionModel_,
-                                              null);
+            return new DefaultNodeInfo<>(fieldProvider,
+                                         new FieldCell(),
+                                         noFieldSelectionModel_,
+                                         null);
          }
          
          ObjectProvider objectProvider = new ObjectProvider(val);
          objectProviders_.put(val, objectProvider);
          
          // does not contain data, so draw as a container cell
-         return new DefaultNodeInfo<DatabaseObject>(
+         return new DefaultNodeInfo<>(
                objectProvider,
                new ContainerCell(),
                noObjectSelectionModel_, null);
@@ -312,7 +312,7 @@ public class ObjectBrowserModel implements TreeViewModel
       private void clearData()
       {
          updateRowCount(0, true);
-         updateRowData(0, new ArrayList<DatabaseObject>());
+         updateRowData(0, new ArrayList<>());
          prefetchedObjectList_ = null; 
          fireUpdateCompleted();
       }
@@ -439,7 +439,7 @@ public class ObjectBrowserModel implements TreeViewModel
                   @Override
                   public void onResponseReceived(JsArray<Field> fields)
                   {
-                     ArrayList<Field> data = new ArrayList<Field>();
+                     ArrayList<Field> data = new ArrayList<>();
                      if (fields != null)
                      {
                         for (int i=0; i<fields.length(); i++)
@@ -462,7 +462,7 @@ public class ObjectBrowserModel implements TreeViewModel
       private void clearData()
       {
          updateRowCount(0, true);
-         updateRowData(0, new ArrayList<Field>());
+         updateRowData(0, new ArrayList<>());
          dequeNodeExpansion(table_);
       }
       
@@ -535,10 +535,8 @@ public class ObjectBrowserModel implements TreeViewModel
    }
    
    private ObjectProvider objectProvider_;
-   private HashMap<DatabaseObject,FieldProvider> fieldProviders_ 
-                              = new HashMap<DatabaseObject,FieldProvider>();
-   private HashMap<DatabaseObject,ObjectProvider> objectProviders_ 
-                              = new HashMap<DatabaseObject,ObjectProvider>();
+   private HashMap<DatabaseObject,FieldProvider> fieldProviders_ = new HashMap<>();
+   private HashMap<DatabaseObject,ObjectProvider> objectProviders_ = new HashMap<>();
    
    private Connection connection_;
    private String filter_;
@@ -550,13 +548,11 @@ public class ObjectBrowserModel implements TreeViewModel
    private ConnectionsServerOperations server_;
    private EventBus eventBus_;
 
-   private final ArrayList<CommandWithArg<JsArray<DatabaseObject>>> objectListContinuations_ = 
-         new ArrayList<CommandWithArg<JsArray<DatabaseObject>>>();
+   private final ArrayList<CommandWithArg<JsArray<DatabaseObject>>> objectListContinuations_ =
+      new ArrayList<>();
    
-   private static NoSelectionModel<DatabaseObject> noObjectSelectionModel_ = 
-         new NoSelectionModel<DatabaseObject>();
-   private static NoSelectionModel<Field> noFieldSelectionModel_ =
-         new NoSelectionModel<Field>();
+   private static NoSelectionModel<DatabaseObject> noObjectSelectionModel_ = new NoSelectionModel<>();
+   private static NoSelectionModel<Field> noFieldSelectionModel_ = new NoSelectionModel<>();
    
    static final ObjectBrowser.Resources RES = ObjectBrowser.RES;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellInputAnimator.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/ShellInputAnimator.java
@@ -124,7 +124,6 @@ public class ShellInputAnimator
    
    private InputEditorDisplay display_;
    
-   private ArrayList<InputAnimator> pendingAnimatedInput_ =
-      new ArrayList<InputAnimator>();
+   private ArrayList<InputAnimator> pendingAnimatedInput_ = new ArrayList<>();
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
@@ -41,7 +41,7 @@ public class CompletionCache
 {
    public CompletionCache()
    {
-      cache_ = new SafeMap<String, Completions>();
+      cache_ = new SafeMap<>();
    }
    
    public boolean satisfyRequest(String line,
@@ -115,7 +115,7 @@ public class CompletionCache
       }
       
       // Finally, sort these based on score
-      List<Integer> indices = new ArrayList<Integer>();
+      List<Integer> indices = new ArrayList<>();
       for (int i = 0, n = completionsNarrow.size(); i < n; i++)
          indices.add(i);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionListPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionListPopupPanel.java
@@ -26,7 +26,7 @@ public class CompletionListPopupPanel<TItem> extends ThemedPopupPanel
    public CompletionListPopupPanel(TItem[] entries)
    {
       super(true);
-      list_ = new CompletionList<TItem>(entries, 10, true, true);
+      list_ = new CompletionList<>(entries, 10, true, true);
       setWidget(list_);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -82,7 +82,7 @@ public abstract class CompletionManagerBase
       completionCache_ = new CompletionCache();
       suggestTimer_ = new SuggestionTimer();
       helpTimer_ = new HelpTimer();
-      handlers_ = new ArrayList<HandlerRegistration>();
+      handlers_ = new ArrayList<>();
       snippets_ = new SnippetHelper((AceEditor) docDisplay, context.getId());
       
       // deferred so that handlers are toggled after subclasses have finished
@@ -137,7 +137,7 @@ public abstract class CompletionManagerBase
          completionCache_.store(line, completions);
       
       int n = completions.getCompletions().length();
-      List<QualifiedName> names = new ArrayList<QualifiedName>();
+      List<QualifiedName> names = new ArrayList<>();
       for (int i = 0; i < n; i++)
       {
          names.add(new QualifiedName(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -144,11 +144,10 @@ public class CompletionPopupPanel extends ThemedPopupPanel
                                     boolean truncated)
    {
       registerIgnoredKeys();
-      CompletionList<QualifiedName> list = new CompletionList<QualifiedName>(
-                                       values,
-                                       6,
-                                       true,
-                                       true);
+      CompletionList<QualifiedName> list = new CompletionList<>(values,
+                                                                6,
+                                                                true,
+                                                                true);
 
       list.addSelectionCommitHandler((SelectionCommitEvent<QualifiedName> event) ->
       {
@@ -446,7 +445,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    private void registerIgnoredKeys()
    {
       resetIgnoredKeysHandle();
-      Set<KeyCombination> keySet = new HashSet<KeyCombination>();
+      Set<KeyCombination> keySet = new HashSet<>();
       keySet.add(new KeyCombination("n", KeyCodes.KEY_N, KeyboardShortcut.CTRL));
       keySet.add(new KeyCombination("p", KeyCodes.KEY_P, KeyboardShortcut.CTRL));
       handle_ = ShortcutManager.INSTANCE.addIgnoredKeys(keySet);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
@@ -35,7 +35,7 @@ public abstract class DelegatingCompletionManager implements CompletionManager
    public DelegatingCompletionManager(DocDisplay docDisplay, CompletionContext context)
    {
       docDisplay_ = docDisplay;
-      completionManagerMap_ = new HashMap<Mode, CompletionManager>();
+      completionManagerMap_ = new HashMap<>();
       nullManager_ = new NullCompletionManager();
       
       if (docDisplay_ instanceof AceEditor)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
@@ -38,7 +38,7 @@ public class HelpStrategy
    public HelpStrategy(CodeToolsServerOperations server)
    {
       server_ = server;
-      cache_ = new HashMap<QualifiedName, ParsedInfo>();
+      cache_ = new HashMap<>();
    }
    
    public void showHelpTopic(final QualifiedName selectedItem)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HistoryCompletionManager.java
@@ -262,8 +262,7 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
 
          if (resp.length() == 0)
          {
-            popup_ = new CompletionListPopupPanel<HistoryMatch>(
-                  new HistoryMatch[0]);
+            popup_ = new CompletionListPopupPanel<>(new HistoryMatch[0]);
             popup_.setText("(No matching commands)");
             mode_ = PopupMode.PopupNoResults;
          }
@@ -272,7 +271,7 @@ public class HistoryCompletionManager implements KeyDownPreviewHandler,
             HistoryMatch[] entries = new HistoryMatch[resp.length()];
             for (int i = 0; i < entries.length; i++)
                entries[i] = new HistoryMatch(resp.get(entries.length - i - 1).getCommand(), text_, i);
-            popup_ = new CompletionListPopupPanel<HistoryMatch>(entries);
+            popup_ = new CompletionListPopupPanel<>(entries);
             mode_ = desiredMode_;
          }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -102,7 +102,7 @@ public class StanCompletionManager extends CompletionManagerBase
    protected void addExtraCompletions(String token,
                                       List<QualifiedName> completions)
    {
-      Set<String> discoveredIdentifiers = new HashSet<String>();
+      Set<String> discoveredIdentifiers = new HashSet<>();
       
       Token cursorToken = docDisplay_.getTokenAt(docDisplay_.getCursorPosition());
       TokenIterator it = docDisplay_.createTokenIterator();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/events/SuppressNextShellFocusEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/events/SuppressNextShellFocusEvent.java
@@ -70,6 +70,6 @@ public class SuppressNextShellFocusEvent extends GwtEvent<SuppressNextShellFocus
       handler.onSuppressNextShellFocus(this);
    }
 
-   public static final Type<Handler> TYPE = new Type<Handler>();
+   public static final Type<Handler> TYPE = new Type<>();
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -101,7 +101,7 @@ public class EnvironmentPane extends WorkbenchPane
       prefs_ = prefs;
       dependencyManager_ = dependencyManager;
 
-      expandedObjects_ = new ArrayList<String>();
+      expandedObjects_ = new ArrayList<>();
       scrollPosition_ = 0;
       isClientStateDirty_ = false;
       environments_ = null;
@@ -109,7 +109,7 @@ public class EnvironmentPane extends WorkbenchPane
       EnvironmentContextData environmentState = session.getSessionInfo().getEnvironmentState();
       environmentName_ = environmentState.environmentName();
       environmentIsLocal_ = environmentState.environmentIsLocal();
-      environmentMonitoring_ = new Value<Boolean>(environmentState.environmentMonitoring());
+      environmentMonitoring_ = new Value<>(environmentState.environmentMonitoring());
 
       EnvironmentPaneResources.INSTANCE.environmentPaneStyle().ensureInjected();
 
@@ -227,7 +227,7 @@ public class EnvironmentPane extends WorkbenchPane
             // no suggestions
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
 
@@ -389,7 +389,7 @@ public class EnvironmentPane extends WorkbenchPane
    {
       server_.setContextDepth(
             newDepth,
-            new SimpleRequestCallback<Void>("Error opening call frame"));
+            new SimpleRequestCallback<>("Error opening call frame"));
    }
 
    public boolean clientStateDirty()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -47,7 +47,6 @@ import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.WorkbenchView;
@@ -178,7 +177,7 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void run()
          {
-            server_.requeryContext(new QuietServerRequestCallback<Void>());
+            server_.requeryContext(new QuietServerRequestCallback<>());
          }
       };
 
@@ -968,8 +967,7 @@ public class EnvironmentPresenter extends BasePresenter
    private String makeCommand(ImportFileSettings input,
                               boolean defaultStringsAsFactors)
    {
-      HashMap<String, ImportFileSettings> commandDefaults_ =
-              new HashMap<String, ImportFileSettings>();
+      HashMap<String, ImportFileSettings> commandDefaults_ = new HashMap<>();
 
       commandDefaults_.put("read.table", new ImportFileSettings(
               null, null, "unknown", false, null, "", ".", "\"'", "#", "NA", defaultStringsAsFactors));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -496,7 +496,7 @@ public class DataImport extends Composite
       {
          server_.previewDataImportClean(
                getOptions(),
-               new ErrorLoggingServerRequestCallback<Void>());
+               new ErrorLoggingServerRequestCallback<>());
       }
       
       localFiles_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportColumnTypesMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportColumnTypesMenu.java
@@ -82,9 +82,9 @@ public class DataImportColumnTypesMenu extends PopupPanel
       super(true);
       setWidget(uiBinder.createAndBindUi(this));
       
-      menuItemsMap_ = new HashMap<String, MenuItem>();
+      menuItemsMap_ = new HashMap<>();
       
-      menuItems_ = new ArrayList<MenuItem>();
+      menuItems_ = new ArrayList<>();
       menuItems_.add(new MenuItem("include", (Widget)include_));
       menuItems_.add(new MenuItem("skip", (Widget)skip_));
       menuItems_.add(new MenuItem("only", (Widget)only_));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/DebugSourceCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/DebugSourceCompletedEvent.java
@@ -28,8 +28,7 @@ public class DebugSourceCompletedEvent
       void onDebugSourceCompleted(DebugSourceCompletedEvent event);
    }
 
-   public static final GwtEvent.Type<DebugSourceCompletedEvent.Handler> TYPE =
-      new GwtEvent.Type<DebugSourceCompletedEvent.Handler>();
+   public static final GwtEvent.Type<DebugSourceCompletedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DebugSourceCompletedEvent(DebugSourceResult result)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentObjectAssignedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentObjectAssignedEvent.java
@@ -28,8 +28,7 @@ public class EnvironmentObjectAssignedEvent
       void onEnvironmentObjectAssigned(EnvironmentObjectAssignedEvent event);
    }
 
-   public static final GwtEvent.Type<EnvironmentObjectAssignedEvent.Handler> TYPE =
-      new GwtEvent.Type<EnvironmentObjectAssignedEvent.Handler>();
+   public static final GwtEvent.Type<EnvironmentObjectAssignedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public EnvironmentObjectAssignedEvent(RObject objectInfo)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentObjectRemovedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/events/EnvironmentObjectRemovedEvent.java
@@ -25,8 +25,7 @@ public class EnvironmentObjectRemovedEvent
       void onEnvironmentObjectRemoved(EnvironmentObjectRemovedEvent event);
    }
 
-   public static final GwtEvent.Type<EnvironmentObjectRemovedEvent.Handler> TYPE =
-      new GwtEvent.Type<EnvironmentObjectRemovedEvent.Handler>();
+   public static final GwtEvent.Type<EnvironmentObjectRemovedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public EnvironmentObjectRemovedEvent(String objectName)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.java
@@ -124,7 +124,7 @@ public class CallFramePanel extends ResizeComposite
                                                          14, Style.Unit.PX);
       
       observer_ = observer;
-      callFrameItems_ = new ArrayList<CallFrameItem>();
+      callFrameItems_ = new ArrayList<>();
    }
 
    public void setCallFrames(JsArray<CallFrame> frameList, int contextDepth)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -77,8 +77,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       // disable persistent and transient row selection (currently necessary
       // because we emit more than one row per object and the DataGrid selection
       // behaviors aren't designed to work that way)
-      setSelectionModel(new NoSelectionModel<RObjectEntry>(
-              RObjectEntry.KEY_PROVIDER));
+      setSelectionModel(new NoSelectionModel<>(RObjectEntry.KEY_PROVIDER));
       setKeyboardSelectionPolicy(KeyboardSelectionPolicy.DISABLED);
 
       createColumns();
@@ -101,11 +100,11 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       // If the view is unfiltered, return nothing.
       if (host_.getFilterText().isEmpty())
       {
-         return new ArrayList<String>();
+         return new ArrayList<>();
       }
 
       // If the view is filtered, return items that are visible.
-      ArrayList<String> objectNames = new ArrayList<String>();
+      ArrayList<String> objectNames = new ArrayList<>();
       List<RObjectEntry> objects = getVisibleItems();
       for (RObjectEntry object: objects)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
@@ -86,7 +86,7 @@ public class EnvironmentObjects extends ResizeComposite
       environmentName_ = EnvironmentPane.GLOBAL_ENVIRONMENT_NAME;
 
       objectDisplayType_ = OBJECT_LIST_VIEW;
-      objectDataProvider_ = new ListDataProvider<RObjectEntry>();
+      objectDataProvider_ = new ListDataProvider<>();
       objectSort_ = new RObjectEntrySort();
 
       // timer used to scroll table element into view
@@ -214,7 +214,7 @@ public class EnvironmentObjects extends ResizeComposite
    {
       // create an entry for each object and sort the array
       int numObjects = objects.length();
-      ArrayList<RObjectEntry> objectEntryList = new ArrayList<RObjectEntry>();
+      ArrayList<RObjectEntry> objectEntryList = new ArrayList<>();
       for (int i = 0; i < numObjects; i++)
       {
          RObjectEntry entry = entryFromRObject(objects.get(i));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/RObjectEntry.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/RObjectEntry.java
@@ -126,8 +126,8 @@ public class RObjectEntry
 
    public static final String NO_VALUE = "NO_VALUE";
    
-   private static final Set<String> DATA_CLASSES = new HashSet<String>();
-   private static final Set<String> HIERARCHICAL_CLASSES = new HashSet<String>();
+   private static final Set<String> DATA_CLASSES = new HashSet<>();
+   private static final Set<String> HIERARCHICAL_CLASSES = new HashSet<>();
    
    static {
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -39,7 +39,6 @@ import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserHandler;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
-import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperations;
 import org.rstudio.studio.client.events.RStudioApiRequestEvent;
 import org.rstudio.studio.client.server.*;
 import org.rstudio.studio.client.workbench.WorkbenchContext;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesCopy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesCopy.java
@@ -40,8 +40,7 @@ public class FilesCopy
                        Command completedCommand)
    {
       // copy list so we don't modify passed list
-      ArrayList<FileSystemItem> filesQueue = new ArrayList<FileSystemItem>(
-                                                               files);
+      ArrayList<FileSystemItem> filesQueue = new ArrayList<>(files);
       
       // begin copy sequence (this method keeps calling itself until
       // the queue of files is empty)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/DirectoryNavigateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/DirectoryNavigateEvent.java
@@ -36,8 +36,7 @@ public class DirectoryNavigateEvent extends GwtEvent<DirectoryNavigateHandler>
       }-*/;      
    }
    
-   public static final GwtEvent.Type<DirectoryNavigateHandler> TYPE =
-      new GwtEvent.Type<DirectoryNavigateHandler>();
+   public static final GwtEvent.Type<DirectoryNavigateHandler> TYPE = new GwtEvent.Type<>();
    
    public DirectoryNavigateEvent(Data data)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/FileChangeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/FileChangeEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.studio.client.workbench.views.files.model.FileChange;
 
 public class FileChangeEvent extends GwtEvent<FileChangeHandler>
 {
-   public static final GwtEvent.Type<FileChangeHandler> TYPE =
-      new GwtEvent.Type<FileChangeHandler>();
+   public static final GwtEvent.Type<FileChangeHandler> TYPE = new GwtEvent.Type<>();
    
    public FileChangeEvent(FileChange fileChange)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/ShowFolderEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/events/ShowFolderEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 public class ShowFolderEvent extends GwtEvent<ShowFolderHandler>
 {
-   public static final Type<ShowFolderHandler> TYPE =
-         new Type<ShowFolderHandler>();
+   public static final Type<ShowFolderHandler> TYPE = new Type<>();
 
    public ShowFolderEvent(FileSystemItem path)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/ToolbarLinkMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/ToolbarLinkMenu.java
@@ -112,7 +112,7 @@ public class ToolbarLinkMenu implements LinkMenu
    
    public ArrayList<Link> getLinks()
    {
-      return new ArrayList<Link>(links_);
+      return new ArrayList<>(links_);
    }
 
    public HandlerRegistration addSelectionHandler(
@@ -173,7 +173,7 @@ public class ToolbarLinkMenu implements LinkMenu
    private final ToolbarPopupMenu menu_;
    private final MenuItem[] pre_;
    private final MenuItem[] post_;
-   private final ArrayList<Link> links_ = new ArrayList<Link>();
+   private final ArrayList<Link> links_ = new ArrayList<>();
    private final int maxLinks_;
    private boolean top_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -33,9 +33,9 @@ public class HelpInfo extends JavaScriptObject
 
    public final ParsedInfo parse(String defaultSignature)
    {
-      HashMap<String, String> values = new HashMap<String, String>();
-      HashMap<String, String> args = new HashMap<String, String>();
-      HashMap<String, String> slots = new HashMap<String, String>();
+      HashMap<String, String> values = new HashMap<>();
+      HashMap<String, String> args = new HashMap<>();
+      HashMap<String, String> slots = new HashMap<>();
 
       String html = getHTML();
       if (html != null)
@@ -65,7 +65,7 @@ public class HelpInfo extends JavaScriptObject
          // get all h2 and h3 headings
          NodeList<Element> h2headings = div.getElementsByTagName("h2");
          NodeList<Element> h3headings = div.getElementsByTagName("h3");
-         ArrayList<Element> headings = new ArrayList<Element>();
+         ArrayList<Element> headings = new ArrayList<>();
          for (int i = 0; i < h2headings.getLength(); i++)
             headings.add(h2headings.getItem(i));
          for (int i = 0; i < h3headings.getLength(); i++)
@@ -242,7 +242,7 @@ public class HelpInfo extends JavaScriptObject
       public final ParsedInfo toParsedInfo() 
       {
          // values
-         HashMap<String,String> values = new HashMap<String,String>();
+         HashMap<String,String> values = new HashMap<>();
          values.put("Title", getTitle());
          values.put("Description", getDescription());
          
@@ -252,7 +252,7 @@ public class HelpInfo extends JavaScriptObject
          JsArrayString jsArgDescriptions = getArgDescriptions();
          if (jsArgs != null && jsArgDescriptions != null)
          {
-            args = new HashMap<String,String>();
+            args = new HashMap<>();
             for (int i =0; i<jsArgs.length(); i++)
                args.put(jsArgs.get(i), jsArgDescriptions.get(i));
          }
@@ -282,7 +282,7 @@ public class HelpInfo extends JavaScriptObject
          super();
          this.pkgName = pkgName;
          this.signature = signature;
-         this.values = values != null ? values : new HashMap<String, String>();
+         this.values = values != null ? values : new HashMap<>();
          this.args = args;
          this.slots = slots;
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/VirtualHistory.java
@@ -103,6 +103,6 @@ public class VirtualHistory
    }
    
    private final Frame frame_;
-   private List<Data> stack_ = new ArrayList<Data>();
+   private List<Data> stack_ = new ArrayList<>();
    private int pos_ = -1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/search/HelpSearchOracle.java
@@ -48,8 +48,7 @@ public class HelpSearchOracle extends SuggestOracle
          {
             int maxCount = Math.min(suggestions.length(), request.getLimit());
 
-            ArrayList<SearchSuggestion> results =
-               new ArrayList<SearchSuggestion>();
+            ArrayList<SearchSuggestion> results = new ArrayList<>();
             for (int i = 0; i< maxCount; i++)
                results.add(new SearchSuggestion(suggestions.get(i)));
             

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
@@ -238,7 +238,7 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
             }
 
             // set recent commands
-            ArrayList<HistoryEntry> subList = new ArrayList<HistoryEntry>();
+            ArrayList<HistoryEntry> subList = new ArrayList<>();
             subList.addAll(commands.subList(startIndex, commands.size()));
             boolean scrollToBottom = preservedScrollPos == -1;
             setRecentCommands(subList, scrollToBottom);
@@ -575,7 +575,7 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
 
    private ArrayList<HistoryEntry> toList(RpcObjectList<HistoryEntry> response)
    {
-      ArrayList<HistoryEntry> entries = new ArrayList<HistoryEntry>();
+      ArrayList<HistoryEntry> entries = new ArrayList<>();
       for (int i = 0; i < response.length(); i++)
          entries.add(response.get(i));
       return entries;
@@ -584,7 +584,7 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
    private ArrayList<HistoryEntry> toRecentCommandsList(
                                              JsArrayString jsCommands)
    {
-      ArrayList<HistoryEntry> commands = new ArrayList<HistoryEntry>();
+      ArrayList<HistoryEntry> commands = new ArrayList<>();
       for (int i=0; i<jsCommands.length(); i++)
          commands.add(HistoryEntry.create(i, jsCommands.get(i)));
       return commands;
@@ -593,7 +593,7 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
    private ArrayList<HistoryEntry> toRecentCommandsList(
                                  RpcObjectList<HistoryEntry> response)
    {
-      ArrayList<HistoryEntry> entries = new ArrayList<HistoryEntry>();
+      ArrayList<HistoryEntry> entries = new ArrayList<>();
       for (int i = 0; i < response.length(); i++)
          entries.add(response.get(i));
       return entries;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/FetchCommandsEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/FetchCommandsEvent.java
@@ -18,8 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class FetchCommandsEvent extends GwtEvent<FetchCommandsHandler>
 {
-   public static final Type<FetchCommandsHandler> TYPE =
-         new Type<FetchCommandsHandler>();
+   public static final Type<FetchCommandsHandler> TYPE = new Type<>();
    
    @Override
    public Type<FetchCommandsHandler> getAssociatedType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/HistoryEntriesAddedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/events/HistoryEntriesAddedEvent.java
@@ -20,8 +20,7 @@ import org.rstudio.studio.client.workbench.views.history.model.HistoryEntry;
 
 public class HistoryEntriesAddedEvent extends GwtEvent<HistoryEntriesAddedHandler>
 {
-   public static final GwtEvent.Type<HistoryEntriesAddedHandler> TYPE =
-      new GwtEvent.Type<HistoryEntriesAddedHandler>();
+   public static final GwtEvent.Type<HistoryEntriesAddedHandler> TYPE = new GwtEvent.Type<>();
    
    public HistoryEntriesAddedEvent(RpcObjectList<HistoryEntry> entries)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.java
@@ -575,7 +575,7 @@ public class HistoryPane extends WorkbenchPane
          {
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
       searchWidget_.addKeyDownHandler(new KeyDownHandler()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/model/JobManager.java
@@ -386,7 +386,7 @@ public class JobManager implements JobRefreshEvent.Handler,
             code,
             spec ->
             {
-               server_.startJob(spec, new ErrorLoggingServerRequestCallback<String>());
+               server_.startJob(spec, new ErrorLoggingServerRequestCallback<>());
             }
       );
       
@@ -409,7 +409,7 @@ public class JobManager implements JobRefreshEvent.Handler,
                }
 
                // tell the server to start running this script
-               server_.startJob(spec, new ErrorLoggingServerRequestCallback<String>());
+               server_.startJob(spec, new ErrorLoggingServerRequestCallback<>());
             });
       
       dialog.showModal();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.output.find;
 
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.TableRowElement;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintMarkers.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintMarkers.java
@@ -52,7 +52,7 @@ public class LintMarkers
                       JsArray<AceAnnotation> annotations)
    {
       document_ = document;
-      annotations_ = new ArrayList<AnchoredAceAnnotation>();
+      annotations_ = new ArrayList<>();
       annotations_.ensureCapacity(annotations.length());
       for (int i = 0; i < annotations.length(); i++)
          annotations_.set(i, new AnchoredAceAnnotation(annotations.get(i)));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/Packages.java
@@ -446,15 +446,14 @@ public class Packages
                               final PackageInstallContext installContext)
    {
       // split the updates into their respective target libraries
-      List<String> packages = new ArrayList<String>();
-      LinkedHashMap<String, ArrayList<PackageUpdate>> updatesByLibPath = 
-         new  LinkedHashMap<String, ArrayList<PackageUpdate>>();  
+      List<String> packages = new ArrayList<>();
+      LinkedHashMap<String, ArrayList<PackageUpdate>> updatesByLibPath = new LinkedHashMap<>();  
       for (PackageUpdate update : updates)
       {
          // auto-create target list if necessary
          String libPath = update.getLibPath();
          if (!updatesByLibPath.containsKey(libPath))
-            updatesByLibPath.put(libPath, new ArrayList<PackageUpdate>());
+            updatesByLibPath.put(libPath, new ArrayList<>());
          
          // insert into list
          updatesByLibPath.get(libPath).add(update); 
@@ -848,7 +847,7 @@ public class Packages
       // apply filter (if any)
       if (packageFilter_.length() > 0)
       {
-         packages = new ArrayList<PackageInfo>();
+         packages = new ArrayList<>();
          
          // first do prefix search
          for (PackageInfo pkgInfo : allPackages_)
@@ -1157,8 +1156,7 @@ public class Packages
    private TreeMap<String, PackratPackageAction> createMapFromActions(
          JsArray<PackratPackageAction> actions)
    {
-      TreeMap<String, PackratPackageAction> result = 
-            new TreeMap<String, PackratPackageAction>();
+      TreeMap<String, PackratPackageAction> result = new TreeMap<>();
       for (int i = 0; i < actions.length(); i++)
       {
          result.put(actions.get(i).getPackage(), actions.get(i));
@@ -1171,15 +1169,14 @@ public class Packages
          JsArray<PackratPackageAction> snapshotActions)
    {
       // build a map of all the package actions
-      ArrayList<PackratConflictActions> conflicts = 
-            new ArrayList<PackratConflictActions>();
+      ArrayList<PackratConflictActions> conflicts = new ArrayList<>();
       TreeMap<String, PackratPackageAction> restoreMap = 
             createMapFromActions(restoreActions);
       TreeMap<String, PackratPackageAction> snapshotMap = 
             createMapFromActions(snapshotActions);
 
       // build a union of all affected package names
-      Set<String> packageNames = new TreeSet<String>();
+      Set<String> packageNames = new TreeSet<>();
       getPackageNamesFromActions(restoreActions, packageNames);
       getPackageNamesFromActions(snapshotActions, packageNames);
       
@@ -1220,7 +1217,7 @@ public class Packages
    private void setPackageState(PackageState newState)
    {
       // sort the packages
-      allPackages_ = new ArrayList<PackageInfo>();
+      allPackages_ = new ArrayList<>();
       JsArray<PackageInfo> serverPackages = newState.getPackageList();
       for (int i = 0; i < serverPackages.length(); i++)
          allPackages_.add(serverPackages.get(i));
@@ -1273,7 +1270,7 @@ public class Packages
    private final PackagesServerOperations server_;
    private final PackratServerOperations packratServer_;
    private final RenvServerOperations renvServer_;
-   private ArrayList<PackageInfo> allPackages_ = new ArrayList<PackageInfo>();
+   private ArrayList<PackageInfo> allPackages_ = new ArrayList<>();
    private ProjectContext projectContext_;
    private String packageFilter_ = new String();
    private HandlerRegistration consolePromptHandlerReg_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/PackagesPane.java
@@ -245,7 +245,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
             // no suggestions
             callback.onSuggestionsReady(
                   request,
-                  new Response(new ArrayList<Suggestion>()));
+                  new Response(new ArrayList<>()));
          }
       });
       
@@ -301,7 +301,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    @Override
    protected Widget createMainWidget()
    {
-      packagesDataProvider_ = new ListDataProvider<PackageInfo>();
+      packagesDataProvider_ = new ListDataProvider<>();
       packagesTableContainer_ = new LayoutPanel();
       packagesTableContainer_.addStyleName("ace_editor_theme");
       return packagesTableContainer_;
@@ -334,7 +334,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
       try
       {
          packagesTableContainer_.clear();
-         packagesTable_ = new RStudioDataGrid<PackageInfo>(
+         packagesTable_ = new RStudioDataGrid<>(
             packagesDataProvider_.getList().size(), dataGridRes_);
       }
       catch (Exception e)
@@ -379,7 +379,7 @@ public class PackagesPane extends WorkbenchPane implements Packages.Display
    private void initPackagesTable()
    {
       packagesTable_.setKeyboardSelectionPolicy(KeyboardSelectionPolicy.DISABLED);
-      packagesTable_.setSelectionModel(new NoSelectionModel<PackageInfo>());
+      packagesTable_.setSelectionModel(new NoSelectionModel<>());
         
       LoadedColumn loadedColumn = new LoadedColumn();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageStateChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageStateChangedEvent.java
@@ -21,8 +21,7 @@ import com.google.gwt.event.shared.GwtEvent;
 public class PackageStateChangedEvent extends
                               GwtEvent<PackageStateChangedHandler>
 {
-   public static final GwtEvent.Type<PackageStateChangedHandler> TYPE =
-      new GwtEvent.Type<PackageStateChangedHandler>();
+   public static final GwtEvent.Type<PackageStateChangedHandler> TYPE = new GwtEvent.Type<>();
    
    public PackageStateChangedEvent(PackageState newState)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageStatusChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/events/PackageStatusChangedEvent.java
@@ -20,8 +20,7 @@ import org.rstudio.studio.client.workbench.views.packages.model.PackageStatus;
 public class PackageStatusChangedEvent 
                      extends GwtEvent<PackageStatusChangedHandler>
 {
-   public static final GwtEvent.Type<PackageStatusChangedHandler> TYPE =
-      new GwtEvent.Type<PackageStatusChangedHandler>();
+   public static final GwtEvent.Type<PackageStatusChangedHandler> TYPE = new GwtEvent.Type<>();
    
    public PackageStatusChangedEvent(PackageStatus packageStatus)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/CheckForUpdatesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/CheckForUpdatesDialog.java
@@ -98,8 +98,8 @@ public class CheckForUpdatesDialog extends PackageActionConfirmationDialog<Packa
       table.addColumn(availableColumn, "Available");
       table.setColumnWidth(availableColumn, 28, Unit.PCT);
 
-      ImageButtonColumn<PendingAction> newsColumn = 
-            new ImageButtonColumn<PendingAction>(
+      ImageButtonColumn<PendingAction> newsColumn =
+            new ImageButtonColumn<>(
                   new ImageResource2x(ThemeResources.INSTANCE.newsButton2x()),
                   new OperationWithInput<PendingAction>() {
                      

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageActionConfirmationDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/ui/PackageActionConfirmationDialog.java
@@ -77,7 +77,7 @@ public abstract class PackageActionConfirmationDialog<T extends JavaScriptObject
    @Override
    protected ArrayList<T> collectInput()
    {
-      ArrayList<T> actions = new ArrayList<T>();
+      ArrayList<T> actions = new ArrayList<>();
       for (PendingAction action : actionsDataProvider_.getList())
       {
          if (action.getPerformAction().getBool())
@@ -219,7 +219,7 @@ public abstract class PackageActionConfirmationDialog<T extends JavaScriptObject
    private void setGlobalPerformAction(String label, Boolean performAction)
    {
       List<PendingAction> actions = actionsDataProvider_.getList();
-      ArrayList<PendingAction> newActions = new ArrayList<PendingAction>();
+      ArrayList<PendingAction> newActions = new ArrayList<>();
       for(PendingAction action : actions)
          newActions.add(new PendingAction(action.getActionInfo(), new LabeledBoolean(label, performAction)));
       actionsDataProvider_.setList(newActions);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/LocatorPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/LocatorPanel.java
@@ -180,7 +180,7 @@ public class LocatorPanel extends LayoutPanel
          public void run()
          {
             feedbackTimer_ = null;
-            ArrayList<Widget> widgets = new ArrayList<Widget>();
+            ArrayList<Widget> widgets = new ArrayList<>();
             widgets.add(feedbackImage_);
             feedbackAnimation_ = new FadeOutAnimation(widgets,
                                                       new Command() {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/Plots.java
@@ -133,7 +133,7 @@ public class Plots extends BasePresenter implements PlotsChangedEvent.Handler,
 
             }
 
-            server.locatorCompleted(p, new SimpleRequestCallback<Void>());
+            server.locatorCompleted(p, new SimpleRequestCallback<>());
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -529,7 +529,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
       private ListBox paperSizeListBox_;
       private final TextBox widthTextBox_;
       private final TextBox heightTextBox_;
-      private final List<PaperSize> paperSizes_ = new ArrayList<PaperSize>(); 
+      private final List<PaperSize> paperSizes_ = new ArrayList<>(); 
       private final NumberFormat sizeFormat_ = NumberFormat.getFormat("##0.00");
       
       private final double kMimimumSize = 3.0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocsMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/DocsMenu.java
@@ -133,7 +133,7 @@ public class DocsMenu extends AppMenuBar
    
    private String[] deduplicate(String[] names, String[] paths)
    {
-      Map<String, Integer> counts = new HashMap<String, Integer>();
+      Map<String, Integer> counts = new HashMap<>();
       
       // initialize map with zeroes
       int n = names.length;
@@ -195,9 +195,9 @@ public class DocsMenu extends AppMenuBar
       }
    }
 
-   private ArrayList<String> ids_ = new ArrayList<String>();
-   private ArrayList<String> names_ = new ArrayList<String>();
-   private ArrayList<MenuItem> menuItems_ = new ArrayList<MenuItem>();
+   private ArrayList<String> ids_ = new ArrayList<>();
+   private ArrayList<String> names_ = new ArrayList<>();
+   private ArrayList<MenuItem> menuItems_ = new ArrayList<>();
    private EventBus events_;
    private PopupPanel panel_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -102,7 +102,6 @@ import org.rstudio.studio.client.events.ReplaceRangesEvent;
 import org.rstudio.studio.client.events.ReplaceRangesEvent.ReplacementData;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.events.SetSelectionRangesEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -191,7 +190,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.Queue;
-import java.util.List;
 import java.util.Set;
 
 @Singleton
@@ -1574,8 +1572,7 @@ public class Source implements InsertSourceHandler,
 
    public ArrayList<UnsavedChangesTarget> getUnsavedChanges(int type, Set<String> ids)
    {
-      ArrayList<UnsavedChangesTarget> targets =
-          new ArrayList<UnsavedChangesTarget>();
+      ArrayList<UnsavedChangesTarget> targets = new ArrayList<>();
 
       // if this is the main window, collect all unsaved changes from
       // the satellite windows as well
@@ -1633,7 +1630,7 @@ public class Source implements InsertSourceHandler,
    public Command revertUnsavedChangesBeforeExitCommand(
                                                final Command onCompleted)
    {
-      return () -> handleUnsavedChangesBeforeExit(new ArrayList<UnsavedChangesTarget>(),
+      return () -> handleUnsavedChangesBeforeExit(new ArrayList<>(),
                                                   onCompleted);
    }
 
@@ -2462,9 +2459,7 @@ public class Source implements InsertSourceHandler,
          columnManager_.activateCodeBrowser(
             navigation.getPath(),
             false,
-            new SourceNavigationResultCallback<CodeBrowserEditingTarget>(
-                                                      navigation.getPosition(),
-                                                      retryCommand));
+            new SourceNavigationResultCallback<>(navigation.getPosition(), retryCommand));
       }
 
       // check for file path navigation
@@ -2478,9 +2473,7 @@ public class Source implements InsertSourceHandler,
          // open the file and restore the position
          columnManager_.openFile(file,
                                  fileType,
-                                 new SourceNavigationResultCallback<EditingTarget>(
-                                                                  navigation.getPosition(),
-                                                                  retryCommand));
+            new SourceNavigationResultCallback<>(navigation.getPosition(), retryCommand));
       }
       else
       {
@@ -2682,7 +2675,7 @@ public class Source implements InsertSourceHandler,
       // the current save code is wired up in such a way that it's difficult
       // to distinguish a success from failure, so we just make sure the
       // server receives a response after 5s (defaulting to failure)
-      final Mutable<Boolean> savedSuccessfully = new Mutable<Boolean>(false);
+      final Mutable<Boolean> savedSuccessfully = new Mutable<>(false);
       final Timer completedTimer = new Timer()
       {
          @Override
@@ -2709,7 +2702,7 @@ public class Source implements InsertSourceHandler,
       }
       else
       {
-         final Set<String> idSet = new HashSet<String>();
+         final Set<String> idSet = new HashSet<>();
          for (String id : JsUtil.asIterable(ids))
             idSet.add(id);
 
@@ -3126,7 +3119,7 @@ public class Source implements InsertSourceHandler,
    }
 
    private final Commands commands_;
-   final Queue<StatFileEntry> statQueue_ = new LinkedList<StatFileEntry>();
+   final Queue<StatFileEntry> statQueue_ = new LinkedList<>();
    SourceColumnManager columnManager_;
    private final SourceServerOperations server_;
    private final FileTypeRegistry fileTypeRegistry_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -55,7 +55,6 @@ import org.rstudio.studio.client.common.synctex.Synctex;
 import org.rstudio.studio.client.events.GetEditorContextEvent;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.rmarkdown.model.RmdChosenTemplate;
 import org.rstudio.studio.client.rmarkdown.model.RmdFrontMatter;
 import org.rstudio.studio.client.rmarkdown.model.RmdOutputFormat;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
@@ -267,7 +267,7 @@ public class SourceWindow implements LastSourceDocClosedHandler,
       Set<String> ids = null;
       if (idArray != null)
       {
-         ids = new HashSet<String>();
+         ids = new HashSet<>();
          for (String id : JsUtil.asIterable(idArray))
             ids.add(id);
       }
@@ -279,8 +279,7 @@ public class SourceWindow implements LastSourceDocClosedHandler,
          Command onCompleted)
    {
       JsArray<UnsavedChangesItem> items = jsoItems.cast();
-      ArrayList<UnsavedChangesTarget> targets = 
-            new ArrayList<UnsavedChangesTarget>();
+      ArrayList<UnsavedChangesTarget> targets = new ArrayList<>();
       for (int i = 0; i < items.length(); i++)
       {
          targets.add(items.get(i));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -615,7 +615,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
             break;
          }
       }
-      HashMap<String,String> props = new HashMap<String,String>();
+      HashMap<String,String> props = new HashMap<>();
       props.put(SourceColumnManager.COLUMN_PREFIX, name);
 
       if (write)
@@ -1052,7 +1052,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
 
    private boolean updateWindowGeometry()
    {
-      final ArrayList<String> changedWindows = new ArrayList<String>();
+      final ArrayList<String> changedWindows = new ArrayList<>();
       final JsObject newGeometries = JsObject.createJsObject();
 
       doForAllSourceWindows(new OperationWithInput<Pair<String,WindowEx>>()
@@ -1112,7 +1112,7 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
          if (window == null || window.isClosed())
             continue;
 
-         command.execute(new Pair<String,WindowEx>(windowId, window));
+         command.execute(new Pair<>(windowId, window));
       }
    }
 
@@ -1168,14 +1168,14 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
             // no point in writing a value to the server if we're not changing
             // it
             if (doc.getSourceWindowId() == windowId)
-               return new HashMap<String,String>();
+               return new HashMap<>();
             doc.assignSourceWindowId(windowId);
             break;
          }
       }
 
       // create the new property map
-      HashMap<String,String> props = new HashMap<String,String>();
+      HashMap<String,String> props = new HashMap<>();
       props.put(SOURCE_WINDOW_ID, windowId);
 
       return props;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetInlineChunkExecution.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/EditingTargetInlineChunkExecution.java
@@ -62,7 +62,7 @@ public class EditingTargetInlineChunkExecution
       
       display_ = display;
       docId_ = docId;
-      outputs_ = new HashMap<String, ChunkInlineOutput>();
+      outputs_ = new HashMap<>();
    }
    
    public void execute(Range range)
@@ -105,8 +105,7 @@ public class EditingTargetInlineChunkExecution
             display_.createAnchoredSelection(range.getStart(), range.getEnd()));
       
       // auto dismiss the panel when the cursor leaves the inline chunk
-      final Mutable<HandlerRegistration> cursorHandler =
-            new Mutable<HandlerRegistration>();
+      final Mutable<HandlerRegistration> cursorHandler = new Mutable<>();
       cursorHandler.set(display_.addCursorChangedHandler(
             new CursorChangedHandler()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTarget.java
@@ -47,7 +47,6 @@ import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -78,7 +77,6 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperat
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 
 public class CodeBrowserEditingTarget implements EditingTarget
 {
@@ -231,7 +229,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
                         CodeBrowserContents.create(getContext());
       if (!contents.equalTo(getContents()))
       {
-         HashMap<String, String> props = new HashMap<String, String>();
+         HashMap<String, String> props = new HashMap<>();
          contents.fillProperties(props);
          server_.modifyDocumentProperties(
                doc_.getId(),
@@ -452,7 +450,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
    @Override
    public HashSet<AppCommand> getSupportedCommands()
    {
-      HashSet<AppCommand> commands = new HashSet<AppCommand>();
+      HashSet<AppCommand> commands = new HashSet<>();
       commands.add(commands_.printSourceDoc());
       commands.add(commands_.findReplace());
       commands.add(commands_.findNext());
@@ -845,7 +843,7 @@ public class CodeBrowserEditingTarget implements EditingTarget
 
    private SourceDocument doc_;
 
-   private final Value<Boolean> dirtyState_ = new Value<Boolean>(false);
+   private final Value<Boolean> dirtyState_ = new Value<>(false);
    private ArrayList<HandlerRegistration> releaseOnDismiss_ = new ArrayList<>();
    private final SourceServerOperations server_;
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/codebrowser/CodeBrowserEditingTargetWidget.java
@@ -53,7 +53,6 @@ import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionManager;
@@ -176,7 +175,7 @@ public class CodeBrowserEditingTargetWidget extends ResizeComposite
         
             server.getHelpAtCursor(
                linePos.getLine(), linePos.getPosition(),
-               new SimpleRequestCallback<Void>("Help")); 
+               new SimpleRequestCallback<>("Help")); 
          }
          
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -214,7 +214,7 @@ public class DataEditingTarget extends UrlContentEditingTarget
       
       final String oldCacheKey = getCacheKey();
 
-      HashMap<String, String> props = new HashMap<String, String>();
+      HashMap<String, String> props = new HashMap<>();
       data.fillProperties(props);
       server_.modifyDocumentProperties(
             doc_.getId(),
@@ -226,7 +226,7 @@ public class DataEditingTarget extends UrlContentEditingTarget
                {
                   server_.removeCachedData(
                         oldCacheKey,
-                        new ErrorLoggingServerRequestCallback<Void>());
+                        new ErrorLoggingServerRequestCallback<>());
 
                   data.fillProperties(doc_.getProperties());
                   reloadDisplay();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/view/ObjectExplorerDataGrid.java
@@ -311,7 +311,7 @@ public class ObjectExplorerDataGrid
          return null;
 
       // extract all access strings from data + parents
-      List<String> accessors = new ArrayList<String>();
+      List<String> accessors = new ArrayList<>();
       while (data != null && data.getObjectAccess() != null)
       {
          accessors.add(data.getObjectAccess());
@@ -571,20 +571,20 @@ public class ObjectExplorerDataGrid
       setSize("100%", "100%");
 
       // add columns
-      nameColumn_ = new IdentityColumn<Data>(new NameCell());
+      nameColumn_ = new IdentityColumn<>(new NameCell());
       addColumn(nameColumn_, new TextHeader("Name"));
 
-      typeColumn_ = new IdentityColumn<Data>(new TypeCell());
+      typeColumn_ = new IdentityColumn<>(new TypeCell());
       addColumn(typeColumn_, new ResizableHeader(this, "Type"));
 
-      valueColumn_ = new IdentityColumn<Data>(new ValueCell());
+      valueColumn_ = new IdentityColumn<>(new ValueCell());
       addColumn(valueColumn_, new ResizableHeader(this, "Value"));
 
       initializeColumnWidths();
 
       // set updater
-      dataProvider_ = new ListDataProvider<Data>();
-      dataProvider_.setList(new ArrayList<Data>());
+      dataProvider_ = new ListDataProvider<>();
+      dataProvider_.setList(new ArrayList<>());
       dataProvider_.addDataDisplay(this);
 
       // register handlers
@@ -1305,7 +1305,7 @@ public class ObjectExplorerDataGrid
    private final List<Data> flatten(Data data,
                                     Filter<Data> filter)
    {
-      List<Data> list = new ArrayList<Data>();
+      List<Data> list = new ArrayList<>();
       flattenImpl(data, filter, list);
       return list;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/profiler/ProfilerEditingTarget.java
@@ -59,7 +59,6 @@ import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.ProfilerType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.rsconnect.model.PublishHtmlSource;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
@@ -88,7 +87,6 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperat
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 
 public class ProfilerEditingTarget implements EditingTarget,
                                               HasSelectionCommitHandlers<CodeNavigationTarget>
@@ -698,7 +696,7 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    private void persistDocumentProperty(String property, String value)
    {
-      HashMap<String, String> props = new HashMap<String, String>();
+      HashMap<String, String> props = new HashMap<>();
       props.put(property, value);
 
       sourceServer_.modifyDocumentProperties(
@@ -892,7 +890,7 @@ public class ProfilerEditingTarget implements EditingTarget,
    private ProfilerEditingTargetWidget view_;
    private final ProfilerPresenter presenter_;
 
-   private final Value<Boolean> neverDirtyState_ = new Value<Boolean>(false);
+   private final Value<Boolean> neverDirtyState_ = new Value<>(false);
 
    private final EventBus events_;
    private final Commands commands_;
@@ -915,7 +913,7 @@ public class ProfilerEditingTarget implements EditingTarget,
 
    private static boolean initializedEvents_;
 
-   private Value<String> name_ = new Value<String>(null);
+   private Value<String> name_ = new Value<>(null);
    private String tempName_;
 
    private String htmlPath_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1644,7 +1644,7 @@ public class AceEditor implements DocDisplay,
    {
       // detach anchors on dispose
       ArrayList<org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor> 
-        anchors = new ArrayList<org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor>();
+        anchors = new ArrayList<>();
       
       return new SpellingDoc() {
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -738,8 +738,7 @@ public class AceEditorWidget extends Composite
          if (state == ChunkRowExecState.LINE_QUEUED)
          {
             // queued state: introduce to the editor
-            final Value<ChunkRowAceExecState> execState =
-                  new Value<ChunkRowAceExecState>(null);
+            final Value<ChunkRowAceExecState> execState = new Value<>(null);
             execState.setValue(
                   new ChunkRowAceExecState(editor_, i, state, new Command()
                         {
@@ -1109,8 +1108,7 @@ public class AceEditorWidget extends Composite
    {
       Range range = event.getRange();
 
-      ArrayList<AnchoredAceAnnotation> annotations =
-            new ArrayList<AnchoredAceAnnotation>();
+      ArrayList<AnchoredAceAnnotation> annotations = new ArrayList<>();
 
       for (int i = 0; i < annotations_.size(); i++)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceKeyboardPreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceKeyboardPreviewer.java
@@ -115,5 +115,5 @@ public class AceKeyboardPreviewer
       return false;
    }
    
-   private ArrayList<Handler> handlers_ = new ArrayList<Handler>();
+   private ArrayList<Handler> handlers_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputGallery.java
@@ -73,7 +73,7 @@ public class ChunkOutputGallery extends Composite
       ChunkOutputPresenter.Host host,
       ChunkOutputSize chunkOutputSize)
    {
-      pages_ = new ArrayList<ChunkOutputPage>();
+      pages_ = new ArrayList<>();
       host_ = host;
       chunkOutputSize_ = chunkOutputSize;
       initWidget(uiBinder.createAndBindUi(this));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -66,7 +66,7 @@ public class ChunkOutputStream extends FlowPanel
    {
       host_ = host;
       chunkOutputSize_ = chunkOutputSize;
-      metadata_ = new HashMap<Integer, JavaScriptObject>();
+      metadata_ = new HashMap<>();
 
       if (chunkOutputSize_ == ChunkOutputSize.Full) {
          getElement().getStyle().setWidth(100, Unit.PCT);
@@ -571,8 +571,8 @@ public class ChunkOutputStream extends FlowPanel
       // flush any errors so they are properly accounted for
       flushQueuedErrors();
       
-      List<ChunkOutputPage> pages = new ArrayList<ChunkOutputPage>();
-      List<Widget> removed = new ArrayList<Widget>();
+      List<ChunkOutputPage> pages = new ArrayList<>();
+      List<Widget> removed = new ArrayList<>();
       for (Widget w: this)
       {
          // extract ordinal and metadata

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.java
@@ -114,7 +114,7 @@ public class ChunkOutputWidget extends Composite
       options_ = options;
       chunkOutputSize_ = chunkOutputSize;
       initWidget(uiBinder.createAndBindUi(this));
-      expansionState_ = new Value<Integer>(expansionState);
+      expansionState_ = new Value<>(expansionState);
       applyCachedEditorStyle();
       if (expansionState_.getValue() == COLLAPSED)
          setCollapsedStyles();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkSatelliteWindow.java
@@ -43,7 +43,6 @@ import org.rstudio.studio.client.rmarkdown.model.RmdChunkOptions;
 import org.rstudio.studio.client.server.QuietServerRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.ui.FontSizeManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCacheEditorStyleEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.ChunkSatelliteCodeExecutingEvent;
@@ -144,7 +143,7 @@ public class ChunkSatelliteWindow extends SatelliteWindow
             server_.cleanReplayNotebookChunkPlots(
                chunkWindowParams_.getDocId(), 
                chunkWindowParams_.getChunkId(),
-               new QuietServerRequestCallback<Void>());
+               new QuietServerRequestCallback<>());
          }
       });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkWindowManager.java
@@ -54,7 +54,7 @@ public class ChunkWindowManager
       pSatelliteManager_ = pSatelliteManager;
       events_ = events;
 
-      satelliteChunks_ = new ArrayList<Pair<String, String>>();
+      satelliteChunks_ = new ArrayList<>();
       
       if (!Satellite.isCurrentWindowSatellite())
       {
@@ -87,7 +87,7 @@ public class ChunkWindowManager
    @Override
    public void onChunkSatelliteCloseAllWindow(ChunkSatelliteCloseAllWindowEvent event)
    {
-      ArrayList<Pair<String,String>> newSatelliteChunks = new ArrayList<Pair<String,String>>();
+      ArrayList<Pair<String,String>> newSatelliteChunks = new ArrayList<>();
 
       for (Pair<String, String> chunkPair : satelliteChunks_)
       {
@@ -117,7 +117,7 @@ public class ChunkWindowManager
       String docId = event.getDocId();
       String chunkId = event.getChunkId();
 
-      satelliteChunks_.add(new Pair<String, String>(docId, chunkId));
+      satelliteChunks_.add(new Pair<>(docId, chunkId));
       events_.fireEventToAllSatellites(event);
 
       ChunkSatelliteWindowRegisteredEvent registeredEvent = new ChunkSatelliteWindowRegisteredEvent(docId, chunkId);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/Fold.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/Fold.java
@@ -60,7 +60,7 @@ public class Fold
 
    public static ArrayList<Fold> decode(String foldData)
    {
-      ArrayList<Fold> results = new ArrayList<Fold>();
+      ArrayList<Fold> results = new ArrayList<>();
       String[] chunks = foldData.split("\n");
       for (String chunk : chunks)
       {
@@ -95,7 +95,7 @@ public class Fold
 
    public static ArrayList<Fold> fromJs(JsArray<JsArrayMixed> folds)
    {
-      ArrayList<Fold> results = new ArrayList<Fold>();
+      ArrayList<Fold> results = new ArrayList<>();
       for (int i = 0; i < folds.length(); i++)
       {
          JsArrayMixed foldData = folds.get(i);
@@ -115,7 +115,7 @@ public class Fold
     */
    public static ArrayList<Fold> flatten(JsArray<AceFold> folds)
    {
-      ArrayList<Fold> results = new ArrayList<Fold>();
+      ArrayList<Fold> results = new ArrayList<>();
       for (int i = 0; i < folds.length(); i++)
          collect(folds.get(i), results, Position.create(0, 0));
       return results;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -149,12 +149,10 @@ public class ImagePreviewer
          return;
       
       // shared mutable state that we hide in this closure
-      final Mutable<PinnedLineWidget>  plw = new Mutable<PinnedLineWidget>();
-      final Mutable<ChunkOutputWidget> cow = new Mutable<ChunkOutputWidget>();
-      final Mutable<HandlerRegistration> docChangedHandler = 
-            new Mutable<HandlerRegistration>(); 
-      final Mutable<HandlerRegistration> renderHandler = 
-            new Mutable<HandlerRegistration>();
+      final Mutable<PinnedLineWidget>  plw = new Mutable<>();
+      final Mutable<ChunkOutputWidget> cow = new Mutable<>();
+      final Mutable<HandlerRegistration> docChangedHandler = new Mutable<>(); 
+      final Mutable<HandlerRegistration> renderHandler = new Mutable<>();
       
       // command that ensures state is cleaned up when widget hidden
       final Command onDetach = new Command()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ScopeList.java
@@ -155,5 +155,5 @@ public class ScopeList implements Iterable<Scope>
       }
    }
 
-   private final ArrayList<Scope> scopes_ = new ArrayList<Scope>();
+   private final ArrayList<Scope> scopes_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetChunks.java
@@ -47,8 +47,8 @@ public class TextEditingTargetChunks
    public TextEditingTargetChunks(TextEditingTarget target)
    {
       target_ = target;
-      toolbars_ = new ArrayList<ChunkContextCodeUi>();
-      modifiedRanges_ = new ArrayList<Range>();
+      toolbars_ = new ArrayList<>();
+      modifiedRanges_ = new ArrayList<>();
       renderPass_ = 0;
       
       target.getDocDisplay().addScopeTreeReadyHandler(this);
@@ -210,7 +210,7 @@ public class TextEditingTargetChunks
    
    private void syncModifiedWidgets()
    {
-      Set<Scope> modifiedScopes = new HashSet<Scope>();
+      Set<Scope> modifiedScopes = new HashSet<>();
       
       for (Range range : modifiedRanges_)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCompilePdfHelper.java
@@ -460,6 +460,5 @@ public class TextEditingTargetCompilePdfHelper
    private static final Pattern concordancePattern_ = Pattern.create(
                      "\\\\[\\s]*SweaveOpts[\\s]*{.*concordance[\\s]*=.*}");
    
-   private static HashMap<String, RnwChunkOptions> chunkOptionsCache_ = 
-                                    new HashMap<String, RnwChunkOptions>();
+   private static HashMap<String, RnwChunkOptions> chunkOptionsCache_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCppHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCppHelper.java
@@ -19,7 +19,6 @@ import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionContext;
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionOperation;
@@ -115,7 +114,7 @@ public class TextEditingTargetCppHelper
                   docPath, 
                   line, 
                   column, 
-                  new CppCompletionServerRequestCallback<Void>(
+                  new CppCompletionServerRequestCallback<>(
                                           "Finding usages..."));
          }
          

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetIdleMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetIdleMonitor.java
@@ -63,7 +63,7 @@ public class TextEditingTargetIdleMonitor
       
       display_ = editingTarget.getDocDisplay();
       sentinel_ = sentinel;
-      monitors_ = new ArrayList<HandlerRegistration>();
+      monitors_ = new ArrayList<>();
       commands_ = target.commands;
       timer_ = new Timer()
       {
@@ -231,7 +231,7 @@ public class TextEditingTargetIdleMonitor
       {
          target = t;
          sentinel = s;
-         commands = new HashMap<HandlerRegistration, IdleCommand>();
+         commands = new HashMap<>();
       }
       public final TextEditingTarget target;
       public final DocUpdateSentinel sentinel;
@@ -279,7 +279,7 @@ public class TextEditingTargetIdleMonitor
          }
       });
 
-       TARGET_MAP = new SafeMap<DocDisplay, IdleTarget>();
+       TARGET_MAP = new SafeMap<>();
    }
    
    private static final int DELAY_MS = 700;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetReformatHelper.java
@@ -55,7 +55,7 @@ public class TextEditingTargetReformatHelper
                                 int offset,
                                 int n)
       {
-         complements_ = new HashMap<String, String>();
+         complements_ = new HashMap<>();
          
          complements_.put("(", ")");
          complements_.put("[", "]");
@@ -194,7 +194,7 @@ public class TextEditingTargetReformatHelper
          int index = offset_ + offset;
          if (index < 0 || index >= n_)
          {
-            ArrayList<Token> dummyTokens = new ArrayList<Token>();
+            ArrayList<Token> dummyTokens = new ArrayList<>();
             dummyTokens.add(Token.create("__ERROR__", "error", 0));
             return new SimpleTokenCursor(dummyTokens, 0, 1, complements_);
          }
@@ -235,7 +235,7 @@ public class TextEditingTargetReformatHelper
          
          boolean isCounterActive = true;
          
-         Stack<String> braceStack = new Stack<String>();
+         Stack<String> braceStack = new Stack<>();
          
          int stack = 0;
          String rhs = complements_.get(lhs);
@@ -698,7 +698,7 @@ public class TextEditingTargetReformatHelper
                   clone.fwdToMatchingToken();
                else
                {
-                  Mutable<Integer> counter = new Mutable<Integer>(0);
+                  Mutable<Integer> counter = new Mutable<>(0);
                   clone.fwdToMatchingToken(counter);
                   accumulatedLength += counter.get();
                }
@@ -1155,9 +1155,9 @@ public class TextEditingTargetReformatHelper
       
       String[] splat = docDisplay_.getSelectionValue().split("\n");
       
-      ArrayList<String> starts = new ArrayList<String>();
-      ArrayList<String> delimiters = new ArrayList<String>();
-      ArrayList<String> ends = new ArrayList<String>();
+      ArrayList<String> starts = new ArrayList<>();
+      ArrayList<String> delimiters = new ArrayList<>();
+      ArrayList<String> ends = new ArrayList<>();
       for (int i = 0; i < splat.length; i++)
       {
          String line = splat[i];
@@ -1194,7 +1194,7 @@ public class TextEditingTargetReformatHelper
       //    y =  10,
       //    z = 100
       //
-      ArrayList<Integer> endPrefixes = new ArrayList<Integer>();
+      ArrayList<Integer> endPrefixes = new ArrayList<>();
       boolean success = true;
       for (int i = 0; i < ends.size(); i++)
       {
@@ -1264,8 +1264,7 @@ public class TextEditingTargetReformatHelper
       int selectionStart = docDisplay_.getSelectionStart().getRow();
       int selectionEnd = docDisplay_.getSelectionEnd().getRow();
       
-      ArrayList<Pair<Integer, Integer>> ranges =
-            new ArrayList<Pair<Integer, Integer>>();
+      ArrayList<Pair<Integer, Integer>> ranges = new ArrayList<>();
       
       for (int i = selectionStart; i <= selectionEnd; i++)
       {
@@ -1304,7 +1303,7 @@ public class TextEditingTargetReformatHelper
                line = docDisplay_.getLine(rangeEnd);
             }
             
-            ranges.add(new Pair<Integer, Integer>(rangeStart, rangeEnd));
+            ranges.add(new Pair<>(rangeStart, rangeEnd));
          }
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRenameHelper.java
@@ -18,9 +18,9 @@ public class TextEditingTargetRenameHelper
    public TextEditingTargetRenameHelper(DocDisplay docDisplay)
    {
       editor_ = (AceEditor) docDisplay;
-      state_ = new Stack<Integer>();
-      protectedNamesList_ = new ArrayList<Set<String>>();
-      ranges_ = new ArrayList<Range>();
+      state_ = new Stack<>();
+      protectedNamesList_ = new ArrayList<>();
+      ranges_ = new ArrayList<>();
    }
    
    public int renameInScope()
@@ -178,7 +178,7 @@ public class TextEditingTargetRenameHelper
    private int renameFunctionArgument(String functionName, String argName)
    {
       TokenCursor cursor = editor_.getSession().getMode().getCodeModel().getTokenCursor();
-      Stack<String> functionNames = new Stack<String>();
+      Stack<String> functionNames = new Stack<>();
       boolean renaming = false;
       
       do
@@ -396,7 +396,7 @@ public class TextEditingTargetRenameHelper
       ranges_.clear();
       state_.clear();
       protectedNamesList_.clear();
-      protectedNamesList_.add(new HashSet<String>());
+      protectedNamesList_.add(new HashSet<>());
    }
    
    private int peekState()
@@ -442,7 +442,7 @@ public class TextEditingTargetRenameHelper
    
    private void pushProtectedNames(Position position, Scope parentScope)
    {
-      protectedNamesList_.add(new HashSet<String>());
+      protectedNamesList_.add(new HashSet<>());
       Scope scope = editor_.getScopeAtPosition(position);
       if (scope.isFunction() && scope != parentScope)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -1091,7 +1091,7 @@ public class TextEditingTargetWidget
 
       Command onInstall = () -> {
          // Form a list of all the dependencies to install
-         ArrayList<Dependency> deps = new ArrayList<Dependency>();
+         ArrayList<Dependency> deps = new ArrayList<>();
          for (String pkg: packages)
             deps.add(Dependency.cranPackage(pkg));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditorContainer.java
@@ -176,5 +176,5 @@ public class TextEditorContainer extends LayoutPanel implements CanFocus
    }
   
    private final Editor editor_;
-   private ArrayList<IsHideableWidget> widgets_ = new ArrayList<IsHideableWidget>();
+   private ArrayList<IsHideableWidget> widgets_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceBackgroundHighlighter.java
@@ -161,7 +161,7 @@ public class AceBackgroundHighlighter
       editor_ = editor;
       session_ = editor.getSession();
       
-      highlightPatterns_ = new ArrayList<HighlightPattern>();
+      highlightPatterns_ = new ArrayList<>();
       editor.addEditorModeChangedHandler(this);
       
       int n = editor.getRowCount();
@@ -455,7 +455,7 @@ public class AceBackgroundHighlighter
    // Static Members ----
    
    static {
-      HIGHLIGHT_PATTERN_REGISTRY = new HashMap<String, List<HighlightPattern>>();
+      HIGHLIGHT_PATTERN_REGISTRY = new HashMap<>();
       HIGHLIGHT_PATTERN_REGISTRY.put("mode/rmarkdown", rMarkdownHighlightPatterns());
       HIGHLIGHT_PATTERN_REGISTRY.put("mode/c_cpp", cStyleHighlightPatterns());
       HIGHLIGHT_PATTERN_REGISTRY.put("mode/sweave", sweaveHighlightPatterns());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -44,7 +44,6 @@ import org.rstudio.studio.client.common.filetypes.model.NavigationMethods;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
-import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.DocumentChangedEvent;
@@ -108,7 +107,7 @@ public class AceEditorBackgroundLinkHighlighter
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       editor_ = editor;
-      activeMarkers_ = new SafeMap<Integer, List<MarkerRegistration>>();
+      activeMarkers_ = new SafeMap<>();
       
       nextHighlightStart_ = 0;
       timer_ = new Timer()
@@ -130,9 +129,9 @@ public class AceEditorBackgroundLinkHighlighter
       };
       
       
-      highlighters_ = new ArrayList<Highlighter>();
+      highlighters_ = new ArrayList<>();
       
-      handlers_ = new ArrayList<HandlerRegistration>();
+      handlers_ = new ArrayList<>();
       handlers_.add(editor_.addAceClickHandler(this));
       handlers_.add(editor_.addAttachHandler(this));
       handlers_.add(editor_.addDocumentChangedHandler(this));
@@ -185,7 +184,7 @@ public class AceEditorBackgroundLinkHighlighter
                                      final AnchoredRange range)
    {
       if (!activeMarkers_.containsKey(row))
-         activeMarkers_.put(row, new ArrayList<MarkerRegistration>());
+         activeMarkers_.put(row, new ArrayList<>());
       List<MarkerRegistration> markers = activeMarkers_.get(row);
       
       // if we're adding a marker that subsumes an old one, clear the old marker
@@ -606,8 +605,7 @@ public class AceEditorBackgroundLinkHighlighter
          @Override
          public void execute()
          {
-            final SafeMap<Integer, List<MarkerRegistration>> newMarkers =
-                  new SafeMap<Integer, List<MarkerRegistration>>();
+            final SafeMap<Integer, List<MarkerRegistration>> newMarkers = new SafeMap<>();
             MapUtil.forEach(activeMarkers_, new ForEachCommand<Integer, List<MarkerRegistration>>()
             {
                @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -184,7 +184,7 @@ public class AceEditorNative extends JavaScriptObject
 
    public final HandlerRegistration delegateEventsTo(HasHandlers handlers)
    {
-      final LinkedList<JavaScriptObject> handles = new LinkedList<JavaScriptObject>();
+      final LinkedList<JavaScriptObject> handles = new LinkedList<>();
       handles.add(addDomListener(getTextInputElement(), "keydown", handlers));
       handles.add(addDomListener(getTextInputElement(), "keypress", handlers));
       handles.add(addDomListener(getTextInputElement(), "changeScrollTop", handlers));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/Tokenizer.java
@@ -157,6 +157,6 @@ public class Tokenizer extends JavaScriptObject
    
    public final List<Token> tokenize(String line)
    {
-      return new ArrayList<Token>(Arrays.asList(doTokenize(line)));
+      return new ArrayList<>(Arrays.asList(doTokenize(line)));
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
@@ -28,7 +28,7 @@ public class RChunkHeaderParser
 {
    public static Map<String, String> parse(String line)
    {
-      Map<String, String> options = new HashMap<String, String>();
+      Map<String, String> options = new HashMap<>();
       parse(line, options);
       return options;
    }
@@ -36,10 +36,10 @@ public class RChunkHeaderParser
    public static final void parse(String line, Map<String, String> options)
    {
       // set up state
-      Mutable<String> key = new Mutable<String>();
+      Mutable<String> key = new Mutable<>();
       Consumer keyConsumer = new MutableConsumer(key);
       
-      Mutable<String> val = new Mutable<String>();
+      Mutable<String> val = new Mutable<>();
       Consumer valConsumer = new MutableConsumer(val);
       
       // determine an appropriate pattern for extracting options from

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/CursorChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/CursorChangedEvent.java
@@ -19,7 +19,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Positio
 
 public class CursorChangedEvent extends GwtEvent<CursorChangedHandler>
 {
-   public static final Type<CursorChangedHandler> TYPE = new Type<CursorChangedHandler>();
+   public static final Type<CursorChangedHandler> TYPE = new Type<>();
 
    public CursorChangedEvent(Position position)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/EditorLoadedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/EditorLoadedEvent.java
@@ -32,7 +32,7 @@ public class EditorLoadedEvent extends GwtEvent<EditorLoadedHandler>
    
    private final AceEditorNative editor_;
    
-   public static final Type<EditorLoadedHandler> TYPE = new Type<EditorLoadedHandler>();
+   public static final Type<EditorLoadedHandler> TYPE = new Type<>();
 
    @Override
    public Type<EditorLoadedHandler> getAssociatedType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/FileTypeChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/FileTypeChangedEvent.java
@@ -18,8 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class FileTypeChangedEvent extends GwtEvent<FileTypeChangedHandler>
 {
-   public static final Type<FileTypeChangedHandler> TYPE =
-         new Type<FileTypeChangedHandler>();
+   public static final Type<FileTypeChangedHandler> TYPE = new Type<>();
 
    public FileTypeChangedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/SourceOnSaveChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/SourceOnSaveChangedEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class SourceOnSaveChangedEvent extends GwtEvent<SourceOnSaveChangedHandler>
 {
-   public static final Type<SourceOnSaveChangedHandler> TYPE = new Type<SourceOnSaveChangedHandler>();
+   public static final Type<SourceOnSaveChangedHandler> TYPE = new Type<>();
 
    @Override
    public Type<SourceOnSaveChangedHandler> getAssociatedType()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/UndoRedoEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/events/UndoRedoEvent.java
@@ -40,6 +40,6 @@ public class UndoRedoEvent extends GwtEvent<UndoRedoHandler>
       handler.onUndoRedo(this);
    }
 
-   public static Type<UndoRedoHandler> TYPE = new Type<UndoRedoHandler>();
+   public static Type<UndoRedoHandler> TYPE = new Type<>();
    private final boolean redo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -186,7 +186,7 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       }
       else
       {
-         List<ChunkExecUnit> chunks = new ArrayList<ChunkExecUnit>();
+         List<ChunkExecUnit> chunks = new ArrayList<>();
          chunks.add(chunk);
          executeChunks("Run Chunk", chunks);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/TextEditingTargetNotebook.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import com.google.gwt.dom.client.Element;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
@@ -141,7 +140,7 @@ public class TextEditingTargetNotebook
       releaseOnDismiss_ = releaseOnDismiss;
       notebookDoc_ = document.getNotebookDoc();
       initialChunkDefs_ = JsArrayUtil.deepCopy(notebookDoc_.getChunkDefs());
-      satelliteChunkRequestIds_ = new ArrayList<String>();
+      satelliteChunkRequestIds_ = new ArrayList<>();
       setupCrc32_ = docUpdateSentinel_.getProperty(LAST_SETUP_CRC32);
       editingTarget_ = editingTarget;
       chunks_ = chunks;
@@ -151,10 +150,10 @@ public class TextEditingTargetNotebook
       RStudioGinjector.INSTANCE.injectMembers(this);
       
       // Notebook outputs for code (text) editing mode; map of chunk ID to output UI
-      codeOutputs_ = new HashMap<String, ChunkOutputUi>();
+      codeOutputs_ = new HashMap<>();
       
       // Notebook outputs for visual editing mode
-      visualOutputs_ = new HashMap<String, ChunkOutputUi>();
+      visualOutputs_ = new HashMap<>();
 
       releaseOnDismiss.add(docDisplay_.addEditorFocusHandler(new FocusHandler()
       {
@@ -457,7 +456,7 @@ public class TextEditingTargetNotebook
             if (!isSetupChunkScope(chunk) &&
                 needsSetupChunkExecuted())
             {
-               List<ChunkExecUnit> chunks = new ArrayList<ChunkExecUnit>();
+               List<ChunkExecUnit> chunks = new ArrayList<>();
                chunks.add(new ChunkExecUnit(getSetupChunkScope(), 
                      NotebookQueueUnit.EXEC_MODE_BATCH));
                chunks.add(new ChunkExecUnit(chunk,
@@ -665,7 +664,7 @@ public class TextEditingTargetNotebook
       // execute setup chunk first if necessary
       if (needsSetupChunkExecuted() && !isSetupChunkScope(event.getScope()))
       {
-         List<ChunkExecUnit> chunks = new ArrayList<ChunkExecUnit>();
+         List<ChunkExecUnit> chunks = new ArrayList<>();
          chunks.add(new ChunkExecUnit(getSetupChunkScope(), 
                NotebookQueueUnit.EXEC_MODE_BATCH));
          chunks.add(new ChunkExecUnit(event.getScope(), event.getRange(), 
@@ -1688,7 +1687,7 @@ public class TextEditingTargetNotebook
       // remove any errors in the gutter associated with this chunk
       cleanScopeErrorState(output.getScope());
 
-      ArrayList<Widget> widgets = new ArrayList<Widget>();
+      ArrayList<Widget> widgets = new ArrayList<>();
       widgets.add(output.getOutputWidget());
       FadeOutAnimation anim = new FadeOutAnimation(widgets, new Command()
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/DefaultChunkOptionsPopupPanel.java
@@ -111,15 +111,15 @@ public class DefaultChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
    private Pair<String, String> getChunkHeaderBounds(String modeId)
    {
       if (modeId == "mode/rmarkdown")
-         return new Pair<String, String>("```{", "}");
+         return new Pair<>("```{", "}");
       else if (modeId == "mode/sweave")
-         return new Pair<String, String>("<<", ">>=");
+         return new Pair<>("<<", ">>=");
       else if (modeId == "mode/rhtml")
-         return new Pair<String, String>("<!--", "");
+         return new Pair<>("<!--", "");
       else if (modeId == "mode/c_cpp")
-         return new Pair<String, String>("/***", "");
+         return new Pair<>("/***", "");
       else if (modeId == "mode/r")  // Used in visual mode for embedded chunk editor
-         return new Pair<String, String>("{", "}");
+         return new Pair<>("{", "}");
       
       return null;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/display/SetupChunkOptionsPopupPanel.java
@@ -229,7 +229,7 @@ public class SetupChunkOptionsPopupPanel extends ChunkOptionsPopupPanel
    protected void synchronize()
    {
       syncSelection();
-      Map<String, String> options = new LinkedHashMap<String, String>();
+      Map<String, String> options = new LinkedHashMap<>();
       
       Set<String> keys = chunkOptions_.keySet();
       for (String key : keys)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/CheckSpelling.java
@@ -172,8 +172,8 @@ public class CheckSpelling
                currentPos_,
                wrapped_ ? initialCursorPos_.getPosition() : -1);
 
-         final ArrayList<String> words = new ArrayList<String>();
-         final ArrayList<SpellingDoc.WordRange> checkWords = new ArrayList<SpellingDoc.WordRange>();
+         final ArrayList<String> words = new ArrayList<>();
+         final ArrayList<SpellingDoc.WordRange> checkWords = new ArrayList<>();
 
          SpellingDoc.WordRange lastWord = null;
          for (SpellingDoc.WordRange w : wordSource)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/spelling/SpellingContext.java
@@ -106,8 +106,7 @@ public abstract class SpellingContext implements TypoSpellChecker.Context
 
    private final DocUpdateSentinel docUpdateSentinel_;
    
-   private ArrayList<HandlerRegistration> releaseOnDismiss_ = 
-         new ArrayList<HandlerRegistration>();
+   private ArrayList<HandlerRegistration> releaseOnDismiss_ = new ArrayList<>();
    
    private final static String IGNORED_WORDS = "ignored_words";
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/NotebookProgressWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/status/NotebookProgressWidget.java
@@ -130,7 +130,7 @@ public class NotebookProgressWidget extends Composite
    public NotebookProgressWidget()
    {
       manager_ = new HandlerManager(this);
-      cancelCommands_ = new ArrayList<Command>();
+      cancelCommands_ = new ArrayList<>();
 
       initWidget(uiBinder.createAndBindUi(this));
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -40,7 +40,6 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.Value;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.panmirror.PanmirrorChanges;
 import org.rstudio.studio.client.panmirror.PanmirrorCode;
 import org.rstudio.studio.client.panmirror.PanmirrorContext;
@@ -1741,7 +1740,7 @@ public class VisualMode implements VisualModeEditorSync,
    private void alignScopeOutline(PanmirrorEditingOutlineLocation location)
    {
       // Get all of the chunks from the document (code view)
-      ArrayList<Scope> chunkScopes = new ArrayList<Scope>();
+      ArrayList<Scope> chunkScopes = new ArrayList<>();
       ScopeList chunks = new ScopeList(docDisplay_);
       chunks.selectAll(ScopeList.CHUNK);
       for (Scope chunk : chunks)
@@ -1750,8 +1749,7 @@ public class VisualMode implements VisualModeEditorSync,
       }
       
       // Get all of the chunks from the outline emitted by visual mode
-      ArrayList<PanmirrorEditingOutlineLocationItem> chunkItems = 
-            new ArrayList<PanmirrorEditingOutlineLocationItem>();
+      ArrayList<PanmirrorEditingOutlineLocationItem> chunkItems = new ArrayList<>();
       for (int j = 0; j < location.items.length; j++)
       {
          if (StringUtil.equals(location.items[j].type, PanmirrorOutlineItemType.RmdChunk))
@@ -1794,7 +1792,7 @@ public class VisualMode implements VisualModeEditorSync,
     */
    private void alignScopeTreeAfterUpdate(PanmirrorEditingOutlineLocation location)
    {
-      final Value<HandlerRegistration> handler = new Value<HandlerRegistration>(null);
+      final Value<HandlerRegistration> handler = new Value<>(null);
       handler.setValue(docDisplay_.addScopeTreeReadyHandler((evt) ->
       {
          if (location != null)
@@ -1839,14 +1837,14 @@ public class VisualMode implements VisualModeEditorSync,
   
    private ToolbarButton findReplaceButton_;
    
-   private ArrayList<AppCommand> disabledForVisualMode_ = new ArrayList<AppCommand>();
+   private ArrayList<AppCommand> disabledForVisualMode_ = new ArrayList<>();
    
    private final ProgressPanel progress_;
    
    private SerializedCommandQueue syncToEditorQueue_ = new SerializedCommandQueue();
    
    private boolean isLoading_ = false;
-   private List<ScheduledCommand> onReadyHandlers_ = new ArrayList<ScheduledCommand>(); 
+   private List<ScheduledCommand> onReadyHandlers_ = new ArrayList<>(); 
    
    private static final int kCreationProgressDelayMs = 0;
    private static final int kSerializationProgressDelayMs = 5000;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -102,9 +102,9 @@ public class VisualModeChunk
 
       PanmirrorUIChunkEditor chunk = new PanmirrorUIChunkEditor();
       
-      releaseOnDismiss_ = new ArrayList<HandlerRegistration>();
-      destroyHandlers_ = new ArrayList<Command>();
-      rowState_ = new HashMap<Integer,VisualModeChunkRowState>();
+      releaseOnDismiss_ = new ArrayList<>();
+      destroyHandlers_ = new ArrayList<>();
+      rowState_ = new HashMap<>();
 
       // Create a new AceEditor instance and allow access to the underlying
       // native JavaScript object it represents (AceEditorNative)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -31,7 +31,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.rmd.TextEdi
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.user.client.Command;
 
 public class VisualModeChunks implements ChunkDefinition.Provider
 {
@@ -44,7 +43,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
       sentinel_ = sentinel;
       parent_ = display;
       sync_ = sync;
-      chunks_ = new ArrayList<VisualModeChunk>();
+      chunks_ = new ArrayList<>();
    }
 
    public PanmirrorUIChunks uiChunks()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeEditingLocation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeEditingLocation.java
@@ -91,15 +91,14 @@ public class VisualModeEditingLocation
          return null;
       
       // build the outline
-      ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>> outlineItems = 
-         new ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>>();
+      ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>> outlineItems = new ArrayList<>();
       buildOutlineLocation(docDisplay_.getScopeTree(), outlineItems);
       
       // return the location, set the active item by scanning backwards until
       // we find an item with a position before the cursor
       boolean foundActive = false;
       Position cursorPos = docDisplay_.getCursorPosition();
-      ArrayList<PanmirrorEditingOutlineLocationItem> items = new ArrayList<PanmirrorEditingOutlineLocationItem>();
+      ArrayList<PanmirrorEditingOutlineLocationItem> items = new ArrayList<>();
       for (int i = outlineItems.size() - 1; i >= 0; i--) 
       {
          Pair<PanmirrorEditingOutlineLocationItem, Scope> outlineItem = outlineItems.get(i);
@@ -125,8 +124,7 @@ public class VisualModeEditingLocation
          return;
       
       // build flattened version of scope tree which includes outline items
-      ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>> outlineItems = 
-         new ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>>();
+      ArrayList<Pair<PanmirrorEditingOutlineLocationItem, Scope>> outlineItems = new ArrayList<>();
       buildOutlineLocation(docDisplay_.getScopeTree(), outlineItems);
       
       // if the lengths differ then bail
@@ -172,19 +170,19 @@ public class VisualModeEditingLocation
          if (scope.isYaml())
          {
             item.type = PanmirrorOutlineItemType.YamlMetadata;
-            outlineItems.add(new Pair<PanmirrorEditingOutlineLocationItem, Scope>(item, scope));
+            outlineItems.add(new Pair<>(item, scope));
          }
          else if (scope.isMarkdownHeader())
          {
             item.type = PanmirrorOutlineItemType.Heading;
-            outlineItems.add(new Pair<PanmirrorEditingOutlineLocationItem, Scope>(item, scope));
+            outlineItems.add(new Pair<>(item, scope));
             buildOutlineLocation(scope.getChildren(), outlineItems);
          }
          else if (scope.isChunk())
          {
             item.type = PanmirrorOutlineItemType.RmdChunk;
             item.title = scope.getChunkLabel();
-            outlineItems.add(new Pair<PanmirrorEditingOutlineLocationItem, Scope>(item, scope));
+            outlineItems.add(new Pair<>(item, scope));
          }
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -114,7 +114,7 @@ public class VisualModePanmirrorContext
       };
       
       uiContext.withSavedDocument = () -> {
-         return new Promise<Boolean>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
+         return new Promise<>((ResolveCallbackFn<Boolean> resolve, RejectCallbackFn reject) -> {
            target_.withSavedDoc(() -> {
               resolve.onInvoke(true);
            });
@@ -185,7 +185,7 @@ public class VisualModePanmirrorContext
       };
       
       uiContext.clipboardUris = () -> {
-         return new Promise<JsArrayString>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
+         return new Promise<>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
            if (Desktop.isDesktop() && !Desktop.isRemoteDesktop())
            {
               Desktop.getFrame().getClipboardUris(uris -> {
@@ -200,7 +200,7 @@ public class VisualModePanmirrorContext
       };
       
       uiContext.clipboardImage = () -> {
-         return new Promise<String>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
+         return new Promise<>((ResolveCallbackFn<String> resolve, RejectCallbackFn reject) -> {
             if (Desktop.isDesktop() && !Desktop.isRemoteDesktop())
             {
                Desktop.getFrame().getClipboardImage(image -> {
@@ -218,7 +218,7 @@ public class VisualModePanmirrorContext
       };
       
       uiContext.resolveImageUris = (imageUris) -> {
-         return new Promise<JsArrayString>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
+         return new Promise<>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
            
             JsArrayString resolvedUris = JsArrayString.createArray().cast();
             JsArrayString unresolvedUris = JsArrayString.createArray().cast();
@@ -345,7 +345,7 @@ public class VisualModePanmirrorContext
    private List<FileSystemItem> hugoStaticDirs()
    {
       FileSystemItem siteDir = getBlogdownConfig().site_dir;
-      List<FileSystemItem> staticDirs = new ArrayList<FileSystemItem>();
+      List<FileSystemItem> staticDirs = new ArrayList<>();
       for (String dir : getBlogdownConfig().static_dirs)
          staticDirs.add(FileSystemItem.createDir(siteDir.completePath(dir)));
       return staticDirs;
@@ -377,7 +377,7 @@ public class VisualModePanmirrorContext
       private FileSystemItem file_;
       private JsVoidFunction notify_;
    }
-   private HashSet<FileWatcher> fileWatchers_ = new HashSet<FileWatcher>();
+   private HashSet<FileWatcher> fileWatchers_ = new HashSet<>();
    
    private final DocUpdateSentinel docUpdateSentinel_;
    private final TextEditingTarget target_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorFormat.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorFormat.java
@@ -86,7 +86,7 @@ public class VisualModePanmirrorFormat
             // doctypes
             if (formatComment.doctypes == null || formatComment.doctypes.length == 0)
             {
-               List<String> configDocTypes = new ArrayList<String>();
+               List<String> configDocTypes = new ArrayList<>();
                if (isBookdownProjectDocument())
                   configDocTypes.add(PanmirrorExtendedDocType.bookdown);
                if (isHugoProjectDocument() || isHugodownDocument())
@@ -221,13 +221,13 @@ public class VisualModePanmirrorFormat
       String yaml = YamlFrontMatter.getFrontMatter(docDisplay_);
       if (yaml == null)
       {
-         return new ArrayList<String>();
+         return new ArrayList<>();
       }
       else
       {
          List<String> formats = TextEditingTargetRMarkdownHelper.getOutputFormats(yaml);
          if (formats == null)
-            return new ArrayList<String>();
+            return new ArrayList<>();
          else
             return formats;   
       }
@@ -356,7 +356,7 @@ public class VisualModePanmirrorFormat
       {   
          // collect any alternate mode we may have
          BlogdownConfig config = getBlogdownConfig();
-         Pair<String,String> alternateMode = new Pair<String,String>(
+         Pair<String,String> alternateMode = new Pair<>(
             config.markdown_engine,
             config.markdown_extensions
          );
@@ -380,12 +380,12 @@ public class VisualModePanmirrorFormat
          // other valid ways of having a hugo document
          else if (isHugodownDocument() || hasHugoDocType(docTypes))
          {
-            return new Pair<String,String>("goldmark", "");
+            return new Pair<>("goldmark", "");
          }
          // github document
          else if (isGitHubDocument())
          {
-            return new Pair<String,String>("gfm", "");
+            return new Pair<>("gfm", "");
          }
       }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeSpelling.java
@@ -201,7 +201,7 @@ public class VisualModeSpelling extends SpellingContext
       
       uiSpelling.suggestionList = (word) -> {
         String[] suggestions = typo().suggestionList(word);
-        return new JsArray<String>(suggestions);
+        return new JsArray<>(suggestions);
       };
       
       uiSpelling.isWordIgnored = (word) -> {
@@ -223,7 +223,7 @@ public class VisualModeSpelling extends SpellingContext
       uiSpelling.breakWords = (String text) -> {
       
         
-         JsArray<PanmirrorWordRange> words = new JsArray<PanmirrorWordRange>();
+         JsArray<PanmirrorWordRange> words = new JsArray<>();
          
          int pos = 0;
          while (pos < text.length()) 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/urlcontent/UrlContentEditingTarget.java
@@ -41,7 +41,6 @@ import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
-import org.rstudio.studio.client.palette.model.CommandPaletteItem;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.SourceColumn;
@@ -61,7 +60,6 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperat
 
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 
 public class UrlContentEditingTarget implements EditingTarget
 {
@@ -148,7 +146,7 @@ public class UrlContentEditingTarget implements EditingTarget
 
    public HashSet<AppCommand> getSupportedCommands()
    {
-      HashSet<AppCommand> commands = new HashSet<AppCommand>();
+      HashSet<AppCommand> commands = new HashSet<>();
       commands.add(commands_.printSourceDoc());
       if (SourceWindowManager.isMainSourceWindow())
          commands.add(commands_.popoutDoc());
@@ -499,7 +497,7 @@ public class UrlContentEditingTarget implements EditingTarget
 
    protected SourceColumn column_;
    protected SourceDocument doc_;
-   private Value<Boolean> dirtyState_ = new Value<Boolean>(false);
+   private Value<Boolean> dirtyState_ = new Value<>(false);
 
    protected final SourceServerOperations server_;
    protected final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ChunkChangeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ChunkChangeEvent.java
@@ -29,8 +29,7 @@ public class ChunkChangeEvent
       void onChunkChange(ChunkChangeEvent event);
    }
 
-   public static final GwtEvent.Type<ChunkChangeEvent.Handler> TYPE =
-      new GwtEvent.Type<ChunkChangeEvent.Handler>();
+   public static final GwtEvent.Type<ChunkChangeEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public ChunkChangeEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ChunkContextChangeEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ChunkContextChangeEvent.java
@@ -29,8 +29,7 @@ public class ChunkContextChangeEvent
       void onChunkContextChange(ChunkContextChangeEvent event);
    }
 
-   public static final GwtEvent.Type<ChunkContextChangeEvent.Handler> TYPE =
-      new GwtEvent.Type<ChunkContextChangeEvent.Handler>();
+   public static final GwtEvent.Type<ChunkContextChangeEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public ChunkContextChangeEvent(String docId, String contextId,
          JsArray<ChunkDefinition> chunkDefs)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserCreatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserCreatedEvent.java
@@ -29,8 +29,7 @@ public class CodeBrowserCreatedEvent
       void onCodeBrowserCreated(CodeBrowserCreatedEvent event);
    }
 
-   public static final GwtEvent.Type<CodeBrowserCreatedEvent.Handler> TYPE =
-      new GwtEvent.Type<CodeBrowserCreatedEvent.Handler>();
+   public static final GwtEvent.Type<CodeBrowserCreatedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public CodeBrowserCreatedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserFinishedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserFinishedEvent.java
@@ -26,8 +26,7 @@ import com.google.gwt.event.shared.GwtEvent;
 public class CodeBrowserFinishedEvent extends 
              CrossWindowEvent<CodeBrowserFinishedHandler>
 {
-   public static final GwtEvent.Type<CodeBrowserFinishedHandler> TYPE =
-      new GwtEvent.Type<CodeBrowserFinishedHandler>();
+   public static final GwtEvent.Type<CodeBrowserFinishedHandler> TYPE = new GwtEvent.Type<>();
    
    public CodeBrowserFinishedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserHighlightEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserHighlightEvent.java
@@ -31,8 +31,7 @@ public class CodeBrowserHighlightEvent
       void onCodeBrowserHighlight(CodeBrowserHighlightEvent event);
    }
 
-   public static final GwtEvent.Type<CodeBrowserHighlightEvent.Handler> TYPE =
-      new GwtEvent.Type<CodeBrowserHighlightEvent.Handler>();
+   public static final GwtEvent.Type<CodeBrowserHighlightEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public CodeBrowserHighlightEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserNavigationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CodeBrowserNavigationEvent.java
@@ -25,8 +25,7 @@ import com.google.gwt.event.shared.GwtEvent;
 public class CodeBrowserNavigationEvent 
              extends CrossWindowEvent<CodeBrowserNavigationHandler>
 {
-   public static final GwtEvent.Type<CodeBrowserNavigationHandler> TYPE =
-      new GwtEvent.Type<CodeBrowserNavigationHandler>();
+   public static final GwtEvent.Type<CodeBrowserNavigationHandler> TYPE = new GwtEvent.Type<>();
 
    public CodeBrowserNavigationEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditEndedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditEndedEvent.java
@@ -46,8 +46,7 @@ public class CollabEditEndedEvent
       void onCollabEditEnded(CollabEditEndedEvent event);
    }
 
-   public static final GwtEvent.Type<CollabEditEndedEvent.Handler> TYPE =
-      new GwtEvent.Type<CollabEditEndedEvent.Handler>();
+   public static final GwtEvent.Type<CollabEditEndedEvent.Handler> TYPE = new GwtEvent.Type<>();
 
    public CollabEditEndedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditSavedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditSavedEvent.java
@@ -49,8 +49,7 @@ public class CollabEditSavedEvent extends GwtEvent<CollabEditSavedEvent.Handler>
       void onCollabEditSaved(CollabEditSavedEvent event);
    }
 
-   public static final GwtEvent.Type<CollabEditSavedEvent.Handler> TYPE =
-      new GwtEvent.Type<CollabEditSavedEvent.Handler>();
+   public static final GwtEvent.Type<CollabEditSavedEvent.Handler> TYPE = new GwtEvent.Type<>();
 
    public CollabEditSavedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditStartedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabEditStartedEvent.java
@@ -25,8 +25,7 @@ public class CollabEditStartedEvent extends GwtEvent<CollabEditStartedEvent.Hand
       void onCollabEditStarted(CollabEditStartedEvent event);
    }
 
-   public static final GwtEvent.Type<CollabEditStartedEvent.Handler> TYPE =
-      new GwtEvent.Type<CollabEditStartedEvent.Handler>();
+   public static final GwtEvent.Type<CollabEditStartedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public CollabEditStartedEvent(CollabEditStartParams params)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabExternalEditEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CollabExternalEditEvent.java
@@ -30,8 +30,7 @@ public class CollabExternalEditEvent
       void onCollabExternalEdit(CollabExternalEditEvent event);
    }
 
-   public static final GwtEvent.Type<CollabExternalEditEvent.Handler> TYPE =
-      new GwtEvent.Type<CollabExternalEditEvent.Handler>();
+   public static final GwtEvent.Type<CollabExternalEditEvent.Handler> TYPE = new GwtEvent.Type<>();
 
    public CollabExternalEditEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
@@ -33,8 +33,7 @@ public class DataViewChangedEvent extends GwtEvent<DataViewChangedEvent.Handler>
       }-*/;
    }
 
-   public static final GwtEvent.Type<DataViewChangedEvent.Handler> TYPE =
-      new GwtEvent.Type<DataViewChangedEvent.Handler>();
+   public static final GwtEvent.Type<DataViewChangedEvent.Handler> TYPE = new GwtEvent.Type<>();
 
    public interface Handler extends EventHandler
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocFocusedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocFocusedEvent.java
@@ -29,8 +29,7 @@ public class DocFocusedEvent extends CrossWindowEvent<DocFocusedEvent.Handler>
       void onDocFocused(DocFocusedEvent event);
    }
 
-   public static final GwtEvent.Type<DocFocusedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocFocusedEvent.Handler>();
+   public static final GwtEvent.Type<DocFocusedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocFocusedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabActivatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabActivatedEvent.java
@@ -30,8 +30,7 @@ public class DocTabActivatedEvent
       void onDocTabActivated(DocTabActivatedEvent event);
    }
 
-   public static final GwtEvent.Type<DocTabActivatedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocTabActivatedEvent.Handler>();
+   public static final GwtEvent.Type<DocTabActivatedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocTabActivatedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabClosedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabClosedEvent.java
@@ -30,8 +30,7 @@ public class DocTabClosedEvent
       void onDocTabClosed(DocTabClosedEvent event);
    }
 
-   public static final GwtEvent.Type<DocTabClosedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocTabClosedEvent.Handler>();
+   public static final GwtEvent.Type<DocTabClosedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocTabClosedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabDragInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabDragInitiatedEvent.java
@@ -28,8 +28,7 @@ public class DocTabDragInitiatedEvent
       void onDocTabDragInitiated(DocTabDragInitiatedEvent event);
    }
 
-   public static final GwtEvent.Type<DocTabDragInitiatedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocTabDragInitiatedEvent.Handler>();
+   public static final GwtEvent.Type<DocTabDragInitiatedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocTabDragInitiatedEvent(String docId, int width, int cursorOffset)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabDragStartedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocTabDragStartedEvent.java
@@ -31,8 +31,7 @@ public class DocTabDragStartedEvent
       void onDocTabDragStarted(DocTabDragStartedEvent event);
    }
 
-   public static final GwtEvent.Type<DocTabDragStartedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocTabDragStartedEvent.Handler>();
+   public static final GwtEvent.Type<DocTabDragStartedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocTabDragStartedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocWindowChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DocWindowChangedEvent.java
@@ -32,8 +32,7 @@ public class DocWindowChangedEvent
       void onDocWindowChanged(DocWindowChangedEvent event);
    }
 
-   public static final GwtEvent.Type<DocWindowChangedEvent.Handler> TYPE =
-      new GwtEvent.Type<DocWindowChangedEvent.Handler>();
+   public static final GwtEvent.Type<DocWindowChangedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public DocWindowChangedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/EnsureVisibleSourceWindowEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/EnsureVisibleSourceWindowEvent.java
@@ -25,8 +25,7 @@ public class EnsureVisibleSourceWindowEvent extends GwtEvent<EnsureVisibleSource
       void onEnsureVisibleSourceWindow(EnsureVisibleSourceWindowEvent e);
    }
    
-   public static final GwtEvent.Type<EnsureVisibleSourceWindowEvent.Handler> TYPE =
-      new GwtEvent.Type<EnsureVisibleSourceWindowEvent.Handler>();
+   public static final GwtEvent.Type<EnsureVisibleSourceWindowEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public EnsureVisibleSourceWindowEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/FileEditEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/FileEditEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 
 public class FileEditEvent extends GwtEvent<FileEditHandler>
 {
-   public static final GwtEvent.Type<FileEditHandler> TYPE =
-      new GwtEvent.Type<FileEditHandler>();
+   public static final GwtEvent.Type<FileEditHandler> TYPE = new GwtEvent.Type<>();
    
    public FileEditEvent(FileSystemItem file)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/InsertSourceEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/InsertSourceEvent.java
@@ -18,8 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class InsertSourceEvent extends GwtEvent<InsertSourceHandler>
 {
-   public static final Type<InsertSourceHandler> TYPE =
-         new Type<InsertSourceHandler>();
+   public static final Type<InsertSourceHandler> TYPE = new Type<>();
 
    public InsertSourceEvent(String source, boolean block)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/LastSourceDocClosedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/LastSourceDocClosedEvent.java
@@ -19,7 +19,7 @@ import com.google.gwt.event.shared.GwtEvent;
 public class LastSourceDocClosedEvent extends GwtEvent<LastSourceDocClosedHandler>
 {
    public static final Type<LastSourceDocClosedHandler> TYPE =
-      new Type<LastSourceDocClosedHandler>();
+      new Type<>();
 
    public LastSourceDocClosedEvent() {}
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/MaximizeSourceWindowEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/MaximizeSourceWindowEvent.java
@@ -27,8 +27,7 @@ public class MaximizeSourceWindowEvent extends GwtEvent<MaximizeSourceWindowEven
    }
    
    
-   public static final GwtEvent.Type<MaximizeSourceWindowEvent.Handler> TYPE =
-      new GwtEvent.Type<MaximizeSourceWindowEvent.Handler>();
+   public static final GwtEvent.Type<MaximizeSourceWindowEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public MaximizeSourceWindowEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NotebookRenderFinishedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/NotebookRenderFinishedEvent.java
@@ -29,8 +29,7 @@ public class NotebookRenderFinishedEvent
       void onNotebookRenderFinished(NotebookRenderFinishedEvent event);
    }
 
-   public static final GwtEvent.Type<NotebookRenderFinishedEvent.Handler> TYPE =
-      new GwtEvent.Type<NotebookRenderFinishedEvent.Handler>();
+   public static final GwtEvent.Type<NotebookRenderFinishedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public NotebookRenderFinishedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/RecordNavigationPositionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/RecordNavigationPositionEvent.java
@@ -20,7 +20,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class RecordNavigationPositionEvent extends GwtEvent<RecordNavigationPositionHandler>
 {
-   public static final Type<RecordNavigationPositionHandler> TYPE = new Type<RecordNavigationPositionHandler>();
+   public static final Type<RecordNavigationPositionHandler> TYPE = new Type<>();
 
    public RecordNavigationPositionEvent(SourcePosition position)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFailedEvent.java
@@ -25,8 +25,7 @@ public class SaveFailedEvent extends GwtEvent<SaveFailedEvent.Handler>
       void onSaveFailed(SaveFailedEvent event);
    }
 
-   public static final GwtEvent.Type<SaveFailedEvent.Handler> TYPE =
-      new GwtEvent.Type<SaveFailedEvent.Handler>();
+   public static final GwtEvent.Type<SaveFailedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public SaveFailedEvent(String path,
                           String id)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFileEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveFileEvent.java
@@ -36,8 +36,7 @@ public class SaveFileEvent extends GwtEvent<SaveFileHandler>
    
    // Boilerplate ----
    
-   public static final GwtEvent.Type<SaveFileHandler> TYPE =
-      new GwtEvent.Type<SaveFileHandler>();
+   public static final GwtEvent.Type<SaveFileHandler> TYPE = new GwtEvent.Type<>();
    
    @Override
    protected void dispatch(SaveFileHandler handler)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveInitiatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SaveInitiatedEvent.java
@@ -25,8 +25,7 @@ public class SaveInitiatedEvent extends GwtEvent<SaveInitiatedEvent.Handler>
       void onSaveInitiated(SaveInitiatedEvent event);
    }
 
-   public static final GwtEvent.Type<SaveInitiatedEvent.Handler> TYPE =
-      new GwtEvent.Type<SaveInitiatedEvent.Handler>();
+   public static final GwtEvent.Type<SaveInitiatedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public SaveInitiatedEvent(String path, String id)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ShowContentEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ShowContentEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.studio.client.workbench.views.source.model.ContentItem;
 
 public class ShowContentEvent extends GwtEvent<ShowContentHandler>
 {
-   public static final GwtEvent.Type<ShowContentHandler> TYPE =
-      new GwtEvent.Type<ShowContentHandler>();
+   public static final GwtEvent.Type<ShowContentHandler> TYPE = new GwtEvent.Type<>();
    
    public ShowContentEvent(ContentItem content)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ShowDataEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/ShowDataEvent.java
@@ -19,8 +19,7 @@ import org.rstudio.studio.client.workbench.views.source.model.DataItem;
 
 public class ShowDataEvent extends GwtEvent<ShowDataHandler>
 {
-   public static final GwtEvent.Type<ShowDataHandler> TYPE =
-      new GwtEvent.Type<ShowDataHandler>();
+   public static final GwtEvent.Type<ShowDataHandler> TYPE = new GwtEvent.Type<>();
    
    public ShowDataEvent(DataItem data)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourceFileSavedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourceFileSavedEvent.java
@@ -25,8 +25,7 @@ import org.rstudio.studio.client.application.events.CrossWindowEvent;
 public class SourceFileSavedEvent
              extends CrossWindowEvent<SourceFileSavedHandler>
 {
-   public static final Type<SourceFileSavedHandler> TYPE = 
-         new Type<SourceFileSavedHandler>();
+   public static final Type<SourceFileSavedHandler> TYPE = new Type<>();
    
    public SourceFileSavedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourceNavigationEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourceNavigationEvent.java
@@ -20,7 +20,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class SourceNavigationEvent extends GwtEvent<SourceNavigationHandler>
 {
-   public static final Type<SourceNavigationHandler> TYPE = new Type<SourceNavigationHandler>();
+   public static final Type<SourceNavigationHandler> TYPE = new Type<>();
 
    public SourceNavigationEvent(SourceNavigation navigation)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourcePathChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SourcePathChangedEvent.java
@@ -29,8 +29,7 @@ public class SourcePathChangedEvent
       void onSourcePathChanged(SourcePathChangedEvent event);
    }
 
-   public static final GwtEvent.Type<SourcePathChangedEvent.Handler> TYPE =
-      new GwtEvent.Type<SourcePathChangedEvent.Handler>();
+   public static final GwtEvent.Type<SourcePathChangedEvent.Handler> TYPE = new GwtEvent.Type<>();
    
    public SourcePathChangedEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SwitchToDocEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/SwitchToDocEvent.java
@@ -18,7 +18,7 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class SwitchToDocEvent extends GwtEvent<SwitchToDocHandler>
 {
-   public static final Type<SwitchToDocHandler> TYPE = new Type<SwitchToDocHandler>();
+   public static final Type<SwitchToDocHandler> TYPE = new Type<>();
 
    public SwitchToDocEvent(int selectedIndex)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/CompletionOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/CompletionOptions.java
@@ -27,7 +27,7 @@ public class CompletionOptions
 
    public ArrayList<String> getCompletions(String prefix)
    {
-      ArrayList<String> results = new ArrayList<String>();
+      ArrayList<String> results = new ArrayList<>();
       for (int i = 0; i < options_.size(); i++)
       {
          if (options_.get(i).startsWith(prefix) &&
@@ -39,6 +39,6 @@ public class CompletionOptions
       return results;
    }
 
-   private ArrayList<String> options_ = new ArrayList<String>();
-   private ArrayList<String> filterPrefixes_ = new ArrayList<String>();
+   private ArrayList<String> options_ = new ArrayList<>();
+   private ArrayList<String> filterPrefixes_ = new ArrayList<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/RnwChunkOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/RnwChunkOptions.java
@@ -36,8 +36,7 @@ public class RnwChunkOptions extends JavaScriptObject
    
    public final ArrayList<String> getOptions() 
    {
-      ArrayList<String> options = new ArrayList<String>(
-                                                new JSONObject(this).keySet());
+      ArrayList<String> options = new ArrayList<>(new JSONObject(this).keySet());
       Collections.sort(options);
       return options;
    }
@@ -58,7 +57,7 @@ public class RnwChunkOptions extends JavaScriptObject
    public final ArrayList<String> getOptionValues(String name)
    {
       JSONArray arr = new JSONArray(getOptionTypeNative(name));
-      ArrayList<String> values = new ArrayList<String>();
+      ArrayList<String> values = new ArrayList<>();
       for (int i=0; i<arr.size(); i++)
       {
          JSONArray array = arr.get(i).isArray();
@@ -107,8 +106,8 @@ public class RnwChunkOptions extends JavaScriptObject
 
       String token = null;
       JsArrayString completions = JsArrayString.createArray().cast();
-      ArrayList<String> names = new ArrayList<String>();
-      ArrayList<String> values = new ArrayList<String>();
+      ArrayList<String> names = new ArrayList<>();
+      ArrayList<String> values = new ArrayList<>();
       parseRnwChunkHeader(linePart, names, values);
 
       assert names.size() == values.size();
@@ -192,7 +191,7 @@ public class RnwChunkOptions extends JavaScriptObject
       String currentValue = null;
 
       int currentPartBegin = 0;
-      Stack<Integer> braceStack = new Stack<Integer>();
+      Stack<Integer> braceStack = new Stack<>();
 
       RTokenizer tokenizer = new RTokenizer(line);
       for (RToken token; null != (token = tokenizer.nextToken()); )

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceNavigationHistory.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceNavigationHistory.java
@@ -37,7 +37,7 @@ public class SourceNavigationHistory
    public SourceNavigationHistory(int maxItems)
    {
       maxItems_ = maxItems;
-      history_ = new LinkedList<SourceNavigation>();
+      history_ = new LinkedList<>();
       currentLocation_ = -1;
    }
   

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/TerminalPopupMenu.java
@@ -28,7 +28,6 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.WorkbenchServerOperations;
 import org.rstudio.studio.client.workbench.views.terminal.events.SwitchToTerminalEvent;
 import org.rstudio.studio.client.server.ErrorLoggingServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.ui.MenuItem;
@@ -148,7 +147,7 @@ public class TerminalPopupMenu extends ToolbarPopupMenu
       // inform server of the selection
       server_.processNotifyVisible(
             activeTerminalHandle_,
-            new ErrorLoggingServerRequestCallback<Void>());
+            new ErrorLoggingServerRequestCallback<>());
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalReceivedConsoleProcessInfoEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/events/TerminalReceivedConsoleProcessInfoEvent.java
@@ -54,6 +54,5 @@ public class TerminalReceivedConsoleProcessInfoEvent extends GwtEvent<TerminalRe
    }
 
    private ConsoleProcessInfo data_;
-   public static final Type<TerminalReceivedConsoleProcessInfoEvent.Handler> TYPE =
-         new Type<TerminalReceivedConsoleProcessInfoEvent.Handler>();
+   public static final Type<TerminalReceivedConsoleProcessInfoEvent.Handler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/BranchToolbarButton.java
@@ -216,8 +216,8 @@ public class BranchToolbarButton extends ToolbarMenuButton
       }
       
       // separate branches based on remote name
-      Map<String, List<String>> branchMap = new LinkedHashMap<String, List<String>>();
-      List<String> localBranches = new ArrayList<String>();
+      Map<String, List<String>> branchMap = new LinkedHashMap<>();
+      List<String> localBranches = new ArrayList<>();
       branchMap.put(LOCAL_BRANCHES, localBranches);
       for (String branch : JsUtil.asIterable(branches))
       {
@@ -228,7 +228,7 @@ public class BranchToolbarButton extends ToolbarMenuButton
             {
                String remote = parts.get(1);
                if (!branchMap.containsKey(remote))
-                  branchMap.put(remote, new ArrayList<String>());
+                  branchMap.put(remote, new ArrayList<>());
                List<String> remoteBranches = branchMap.get(remote);
                remoteBranches.add(branch);
             }
@@ -447,10 +447,10 @@ public class BranchToolbarButton extends ToolbarMenuButton
       // iterate through initial branch map and copy branches
       // matching the current query. TODO: should we re-order
       // based on how 'close' a match we have?
-      Map<String, List<String>> branchMap = new HashMap<String, List<String>>();
+      Map<String, List<String>> branchMap = new HashMap<>();
       for (String key : initialBranchMap_.keySet())
       {
-         List<String> filteredBranches = new ArrayList<String>();
+         List<String> filteredBranches = new ArrayList<>();
          List<String> branches = initialBranchMap_.get(key);
          for (String branch : branches)
             if (branch.indexOf(query) != -1)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/CreateBranchDialog.java
@@ -205,7 +205,7 @@ public class CreateBranchDialog extends ModalDialog<CreateBranchDialog.Input>
    {
       remotesInfo_ = remotesInfo;
       
-      List<String> remotes = new ArrayList<String>();
+      List<String> remotes = new ArrayList<>();
       for (RemotesInfo info : JsUtil.asIterable(remotesInfo))
       {
          if (!remotes.contains(info.getRemote()))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/ChangelistTable.java
@@ -124,16 +124,15 @@ public abstract class ChangelistTable extends Composite
          return false;
       }
 
-      private Set<String> consumedEvents_ = new HashSet<String>();
+      private Set<String> consumedEvents_ = new HashSet<>();
    }
 
    public ChangelistTable()
    {
-      table_ = new MultiSelectCellTable<StatusAndPath>(100, resources_);
+      table_ = new MultiSelectCellTable<>(100, resources_);
 
-      dataProvider_ = new ListDataProvider<StatusAndPath>();
-      sortHandler_ = new ColumnSortEvent.ListHandler<StatusAndPath>(
-            dataProvider_.getList());
+      dataProvider_ = new ListDataProvider<>();
+      sortHandler_ = new ColumnSortEvent.ListHandler<>(dataProvider_.getList());
       table_.addColumnSortHandler(sortHandler_);
 
       selectionModel_ = createSelectionModel();
@@ -163,7 +162,7 @@ public abstract class ChangelistTable extends Composite
 
    protected MultiSelectionModel<StatusAndPath> createSelectionModel()
    {
-      return new MultiSelectionModel<StatusAndPath>(
+      return new MultiSelectionModel<>(
             new ProvidesKey<StatusAndPath>()
             {
                @Override
@@ -321,7 +320,7 @@ public abstract class ChangelistTable extends Composite
    {
       SelectionModel<? super StatusAndPath> selectionModel = table_.getSelectionModel();
 
-      ArrayList<StatusAndPath> results = new ArrayList<StatusAndPath>();
+      ArrayList<StatusAndPath> results = new ArrayList<>();
       for (StatusAndPath item : dataProvider_.getList())
       {
          if (selectionModel.isSelected(item))
@@ -334,7 +333,7 @@ public abstract class ChangelistTable extends Composite
    {
       SelectionModel<? super StatusAndPath> selectionModel = table_.getSelectionModel();
 
-      ArrayList<String> results = new ArrayList<String>();
+      ArrayList<String> results = new ArrayList<>();
       for (StatusAndPath item : dataProvider_.getList())
       {
          if (selectionModel.isSelected(item))
@@ -354,7 +353,7 @@ public abstract class ChangelistTable extends Composite
    {
       SelectionModel<? super StatusAndPath> selectionModel = table_.getSelectionModel();
 
-      ArrayList<String> results = new ArrayList<String>();
+      ArrayList<String> results = new ArrayList<>();
       for (StatusAndPath item : dataProvider_.getList())
       {
          if (selectionModel.isSelected(item) && item.isDiscardable())
@@ -372,7 +371,7 @@ public abstract class ChangelistTable extends Composite
             selectNext = true;
          else if (selectNext)
          {
-            ArrayList<StatusAndPath> selection = new ArrayList<StatusAndPath>();
+            ArrayList<StatusAndPath> selection = new ArrayList<>();
             selection.add(path);
             setSelectedStatusAndPaths(selection);
             return;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/ChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/ChunkHeaderParser.java
@@ -37,7 +37,7 @@ class ChunkHeaderParser
          return null;
 
       // match atCount many ranges
-      ArrayList<Range> ranges = new ArrayList<Range>(atCount);
+      ArrayList<Range> ranges = new ArrayList<>(atCount);
       for (int i = 0; i < atCount; i++)
       {
          matchWhitespace();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/ChunkOrLine.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/ChunkOrLine.java
@@ -20,7 +20,7 @@ public class ChunkOrLine
 {
    public static ArrayList<ChunkOrLine> fromChunk(DiffChunk chunk)
    {
-      ArrayList<ChunkOrLine> list = new ArrayList<ChunkOrLine>();
+      ArrayList<ChunkOrLine> list = new ArrayList<>();
       if (!chunk.shouldIgnore())
          list.add(new ChunkOrLine(chunk));
       for (Line line : chunk.getLines())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/Line.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/Line.java
@@ -143,7 +143,7 @@ public class Line implements Comparable<Line>
 
    public static ArrayList<Line> reverseLines(ArrayList<Line> lines)
    {
-      ArrayList<Line> rlines = new ArrayList<Line>(lines.size());
+      ArrayList<Line> rlines = new ArrayList<>(lines.size());
       for (Line line : lines)
          rlines.add(line.reverse());
       return rlines;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableView.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/LineTableView.java
@@ -379,7 +379,7 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
       });
       setSelectionModel(selectionModel_);
 
-      setData(new ArrayList<ChunkOrLine>(), PatchMode.Working);
+      setData(new ArrayList<>(), PatchMode.Working);
    }
 
    private void refreshValue(ChunkOrLine value)
@@ -387,7 +387,7 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
       int index = lines_.indexOf(value);
       if (index >= 0)
       {
-         ArrayList<ChunkOrLine> list = new ArrayList<ChunkOrLine>();
+         ArrayList<ChunkOrLine> list = new ArrayList<>();
          list.add(value);
          setRowData(index, list);
       }
@@ -498,13 +498,13 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
    @Override
    public void clear()
    {
-      setData(new ArrayList<ChunkOrLine>(), PatchMode.Working);
+      setData(new ArrayList<>(), PatchMode.Working);
    }
 
    @Override
    public ArrayList<Line> getSelectedLines()
    {
-      ArrayList<Line> selected = new ArrayList<Line>();
+      ArrayList<Line> selected = new ArrayList<>();
       for (ChunkOrLine line : lines_)
          if (line.getLine() != null && selectionModel_.isSelected(line))
             selected.add(line.getLine());
@@ -514,7 +514,7 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
    @Override
    public ArrayList<Line> getAllLines()
    {
-      ArrayList<Line> selected = new ArrayList<Line>();
+      ArrayList<Line> selected = new ArrayList<>();
       for (ChunkOrLine line : lines_)
          if (line.getLine() != null)
             selected.add(line.getLine());
@@ -547,8 +547,8 @@ public class LineTableView extends MultiSelectCellTable<ChunkOrLine> implements 
    private boolean showActions_ = true;
    private ArrayList<ChunkOrLine> lines_;
    private SwitchableSelectionModel<ChunkOrLine> selectionModel_;
-   private HashSet<Integer> startRows_ = new HashSet<Integer>();
-   private HashSet<Integer> endRows_ = new HashSet<Integer>();
+   private HashSet<Integer> startRows_ = new HashSet<>();
+   private HashSet<Integer> endRows_ = new HashSet<>();
    private boolean useStartBorder_ = false;
    private boolean useEndBorder_ = true;
    // Keep explicit track of the first selected line so we can render it differently

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedEmitter.java
@@ -141,7 +141,7 @@ public class UnifiedEmitter
     */
    private ArrayList<DiffChunk> toDiffChunks(ArrayList<Line> lines)
    {
-      ArrayList<DiffChunk> chunks = new ArrayList<DiffChunk>();
+      ArrayList<DiffChunk> chunks = new ArrayList<>();
 
       if (lines.size() == 0)
          return chunks;
@@ -195,7 +195,7 @@ public class UnifiedEmitter
 
       return new DiffChunk(ranges,
                            "",
-                           new ArrayList<Line>(sublist),
+                           new ArrayList<>(sublist),
                            -1);
    }
 
@@ -218,7 +218,7 @@ public class UnifiedEmitter
     */
    private static class OutputLinesGenerator
    {
-      private final ArrayList<Line> output = new ArrayList<Line>();
+      private final ArrayList<Line> output = new ArrayList<>();
 
       private final Iterator<Line> ctxit; // Iterator for all context lines
       private final Iterator<Line> dffit; // Iterator for all diff lines
@@ -382,8 +382,8 @@ public class UnifiedEmitter
       }
    }
 
-   private final ArrayList<Line> contextLines_ = new ArrayList<Line>();
-   private final ArrayList<Line> diffLines_ = new ArrayList<Line>();
+   private final ArrayList<Line> contextLines_ = new ArrayList<>();
+   private final ArrayList<Line> diffLines_ = new ArrayList<>();
    private final String fileA_;
    private final String fileB_;
    private static final String EOL = "\n";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/diff/UnifiedParser.java
@@ -40,7 +40,7 @@ public class UnifiedParser implements DiffParser
    @Override
    public DiffFileHeader nextFilePair()
    {
-      ArrayList<String> headerLines = new ArrayList<String>();
+      ArrayList<String> headerLines = new ArrayList<>();
 
       boolean inDiff = false;
 
@@ -105,7 +105,7 @@ public class UnifiedParser implements DiffParser
 
       boolean[] mask = new boolean[ranges.length];
 
-      ArrayList<Line> lines = new ArrayList<Line>();
+      ArrayList<Line> lines = new ArrayList<>();
       for (;
            !isEmpty(counts) || nextLineIsComment();
            diffIndex_++)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/DiffChunkActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/DiffChunkActionEvent.java
@@ -57,5 +57,5 @@ public class DiffChunkActionEvent extends GwtEvent<DiffChunkActionHandler>
    private Action action_;
    private DiffChunk diffChunk_;
 
-   public static final Type<DiffChunkActionHandler> TYPE = new Type<DiffChunkActionHandler>();
+   public static final Type<DiffChunkActionHandler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/DiffLinesActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/DiffLinesActionEvent.java
@@ -43,5 +43,5 @@ public class DiffLinesActionEvent extends GwtEvent<DiffLinesActionHandler>
 
    private final Action action_;
 
-   public static final Type<DiffLinesActionHandler> TYPE = new Type<DiffLinesActionHandler>();
+   public static final Type<DiffLinesActionHandler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/StageUnstageEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/StageUnstageEvent.java
@@ -52,5 +52,5 @@ public class StageUnstageEvent extends GwtEvent<StageUnstageHandler>
    private final boolean unstage_;
    private final ArrayList<StatusAndPath> paths;
 
-   public static final Type<StageUnstageHandler> TYPE = new Type<StageUnstageHandler>();
+   public static final Type<StageUnstageHandler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/VcsRefreshEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/VcsRefreshEvent.java
@@ -23,7 +23,7 @@ public class VcsRefreshEvent extends GwtEvent<VcsRefreshHandler>
    private final Reason reason_;
    private final int delayMs_;
 
-   public static final Type<VcsRefreshHandler> TYPE = new Type<VcsRefreshHandler>();
+   public static final Type<VcsRefreshHandler> TYPE = new Type<>();
 
    public VcsRefreshEvent(Reason reason)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/ViewFileRevisionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/common/events/ViewFileRevisionEvent.java
@@ -49,5 +49,5 @@ public class ViewFileRevisionEvent extends GwtEvent<ViewFileRevisionHandler>
    private final String revision_;
    private final String filename_;
 
-   public static final Type<ViewFileRevisionHandler> TYPE = new Type<ViewFileRevisionHandler>();
+   public static final Type<ViewFileRevisionHandler> TYPE = new Type<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitDetail.java
@@ -121,7 +121,7 @@ public class CommitDetail extends Composite implements CommitDetailDisplay
                return false;
 
             int filesCompared = 2;
-            ArrayList<ChunkOrLine> lines = new ArrayList<ChunkOrLine>();
+            ArrayList<ChunkOrLine> lines = new ArrayList<>();
             DiffChunk chunk;
             while (null != (chunk = unifiedParser.nextChunk()))
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitListTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/CommitListTable.java
@@ -237,7 +237,7 @@ public class CommitListTable extends MultiSelectCellTable<CommitInfo>
       setColumnWidth(authorCol, "33%");
       setColumnWidth(dateCol, "100px");
 
-      selectionModel_ = new SingleSelectionModel<CommitInfo>();
+      selectionModel_ = new SingleSelectionModel<>();
       setSelectionModel(selectionModel_);
 
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryAsyncDataProvider.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryAsyncDataProvider.java
@@ -34,8 +34,8 @@ public abstract class HistoryAsyncDataProvider extends AsyncDataProvider<CommitI
    public HistoryAsyncDataProvider()
    {
       rev_ = "";
-      searchText_ = new Value<String>("");
-      fileFilter_ = new Value<FileSystemItem>(null);
+      searchText_ = new Value<>("");
+      fileFilter_ = new Value<>(null);
    }
    
    public void setHistoryStrategy(HistoryStrategy strategy)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/graph/GraphTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/graph/GraphTheme.java
@@ -75,5 +75,5 @@ public class GraphTheme
 
    private final String className_;
 
-   private static HashMap<Integer, String> colors_ = new HashMap<Integer, String>();
+   private static HashMap<Integer, String> colors_ = new HashMap<>();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTable.java
@@ -55,7 +55,7 @@ public class GitChangelistTable extends ChangelistTable
    protected void configureTable()
    {
       final Column<StatusAndPath, Boolean> stagedColumn = new Column<StatusAndPath, Boolean>(
-            new TriStateCheckboxCell<StatusAndPath>(selectionModel_))
+            new TriStateCheckboxCell<>(selectionModel_))
       {
          @Override
          public Boolean getValue(StatusAndPath object)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitChangelistTablePresenter.java
@@ -19,7 +19,6 @@ import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.vcs.GitServerOperations;
 import org.rstudio.studio.client.common.vcs.RemoteBranchInfo;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.StageUnstageEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.StageUnstageHandler;
@@ -47,19 +46,19 @@ public class GitChangelistTablePresenter
          @Override
          public void onStageUnstage(StageUnstageEvent event)
          {
-            ArrayList<String> paths = new ArrayList<String>();
+            ArrayList<String> paths = new ArrayList<>();
             for (StatusAndPath path : event.getPaths())
                paths.add(path.getPath());
 
             if (event.isUnstage())
             {
                server_.gitUnstage(paths,
-                                  new SimpleRequestCallback<Void>());
+                                  new SimpleRequestCallback<>());
             }
             else
             {
                server_.gitStage(paths,
-                                new SimpleRequestCallback<Void>());
+                                new SimpleRequestCallback<>());
             }
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPresenter.java
@@ -36,7 +36,6 @@ import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
 import org.rstudio.studio.client.common.vcs.GitServerOperations;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.vcs.VCSApplicationParams;
 import org.rstudio.studio.client.workbench.WorkbenchView;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -270,14 +269,14 @@ public class GitPresenter extends BaseVcsPresenter implements IsWidget
    @Override
    public void showHistory(FileSystemItem fileFilter)
    {
-      showReviewPane(true, fileFilter, new ArrayList<StatusAndPath>());
+      showReviewPane(true, fileFilter, new ArrayList<>());
    }
    
    @Override
    public void showDiff(FileSystemItem file)
    {
       // build an ArrayList<StatusAndPath> so we can call the core helper
-      ArrayList<StatusAndPath> diffList = new ArrayList<StatusAndPath>();
+      ArrayList<StatusAndPath> diffList = new ArrayList<>();
       for (StatusAndPath item :  gitState_.getStatus())
       {
          if (item.getRawPath() == file.getPath())
@@ -305,7 +304,7 @@ public class GitPresenter extends BaseVcsPresenter implements IsWidget
    public void revertFile(FileSystemItem file)
    {
       // build an ArrayList<String> so we can call the core helper
-      ArrayList<String> revertList = new ArrayList<String>();
+      ArrayList<String> revertList = new ArrayList<>();
       for (StatusAndPath item :  gitState_.getStatus())
       {
          if (item.getRawPath() == file.getPath())
@@ -350,7 +349,7 @@ public class GitPresenter extends BaseVcsPresenter implements IsWidget
                   
                   server_.gitRevert(
                         revertList,
-                        new SimpleRequestCallback<Void>("Revert Changes"));
+                        new SimpleRequestCallback<>("Revert Changes"));
                   
                }
             },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPresenterCore.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPresenterCore.java
@@ -178,7 +178,7 @@ public class GitPresenterCore
    
    private ArrayList<String> getPathArray(ArrayList<StatusAndPath> items)
    {
-      ArrayList<String> paths = new ArrayList<String>();
+      ArrayList<String> paths = new ArrayList<>();
       for (StatusAndPath item : items)
          paths.add(item.getPath());
       return paths;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -55,7 +55,6 @@ import org.rstudio.studio.client.common.vcs.StatusAndPath;
 import org.rstudio.studio.client.common.vcs.StatusAndPathInfo;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -147,13 +146,13 @@ public class GitReviewPresenter implements ReviewPresenter
          ArrayList<String> paths = view_.getSelectedPaths();
 
          if (patchMode_ == PatchMode.Stage && !reverse_)
-            server_.gitStage(paths, new SimpleRequestCallback<Void>("Stage"));
+            server_.gitStage(paths, new SimpleRequestCallback<>("Stage"));
          else if (patchMode_ == PatchMode.Stage && reverse_)
             server_.gitUnstage(paths,
-                               new SimpleRequestCallback<Void>("Unstage"));
+                               new SimpleRequestCallback<>("Unstage"));
          else if (patchMode_ == PatchMode.Working && reverse_)
             server_.gitDiscard(paths,
-                               new SimpleRequestCallback<Void>("Discard"));
+                               new SimpleRequestCallback<>("Discard"));
          else
             throw new RuntimeException("Unknown patchMode and reverse combo");
 
@@ -170,7 +169,7 @@ public class GitReviewPresenter implements ReviewPresenter
       @Override
       public void onDiffChunkAction(DiffChunkActionEvent event)
       {
-         ArrayList<DiffChunk> chunks = new ArrayList<DiffChunk>();
+         ArrayList<DiffChunk> chunks = new ArrayList<>();
          chunks.add(event.getDiffChunk());
          doPatch(event.getAction(), event.getDiffChunk().getLines(), chunks);
       }
@@ -376,7 +375,7 @@ public class GitReviewPresenter implements ReviewPresenter
             ArrayList<String> paths = view_.getSelectedPaths();
             if (paths.size() == 0)
                return;
-            server_.gitStage(paths, new SimpleRequestCallback<Void>());
+            server_.gitStage(paths, new SimpleRequestCallback<>());
             
             view_.getChangelistTable().focus();
          }
@@ -405,7 +404,7 @@ public class GitReviewPresenter implements ReviewPresenter
 
                         server_.gitRevert(
                               paths,
-                              new SimpleRequestCallback<Void>("Revert Changes"));
+                              new SimpleRequestCallback<>("Revert Changes"));
                         
                         view_.getChangelistTable().focus();
                      }
@@ -548,7 +547,7 @@ public class GitReviewPresenter implements ReviewPresenter
          public void onClick(ClickEvent event)
          {
             // record the current selected paths (as a set)
-            final Set<String> selectedPaths = new HashSet<String>();
+            final Set<String> selectedPaths = new HashSet<>();
             selectedPaths.addAll(view_.getSelectedPaths());
             
             // first, double-check the file sizes of any files that are going
@@ -708,7 +707,7 @@ public class GitReviewPresenter implements ReviewPresenter
                            boolean reverse,
                            PatchMode patchMode)
    {
-      chunks = new ArrayList<DiffChunk>(chunks);
+      chunks = new ArrayList<>(chunks);
 
       if (reverse)
       {
@@ -729,7 +728,7 @@ public class GitReviewPresenter implements ReviewPresenter
       softModeSwitch_ = true;
       server_.gitApplyPatch(patch, patchMode,
                             StringUtil.notNull(currentSourceEncoding_),
-                            new SimpleRequestCallback<Void>());
+                            new SimpleRequestCallback<>());
    }
 
    private void updateDiff(boolean allowModeSwitch)
@@ -815,7 +814,7 @@ public class GitReviewPresenter implements ReviewPresenter
                   UnifiedParser parser = new UnifiedParser(response);
                   parser.nextFilePair();
 
-                  ArrayList<ChunkOrLine> allLines = new ArrayList<ChunkOrLine>();
+                  ArrayList<ChunkOrLine> allLines = new ArrayList<>();
 
                   activeChunks_.clear();
                   for (DiffChunk chunk;
@@ -931,7 +930,7 @@ public class GitReviewPresenter implements ReviewPresenter
    private final GitPresenterCore gitPresenterCore_;
    private final Display view_;
    private final GlobalDisplay globalDisplay_;
-   private ArrayList<DiffChunk> activeChunks_ = new ArrayList<DiffChunk>();
+   private ArrayList<DiffChunk> activeChunks_ = new ArrayList<>();
    private String currentResponse_;
    private String currentSourceEncoding_;
    private String currentFilename_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNChangelistTablePresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNChangelistTablePresenter.java
@@ -36,8 +36,7 @@ public class SVNChangelistTablePresenter
          @Override
          public void onVcsRefresh(VcsRefreshEvent event)
          {
-            ArrayList<StatusAndPath> items =
-                  new ArrayList<StatusAndPath>(svnState.getStatus());
+            ArrayList<StatusAndPath> items = new ArrayList<>(svnState.getStatus());
 
             boolean usesChangelists = false;
             for (int i = items.size()-1; i >= 0; i--)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNCommandHandler.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNCommandHandler.java
@@ -131,8 +131,7 @@ public class SVNCommandHandler
             String path = item.getPath();
             if (path == ".")
                path = "";
-            IgnoreList ignoreList = new IgnoreList(path, 
-                                                   new ArrayList<String>());
+            IgnoreList ignoreList = new IgnoreList(path, new ArrayList<>());
             pIgnore_.get().showDialog(ignoreList, ignoreStrategy_);
             return;
          }
@@ -250,7 +249,7 @@ public class SVNCommandHandler
       if (items.size() == 0)
          return;
 
-      final ArrayList<String> paths = new ArrayList<String>();
+      final ArrayList<String> paths = new ArrayList<>();
 
       boolean conflict = false;
       for (StatusAndPath item : items)
@@ -306,7 +305,7 @@ public class SVNCommandHandler
    public void revertFile(FileSystemItem file)
    {
       // build an ArrayList<String> so we can call the core helper
-      ArrayList<String> revertList = new ArrayList<String>();
+      ArrayList<String> revertList = new ArrayList<>();
       for (StatusAndPath item :  svnState_.getStatus())
       {
          if (item.getRawPath() == file.getPath())
@@ -359,7 +358,7 @@ public class SVNCommandHandler
    private ArrayList<String> getPathArray()
    {
       ArrayList<StatusAndPath> items = display_.getSelectedItems();
-      ArrayList<String> paths = new ArrayList<String>();
+      ArrayList<String> paths = new ArrayList<>();
       for (StatusAndPath item : items)
          paths.add(item.getPath());
       return paths;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNDiffParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNDiffParser.java
@@ -50,8 +50,8 @@ public class SVNDiffParser implements DiffParser
       Pattern sectionHeaderPattern = Pattern.create(
             "^((Index: ([^\\r\\n]+)\\r?\\n=+)|(\\r?\\nProperty changes on: ([^\\r\\n]+)\\r?\\n_+))$");
 
-      ArrayList<String> sectionData = new ArrayList<String>();
-      ArrayList<Match> sectionMatches = new ArrayList<Match>();
+      ArrayList<String> sectionData = new ArrayList<>();
+      ArrayList<Match> sectionMatches = new ArrayList<>();
 
       int pos = 0;
       int lastHeaderStart = -1;
@@ -69,7 +69,7 @@ public class SVNDiffParser implements DiffParser
       if (lastHeaderStart >= 0)
          sectionData.add(data.substring(lastHeaderStart));
 
-      sections_ = new ArrayList<Section>();
+      sections_ = new ArrayList<>();
       for (int i = 0; i < sectionData.size(); i++)
       {
          sections_.add(parseSection(sectionMatches.get(i), sectionData.get(i)));
@@ -99,7 +99,7 @@ public class SVNDiffParser implements DiffParser
       if (sections_.size() == 0)
          return null;
 
-      ArrayList<Section> sectionsToUse = new ArrayList<Section>();
+      ArrayList<Section> sectionsToUse = new ArrayList<>();
 
       sectionsToUse.add(sections_.remove(0));
       String filename = sectionsToUse.get(0).filename;
@@ -176,12 +176,12 @@ public class SVNDiffParser implements DiffParser
          lastSection = section;
       }
 
-      return new DiffFileHeader(new ArrayList<String>(), filename, filename);
+      return new DiffFileHeader(new ArrayList<>(), filename, filename);
    }
 
    private DiffChunk createInfoChunk(Iterable<String> lines)
    {
-      ArrayList<Line> outLines = new ArrayList<Line>();
+      ArrayList<Line> outLines = new ArrayList<>();
       int chunkDiffIndex = diffIndex_++;
       for (String line : lines)
       {
@@ -203,7 +203,7 @@ public class SVNDiffParser implements DiffParser
       return pendingDiffChunks_.remove(0);
    }
 
-   private final ArrayList<DiffChunk> pendingDiffChunks_ = new ArrayList<DiffChunk>();
+   private final ArrayList<DiffChunk> pendingDiffChunks_ = new ArrayList<>();
    private final ArrayList<Section> sections_;
    private int diffIndex_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPresenter.java
@@ -180,14 +180,14 @@ public class SVNPresenter extends BaseVcsPresenter
    @Override
    public void showHistory(FileSystemItem fileFilter)
    {
-      showReviewPane(true, fileFilter, new ArrayList<StatusAndPath>());  
+      showReviewPane(true, fileFilter, new ArrayList<>());  
    }
    
    @Override
    public void showDiff(FileSystemItem file)
    {
       // build an ArrayList<StatusAndPath> so we can call the core helper
-      ArrayList<StatusAndPath> diffList = new ArrayList<StatusAndPath>();
+      ArrayList<StatusAndPath> diffList = new ArrayList<>();
       for (StatusAndPath item :  svnState_.getStatus())
       {
          if (item.getRawPath() == file.getPath())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNSelectChangelistTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNSelectChangelistTable.java
@@ -56,7 +56,7 @@ public class SVNSelectChangelistTable extends SVNChangelistTable
    @Override
    public ArrayList<String> getSelectedPaths()
    {
-      ArrayList<String> selectedPaths = new ArrayList<String>();
+      ArrayList<String> selectedPaths = new ArrayList<>();
       for (Map.Entry<String, Boolean> entry : selected_.entrySet())
          if (entry.getValue() != null && entry.getValue())
             selectedPaths.add(entry.getKey());
@@ -103,7 +103,7 @@ public class SVNSelectChangelistTable extends SVNChangelistTable
    protected void configureTable()
    {
       commitColumn_ = new Column<StatusAndPath, Boolean>(
-            new TriStateCheckboxCell<StatusAndPath>(selectionModel_))
+            new TriStateCheckboxCell<>(selectionModel_))
       {
          @Override
          public Boolean getValue(StatusAndPath object)
@@ -141,8 +141,7 @@ public class SVNSelectChangelistTable extends SVNChangelistTable
          list.set(i, list.get(i));
    }
 
-   private final HashMap<String, Boolean> selected_ =
-                                                 new HashMap<String, Boolean>();
-   private final HashSet<String> uncommitableStatuses = new HashSet<String>();
+   private final HashMap<String, Boolean> selected_ = new HashMap<>();
+   private final HashSet<String> uncommitableStatuses = new HashSet<>();
    private Column<StatusAndPath, Boolean> commitColumn_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNSelectChangelistTablePresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNSelectChangelistTablePresenter.java
@@ -112,7 +112,7 @@ public class SVNSelectChangelistTablePresenter extends SVNChangelistTablePresent
 
          private ArrayList<String> toArray(String path)
          {
-            ArrayList<String> result = new ArrayList<String>();
+            ArrayList<String> result = new ArrayList<>();
             result.add(path);
             return result;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/dialog/SVNReviewPresenter.java
@@ -44,7 +44,6 @@ import org.rstudio.studio.client.common.vcs.DiffResult;
 import org.rstudio.studio.client.common.vcs.SVNServerOperations;
 import org.rstudio.studio.client.common.vcs.StatusAndPath;
 import org.rstudio.studio.client.server.ServerError;
-import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -125,7 +124,7 @@ public class SVNReviewPresenter implements ReviewPresenter
       @Override
       public void onDiffChunkAction(DiffChunkActionEvent event)
       {
-         ArrayList<DiffChunk> chunks = new ArrayList<DiffChunk>();
+         ArrayList<DiffChunk> chunks = new ArrayList<>();
          chunks.add(event.getDiffChunk());
          doPatch(event.getAction(), event.getDiffChunk().getLines(), chunks);
       }
@@ -342,7 +341,7 @@ public class SVNReviewPresenter implements ReviewPresenter
                            ArrayList<Line> lines,
                            boolean reverse)
    {
-      chunks = new ArrayList<DiffChunk>(chunks);
+      chunks = new ArrayList<>(chunks);
 
       if (reverse)
       {
@@ -361,7 +360,7 @@ public class SVNReviewPresenter implements ReviewPresenter
 
       server_.svnApplyPatch(path, patch,
                             StringUtil.notNull(currentEncoding_),
-                            new SimpleRequestCallback<Void>());
+                            new SimpleRequestCallback<>());
    }
 
    private void updateDiff()
@@ -413,7 +412,7 @@ public class SVNReviewPresenter implements ReviewPresenter
                   SVNDiffParser parser = new SVNDiffParser(response);
                   parser.nextFilePair();
 
-                  ArrayList<ChunkOrLine> allLines = new ArrayList<ChunkOrLine>();
+                  ArrayList<ChunkOrLine> allLines = new ArrayList<>();
 
                   activeChunks_.clear();
                   for (DiffChunk chunk;
@@ -509,7 +508,7 @@ public class SVNReviewPresenter implements ReviewPresenter
    private final SVNServerOperations server_;
    private final SVNCommandHandler commandHandler_;
    private final Display view_;
-   private ArrayList<DiffChunk> activeChunks_ = new ArrayList<DiffChunk>();
+   private ArrayList<DiffChunk> activeChunks_ = new ArrayList<>();
    private String currentResponse_;
    private String currentEncoding_;
    private String currentFilename_;
@@ -518,7 +517,7 @@ public class SVNReviewPresenter implements ReviewPresenter
    private static final String MODULE_SVN = "vcs_svn";
    private static final String KEY_CONTEXT_LINES = "context_lines";
    
-   private final HashSet<String> undiffableStatuses_ = new HashSet<String>();
+   private final HashSet<String> undiffableStatuses_ = new HashSet<>();
 
    private boolean overrideSizeWarning_ = false;
 


### PR DESCRIPTION
### Intent
Java7+ can infer types in code such as:

```
      ArrayList<Element> focusable = new ArrayList<Element>();
```

Shortening it to:

```
      ArrayList<Element> focusable = new ArrayList<>();
```

I fix these when I come across them, taking this opportunity at start of 1.4-juliet-rose to do a bulk cleanup.

### Approach

Refactored via IntelliJ and also removed unused imports resulting from this cleanup and a couple of others that had crept in.

### QA Notes

Purely mechanical source code cleanup, doesn't change the resulting executable code. Nothing to specifically test.

