### PR TITLE
VirtualScroller bugfix: truncation indication, ConsoleError interactivity

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -331,8 +331,9 @@ var VirtualScroller;
         newlinesToPrune -= 1;
       }
 
-      if (indexToSlice > 0)
-        element.innerText = element.innerText.substring(indexToSlice);
+      if (indexToSlice > 0) {
+        element.innerText = "[...]" + element.innerText.substring(indexToSlice);
+      }
     },
 
     ensureStartingOnNewLine: function() {

--- a/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
+++ b/src/gwt/src/org/rstudio/core/client/virtualscroller/virtualscroller.js
@@ -332,7 +332,8 @@ var VirtualScroller;
       }
 
       if (indexToSlice > 0) {
-        element.innerText = "[...]" + element.innerText.substring(indexToSlice);
+        element.innerText = "<console output truncated>" +
+          element.innerText.substring(indexToSlice);
       }
     },
 

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
@@ -74,8 +74,8 @@
                   ui:field="showTracebackImage"
                   width="9"
                   height="9"
-                  styleName="{style.errorCommandImage}"/>
-           <g:Anchor styleName="{style.errorCommandText}" ui:field="showTracebackText">
+                  styleName="{style.errorCommandImage} show_traceback_image"/>
+           <g:Anchor styleName="{style.errorCommandText} show_traceback_text" ui:field="showTracebackText">
               Show Traceback
            </g:Anchor>
         </g:HTMLPanel>
@@ -84,14 +84,14 @@
                     ui:field="rerunImage"
                     width="9"
                     height="9"
-                    styleName="{style.errorCommandImage}"/>
-           <g:Anchor styleName="{style.errorCommandText}" ui:field="rerunText">
+                    styleName="{style.errorCommandImage} rerun_image"/>
+           <g:Anchor styleName="{style.errorCommandText} rerun_text" ui:field="rerunText">
               Rerun with Debug
            </g:Anchor>
         </g:HTMLPanel>
      </g:HTMLPanel>
      <g:HTML ui:field="errorMessage" styleName="{style.errorMessage}"></g:HTML>
-     <g:HTMLPanel ui:field="framePanel" visible="false" styleName="{style.framePanel}">
+     <g:HTMLPanel ui:field="framePanel" visible="false" styleName="{style.framePanel} stack_trace">
      </g:HTMLPanel>
    </g:HTMLPanel>
 </ui:UiBinder> 


### PR DESCRIPTION
### Intent

To address: https://github.com/rstudio/rstudio/issues/8940

I've had to rewrite the element manipulation to be compatible with raw Javascript. Unfortunately, when an element is added to the DOM through an external source, GWT loses the bindings are we aren't able to manipulate the elements through GWT variables anymore. I rewrote the functionality with plain DOM manipulation functions.

To address: https://github.com/rstudio/rstudio/issues/7918

I've added `[...]` to the top of the output to indicate that it has been truncated. I'm open to ideas for alternatives to put there but this is very similar to what Visual Studio does when outputting large collections. I don't think clearing the console cutting off everything (including the command prompt) like we do without the VirtualScroller is the right move as it kind of defeats the purpose of the feature entirely.

![RexuPhv](https://user-images.githubusercontent.com/136863/109201091-68e75b80-776f-11eb-9a51-0eb05d86ca81.png)

### Automated Tests

There are no automated tests for this feature as there is already some coverage.

### QA Notes

Verify that ConsoleErrors with traceback function properly with VirtualScroller both on and off.

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests


