### PR TITLE
Account for nested code chunks when scrolling visual editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -65,6 +65,7 @@
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
 * The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)
+* Fixed issue causing the document to scroll unpredictably when a code chunk inside a list item is executed in the visual editor (#8883)
 * Fixed issue preventing R Notebook chunks from being queued for execution if they had never been previously run (#4238)
 * Fix various issues when the "Limit Console Output" performance setting was enabled, and enable it by default (#8544, #8504, #8529, #8552)
 * Fix display of condition messages (errors and warnings) in some character encodings (#8546)

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -418,10 +418,24 @@ export class AceNodeView implements NodeView {
       const container = this.view.nodeDOM(editingRoot.pos) as HTMLElement;
       const scroller = zenscroll.createScroller(container);
 
+      let top = 0;
+
+      // The DOM node representing this editor chunk (this.dom) may not be a
+      // direct child of the scrollable container. If it isn't, walk up the DOM
+      // tree until we find the main content node (pm-content), which is the
+      // offset parent against which we need to compute scroll position.
+      let scrollParent = this.dom;
+      while (scrollParent.offsetParent != null &&
+             !scrollParent.offsetParent.classList.contains("pm-content"))
+      {
+        top += scrollParent.offsetTop;
+        scrollParent = scrollParent.offsetParent as HTMLElement;
+      }
+
       // Since the element we want to scroll into view is not a direct child of
       // the scrollable container, do a little math to figure out the
       // destination scroll position.
-      const top = ele.offsetTop + this.dom.offsetTop;
+      top += ele.offsetTop + scrollParent.offsetTop;
       const bottom = top + ele.offsetHeight;
       const viewTop = container.scrollTop;
       const viewBottom = container.scrollTop + container.offsetHeight;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8883, in which executing a code chunk that is nested inside a list item can cause the visual editor to scroll up unpredictably (often to the very top of the document). 

The underlying issue is that the math that computes scrolling offsets (used to ensure that at least some of the code chunk output is visible after it runs) does not account for the fact that the parent of the code chunk might not be the document.

### Approach

Before scrolling, walk up the DOM tree until we find the `pm-content` element, which represents the content that will ultimately be scrolled. 

### Automated Tests

There is currently no automation support for the visual editor. See https://github.com/rstudio/rstudio-ide-automation/issues/106.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8883. This reproduces reliably with chunks inside a list. Note that the math which determines where to scroll to view the output still doesn't feel great in my testing. That'd be nice to fix but this change does not do so. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


