### PR TITLE
fix building with boost 1.75 (2)

### DIFF
--- a/src/cpp/session/SessionConsoleProcessSocketTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessSocketTests.cpp
@@ -227,8 +227,6 @@ public:
 
    bool connectToServer()
    {
-      using websocketpp::lib::placeholders::_1;
-      using websocketpp::lib::placeholders::_2;
       using websocketpp::lib::bind;
 
       try {
@@ -246,13 +244,13 @@ public:
          // Register our message handler
          client_.set_message_handler(bind(&SocketClient::on_message,
                                           SocketClient::shared_from_this(),
-                                          &client_, ::_1, ::_2));
+                                          &client_, _1, _2));
          client_.set_open_handler(bind(&SocketClient::on_open,
                                        SocketClient::shared_from_this(),
-                                       &client_, ::_1));
+                                       &client_, _1));
          client_.set_fail_handler(bind(&SocketClient::on_fail,
                                        SocketClient::shared_from_this(),
-                                       &client_, ::_1));
+                                       &client_, _1));
 
          websocketpp::lib::error_code ec;
          client::connection_ptr con = client_.get_connection(uri, ec);


### PR DESCRIPTION
### Intent

Boost 1.75 landed in Fedora rawhide, and apparently #8606 is not enough. As discussed there, we see

```
/builddir/build/BUILD/rstudio-1.4.1103/src/cpp/session/SessionConsoleProcessSocketTests.cpp: In member function 'bool rstudio::session::console_process::{anonymous}::SocketClient::connectToServer()':
/builddir/build/BUILD/rstudio-1.4.1103/src/cpp/session/SessionConsoleProcessSocketTests.cpp:249:55: error: '::_1' has not been declared
  249 |                                           &client_, ::_1, ::_2));
```

### Approach

That piece of code declares the use of websocketpp's placeholders and then avoids using them with `::_1` and `::_2`, and this is what fails in Fedora. This simple patch uses boost placeholders directly.

### QA Notes

You can see a successful build here: https://koji.fedoraproject.org/koji/taskinfo?taskID=60466057