### PR TITLE
add unique IDs to workbench tab context menus and commands

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -579,4 +579,18 @@ public class ElementIds
    public final static String COMMAND_PALETTE_LIST = "command_palette_list";
    public final static String COMMAND_PALETTE_SEARCH = "command_palette_search";
    public final static String COMMAND_ENTRY_PREFIX = "command_entry_";
+
+   // Right-click tab context menus
+   public final static String FEATURE_TAB_CONTEXT = "feature_tab_context";
+   public final static String EDITOR_TAB_CONTEXT = "editor_tab_context";
+   public final static String GIT_TAB_CONTEXT = "git_tab_context";
+   public final static String SVN_TAB_CONTEXT = "svn_tab_context";
+
+   // Right-click tab context menus commands
+   public final static String TAB_CLOSE = "tab_close";
+   public final static String TAB_RENAME_FILE = "tab_rename_file";
+   public final static String TAB_COPY_PATH = "tab_copy_path";
+   public final static String TAB_CLOSE_ALL = "tab_close_all";
+   public final static String TAB_CLOSE_OTHERS = "tab_close_others";
+
 }

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -19,6 +19,7 @@ import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.user.client.ui.MenuItem;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ClassIds;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -219,33 +220,35 @@ public class DocTabLayoutPanel
             if (target != null && target.getExtendedFileType() != null && target.getPath() != null)
             {
                final String filePath = target.getPath();
-               menu.addItem(new MenuItem("Rename", () ->
+               menu.addItem(ElementIds.TAB_RENAME_FILE, new MenuItem("Rename", () ->
                {
                   events_.fireEvent(new RenameSourceFileEvent(filePath));
                }));
-               menu.addItem(new MenuItem("Copy Path", () ->
+               menu.addItem(ElementIds.TAB_COPY_PATH, new MenuItem("Copy Path", () ->
                {
                   events_.fireEvent(new CopySourcePathEvent(filePath));
                }));
                menu.addSeparator();
             }
 
-            menu.addItem(new MenuItem("Close", () ->
+            menu.addItem(ElementIds.TAB_CLOSE, new MenuItem("Close", () ->
             {
                events_.fireEvent(new RequestDocumentCloseEvent(docId));
             }));
 
-            menu.addItem(new MenuItem("Close All", () ->
+            menu.addItem(ElementIds.TAB_CLOSE_ALL, new MenuItem("Close All", () ->
             {
                commands_.closeAllSourceDocs().execute();
             }));
 
-            menu.addItem(new MenuItem("Close All Others", () ->
+            menu.addItem(ElementIds.TAB_CLOSE_OTHERS, new MenuItem("Close All Others", () ->
             {
                events_.fireEvent(new CloseAllSourceDocsExceptEvent(docId));
             }));
 
-            menu.showRelativeTo(nativeEvent.getClientX(), nativeEvent.getClientY());
+            menu.showRelativeTo(nativeEvent.getClientX(),
+                                nativeEvent.getClientY(),
+                                ElementIds.EDITOR_TAB_CONTEXT);
             contextMenuEvent.preventDefault();
             contextMenuEvent.stopPropagation();
          });

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarPopupMenu.java
@@ -33,6 +33,7 @@ import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.user.client.ui.MenuItemSeparator;
 import com.google.gwt.user.client.ui.Widget;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppMenuItem;
@@ -86,9 +87,11 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
     * Position popup relative to a point, typically for a right-click context menu
     * @param clientX
     * @param clientY
+    * @param elementId - unique elementId for automation
     */
-   public void showRelativeTo(int clientX, int clientY)
+   public void showRelativeTo(int clientX, int clientY, String elementId)
    {
+      ElementIds.assignElementId(this, elementId);
       setPopupPositionAndShow((offsetWidth, offsetHeight) ->
       {
          // Calculate left position for the popup; normally the clicked location but
@@ -195,6 +198,12 @@ public class ToolbarPopupMenu extends ThemedPopupPanel
    public void selectItem(MenuItem menuItem)
    {
       menuBar_.selectItem(menuItem);
+   }
+
+   public void addItem(String menuElementId, MenuItem menuItem)
+   {
+      addItem(menuItem);
+      ElementIds.assignElementId(menuItem.getElement(), menuElementId);
    }
 
    public void addItem(MenuItem menuItem)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchTabPanel.java
@@ -31,6 +31,7 @@ import com.google.gwt.user.client.ui.RequiresResize;
 import com.google.gwt.user.client.ui.Widget;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.events.*;
 import org.rstudio.core.client.layout.LogicalWindow;
@@ -187,14 +188,16 @@ class WorkbenchTabPanel
                final ToolbarPopupMenu menu = new ToolbarPopupMenu();
                final NativeEvent nativeEvent = contextMenuEvent.getNativeEvent();
 
-               menu.addItem(new MenuItem("Close", () ->
+               menu.addItem(ElementIds.TAB_CLOSE, new MenuItem("Close", () ->
                {
                   tab.confirmClose(() -> tab.ensureHidden());
                }));
 
-               menu.showRelativeTo(nativeEvent.getClientX(), nativeEvent.getClientY());
+               menu.showRelativeTo(nativeEvent.getClientX(),
+                                   nativeEvent.getClientY(),
+                                   ElementIds.FEATURE_TAB_CONTEXT);
             }
-            
+
             // a tab that isn't closable will no-op when right-clicked, seems
             // preferable to bringing up the browser context menu
             contextMenuEvent.preventDefault();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/GitPane.java
@@ -285,7 +285,7 @@ public class GitPane extends WorkbenchPane implements Display
       menu.addSeparator();
       menu.addItem(commands_.vcsOpen().createMenuItem(false));
 
-      menu.showRelativeTo(clientX, clientY);
+      menu.showRelativeTo(clientX, clientY, ElementIds.GIT_TAB_CONTEXT);
    }
 
    private ToolbarButton historyButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/svn/SVNPane.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.vcs.svn;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
@@ -131,7 +132,7 @@ public class SVNPane extends WorkbenchPane implements Display
       menu.addSeparator();
       menu.addItem(commands_.vcsOpen().createMenuItem(false));
 
-      menu.showRelativeTo(clientX, clientY);
+      menu.showRelativeTo(clientX, clientY, ElementIds.SVN_TAB_CONTEXT);
    }
 
    @Override


### PR DESCRIPTION
### Intent

The tab context menus don't have unique ids for automated testing. For example, this menu shown when I right-clicked on a tab in the editor region:

![screenshot of document tab context menu](https://user-images.githubusercontent.com/10569626/105928305-8f906600-5ffa-11eb-85e8-37d5de2f89a6.png)

### Approach

Added unique ids both for the context menus themselves, and for the commands in the menus. Only worrying about the commands on the new workbench tab context menus added in v1.4-juliet-rose, but I did add ids on the existing context menus for Git and SVN.

### Automated Tests

This is to facilitate implementing automated tests per https://github.com/rstudio/rstudio-ide-automation/issues/143.

### QA Notes

Nothing to validate, I will be authoring automation to use these IDs.
