### PR TITLE
fix auto-outdenting when rainbow parens active

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -54,6 +54,7 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Fixed issue where attempting to profile lines ending in comment would fail (#8407)
 * Fixed issue where warnings + messages were mis-encoded in chunk outputs on Windows (#8565)
 * Fixed issue where C++ compilation database was not invalidated when compiler was updated (#8588)
+* Fixed issue where 'case:' statements were not outdented when rainbow parentheses were active. (#8846)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
 * The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)

--- a/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
@@ -366,7 +366,7 @@ var $alignCase                 = true; // case 'a':
                row: row,
                column: line.length
             },
-            /(?:^|[.])paren(?:$|[.])/
+            Utils.getTokenTypeRegex("paren")
          );
 
          if (openBracePos) {
@@ -398,7 +398,7 @@ var $alignCase                 = true; // case 'a':
                row: row,
                column: /(\S)/.exec(line).index + 1
             },
-            /(?:^|[.])paren(?:$|[.])/
+            Utils.getTokenTypeRegex("paren")
          );
 
          if (openBracePos) {

--- a/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
+++ b/src/gwt/acesupport/acemode/c_cpp_matching_brace_outdent.js
@@ -55,6 +55,7 @@ var $alignCase                 = true; // case 'a':
    };
 
    this.checkOutdent = function(state, line, input) {
+      
       if (Utils.endsWith(state, "start")) {
 
          // private: / public: / protected
@@ -365,7 +366,7 @@ var $alignCase                 = true; // case 'a':
                row: row,
                column: line.length
             },
-            new RegExp("(?:^|[.])paren(?:$|[.])", "")
+            /(?:^|[.])paren(?:$|[.])/
          );
 
          if (openBracePos) {
@@ -396,7 +397,8 @@ var $alignCase                 = true; // case 'a':
             {
                row: row,
                column: /(\S)/.exec(line).index + 1
-            }
+            },
+            /(?:^|[.])paren(?:$|[.])/
          );
 
          if (openBracePos) {

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1259,11 +1259,20 @@ var RCodeModel = function(session, tokenizer,
          return Range.fromPoints(pos, end);
       }
       else if (foldToken.value == '}') {
-         var start = session.$findOpeningBracket(foldToken.value, pos);
+
+         var start = session.$findOpeningBracket(
+            foldToken.value,
+            pos,
+            /(?:^|[.])paren(?:$|[.])/
+         );
+         
          if (!start)
             return;
-         return Range.fromPoints({row: start.row, column: start.column+1},
-                                 {row: pos.row, column: pos.column-1});
+
+         return Range.fromPoints(
+            {row: start.row, column: start.column + 1},
+            {row: pos.row, column: pos.column - 1}
+         );
       }
       else if (/\bcodebegin\b/.test(foldToken.type)) {
          // Find next codebegin or codeend

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1252,18 +1252,26 @@ var RCodeModel = function(session, tokenizer,
 
       var pos = {row: row, column: foldToken.column + 1};
 
-      if (foldToken.value == '{') {
-         var end = session.$findClosingBracket(foldToken.value, pos);
+      if (foldToken.value == '{')
+      {
+         var end = session.$findClosingBracket(
+            foldToken.value,
+            pos,
+            Utils.getTokenTypeRegex("paren")
+         );
+
          if (!end)
             return;
+
          return Range.fromPoints(pos, end);
       }
-      else if (foldToken.value == '}') {
+      else if (foldToken.value == '}')
+      {
 
          var start = session.$findOpeningBracket(
             foldToken.value,
             pos,
-            /(?:^|[.])paren(?:$|[.])/
+            Utils.getTokenTypeRegex("paren")
          );
          
          if (!start)
@@ -1274,7 +1282,8 @@ var RCodeModel = function(session, tokenizer,
             {row: pos.row, column: pos.column - 1}
          );
       }
-      else if (/\bcodebegin\b/.test(foldToken.type)) {
+      else if (/\bcodebegin\b/.test(foldToken.type))
+      {
          // Find next codebegin or codeend
          var tokenIterator = new TokenIterator(session, row, 0);
          for (var tok; tok = tokenIterator.stepForward(); ) {

--- a/src/gwt/acesupport/acemode/token_cursor.js
+++ b/src/gwt/acesupport/acemode/token_cursor.js
@@ -15,10 +15,11 @@
 
 define("mode/token_cursor", ["require", "exports", "module"], function(require, exports, module) {
 
-var $reParenType = /(?:^|[.])paren(?:$|[.])/;
-
 var oop = require("ace/lib/oop");
 var Utils = require("mode/utils");
+
+var $reParenType = Utils.getTokenTypeRegex("paren");
+
 var TokenCursor = function(tokens, row, offset) {
 
    this.$tokens = tokens;

--- a/src/gwt/acesupport/acemode/utils.js
+++ b/src/gwt/acesupport/acemode/utils.js
@@ -268,6 +268,11 @@ var unicode = require("ace/unicode");
       return true;
    };
 
+   this.getTokenTypeRegex = function(type)
+   {
+      return new RegExp("(?:^|[.])" + type + "(?:$|[.])", "");
+   }
+
 
 }).call(exports);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8846.

### Approach

Regression in outdenting for C++ files when rainbow parentheses is active. A prior PR fixed up some of these:

https://github.com/rstudio/rstudio/pull/7214

but some spots were missed.

### Automated Tests


### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8846.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
