### PR TITLE
properly access cursor column attribute

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,5 +62,6 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Fix out-of-date tooltip when renaming files (#8490, #8491)
 * Fix incorrect keyboard shortcuts shown in some places in the Command Palette (#8735)
 * Fixed an issue where Load Balanced Local Launcher instances could get into a state where they would no longer receive job updates from other nodes due to silent network drops (Pro #2281)
+* Fixed issue with formatting of closing braces when inserting newline in C++ code (#8770)
 
 

--- a/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
+++ b/src/gwt/acesupport/acemode/c_cpp_style_behaviour.js
@@ -130,7 +130,7 @@ var CStyleBehaviour = function(codeModel) {
          // Get some needed variables.
          var cursor = editor.getCursorPosition();
          var row = cursor.row;
-         var col = cursor.col;
+         var col = cursor.column;
          var tab = session.getTabString();
          var lines = session.doc.$lines;
          var line = lines[row];


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8770.

### Approach

Fixed a regression caused by https://github.com/rstudio/rstudio/commit/fc8f151b583ae780610fe11d851b9aa6624ad4a0#diff-31013968227dcb90d3326f826589a8ebb0b4bc2e28c0591d4576ff0dc1d86e42 -- the access was accidentally renamed from `.column` to `.col`.

### Automated Tests

To be done later, filed here: https://github.com/rstudio/rstudio-ide-automation/issues/151

### QA Notes

In a C++ file, try inserting `{` followed by a newline, and verify that:

(1) A closing `}` is inserted, and
(2) It is formatted appropriately.


https://user-images.githubusercontent.com/1976582/106065332-063b6b00-60b0-11eb-95a8-e133b9f496e3.mov

