### PR TITLE
fixups for Python environments on Windows

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -197,6 +197,14 @@
    paths <- strsplit(Sys.getenv("PATH"), split = .Platform$path.sep, fixed = TRUE)[[1]]
    for (path in paths) {
       
+      # skip fake broken Windows Python interpreters
+      skip <-
+         .rs.platform.isWindows &&
+         grepl("AppData\\Local\\Microsoft\\WindowsApps", path, fixed = TRUE)
+      
+      if (skip)
+         next
+      
       # create pattern matching interpreter paths
       pattern <- if (.rs.platform.isWindows)
          "^python[[:digit:].]*exe$"
@@ -211,7 +219,8 @@
       )
       
       # loop over interpreters and add
-      for (python in pythons) {
+      for (python in pythons)
+      {
          info <- .rs.python.getPythonInfo(python, strict = TRUE)
          interpreters[[length(interpreters) + 1]] <- info
       }

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -127,6 +127,9 @@
 
 .rs.addFunction("python.interpreterInfo", function(path, type)
 {
+   # prefer UTF-8 path when possible
+   path <- enc2utf8(path)
+   
    # defaults for version, description
    valid <- TRUE
    version <- "[unknown]"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -37,7 +37,7 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
       widgets_.setAriaLabel("Python Interpreters");
       
       for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))
-         if (interpreter.getVersion() != null)
+         if (interpreter.isValid())
             widgets_.addItem(new PythonInterpreterListEntryUi(interpreter));
    }
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8551.

### Approach

- Ensure Python path is UTF-8 encoded, as this is the expected encoding for our front-end UI.
- Don't display "invalid" interpreters in the dropdown list.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8551.