### PR TITLE
Emit addin path where error occurred

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 * Option to restore RStudio 1.2 tab key behavior in editor find panel; search in Command Palette for "Tab key behavior in find panel matches RStudio 1.2 and earlier" (#7295)
 * Show `.renvignore` in Files pane (#8658)
 * Make the set of always-shown files and extensions in the Files pane configurable (#3221)
+* Log location of addins that raise parse errors at startup (#8012)
 
 ### Bugfixes
 

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -236,7 +236,7 @@ public:
 
          for (; it != end; ++it)
          {
-            std::map<std::string, std::string> fields = parseAddinDcf(*it);
+            std::map<std::string, std::string> fields = parseAddinDcf(addinPath, *it);
             add(pkgName, fields);
          }
       }
@@ -270,6 +270,7 @@ public:
 private:
    
    static std::map<std::string, std::string> parseAddinDcf(
+                                          const FilePath& addinPath,
                                           const std::string& contents)
    {
       // read and parse the DCF file
@@ -277,7 +278,10 @@ private:
       std::string errMsg;
       Error error = text::parseDcfFile(contents, true, &fields, &errMsg);
       if (error)
+      {
+         error.addProperty("path", addinPath.getAbsolutePath());
          LOG_ERROR(error);
+      }
 
       return fields;
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8012, in which malformed R addins cause hard-to-diagnose errors at startup. 

### Approach

Log the path to the addin that raised the parse error.

Note that #8012 also suggested that we log the path for a tutorial error, but that was already addressed by https://github.com/rstudio/rstudio/commit/0d075310a5350c4a083ec90e5599f672a7072a37.

### Automated Tests

This is an upgrade to a log message, which doesn't warrant a test.

### QA Notes

Test via notes in #8012.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


