### PR TITLE
fix osx dependency script to correctly install prebuilt crashpad

### DIFF
--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -17,6 +17,37 @@
 
 set -e
 
+function help() {
+  cat <<EOF
+usage: install-common [options]
+
+Options
+  --install-crashpad-sudo
+      When installing dependencies to setup a dev environment, need to run install-crashpad
+      via sudo; however, this causes problems if used when building a Dockerfile
+
+EOF
+}
+
+INSTALL_CRASHPAD_SUDO=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --install-crashpad-sudo)
+      INSTALL_CRASHPAD_SUDO="sudo"
+      echo Installing crashpad via sudo
+      shift
+      ;;
+    --help|-h)
+      help
+      exit 0
+      ;;
+    *)
+      help
+      exit 1
+      ;;
+  esac
+done
+
 ./install-dictionaries
 ./install-mathjax
 ./install-boost
@@ -26,19 +57,13 @@ set -e
 ./install-npm-dependencies
 ./install-soci
 
-# when installing dependencies to setup a dev environment, need to run install-crashpad
-# via sudo; however, this causes problems if used when building a Dockerfile
-if [ "$1" != "--install-crashpad-sudo" ]
-then
-  if [[ "$OSTYPE" == "darwin"* ]]; then 
-    # use pre-built binaries on macos as compilation environment is difficult
-    # to configure there
-    ./install-crashpad osx
-  else 
-    ./install-crashpad
-  fi
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # use pre-built binaries on macos as compilation environment is difficult
+  # to configure there
+  echo Using pre-built osx binaries
+  $INSTALL_CRASHPAD_SUDO ./install-crashpad osx
 else
-  sudo ./install-crashpad
+  $INSTALL_CRASHPAD_SUDO ./install-crashpad
 fi
 
 if [ -e install-overlay ]


### PR DESCRIPTION
### Intent

Running `install-dependencies-osx` on Mac should successfully install the dependencies including pre-built crashpad. It does not and the attempt to build crashpad always fails.

### Approach

This was partially fixed in #8467 but that didn't account for fact the install-dependencies-osx script invokes install-common with the --install-crashpad-sudo option

Added some basic command-line parsing to install-common for future expansion, and made it do the right thing.

### QA Notes

Purely a dev / build environment thing, nothing to test.
