### PR TITLE
Allow never-executed chunks to be queued for execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -59,6 +59,7 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
 * The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)
+* Fixed issue preventing R Notebook chunks from being queued for execution if they had never been previously run (#4238)
 * Fix various issues when the "Limit Console Output" performance setting was enabled, and enable it by default (#8544, #8504, #8529, #8552)
 * Fix display of condition messages (errors and warnings) in some character encodings (#8546)
 * Fix issues finding words with punctuation in visual mode (#8655)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text.rmd;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -153,8 +154,23 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       {
          String chunkId = notebook_.getRowChunkId(
                chunk.getScope().getPreamble().getRow());
+
          if (chunkId == null)
-            return;
+         {
+            // If this chunk has never been executed before, it doesn't have a ID yet;
+            // create one so that we can queue the chunk.
+            ChunkDefinition def = getChunkDefAtRow(chunk.getScope().getEnd().getRow(), null);
+            if (def == null)
+            {
+               // Could not create an ID for the chunk; this is not expected.
+               Debug.logWarning("Could not create a notebook output chunk at row " +
+                  chunk.getScope().getBodyStart().getRow() + " of " +
+                  sentinel_.getPath());
+               return;
+            }
+
+            chunkId = def.getChunkId();
+         }
 
          NotebookQueueUnit unit = getUnit(chunkId);
          if (unit == null)


### PR DESCRIPTION
### Intent

Addresses #4238, in which chunks cannot be queued for execution if they have never before been executed. 

### Approach

Every chunk has a unique ID, which it receives when it is executed for the first time. Queuing a chunk for execution involves placing its ID into the execution queue. However, if the chunk has never been run, it doesn't have an ID, and is not placed on the queue. The fix is to allocate an ID for the chunk so that it can be placed in the queue. 

### Automated Tests

This is a UI only change that cannot be covered by the current unit test infrastructure. 

### QA Notes

The affected code runs only when you run a chunk while other chunks are executing; test the scenario in both visual and source mode as they're both affected. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

