### PR TITLE
discover python installations in common locations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,9 +11,10 @@
 
 ### Python
 
-* The Python REPL can now be interrupted. (#8763, #8785)
-* Fixed issue where inspecting a null Python object would cause emit errors to console (#8185)
+* The Python REPL can now be interrupted (#8763, #8785)
+* Python installs within `/opt/python` and `/opt/local/python` are now discovered by RStudio (#8852)
 * Improved handling of unicode input on Windows (#8549)
+* Fixed issue where inspecting a null Python object would cause emit errors to console (#8185)
 * Detect active Python version when publishing content (#8636)
 
 ### RStudio Server

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -179,6 +179,7 @@
 {
    interpreters <- c(
       .rs.python.findPythonSystemInterpreters(),
+      .rs.python.findPythonInterpretersInKnownLocations(),
       .rs.python.findPythonPyenvInterpreters(),
       .rs.python.findPythonVirtualEnvironments(),
       .rs.python.findPythonCondaEnvironments()
@@ -232,6 +233,50 @@
    }
    
    interpreters
+   
+})
+
+.rs.addFunction("python.findPythonInterpretersInKnownLocations", function()
+{
+   # set of discovered paths
+   pythonPaths <- character()
+   
+   # Python root paths we'll search in
+   roots <- c(
+      "/opt/python",
+      "/opt/local/python",
+      "/usr/local/opt/python",
+      getOption("rstudio.python.installationPath")
+   )
+   
+   # check and see if any of these roots point directly
+   # to a particular version of Python
+   paths <- vapply(roots, function(root) {
+      paths <- file.path(root, c("bin/python", "bin/python3"))
+      paths[file.exists(paths)][1]
+   }, FUN.VALUE = character(1))
+   
+   # collect the discovered python paths, if any
+   exists <- !is.na(paths)
+   pythonPaths <- c(pythonPaths, paths[exists])
+   roots <- roots[!exists]
+   
+   # treat any remaining root directories as versioned roots
+   roots <- list.files(roots, full.names = TRUE)
+   
+   # check and see if any of these roots point directly
+   # to a particular version of Python
+   paths <- vapply(roots, function(root) {
+      paths <- file.path(root, c("bin/python", "bin/python3"))
+      paths[file.exists(paths)][1]
+   }, FUN.VALUE = character(1))
+   
+   # collect the discovered python paths, if any
+   exists <- !is.na(paths)
+   pythonPaths <- c(pythonPaths, paths[exists])
+   
+   # return the discovered paths
+   lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
    
 })
 


### PR DESCRIPTION
### Intent

Many users and system administrators will install multiple copies of Python into the `/opt` folder; e.g. as:

```
/opt/python/3.7.2/bin/python
```

This PR makes it possible for RStudio to discover Python installations in such paths.

Addresses https://github.com/rstudio/rstudio/issues/8852.

### Approach

Relatively straightforward searching of `python` and `python3` executables within a set of common root paths.

### Automated Tests

None yet.

### QA Notes

TODO: Need instructions for installing Python into locations like `/opt/python`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

