### PR TITLE
Fix incorrect shortcuts for some commands in the Command Palette

### DIFF
--- a/NEWS-1.4-juliet-rose.md
+++ b/NEWS-1.4-juliet-rose.md
@@ -44,6 +44,7 @@
 * Fix issues finding words with punctuation in visual mode (#8655)
 * Fix spurious image insertion when pasting into visual mode from Excel (#8665)
 * Fix out-of-date tooltip when renaming files (#8490, #8491)
+* Fix incorrect keyboard shortcuts shown in some places in the Command Palette (#8735)
 
 
 

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommandBinding.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommandBinding.java
@@ -38,14 +38,24 @@ public class AppCommandBinding implements CommandBinding
       command_.executeFromShortcut();
    }
 
+   /**
+    * Indicates whether the binding is enabled in the current editor mode
+    *
+    * @return Whether the binding is enabled
+    */
+   public boolean isEnabledInCurrentMode()
+   {
+      int mode = ShortcutManager.INSTANCE.getEditorMode();
+      return (disableModes_ & mode) == 0;
+   }
+
    @Override
    public boolean isEnabled()
    {
       if (!command_.isEnabled())
          return false;
 
-      int mode = ShortcutManager.INSTANCE.getEditorMode();
-      if ((disableModes_ & mode) != 0)
+      if (!isEnabledInCurrentMode())
          return false;
 
       return true;

--- a/src/gwt/src/org/rstudio/core/client/command/KeyCommandBinding.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyCommandBinding.java
@@ -1,0 +1,40 @@
+/*
+ * KeyCommandBinding.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.command;
+
+/**
+ * Represents a key sequence associated with a command binding
+ */
+public class KeyCommandBinding
+{
+   public KeyCommandBinding(KeyMap.CommandBinding binding, KeySequence keys)
+   {
+      binding_ = binding;
+      keys_ = keys;
+   }
+
+   public KeyMap.CommandBinding getBinding()
+   {
+      return binding_;
+   }
+
+   public KeySequence getKeys()
+   {
+      return keys_;
+   }
+
+   private final KeyMap.CommandBinding binding_;
+   private final KeySequence keys_;
+}

--- a/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
+++ b/src/gwt/src/org/rstudio/core/client/command/KeyMap.java
@@ -20,6 +20,7 @@ package org.rstudio.core.client.command;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.user.client.Command;
 import org.rstudio.core.client.CommandWith2Args;
 import org.rstudio.core.client.DirectedGraph;
 import org.rstudio.core.client.Mutable;
@@ -130,6 +131,38 @@ public class KeyMap
          keys.add(new KeySequence(bindings.get(i).getKeyChain()));
 
       return keys;
+   }
+
+   /**
+    * Returns a list of key/command bindings for the given command.
+    *
+    * @param id The command to look up bindings for
+    * @return A list of key bindings for the command
+    */
+   public List<KeyCommandBinding> getKeyCommandBindings(String id)
+   {
+      List<KeyCommandBinding> keyBindings = new ArrayList<>();
+      List<DirectedGraph<KeyCombination, List<CommandBinding>>> bindings = idToNodeMap_.get(id);
+      if (bindings == null)
+      {
+         // No bindings found, so return an empty list
+         return keyBindings;
+      }
+
+      for (int i = 0, n = bindings.size(); i < n; i++)
+      {
+         // For this purpose, we're only interested in the first command binding
+         // for the key sequence
+         List<CommandBinding> commandBindings = bindings.get(i).getValue();
+         if (commandBindings.size() > 0)
+         {
+            keyBindings.add(new KeyCommandBinding(
+               commandBindings.get(0),
+               new KeySequence(bindings.get(i).getKeyChain())));
+         }
+      }
+
+      return keyBindings;
    }
 
    public CommandBinding getActiveBinding(KeySequence keys, boolean includeDisabled)

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
@@ -34,7 +34,13 @@ public class ShortcutInfo
                      true;
       order_ = shortcut.getOrder();
       disableModes_ = shortcut.getDisableModes();
+      command_ = command;
       addShortcut(shortcut);
+   }
+
+   public AppCommand getCommand()
+   {
+      return command_;
    }
 
    public String getDescription()
@@ -44,13 +50,23 @@ public class ShortcutInfo
 
    public List<String> getShortcuts()
    {
+      List<String> shortcuts = new ArrayList<>();
+      for (KeyboardShortcut shortcut: shortcuts_)
+      {
+         shortcuts.add(shortcut.toString(true));
+      }
+      return shortcuts;
+   }
+
+   public List<KeyboardShortcut> getKeyboardShortcuts()
+   {
       return shortcuts_;
    }
 
    public void addShortcut(KeyboardShortcut shortcut)
    {
       shortcuts_.clear();
-      shortcuts_.add(shortcut.toString(true));
+      shortcuts_.add(shortcut);
    }
 
    public String getGroupName()
@@ -73,10 +89,11 @@ public class ShortcutInfo
       return disableModes_;
    }
 
-   private List<String> shortcuts_;
+   private List<KeyboardShortcut> shortcuts_;
    private String description_;
    private String groupName_;
    private boolean isActive_;
    private int order_;
    private int disableModes_;
+   private final AppCommand command_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/palette/AppCommandPaletteSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/palette/AppCommandPaletteSource.java
@@ -22,8 +22,9 @@ import java.util.Set;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.AppCommand;
+import org.rstudio.core.client.command.AppCommandBinding;
+import org.rstudio.core.client.command.KeyCommandBinding;
 import org.rstudio.core.client.command.KeyMap;
-import org.rstudio.core.client.command.KeyMap.KeyMapType;
 import org.rstudio.core.client.command.KeySequence;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
@@ -36,7 +37,7 @@ public class AppCommandPaletteSource implements CommandPaletteEntryProvider
    public AppCommandPaletteSource(ShortcutManager shortcuts, Commands commands)
    {
       commands_ = commands;
-      map_ = shortcuts.getKeyMap(KeyMapType.APPLICATION);
+      map_ = shortcuts.getKeyMap(KeyMap.KeyMapType.APPLICATION);
    }
 
    @Override
@@ -106,11 +107,8 @@ public class AppCommandPaletteSource implements CommandPaletteEntryProvider
             continue;
          }
 
-         // Look up the key binding for this command
-         List<KeySequence> keys = map_.getBindings(command.getId());
-         
          // Create an application command entry
-         items.add(new AppCommandPaletteItem(command, keys));
+         items.add(new AppCommandPaletteItem(command, getKeyBindings(command)));
       }
 
       return items;
@@ -131,7 +129,44 @@ public class AppCommandPaletteSource implements CommandPaletteEntryProvider
          return null;
       }
 
-      return new AppCommandPaletteItem(command, map_.getBindings(id));
+      return new AppCommandPaletteItem(command, getKeyBindings(command));
+   }
+
+   /**
+    * Look up the active key bindings for a given command
+    *
+    * @param command The app command to find key bindings for
+    * @return A list of key sequences bound to the command
+    */
+   private List<KeySequence> getKeyBindings(AppCommand command)
+   {
+      List<KeySequence> keys = new ArrayList<>();
+
+      // Look up the bindings for this command and iterate over each
+      List<KeyCommandBinding> bindings = map_.getKeyCommandBindings(command.getId());
+      for (KeyCommandBinding binding: bindings)
+      {
+         // Check if this binding is for an app command for sanity; we would not
+         // expect another kind of binding since this is an AppCommand
+         KeyMap.CommandBinding commandBinding = binding.getBinding();
+         if (!(commandBinding instanceof AppCommandBinding))
+         {
+            continue;
+         }
+
+         // Check to see whether this binding is enabled in the current mode; some
+         // command bindings are specific to (or exclusive of) Vim/Emacs mode
+         AppCommandBinding appBinding = (AppCommandBinding) commandBinding;
+         if (!appBinding.isEnabledInCurrentMode())
+         {
+            continue;
+         }
+
+         // This binding is active
+         keys.add(binding.getKeys());
+      }
+
+      return keys;
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8735, in which some commands in the Command Palette show the wrong shortcut if they have multiple shortcuts that depend on the editor mode. 

### Approach

This bug exists because we look up all the key bindings for a command, but not all of them are necessarily active in the current mode. The fix is somewhat verbose but conceptually simple: we now plumb the command binding through to the command palette, and query it to see if it's enabled in the current mode before adding it to the palette. 

### QA Notes

All shortcuts should now be correct; test via notes in #8735. Ensure that user-created shortcuts are still shown, ideally in preference to built-in shortcuts. 
