### PR TITLE
option to enable legacy tab key behavior in editor's Find panel

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Cmd+U now toggles underlining in the visual editor on macOS (#8656)
 * Improve YAML cursor position after omni-insert in the visual editor (#8670)
 * Detect newer plumber tags when enabling plumber integration (#8118)
+* Option to restore RStudio 1.2 tab key behavior in editor find panel; search in Command Palette for "Tab key behavior in find panel matches RStudio 1.2 and earlier" (#7295)
 
 ### Bugfixes
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -316,6 +316,7 @@ namespace prefs {
 #define kTypingStatusDelayMs "typing_status_delay_ms"
 #define kReducedMotion "reduced_motion"
 #define kTabKeyMoveFocus "tab_key_move_focus"
+#define kFindPanelLegacyTabSequence "find_panel_legacy_tab_sequence"
 #define kShowFocusRectangles "show_focus_rectangles"
 #define kShowPanelFocusRectangle "show_panel_focus_rectangle"
 #define kAutoSaveOnIdle "auto_save_on_idle"
@@ -1484,6 +1485,12 @@ public:
     */
    bool tabKeyMoveFocus();
    core::Error setTabKeyMoveFocus(bool val);
+
+   /**
+    * In source editor tab panel, tab key moves focus directly from find text to replace text.
+    */
+   bool findPanelLegacyTabSequence();
+   core::Error setFindPanelLegacyTabSequence(bool val);
 
    /**
     * Control with keyboard focus displays a visual focus indicator.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1487,7 +1487,7 @@ public:
    core::Error setTabKeyMoveFocus(bool val);
 
    /**
-    * In source editor tab panel, tab key moves focus directly from find text to replace text.
+    * In source editor find panel, tab key moves focus directly from find text to replace text.
     */
    bool findPanelLegacyTabSequence();
    core::Error setFindPanelLegacyTabSequence(bool val);

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2403,6 +2403,19 @@ core::Error UserPrefValues::setTabKeyMoveFocus(bool val)
 }
 
 /**
+ * In source editor tab panel, tab key moves focus directly from find text to replace text.
+ */
+bool UserPrefValues::findPanelLegacyTabSequence()
+{
+   return readPref<bool>("find_panel_legacy_tab_sequence");
+}
+
+core::Error UserPrefValues::setFindPanelLegacyTabSequence(bool val)
+{
+   return writePref("find_panel_legacy_tab_sequence", val);
+}
+
+/**
  * Control with keyboard focus displays a visual focus indicator.
  */
 bool UserPrefValues::showFocusRectangles()
@@ -3017,6 +3030,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kTypingStatusDelayMs,
       kReducedMotion,
       kTabKeyMoveFocus,
+      kFindPanelLegacyTabSequence,
       kShowFocusRectangles,
       kShowPanelFocusRectangle,
       kAutoSaveOnIdle,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2403,7 +2403,7 @@ core::Error UserPrefValues::setTabKeyMoveFocus(bool val)
 }
 
 /**
- * In source editor tab panel, tab key moves focus directly from find text to replace text.
+ * In source editor find panel, tab key moves focus directly from find text to replace text.
  */
 bool UserPrefValues::findPanelLegacyTabSequence()
 {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1213,6 +1213,12 @@
             "title": "Tab key always moves focus",
             "description": "Tab key moves focus out of text editing controls instead of inserting tabs."
         },
+        "find_panel_legacy_tab_sequence": {
+            "type": "boolean",
+            "default": false,
+            "title": "Tab key behavior in find panel matches RStudio 1.2 and earlier",
+            "description": "In source editor tab panel, tab key moves focus directly from find text to replace text."
+        },
         "show_focus_rectangles": {
             "type": "boolean",
             "default": true,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1216,8 +1216,8 @@
         "find_panel_legacy_tab_sequence": {
             "type": "boolean",
             "default": false,
-            "title": "Tab key behavior in find panel matches RStudio 1.2 and earlier",
-            "description": "In source editor tab panel, tab key moves focus directly from find text to replace text."
+            "title": "Tab key moves focus directly from find text to replace text in find panel",
+            "description": "In source editor find panel, tab key moves focus directly from find text to replace text."
         },
         "show_focus_rectangles": {
             "type": "boolean",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2023,7 +2023,7 @@ public class UserPrefsAccessor extends Prefs
       return bool(
          "show_launcher_jobs_tab",
          "", 
-         "Whether to show the Launcher jobs tab in RStudio Pro and RStudio Workbench.",
+         "Whether to show the Launcher jobs tab in RStudio Pro and RStudio Workbench.", 
          true);
    }
 
@@ -2035,7 +2035,7 @@ public class UserPrefsAccessor extends Prefs
       return enumeration(
          "launcher_jobs_sort",
          "", 
-         "How to sort jobs in the Launcher tab in RStudio Pro and RStudio Workbench.",
+         "How to sort jobs in the Launcher tab in RStudio Pro and RStudio Workbench.", 
          new String[] {
             LAUNCHER_JOBS_SORT_RECORDED,
             LAUNCHER_JOBS_SORT_STATE
@@ -2230,8 +2230,8 @@ public class UserPrefsAccessor extends Prefs
    {
       return enumeration(
          "show_user_home_page",
-         "Show user home page in RStudio Workbench",
-         "When to show the server home page in RStudio Workbench.",
+         "Show user home page in RStudio Workbench", 
+         "When to show the server home page in RStudio Workbench.", 
          new String[] {
             SHOW_USER_HOME_PAGE_ALWAYS,
             SHOW_USER_HOME_PAGE_NEVER,
@@ -2252,7 +2252,7 @@ public class UserPrefsAccessor extends Prefs
       return bool(
          "reuse_sessions_for_project_links",
          "", 
-         "Whether to reuse sessions when opening projects in RStudio Workbench.",
+         "Whether to reuse sessions when opening projects in RStudio Workbench.", 
          false);
    }
 
@@ -2467,8 +2467,8 @@ public class UserPrefsAccessor extends Prefs
    {
       return bool(
          "restore_project_r_version",
-         "Restore project R version in RStudio Pro and RStudio Workbench",
-         "Whether to restore the last version of R used by the project in RStudio Pro and RStudio Workbench.",
+         "Restore project R version in RStudio Pro and RStudio Workbench", 
+         "Whether to restore the last version of R used by the project in RStudio Pro and RStudio Workbench.", 
          true);
    }
 
@@ -2583,6 +2583,18 @@ public class UserPrefsAccessor extends Prefs
          "tab_key_move_focus",
          "Tab key always moves focus", 
          "Tab key moves focus out of text editing controls instead of inserting tabs.", 
+         false);
+   }
+
+   /**
+    * In source editor tab panel, tab key moves focus directly from find text to replace text.
+    */
+   public PrefValue<Boolean> findPanelLegacyTabSequence()
+   {
+      return bool(
+         "find_panel_legacy_tab_sequence",
+         "Tab key behavior in find panel matches RStudio 1.2 and earlier", 
+         "In source editor tab panel, tab key moves focus directly from find text to replace text.", 
          false);
    }
 
@@ -3443,6 +3455,8 @@ public class UserPrefsAccessor extends Prefs
          reducedMotion().setValue(layer, source.getBool("reduced_motion"));
       if (source.hasKey("tab_key_move_focus"))
          tabKeyMoveFocus().setValue(layer, source.getBool("tab_key_move_focus"));
+      if (source.hasKey("find_panel_legacy_tab_sequence"))
+         findPanelLegacyTabSequence().setValue(layer, source.getBool("find_panel_legacy_tab_sequence"));
       if (source.hasKey("show_focus_rectangles"))
          showFocusRectangles().setValue(layer, source.getBool("show_focus_rectangles"));
       if (source.hasKey("show_panel_focus_rectangle"))
@@ -3512,7 +3526,7 @@ public class UserPrefsAccessor extends Prefs
    }
    public List<PrefValue<?>> allPrefs()
    {
-      ArrayList<PrefValue<?>> prefs = new ArrayList<>();
+      ArrayList<PrefValue<?>> prefs = new ArrayList<PrefValue<?>>();
       prefs.add(runRprofileOnResume());
       prefs.add(saveWorkspace());
       prefs.add(loadWorkspace());
@@ -3696,6 +3710,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(typingStatusDelayMs());
       prefs.add(reducedMotion());
       prefs.add(tabKeyMoveFocus());
+      prefs.add(findPanelLegacyTabSequence());
       prefs.add(showFocusRectangles());
       prefs.add(showPanelFocusRectangle());
       prefs.add(autoSaveOnIdle());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2587,14 +2587,14 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * In source editor tab panel, tab key moves focus directly from find text to replace text.
+    * In source editor find panel, tab key moves focus directly from find text to replace text.
     */
    public PrefValue<Boolean> findPanelLegacyTabSequence()
    {
       return bool(
          "find_panel_legacy_tab_sequence",
-         "Tab key behavior in find panel matches RStudio 1.2 and earlier", 
-         "In source editor tab panel, tab key moves focus directly from find text to replace text.", 
+         "Tab key moves focus directly from find text to replace text in find panel", 
+         "In source editor find panel, tab key moves focus directly from find text to replace text.", 
          false);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -566,7 +566,7 @@ public class UserStateAccessor extends Prefs
    }
    public List<PrefValue<?>> allPrefs()
    {
-      ArrayList<PrefValue<?>> prefs = new ArrayList<>();
+      ArrayList<PrefValue<?>> prefs = new ArrayList<PrefValue<?>>();
       prefs.add(contextId());
       prefs.add(autoCreatedProfile());
       prefs.add(theme());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -136,6 +136,33 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
 
       shelf.addLeftWidget(panel);
 
+
+      if (RStudioGinjector.INSTANCE.getUserPrefs().findPanelLegacyTabSequence().getValue())
+      {
+         // RStudio 1.2 and earlier set custom tabindexes so hitting Tab key would go from the
+         // "find" text to the "replace" text and skip some of the other controls. This was
+         // a keyboard accessibility violation, but some users would like option to get that
+         // old behavior back. https://github.com/rstudio/rstudio/issues/7295
+
+         // fixup tab indexes of controls
+         txtFind_.setTabIndex(100);
+         txtReplace_.setTabIndex(101);
+         chkInSelection_.setTabIndex(102);
+         chkCaseSensitive_.setTabIndex(103);
+         chkWholeWord_.setTabIndex(104);
+         chkRegEx_.setTabIndex(105);
+         chkWrapSearch_.setTabIndex(106);
+
+         // remove SmallButton instances from tab order since (a) they aren't
+         // capable of showing a focused state; and (b) enter is already a
+         // keyboard shortcut for both find and replace
+         btnFindNext_.setTabIndex(-1);
+         btnFindPrev_.setTabIndex(-1);
+         btnSelectAll_.setTabIndex(-1);
+         btnReplace_.setTabIndex(-1);
+         btnReplaceAll_.setTabIndex(-1);
+      }
+
       shelf.setRightVerticalAlignment(HasVerticalAlignment.ALIGN_TOP);
       shelf.addRightWidget(btnClose_ = new Button());
       btnClose_.setStyleName(RES.styles().closeButton());


### PR DESCRIPTION
### Intent

Requested in #7295

![screenshot of the find panel](https://user-images.githubusercontent.com/10569626/106531134-7f690280-64a2-11eb-88b2-e62c6a58c549.png)

In RStudio 1.3 (and newer) I made most UI controls accessible via keyboard tab sequence, and accessibility rules are that the tab key should move through controls in the same order they are represented on screen.

Some users prefer the old behavior in the Find panel, where hitting tab when focus is on the "Find" text moves directly to the "Replace" text, skipping over the "Next/Prev/All" buttons. Currently you must tab through those controls (so 4 presses of tab key instead of one).

### Approach

Added a user preference to reenable the old behavior and conditionally set the exact same behavior found in RStudio 1.2 and earlier. Preference is shown as "Tab key moves focus directly from find text to replace text in find panel" in the command palette. I did not add it to the Global Options dialog. If the find panel is displayed and the option is changed, must close and reopen the find panel for the option to take effect.

![screenshot of command palette showing new option](https://user-images.githubusercontent.com/10569626/106550704-860a7080-64c8-11eb-9d46-4ad5bc1e8f09.png)

Note the code that sets custom tabindexes is taken verbatim from RStudio 1.2 sources.

### Automated Tests

Not necessary; this is a fringe case that must be enabled by the user and is known to break accessibility validation.

### QA Notes

Mainly, verify that tab key behavior is no different by default in the Find panel between 1.4_wax_begonia and 1.4_juliet-rose.

If you turn on the option, verify that the tab key behavior is the same as RStudio 1.2 and earlier, mainly that when focus is in "find", hitting tab once moves focus to "replace".

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


