### PR TITLE
Fix segfault occuring when shutting down the async server in a small amount of cases

### DIFF
--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -385,6 +385,9 @@ private:
    
    void handleAccept(const boost::system::error_code& ec)
    {
+      if (ec == boost::asio::error::operation_aborted)
+         return;
+
       try
       {
          if (!ec) 
@@ -395,11 +398,9 @@ private:
          }
          else
          {
-            // for errors, log and continue (but don't log operation aborted
-            // or bad file descriptor since it happens in the ordinary course
-            // of shutting down the server)
-            if (ec != boost::asio::error::operation_aborted &&
-                ec != boost::asio::error::bad_descriptor)
+            // for errors, log and continue (but don't log bad file descriptor
+            // since it happens in the ordinary course of shutting down the server)
+            if (ec != boost::asio::error::bad_descriptor)
             {
                // log the error
                LOG_ERROR(Error(ec, ERROR_LOCATION));


### PR DESCRIPTION



### Intent

Fixes a rare crash when stopping the async http server.

### Approach

This appears to be caused by attempting to accept a TCP/IP connection after we have already stopped the acceptor service. The fix is to NOT attempt to accept more connections after we have stopped the acceptor (pending accept gets operation aborted error code).

This was noticed in the launcher unit tests, and tested this fix over the long weekend with no crashes (previously crashes every few hours).

### Automated Tests

None

### QA Notes

None - primarily impacts unit tests.



