### PR TITLE
point Qt download script at a mirror

### DIFF
--- a/dependencies/common/install-qt.sh
+++ b/dependencies/common/install-qt.sh
@@ -244,18 +244,21 @@ function compute_url(){
     else
         REMOTE_BASES=(
             # New repository format (>=6.0.0)
-            "qt6_${VERSION//./}/qt.qt6.${VERSION//./}.${TOOLCHAIN}"
-            "qt6_${VERSION//./}_${ANDROID_ARCH}/qt.qt6.${VERSION//./}.${TOOLCHAIN}"
-            "qt6_${VERSION//./}_${ANDROID_ARCH}/qt.qt6.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
+            # RSTUDIO: skip Qt 6
+            #"qt6_${VERSION//./}/qt.qt6.${VERSION//./}.${TOOLCHAIN}"
+            #"qt6_${VERSION//./}_${ANDROID_ARCH}/qt.qt6.${VERSION//./}.${TOOLCHAIN}"
+            #"qt6_${VERSION//./}_${ANDROID_ARCH}/qt.qt6.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
             # New repository format (>=5.9.6)
             "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${TOOLCHAIN}"
             "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
             # Multi-abi Android since 5.14
-            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${TARGET_PLATFORM}"
-            "qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${COMPONENT}.${TARGET_PLATFORM}"
+            # RSTUDIO: skip Android
+            #"qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${TARGET_PLATFORM}"
+            #"qt5_${VERSION//./}/qt.qt5.${VERSION//./}.${COMPONENT}.${TARGET_PLATFORM}"
             # Older repository format (<5.9.0)
-            "qt5_${VERSION//./}/qt.${VERSION//./}.${TOOLCHAIN}"
-            "qt5_${VERSION//./}/qt.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
+            # RSTUDIO: skip older Qt
+            #"qt5_${VERSION//./}/qt.${VERSION//./}.${TOOLCHAIN}"
+            #"qt5_${VERSION//./}/qt.${VERSION//./}.${COMPONENT}.${TOOLCHAIN}"
         )
 
         for REMOTE_BASE in ${REMOTE_BASES[*]}; do

--- a/dependencies/common/install-qt.sh
+++ b/dependencies/common/install-qt.sh
@@ -230,7 +230,9 @@ DOWNLOAD_DIR=`mktemp -d 2>/dev/null || mktemp -d -t 'install-qt'`
 function compute_url(){
     local COMPONENT=$1
     local CURL="curl -s -L"
-    local BASE_URL="http://download.qt.io/online/qtsdkrepository/${HOST_OS}/${TARGET_PLATFORM}"
+    # RSTUDIO: temporary mirror usage until official servers come back up
+    local BASE_URL="http://qt-mirror.dannhauer.de/online/qtsdkrepository/${HOST_OS}/${TARGET_PLATFORM}"
+    # local BASE_URL="http://download.qt.io/online/qtsdkrepository/${HOST_OS}/${TARGET_PLATFORM}"
     local ANDROID_ARCH=$(echo ${TOOLCHAIN##android_})
 
     if [[ "${COMPONENT}" =~ "qtcreator" ]]; then


### PR DESCRIPTION
### Intent

The official Qt download server is offline with a severe failure. Point our script at a mirror until that gets resolved.

### Approach

Syncing the script with latest Qt version (not strictly necessary for what we care about but I already had that in place) and changed the server URL. Also stopped looking for Qt6 and older Qt5 paths to reduce server load and speed up timeouts.

### QA Notes

Purely dev/build change. If we get builds, then this worked.
