### PR TITLE
Add word option to Find in Files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,5 +64,6 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Fix incorrect keyboard shortcuts shown in some places in the Command Palette (#8735)
 * Fixed an issue where Load Balanced Local Launcher instances could get into a state where they would no longer receive job updates from other nodes due to silent network drops (Pro #2281)
 * Fixed issue with formatting of closing braces when inserting newline in C++ code (#8770)
+* Add 'whole word' filter to Find in Files. (#8594)
 
 

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -186,6 +186,12 @@ public class ElementIds
    public final static String FIND_FILES_TEXT = "find_files_text";
    public static String getFindFilesText() { return getElementId(FIND_FILES_TEXT); }
    public final static String FIND_FILES_PATTERN_EXAMPLE = "find_files_pattern_example";
+   public final static String FIND_FILES_CASE = "find_files_case";
+   public static String getFindFilesCase() { return getElementId(FIND_FILES_CASE); }
+   public final static String FIND_FILES_WHOLE_WORD = "find_files_whole_word";
+   public static String getFindFilesWholeWord() { return getElementId(FIND_FILES_WHOLE_WORD); }
+   public final static String FIND_FILES_REGEX = "find_files_regex";
+   public static String getFindFilesRegex() { return getElementId(FIND_FILES_REGEX); }
 
    // ImportFileSettingsDialog
    public final static String IMPORT_FILE_NAME = "import_file_name";

--- a/src/gwt/src/org/rstudio/core/client/widget/FormCheckBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormCheckBox.java
@@ -1,0 +1,43 @@
+/*
+ * FormCheckBox.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.NodeList;
+import com.google.gwt.user.client.ui.CheckBox;
+
+public class FormCheckBox extends CheckBox
+                          implements CanSetControlId
+{
+   @Override
+   public void setElementId(String id)
+   {
+      Element wrapper = getElement();
+      NodeList<Node> children = wrapper.getChildNodes();
+      for (int i = 0; i < children.getLength(); i++)
+      {
+         Node node = children.getItem(i);
+         if (node.getNodeType() == Node.ELEMENT_NODE)
+         {
+            if (node.getNodeName().equalsIgnoreCase("input"))
+               ((Element)node).setId(id);
+            else if (node.getNodeName().equalsIgnoreCase("label"))
+               ((Element)node).setAttribute("for", id);
+         }
+      }
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -70,7 +70,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
             path: path,
             regex: regex,
             caseSensitive: caseSensitive,
-            wholeWord: wholeWord, 
+            wholeWord: wholeWord,
             filePatterns: filePatterns,
             excludeFilePatterns: excludeFilePatterns,
             resultsCount: 0,
@@ -187,17 +187,13 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       setExampleIdAndAriaProperties(spanPatternExample_, txtFilePattern_);
       setExampleIdAndAriaProperties(spanExcludePatternExample_, txtExcludeFilePattern_);
 
-      checkboxCaseSensitive_.getElement().setId(ElementIds.FIND_FILES_CASE);
-      checkboxWholeWord_.getElement().setId(ElementIds.FIND_FILES_WHOLE_WORD);
-      checkboxRegex_.getElement().setId(ElementIds.FIND_FILES_REGEX);
-
       checkboxRegex_.addValueChangeHandler(event ->
       {
          // Disable "Whole Word" checkbox when regex is selected
          if (event.getValue())
             checkboxWholeWord_.setValue(false);
       });
-      
+
       checkboxWholeWord_.addValueChangeHandler(event ->
       {
          if (event.getValue())
@@ -266,7 +262,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       divCustomFilter_.getStyle().setDisplay(
             (listPresetFilePatterns_.getSelectedIndex() ==
              Include.CustomFilter.ordinal() &&
-             listPresetExcludeFilePatterns_.getSelectedIndex() != 
+             listPresetExcludeFilePatterns_.getSelectedIndex() !=
              Exclude.StandardGit.ordinal())
             ? Style.Display.BLOCK
             : Style.Display.NONE);
@@ -320,7 +316,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
 
       // disable custom filter text box when 'Custom Filter' is not selected
       divExcludeCustomFilter_.getStyle().setDisplay(
-            listPresetExcludeFilePatterns_.getSelectedIndex() == 
+            listPresetExcludeFilePatterns_.getSelectedIndex() ==
             Exclude.CustomFilter.ordinal()
             ? Style.Display.BLOCK
             : Style.Display.NONE);
@@ -344,9 +340,9 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       // if a disabled index is selected, change selection to All Files
       if (disableIncludes &&
           (listPresetFilePatterns_.getSelectedIndex() ==
-              Include.CommonRSourceFiles.ordinal() || 
+              Include.CommonRSourceFiles.ordinal() ||
            listPresetFilePatterns_.getSelectedIndex() ==
-              Include.RScripts.ordinal() || 
+              Include.RScripts.ordinal() ||
            listPresetFilePatterns_.getSelectedIndex() ==
              Include.CustomFilter.ordinal()))
       {
@@ -436,7 +432,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       txtSearchPattern_.selectAll();
       updateOkButtonEnabled();
    }
-   
+
    public void setSearchPattern(String searchPattern)
    {
       txtSearchPattern_.setText(searchPattern);
@@ -476,7 +472,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       txtExcludeFilePattern_.setText(excludeFilePatterns);
       manageExcludeFilePattern();
    }
-   
+
    private void updateOkButtonEnabled()
    {
       enableOkButton(txtSearchPattern_.getText().trim().length() > 0);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -187,12 +187,9 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       setExampleIdAndAriaProperties(spanPatternExample_, txtFilePattern_);
       setExampleIdAndAriaProperties(spanExcludePatternExample_, txtExcludeFilePattern_);
 
-      Roles.getCheckboxRole().setAriaLabelProperty(checkboxCaseSensitive_.getElement(), 
-         checkboxCaseSensitive_.getText());
-      Roles.getCheckboxRole().setAriaLabelProperty(checkboxWholeWord_.getElement(),
-         checkboxWholeWord_.getText());
-      Roles.getCheckboxRole().setAriaLabelProperty(checkboxRegex_.getElement(),
-         checkboxRegex_.getText());
+      checkboxCaseSensitive_.getElement().setId(ElementIds.FIND_FILES_CASE);
+      checkboxWholeWord_.getElement().setId(ElementIds.FIND_FILES_WHOLE_WORD);
+      checkboxRegex_.getElement().setId(ElementIds.FIND_FILES_REGEX);
 
       checkboxRegex_.addValueChangeHandler(event ->
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -443,6 +443,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       if (txtSearchPattern_.getText().isEmpty())
          txtSearchPattern_.setText(dialogState.getQuery());
       checkboxCaseSensitive_.setValue(dialogState.isCaseSensitive());
+      checkboxWholeWord_.setValue(dialogState.isWholeWord());
       checkboxRegex_.setValue(dialogState.isRegex());
       dirChooser_.setText(dialogState.getPath());
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -62,6 +62,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
                                              String path,
                                              boolean regex,
                                              boolean caseSensitive,
+                                             boolean wholeWord,
                                              JsArrayString filePatterns,
                                              JsArrayString excludeFilePatterns) /*-{
          return {
@@ -69,6 +70,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
             path: path,
             regex: regex,
             caseSensitive: caseSensitive,
+            wholeWord: wholeWord, 
             filePatterns: filePatterns,
             excludeFilePatterns: excludeFilePatterns,
             resultsCount: 0,
@@ -93,6 +95,10 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
 
       public native final boolean isCaseSensitive() /*-{
          return this.caseSensitive;
+      }-*/;
+
+      public native final boolean isWholeWord() /*-{
+          return this.wholeWord;
       }-*/;
 
       public final String[] getFilePatterns()
@@ -180,6 +186,19 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
 
       setExampleIdAndAriaProperties(spanPatternExample_, txtFilePattern_);
       setExampleIdAndAriaProperties(spanExcludePatternExample_, txtExcludeFilePattern_);
+
+      checkboxRegex_.addValueChangeHandler(event ->
+      {
+         // Disable "Whole Word" checkbox when regex is selected
+         if (event.getValue())
+            checkboxWholeWord_.setValue(false);
+      });
+      
+      checkboxWholeWord_.addValueChangeHandler(event ->
+      {
+         if (event.getValue())
+            checkboxRegex_.setValue(false);
+      });
 
       listPresetFilePatterns_.addChangeHandler(new ChangeHandler()
       {
@@ -367,6 +386,7 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
                                getEffectivePath(),
                                checkboxRegex_.getValue(),
                                checkboxCaseSensitive_.getValue(),
+                               checkboxWholeWord_.getValue(),
                                JsUtil.toJsArrayString(list),
                                JsUtil.toJsArrayString(excludeList));
    }
@@ -470,9 +490,11 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
    @UiField
    LabeledTextBox txtSearchPattern_;
    @UiField
-   CheckBox checkboxRegex_;
-   @UiField
    CheckBox checkboxCaseSensitive_;
+   @UiField
+   CheckBox checkboxWholeWord_;
+   @UiField
+   CheckBox checkboxRegex_;
    @UiField(provided = true)
    DirectoryChooserTextBox dirChooser_;
    @UiField

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -187,6 +187,13 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       setExampleIdAndAriaProperties(spanPatternExample_, txtFilePattern_);
       setExampleIdAndAriaProperties(spanExcludePatternExample_, txtExcludeFilePattern_);
 
+      Roles.getCheckboxRole().setAriaLabelProperty(checkboxCaseSensitive_.getElement(), 
+         checkboxCaseSensitive_.getText());
+      Roles.getCheckboxRole().setAriaLabelProperty(checkboxWholeWord_.getElement(),
+         checkboxWholeWord_.getText());
+      Roles.getCheckboxRole().setAriaLabelProperty(checkboxRegex_.getElement(),
+         checkboxRegex_.getText());
+
       checkboxRegex_.addValueChangeHandler(event ->
       {
          // Disable "Whole Word" checkbox when regex is selected

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -33,13 +33,13 @@
 
    <g:HTMLPanel styleName="{style.panel}">
       <p>
-         <rw:LabeledTextBox textBoxId="{ElementIds.getFindFilesText}" ui:field="txtSearchPattern_" 
+         <rw:LabeledTextBox textBoxId="{ElementIds.getFindFilesText}" ui:field="txtSearchPattern_"
                             labelText="Find:" enableSpellcheck="false" styleName="{style.pattern}"/>
-         <g:CheckBox ui:field="checkboxCaseSensitive_" text="Case sensitive"/>
+         <rw:FormCheckBox elementId="{ElementIds.getFindFilesCase}" ui:field="checkboxCaseSensitive_" text="Case sensitive"/>
          &#x00a0;
-         <g:CheckBox ui:field="checkboxWholeWord_" text="Whole word"/>
+         <rw:FormCheckBox elementId="{ElementIds.getFindFilesWholeWord}" ui:field="checkboxWholeWord_" text="Whole word"/>
          &#x00a0;
-         <g:CheckBox ui:field="checkboxRegex_" text="Regular expression"/>
+         <rw:FormCheckBox elementId="{ElementIds.getFindFilesRegex}" ui:field="checkboxRegex_" text="Regular expression"/>
          &#x00a0;
       </p>
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -37,6 +37,8 @@
                             labelText="Find:" enableSpellcheck="false" styleName="{style.pattern}"/>
          <g:CheckBox ui:field="checkboxCaseSensitive_" text="Case sensitive"/>
          &#x00a0;
+         <g:CheckBox ui:field="checkboxWholeWord_" text="Whole word"/>
+         &#x00a0;
          <g:CheckBox ui:field="checkboxRegex_" text="Regular expression"/>
          &#x00a0;
       </p>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPane.java
@@ -341,10 +341,11 @@ public class FindOutputPane extends WorkbenchPane
    }
 
    @Override
-   public void updateSearchLabel(String query, String path)
+   public void updateSearchLabel(String query, String path, boolean wholeWord)
    {
+      String intro = wholeWord ? "Results for whole word " : "Results for ";
       SafeHtmlBuilder builder = new SafeHtmlBuilder();
-      builder.appendEscaped("Results for ")
+      builder.appendEscaped(intro)
             .appendHtmlConstant("<strong>")
             .appendEscaped(query)
             .appendHtmlConstant("</strong>")
@@ -354,10 +355,11 @@ public class FindOutputPane extends WorkbenchPane
    }
 
    @Override
-   public void updateSearchLabel(String query, String path, String replace)
+   public void updateSearchLabel(String query, String path, String replace, boolean wholeWord)
    {
+      String intro = wholeWord ? "Replace results for whole word " : "Replace results for ";
       SafeHtmlBuilder builder = new SafeHtmlBuilder();
-      builder.appendEscaped("Replace results for ")
+      builder.appendEscaped(intro)
             .appendHtmlConstant("<strong>")
             .appendEscaped(query)
             .appendHtmlConstant("</strong>")
@@ -371,10 +373,12 @@ public class FindOutputPane extends WorkbenchPane
    }
 
    @Override
-   public void updateSearchLabel(String query, String path, String replace, int successCount, int errorCount)
+   public void updateSearchLabel(String query, String path, String replace,
+                                 boolean wholeWord, int successCount, int errorCount)
    {
+      String intro = wholeWord ? "Replace results for whole word " : "Replace results for ";
       SafeHtmlBuilder builder = new SafeHtmlBuilder();
-      builder.appendEscaped("Replace results for ")
+      builder.appendEscaped(intro)
             .appendHtmlConstant("<strong>")
             .appendEscaped(query)
             .appendHtmlConstant("</strong>")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesState.java
@@ -50,6 +50,10 @@ public class FindInFilesState extends JavaScriptObject
       return this.path;
    }-*/;
 
+   public native final boolean isWholeWord() /*-{
+      return this.wholeWord;
+   }-*/;
+   
    public native final boolean isRegex() /*-{
       return this.regex;
    }-*/;


### PR DESCRIPTION
### Intent

Adds a "Whole word" option to Find in Files to be consistent with our in-editor Find / Replace. This allows the user to search for a complete word or phrase.

### Approach

Added a "Whole word" checkbox and field to the Find in Files state. When checked, the frontend passes the query to the backend as a regular expression padded with `\b` tags e.g. `\bsearchphrase\b`. The backend doesn't know the difference between a regular express and whole word query. 

For simplicity's sake the user cannot enter a regular expression when the Whole word box is checked to prevent unexpected results. The thought is that if the user has a more complicated query than they'd likely want to include the `\b` tags themselves. 

### Automated Tests

rstudio/rstudio-ide-automation#155 includes the infrastructure for testing the Find in Files Dialog and Pane with simple tests that they can be loaded with the expected elements. I've included the new checkbox in this test as well as added aria labels to the other checkboxes so they can be found by automated tests. The PR is on hold until this one gets merged.
Testing the functionality of the new option will be handled as part of rstudio/rstudio-ide-automation#99 which is currently in progress. 

### QA Notes

See original request in #8594

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


