### PR TITLE
be more permissive with whitespace for braces / parens

### DIFF
--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -289,6 +289,11 @@ test_context("Diagnostics")
       EXPECT_NO_ERRORS("`a\nb` <- 1");
       
       EXPECT_NO_ERRORS("mtcars |> data => lm(mpg ~ cyl, data = data)");
+      
+      EXPECT_NO_LINT("x <- { 1 + 1 }");
+      EXPECT_NO_LINT("x <- ( 1 + 1 )");
+      EXPECT_NO_LINT("x <- {1}");
+      EXPECT_NO_LINT("x <- (1)");
    }
    
    lintRStudioRFiles();

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -2181,7 +2181,7 @@ START:
       {
          status.pushState(ParseStatus::ParseStateWithinParens);
          status.pushBracket(cursor);
-         MOVE_TO_NEXT_SIGNIFICANT_TOKEN_WARN_ON_BLANK(cursor, status);
+         MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
          if (cursor.isType(RToken::RPAREN))
             status.lint().unexpectedToken(cursor);
          goto START;
@@ -2192,7 +2192,7 @@ START:
       {
          status.pushState(ParseStatus::ParseStateWithinBraces);
          status.pushBracket(cursor);
-         MOVE_TO_NEXT_SIGNIFICANT_TOKEN_WARN_ON_BLANK(cursor, status);
+         MOVE_TO_NEXT_SIGNIFICANT_TOKEN(cursor, status);
          goto START;
       }
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8822.

### Approach

Don't warn when stepping over whitespace following a `{` or a `(`.

### Automated Tests

Addressed via automated tests for parser.

### QA Notes

Verify via notes in https://github.com/rstudio/rstudio/issues/8822.