### PR TITLE
ensure Close of modified file via context menu prompts to save

### DIFF
--- a/src/cpp/session/modules/SessionSource.cpp
+++ b/src/cpp/session/modules/SessionSource.cpp
@@ -1411,7 +1411,6 @@ SEXP rs_requestDocumentClose(SEXP idsSEXP, SEXP saveSXP) {
    fillIds(idsSEXP, &jsonData);
 
    jsonData["save"] = r::sexp::asLogical(saveSXP);
-   jsonData["notify_complete"] = true;
 
    ClientEvent event(client_events::kRequestDocumentClose, jsonData);
    

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -45,7 +45,7 @@ import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.events.CopySourcePathEvent;
 import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.satellite.Satellite;
-import org.rstudio.studio.client.server.model.RequestDocumentCloseEvent;
+import org.rstudio.studio.client.server.model.DocumentCloseEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
@@ -233,7 +233,7 @@ public class DocTabLayoutPanel
 
             menu.addItem(ElementIds.TAB_CLOSE, new MenuItem("Close", () ->
             {
-               events_.fireEvent(new RequestDocumentCloseEvent(docId));
+               events_.fireEvent(new DocumentCloseEvent(docId));
             }));
 
             menu.addItem(ElementIds.TAB_CLOSE_ALL, new MenuItem("Close All", () ->

--- a/src/gwt/src/org/rstudio/studio/client/server/model/DocumentCloseEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/model/DocumentCloseEvent.java
@@ -1,0 +1,63 @@
+/*
+ * DocumentCloseEvent.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.server.model;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+/**
+ * Request closure of an open file, by docId; will prompt if file is dirty
+ */
+public class DocumentCloseEvent extends GwtEvent<DocumentCloseEvent.Handler>
+{
+   public DocumentCloseEvent(String docId)
+   {
+      docId_ = docId;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onDocumentClose(DocumentCloseEvent event);
+   }
+
+   @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+   public static class Data
+   {
+      public String sample;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onDocumentClose(this);
+   }
+
+   public String getDocId()
+   {
+      return docId_;
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
+   private final String docId_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/model/RequestDocumentCloseEvent.java
@@ -36,30 +36,12 @@ public class RequestDocumentCloseEvent extends GwtEvent<RequestDocumentCloseEven
       /*-{
          return this["save"];
       }-*/;
-      
-      public native final boolean getNotifyComplete()
-      /*-{
-            return this["notify_complete"];
-      }-*/;
+
    }
 
    public RequestDocumentCloseEvent(Data data)
    {
       data_ = data;
-   }
-
-   private static final native JavaScriptObject createData(String id)
-   /*-{
-      var result = {};
-      result["ids"] = [id];
-      result["save"] = true;
-      result["notify_complete"] = false;
-      return result;
-   }-*/;
-
-   public RequestDocumentCloseEvent(String id)
-   {
-      data_ = createData(id).cast();
    }
 
    public JsArrayString getDocumentIds()
@@ -70,11 +52,6 @@ public class RequestDocumentCloseEvent extends GwtEvent<RequestDocumentCloseEven
    public boolean getSave()
    {
       return data_.getSave();
-   }
-
-   public boolean getNotifyComplete()
-   {
-      return data_.getNotifyComplete();
    }
 
    private final Data data_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2727,7 +2727,7 @@ public class Source implements InsertSourceEvent.Handler,
          columnManager_.closeTabs(ids);
 
          // Let the server know we've completed the task
-         if (SourceWindowManager.isMainSourceWindow() && event.getNotifyComplete())
+         if (SourceWindowManager.isMainSourceWindow())
          {
             server_.requestDocumentCloseCompleted(true,
                   new VoidServerRequestCallback());
@@ -2747,7 +2747,7 @@ public class Source implements InsertSourceEvent.Handler,
             else
             {
                // We didn't save (or the user cancelled), so let the server know
-               if (SourceWindowManager.isMainSourceWindow() && event.getNotifyComplete())
+               if (SourceWindowManager.isMainSourceWindow())
                {
                   server_.requestDocumentCloseCompleted(false,
                         new VoidServerRequestCallback());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -64,6 +64,7 @@ import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.server.model.DocumentCloseAllNoSaveEvent;
+import org.rstudio.studio.client.server.model.DocumentCloseEvent;
 import org.rstudio.studio.client.workbench.FileMRUList;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.ClientState;
@@ -102,9 +103,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class SourceColumnManager implements CommandPaletteEntrySource,
                                             SourceExtendedTypeDetectedEvent.Handler,
                                             DocumentCloseAllNoSaveEvent.Handler,
+                                            DocumentCloseEvent.Handler,
                                             DebugModeChangedEvent.Handler
 {
-   public interface CPSEditingTargetCommand
+  public interface CPSEditingTargetCommand
    {
       void execute(EditingTarget editingTarget, Command continuation);
    }
@@ -210,6 +212,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       events_.addHandler(SourceExtendedTypeDetectedEvent.TYPE, this);
       events_.addHandler(DebugModeChangedEvent.TYPE, this);
       events_.addHandler(DocumentCloseAllNoSaveEvent.TYPE, this);
+      events_.addHandler(DocumentCloseEvent.TYPE, this);
 
       WindowEx.addFocusHandler(new FocusHandler()
       {
@@ -1103,6 +1106,15 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
    public void onDocumentCloseAllNoSave(DocumentCloseAllNoSaveEvent event)
    {
       revertUnsavedTargets(() -> closeAllTabs(null, false, null));
+   }
+
+   @Override
+   public void onDocumentClose(DocumentCloseEvent event)
+   {
+      EditingTarget target = findEditor(event.getDocId());
+      if (target == null)
+         return;
+      findByDocument(event.getDocId()).closeTab(target.asWidget(), true, null);
    }
 
    public void nextTabWithWrap()


### PR DESCRIPTION
### Intent

- Addresses #8856

### Approach

- Fixed by connecting into message flow that more closely matches the existing "Close" action (via [x] or File / Close, etc)
- Backed out small addition I had made to RequestDocumentCloseEvent for this scenario now that I'm not using it

### Automated Tests

PR for Selenium test that fails due to this issue, and passes once this is in, here: https://github.com/rstudio/rstudio-ide-automation/pull/175

### QA Notes

Try to close a modified source file via "Close" on context menu and ensure you are prompted to save the changes.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

