### PR TITLE
fix issue with rendering .tex documents with tinytex on Windows

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -27,6 +27,7 @@
 ### Bugfixes
 
 * Fix Windows Desktop installer to support running from path with characters from other codepages (#8421)
+* Fixed issue where rendering .tex document with tinytex would fail on Windows (#8725)
 * Fixed issue where reinstalling an already-loaded package could cause errors (#8265)
 * Fixed issue where right-assignment with multi-line strings gave false-positive diagnostic errors (#8307)
 * Fixed issue where restoring R workspace could fail when project path contained non-ASCII characters (#8321)


### PR DESCRIPTION
### Intent

Resolves https://github.com/rstudio/rstudio/issues/8725.

### Approach

Avoid command line quoting / escaping issues by just writing the associated R code to a file, and then running that script via an R sub-process.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8725.