### PR TITLE
provide APIs for accessing different dictionary paths

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -961,11 +961,19 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 })
 
 .rs.addApiFunction("dictionariesPath", function() {
-   .Call("rs_dictionariesPath", PACKAGE = "(embedding)")
+   .Call("rs_dictionariesPath", "bundled", PACKAGE = "(embedding)")
+})
+
+.rs.addApiFunction("bundledDictionariesPath", function() {
+   .Call("rs_dictionariesPath", "bundled", PACKAGE = "(embedding)")
+})
+
+.rs.addApiFunction("extraDictionariesPath", function() {
+   .Call("rs_dictionariesPath", "extra", PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("userDictionariesPath", function() {
-   .Call("rs_userDictionariesPath", PACKAGE = "(embedding)")
+   .Call("rs_dictionariesPath", "user", PACKAGE = "(embedding)")
 })
 
 # translate a local URL into an externally accessible URL on RStudio Server

--- a/src/cpp/session/modules/SessionSpelling.hpp
+++ b/src/cpp/session/modules/SessionSpelling.hpp
@@ -21,6 +21,7 @@
 namespace rstudio {
 namespace core {
    class Error;
+   class FilePath;
 }
 }
  
@@ -28,6 +29,12 @@ namespace rstudio {
 namespace session {
 namespace modules { 
 namespace spelling {
+
+core::FilePath userDictionariesDir();
+core::FilePath legacyAllLanguagesDir();
+core::FilePath allDictionariesDir();
+core::FilePath allLanguagesDir();
+core::FilePath customDictionariesDir();
 
 core::json::Object spellingPrefsContextAsJson();
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/7658.

### Approach

See comments in https://github.com/rstudio/rstudio/issues/7658#issuecomment-774334584. This PR hence provides 3 new APIs:

- `.rs.api.bundledDictionariesPath()`: The path to the dictionaries bundled with RStudio.
- `.rs.api.extraDictionariesPath()`: The location where updated versions of the bundled dictionaries would be downloaded.
- `.rs.api.userDictionariesPath()`: The location where user-specific dictionaries should be placed.

I'm also not a fan of the name `.rs.api.extraDictionariesPath()`; let me know if you can think of more appropriate name. (`allDictionariesPath()` also doesn't feel quite right)

### Automated Tests

None yet.

### QA Notes

Not sure if this requires QA verification? 

### Checklist

NOTE: intentionally not adding NEWS; updates would be made visible as part of updates in `rstudioapi` later.

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
