### PR TITLE
use consistent escaping scheme for R string literals on front-end

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/RUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/RUtil.java
@@ -1,0 +1,32 @@
+/*
+ * RUtil.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client;
+
+public class RUtil
+{
+   // Given some text, enquote and escape it so that it can be safely submitted
+   // as an R string. For example, an input
+   //
+   //    Hello \ "World"!
+   //
+   // would be escaped as:
+   //
+   //    "Hello \\ \"World\"!"
+   //
+   public static String asStringLiteral(String text)
+   {
+      return "\"" + text.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+   }
+}


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6004.

### Approach

Define and use a helper function for submitting something as an R string literal.

### Automated Tests

None yet; this is easily testable on the GWT side so I'll add those.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6004 -- in particular, confirm from the main menu that `Session -> Set Working Directory -> ...` works as expected for paths containing quotes.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

