### PR TITLE
don't read initial working directory from sessionInfo

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,4 +3,4 @@
 ### Bugfixes
 
 * Fixed issue where R code input could be executed in the wrong order in some cases (#8837)
-
+* Fixed issue where default initial working directory was incorrectly set to a project directory (#8683)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -414,9 +414,13 @@ public class GeneralPreferencesPane extends PreferencesPane
 
       loadRData_.setValue(prefs.loadWorkspace().getValue());
       
+      // NOTE: we intentionally ignore sessionInfo's version of the
+      // initial working directory here as that might reference a
+      // project-specific location, and we don't want that to end up
+      // encoded as part of the user's global preferences
       String workingDir = prefs.initialWorkingDirectory().getValue();
       if (StringUtil.isNullOrEmpty(workingDir))
-         workingDir = session_.getSessionInfo().getInitialWorkingDir();
+         workingDir = "~";
       
       dirChooser_.setText(workingDir);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8683.

### Approach

Don't use the initial working directory from the sessionInfo object, as that might resolve to a project-specific path and hence become sticky globally.

### Automated Tests

Tracked in https://github.com/rstudio/rstudio-ide-automation/issues/165.

### QA Notes

Following Jonathan's instructions in https://github.com/rstudio/rstudio/issues/8683#issuecomment-763191294 to reproduce, and check that the associated issue no longer manifests.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

