### PR TITLE
Baseline align language selector

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -219,6 +219,9 @@ public class EnvironmentPane extends WorkbenchPane
             (ImageResource) null,
             languageMenu_);
 
+      // nudge language selector up to baseline align with environment selector
+      languageButton_.getElement().getStyle().setMarginTop(-4, Unit.PX);
+
       toolbar.addLeftWidget(languageButton_);
       toolbar.addLeftSeparator();
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8769, in which the secondary toolbar in the Environment pane is a little out of alignment.

### Approach

Nudge it with CSS. Now it lines up:

![image](https://user-images.githubusercontent.com/470418/107432627-1a825d80-6add-11eb-9990-c8141bfac9cf.png)

### Automated Tests

Style-only change, no change to logic.

### QA Notes

Ensure that these elements align real nice now.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


