### PR TITLE
Respect repo options when installing R package dependencies

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -55,6 +55,7 @@
 * Support dual/charcell-spaced editor fonts (e.g., Fira Code) on Linux desktop environments (#6894)
 * Improve logging of session RPC failures (Pro #2248)
 * Add support for `rstudioapi` methods enabling callbacks for command execution (Pro #1846)
+* Add support for non-CRAN repositories when installing R packages in the background (#8946)
 
 ### Bugfixes
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1990,8 +1990,8 @@
    if (identical(options[["download.file.method"]], "curl"))
       options[["download.file.extra"]] <- .rs.downloadFileExtraWithCurlArgs()
 
-   # if there is no CRAN mirror specified in the R session, read it from preferences
-   if (is.na(options[["repos"]]["CRAN"])) {
+   # if there is no repo option set in the R session, read it from preferences
+   if (identical(length(options[["repos"]]), 0L)) {
       options[["repos"]]["CRAN"] <- .rs.readUiPref("cran_mirror")$url
    }
    

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1989,6 +1989,11 @@
    options <- options("repos", "download.file.method", "download.file.extra", "HTTPUserAgent")
    if (identical(options[["download.file.method"]], "curl"))
       options[["download.file.extra"]] <- .rs.downloadFileExtraWithCurlArgs()
+
+   # if there is no CRAN mirror specified in the R session, read it from preferences
+   if (is.na(options[["repos"]]["CRAN"])) {
+      options[["repos"]]["CRAN"] <- .rs.readUiPref("cran_mirror")$url
+   }
    
    # drop NULL entries
    options <- Filter(Negate(is.null), options)

--- a/src/cpp/session/modules/SessionDependencies.cpp
+++ b/src/cpp/session/modules/SessionDependencies.cpp
@@ -355,7 +355,9 @@ std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
       }
    }
 
-   // Install the CRAN packages with a single call
+   // Install the CRAN packages with a single call. Note that we do not pass the repos option to
+   // install.packages() since default CRAN repos are already set in the session via
+   // an earlier call to .rs.CRANDownloadOptionsString().
    if (!cranPackages.empty())
    {
       std::string pkgList = boost::algorithm::join(cranPackages, ",");
@@ -366,10 +368,8 @@ std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
       }
       else
       {
-         cmd += "utils::install.packages(c(" + pkgList + "), " +
-                "repos = '"+ module_context::CRANReposURL() + "'";
-         cmd += ")\n\n";
-      }
+         cmd += "utils::install.packages(c(" + pkgList + ")\n\n";
+     }
    }
 
    // Install the CRAN source packages with a single call
@@ -383,8 +383,7 @@ std::string buildCombinedInstallScript(const std::vector<Dependency>& deps)
       }
       else
       {
-         cmd += "utils::install.packages(c(" + pkgList + "), " +
-                "repos = '"+ module_context::CRANReposURL() + "', ";
+         cmd += "utils::install.packages(c(" + pkgList + "), ";
          cmd += "type = 'source')\n\n";
       }
    }

--- a/src/cpp/tests/testthat/test-codetools.R
+++ b/src/cpp/tests/testthat/test-codetools.R
@@ -66,8 +66,8 @@ test_that(".rs.CRANDownloadOptionsString() fills missing CRAN repo", {
    # read default CRAN URL from user preferences
    cran <- .rs.readUiPref("cran_mirror")$url
 
-   # set up only a secondary repo
-   options(repos = c(RSPM = "https://rspm.rstudio.com"))
+   # unset repos
+   options(repos = NULL)
 
    # create dummy environment
    envir <- new.env(parent = globalenv())
@@ -76,6 +76,6 @@ test_that(".rs.CRANDownloadOptionsString() fills missing CRAN repo", {
    # evaluate the download string and confirm that it contains the CRAN URL from user prefs
    string <- .rs.CRANDownloadOptionsString()
    actual <- eval(parse(text = string), envir = envir)
-   expect_equal(actual[["repos"]]["CRAN"], c(CRAN = cran))
+   expect_equal(unlist(actual[["repos"]]["CRAN"]), c(CRAN = cran))
 })
 

--- a/src/cpp/tests/testthat/test-codetools.R
+++ b/src/cpp/tests/testthat/test-codetools.R
@@ -61,3 +61,21 @@ test_that(".rs.CRANDownloadOptionsString() generates a valid R expression", {
    expect_equal(actual$download.file.extra, "embedded 'quotes'")
    
 })
+
+test_that(".rs.CRANDownloadOptionsString() fills missing CRAN repo", {
+   # read default CRAN URL from user preferences
+   cran <- .rs.readUiPref("cran_mirror")$url
+
+   # set up only a secondary repo
+   options(repos = c(RSPM = "https://rspm.rstudio.com"))
+
+   # create dummy environment
+   envir <- new.env(parent = globalenv())
+   envir[["options"]] <- base::list
+
+   # evaluate the download string and confirm that it contains the CRAN URL from user prefs
+   string <- .rs.CRANDownloadOptionsString()
+   actual <- eval(parse(text = string), envir = envir)
+   expect_equal(actual[["repos"]]["CRAN"], c(CRAN = cran))
+})
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8946, in which non-CRAN repositories are not used when installing package dependencies. 

### Approach

The primary change here is that we no longer pass the `repos` option to `install.packages` in the background job, instead relying on `options(repos)` set earlier in the script. 

However, there's a pathological situation in which setting `repos` might be necessary: if for some reason no CRAN repo is set in the parent R session, then we could formerly recover by picking up the CRAN repo from user preferences. This change handles that by extending the download options string generator so that it includes a CRAN repo from user prefs if one is not already set.

### Automated Tests

Unit tests included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8946. Note that this affects scenarios with the RStudio Package Manager specifically, so using an RSPM enabled configuration would be best. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


