### PR TITLE
Fix some warnings in themes unit tests

### DIFF
--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -154,6 +154,12 @@ void getThemesInLocation(
                (std::istreambuf_iterator<char>()));
             themeIFStream.close();
 
+            // Skip theme if file is empty.
+            if (themeContents.empty())
+            {
+               continue;
+            }
+
             boost::smatch matches;
             bool found = boost::regex_search(
                themeContents,
@@ -187,12 +193,14 @@ void getThemesInLocation(
                }
                catch (boost::bad_lexical_cast&)
                {
-                  LOG_WARNING_MESSAGE("rs-theme-is-dark value is not a valid boolean string for theme \"" + name + "\".");
+                  LOG_WARNING_MESSAGE("rs-theme-is-dark value is not a valid boolean string "
+                        " for theme \"" + name + "\" (" + themeFile.getAbsolutePath() + ")");
                }
             }
             else
             {
-               LOG_WARNING_MESSAGE("rs-theme-is-dark is not set for theme \"" + name + "\".");
+               LOG_WARNING_MESSAGE("rs-theme-is-dark is not set for theme \"" + name + "\" (" +
+                     themeFile.getAbsolutePath() + ")");
             }
 
             (*themeMap)[boost::algorithm::to_lower_copy(name)] = std::make_tuple(

--- a/src/cpp/tests/testthat/test-themes.R
+++ b/src/cpp/tests/testthat/test-themes.R
@@ -1681,7 +1681,9 @@ test_that("addTheme gives an error when adding an empty theme", {
 
 test_that_wrapped("addTheme gives error when the theme already exists", {
    themePath <- file.path(inputFileLocation, "rsthemes", paste0(themes[[40]]$fileName, ".rstheme"))
-   .rs.addTheme(themePath, FALSE, FALSE, FALSE)
+   # suppress warning for theme overwrite
+   suppressWarnings(
+      .rs.addTheme(themePath, FALSE, FALSE, FALSE))
    expect_error(
       .rs.addTheme(themePath, FALSE, FALSE, FALSE),
       paste0(
@@ -1698,7 +1700,9 @@ AFTER_FUN = function()
 
 test_that_wrapped("addTheme works correctly with force = TRUE", {
    inputThemePath <- file.path(inputFileLocation, "rsthemes", paste0(themes[[14]]$fileName, ".rstheme"))
-   name <- .rs.addTheme(inputThemePath, FALSE, TRUE, FALSE)
+   # suppress warning for theme overwrite
+   suppressWarnings({
+      name <- .rs.addTheme(inputThemePath, FALSE, TRUE, FALSE)})
    exLines <- readLines(inputThemePath, encoding = "UTF-8")
 
    installedTheme <- .rs.getThemes()[[tolower(name)]]
@@ -1804,13 +1808,14 @@ test_that_wrapped("rs_getThemes location override works correctly", {
       paste0("theme/default/", defaultThemes[[themeName]]$fileName, ".rstheme"),
       info = "default location")
 
-   # Install globally
+   # Install globally; ignore overwrite warning
    expectedDawn <- themes[[themeName]]
-   .rs.addTheme(
-      file.path(inputFileLocation, "rsthemes", paste0(expectedDawn$fileName, ".rstheme")),
-      FALSE,
-      FALSE,
-      TRUE)
+   suppressWarnings(
+      .rs.addTheme(
+         file.path(inputFileLocation, "rsthemes", paste0(expectedDawn$fileName, ".rstheme")),
+         FALSE,
+         FALSE,
+         TRUE))
    dawnTheme <- .rs.getThemes()[[tolower(themeName)]]
    expect_equal(
       dawnTheme$url,
@@ -1819,11 +1824,12 @@ test_that_wrapped("rs_getThemes location override works correctly", {
 
    # Install locally
    expectedDawn <- themes[[themeName]]
-   .rs.addTheme(
-      file.path(inputFileLocation, "rsthemes", paste0(expectedDawn$fileName, ".rstheme")),
-      FALSE,
-      FALSE,
-      FALSE)
+   suppressWarnings(
+      .rs.addTheme(
+         file.path(inputFileLocation, "rsthemes", paste0(expectedDawn$fileName, ".rstheme")),
+         FALSE,
+         FALSE,
+         FALSE))
    dawnTheme <- .rs.getThemes()[[tolower(themeName)]]
    expect_equal(
       dawnTheme$url,


### PR DESCRIPTION
### Intent

Fix variety of warnings in themes unit tests. Addresses https://github.com/rstudio/rstudio/issues/8937. Now all themes tests pass without emitting warnings:

![image](https://user-images.githubusercontent.com/470418/109077037-67a32980-76b0-11eb-969a-bfac39c86004.png)

### Approach

Suppress R warnings that are not relevant to these tests; also skip empty themes when building installation lists since they aren't real themes and were triggering R session warnings.

### Automated Tests

Yes, this change is all about them.

### QA Notes

Test change only, no QA needed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

