### PR TITLE
Add Copy Path to editor tab context menu

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -10,6 +10,7 @@
 * The mouse back / forward buttons can now be used to navigate within the Help pane (#8338)
 * Right-click on document tab provides menu with close, close all, close others (#1664)
 * Rename File added to document tab context menu (#8374)
+* Copy Path command added to document tab context menu (#7289)
 * Compilation of Sweave documents now uses tinytex when requested (#2788)
 * Preliminary compatibility with UCRT builds of R-devel (#8461)
 * Update Windows Desktop to openSSL 1.1.1i (#8574)

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -19,16 +19,21 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.ConfigFileBacked;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.events.EditorKeybindingsChangedEvent;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ResetEditorCommandsEvent;
 import org.rstudio.studio.client.application.events.SetEditorCommandBindingsEvent;
+import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceCommand;
@@ -139,6 +144,18 @@ public class EditorCommandManager
                }
             });
 
+      events_.addHandler(CopySourcePathEvent.TYPE, event ->
+      {
+         String path = event.getPath();
+         if (BrowseCap.isWindowsDesktop() && !Desktop.isRemoteDesktop())
+         {
+            // on Windows desktop, with a regular session (versus an RDP remote
+            // session), resolve the "~" to a full path since Windows doesn't
+            // natively understand "~"
+            path = files_.resolveAliasedPath(FileSystemItem.createFile(path));
+         }
+         DomUtils.copyToClipboard(path);
+      });
    }
 
    @Inject

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -903,7 +903,7 @@ public class DomUtils
    }-*/;
 
    /**
-    * Forwards wheel events between a document and element. Originally written to pass wheel 
+    * Forwards wheel events between a document and element. Originally written to pass wheel
     * events up from an iframe.
     * @param fromDoc The document that first receives the wheel event.
     * @param toElement The element the event is forwarded to.
@@ -913,7 +913,7 @@ public class DomUtils
        function forward(event) {
            toElement.dispatchEvent(new event.constructor(event.type, event));
        }
-       // While "wheel" is the current standard, Ace will not handle the event if "mousewheel" is 
+       // While "wheel" is the current standard, Ace will not handle the event if "mousewheel" is
        // supported by the browser. Older browsers require "DomMouseScroll".
        var wheelEvent = $wnd.document.onmousewheel !== undefined ? "mousewheel" :
            "onwheel" in toElement ? "wheel" : "DomMouseScroll";
@@ -1307,6 +1307,30 @@ public class DomUtils
    public static final native DOMRect getBoundingClientRect(Element el)
    /*-{
       return el.getBoundingClientRect();
+   }-*/;
+
+   public static final native void copyToClipboard(String text)
+   /*-{
+      if (window.clipboardData && window.clipboardData.setData) {
+         // Internet Explorer-specific code path to prevent textarea being shown while dialog is visible.
+         clipboardData.setData("Text", text);
+      }
+      else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
+         var textarea = document.createElement("textarea");
+         textarea.textContent = text;
+         textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in Microsoft Edge.
+         document.body.appendChild(textarea);
+         textarea.select();
+         try {
+            document.execCommand("copy");  // Security exception may be thrown by some browsers.
+         }
+         catch (ex) {
+            console.warn("Copy to clipboard failed.", ex);
+         }
+         finally {
+            document.body.removeChild(textarea);
+         }
+      }
    }-*/;
 
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -41,6 +41,7 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
+import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.server.model.RequestDocumentCloseEvent;
@@ -211,6 +212,10 @@ public class DocTabLayoutPanel
                menu.addItem(new MenuItem("Rename", () ->
                {
                   events_.fireEvent(new RenameSourceFileEvent(filePath));
+               }));
+               menu.addItem(new MenuItem("Copy Path", () ->
+               {
+                  events_.fireEvent(new CopySourcePathEvent(filePath));
                }));
                menu.addSeparator();
             }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/CopySourcePathEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/events/CopySourcePathEvent.java
@@ -1,0 +1,52 @@
+/*
+ * CopySourcePathEvent.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.filetypes.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class CopySourcePathEvent extends GwtEvent<CopySourcePathEvent.Handler>
+{
+   public CopySourcePathEvent(String path)
+   {
+      path_ = path;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onCopySourcePath(CopySourcePathEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCopySourcePath(this);
+   }
+
+   public String getPath()
+   {
+      return path_;
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
+   private final String path_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1588,10 +1588,10 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, RENAME_FILE, paramArray, requestCallback);
    }
 
-   // this method is private as we generally don't want to expose
+   // This method should be rarely used; we generally don't want to expose
    // non-aliased paths to other parts of the client codebase
    // (most client-side APIs assume paths are aliased)
-   private final String resolveAliasedPath(FileSystemItem file)
+   public final String resolveAliasedPath(FileSystemItem file)
    {
       String path = file.getPath();
       if (path.startsWith("~"))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -735,10 +735,10 @@ well as menu structures (for main menu and popup menus).
          <shortcut refid="activateVcs" value="Ctrl+F1" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateBuild" value="Meta+F2" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateBuild" value="Ctrl+F2" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         
+
          <!-- Not using Cmd+F5 (aka Meta+F5) on Mac, it is the standard shortcut for toggling VoiceOver -->
          <shortcut refid="activateConnections" value="Ctrl+F5" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
-         
+
          <shortcut refid="activateFindInFiles" value="Meta+F6" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="activateFindInFiles" value="Ctrl+F6" if="!org.rstudio.core.client.BrowseCap.isMacintosh()"/>
          <shortcut refid="newSourceColumn" value="Meta+F7" if="org.rstudio.core.client.BrowseCap.isMacintosh()"/>
@@ -1122,7 +1122,7 @@ well as menu structures (for main menu and popup menus).
         menuLabel="Open File in New C_olumn..."
         buttonLabel=""
         desc="Open an existing file in a new column"/>
-   
+
    <cmd id="reopenSourceDocWithEncoding"
         label="Reopen Current Document with Encoding..."
         menuLabel="Reopen with _Encoding..."
@@ -1140,6 +1140,12 @@ well as menu structures (for main menu and popup menus).
         menuLabel="_Rename"
         buttonLabel=""
         desc="Rename current document"/>
+
+   <cmd id="copySourceDocPath"
+        label="Copy Document Path"
+        menuLabel="Copy Path"
+        buttonLabel=""
+        desc="Copy current document path"/>
 
    <cmd id="saveSourceDocAs"
         label="Save Current Document As..."

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -59,6 +59,7 @@ public abstract class
    public abstract AppCommand saveSourceDocWithEncoding();
    public abstract AppCommand saveAllSourceDocs();
    public abstract AppCommand renameSourceDoc();
+   public abstract AppCommand copySourceDocPath();
    public abstract AppCommand closeSourceDoc();
    public abstract AppCommand closeOtherSourceDocs();
    public abstract AppCommand closeAllSourceDocs();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -22,7 +22,6 @@ import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
-import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ColumnSortInfo;
 import org.rstudio.core.client.command.CommandBinder;
@@ -37,7 +36,6 @@ import org.rstudio.studio.client.common.ConsoleDispatcher;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.fileexport.FileExport;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
-import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.events.RStudioApiRequestEvent;
@@ -71,7 +69,6 @@ public class Files
                  OpenFileInBrowserEvent.Handler,
                  DirectoryNavigateEvent.Handler,
                  RenameSourceFileEvent.Handler,
-                 CopySourcePathEvent.Handler,
                  RStudioApiRequestEvent.Handler
 {
    interface Binder extends CommandBinder<Commands, Files> {}
@@ -179,7 +176,6 @@ public class Files
 
       eventBus_.addHandler(FileChangeEvent.TYPE, this);
       eventBus_.addHandler(RenameSourceFileEvent.TYPE, this);
-      eventBus_.addHandler(CopySourcePathEvent.TYPE, this);
       eventBus_.addHandler(RStudioApiRequestEvent.TYPE, this);
 
       initSession();
@@ -638,20 +634,6 @@ public class Files
    public void onRenameSourceFile(RenameSourceFileEvent event)
    {
       renameFile(FileSystemItem.createFile(event.getPath()));
-   }
-
-   @Override
-   public void onCopySourcePath(CopySourcePathEvent event)
-   {
-      String path = event.getPath();
-      if (BrowseCap.isWindowsDesktop() && !Desktop.isRemoteDesktop())
-      {
-         // on Windows desktop, with a regular session (versus an RDP remote
-         // session), resolve the "~" to a full path since Windows doesn't
-         // natively understand "~"
-         path = server_.resolveAliasedPath(FileSystemItem.createFile(path));
-      }
-      DomUtils.copyToClipboard(path);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.common.ConsoleDispatcher;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.fileexport.FileExport;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
+import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.common.filetypes.events.OpenFileInBrowserEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.events.RStudioApiRequestEvent;
@@ -69,6 +70,7 @@ public class Files
                  OpenFileInBrowserEvent.Handler,
                  DirectoryNavigateEvent.Handler,
                  RenameSourceFileEvent.Handler,
+                 CopySourcePathEvent.Handler,
                  RStudioApiRequestEvent.Handler
 {
    interface Binder extends CommandBinder<Commands, Files> {}
@@ -176,6 +178,7 @@ public class Files
 
       eventBus_.addHandler(FileChangeEvent.TYPE, this);
       eventBus_.addHandler(RenameSourceFileEvent.TYPE, this);
+      eventBus_.addHandler(CopySourcePathEvent.TYPE, this);
       eventBus_.addHandler(RStudioApiRequestEvent.TYPE, this);
 
       initSession();
@@ -634,6 +637,12 @@ public class Files
    public void onRenameSourceFile(RenameSourceFileEvent event)
    {
       renameFile(FileSystemItem.createFile(event.getPath()));
+   }
+
+   @Override
+   public void onCopySourcePath(CopySourcePathEvent event)
+   {
+      DomUtils.copyToClipboard(event.getPath());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -22,6 +22,7 @@ import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ColumnSortInfo;
 import org.rstudio.core.client.command.CommandBinder;
@@ -642,7 +643,15 @@ public class Files
    @Override
    public void onCopySourcePath(CopySourcePathEvent event)
    {
-      DomUtils.copyToClipboard(event.getPath());
+      String path = event.getPath();
+      if (BrowseCap.isWindowsDesktop() && !Desktop.isRemoteDesktop())
+      {
+         // on Windows desktop, with a regular session (versus an RDP remote
+         // session), resolve the "~" to a full path since Windows doesn't
+         // natively understand "~"
+         path = server_.resolveAliasedPath(FileSystemItem.createFile(path));
+      }
+      DomUtils.copyToClipboard(path);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
@@ -98,4 +98,9 @@ public interface FilesServerOperations
    void readConfigJSON(String relativePath,
                  boolean logErrorIfNotFound,
                  ServerRequestCallback<JavaScriptObject> requestCallback);
+
+   // Use VERY sparingly; we generally don't want to expose
+   // non-aliased paths to other parts of the client codebase
+   // (most client-side APIs assume paths are aliased)
+   String resolveAliasedPath(FileSystemItem file);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
@@ -99,8 +99,10 @@ public interface FilesServerOperations
                  boolean logErrorIfNotFound,
                  ServerRequestCallback<JavaScriptObject> requestCallback);
 
-   // Use VERY sparingly; we generally don't want to expose
-   // non-aliased paths to other parts of the client codebase
-   // (most client-side APIs assume paths are aliased)
+   /**
+    * Use VERY sparingly; we generally don't want to expose
+    * non-aliased paths to other parts of the client codebase
+    * (most client-side APIs assume paths are aliased)
+    */
    String resolveAliasedPath(FileSystemItem file);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -78,6 +78,7 @@ import org.rstudio.studio.client.common.filetypes.FileTypeCommands;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.filetypes.SweaveFileType;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
+import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.mathjax.MathJax;
 import org.rstudio.studio.client.common.r.roxygen.RoxygenHelper;
@@ -3757,6 +3758,12 @@ public class TextEditingTarget implements
    void onRenameSourceDoc()
    {
       events_.fireEvent(new RenameSourceFileEvent(docUpdateSentinel_.getPath()));
+   }
+
+   @Handler
+   void onCopySourceDocPath()
+   {
+      events_.fireEvent(new CopySourcePathEvent(docUpdateSentinel_.getPath()));
    }
 
    @Handler


### PR DESCRIPTION
### Intent

- Fixes #7289
- IDE's typically have a way to copy the path of an open file via context menu, now we do, too
![screenshot of document tab context menu showing new Copy Path command](https://user-images.githubusercontent.com/10569626/104527448-99a57400-55b9-11eb-8a23-20a7baf86a41.png)
- Also added to command palette as "Copy Document Path" for keyboard-only use

### Approach

- Went for simplest approach, just copy the entire path, including filename, to the clipboard
- On Windows Desktop, a leading `~` will be resolved to a full path, since this isn't a native concept on Windows, but on Server, other desktop platforms, and RDP remote sessions, the `~` will be left as-is

### QA Notes

- Test in source columns and in popped-out satellite source editors using both Command Palette and tab context menu
- Test in a variety of browsers; the code I'm using for copying came from [stackoverflow](https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript) and seems to cover all major browsers we support in my testing, but it's possible we might find some edge cases (if so, we could consider using [clipboard.js](https://clipboardjs.com/), instead)
- I expect people will request variations on this, e.g. just copy the filename, just copy the path without the filename, resolve the entire path on all platforms, etc., but just getting in the basic functionality for v1.4-juliet-rose
