### PR TITLE
avoid rearranging console input when fixing newlines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,7 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 ### Bugfixes
 
 * Fix Windows Desktop installer to support running from path with characters from other codepages (#8421)
+* Fixed issue where R code input could be executed in the wrong order in some cases (#8837)
 * Fixed issue where debugger could hang when debugging functions called via do.call() (#5158)
 * Fixed issue where rendering .tex document with tinytex would fail on Windows (#8725)
 * Fixed issue where reinstalling an already-loaded package could cause errors (#8265)


### PR DESCRIPTION
### Intent

Unfortunately, 1.4 has a pretty ugly regression -- lines can be submitted out-of-order in some cases, if the user quickly submits multiple pieces of console input while the R console is busy. See https://github.com/rstudio/rstudio/issues/8837 for details.

This PR seeks to rectify that.

Addresses https://github.com/rstudio/rstudio/issues/8837.

### Approach

When fixing up console input, we now:

1. Take the next console item at the front of the deque,
2. Create a vector of pending console items,
3. Replay those onto the front of the deque

thereby preserving the order of input in the console input queue even after splitting.

### Automated Tests

Tracked in https://github.com/rstudio/rstudio-ide-automation/issues/159.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8837. A simple way to test is with this script -- try executing the following line-by-line quickly, by pressing Ctrl + Enter a number of times:

```
#1.
Sys.sleep(1)

#2.
Sys.sleep(2)

#3.
Sys.sleep(3)
```

After execution, you should see:

```
> #1.
> Sys.sleep(1)
> #2.
> Sys.sleep(2)
> #3.
> Sys.sleep(3)
```

in the console history. If you're running a version of 1.4 with this bug, you will see:

```
> #1.
> Sys.sleep(1)
> #3.
Sys.sleep(3)
> #2.
> Sys.sleep(2)
```

instead.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


