### PR TITLE
fix issue with "close all others" context menu sometimes closing everything

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1480,8 +1480,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       {
          final CPSEditingTargetCommand command = (EditingTarget target, Command continuation) ->
          {
-            if (!StringUtil.isNullOrEmpty(excludeDocId) &&
-               (target == activeColumn_.getDoc(excludeDocId) || target == column.getDoc(excludeDocId)))
+            if (!StringUtil.isNullOrEmpty(excludeDocId) && target == column.getDoc(excludeDocId))
             {
                continuation.execute();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1480,7 +1480,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       {
          final CPSEditingTargetCommand command = (EditingTarget target, Command continuation) ->
          {
-            if (!StringUtil.isNullOrEmpty(excludeDocId) && target == activeColumn_.getDoc(excludeDocId))
+            if (!StringUtil.isNullOrEmpty(excludeDocId) &&
+               (target == activeColumn_.getDoc(excludeDocId) || target == column.getDoc(excludeDocId)))
             {
                continuation.execute();
             }


### PR DESCRIPTION
### Intent

- Addresses #8855
- Bug was triggered when last document (i.e. document that last had focus) was in different source column than the document whose tab context menu was used to invoke "close all others"

### Approach

- As code looped through the columns and editors, the check to see if a given document was the one that wanted to stay open only worked if that document was in the same source column as the last active document
- We already passed in the column containing the given tab, so use it for the test in addition to the "active column" (note, I'm not 100% sure we need to do both, but taking the lowest risk approach here)

### Automated Tests

- https://github.com/rstudio/rstudio-ide-automation/issues/178

### QA Notes

- Try various combinations of opening multiple documents in multiple source columns, then right-clicking on tab and using "Close All Others" command
- Try clicking on the active document, on an inactive document in the same column, and on an inactive document in a different source column (and whatever other combos come to mind)
- Be sure everything closes except the one you clicked on, and you are prompted if any of the files have unsaved modifications

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


