### PR TITLE
avoid defining variables when manipulating handler stack

### DIFF
--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -42,21 +42,24 @@
 
 .rs.addFunction("notebookConditions.connectImpl", function()
 {
-   handlers <- .Internal(.addCondHands(
-      c("warning", "message"),
-      list(
-         warning = .rs.notebookConditions.onWarning,
-         message = .rs.notebookConditions.onMessage
-      ),
-      globalenv(),
-      NULL,
-      TRUE
-   ))
-   
-   envir <- as.environment("tools:rstudio")
-   assign(".rs.notebookConditions.handlerStack", handlers, envir = envir)
-   
-   handlers
+   # NOTE: because the body of this function will be evaluated in the
+   # global environment, we need to avoid defining variables here.
+   #
+   # https://github.com/rstudio/rstudio/issues/8834
+   base::assign(
+      x = ".rs.notebookConditions.handlerStack",
+      value = .Internal(.addCondHands(
+         c("warning", "message"),
+         list(
+            warning = .rs.notebookConditions.onWarning,
+            message = .rs.notebookConditions.onMessage
+         ),
+         base::globalenv(),
+         NULL,
+         TRUE
+      )),
+      envir = base::as.environment("tools:rstudio")
+   )
 })
 
 .rs.addFunction("notebookConditions.disconnectCall", function()
@@ -66,8 +69,19 @@
 
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
-   envir <- as.environment("tools:rstudio")
-   handlers <- get(".rs.notebookConditions.handlerStack", envir = envir)
-   rm(".rs.notebookConditions.handlerStack", envir = envir)
-   .Internal(.resetCondHands(handlers))
+   # NOTE: because the body of this function will be evaluated in the
+   # global environment, we need to avoid defining variables here.
+   #
+   # https://github.com/rstudio/rstudio/issues/8834
+   .Internal(.resetCondHands(
+      base::get(
+         x = ".rs.notebookConditions.handlerStack",
+         envir = base::as.environment("tools:rstudio")
+      )
+   ))
+   
+   base::rm(
+      list = ".rs.notebookConditions.handlerStack",
+      envir = base::as.environment("tools:rstudio")
+   )
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8834.

### Approach

Because the code we execute when managing the handler stack runs in the global environment, we need to be careful to avoid defining any R variables.

### Automated Tests

https://github.com/rstudio/rstudio-ide-automation/issues/157

### QA Notes

Create an R Markdown document, then run an R chunk with no code. Confirm that the Environment pane doesn't see `envir` or `handlers` variables added.

Note: this bug only exists in 1.4-JR (not part of 1.4) so doesn't need NEWS.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
