### PR TITLE
adapt to changes in testthat 3.0.0

### DIFF
--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -1,17 +1,22 @@
 library(testthat)
 
-runAllTests <- function(sourceDir, outputDir, filter = NA)
+runAllTests <- function(sourceDir, outputDir, filter = NULL)
 {
-   testThatDir <- file.path(sourceDir, "tests/testthat")
+   # get path to testthat tests
+   testsRoot <- file.path(sourceDir, "tests/testthat")
    
-   if (!is.na(filter))
-   {
-      tests <- testthat::test_dir(testThatDir, filter = filter)
-   } 
-   else
-   {
-      tests <- testthat::test_dir(testThatDir)
-   }
+   # run tests
+   results <- testthat::test_dir(
+      path = testsRoot,
+      filter = filter,
+      stop_on_failure = FALSE,
+      stop_on_warning = FALSE
+   )
    
-   cat(sum(as.data.frame(tests)$failed), file = file.path(outputDir, "testthat-failures.log"))
+   # compute number of failures
+   df <- as.data.frame(results)
+   failures <- sum(df$failed)
+   
+   # write to file
+   cat(failures, file = file.path(outputDir, "testthat-failures.log"))
 }


### PR DESCRIPTION
### Intent

In the latest versions of testthat, the `test_dir()` function now emits an R error if any tests fail. Fortunately, this behavior can be configured.

### Approach

Set `stop_on_failure` to `FALSE`, as we don't want an R error emitted in that case.

### Automated Tests

Developer only change.

### QA Notes

None.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
