### PR TITLE
Don't build RSTUDIO_SERVER on win32

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -77,7 +77,7 @@ endif()
 
 # set desktop and server build flags
 if(NOT DEFINED RSTUDIO_SERVER)
-   if(RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Server")
+   if(NOT WIN32 AND (RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Server"))
       set(RSTUDIO_SERVER TRUE)
    endif()
 endif()


### PR DESCRIPTION
### Intent

Fixes this error when trying to build on dev environments:

```
-- Configured to build SERVER
-- Configured to build DESKTOP
-- Found R: C:/R/R-3.5.0
-- Found Qt: C:/Qt/Qt5.12.8/5.12.8/msvc2017_64/bin/qmake.exe
CMake Error at C:/Users/jmcphers/git/rstudio/cmake/modules/FindPAM.cmake:72 (message):
  PAM was not found
Call Stack (most recent call first):
  server/pam/CMakeLists.txt:22 (find_package)
```

This problem appears to have been introduced here:

https://github.com/rstudio/rstudio/commit/99dc1fcb7cbecff7753bef7a11fd98167058a4e7#diff-9a73edb1790d89f461c1cb78b348378215277f79e4d9fa7b94344d3c0227bca8L70

In dev configurations, desktop and server are both built by default -- except, formerly, on Windows. Attempting to build server on Windows results in CMake errors as above.

### Approach

Don't attempt to build server bits on Windows.

### Automated Tests

None, non-product change.

### QA Notes

No QA needed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

