### PR TITLE
avoid mangling function call expressions

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -412,6 +412,12 @@
       # return object
       object
    }
+   else if (is.pairlist(object))
+   {
+      # handle pairlists specially, primarily because they're
+      # used directly within function calls
+      object
+   }
    else if (!is.language(object))
    {
       # if the object would be very expensive to deparse,

--- a/src/cpp/tests/testthat/test-debugger.R
+++ b/src/cpp/tests/testthat/test-debugger.R
@@ -44,3 +44,11 @@ test_that("we successfully parse the function name from different calls", {
    expect_equal(.rs.functionNameFromCall(cl), "[Anonymous function]")
    
 })
+
+test_that("function calls are not mangled into something un-printable", {
+   
+   cl <- call("function", pairlist(a = 1, b = 2, c = 3), quote({}))
+   sanitized <- .rs.sanitizeCallSummary(cl)
+   expect_equal(cl, sanitized)
+   
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8885.

### Approach

Avoid mangling pairlists in calls, which are used specially in function calls and in printing.

### Automated Tests

testthat tests included with PR.

### QA Notes

Validate via code example in https://github.com/rstudio/rstudio/issues/8885.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

