### PR TITLE
VirtualScroller: prune fix, MacOS click focus fix

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -649,6 +649,13 @@ public class VirtualConsole
          match = match.nextMatch();
       }
 
+      Entry<Integer, ClassRange> last = class_.lastEntry();
+      if (last != null)
+      {
+         ClassRange range = last.getValue();
+         if (isVirtualized()) VirtualScrollerManager.prune(parent_.getParentElement(), range.element);
+      }
+
       // If there was any plain text after the last control character, add it
       if (tail < data.length())
          text(data.substring(tail), currentClazz, forceNewRange);

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -628,7 +628,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       public void onClick(ClickEvent event)
       {
          // If clicking on the input panel already, stop propagation.
-         if (!scrollOnClick_ || event.getSource() == input_)
+         if (event.getSource() == input_)
          {
             event.stopPropagation();
             return;
@@ -720,7 +720,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
             // https://github.com/rstudio/rstudio/issues/6231
             boolean wasScrolledToBottom = scrollPanel_.isScrolledToBottom();
             input_.setFocus(true);
-            if (wasScrolledToBottom)
+            if (scrollOnClick_ && wasScrolledToBottom)
                scrollPanel_.scrollToBottom();
          }
       };


### PR DESCRIPTION
Note: This is a clone of https://github.com/rstudio/rstudio/pull/8779

**Intent**

Address issues:
#8740 / #8824
#8567

**Approach**

The focus bug was confusing me quite a bit. Turns out MacOS treats focus differently than Windows. Windows is very aggressive about making sure that the most obvious TextArea/Input will get focus even if you don't set it in the JS, MacOS is....much less forgiving. The fix was trivial, just allow the old focus code to run and only skip the "scroll to bottom" portion.

For the pruning issue I turned back on the code that I had removed when fixing the Clear Console issues. I think I was just a little too exuberant about removing code that didn't seem to be necessary.

**QA Notes**

The only potential problem area I see is possibly Clear Console getting into some funky states with the pruning put back in. I tested it in a handful of cases but I could have missed something.

For the focus issue I would just do a quick smoke across Mac/Win/Linux to make sure that it feels good on all platforms.