### PR TITLE
Implement Go to Next Chunk / Go to Previous Chunk in visual editor

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -76,6 +76,7 @@
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Code chunks in the visual editor now respect the "Tab Key Always Moves Focus" accessibility setting (#8584)
 * The commands "Execute Previous Chunks" and "Execute Subsequent Chunks" now work when the cursor is outside a code chunk in the visual editor (#8500)
+* The commands "Go to Next Chunk" and "Go to Previous Chunk" now work in the visual editor (#9005)
 * Fixed issue causing the document to scroll unpredictably when a code chunk inside a list item is executed in the visual editor (#8883)
 * Fixed issue preventing R Notebook chunks from being queued for execution if they had never been previously run (#4238)
 * Fix various issues when the "Limit Console Output" performance setting was enabled, and enable it by default (#8544, #8504, #8529, #8552)

--- a/src/gwt/panmirror/src/editor/src/api/command.ts
+++ b/src/gwt/panmirror/src/editor/src/api/command.ts
@@ -136,6 +136,8 @@ export enum EditorCommandId {
   // outline
   GoToNextSection = 'AE827BDA-96F8-4E84-8030-298D98386765',
   GoToPreviousSection = 'E6AA728C-2B75-4939-9123-0F082837ACDF',
+  GoToNextChunk = '50DD6E51-13B5-4F1E-A46B-6A33EB1609D9',
+  GoToPreviousChunk = '8D105D33-78FE-4A98-8195-6B71361424C5'
 }
 
 export interface EditorCommand {

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommands.java
@@ -124,4 +124,6 @@ public class PanmirrorCommands
    // outline
    public static final String GoToNextSection = "AE827BDA-96F8-4E84-8030-298D98386765";
    public static final String GoToPreviousSection = "E6AA728C-2B75-4939-9123-0F082837ACDF";
+   public static final String GoToNextChunk = "50DD6E51-13B5-4F1E-A46B-6A33EB1609D9";
+   public static final String GoToPreviousChunk = "8D105D33-78FE-4A98-8195-6B71361424C5";
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
@@ -142,6 +142,8 @@ public class PanmirrorToolbarCommands implements CommandPaletteEntryProvider
       // outline
       add(PanmirrorCommands.GoToNextSection, "Go to Next Section");
       add(PanmirrorCommands.GoToPreviousSection, "Go to Previous Section");
+      add(PanmirrorCommands.GoToNextChunk, "Go to Next Chunk");
+      add(PanmirrorCommands.GoToPreviousChunk, "Go to Previous Chunk");
    }
    
    public PanmirrorCommandUI get(String id)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1166,13 +1166,27 @@ public class TextEditingTarget implements
    @Handler
    void onGoToNextChunk()
    {
-      moveCursorToNextSectionOrChunk(false);
+      if (visualMode_.isActivated())
+      {
+         visualMode_.goToNextChunk();
+      }
+      else
+      {
+         moveCursorToNextSectionOrChunk(false);
+      }
    }
 
    @Handler
    void onGoToPrevChunk()
    {
-      moveCursorToPreviousSectionOrChunk(false);
+      if (visualMode_.isActivated())
+      {
+         visualMode_.goToPreviousChunk();
+      }
+      else
+      {
+         moveCursorToPreviousSectionOrChunk(false);
+      }
    }
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -823,7 +823,17 @@ public class VisualMode implements VisualModeEditorSync,
    {
       panmirror_.execCommand(PanmirrorCommands.GoToPreviousSection);
    }
-   
+
+   public void goToNextChunk()
+   {
+      panmirror_.execCommand(PanmirrorCommands.GoToNextChunk);
+   }
+
+   public void goToPreviousChunk()
+   {
+      panmirror_.execCommand(PanmirrorCommands.GoToPreviousChunk);
+   }
+
    public HasFindReplace getFindReplace()
    {
       if (panmirror_ != null) {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9005, in which a pair of chunk navigation commands do not work in visual mode.

### Approach

Implement the commands, using a similar pattern (and most of the code) for previous/next section.

### Automated Tests

Currently no automation runs against the visual editor. See https://github.com/rstudio/rstudio-ide-automation/issues/106.

### QA Notes

Note that this change also fixes a bug (that was never filed) in which the Previous Section / Next Section commands navigate to chunks in addition to sections. Test these commands as well; they should no longer navigate to chunks.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

