### PR TITLE
Add rstudioapi support for command callbacks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,7 @@
 * Log location of addins that raise parse errors at startup (#8012)
 * Support dual/charcell-spaced editor fonts (e.g., Fira Code) on Linux desktop environments (#6894)
 * Improve logging of session RPC failures (Pro #2248)
+* Add support for `rstudioapi` methods enabling callbacks for command execution (Pro #1846)
 
 ### Bugfixes
 

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1060,7 +1060,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 
    # find a unique ID for this callback
    repeat {
-      handle <- .Call("rs_createUUID", PACKAGE = "(embedding)")
+      handle <- .Call("rs_generateShortUuid", PACKAGE = "(embedding)")
       if (!(handle %in% names(.rs.commandCallbacks)))
          break
    } 
@@ -1085,7 +1085,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    if (!is.null(handle) && !exists(handle, envir = .rs.commandCallbacks))
       warning("Handle '", handle, " is not a registered RStudio command callback.")
    else {
-      rm(handle, envir = .rs.notebookChunkCallbacks)
+      rm(list = handle, envir = .rs.commandCallbacks)
    }
 
    invisible(NULL)

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -16,6 +16,9 @@
 # Create environment to store data for registerChunkCallback and unregisterChunkCallback
 .rs.setVar("notebookChunkCallbacks", new.env(parent = emptyenv()))
 
+# Create environment to store data for command callbacks
+.rs.setVar("commandCallbacks", new.env(parent = emptyenv()))
+
 # list of API events (keep in sync with RStudioApiRequestEvent.java)
 .rs.setVar("api.eventTypes", list(
    TYPE_UNKNOWN              = 0L,
@@ -33,8 +36,6 @@
    TYPE_ACTIVE_WINDOW = 1L,
    TYPE_ALL_WINDOWS   = 2L
 ))
-
-
 
 .rs.addApiFunction("restartSession", function(command = NULL) {
    command <- as.character(command)
@@ -1037,6 +1038,90 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    }
 })
 
+# get list of command IDs which currently have callbacks (listeners) attached
+.rs.addFunction("getCommandsWithCallbacks", function() {
+   unique(sort(unlist(lapply(names(.rs.commandCallbacks), function(handle) {
+      handler <- get(handle, envir = .rs.commandCallbacks)
+      if (nzchar(handler$command)) 
+         handler$command
+      else
+         NULL
+   }))))
+})
+
+# register a command callback
+.rs.addApiFunction("registerCommandCallback", function(commandId, commandCallback) {
+
+   # validate arguments
+   if (!nzchar(commandId))
+      stop("'commandId' must be a character vector naming an RStudio command ID")
+   if (!is.function(commandCallback))
+      stop("'commandCallback' must be a function")
+
+   # find a unique ID for this callback
+   repeat {
+      handle <- .Call("rs_createUUID", PACKAGE = "(embedding)")
+      if (!(handle %in% names(.rs.commandCallbacks)))
+         break
+   } 
+
+   # save the ID along with the registered callback
+   assign(handle, 
+          value = list(
+            command = commandId,
+            callback = commandCallback),
+          envir = .rs.commandCallbacks)
+
+   # send event to client indicating which command IDs currently have callbacks registered. 
+   .rs.enqueClientEvent("command_callbacks_changed", 
+                        .rs.scalarListFromList(as.list(.rs.getCommandsWithCallbacks())))
+
+   # return the handle we created
+   handle 
+})
+
+# unregister a command callback
+.rs.addApiFunction("unregisterCommandCallback", function(handle = NULL) {
+   if (!is.null(handle) && !exists(handle, envir = .rs.commandCallbacks))
+      warning("Handle '", handle, " is not a registered RStudio command callback.")
+   else {
+      rm(handle, envir = .rs.notebookChunkCallbacks)
+   }
+
+   invisible(NULL)
+})
+
+# records the execution of a command
+.rs.addJsonRpcHandler("record_command_execution", function(commandId) {
+   # loop over all registered command callbacks
+   for (handle in names(.rs.commandCallbacks)) {
+
+      # retrieve handler metadata
+      handler <- get(handle, envir = .rs.commandCallbacks)
+      
+      # sanity check: ensure this handler looks properly formatted. nothing else should be writing
+      # to this environment, but if it does we don't want it to trip up the processing below.
+      if (!is.list(handler)) {
+         next
+      }
+      if (!is.function(handler$callback)) {
+         next
+      }
+
+      # if this is a stream listener for all commands ("*"), invoke it with the command ID
+      if (identical(handler$command, "*")) {
+         handler$callback(commandId)
+         next
+      }
+
+      # if this is a listener for a specific command, invoke it without arguments
+      if (identical(handler$command, commandId)) {
+         handler$callback()
+      }
+   }
+})
+
+
 # Tutorial ----
 
 # invoked by rstudioapi to instruct RStudio to open a particular
@@ -1152,3 +1237,4 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    .rs.api.sendRequest(request)
    invisible(path)
 })
+

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1072,7 +1072,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
             callback = commandCallback),
           envir = .rs.commandCallbacks)
 
-   # send event to client indicating which command IDs currently have callbacks registered. 
+   # send event to client indicating which command IDs currently have callbacks registered
    .rs.enqueClientEvent("command_callbacks_changed", 
                         .rs.scalarListFromList(as.list(.rs.getCommandsWithCallbacks())))
 
@@ -1086,6 +1086,11 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
       warning("Handle '", handle, " is not a registered RStudio command callback.")
    else {
       rm(list = handle, envir = .rs.commandCallbacks)
+
+      # send event to client indicating which command IDs currently have callbacks registered
+      .rs.enqueClientEvent("command_callbacks_changed", 
+                           .rs.scalarListFromList(as.list(.rs.getCommandsWithCallbacks())))
+
    }
 
    invisible(NULL)

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -203,6 +203,7 @@ const int kEnvironmentChanged = 188;
 const int kRStudioApiRequest = 189;
 const int kDocumentCloseAllNoSave = 190;
 const int kMemoryUsageChanged = 191;
+const int kCommandCallbacksChanged = 192;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -564,6 +565,8 @@ std::string ClientEvent::typeName() const
          return "document_close_all_no_save";
       case client_events::kMemoryUsageChanged:
          return "memory_usage_changed";
+      case client_events::kCommandCallbacksChanged:
+         return "command_callbacks_changed";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " +
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -269,6 +269,8 @@ SEXP rs_enqueClientEvent(SEXP nameSEXP, SEXP dataSEXP)
          type = session::client_events::kEnvironmentRemoved;
       else if (name == "environment_changed")
          type = session::client_events::kEnvironmentChanged;
+      else if (name == "command_callbacks_changed")
+         type = session::client_events::kCommandCallbacksChanged;
 
       if (type != -1)
       {

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -204,6 +204,7 @@ extern const int kEnvironmentChanged;
 extern const int kRStudioApiRequest;
 extern const int kDocumentCloseAllNoSave;
 extern const int kMemoryUsageChanged;
+extern const int kCommandCallbacksChanged;
 }
 
 class ClientEvent

--- a/src/cpp/tests/testthat/test-api.R
+++ b/src/cpp/tests/testthat/test-api.R
@@ -1,0 +1,50 @@
+#
+# test-api.R
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("rstudioapi")
+
+test_that("command callbacks are invoked", {
+   
+   # register a command callback
+   invoked <- 0
+   handle <- .rs.api.registerCommandCallback("insertChunk", function() {
+      invoked <<- invoked + 1 
+   })
+   
+   expect_equal(invoked, 0)
+   
+   # record a command execution
+   .rs.invokeRpc("record_command_execution", "insertChunk")
+   
+   # this should invoke the callback once
+   expect_equal(invoked, 1)
+   
+   # record a second command execution 
+   .rs.invokeRpc("record_command_execution", "insertChunk")
+      
+   # this should invoke the callback a second time
+   expect_equal(invoked, 2)
+   
+   # unregister the callback
+   .rs.api.unregisterCommandCallback(handle)
+   
+   # record a third command execution
+   .rs.invokeRpc("record_command_execution", "insertChunk")
+   
+   # the callback should not be invoked, so execution count should
+   # remain at 2
+   expect_equal(invoked, 2)
+   
+})

--- a/src/cpp/tests/testthat/test-api.R
+++ b/src/cpp/tests/testthat/test-api.R
@@ -46,5 +46,29 @@ test_that("command callbacks are invoked", {
    # the callback should not be invoked, so execution count should
    # remain at 2
    expect_equal(invoked, 2)
+})
+
+test_that("command stream callbacks are invoked", {
+   # register a command stream callback
+   commands <- c()
+   handle <- .rs.api.registerCommandCallback("*", function(id) {
+      commands <<- c(commands, id)
+   })
    
+   # record several command executions
+   .rs.invokeRpc("record_command_execution", "insertChunk")
+   .rs.invokeRpc("record_command_execution", "showHelpMenu")
+   .rs.invokeRpc("record_command_execution", "startJob")
+   
+   # ensure that the callback received all 3
+   expect_equal(commands, c("insertChunk", "showHelpMenu", "startJob"))
+   
+   # unregister the callback
+   .rs.api.unregisterCommandCallback(handle)
+   
+   # invoke one more command execution
+   .rs.invokeRpc("record_command_execution", "startProfiler")
+   
+   # this execution should not be received
+   expect_equal(commands, c("insertChunk", "showHelpMenu", "startJob"))
 })

--- a/src/gwt/src/org/rstudio/core/client/command/CommandCallbacksChangedEvent.java
+++ b/src/gwt/src/org/rstudio/core/client/command/CommandCallbacksChangedEvent.java
@@ -1,0 +1,54 @@
+/*
+ * CommandCallbacksChangedEvent.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.command;
+
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class CommandCallbacksChangedEvent
+   extends GwtEvent<CommandCallbacksChangedEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onCommandCallbacksChanged(CommandCallbacksChangedEvent event);
+   }
+
+   public CommandCallbacksChangedEvent(JsArrayString commands)
+   {
+      commands_ = commands;
+   }
+
+   public JsArrayString getCommands()
+   {
+      return commands_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCommandCallbacksChanged(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<>();
+
+   private final JsArrayString commands_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/rstudioapi/model/RStudioAPIServerOperations.java
@@ -28,4 +28,6 @@ public interface RStudioAPIServerOperations extends CryptoServerOperations
                            boolean remember,
                            boolean changed,
                            ServerRequestCallback<Void> requestCallback);
+
+   void recordCommandExecution(String commandId, ServerRequestCallback<Void> requestCallback);
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -194,6 +194,7 @@ class ClientEvent extends JavaScriptObject
    public static final String RStudioApiRequest = "rstudioapi_request";
    public static final String DocumentCloseAllNoSave = "document_close_all_no_save";
    public static final String MemoryUsageChanged = "memory_usage_changed";
+   public static final String CommandCallbacksChanged = "command_callbacks_changed";
 
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -18,9 +18,12 @@ package org.rstudio.studio.client.server.remote;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.command.CommandCallbacksChangedEvent;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.HighlightEvent;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -1074,6 +1077,11 @@ public class ClientEventDispatcher
          {
             MemoryUsage data = event.getData();
             eventBus_.dispatchEvent(new MemoryUsageChangedEvent(data));
+         }
+         else if (type == ClientEvent.CommandCallbacksChanged)
+         {
+            JsArrayString commands = event.getData();
+            eventBus_.dispatchEvent(new CommandCallbacksChangedEvent(commands));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -22,7 +22,6 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.command.CommandCallbacksChangedEvent;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.HighlightEvent;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -6370,6 +6370,15 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, "get_installed_fonts", callback);
    }
 
+   @Override
+   public void recordCommandExecution(String commandId,
+                                   ServerRequestCallback<Void> callback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(StringUtil.notNull(commandId)));
+      sendRequest(RPC_SCOPE, "record_command_execution", params, callback);
+   }
+
    protected String clientInitId_ = "";
    private String clientId_;
    private String clientVersion_ = "";


### PR DESCRIPTION
### Intent

This change makes it possible for RStudio add-ins and other API consumers to run arbitrary R code when an RStudio command is executed, supporting a variety of extensibility scenarios. Addresses https://github.com/rstudio/rstudio-pro/issues/1846. 

### Approach

This change implements only the RStudio side of the work; it adds command callbacks that function very similarly to the chunk callbacks already implemented in the API. There are two types of command callbacks supported:

1. A callback for a specific command, which will be executed when that specific command is invoked via any means (keyboard shortcut, menu, palette, etc.).
2. A callback for all commands (a "command stream" callback), which will be invoked when *any* command is executed. This callback will be given the ID of the command that was executed. 

A little extra work is done here to synchronize the list of commands that have active callbacks with the client and the server. This allows the client to notify the server of a command execution only when strictly necessary; otherwise, we would have to fire an RPC with every command execution.

### Automated Tests

Unit tests covering registration, deregistration, and invocation of both types of callbacks discussed above are included.

### QA Notes

This will ultimately have rstudioapi wrappers, but can be tested today using the following raw API methods (rstudioapi wrappers will arrive in a separate PR to the rstudoapi package).

```r
# Register a callback for a specific command
handle <- .rs.api.registerCommandCallback("commandId", function() { ... })

# Register a callback for all commands
handle <- .rs.api.registerCommandCallback("*", function(commandId) { ... })

# Unregister callback
.rs.api.unregisterCommandCallback(handle)
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

