### PR TITLE
defer installation of python plot requirements

### DIFF
--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -202,6 +202,8 @@ const int kReticulateEvent = 187;
 const int kEnvironmentChanged = 188;
 const int kRStudioApiRequest = 189;
 const int kDocumentCloseAllNoSave = 190;
+const int kInstallFeatureDependencies = 191;
+const int kInstallFeatureDependenciesCompleted = 192;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -561,6 +563,10 @@ std::string ClientEvent::typeName() const
          return "rstudioapi_request";
       case client_events::kDocumentCloseAllNoSave:
          return "document_close_all_no_save";
+      case client_events::kInstallFeatureDependencies:
+         return "install_feature_dependencies";
+      case client_events::kInstallFeatureDependenciesCompleted:
+         return "install_feature_dependencies_completed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -269,6 +269,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kEnvironmentRemoved;
       else if (name == "environment_changed")
          type = session::client_events::kEnvironmentChanged;
+      else if (name == "install_feature_dependencies")
+         type = session::client_events::kInstallFeatureDependencies;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -203,6 +203,8 @@ extern const int kReticulateEvent;
 extern const int kEnvironmentChanged;
 extern const int kRStudioApiRequest;
 extern const int kDocumentCloseAllNoSave;
+extern const int kInstallFeatureDependencies;
+extern const int kInstallFeatureDependenciesCompleted;
 }
 
 class ClientEvent

--- a/src/cpp/session/modules/SessionDependencies.R
+++ b/src/cpp/session/modules/SessionDependencies.R
@@ -13,6 +13,19 @@
 #
 #
 
+.rs.addFunction("installFeatureDependencies", function(feature,
+                                                       caption,
+                                                       prompt)
+{
+   data <- list(
+      feature = .rs.scalar(feature),
+      caption = .rs.scalar(caption),
+      prompt  = .rs.scalar(prompt)
+   )
+   
+   .Call("rs_installFeatureDependencies", data, PACKAGE = "(embedding)")
+})
+
 # Topographically sorts a list of packages (nodes) by their dependencies (edges). Note that this is
 # not meant to be a general-purpose topo sort algorithm, and that it returns packages in the correct
 # installation order, which is the exact reverse of traditional topological order. For example,

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -146,6 +146,13 @@
 
 .rs.addFunction("reticulate.matplotlib.onLoaded", function(module)
 {
+   # validate feature requirements
+   .rs.installFeatureDependencies(
+      feature = "python_plots",
+      caption = "Generating Python Plots",
+      prompt  = "Generating Python plots"
+   )
+      
    # install matplotlib hook if available
    if (requireNamespace("png", quietly = TRUE) &&
        reticulate::py_module_available("matplotlib"))

--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1404,7 +1404,8 @@ SEXP rs_requestDocumentSave(SEXP idsSEXP)
    return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentSave), &protect);
 }
 
-SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP) {
+SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP)
+{
    r::sexp::Protect protect;
    
    json::Object jsonData;
@@ -1418,7 +1419,8 @@ SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP) {
    return r::sexp::create(waitForSuccess(event, s_waitForRequestDocumentClose), &protect);
 }
 
-SEXP rs_documentCloseAllNoSave() {
+SEXP rs_documentCloseAllNoSave()
+{
    ClientEvent event(client_events::kDocumentCloseAllNoSave);
    module_context::enqueClientEvent(event);
    return R_NilValue;

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -405,8 +405,13 @@
             "description": "Python/Reticulate",
             "packages": [
                 "jsonlite",
-                "png",
                 "reticulate"
+            ]
+        },
+        "python_plots": {
+            "description": "Python plots",
+            "packages": [
+                "png"
             ]
         },
         "stan": {

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/events/InstallFeatureDependenciesEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/events/InstallFeatureDependenciesEvent.java
@@ -1,0 +1,69 @@
+/*
+ * InstallFeatureDependenciesEvent.java
+ *
+ * Copyright (C) 2021 by RStudio, Inc.
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.common.dependencies.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class InstallFeatureDependenciesEvent extends GwtEvent<InstallFeatureDependenciesEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      // Event data accessors ----
+      public final native String getFeature() /*-{ return this["feature"]; }-*/;
+      public final native String getCaption() /*-{ return this["caption"]; }-*/;
+      public final native String getPrompt()  /*-{ return this["prompt"];  }-*/;
+      
+   }
+
+   public InstallFeatureDependenciesEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onInstallFeatureDependencies(InstallFeatureDependenciesEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onInstallFeatureDependencies(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/DependencyServerOperations.java
@@ -16,6 +16,7 @@
 package org.rstudio.studio.client.common.dependencies.model;
 
 import org.rstudio.studio.client.common.crypto.CryptoServerOperations;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 
 import com.google.gwt.core.client.JsArray;
@@ -31,5 +32,9 @@ public interface DependencyServerOperations extends CryptoServerOperations
        String context,
        JsArray<Dependency> dependencies,
        ServerRequestCallback<String> requestCallback);
+   
+   void installFeatureDependenciesCompleted(
+       boolean succeeded,
+       ServerRequestCallback<Void> requestCallback);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -193,6 +193,7 @@ class ClientEvent extends JavaScriptObject
    public static final String ReticulateEvent = "reticulate_event";
    public static final String RStudioApiRequest = "rstudioapi_request";
    public static final String DocumentCloseAllNoSave = "document_close_all_no_save";
+   public static final String InstallFeatureDependencies = "install_feature_dependencies";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -46,6 +46,7 @@ import org.rstudio.studio.client.common.debugging.events.PackageLoadedEvent;
 import org.rstudio.studio.client.common.debugging.events.PackageUnloadedEvent;
 import org.rstudio.studio.client.common.debugging.events.UnhandledErrorEvent;
 import org.rstudio.studio.client.common.debugging.model.UnhandledError;
+import org.rstudio.studio.client.common.dependencies.events.InstallFeatureDependenciesEvent;
 import org.rstudio.studio.client.common.dependencies.events.InstallShinyEvent;
 import org.rstudio.studio.client.common.rpubs.events.RPubsUploadStatusEvent;
 import org.rstudio.studio.client.common.rstudioapi.events.AskSecretEvent;
@@ -1068,6 +1069,11 @@ public class ClientEventDispatcher
          else if (type == ClientEvent.DocumentCloseAllNoSave)
          {
             eventBus_.dispatchEvent(new DocumentCloseAllNoSaveEvent());
+         }
+         else if (type == ClientEvent.InstallFeatureDependencies)
+         {
+            InstallFeatureDependenciesEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new InstallFeatureDependenciesEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5508,6 +5508,21 @@ public class RemoteServer implements Server
                   params,
                   requestCallback);
    }
+   
+   @Override
+   public void installFeatureDependenciesCompleted(boolean succeeded,
+                                                   ServerRequestCallback<Void> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(succeeded)
+            .get();
+      
+      sendRequest(
+            RPC_SCOPE,
+            "install_feature_dependencies_completed",
+            params,
+            requestCallback);
+   }
 
    @Override
    public  void getPackratPrerequisites(


### PR DESCRIPTION
### Intent

Currently, running Python code in the IDE requires `reticulate`, `jsonlite` and `png`. The requirement on `png` is specific to the IDE, and only comes into effect if a user needs to generate plots via `matplotlib`.

This PR separates those requirements, so that `png` is only installed in response to the use of `matplotlib`.

Addresses https://github.com/rstudio/rstudio/issues/8692.

### Approach

Provide a way to use the GWT dependency manager from R, and use it. Implementation is mostly straightforward and uses our existing WaitForMethod tooling.

### Automated Tests

Issue tracking in https://github.com/rstudio/rstudio-ide-automation/issues/153.

### QA Notes

First, remove the `png` package with:

```
remove.packages("png")
```

Then, create a Python script, and try running the code:

```
import matplotlib.pyplot
```

You should be prompted to install the `png` package.