### PR TITLE
update filepath tooltip when renaming file in main or secondary window

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -41,6 +41,7 @@
 * Fix display of condition messages (errors and warnings) in some character encodings (#8546)
 * Fix issues finding words with punctuation in visual mode (#8655)
 * Fix spurious image insertion when pasting into visual mode from Excel (#8665)
+* Fix out-of-date tooltip when renaming files (#8490, #8491)
 
 
 

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -53,6 +53,7 @@ import org.rstudio.studio.client.workbench.views.source.events.DocTabDragStarted
 import org.rstudio.studio.client.workbench.views.source.events.DocTabDragStateChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocWindowChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.PopoutDocInitiatedEvent;
+import org.rstudio.studio.client.workbench.views.source.events.SourceFileSavedEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DocTabDragParams;
 
 import com.google.gwt.animation.client.Animation;
@@ -123,6 +124,15 @@ public class DocTabLayoutPanel
       // to notify us of incoming drags)
       events_ = RStudioGinjector.INSTANCE.getEventBus();
       events_.addHandler(DocTabDragStartedEvent.TYPE, dragManager_);
+
+      events_.addHandler(SourceFileSavedEvent.TYPE, event ->
+      {
+         // update tooltip to reflect current filename after a Rename or Save As
+         DocTab tab = getTabForDocId(event.getDocId());
+         if (tab != null)
+            tab.replaceTooltip(event.getPath());
+      });
+
       commands_ = RStudioGinjector.INSTANCE.getCommands();
 
    }
@@ -1377,6 +1387,19 @@ public class DocTabLayoutPanel
          return "text";
       else
          return "application/rstudio-tab";
+   }
+
+   private DocTab getTabForDocId(String docId)
+   {
+      for (int i = 0; i < getWidgetCount(); i++)
+      {
+         DocTab tab = (DocTab)getTabWidget(i);
+         if (StringUtil.equals(tab.getDocId(), docId))
+         {
+            return tab;
+         }
+      }
+      return null;
    }
 
    public static final int BAR_HEIGHT = 24;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -337,6 +337,9 @@ public class Source implements InsertSourceEvent.Handler,
          @Override
          public void onSourcePathChanged(final SourcePathChangedEvent event)
          {
+            // Satellites also need to know about this happening, for example if a file
+            // is renamed via the tab context menu or externally
+            events_.fireEventToAllSatellites(event);
 
             columnManager_.inEditorForPath(event.getFrom(),
                             new OperationWithInput<EditingTarget>()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindowManager.java
@@ -704,6 +704,9 @@ public class SourceWindowManager implements PopoutDocEvent.Handler,
       // our internal doc mappings so we can route navigations to the right
       // window for that path
       updateDocPath(event.getDocId(), event.getPath());
+
+      // satellites also need to know if a file was renamed
+      events_.fireEventToAllSatellites(event);
    }
 
    @Override


### PR DESCRIPTION
### Intent

- Fixes #8490
- Fixes #8491

### Approach

- Ensure appropriate messages are handled so the tooltip can be updated, and that the underlying filename is updated in satellite windows
- Note that both of these issues have been around forever, just easier to notice now that there's a rename command on the tab context menu in v1.4-juliet-rose

### QA Notes

- Test scenarios described in issues, both on desktop and server
- Note known quirk #8726; always been this way
