### PR TITLE
avoid continuing comment after Markdown header

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,4 +74,4 @@ RStudio Server Pro has been renamed to RStudio Workbench to more accurately refl
 * Add 'whole word' filter to Find in Files. (#8594)
 * Fixed issue where empty panes would remain open and pop open unexpectedly (#8460)
 * Fixed an issue where the Kubernetes Launcher could hang in Azure Kubernetes Service (AKS) environments by lowering the watch-timeout-seconds parameter default down to 3 minutes instead of 5 (Pro #2312)
-
+* Fixed issue where 'continue comment on newline' would treat Markdown headers as comments (#6421)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -7616,7 +7616,7 @@ public class TextEditingTarget implements
    private boolean isCursorInRMode(DocDisplay display)
    {
       TextFileType type = display.getFileType();
-      if (type instanceof TexFileType)
+      if (type != null && type instanceof TexFileType)
          return false;
       
       String mode = display.getLanguageMode(display.getCursorPosition());


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6421.

### Approach

When choosing whether we should continue a comment on a newline, we validate that the associated line is made up of only whitespace and comments. This catches the case where our comment pattern might match something (ie, a Markdown header) which isn't truly tokenized as a comment.

### Automated Tests

https://github.com/rstudio/rstudio-ide-automation/issues/181

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6421 -- this PR should be low risk.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
