### PR TITLE
add unique element IDs to some checkboxes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -599,4 +599,13 @@ public class ElementIds
    public final static String TAB_CLOSE_ALL = "tab_close_all";
    public final static String TAB_CLOSE_OTHERS = "tab_close_others";
 
+   // OpenProjectDialog
+   public final static String OP_NEW_SESSION = "op_new_session";
+
+   // FilePathToolbar
+   public final static String FP_SELECT_ALL = "fp_select_all";
+
+   // ChooseEncodingDialog
+   public final static String ENC_SHOW_ALL = "enc_show_all";
+   public final static String ENC_SET_DEFAULT = "enc_set_default";
 }

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenProjectDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenProjectDialog.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.files.FileSystemContext;
 import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.widget.FormCheckBox;
 import org.rstudio.core.client.widget.ProgressIndicator;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -43,8 +44,8 @@ public class OpenProjectDialog extends FileDialog
                 boolean newSessionOption,
                 final ProgressOperationWithInput<OpenProjectParams> operation)
    {
-      super("Open Project", null, Roles.getDialogRole(), "Open", false, false, false, context, 
-            "R Projects (*.RProj)", 
+      super("Open Project", null, Roles.getDialogRole(), "Open", false, false, false, context,
+            "R Projects (*.RProj)",
             new ProgressOperationWithInput<FileSystemItem>()
             {
                @Override
@@ -54,15 +55,15 @@ public class OpenProjectDialog extends FileDialog
                   // NOTE: we currently do not expose R version selection
                   // for the open project dialog since projects already
                   // have a pinned R version by default
-                  operation.execute(new OpenProjectParams(input, 
+                  operation.execute(new OpenProjectParams(input,
                                                           null,
                                                           inNewSession_),
                         indicator);
                }
             });
-      
+
       RStudioGinjector.INSTANCE.injectMembers(this);
-      
+
       // Used to create a project in an existing directory which
       // does not already have a .Rproj file.
       ThemedButton createButton = new ThemedButton("Create", new ClickHandler()
@@ -79,7 +80,7 @@ public class OpenProjectDialog extends FileDialog
                      {
                         accept(FileSystemItem.createFile(response));
                      }
-                     
+
                      @Override
                      public void onError(ServerError error)
                      {
@@ -90,8 +91,8 @@ public class OpenProjectDialog extends FileDialog
          }
       });
       addButton(createButton, ElementIds.CREATE_BUTTON);
-      
-      newSessionCheck_ = new CheckBox("Open in new session");
+
+      newSessionCheck_ = new FormCheckBox("Open in new session", ElementIds.OP_NEW_SESSION);
       newSessionCheck_.addValueChangeHandler(new ValueChangeHandler<Boolean>()
       {
          @Override
@@ -103,16 +104,16 @@ public class OpenProjectDialog extends FileDialog
       if (newSessionOption)
          addLeftWidget(newSessionCheck_);
    }
-   
+
    @Inject
    private void initialize(ProjectsServerOperations server)
    {
       server_ = server;
    }
-   
+
    private CheckBox newSessionCheck_;
    private static boolean inNewSession_ = false;
-   
+
    // Injected ----
    private ProjectsServerOperations server_;
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/CheckBoxHiddenLabel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/CheckBoxHiddenLabel.java
@@ -17,17 +17,16 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
-import com.google.gwt.user.client.ui.CheckBox;
 
 /**
  * A CheckBox with a label only visible to screen readers. Not recommended, avoid using.
  */
-public class CheckBoxHiddenLabel extends CheckBox
+public class CheckBoxHiddenLabel extends FormCheckBox
 {
-   public CheckBoxHiddenLabel(String visuallyHiddenLabel)
+   public CheckBoxHiddenLabel(String visuallyHiddenLabel, String id)
    {
       super();
-      
+
       // CheckBox consists of a span with input (checkbox) element followed
       // by a label element (empty in this case).
       Element label = DOM.getChild(getElement(), 1);
@@ -35,5 +34,6 @@ public class CheckBoxHiddenLabel extends CheckBox
       {
          Roles.getCheckboxRole().setAriaLabelProperty(label, visuallyHiddenLabel);
       }
+      setElementId(id);
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/FormCheckBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FormCheckBox.java
@@ -23,6 +23,21 @@ import com.google.gwt.user.client.ui.CheckBox;
 public class FormCheckBox extends CheckBox
                           implements CanSetControlId
 {
+   public FormCheckBox()
+   {
+      super();
+   }
+
+   /**
+    * @param label label text
+    * @param id unique element ID
+    */
+   public FormCheckBox(String label, String id)
+   {
+      super(label);
+      setElementId(id);
+   }
+
    @Override
    public void setElementId(String id)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -18,6 +18,7 @@ import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.user.client.ui.*;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.events.SelectionCommitEvent;
@@ -115,7 +116,8 @@ public class FilePathToolbar extends Composite
       navigationObserver_ = navigationObserver;
 
       // select all check box
-      CheckBoxHiddenLabel selectAllCheckBox = new CheckBoxHiddenLabel("Select all files");
+      CheckBoxHiddenLabel selectAllCheckBox = new CheckBoxHiddenLabel("Select all files",
+                                                                      ElementIds.FP_SELECT_ALL);
       selectAllCheckBox.addStyleDependentName("FilesSelectAll");
       selectAllCheckBox.addValueChangeHandler(new ValueChangeHandler<Boolean>(){
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/ChooseEncodingDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/ChooseEncodingDialog.java
@@ -22,7 +22,9 @@ import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.ListBox;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.widget.FormCheckBox;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.studio.client.RStudioGinjector;
@@ -92,7 +94,7 @@ public class ChooseEncodingDialog extends ModalDialog<String>
 
       setEncodings(commonEncodings_, currentEncoding_);
 
-      CheckBox showAll = new CheckBox("Show all encodings");
+      CheckBox showAll = new FormCheckBox("Show all encodings", ElementIds.ENC_SHOW_ALL);
       showAll.addValueChangeHandler(valueChangeEvent ->
       {
          if (valueChangeEvent.getValue())
@@ -108,8 +110,8 @@ public class ChooseEncodingDialog extends ModalDialog<String>
 
       if (includeSaveAsDefault_)
       {
-         saveAsDefault_ = new CheckBox("Set as default encoding for " +
-                                       "source files");
+         saveAsDefault_ = new FormCheckBox("Set as default encoding for source files",
+                                           ElementIds.ENC_SET_DEFAULT);
          setCheckBoxMargins(showAll, 8, 0);
          setCheckBoxMargins(saveAsDefault_, 3, 12);
          panel.add(saveAsDefault_);


### PR DESCRIPTION
### Intent

Most checkboxes in the UI don't have unique IDs for automation. Recently added `FormCheckBox` class to make this easier; use it in a few more places to serve as example.

### Approach

Gave a handful of checkboxes unique element IDs. Specifically:

![screenshot of select all checkbox in Files pane](https://user-images.githubusercontent.com/10569626/106654087-84828c00-654c-11eb-9cf0-8fb446c64de4.png)

![screenshot of checkboxes in Choose Encoding dialog](https://user-images.githubusercontent.com/10569626/106654125-8f3d2100-654c-11eb-9e19-8a3a8e271e22.png)

![screenshot of Open Project dialog](https://user-images.githubusercontent.com/10569626/106654157-9cf2a680-654c-11eb-8255-db04c92b990f.png)

Note that last dialog is only used from RSP with multi-session support enabled.

### Automated Tests

These will be used to author automation, don't require specific automation of their own.

### QA Notes

Nothing to test here unless you want to view the HTML and confirm that these new IDs are assigned to the elements (which I've done with my own ad-hoc testing). Even if they weren't, somehow, nothing would currently break.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


