### PR TITLE
fix issue with debugger hang when using do.call()

### DIFF
--- a/src/cpp/tests/testthat/test-debugger.R
+++ b/src/cpp/tests/testthat/test-debugger.R
@@ -1,0 +1,46 @@
+#
+# test-debugger.R
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+library(testthat)
+
+context("debugger")
+
+test_that("deparsing large calls is not overly expensive", {
+   
+   big <- data.frame(x = as.numeric(1:1E5))
+   cl <- call("dummy", big)
+   summary <- .rs.callSummary(cl)
+   expect_true(nchar(summary) < 1000)
+   
+   data <- as.list(0:200)
+   data[[1L]] <- as.name("c")
+   cl <- as.call(data)
+   summary <- .rs.callSummary(cl)
+   expect_equal(summary, "c(...)")
+   
+})
+
+test_that("we successfully parse the function name from different calls", {
+   
+   # regular old call
+   cl <- call("eval", quote(1 + 1))
+   expect_equal(.rs.functionNameFromCall(cl), "eval")
+   
+   # function directly in call object
+   cl <- quote(c(1, 2, 3))
+   cl[[1L]] <- c
+   expect_equal(.rs.functionNameFromCall(cl), "[Anonymous function]")
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/5158.

Normally, deparsing a call is cheap, as the only things embedded in a call object are symbols, calls, and literals. However, some calls (notably, those generated when a function is invoked via `do.call()`), will be very expensive to deparse, as deparsing those implies also deparsing the objects embedded in those calls.

Similarly, the "expression" associated with the promise of such a call might not actually be an expression, as `do.call()` can force early evaluation of its arguments -- and so R generated a promise mapping to an already-evaluated expression; that is, the expression is just the requested value itself.

### Approach

Detect and handle both of these cases when opening the debugger.

### Automated Tests

Unit tests included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5158. Fix has some risk as it touches the code used for formatting things for display in the debugger + environment pane.