### PR TITLE
Fix issue with driver installation when ~/odbcinst.ini is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -86,3 +86,5 @@
 * Fixed an issue where the Kubernetes Launcher could hang in Azure Kubernetes Service (AKS) environments by lowering the watch-timeout-seconds parameter default down to 3 minutes instead of 5 (Pro #2312)
 * Fixed issue where 'continue comment on newline' would treat Markdown headers as comments (#6421)
 * Fixed issue where Set Working Directory command could fail if path contained quotes (#6004)
+* Fixed issue where Pro database drivers will not install if `~/odbcinst.ini` is missing (Pro #2284)
+

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -354,6 +354,11 @@
 })
 
 .rs.addFunction("odbcBundleReadIni", function(odbcinstPath) {
+
+   # return nothing if file doesn't exist
+   if (!file.exists(odbcinstPath))
+      return(list())
+
    lines <- readLines(odbcinstPath)
    data <- list()
    

--- a/src/cpp/tests/testthat/test-connections.R
+++ b/src/cpp/tests/testthat/test-connections.R
@@ -1,0 +1,41 @@
+#
+# test-connections.R
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+library(testthat)
+
+context("connections")
+
+test_that("ODBC ini file is read", {
+   # write a test file containing a sample driver
+   test_file <- file.path(tempdir(), "odbcinst.ini")
+   on.exit(unlink(test_file), add = TRUE)
+   writeLines(text = c(
+      "[PostgreSQL]",
+      "Description = PostgreSQL driver for GNU/Linux",
+      "Driver = /usr/lib/psqlodbcw.so",
+      "Setup = /usr/lib/libodbcpsqlS.so"),
+     con = test_file)
+
+   # ensure this file is read
+   bundle <- .rs.odbcBundleReadIni(test_file)
+   expect_equal(bundle, 
+      list(PostgreSQL = c("Description = PostgreSQL driver for GNU/Linux",
+                          "Driver = /usr/lib/psqlodbcw.so",
+                          "Setup = /usr/lib/libodbcpsqlS.so")))
+
+   # ensure we get an empty list if no file is present
+   bundle <- .rs.odbcBundleReadIni(file.path(tempdir(), "missing.ini"))
+   expect_equal(bundle, list())
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2284.

### Approach

Deal gracefully with the case where this file is missing; return empty data instead of an error.

### Automated Tests

Adds new unit tests which test parsing a basic `odbcinst.ini` file and check this specific failure case.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2284.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

