### PR TITLE
Fix Run Tests button in non-project sessions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -94,4 +94,5 @@
 * Fixed issue where Set Working Directory command could fail if path contained quotes (#6004)
 * Fixed issue where Pro database drivers will not install if `~/odbcinst.ini` is missing (Pro #2284)
 * Fixed issue causing the mouse cursor to become too small in certain areas on Linux Desktop (#8781)
+* Fixed issue causing Run Tests command to do nothing unless the Build tab was available (#8775)
 

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -30,7 +30,7 @@ namespace rstudio {
 namespace session {
 
 namespace client_events {
-
+   
 const int kBusy = 1;
 const int kConsolePrompt = 2;
 const int kConsoleWriteOutput = 3;
@@ -181,6 +181,9 @@ const int kOpenFileDialog = 163;
 const int kRemoveTerminal = 164;
 const int kShowPageViewerEvent = 165;
 const int kAskSecret = 166;
+const int kTestsStarted = 167;
+const int kTestsOutput = 168;
+const int kTestsCompleted = 169;
 const int kJobUpdated = 170;
 const int kJobRefresh = 171;
 const int kJobOutput = 172;
@@ -212,7 +215,7 @@ void ClientEvent::init(int type, const json::Value& data)
    data_ = data;
    id_ = core::system::generateUuid();
 }
-
+   
 void ClientEvent::asJsonObject(int id, json::Object* pObject) const
 {
    json::Object& object = *pObject;
@@ -220,8 +223,8 @@ void ClientEvent::asJsonObject(int id, json::Object* pObject) const
    object["type"] = typeName();
    object["data"] = data();
 }
-
-std::string ClientEvent::typeName() const
+   
+std::string ClientEvent::typeName() const 
 {
    switch (type_)
    {
@@ -231,33 +234,33 @@ std::string ClientEvent::typeName() const
          return "console_prompt";
       case client_events::kConsoleWriteOutput:
          return "console_output";
-      case client_events::kConsoleWriteError:
+      case client_events::kConsoleWriteError: 
          return "console_error";
-      case client_events::kShowErrorMessage:
+      case client_events::kShowErrorMessage: 
          return "show_error_message";
-      case client_events::kShowHelp:
+      case client_events::kShowHelp: 
          return "show_help";
-      case client_events::kBrowseUrl:
+      case client_events::kBrowseUrl: 
          return "browse_url";
-      case client_events::kShowEditor:
+      case client_events::kShowEditor: 
          return "show_editor";
-      case client_events::kChooseFile:
+      case client_events::kChooseFile: 
          return "choose_file";
       case client_events::kAbendWarning:
          return "abend_warning";
       case client_events::kQuit:
          return "quit";
-      case client_events::kSuicide:
+      case client_events::kSuicide: 
          return "suicide";
       case client_events::kFileChanged:
          return "file_changed";
-      case client_events::kWorkingDirChanged:
+      case client_events::kWorkingDirChanged: 
          return "working_dir_changed";
-      case client_events::kPlotsStateChanged:
+      case client_events::kPlotsStateChanged: 
          return "plots_state_changed";
-      case client_events::kPackageStatusChanged:
+      case client_events::kPackageStatusChanged: 
          return "package_status_changed";
-      case client_events::kPackageStateChanged:
+      case client_events::kPackageStateChanged: 
          return "package_state_changed";
       case client_events::kLocator:
          return "locator";
@@ -521,6 +524,12 @@ std::string ClientEvent::typeName() const
          return "show_page_viewer";
       case client_events::kAskSecret:
          return "ask_secret";
+      case client_events::kTestsStarted:
+         return "tests_started";
+      case client_events::kTestsOutput:
+         return "tests_output";
+      case client_events::kTestsCompleted:
+         return "tests_completed";
       case client_events::kJobUpdated:
          return "job_updated";
       case client_events::kJobRefresh:
@@ -568,7 +577,7 @@ std::string ClientEvent::typeName() const
       case client_events::kCommandCallbacksChanged:
          return "command_callbacks_changed";
       default:
-         LOG_WARNING_MESSAGE("unexpected event type: " +
+         LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));
          return "";
    }
@@ -592,8 +601,8 @@ ClientEvent browseUrlEvent(const std::string& url, const std::string& window)
    browseURLInfo["window"] = window;
    return ClientEvent(client_events::kBrowseUrl, browseURLInfo);
 }
-
-
+    
+   
 ClientEvent showErrorMessageEvent(const std::string& title,
                                   const std::string& message)
 {
@@ -604,7 +613,7 @@ ClientEvent showErrorMessageEvent(const std::string& title,
 }
 
 
-
-
+   
+   
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -28,9 +28,9 @@ namespace core {
 
 namespace rstudio {
 namespace session {
-
+   
 namespace client_events {
-
+   
 extern const int kConsolePrompt;
 extern const int kConsoleWriteOutput;
 extern const int kConsoleWriteError;
@@ -182,6 +182,9 @@ extern const int kOpenFileDialog;
 extern const int kRemoveTerminal;
 extern const int kShowPageViewerEvent;
 extern const int kAskSecret;
+extern const int kTestsStarted;
+extern const int kTestsOutput;
+extern const int kTestsCompleted;
 extern const int kJobUpdated;
 extern const int kJobRefresh;
 extern const int kJobOutput;
@@ -206,37 +209,37 @@ extern const int kDocumentCloseAllNoSave;
 extern const int kMemoryUsageChanged;
 extern const int kCommandCallbacksChanged;
 }
-
+   
 class ClientEvent
-{
+{   
 public:
    explicit ClientEvent(int type)
    {
       init(type, core::json::Value());
    }
-
+   
    ClientEvent(int type, const core::json::Value& data)
    {
       init(type, data);
    }
-
+   
    ClientEvent(int type, const char* data)
    {
       init(type, core::json::Value(std::string(data)));
    }
-
+   
    ClientEvent(int type, const std::string& data)
    {
       init(type, core::json::Value(data));
    }
-
+   
    ClientEvent(int type, bool data)
    {
       core::json::Object boolObject;
       boolObject["value"] = data;
       init(type, boolObject);
    }
-
+      
    // COPYING: via compiler (copyable members)
 
 public:
@@ -244,12 +247,12 @@ public:
    std::string typeName() const;
    const core::json::Value& data() const { return data_; }
    const std::string& id() const { return id_; }
-
+   
    void asJsonObject(int id, core::json::Object* pObject) const;
-
+     
 private:
    void init(int type, const core::json::Value& data);
-
+  
 private:
    int type_;
    core::json::Value data_;
@@ -262,10 +265,10 @@ ClientEvent showEditorEvent(const std::string& content,
 
 ClientEvent browseUrlEvent(const std::string& url,
                            const std::string& window = "_blank");
-
+   
 ClientEvent showErrorMessageEvent(const std::string& title,
                                   const std::string& message);
-
+   
 } // namespace session
 } // namespace rstudio
 

--- a/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
+++ b/src/gwt/src/org/rstudio/studio/client/RStudioGinModule.java
@@ -190,6 +190,7 @@ import org.rstudio.studio.client.workbench.views.output.rsconnectdeploy.RSConnec
 import org.rstudio.studio.client.workbench.views.output.sourcecpp.SourceCppOutputPane;
 import org.rstudio.studio.client.workbench.views.output.sourcecpp.SourceCppOutputPresenter;
 import org.rstudio.studio.client.workbench.views.output.sourcecpp.SourceCppOutputTab;
+import org.rstudio.studio.client.workbench.views.output.tests.TestsOutputTab;
 import org.rstudio.studio.client.workbench.views.help.Help;
 import org.rstudio.studio.client.workbench.views.help.HelpPane;
 import org.rstudio.studio.client.workbench.views.help.HelpTab;
@@ -307,7 +308,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(FileTypeCommands.class).in(Singleton.class);
       bind(Synctex.class).in(Singleton.class);
       bind(PDFViewer.class).in(Singleton.class);
-      bind(HTMLPreview.class).in(Singleton.class);
+      bind(HTMLPreview.class).in(Singleton.class);      
       bind(ShinyApplication.class).in(Singleton.class);
       bind(PlumberAPI.class).in(Singleton.class);
       bind(BreakpointManager.class).asEagerSingleton();
@@ -337,17 +338,17 @@ public class RStudioGinModule extends AbstractGinModule
 
       bind(ApplicationView.class).to(ApplicationWindow.class)
             .in(Singleton.class);
-
+      
       bind(VCSApplicationView.class).to(VCSApplicationWindow.class)
             .in(Singleton.class);
       bind(ReviewPresenter.class).to(ReviewPresenterImpl.class);
-
+      
       bind(HTMLPreviewApplicationView.class).to(HTMLPreviewApplicationWindow.class);
       bind(ShinyApplicationView.class).to(ShinyApplicationWindow.class);
       bind(PlumberAPIView.class).to(PlumberAPIWindow.class);
       bind(RmdOutputView.class).to(RmdOutputWindow.class);
       bind(SourceSatelliteView.class).to(SourceSatelliteWindow.class);
-
+      
       bind(Server.class).to(RemoteServer.class);
       bind(WorkbenchServerOperations.class).to(RemoteServer.class);
 
@@ -397,13 +398,14 @@ public class RStudioGinModule extends AbstractGinModule
       bindTab("Deploy", RSConnectDeployOutputTab.class);
       bindTab("Markers", MarkersOutputTab.class);
       bindTab("Terminal", TerminalTab.class);
+      bindTab("Tests", TestsOutputTab.class);
       bindTab("Jobs", JobsTab.class);
       bindTab("Launcher", LauncherJobsTab.class);
       bindTab("Data Output", DataOutputTab.class);
       bindTab("Tutorial", TutorialTab.class);
 
       bind(Shell.Display.class).to(ShellPane.class);
-
+           
       bind(HelpSearch.Display.class).to(HelpSearchWidget.class);
       bind(CodeSearch.Display.class).to(CodeSearchWidget.class);
 
@@ -412,12 +414,12 @@ public class RStudioGinModule extends AbstractGinModule
       bind(LineTablePresenter.Display.class).to(LineTableView.class);
       bind(HistoryPresenter.DisplayBuilder.class).to(
                                                     HistoryPanel.Builder.class);
-
+      
       bind(HTMLPreviewPresenter.Display.class).to(HTMLPreviewPanel.class);
       bind(ShinyApplicationPresenter.Display.class).to(ShinyApplicationPanel.class);
       bind(PlumberAPIPresenter.Display.class).to(PlumberAPIPanel.class);
       bind(RmdOutputPresenter.Display.class).to(RmdOutputPanel.class);
-
+      
       bind(GlobalDisplay.class)
             .to(DefaultGlobalDisplay.class)
             .in(Singleton.class);
@@ -490,7 +492,7 @@ public class RStudioGinModule extends AbstractGinModule
       bind(WorkbenchMainView.class).to(WorkbenchScreen.class);
 
       bind(DocDisplay.class).to(AceEditor.class);
-
+      
       install(new GinFactoryModuleBuilder()
          .implement(CompileOutputPaneDisplay.class, CompileOutputPane.class)
          .build(CompileOutputPaneFactory.class));

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -17,7 +17,7 @@ package org.rstudio.studio.client.server.remote;
 import com.google.gwt.core.client.JavaScriptObject;
 
 class ClientEvent extends JavaScriptObject
-{
+{   
    public static final String Busy = "busy";
    public static final String ConsolePrompt = "console_prompt";
    public static final String ConsoleOutput = "console_output";
@@ -177,6 +177,9 @@ class ClientEvent extends JavaScriptObject
    public static final String OpenFileDialog = "open_file_dialog";
    public static final String ShowPageViewer = "show_page_viewer";
    public static final String AskSecret = "ask_secret";
+   public static final String TestsStarted = "tests_started";
+   public static final String TestsOutput = "tests_output";
+   public static final String TestsCompleted = "tests_completed";
    public static final String JobUpdated = "job_updated";
    public static final String JobRefresh = "job_refresh";
    public static final String JobOutput = "job_output";
@@ -199,15 +202,15 @@ class ClientEvent extends JavaScriptObject
    protected ClientEvent()
    {
    }
-
+   
    public final native int getId() /*-{
       return this.id;
    }-*/;
-
+   
    public final native String getType() /*-{
       return this.type;
    }-*/;
-
+   
    public final native <T> T getData() /*-{
       return this.data;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -105,6 +105,10 @@ import org.rstudio.studio.client.server.model.RequestDocumentSaveEvent;
 import org.rstudio.studio.client.shiny.events.ShinyApplicationStatusEvent;
 import org.rstudio.studio.client.shiny.events.ShinyFrameNavigatedEvent;
 import org.rstudio.studio.client.shiny.model.ShinyApplicationParams;
+import org.rstudio.studio.client.tests.events.TestsCompletedEvent;
+import org.rstudio.studio.client.tests.events.TestsOutputEvent;
+import org.rstudio.studio.client.tests.events.TestsStartedEvent;
+import org.rstudio.studio.client.tests.model.TestsResult;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.addins.events.AddinRegistryUpdatedEvent;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
@@ -205,13 +209,13 @@ import org.rstudio.studio.client.workbench.views.viewer.events.ViewerNavigateEve
 
 import java.util.ArrayList;
 
-public class ClientEventDispatcher
+public class ClientEventDispatcher 
 {
    public ClientEventDispatcher(EventBus eventBus)
    {
       eventBus_ = eventBus;
    }
-
+   
    public void enqueEventAsJso(JavaScriptObject event)
    {
       ClientEvent clientEvent = event.<ClientEvent>cast();
@@ -240,9 +244,9 @@ public class ClientEventDispatcher
          });
       }
    }
-
-   private void dispatchEvent(ClientEvent event)
-   {
+   
+   private void dispatchEvent(ClientEvent event) 
+   { 
       String type = event.getType();
       try
       {
@@ -366,7 +370,7 @@ public class ClientEventDispatcher
             eventBus_.dispatchEvent(new ShowDataEvent(data));
          }
          else if (type == ClientEvent.AbendWarning)
-         {
+         {            
             eventBus_.dispatchEvent(new SessionAbendWarningEvent());
          }
          else if (type == ClientEvent.ShowWarningBar)
@@ -573,7 +577,7 @@ public class ClientEventDispatcher
          {
             // NOTE: we don't explicitly stop listening for events here
             // for the reasons cited above in ClientEvent.Quit
-
+            
             // fire event
             String message = event.getData();
             eventBus_.dispatchEvent(new SuicideEvent(message));
@@ -994,6 +998,21 @@ public class ClientEventDispatcher
             AskSecretEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new AskSecretEvent(data));
          }
+         else if (type == ClientEvent.TestsStarted)
+         {
+            TestsStartedEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new TestsStartedEvent(data));
+         }
+         else if (type == ClientEvent.TestsOutput)
+         {
+            CompileOutput data = event.getData();
+            eventBus_.dispatchEvent(new TestsOutputEvent(data));
+         }
+         else if (type == ClientEvent.TestsCompleted)
+         {
+            TestsResult result = event.getData();
+            eventBus_.dispatchEvent(new TestsCompletedEvent(result));
+         }
          else if (type == ClientEvent.JobUpdated)
          {
             JobUpdate data = event.getData();
@@ -1092,7 +1111,7 @@ public class ClientEventDispatcher
          GWT.log("WARNING: Exception occurred dispatching event: " + type, e);
       }
    }
-
+   
 
    private final EventBus eventBus_;
 

--- a/src/gwt/src/org/rstudio/studio/client/tests/events/TestsCompletedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/tests/events/TestsCompletedEvent.java
@@ -1,0 +1,55 @@
+/*
+ * TestsCompletedEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.tests.events;
+
+import org.rstudio.studio.client.tests.model.TestsResult;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class TestsCompletedEvent extends GwtEvent<TestsCompletedEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onTestsCompleted(TestsCompletedEvent event);
+   }
+
+   public TestsCompletedEvent(TestsResult result)
+   {
+      result_ = result;
+   }
+
+   public TestsResult getResult()
+   {
+      return result_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTestsCompleted(this);
+   }
+
+   private final TestsResult result_;
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/tests/events/TestsOutputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/tests/events/TestsOutputEvent.java
@@ -1,0 +1,55 @@
+/*
+ * TestsOutputEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.tests.events;
+
+import org.rstudio.studio.client.common.compile.CompileOutput;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class TestsOutputEvent extends GwtEvent<TestsOutputEvent.Handler>
+{
+   public interface Handler extends EventHandler
+   {
+      void onTestsOutput(TestsOutputEvent event);
+   }
+
+   public TestsOutputEvent(CompileOutput output)
+   {
+      output_ = output;
+   }
+
+   public CompileOutput getOutput()
+   {
+      return output_;
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTestsOutput(this);
+   }
+
+   private final CompileOutput output_;
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/tests/events/TestsStartedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/tests/events/TestsStartedEvent.java
@@ -1,0 +1,65 @@
+/*
+ * TestsStartedEvent.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.tests.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class TestsStartedEvent extends GwtEvent<TestsStartedEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public final native String getTargetFile() /*-{
+         return this.target_file;
+      }-*/;
+   }
+
+   public interface Handler extends EventHandler
+   {
+      void onTestsStarted(TestsStartedEvent event);
+   }
+
+   public TestsStartedEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public String getTargetFile()
+   {
+      return data_.getTargetFile();
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onTestsStarted(this);
+   }
+
+   private final Data data_;
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/tests/model/TestsResult.java
+++ b/src/gwt/src/org/rstudio/studio/client/tests/model/TestsResult.java
@@ -1,0 +1,44 @@
+/*
+ * TestsResult.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.tests.model;
+
+import org.rstudio.studio.client.common.sourcemarkers.SourceMarker;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+
+public class TestsResult extends JavaScriptObject
+{
+   protected TestsResult() 
+   {
+   }
+
+   public native final boolean getSucceeded() /*-{
+      return this.succeeded;
+   }-*/;
+
+   public native final String getTargetFile() /*-{
+      return this.target_file;
+   }-*/;
+
+   public final native JsArray<SourceMarker> getTestsErrors() /*-{
+      return this.tests_errors;
+   }-*/;
+   
+   public final boolean equals(TestsResult other)
+   {
+      return getTargetFile() == other.getTargetFile();
+   }
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -55,19 +55,20 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       userPrefs_ = uiPrefs;
       session_ = session;
    }
-
+   
    public ConsoleTabPanel(final PrimaryWindowFrame owner,
                           final LogicalWindow parentWindow,
                           ConsolePane consolePane,
                           WorkbenchTab compilePdfTab,
                           FindOutputTab findResultsTab,
                           WorkbenchTab sourceCppTab,
-                          WorkbenchTab renderRmdTab,
+                          WorkbenchTab renderRmdTab, 
                           WorkbenchTab deployContentTab,
                           MarkersOutputTab markersTab,
                           WorkbenchTab terminalTab,
                           EventBus events,
                           ToolbarButton goToWorkingDirButton,
+                          WorkbenchTab testsTab,
                           WorkbenchTab dataTab,
                           WorkbenchTab jobsTab,
                           WorkbenchTab launcherJobsTab)
@@ -83,10 +84,11 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       deployContentTab_ = deployContentTab;
       markersTab_ = markersTab;
       terminalTab_ = terminalTab;
+      testsTab_ = testsTab;
       dataTab_ = dataTab;
       jobsTab_ = jobsTab;
       launcherJobsTab_ = launcherJobsTab;
-
+      
       RStudioGinjector.INSTANCE.injectMembers(this);
 
       compilePdfTab.addEnsureVisibleHandler(ensureVisibleEvent ->
@@ -119,7 +121,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          if (!consoleOnly_)
             selectTab(0);
       });
-
+      
       sourceCppTab.addEnsureVisibleHandler(ensureVisibleEvent ->
       {
          sourceCppTabVisible_ = true;
@@ -145,6 +147,21 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       renderRmdTab.addEnsureHiddenHandler(ensureHiddenEvent ->
       {
          renderRmdTabVisible_ = false;
+         managePanels();
+         if (!consoleOnly_)
+            selectTab(0);
+      });
+
+      testsTab.addEnsureVisibleHandler(ensureVisibleEvent ->
+      {
+         testsTabVisible_ = true;
+         managePanels();
+         if (ensureVisibleEvent.getActivate())
+            selectTab(testsTab_);
+      });
+      testsTab.addEnsureHiddenHandler(ensureHiddenEvent ->
+      {
+         testsTabVisible_ = false;
          managePanels();
          if (!consoleOnly_)
             selectTab(0);
@@ -179,7 +196,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          if (!consoleOnly_)
             selectTab(0);
       });
-
+      
       markersTab.addEnsureVisibleHandler(ensureVisibleEvent ->
       {
          markersTabVisible_ = true;
@@ -240,7 +257,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          if (!consoleOnly_)
             selectTab(0);
       });
-
+      
       events.addHandler(WorkingDirChangedEvent.TYPE, workingDirChangedEvent ->
       {
          String path = workingDirChangedEvent.getPath();
@@ -256,7 +273,7 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
       {
          terminalTabVisible_ = false;
       }
-
+      
       // Determine initial visibility of local jobs and launcher jobs tabs
       String jobsTabVisibilitySetting = userPrefs_.jobsTabVisibility().getValue();
       Command showLauncherTab = () ->
@@ -339,21 +356,22 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
    private void managePanels()
    {
       boolean consoleOnly = !terminalTabVisible_ &&
-                            !compilePdfTabVisible_ &&
+                            !compilePdfTabVisible_ && 
                             !findResultsTabVisible_ &&
                             !sourceCppTabVisible_ &&
                             !renderRmdTabVisible_ &&
                             !deployContentTabVisible_ &&
                             !markersTabVisible_ &&
+                            !testsTabVisible_ &&
                             !dataTabVisible_ &&
                             !jobsTabVisible_ &&
                             !launcherJobsTabVisible_;
-
+      
       if (consoleOnly)
          owner_.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
       else
          owner_.removeStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
-
+      
       if (!consoleOnly)
       {
          ArrayList<WorkbenchTab> tabs = new ArrayList<>();
@@ -372,6 +390,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
             tabs.add(deployContentTab_);
          if (markersTabVisible_)
             tabs.add(markersTab_);
+         if (testsTabVisible_)
+            tabs.add(testsTab_);
          if (dataTabVisible_)
             tabs.add(dataTab_);
          if (jobsTabVisible_)
@@ -419,10 +439,10 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
             owner_.setContextButton(null, 0, 0, 2);
          }
       }
-
+      
       addLayoutStyles(owner_.getElement());
    }
-
+   
    public void addLayoutStyles(Element parent)
    {
       // In order to be able to style the actual layout div that GWT uses internally
@@ -432,21 +452,21 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
          boolean hasHeaderClass = false;
          boolean hasMinimizeClass = false;
          boolean hasMaximizeClass = false;
-
+         
          for (Element c = e.getFirstChildElement(); c != null; c = c.getNextSiblingElement()) {
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().windowFrameWidget()))
                hasWidgetClass = true;
-
+            
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().primaryWindowFrameHeader()))
                hasHeaderClass = true;
-
+            
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().minimize()))
                hasMinimizeClass = true;
-
+            
             if (c.hasClassName(ThemeResources.INSTANCE.themeStyles().maximize()))
                hasMaximizeClass = true;
          }
-
+         
          if (hasWidgetClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleWidgetLayout());
          if (hasHeaderClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleHeaderLayout());
          if (hasMinimizeClass) e.addClassName(ThemeResources.INSTANCE.themeStyles().consoleMinimizeLayout());
@@ -478,6 +498,8 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
    private boolean consoleOnly_;
    private UserPrefs userPrefs_;
    private Session session_;
+   private final WorkbenchTab testsTab_;
+   private boolean testsTabVisible_;
    private final WorkbenchTab dataTab_;
    private boolean dataTabVisible_;
    private final WorkbenchTab jobsTab_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/PaneManager.java
@@ -234,6 +234,7 @@ public class PaneManager
                       @Named("R Markdown") final WorkbenchTab renderRmdTab,
                       @Named("Deploy") final WorkbenchTab deployContentTab,
                       @Named("Terminal") final WorkbenchTab terminalTab,
+                      @Named("Tests") final WorkbenchTab testsTab,
                       @Named("Jobs") final WorkbenchTab jobsTab,
                       @Named("Launcher") final WorkbenchTab launcherJobsTab,
                       @Named("Data Output") final WorkbenchTab dataTab,
@@ -271,6 +272,7 @@ public class PaneManager
       jobsTab_ = jobsTab;
       launcherJobsTab_ = launcherJobsTab;
       optionsLoader_ = optionsLoader;
+      testsTab_ = testsTab;
       dataTab_ = dataTab;
       tutorialTab_ = tutorialTab;
       pGlobalDisplay_ = pGlobalDisplay;
@@ -1693,6 +1695,7 @@ public class PaneManager
             terminalTab_,
             eventBus_,
             goToWorkingDirButton,
+            testsTab_,
             dataTab_,
             jobsTab_,
             launcherJobsTab_);
@@ -1983,6 +1986,7 @@ public class PaneManager
    private final WorkbenchTab deployContentTab_;
    private final MarkersOutputTab markersTab_;
    private final WorkbenchTab terminalTab_;
+   private final WorkbenchTab testsTab_;
    private final WorkbenchTab jobsTab_;
    private final WorkbenchTab launcherJobsTab_;
    private final WorkbenchTab dataTab_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputPresenter.java
@@ -1,0 +1,160 @@
+/*
+ * TestsOutputPresenter.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.output.tests;
+
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+
+import org.rstudio.core.client.CodeNavigationTarget;
+import org.rstudio.core.client.events.SelectionCommitEvent;
+import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.RestartStatusEvent;
+import org.rstudio.studio.client.common.DelayedProgressRequestCallback;
+import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.ui.PaneManager;
+import org.rstudio.studio.client.workbench.ui.PaneManager.Tab;
+import org.rstudio.studio.client.workbench.views.BusyPresenter;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildCompletedEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildErrorsEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildOutputEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildStartedEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.model.BuildServerOperations;
+import org.rstudio.studio.client.workbench.views.output.common.CompileOutputPaneDisplay;
+import org.rstudio.studio.client.workbench.views.output.common.CompileOutputPaneFactory;
+
+public class TestsOutputPresenter extends BusyPresenter
+   implements BuildStartedEvent.Handler,
+              BuildOutputEvent.Handler,
+              BuildCompletedEvent.Handler,
+              BuildErrorsEvent.Handler,
+              RestartStatusEvent.Handler
+{
+   @Inject
+   public TestsOutputPresenter(CompileOutputPaneFactory outputFactory,
+                               BuildServerOperations server,
+                               GlobalDisplay globalDisplay,
+                               PaneManager paneManager,
+                               Commands commands,
+                               EventBus events)
+   {
+      super(outputFactory.create("Tests",
+                                 "View test results"));
+      view_ = (CompileOutputPaneDisplay) getView();
+      view_.setHasLogs(false);
+      server_ = server;
+      paneManager_ = paneManager;
+
+      view_.stopButton().addClickHandler(event ->
+      {
+         terminateTests();
+      });
+
+      view_.errorList().addSelectionCommitHandler((
+            SelectionCommitEvent<CodeNavigationTarget> event) ->
+      {
+         CodeNavigationTarget target = event.getSelectedItem();
+         FileSystemItem fsi = FileSystemItem.createFile(target.getFile());
+         RStudioGinjector.INSTANCE.getFileTypeRegistry()
+            .editFile(fsi, target.getPosition());
+      });
+      globalDisplay_ = globalDisplay;
+   }
+
+   public void initialize()
+   {
+   }
+
+   public void confirmClose(final Command onConfirmed)
+   {
+      if (isBusy())
+      {
+         terminateTests();
+      }
+
+      onConfirmed.execute();
+   }
+
+   private boolean isEnabled()
+   {
+      return paneManager_.getTab(Tab.Build).isSuppressed();
+   }
+
+   @Override
+   public void onBuildStarted(BuildStartedEvent event)
+   {
+      if (!isEnabled()) return;
+
+      view_.ensureVisible(true);
+      view_.compileStarted(event.getSubType());
+      setIsBusy(true);
+   }
+
+   @Override
+   public void onBuildOutput(BuildOutputEvent event)
+   {
+      if (!isEnabled()) return;
+
+      view_.showOutput(event.getOutput(), true);
+   }
+
+   @Override
+   public void onBuildCompleted(BuildCompletedEvent event)
+   {
+      if (!isEnabled()) return;
+
+      view_.compileCompleted();
+      setIsBusy(false);
+      view_.ensureVisible(true);
+   }
+
+   @Override
+   public void onBuildErrors(BuildErrorsEvent event)
+   {
+      if (!isEnabled()) return;
+
+      view_.showErrors(event.getErrors());
+   }
+
+   @Override
+   public void onRestartStatus(RestartStatusEvent event)
+   {
+   }
+
+   private void terminateTests()
+   {
+      server_.terminateBuild(new DelayedProgressRequestCallback<Boolean>(
+                                                       "Terminating Tests..."){
+         @Override
+         protected void onSuccess(Boolean response)
+         {
+            if (!response)
+            {
+               globalDisplay_.showErrorMessage(
+                  "Error Terminating Tests",
+                  "Unable to terminate tests. Please try again.");
+            }
+         }
+      });
+   }
+
+   private final BuildServerOperations server_;
+   private final CompileOutputPaneDisplay view_;
+   private final GlobalDisplay globalDisplay_;
+   private final PaneManager paneManager_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputTab.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/tests/TestsOutputTab.java
@@ -1,0 +1,85 @@
+
+/*
+ * TestsOutputTab.java
+ *
+ * Copyright (C) 2020 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.output.tests;
+
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+
+import org.rstudio.core.client.widget.model.ProvidesBusy;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.application.events.RestartStatusEvent;
+import org.rstudio.studio.client.workbench.events.BusyEvent;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.ui.DelayLoadTabShim;
+import org.rstudio.studio.client.workbench.ui.DelayLoadWorkbenchTab;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildCompletedEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildErrorsEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildOutputEvent;
+import org.rstudio.studio.client.workbench.views.buildtools.events.BuildStartedEvent;
+
+public class TestsOutputTab
+   extends DelayLoadWorkbenchTab<TestsOutputPresenter>
+   implements ProvidesBusy
+{
+   public abstract static class Shim extends
+                DelayLoadTabShim<TestsOutputPresenter, TestsOutputTab>
+      implements BuildStartedEvent.Handler,
+                 BuildOutputEvent.Handler,
+                 BuildCompletedEvent.Handler,
+                 BuildErrorsEvent.Handler,
+                 RestartStatusEvent.Handler,
+                 ProvidesBusy
+   {
+      abstract void initialize();
+      abstract void confirmClose(Command onConfirmed);
+   }
+
+   @Inject
+   public TestsOutputTab(Shim shim,
+                         EventBus events,
+                         final Session session)
+   {
+      super("Tests", shim);
+      shim_ = shim;
+
+      events.addHandler(BuildStartedEvent.TYPE, shim);
+      events.addHandler(BuildOutputEvent.TYPE, shim);
+      events.addHandler(BuildCompletedEvent.TYPE, shim);
+      events.addHandler(BuildErrorsEvent.TYPE, shim);
+      events.addHandler(RestartStatusEvent.TYPE, shim);
+   }
+
+   @Override
+   public boolean closeable()
+   {
+      return true;
+   }
+
+   @Override
+   public void confirmClose(Command onConfirmed)
+   {
+      shim_.confirmClose(onConfirmed);
+   }
+
+   @Override
+   public void addBusyHandler(BusyEvent.Handler handler)
+   {
+      shim_.addBusyHandler(handler);
+   }
+
+   private final Shim shim_;
+}


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8775. 

### Approach

This change just reverts https://github.com/rstudio/rstudio/pull/7756, which removed the Tests pane. 

### Automated Tests

None, this change restores the product to a previous state.

### QA Notes

There are 3 main cases to consider here:

1. Sessions in which projects are not open
2. Project sessions without a Build pane (e.g. New Empty Project)
3. Project sessions with a Build pane (e.g. New Package Project)

The Tests pane should show up in cases (1) and (2). In case (3), tests should be run in the Build pane instead.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


