### PR TITLE
Make always-shown files and directories configurable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Improve YAML cursor position after omni-insert in the visual editor (#8670)
 * Detect newer plumber tags when enabling plumber integration (#8118)
 * Option to restore RStudio 1.2 tab key behavior in editor find panel; search in Command Palette for "Tab key behavior in find panel matches RStudio 1.2 and earlier" (#7295)
+* Show `.renvignore` in Files pane (#8658)
+* Make the set of always-shown files and extensions in the Files pane configurable (#3221)
 
 ### Bugfixes
 

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1934,38 +1934,37 @@ SEXP rs_isRScriptInPackageBuildTarget(SEXP filePathSEXP)
 
 bool fileListingFilter(const core::FileInfo& fileInfo, bool hideObjectFiles)
 {
-   // check extension for special file types which are always visible
    core::FilePath filePath(fileInfo.absolutePath());
+
+   // Check to see if this is one of the extensions we always show
    std::string ext = filePath.getExtensionLowerCase();
+   core::json::Array exts = prefs::userPrefs().alwaysShownExtensions();
+   for (json::Value val: exts)
+   {
+      if (json::isType<std::string>(val))
+      {
+         if (ext == string_utils::toLower(val.getString()))
+         {
+            return true;
+         }
+      }
+   }
+
+   // Check to see if this is one of the files we always show
    std::string name = filePath.getFilename();
-   if (ext == ".r" ||
-       ext == ".rprofile" ||
-       ext == ".rbuildignore" ||
-       ext == ".rdata"    ||
-       ext == ".rhistory" ||
-       ext == ".ruserdata" ||
-       ext == ".renviron" ||
-       ext == ".httr-oauth" ||
-       ext == ".github" ||
-       ext == ".gitignore" ||
-       ext == ".gitattributes" ||
-       ext == ".circleci")
+   core::json::Array files = prefs::userPrefs().alwaysShownFiles();
+   for (json::Value val: files)
    {
-      return true;
+      if (json::isType<std::string>(val))
+      {
+         if (name == val.getString())
+         {
+            return true;
+         }
+      }
    }
-   else if (name == ".travis.yml")
-   {
-      return true;
-   }
-   else if (name == ".gitlab-ci.yml")
-   {
-      return true;
-   }
-   else if (name == ".build.yml")
-   {
-      return true;
-   }
-   else if (hideObjectFiles &&
+
+   if (hideObjectFiles &&
             (ext == ".o" || ext == ".so" || ext == ".dll") &&
             filePath.getParent().getFilename() == "src")
    {

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -247,6 +247,8 @@ namespace prefs {
 #define kShowRmdRenderCommand "show_rmd_render_command"
 #define kEnableTextDrag "enable_text_drag"
 #define kShowHiddenFiles "show_hidden_files"
+#define kAlwaysShownFiles "always_shown_files"
+#define kAlwaysShownExtensions "always_shown_extensions"
 #define kSortFileNamesNaturally "sort_file_names_naturally"
 #define kJobsTabVisibility "jobs_tab_visibility"
 #define kJobsTabVisibilityClosed "closed"
@@ -1229,6 +1231,18 @@ public:
     */
    bool showHiddenFiles();
    core::Error setShowHiddenFiles(bool val);
+
+   /**
+    * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+    */
+   core::json::Array alwaysShownFiles();
+   core::Error setAlwaysShownFiles(core::json::Array val);
+
+   /**
+    * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+    */
+   core::json::Array alwaysShownExtensions();
+   core::Error setAlwaysShownExtensions(core::json::Array val);
 
    /**
     * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1233,13 +1233,13 @@ public:
    core::Error setShowHiddenFiles(bool val);
 
    /**
-    * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+    * List of file names (case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
     */
    core::json::Array alwaysShownFiles();
    core::Error setAlwaysShownFiles(core::json::Array val);
 
    /**
-    * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+    * List of file extensions (beginning with ., not case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
     */
    core::json::Array alwaysShownExtensions();
    core::Error setAlwaysShownExtensions(core::json::Array val);

--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -329,6 +329,11 @@
 .rs.addFunction("readUserPref", .rs.readUiPref)
 
 .rs.addFunction("writeUiPref", function(prefName, value) {
+  # some preferences can take values that are lists of scalars; ensure the deserializer treats lists
+  # accordingly                 
+  if (is.list(value)) {
+     value <- .rs.scalarListFromList(value)
+  }
   .rs.writePrefInternal("rs_writeUserPref", prefName, value)
 })
 .rs.addFunction("writeUserPref", .rs.writeUiPref)

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1844,7 +1844,7 @@ core::Error UserPrefValues::setShowHiddenFiles(bool val)
 }
 
 /**
- * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+ * List of file names (case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
  */
 core::json::Array UserPrefValues::alwaysShownFiles()
 {
@@ -1857,7 +1857,7 @@ core::Error UserPrefValues::setAlwaysShownFiles(core::json::Array val)
 }
 
 /**
- * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+ * List of file extensions (beginning with ., not case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
  */
 core::json::Array UserPrefValues::alwaysShownExtensions()
 {

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1844,6 +1844,32 @@ core::Error UserPrefValues::setShowHiddenFiles(bool val)
 }
 
 /**
+ * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+ */
+core::json::Array UserPrefValues::alwaysShownFiles()
+{
+   return readPref<core::json::Array>("always_shown_files");
+}
+
+core::Error UserPrefValues::setAlwaysShownFiles(core::json::Array val)
+{
+   return writePref("always_shown_files", val);
+}
+
+/**
+ * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+ */
+core::json::Array UserPrefValues::alwaysShownExtensions()
+{
+   return readPref<core::json::Array>("always_shown_extensions");
+}
+
+core::Error UserPrefValues::setAlwaysShownExtensions(core::json::Array val)
+{
+   return writePref("always_shown_extensions", val);
+}
+
+/**
  * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R
  */
 bool UserPrefValues::sortFileNamesNaturally()
@@ -3013,6 +3039,8 @@ std::vector<std::string> UserPrefValues::allKeys()
       kShowRmdRenderCommand,
       kEnableTextDrag,
       kShowHiddenFiles,
+      kAlwaysShownFiles,
+      kAlwaysShownExtensions,
       kSortFileNamesNaturally,
       kJobsTabVisibility,
       kShowLauncherJobsTab,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -945,7 +945,7 @@
         },
         "always_shown_files": {
             "type": "array",
-            "description": "List of files that are always shown in the Files Pane, regardless of whether hidden files are shown",
+            "description": "List of file names (case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown",
             "title": "Files always shown in the Files Pane",
             "items": {
                 "type": "string"
@@ -958,7 +958,7 @@
         },
         "always_shown_extensions": {
             "type": "array",
-            "description": "List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown",
+            "description": "List of file extensions (beginning with ., not case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown",
             "title": "Extensions always shown in the Files Pane",
             "items": {
                 "type": "string"

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -919,7 +919,7 @@
             "title": "Terminal tab rendering engine",
             "description": "Terminal rendering engine: canvas is faster, dom may be needed for some browsers or graphics cards"
         },
-         "terminal_weblinks": {
+        "terminal_weblinks": {
             "type": "boolean",
             "default": true,
             "title": "Make links in Terminal clickable",
@@ -942,6 +942,42 @@
             "default": false,
             "title": "Show hidden files in Files pane",
             "description": "Whether to show hidden files in the Files pane."
+        },
+        "always_shown_files": {
+            "type": "array",
+            "description": "List of files that are always shown in the Files Pane, regardless of whether hidden files are shown",
+            "title": "Files always shown in the Files Pane",
+            "items": {
+                "type": "string"
+            },
+            "default": [
+                ".build.yml",
+                ".gitlab-ci.yml",
+                ".travis.yml"
+            ]
+        },
+        "always_shown_extensions": {
+            "type": "array",
+            "description": "List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown",
+            "title": "Extensions always shown in the Files Pane",
+            "items": {
+                "type": "string"
+            },
+            "default": [
+                ".circleci",
+                ".gitattributes",
+                ".github",
+                ".gitignore",
+                ".httr-oauth",
+                ".r",
+                ".rbuildignore",
+                ".rdata"   ,
+                ".renvignore",
+                ".renviron",
+                ".rhistory",
+                ".rprofile",
+                ".ruserdata"
+            ]
         },
         "sort_file_names_naturally": {
             "type": "boolean",

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -16,6 +16,12 @@
 context("environment")
 
 test_that("environment object listings are correct", {
+
+   # temporarily disable showing the .Last.value so we don't have to account for it in test results
+   lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
+   on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue))
+   .rs.api.writeRStudioPreference("show_last_dot_value", FALSE)
+
    # our test-runner sets runAllTests function in the global environment, so initial
    # length is one
    .rs.invokeRpc("set_environment", "R_GlobalEnv")
@@ -48,6 +54,12 @@ test_that("flag must be specified when removing objects", {
 })
 
 test_that("all objects are removed when requested", {
+
+   # temporarily disable showing the .Last.value so we don't have to account for it in test results
+   lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
+   on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue))
+   .rs.api.writeRStudioPreference("show_last_dot_value", FALSE)
+
    contents <- .rs.invokeRpc("list_environment")
    expect_true(length(contents) > 0)
 

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -1,0 +1,74 @@
+#
+# test-files.R
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("files")
+
+test_that("file listings are correct", {
+
+  # Create temporary directory to host a directory listing
+  testdir <- tempdir()
+  on.exit(unlink(testdir, recursive = TRUE), add = TRUE)
+
+  # Read old pref values
+  alwaysShownFiles <- .rs.api.readRStudioPreference("always_shown_files")
+  on.exit(.rs.api.writeRStudioPreference("always_shown_files", as.list(alwaysShownFiles)))
+  alwaysShownExts <- .rs.api.readRStudioPreference("always_shown_extensions")
+  on.exit(.rs.api.writeRStudioPreference("always_shown_extensions", as.list(alwaysShownExts)))
+
+  # Prepare dummy set of files
+  files <- c(
+    ".shown",
+    ".hidden",
+    ".shown.yml",
+    ".also.shown.yml",
+    ".hidden.yml",
+    "normal.R",
+    "data.csv")
+  for (f in files) {
+    writeLines(text = "", con = file.path(testdir, f))
+  }
+
+  # Set up preferences
+  .rs.api.writeRStudioPreference("always_shown_files", list(
+    ".shown.yml",
+    ".also.shown.yml"
+  ))
+  .rs.api.writeRStudioPreference("always_shown_extensions", list(
+    ".shown"
+   ))
+
+  # Perform a file listing on the directory
+  listing <- .rs.invokeRpc("list_files",
+                testdir, # Dir to list
+                FALSE,   # Monitor listing
+                FALSE    # Show hidden files
+  )
+
+  # Extract the filenames that were returned
+  filenames <- unlist(lapply(listing$files, function(f) {
+    basename(f$path)
+  }))
+
+  # Check to ensure that we got what we expected
+  expect_equal(sort(filenames), c(
+    ".also.shown.yml",  # An always shown file
+    ".shown",           # An always shown extension
+    ".shown.yml",       # An always shown file
+    "data.csv",         # A regular file
+    "normal.R"          # A regular file
+  ))
+
+})
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1983,6 +1983,30 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+    */
+   public PrefValue<JsArrayString> alwaysShownFiles()
+   {
+      return object(
+         "always_shown_files",
+         "Files always shown in the Files Pane", 
+         "List of files that are always shown in the Files Pane, regardless of whether hidden files are shown", 
+         JsArrayUtil.createStringArray(".build.yml", ".gitlab-ci.yml", ".travis.yml"));
+   }
+
+   /**
+    * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+    */
+   public PrefValue<JsArrayString> alwaysShownExtensions()
+   {
+      return object(
+         "always_shown_extensions",
+         "Extensions always shown in the Files Pane", 
+         "List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown", 
+         JsArrayUtil.createStringArray(".circleci", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
+   }
+
+   /**
     * Whether to sort file names naturally, so that e.g., file10.R comes after file9.R
     */
    public PrefValue<Boolean> sortFileNamesNaturally()
@@ -3393,6 +3417,10 @@ public class UserPrefsAccessor extends Prefs
          enableTextDrag().setValue(layer, source.getBool("enable_text_drag"));
       if (source.hasKey("show_hidden_files"))
          showHiddenFiles().setValue(layer, source.getBool("show_hidden_files"));
+      if (source.hasKey("always_shown_files"))
+         alwaysShownFiles().setValue(layer, source.getObject("always_shown_files"));
+      if (source.hasKey("always_shown_extensions"))
+         alwaysShownExtensions().setValue(layer, source.getObject("always_shown_extensions"));
       if (source.hasKey("sort_file_names_naturally"))
          sortFileNamesNaturally().setValue(layer, source.getBool("sort_file_names_naturally"));
       if (source.hasKey("jobs_tab_visibility"))
@@ -3695,6 +3723,8 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(showRmdRenderCommand());
       prefs.add(enableTextDrag());
       prefs.add(showHiddenFiles());
+      prefs.add(alwaysShownFiles());
+      prefs.add(alwaysShownExtensions());
       prefs.add(sortFileNamesNaturally());
       prefs.add(jobsTabVisibility());
       prefs.add(showLauncherJobsTab());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1983,26 +1983,26 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * List of files that are always shown in the Files Pane, regardless of whether hidden files are shown
+    * List of file names (case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
     */
    public PrefValue<JsArrayString> alwaysShownFiles()
    {
       return object(
          "always_shown_files",
          "Files always shown in the Files Pane", 
-         "List of files that are always shown in the Files Pane, regardless of whether hidden files are shown", 
+         "List of file names (case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown", 
          JsArrayUtil.createStringArray(".build.yml", ".gitlab-ci.yml", ".travis.yml"));
    }
 
    /**
-    * List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown
+    * List of file extensions (beginning with ., not case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown
     */
    public PrefValue<JsArrayString> alwaysShownExtensions()
    {
       return object(
          "always_shown_extensions",
          "Extensions always shown in the Files Pane", 
-         "List of extensions that are always shown in the Files Pane, regardless of whether hidden files are shown", 
+         "List of file extensions (beginning with ., not case sensitive) that are always shown in the Files Pane, regardless of whether hidden files are shown", 
          JsArrayUtil.createStringArray(".circleci", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8658, in which the file `.renvignore` needs to be shown in the Files pane (it is currently hidden). 

### Approach

Technically we could have just added this to our growing hard-coded whitelist, but this change adds a little more flexibility. The list of files we always show and extensions we always show is now configurable (only via config files). This makes it possible for users or administrators to force specific files to show up in the Files pane. 

It is also now possible via configuration to make the Files pane just show all hidden files or none of them by using empty option values. In this way, it addresses https://github.com/rstudio/rstudio/issues/3221.

Of course we could have gone even further and added additional prefs/UI to make such configuration possible by ordinary users, but wanted to keep this scoped for Juliet Rose.

### Automated Tests

This change includes a unit test that ensures the new preferences are respected. It also has a few minor unit test improvements in other files (in particular the `show_last_dot_value` pref could make some unit tests fail; now it can't).

### QA Notes

Aside from checking to ensure `.renvignore` files now appear in the Files pane, test to ensure that you can use the prefs to control which files are shown. For example, to enable the behavior requested in #3221, add this to `rstudio-prefs.json`:

```json
{
  "always_shown_extensions": [],
  "always_shown_files": []
}
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


