### PR TITLE
More verbose logging for RPC failures

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 * Make the set of always-shown files and extensions in the Files pane configurable (#3221)
 * Log location of addins that raise parse errors at startup (#8012)
 * Support dual/charcell-spaced editor fonts (e.g., Fira Code) on Linux desktop environments (#6894)
+* Improve logging of session RPC failures (Pro #2248)
 
 ### Bugfixes
 

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -166,15 +166,15 @@ public class RpcRequest
                   // default error message
                   String message = "Status code " + 
                                    Integer.toString(status) + 
-                                   " returned";
+                                   " returned by R session when executing '" +
+                                   getMethod() + "'";
                   
                   // override error message for status code 0
                   if (status == 0)
                   {
-                     message = "Unable to establish connection with R session"; 
+                     message = "Unable to establish connection with R session to execute '" + getMethod() + "'";
                   }
-                  
-                 
+
                   requestLogEntry_.logResponse(ResponseType.Unknown,
                                               message);
                   RpcError error = RpcError.create(

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -166,13 +166,17 @@ public class RpcRequest
                   // default error message
                   String message = "Status code " + 
                                    Integer.toString(status) + 
-                                   " returned by R session when executing '" +
+                                   " returned by " +
+                                   (Desktop.isDesktop() ? "R session" : "RStudio Server") +
+                                   " when executing '" +
                                    getMethod() + "'";
                   
                   // override error message for status code 0
                   if (status == 0)
                   {
-                     message = "Unable to establish connection with R session to execute '" + getMethod() + "'";
+                     message = "Unable to establish connection with " +
+                        (Desktop.isDesktop() ? "R session" : "RStudio Server") +
+                        " when executing '" + getMethod() + "'";
                   }
 
                   requestLogEntry_.logResponse(ResponseType.Unknown,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2248. 

### Approach

Makes some improvements to the logging message:

- The name of the RPC is now included, so we know what exactly we were trying to do when the failure occurred
- The message now indicates the kind of failure more clearly
- The message is now specific to Server / Desktop and uses language that makes more sense in each case

The issue suggests that we might also log these RPC failures on the server. I didn't do this because in my experience 100% of RPC failures are due to a networking issue or failure between the client and server. In this case it is not possible for the client to tell the server to log an error, since the client can't reach the server in the first place. 

### Automated Tests

This is an improvement to the wording of a log message, which doesn't warrant a test. 

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2248. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

