### PR TITLE
Better autoscrolling with Virtualized Console

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -489,6 +489,10 @@ public class VirtualConsole
     */
    public void submit(String data, String clazz, boolean forceNewRange, boolean ariaLiveAnnounce)
    {
+      boolean wasAtBottom = false;
+      if (isVirtualized())
+         wasAtBottom = VirtualScrollerManager.scrolledToBottom(parent_.getParentElement());
+
       // Only capture new elements when dealing with error output, which
       // is the only place that sets forceNewRange to true. This is just an
       // optimization to avoid unnecessary overhead for large (non-error)
@@ -659,6 +663,9 @@ public class VirtualConsole
       // If there was any plain text after the last control character, add it
       if (tail < data.length())
          text(data.substring(tail), currentClazz, forceNewRange);
+
+      if (wasAtBottom && isVirtualized())
+         VirtualScrollerManager.scrollToBottom(parent_.getParentElement());
    }
 
    // Elements added by last submit call; only captured if forceNewRange was true

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerManager.java
@@ -76,6 +76,32 @@ public class VirtualScrollerManager
       scrollers_.get(parent.getAttribute(scrollerAttribute_)).append(content);
    }
 
+   public static boolean scrolledToBottom(Element parent)
+   {
+      // if we don't have a connection to that parent there's nothing to clear
+      if (!initialized_ || parent == null ) return false;
+
+      parent = getVirtualScrollerAncestor(parent);
+
+      if (scrollers_.get(parent.getAttribute(scrollerAttribute_)) == null)
+         return false;
+
+      return scrollerForElement(parent).scrolledToBottom();
+   }
+
+   public static void scrollToBottom(Element parent)
+   {
+      // if we don't have a connection to that parent there's nothing to clear
+      if (!initialized_ || parent == null ) return;
+
+      parent = getVirtualScrollerAncestor(parent);
+
+      if (scrollers_.get(parent.getAttribute(scrollerAttribute_)) == null)
+         return;
+
+      scrollerForElement(parent).scrollToBottom();
+   }
+
    public static void prune(Element parent, Element ele)
    {
       // if we don't have a connection to that parent there's nothing to clear

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/VirtualScrollerNative.java
@@ -26,6 +26,8 @@ public class VirtualScrollerNative
    public native void setup(Element ele, String visuallyHiddenClass);
    public native void append(Element ele);
    public native Element getCurBucket();
+   public native boolean scrolledToBottom();
+   public native void scrollToBottom();
    public native void clear();
    public native void prune(Element ele);
    public native void ensureStartingOnNewLine();

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -53,12 +53,13 @@ var VirtualScroller;
       self._isAtTopBucket = self._isAtTopBucket.bind(self);
       self._isBucketHidden = self._isBucketHidden.bind(self);
       self._isBucketFull = self._isBucketFull.bind(self);
-      self._jumpToBottom = self._jumpToBottom.bind(self);
       self._moveWindow = self._moveWindow.bind(self);
       self._onParentScroll = self._onParentScroll.bind(self);
       self._showBucket = self._showBucket.bind(self);
       self.append = self.append.bind(self);
       self.clear = self.clear.bind(self);
+      self.scrollToBottom = self.scrollToBottom.bind(self);
+      self.scrolledToBottom = self.scrolledToBottom.bind(self);
       self.getCurBucket = self.getCurBucket.bind(self);
       self.setScrollParent = self.setScrollParent.bind(self);
 
@@ -192,8 +193,14 @@ var VirtualScroller;
       return this.scrollerEle.scrollTop < 4;
     },
 
-    _scrolledToBottom: function() {
-      return Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 4;
+    scrolledToBottom: function() {
+      return Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 50;
+    },
+
+    scrollToBottom: function() {
+      if (!!this.scrollerEle)  {
+        this.scrollerEle.scrollTop = this.scrollerEle.scrollHeight;
+      }
     },
 
     // this BOUND callback function
@@ -238,7 +245,7 @@ var VirtualScroller;
           this._moveWindow(true);
         }
         // if we scrolled to the bottom, move the window down
-        else if (this._scrolledToBottom() && !this._isAtBottomBucket()) {
+        else if (this.scrolledToBottom() && !this._isAtBottomBucket()) {
           this._moveWindow(false);
         }
         else {
@@ -252,7 +259,7 @@ var VirtualScroller;
         // load in a bit more data so the user knows there's more content above
         var self = this;
         setTimeout(function () {
-          if (self._scrolledToBottom() || self._scrolledToTop())
+          if (self.scrolledToBottom() || self._scrolledToTop())
             self._onParentScroll();
         }, this._SCROLL_DEBOUNCE_MS + 10);
       }
@@ -271,7 +278,7 @@ var VirtualScroller;
       if (element === null)
         return;
 
-      var keepScrolled = !!this.scrollerEle && this._scrolledToBottom();
+      var keepScrolled = !!this.scrollerEle && this.scrolledToBottom();
 
       if (this._isBucketFull(this.getCurBucket())) {
         this._createAndAddNewBucket();

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -194,7 +194,8 @@ var VirtualScroller;
     },
 
     scrolledToBottom: function() {
-      return Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 50;
+      return !!this.scrollerEle &&
+          Math.abs(this.scrollerEle.scrollHeight - this.scrollerEle.offsetHeight - this.scrollerEle.scrollTop) < 50;
     },
 
     scrollToBottom: function() {


### PR DESCRIPTION
### Intent

There are two different kinds of ways to add text to the console: adding new elements and appending to existing elements. Before this PR we only scrolled to the bottom in the first situation. The intent is to always scroll to the bottom now

Addresses: https://github.com/rstudio/rstudio/issues/8504

### Approach

Always check the scroll status in the VirtualConsole.submit function and use a larger window for detecting whether we are near the bottom.

### Automated Tests

No automated tests added for this at the moment.

### QA Notes

Verify that we always properly keep the scrolling at the bottom with all permutations of "Limit Console Visible" on and off with these two lines:

`while (TRUE) { message("polluting the console"); Sys.sleep(0.5) }`

`while (TRUE) { print("polluting the console"); Sys.sleep(0.5) }`

Also that it stops scrolling if you scroll up a bit while the function is operating.

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests


