### PR TITLE
allow user to interrupt Python REPL

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -18,6 +18,7 @@
    PYTHON_INITIALIZED = "python_initialized",
    REPL_INITIALIZED   = "repl_initialized",
    REPL_ITERATION     = "repl_iteration",
+   REPL_BUSY          = "repl_busy",
    REPL_TEARDOWN      = "repl_teardown"
 ))
 
@@ -273,6 +274,13 @@
    FALSE
 })
 
+.rs.addFunction("reticulate.replBusy", function(busy)
+{
+   .rs.reticulate.enqueueClientEvent(
+      .rs.reticulateEvents$REPL_BUSY,
+      list(busy = .rs.scalar(busy))
+   )
+})
 
 .rs.addFunction("reticulate.replTeardown", function()
 {
@@ -1976,6 +1984,11 @@ options(reticulate.repl.initialize = function()
 options(reticulate.repl.hook = function(buffer, contents, trimmed)
 {
    .rs.reticulate.replHook(buffer, contents, trimmed)
+})
+
+options(reticulate.repl.busy = function(busy)
+{
+   .rs.reticulate.replBusy(busy)
 })
 
 options(reticulate.repl.teardown = function()

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -27,7 +27,8 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
       }
 
       // Event data accessors ----
-      public final native String getType() /*-{ return this["type"]; }-*/;
+      public final native String getType()           /*-{ return this["type"]; }-*/;
+      public final native JavaScriptObject getData() /*-{ return this["data"]; }-*/;
 
    }
 
@@ -39,6 +40,11 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
    public Data getData()
    {
       return data_;
+   }
+   
+   public JavaScriptObject getPayload()
+   {
+      return data_.getData();
    }
 
    public String getType()
@@ -70,8 +76,9 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
    public static final Type<Handler> TYPE = new Type<>();
 
    // synchronize with SessionReticulate.R
-   public static final String TYPE_PYTHON_INITIALIZED = "python_initialized";
+   public static final String TYPE_PYTHON_INITIALIZED = "pythAon_initialized";
    public static final String TYPE_REPL_INITIALIZED   = "repl_initialized";
    public static final String TYPE_REPL_ITERATION     = "repl_iteration";
+   public static final String TYPE_REPL_BUSY          = "repl_busy";
    public static final String TYPE_REPL_TEARDOWN      = "repl_teardown";
 }

--- a/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/ReticulateEvent.java
@@ -76,7 +76,7 @@ public class ReticulateEvent extends GwtEvent<ReticulateEvent.Handler>
    public static final Type<Handler> TYPE = new Type<>();
 
    // synchronize with SessionReticulate.R
-   public static final String TYPE_PYTHON_INITIALIZED = "pythAon_initialized";
+   public static final String TYPE_PYTHON_INITIALIZED = "python_initialized";
    public static final String TYPE_REPL_INITIALIZED   = "repl_initialized";
    public static final String TYPE_REPL_ITERATION     = "repl_iteration";
    public static final String TYPE_REPL_BUSY          = "repl_busy";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/Console.java
@@ -19,12 +19,15 @@ import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.IsWidget;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.layout.DelayFadeInHelper;
 import org.rstudio.core.client.widget.FocusContext;
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.events.ReticulateEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.events.BusyEvent;
 import org.rstudio.studio.client.workbench.events.ZoomPaneEvent;
@@ -71,11 +74,33 @@ public class Console
 
       interruptFadeInHelper_ = new DelayFadeInHelper(
             view_.getConsoleInterruptButton().asWidget());
+      
       events.addHandler(BusyEvent.TYPE, event ->
       {
          if (event.isBusy())
          {
             interruptFadeInHelper_.beginShow();
+         }
+      });
+      
+      events.addHandler(ReticulateEvent.TYPE, event ->
+      {
+         String type = event.getType();
+         if (StringUtil.equals(type, ReticulateEvent.TYPE_REPL_BUSY))
+         {
+            JsObject data = event.getPayload().cast();
+            
+            boolean busy = data.getBoolean("busy");
+            if (busy)
+            {
+               interruptFadeInHelper_.beginShow();
+            }
+            else
+            {
+               interruptFadeInHelper_.hide();
+            }
+            
+            commands.interruptR().setEnabled(busy, true);
          }
       });
 


### PR DESCRIPTION
### Intent

This PR ensures that the Stop button is displayed in the Console Pane when the Python REPL is busy, and clicking that will interrupt the associated Python computation.

Addresses https://github.com/rstudio/rstudio/issues/8763.
Addresses https://github.com/rstudio/rstudio/issues/8785.

### Approach

Listen for reticulate "busy" events, and use those to control the display + enabled-ness of the R interrupt command (which is handled appropriately when `reticulate` is running).

### QA Notes

Note: requires the development version of `reticulate` for interrupt support. Install it with:

```
remotes::install_github("rstudio/reticulate")
```

Then, try running a Python script with the contents:

```
import time
time.sleep(30)
```

and check that the associated computation can be interrupted.


https://user-images.githubusercontent.com/1976582/105775097-19690200-5f1b-11eb-990d-3bd36b169f73.mov

