### PR TITLE
properly handle Python null pointers when building Environment pane

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -34,6 +34,7 @@
 * Fixed issue where attempting to profile lines ending in comment would fail (#8407)
 * Fixed issue where warnings + messages were mis-encoded in chunk outputs on Windows (#8565)
 * Fixed issue where C++ compilation database was not invalidated when compiler was updated (#8588)
+* Fixed issue where restarting session with reticulate Python objects could cause errors in console (#8185)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
 * The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -2433,7 +2433,7 @@ START:
          if (isBinaryOp(next))
          {
             // handle '\n' within the token
-            int row =
+            std::size_t row =
                   cursor.row() +
                   std::count(cursor.begin(), cursor.end(), '\n');
             

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1496,6 +1496,25 @@ html.heading = _heading
    else
       get(name, envir = parent)
    
+   # is this a null pointer? if so, handle that up-front
+   if (reticulate:::py_is_null_xptr(object))
+   {
+      result <- list(
+         name              = .rs.scalar(name),
+         type              = .rs.scalar("<unknown>"),
+         clazz             = "<unknown>",
+         is_data           = .rs.scalar(TRUE),
+         value             = .rs.scalar("<Null pointer>"),
+         description       = .rs.scalar("<Null pointer>"),
+         size              = .rs.scalar(0L),
+         length            = .rs.scalar(0L),
+         contents          = list(),
+         contents_deferred = .rs.scalar(FALSE)
+      )
+      
+      return(result)
+   }
+   
    # is this object 'data'? consider non-callable, non-module objects as data
    isData <- !(
       grepl("^__.*__$", name) ||


### PR DESCRIPTION
### Intent

When a session is restarted, it's possible that some R objects acting as proxies for Python objects are saved and then later restored as null pointers. We need to handle these specially to avoid errors on restart, as reported in https://github.com/rstudio/rstudio/issues/8185.

### Approach

Check for null pointers up-front and handle them specifically.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8185.

Closes https://github.com/rstudio/rstudio/issues/8185.