### PR TITLE
Ensure toolbars have height in satellite windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/theme/res/themeStyles.css
@@ -1343,7 +1343,7 @@ body.windows .toolbar {
 }
 
 .rstheme_toolbarWrapper {
-
+   height: 100%;
 }
 
 .rstudio-themes-flat .rstheme_toolbarWrapper {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/dialog/HistoryPanel.css
@@ -40,6 +40,7 @@
 }
 
 .toolbarInnerWrapper {
+   height: 100%;
 }
 
 .diffToolbarInnerWrapper {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8983. 

### Approach

Fix regression from https://github.com/rstudio/rstudio/pull/8964. It turns out that SimpleLayoutPanels don't fill their parent elements in the same way HTML panels do, due to their GWT implementation which includes yet another nested div. The fix is to add a couple of lines of CSS which make them space-filling in our usage.

### Automated Tests

CSS only change, automation not appropriate here.

### QA Notes

This problem affects satellite toolbars generally (not just in the Git window) so take a tour of other satellite windows in the IDE and make sure their toolbars are showing up correctly too. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

