### PR TITLE
Include dual cell coding fonts on Linux

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@
 * Show `.renvignore` in Files pane (#8658)
 * Make the set of always-shown files and extensions in the Files pane configurable (#3221)
 * Log location of addins that raise parse errors at startup (#8012)
+* Support dual/charcell-spaced editor fonts (e.g., Fira Code) on Linux desktop environments (#6894)
 
 ### Bugfixes
 

--- a/src/cpp/desktop/DesktopInfo.cpp
+++ b/src/cpp/desktop/DesktopInfo.cpp
@@ -114,7 +114,7 @@ void buildFontDatabase()
       core::system::ProcessOptions options;
       core::system::ProcessResult result;
       Error error = core::system::runCommand(
-               "fc-list :spacing=100 -f '%{family}\n' | cut -d ',' -f 1 | sort | uniq",
+               "{ fc-list :mono -f '%{family}\n' & fc-list :dual -f '%{family}\n' & fc-list :charcell -f '%{family}\n'; } | cut -d ',' -f 1 | sort | uniq",
                options,
                &result);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6894, in which you can't use the most popular coding fonts (e.g., Fira Code) on RStudio Desktop for Linux.

### Approach

As noted by the original commenter, this is a consequence of way we form `fc-list` call we make to enumerate fonts on Linux. We need two `fc-list` calls to enumerate the fonts correctly. 

### Automated Tests

This one-line fix only applies to certain Linux system configurations and is not appropriate for a unit test.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/6894. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests




