### PR TITLE
Use active Python version when knitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Improved handling of unicode input on Windows (#8549)
 * Fixed issue where inspecting a null Python object would cause emit errors to console (#8185)
 * Detect active Python version when publishing content (#8636)
+* Use active Python version when knitting R Markdown files (#8854)
 
 ### RStudio Server
 

--- a/src/cpp/session/modules/SessionRSConnect.R
+++ b/src/cpp/session/modules/SessionRSConnect.R
@@ -431,49 +431,6 @@
     dir_size = .rs.scalar(dirlist$totalSize))
 })
 
-# Attempts to infer the current Python interpreter used by reticulate
-.rs.addFunction("inferReticulatePython", function() {
-   # Use existing RETICULATE_PYTHON if set
-   env_value <- Sys.getenv("RETICULATE_PYTHON")
-   if (nzchar(env_value)) {
-      return(env_value)
-   }
-
-   # If the reticulate package is installed, we can ask it what it's using
-   if (.rs.isPackageInstalled("reticulate")) {
-      if (reticulate::py_available(initialize = FALSE)) {
-         # Python is available/initialized; use it
-         py_config <- reticulate::py_config()
-         if (!is.null(py_config) && !is.null(py_config$python)) {
-            return(py_config$python)
-         }
-      } 
-
-      # Couldn't find initialized Python; attempt to discover it
-
-      # First, turn off Miniconda support in reticulate so that it doesn't 
-      # prompt the user to install it during Python version discovery
-      prev_miniconda <- Sys.getenv("RETICULATE_MINICONDA_ENABLED")
-      Sys.setenv(RETICULATE_MINICONDA_ENABLED = "FALSE")
-
-      # Then perform a Python version scan/discovery
-      py_config <- NULL
-      tryCatch({
-         py_config <- reticulate::py_discover_config()
-      }, finally = {
-         Sys.setenv(RETICULATE_MINICONDA_ENABLED = prev_miniconda)
-      })
-
-      # Return a Python binary if we found one
-      if (!is.null(py_config) && !is.null(py_config$python)) {
-         return(py_config$python)
-      }
-   }
-
-   # We didn't find any indication of the python version
-   ""
-})
-
 .rs.addFunction("enableRStudioConnectUI", function(enable) {
   .rs.enqueClientEvent("enable_rstudio_connect", enable);
   message("RStudio Connect UI ", if (enable) "enabled" else "disabled", ".")

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1996,3 +1996,45 @@ options(reticulate.repl.teardown = function()
    .rs.reticulate.replTeardown()
 })
 
+# Attempts to infer the current Python interpreter used by reticulate
+.rs.addFunction("inferReticulatePython", function() {
+   # Use existing RETICULATE_PYTHON if set
+   env_value <- Sys.getenv("RETICULATE_PYTHON")
+   if (nzchar(env_value)) {
+      return(env_value)
+   }
+
+   # If the reticulate package is installed, we can ask it what it's using
+   if (.rs.isPackageInstalled("reticulate")) {
+      if (reticulate::py_available(initialize = FALSE)) {
+         # Python is available/initialized; use it
+         py_config <- reticulate::py_config()
+         if (!is.null(py_config) && !is.null(py_config$python)) {
+            return(py_config$python)
+         }
+      } 
+
+      # Couldn't find initialized Python; attempt to discover it
+
+      # First, turn off Miniconda support in reticulate so that it doesn't 
+      # prompt the user to install it during Python version discovery
+      prev_miniconda <- Sys.getenv("RETICULATE_MINICONDA_ENABLED")
+      Sys.setenv(RETICULATE_MINICONDA_ENABLED = "FALSE")
+
+      # Then perform a Python version scan/discovery
+      py_config <- NULL
+      tryCatch({
+         py_config <- reticulate::py_discover_config()
+      }, finally = {
+         Sys.setenv(RETICULATE_MINICONDA_ENABLED = prev_miniconda)
+      })
+
+      # Return a Python binary if we found one
+      if (!is.null(py_config) && !is.null(py_config$python)) {
+         return(py_config$python)
+      }
+   }
+
+   # We didn't find any indication of the python version
+   ""
+})

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -565,6 +565,18 @@ private:
       // set the not cran env var
       environment.push_back(std::make_pair("NOT_CRAN", "true"));
 
+      // pass along the current Python environment, if any
+      std::string reticulatePython;
+      error = r::exec::RFunction(".rs.inferReticulatePython").call(&reticulatePython);
+      if (error) {
+         LOG_ERROR(error);
+      }
+      if (!reticulatePython.empty())
+      {
+         // we found a Python version; forward it
+         environment.push_back(std::make_pair("RETICULATE_PYTHON", reticulatePython));
+      }
+
       // render unless we were handed an existing output file
       allOutput_.clear();
       if (existingOutputFile.empty())

--- a/src/cpp/tests/testthat/test-reticulate.R
+++ b/src/cpp/tests/testthat/test-reticulate.R
@@ -1,0 +1,32 @@
+#
+# test-reticulate.R
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("reticulate")
+
+test_that("RETICULATE_PYTHON environment variable is respected", {
+   # save old value and set a dummy value
+   oldPython <- Sys.getenv("RETICULATE_PYTHON")
+   Sys.setenv(RETICULATE_PYTHON = "/opt/testthat/python")
+   on.exit({
+      # restore old value
+      Sys.setenv(RETICULATE_PYTHON = oldPython)
+   }, add = TRUE)
+
+   # perform autodiscovery
+   python <- .rs.inferReticulatePython()
+
+   # we expect that since we set a custom value it'll be reflected
+   expect_equal(python, Sys.getenv("RETICULATE_PYTHON"))
+})

--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -49,19 +49,3 @@ test_that("setting UI prefs updates options", {
    .rs.writeUiPref("use_publish_ca_bundle", FALSE)
    expect_null(getOption("rsconnect.ca.bundle"))
 })
-
-test_that("RETICULATE_PYTHON environment variable is respected", {
-   # save old value and set a dummy value
-   oldPython <- Sys.getenv("RETICULATE_PYTHON")
-   Sys.setenv(RETICULATE_PYTHON = "/opt/testthat/python")
-   on.exit({
-      # restore old value
-      Sys.setenv(RETICULATE_PYTHON = oldPython)
-   }, add = TRUE)
-
-   # perform autodiscovery
-   python <- .rs.inferReticulatePython()
-
-   # we expect that since we set a custom value it'll be reflected
-   expect_equal(python, Sys.getenv("RETICULATE_PYTHON"))
-})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8854, in which reticulated R Markdown files don't inherit the active Python version when knitting. 

### Approach

As we do for published content (#8636), detect the active Python version and pass it as the environment variable `RETICULATE_PYTHON` to the clean R session that performs the knit.

### Automated Tests

No new tests, but this is a thin wrapper on an existing Python detection mechanism that does have a test. For clarity, this test and the underlying method have been moved the the Reticulate module (formerly was in the publish codepath which was kind of a weird spot for something that's now shared). 

### QA Notes

Test via notes in #8854. Try switching Python versions (in Global Options or Project Options) and re-knitting to see changes.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests




