### PR TITLE
Remove self-assignment test (compiler warning)

### DIFF
--- a/src/cpp/shared_core/json/JsonTests.cpp
+++ b/src/cpp/shared_core/json/JsonTests.cpp
@@ -455,14 +455,6 @@ TEST_CASE("Json")
       REQUIRE(arr.getSize() == 0);
    }
 
-   SECTION("Test self assignment")
-   {
-      json::Value val = createValue();
-      val = val;
-
-      REQUIRE(val.getObject()["a"].getBool());
-   }
-
    SECTION("Unicode string test")
    {
       std::string jsonStr = "{\"a\": \"的中文翻譯 | 英漢字典\"}";


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8891.

### Approach

This code generates a noisy compiler warning. As far as I can tell, it is not needed since any self-assignment that would cause a bug would also trigger the same warning. 

### Automated Tests

This change removes an automated test that generates a compiler warning.

### QA Notes

No product change; QA not needed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

