### PR TITLE
add automation ids for parts of the environment pane

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ClassIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ClassIds.java
@@ -88,4 +88,9 @@ public class ClassIds
 
    // FastSelectTable
    public final static String FAST_SELECT_TABLE = "fast_select_tbl";
+
+   // EnvironmentList
+   public final static String ENV_LIST_DATA_HDR = "env_list_data_hdr";
+   public final static String ENV_LIST_FUNCTIONS_HDR = "env_list_functions_hdr";
+   public final static String ENV_LIST_VALUES_HDR = "env_list_values_hdr";
 }

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -235,6 +235,7 @@ public class ElementIds
    public final static String MEMORY_PIE_FULL = "memory_pie_full";
    public final static String MEMORY_USAGE_TABLE = "memory_usage_table";
    public final static String MEMORY_TABLE_TITLE = "memory_table_title";
+   public final static String MEMORY_MB_DROPDOWN = "memory_mb_dropdown";
 
    // TextBoxWithButton and subclasses -- prefixes for button/text/help, combined with suffixes
    public final static String TBB_TEXT = "tbb_text";
@@ -404,6 +405,9 @@ public class ElementIds
    public static String getMbObjectListView() { return getElementId(MB_OBJECT_LIST_VIEW); }
    public final static String SW_ENVIRONMENT = "sw_environment";
    public static String getSwEnvironment() { return getElementId(SW_ENVIRONMENT); }
+   public final static String MB_REFRESH_OPTS = "mb_refresh_opts";
+   public final static String MB_ENV_LANGUAGE = "mb_env_language";
+   public final static String ENV_EMPTY = "env_empty";
 
    // HistoryPane
    public final static String SW_HISTORY = "sw_history";

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -235,7 +235,7 @@ public class ElementIds
    public final static String MEMORY_PIE_FULL = "memory_pie_full";
    public final static String MEMORY_USAGE_TABLE = "memory_usage_table";
    public final static String MEMORY_TABLE_TITLE = "memory_table_title";
-   public final static String MEMORY_MB_DROPDOWN = "memory_mb_dropdown";
+   public final static String MEMORY_DROPDOWN = "memory_dropdown";
 
    // TextBoxWithButton and subclasses -- prefixes for button/text/help, combined with suffixes
    public final static String TBB_TEXT = "tbb_text";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPane.java
@@ -184,8 +184,10 @@ public class EnvironmentPane extends WorkbenchPane
             AppCommand.formatMenuLabel(null, "Refresh Now", null),
             true, // as HTML
             () -> commands_.refreshEnvironment().execute()));
-      toolbar.addRightWidget(
-            new ToolbarMenuButton(ToolbarButton.NoText, "Refresh options", refreshMenu, false));
+      ToolbarMenuButton refreshMenuBtn =
+         new ToolbarMenuButton(ToolbarButton.NoText, "Refresh options", refreshMenu, false);
+      ElementIds.assignElementId(refreshMenuBtn, ElementIds.MB_REFRESH_OPTS);
+      toolbar.addRightWidget(refreshMenuBtn);
 
       return toolbar;
    }
@@ -228,6 +230,7 @@ public class EnvironmentPane extends WorkbenchPane
             ToolbarButton.NoTitle,
             (ImageResource) null,
             languageMenu_);
+      ElementIds.assignElementId(languageButton_, ElementIds.MB_ENV_LANGUAGE);
 
       // nudge language selector up to baseline align with environment selector
       languageButton_.getElement().getStyle().setMarginTop(-4, Unit.PX);
@@ -743,7 +746,7 @@ public class EnvironmentPane extends WorkbenchPane
          setActiveLanguage("R", true);
       }
    }
-   
+
    @Override
    public void onSuspendAndRestart(SuspendAndRestartEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjectList.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.environment.view;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.resources.CoreResources;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -90,7 +91,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       style_.ensureInjected();
       addStyleName(style_.objectList());
       addStyleName("ace_editor_theme");
-      
+
       exportResizer();
    }
 
@@ -188,8 +189,8 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
                if (object.canExpand())
                {
                   imageStyle = imageStyle + " " + ThemeStyles.INSTANCE.handCursor();
-                  ImageResource expandImage = 
-                      object.isExpanding ? 
+                  ImageResource expandImage =
+                      object.isExpanding ?
                          CoreResources.INSTANCE.progress() :
                          object.expanded ?
                             new ImageResource2x(EnvironmentResources.INSTANCE.collapseIcon2x()) :
@@ -227,7 +228,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
                  }
               });
    }
-   
+
    private void createResizeColumn()
    {
       SafeHtmlRenderer<String> resizerRenderer =
@@ -256,9 +257,9 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
             }
          };
    }
-   
+
    private final native void exportResizer() /*-{
-      $wnd.rstudio_beginResize = function(ele, event, clazz) 
+      $wnd.rstudio_beginResize = function(ele, event, clazz)
       {
          // Ignore non-primary buttons
          if (event.button !== 0)
@@ -279,34 +280,34 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          var width = resizer.clientWidth;
 
          // Resize method; given a mouse move event, adjust the size accordingly
-         var resize = function(evt) 
+         var resize = function(evt)
          {
             if (start === -1)
                start = evt.clientX;
             var newWidth = (width + (evt.clientX - start));
-            
+
             // Enforce minimum/maximum width
             if (newWidth < 40)
                newWidth = 40;
             else if (newWidth > 500)
                newWidth = 500;
-               
+
             resizer.style.width = newWidth + "px";
          };
 
          // Wire up event listeners
          $wnd.addEventListener("mousemove", resize);
-         $wnd.addEventListener("mouseup", function(evt) 
+         $wnd.addEventListener("mouseup", function(evt)
          {
             $wnd.removeEventListener("mousemove", resize);
          });
       }
    }-*/;
-   
+
    private void expandObject(final int index, final RObjectEntry object)
    {
-      if (!object.expanded && 
-          !object.isExpanding && 
+      if (!object.expanded &&
+          !object.isExpanding &&
           object.rObject.getContentsDeferred())
       {
          host_.fillEntryContents(object, index, true);
@@ -314,7 +315,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       else if (!object.rObject.getContentsDeferred())
       {
          object.expanded = !object.expanded;
-         
+
          // Tell the observer this happened, so it can persist. Don't persist
          // expansion state for deferred-content objects, since we don't want
          // those to try to expand at app init.
@@ -346,7 +347,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          // build nothing for invisible rows
          if (!rowValue.visible)
             return;
-         
+
          // build the header for the row (if any)
          buildRowHeader(rowValue, absRowIndex);
 
@@ -374,7 +375,7 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          renderCell(expandCol, createContext(0), objectExpandColumn_, rowValue);
          expandCol.endTD();
       }
-      
+
       private void buildResizeColumn(RObjectEntry rowValue, TableRowBuilder row)
       {
          TableCellBuilder resizeCol = row.startTD();
@@ -387,16 +388,16 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
       {
          TableCellBuilder nameCol = row.startTD();
          String styleName = style_.nameCol();
-         
+
          boolean isClickable =
                host_.enableClickableObjects() &&
                rowValue.getCategory() != Categories.Value;
-         
+
          if (isClickable)
          {
             styleName += (" " + style_.clickableCol() + " " +
                           ThemeStyles.INSTANCE.handCursor());
-            
+
          }
          String size = rowValue.rObject.getSize() > 0 ?
                               ", " + rowValue.rObject.getSize() + " bytes" :
@@ -429,33 +430,33 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          String descriptionStyle = style_.valueCol();
          if (rowValue.isPromise())
          {
-            descriptionStyle += (" " + style_.unevaluatedPromise() + 
+            descriptionStyle += (" " + style_.unevaluatedPromise() +
                                  " " + ThemeStyles.INSTANCE.handCursor());
          }
          else if (isClickable)
          {
             descriptionStyle += (" " +
                                  style_.decoratedValueCol() + " " +
-                                 style_.clickableCol() + " " + 
+                                 style_.clickableCol() + " " +
                                  ThemeStyles.INSTANCE.handCursor());
          }
-         
+
          if (rowValue.getCategory() == RObjectEntry.Categories.Data)
          {
             if (rowValue.isHierarchical())
             {
-               descriptionStyle += (" " + 
+               descriptionStyle += (" " +
                      ThemeStyles.INSTANCE.environmentHierarchicalCol());
             }
             else
             {
-               descriptionStyle += (" " + 
+               descriptionStyle += (" " +
                      ThemeStyles.INSTANCE.environmentDataFrameCol());
             }
          }
          else if (rowValue.getCategory() == RObjectEntry.Categories.Function)
          {
-            descriptionStyle += (" " + 
+            descriptionStyle += (" " +
                                 ThemeStyles.INSTANCE.environmentFunctionCol());
          }
          descCol.className(descriptionStyle);
@@ -483,23 +484,28 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          if (rowValue.isCategoryLeader)
          {
             String categoryTitle;
+            String categoryClass;
             switch (rowValue.getCategory())
             {
                case RObjectEntry.Categories.Data:
                   categoryTitle = "Data";
+                  categoryClass = ClassIds.ENV_LIST_DATA_HDR;
                   break;
                case RObjectEntry.Categories.Function:
                   categoryTitle = "Functions";
+                  categoryClass = ClassIds.ENV_LIST_FUNCTIONS_HDR;
                   break;
                default:
                   categoryTitle = "Values";
+                  categoryClass = ClassIds.ENV_LIST_VALUES_HDR;
                   break;
             }
             TableRowBuilder leaderRow = startRow().className(
                     style_.categoryHeaderRow());
             TableCellBuilder objectHeader = leaderRow.startTD();
             objectHeader.colSpan(4)
-                    .className(style_.categoryHeaderText() + " rstudio-themes-background")
+                    .className(style_.categoryHeaderText() + " rstudio-themes-background" + " " +
+                       ClassIds.getClassId(categoryClass))
                     .text(categoryTitle)
                     .endTD();
             leaderRow.endTR();
@@ -514,22 +520,22 @@ public class EnvironmentObjectList extends EnvironmentObjectDisplay
          for (int idx = 0; idx < contents.length(); idx++)
          {
             TableRowBuilder detail = startRow().className(style_.detailRow());
-            
+
             detail.startTD().endTD();
-            
+
             String content = contents.get(idx);
-            
+
             TableCellBuilder objectDetail = detail.startTD();
             objectDetail.colSpan(3)
                     .title(content)
                     .text(content)
                     .endTD();
             detail.endTR();
-            
+
          }
       }
    }
-   
+
    private Style style_;
 
    private Column<RObjectEntry, String> objectExpandColumn_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/EnvironmentObjects.java
@@ -33,6 +33,7 @@ import com.google.gwt.user.client.ui.*;
 import com.google.gwt.view.client.ListDataProvider;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.FontSizer;
@@ -644,6 +645,7 @@ public class EnvironmentObjects extends ResizeComposite
       environmentEmptyMessage_ = new Label(EMPTY_ENVIRONMENT_MESSAGE);
       environmentEmptyMessage_.setStyleName(styles.subtitle());
       environmentEmptyMessage_.setStylePrimaryName(style.emptyEnvironmentMessage());
+      ElementIds.assignElementId(environmentEmptyMessage_, ElementIds.ENV_EMPTY);
       messagePanel.add(environmentEmptyMessage_);
       return messagePanel;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemUsageWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemUsageWidget.java
@@ -68,7 +68,7 @@ public class MemUsageWidget extends Composite
          ToolbarButton.NoTitle,
          (ImageResource) null,
          memoryMenu);
-      ElementIds.assignElementId(menu_, ElementIds.MEMORY_MB_DROPDOWN);
+      ElementIds.assignElementId(menu_, ElementIds.MEMORY_DROPDOWN);
       menu_.getElement().getStyle().setMarginTop(-3, Style.Unit.PX);
       host_.add(menu_);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemUsageWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemUsageWidget.java
@@ -68,6 +68,7 @@ public class MemUsageWidget extends Composite
          ToolbarButton.NoTitle,
          (ImageResource) null,
          memoryMenu);
+      ElementIds.assignElementId(menu_, ElementIds.MEMORY_MB_DROPDOWN);
       menu_.getElement().getStyle().setMarginTop(-3, Style.Unit.PX);
       host_.add(menu_);
 


### PR DESCRIPTION
### Intent

Add ids (element IDs and class IDs) for various elements of Environment Pane for automation.

This is part of the work for #9016 but not considering it completed. This has automation value on its own, and not sure when I'll get to the rest of it.

### Approach

Added unique IDs for Environment Toolbar controls that didn't have them, plus one for the "Environment is empty" message as a way to quickly determine if pane is empty.

![2021-02-24_15-31-16](https://user-images.githubusercontent.com/10569626/109100389-9f729700-76d9-11eb-9118-110533476a04.png)

Also added classes to the List View headers to provide a place from which to navigate (via xpaths, etc.) to the following content. Ideally would have easier way to do this, but if you examine the HTML can deduce the table structure pretty easily.

![2021-02-24_15-28-57](https://user-images.githubusercontent.com/10569626/109082418-d2f0f980-76b8-11eb-9c0b-8fce3408d3c1.png)

### Automated Tests

None, this is for creating automated tests.

### QA Notes

Verify IDs as shown when creating automation (no end-user impact). Note these will now show up via the Help / Diagnostics / Show DOM Elements mode.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

