### PR TITLE
Graceful resize for Environment pane toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -2278,6 +2278,7 @@ body.ubuntu_mono .searchBox {
 
 .logoAnchor {
    top: 12px;
+   z-index: 1;
 }
 
 .rstudio-themes-flat .logoAnchor {

--- a/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/Toolbar.java
@@ -22,9 +22,15 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Style.Overflow;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.logical.shared.HasResizeHandlers;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
+import com.google.gwt.event.shared.HandlerManager;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.*;
 import com.google.gwt.user.client.ui.HasVerticalAlignment.VerticalAlignmentConstant;
 
+import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.SeparatorManager;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -32,8 +38,9 @@ import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 
 import java.util.AbstractList;
+import java.util.List;
 
-public class Toolbar extends Composite
+public class Toolbar extends ResizeComposite implements HasResizeHandlers
 {
    private static class ChildWidgetList extends AbstractList<Widget>
    {
@@ -210,7 +217,7 @@ public class Toolbar extends Composite
    {
       super();
 
-      toolbarWrapper_ = new HTMLPanel("");
+      toolbarWrapper_ = new SimpleLayoutPanel();
 
       Roles.getToolbarRole().set(toolbarWrapper_.getElement());
       Roles.getToolbarRole().setAriaLabelProperty(toolbarWrapper_.getElement(), label);
@@ -404,6 +411,18 @@ public class Toolbar extends Composite
    }
 
    @Override
+   public void onResize()
+   {
+      ResizeEvent.fire(this, getOffsetWidth(), getHeight());
+   }
+
+   @Override
+   public HandlerRegistration addResizeHandler(ResizeHandler handler)
+   {
+      return handlers_.addHandler(ResizeEvent.getType(), handler);
+   }
+
+   @Override
    public void addStyleName(String styleName)
    {
       horizontalPanel_.addStyleName(styleName);
@@ -460,7 +479,8 @@ public class Toolbar extends Composite
    private HorizontalPanel horizontalPanel_;
    private HorizontalPanel leftToolbarPanel_;
    private HorizontalPanel rightToolbarPanel_;
-   private HTMLPanel toolbarWrapper_;
+   private SimpleLayoutPanel toolbarWrapper_;
+   private final HandlerManager handlers_ = new HandlerManager(this);
    protected final ThemeStyles styles_ = ThemeResources.INSTANCE.themeStyles();
    private boolean separatorsInvalidated_ = false;
 

--- a/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ToolbarButton.java
@@ -293,7 +293,12 @@ public class ToolbarButton extends FocusWidget
          addStyleName(styles_.noLabel());
       }
    }
-   
+
+   public boolean hasLabel()
+   {
+      return !getStyleName().contains(styles_.noLabel());
+   }
+
    public void setInfoText(String infoText)
    {
       if (!StringUtil.isNullOrEmpty(infoText))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -444,7 +444,9 @@ public class EnvironmentPane extends WorkbenchPane
    @Override
    public void setObjectDisplayType(int type)
    {
-      viewButton_.setText(nameOfViewType(type));
+      // Adjust the List/Grid text label, but only if that text label is shown (it can be hidden
+      // when the Environment pane is very narrow)
+      viewButton_.setText(viewButton_.hasLabel(), nameOfViewType(type));
       viewButton_.setLeftImage(imageOfViewType(type));
       objects_.setObjectDisplay(type);
    }
@@ -881,29 +883,43 @@ public class EnvironmentPane extends WorkbenchPane
       Scheduler.get().scheduleDeferred(() -> commands_.refreshEnvironment().execute());
    }
 
+   /**
+    * Manages the size of the Environment pane's toolbar, reducing the width of elements
+    * so all the controls are visible and usable even at narrow widths.
+    *
+    * @param width The new width of the Environment pane
+    */
    private void manageToolbarSizes(int width)
    {
+      // At startup, we get a resize event with 0 width; ignore this.
       if (width == 0)
       {
          return;
       }
 
+      // The View button has text by default
+      viewButton_.setText(true, viewButton_.getText());
+
       if (width > 400)
       {
+         // Full width: show full label for data import
          dataImportButton_.setText("Import Dataset");
       }
       else if (width > 350)
       {
+         // Reduced width: shorten label
          dataImportButton_.setText("Import");
       }
-      else if (width > 300)
+      else if (width > 325)
       {
+         // Even more reduced width: shorten label more
          dataImportButton_.setText("");
       }
       else
       {
+         // Extremely narrow: no labels at all, just buttons
          dataImportButton_.setText("");
-         viewButton_.setText("");
+         viewButton_.setText(false, viewButton_.getText());
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -18,6 +18,8 @@ package org.rstudio.studio.client.workbench.views.environment;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.DebugFilePosition;
 import org.rstudio.core.client.ElementIds;
@@ -200,6 +202,14 @@ public class EnvironmentPane extends WorkbenchPane
       SecondaryToolbar toolbar = new SecondaryToolbar("Environment Tab Second");
 
       languageMenu_ = new ToolbarPopupMenu();
+      toolbar.addHandler(new ResizeHandler()
+      {
+         @Override
+         public void onResize(ResizeEvent event)
+         {
+            manageToolbarSizes(event.getWidth());
+         }
+      }, ResizeEvent.getType());
 
       MenuItem rMenuItem = new MenuItem("R", () -> setActiveLanguage("R", true));
       languageMenu_.addItem(rMenuItem);
@@ -869,6 +879,32 @@ public class EnvironmentPane extends WorkbenchPane
       }
 
       Scheduler.get().scheduleDeferred(() -> commands_.refreshEnvironment().execute());
+   }
+
+   private void manageToolbarSizes(int width)
+   {
+      if (width == 0)
+      {
+         return;
+      }
+
+      if (width > 400)
+      {
+         dataImportButton_.setText("Import Dataset");
+      }
+      else if (width > 350)
+      {
+         dataImportButton_.setText("Import");
+      }
+      else if (width > 300)
+      {
+         dataImportButton_.setText("");
+      }
+      else
+      {
+         dataImportButton_.setText("");
+         viewButton_.setText("");
+      }
    }
 
    public String getActiveLanguage()


### PR DESCRIPTION
### Intent

This change makes the Environment pane respond gracefully to resizes, even at very narrow widths. Addresses https://github.com/rstudio/rstudio/issues/8959. 

### Approach

The Environment pane now has a number of width breakpoints. At full width, it looks like it does today:

![image](https://user-images.githubusercontent.com/470418/107805939-f14f1080-6d1a-11eb-97fe-2e6c516e957e.png)

When it gets cramped, `Import Dataset` becomes simply `Import`.

![image](https://user-images.githubusercontent.com/470418/107806189-599df200-6d1b-11eb-9512-13303ac8ff9f.png)

At even narrower widths, the `Import` button loses its label entirely:

![image](https://user-images.githubusercontent.com/470418/107806287-79cdb100-6d1b-11eb-87c1-14a56f07f95a.png)

And at the most constrained, there's only one label; everything else is just buttons.

![image](https://user-images.githubusercontent.com/470418/107806366-9d90f700-6d1b-11eb-82fa-94f1c1d9eab2.png)

As a bonus, toolbars now emit resize events, making it easier to add graceful resize to other toolbars.

### Automated Tests

This change is purely visual (no impact on functionality or logic) and does not deserve automated testing.

### QA Notes

Check that the toolbar shrinks as advertised above, and grows correctly in the opposite direction. 

No NEWS entry since this is largely being done to address a shortcoming introduced in Juliet Rose, though it is now improved over Wax Begonia.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

