### PR TITLE
Check for JDK8 when building GWT

### DIFF
--- a/src/gwt/tools/build-gwt
+++ b/src/gwt/tools/build-gwt
@@ -15,6 +15,15 @@ if [ ! -d gwt ] || [ ! -d gwt/gwt ] || [ ! -d gwt/tools ]; then
     exit 1
 fi
 
+# make sure we have Java 1.8 compiler
+command -v javac >/dev/null 2>&1 || { echo >&2 "javac required but not found: exiting."; exit 1; }
+if javac -version 2>&1 | grep -q 'javac 1\.8\.'; then
+    echo Building with JDK 1.8.
+else
+    echo Error: javac version 1.8 required but not found: exiting.
+    exit 1
+fi
+
 # Build GWT disto with custom version
 cd ${RUN_DIR}/gwt/gwt
 ant clean dist -Dgwt.version="${GWT_VER}"

--- a/src/gwt/tools/build-gwt
+++ b/src/gwt/tools/build-gwt
@@ -20,7 +20,8 @@ command -v javac >/dev/null 2>&1 || { echo >&2 "javac required but not found: ex
 if javac -version 2>&1 | grep -q 'javac 1\.8\.'; then
     echo Building with JDK 1.8.
 else
-    echo Error: javac version 1.8 required but not found: exiting.
+    echo Error: javac version 1.8 required but not found
+    echo Error: consider setting JAVA_HOME to a Java 8 installation
     exit 1
 fi
 


### PR DESCRIPTION
### Intent

When we make changes to our fork of GWT, the build script should enforce using JDK8, since that's what we've tested.

### Approach

Tweak the script and give an error if a different (or no) JDK is found.

### Automated Tests

This is a manually executed and infrequently-used dev script.

### QA Notes

This is a manually executed and infrequently-used dev script. Nothing to test.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


