### PR TITLE
use Python-compatible unicode escapes

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -287,9 +287,18 @@ std::string utf8ToSystem(const std::string& str,
       if (n == -1)
       {
          if (escapeInvalidChars)
-            output << "\\u{" << std::hex << wide[i] << "}";
+         {
+            // NOTE: in R, both '\u{1234}' and '\u1234' are valid
+            // ways of specifying a unicode literal, but only the
+            // latter is accepted by Python, and since the reticulate
+            // REPL uses the same conversion routines we prefer the
+            // format compatible with both parsers
+            output << "\\u" << std::hex << wide[i];
+         }
          else
+         {
             output << "?"; // TODO: Use GetCPInfo()
+         }
       }
       else
       {


### PR DESCRIPTION
### Intent

Ensure that unicode inputs are handled correctly when the Python REPL is active.

### Approach

When escaping unicode text as console input, use an escaping format that is compatible with both the R and Python REPLs.

### QA Notes

Test that the following can be run from a Python script on Windows:

```
print("안녕")
print("你好")
```

<img width="249" alt="Screen Shot 2021-01-15 at 2 52 32 PM" src="https://user-images.githubusercontent.com/1976582/104786260-4d853b80-5741-11eb-8f12-e46837be9576.png">

---

https://github.com/rstudio/rstudio/issues/8549.
