### PR TITLE
fix bugs when changes applied to Pane Layout

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/MainSplitPanel.java
@@ -185,10 +185,7 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
             {
                // When there are only two panels, make the left side slightly larger than the right,
                // otherwise divide the space equally.
-               double splitWidth = (leftList_.isEmpty()) ?
-                                   Window.getClientWidth() * 0.45 :
-                                   Window.getClientWidth() / (2 + leftList_.size());
-
+               double splitWidth = getDefaultSplitterWidth();
                addEast(right_, splitWidth);
 
                for (Widget w : leftList_)
@@ -258,6 +255,13 @@ public class MainSplitPanel extends NotifyingSplitLayoutPanel
       initialize(leftList_, center_, right_);
    }
 
+   public double getDefaultSplitterWidth()
+   {
+      return leftList_.isEmpty() ?
+         Window.getClientWidth() * 0.45 :
+         Window.getClientWidth() / (2 + leftList_.size());
+   }
+   
    public double getLeftSize()
    {
       double sum = 0.0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneConfig.java
@@ -175,6 +175,20 @@ public class PaneConfig extends UserPrefsAccessor.Panes
       return !getConsoleLeft();
    }
 
+   public final boolean getTabSet1Left()
+   {
+      JsArrayString panes = getQuadrants();
+      return StringUtil.equals(panes.get(0), "TabSet1") ||
+         StringUtil.equals(panes.get(1), "TabSet1");
+   }
+   
+   public final boolean getTabSet2Left()
+   {
+      JsArrayString panes = getQuadrants();
+      return StringUtil.equals(panes.get(0), "TabSet2") ||
+         StringUtil.equals(panes.get(1), "TabSet2");
+   }
+   
    public final boolean validateAndAutoCorrect()
    {
       JsArrayString panes = getQuadrants();


### PR DESCRIPTION
### Intent

Address testing feedback from #8460.

### Approach

The (sometimes) invisible Presentation tab caused the Pane Manager to act as if a tab was being displayed when one was not. I updated the code to consider a TabSet with only the Presentation Tab present while Presentation is not active to be empty. With additional testing, I realized minimizing panes to hide them wasn't sufficient when both sets were empty and in the same column so I updated the code to adjust the splitter in this case. 

### Automated Tests

rstudio/rstudio-ide-automation#150

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


