### PR TITLE
Fix warning in unit tests

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1040,13 +1040,14 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 
 # get list of command IDs which currently have callbacks (listeners) attached
 .rs.addFunction("getCommandsWithCallbacks", function() {
-   unique(sort(unlist(lapply(names(.rs.commandCallbacks), function(handle) {
+   commands <- unique(sort(unlist(lapply(names(.rs.commandCallbacks), function(handle) {
       handler <- get(handle, envir = .rs.commandCallbacks)
       if (nzchar(handler$command)) 
          handler$command
       else
-         NULL
+         ""
    }))))
+   commands[nzchar(commands)]
 })
 
 # register a command callback


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9041.

### Approach

Warning comes from sorting a list with `NULL` values, so use empty strings instead and remove them later. 

### Automated Tests

Only.

### QA Notes

No QA necessary, internal testing change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

