### PR TITLE
Run tests with blank prefs/state

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -185,6 +185,11 @@ if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
         TESTTHAT_FILTER=", filter = '$TEST_FILTER'"
     fi
 
+    # Establish temporary folders for user state and data; this prevents the state/config on the 
+    # machine from affecting the tests
+    RSTUDIO_FOLDER=$(mktemp -d -t rstudio-tests-XXXXXXXXXX)
+    export RSTUDIO_DATA_HOME="$RSTUDIO_FOLDER/data"
+    export RSTUDIO_CONFIG_HOME="$RSTUDIO_FOLDER/config"
     export RS_CRASH_HANDLER_PATH="${CMAKE_CURRENT_BINARY_DIR}/server/crash-handler-proxy/crash-handler-proxy"
     export RS_CRASHPAD_HANDLER_PATH="/opt/rstudio-tools/crashpad/crashpad/out/Default/crashpad_handler"
     runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN" \


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8871.

### Approach

The R session in which the unit tests run can be affected by your own local config (state and preferences), which means the unit tests can fail (or even succeed) when they shouldn't. This change gives unit tests a blank config and state folder to start with, so that they are more reproducible. 

### Automated Tests

Yes, all of them. 

### QA Notes

Unit test change only, no QA needed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

