### PR TITLE
minor tweaks for aarch64 builds on Linux

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -57,6 +57,11 @@ if(UNIX)
       OUTPUT_STRIP_TRAILING_WHITESPACE)
    message(STATUS "Machine architecture: ${UNAME_M}")
 
+else()
+
+   # assume x86_64 on Windows for now
+   set(UNAME_M x86_64)
+
 endif()
 
 # default to debug builds
@@ -84,13 +89,11 @@ if(NOT DEFINED RSTUDIO_SERVER)
    endif()
 endif()
 
-if(NOT DEFINED RSTUDIO_DESKTOP)
-   if(APPLE AND UNAME_M STREQUAL arm64)
-      message(STATUS "Desktop builds not currently supported on arm64; disabling RSTUDIO_DESKTOP")
-      set(RSTUDIO_DESKTOP FALSE)
-   elseif(RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Desktop")
-      set(RSTUDIO_DESKTOP TRUE)
-   endif()
+if(NOT UNAME_M STREQUAL x86_64)
+   message(STATUS "Desktop builds not yet supported on ${UNAME_M}; disabling RSTUDIO_DESKTOP")
+   set(RSTUDIO_DESKTOP FALSE)
+elseif(RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Desktop")
+   set(RSTUDIO_DESKTOP TRUE)
 endif()
 
 # override if requested

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -89,11 +89,13 @@ if(NOT DEFINED RSTUDIO_SERVER)
    endif()
 endif()
 
-if(NOT UNAME_M STREQUAL x86_64)
-   message(STATUS "Desktop builds not yet supported on ${UNAME_M}; disabling RSTUDIO_DESKTOP")
-   set(RSTUDIO_DESKTOP FALSE)
-elseif(RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Desktop")
-   set(RSTUDIO_DESKTOP TRUE)
+if(NOT DEFINED RSTUDIO_DESKTOP)
+   if(NOT UNAME_M STREQUAL x86_64)
+      message(STATUS "Desktop builds not yet supported on ${UNAME_M}; disabling RSTUDIO_DESKTOP")
+      set(RSTUDIO_DESKTOP FALSE)
+   elseif(RSTUDIO_TARGET STREQUAL "Development" OR RSTUDIO_TARGET STREQUAL "Desktop")
+      set(RSTUDIO_DESKTOP TRUE)
+   endif()
 endif()
 
 # override if requested

--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -27,7 +27,7 @@ set -e
 ./install-yaml-cpp
 ./install-crashpad
 
-if [ "$(uname -m)" = "x86_64" ]; then
+if [ "$(uname)" = "Darwin" ] || [ "$(uname -m)" = "x86_64" ]; then
 	./install-npm-dependencies
 fi
 

--- a/dependencies/common/install-common
+++ b/dependencies/common/install-common
@@ -23,12 +23,15 @@ set -e
 ./install-pandoc
 ./install-packages
 ./install-sentry-cli
-./install-npm-dependencies
 ./install-soci
 ./install-yaml-cpp
 ./install-crashpad
 
-if [ -e install-overlay ]
-then
-   ./install-overlay
+if [ "$(uname -m)" = "x86_64" ]; then
+	./install-npm-dependencies
 fi
+
+if [ -e install-overlay ]; then
+	./install-overlay
+fi
+

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -71,7 +71,7 @@ sudo apt-get -y install \
 sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get update
 sudo apt-get -y install openjdk-8-jdk
-sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/jre/bin/java
 
 # R
 if ! [ -x "$(command -v R)" ]; then

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -318,12 +318,14 @@ add_definitions(-DRSTUDIO_BOOST_SIGNALS_VERSION=2)
 # add boost as system include directory
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-if(NOT DEFINED RSTUDIO_CRASHPAD_ENABLED AND APPLE AND UNAME_M STREQUAL arm64)
-   message(STATUS "Crashpad not yet supported on M1 macOS machines; disabling Crashpad")
+# Crashpad
+
+# disabled on non-x86_64 architectures for now
+if(NOT UNAME_M STREQUAL "x86_64")
+   message(STATUS "Crashpad not yet supported on ${UNAME_M}; disabling Crashpad")
    set(RSTUDIO_CRASHPAD_ENABLED FALSE)
 endif()
 
-# Crashpad
 if (NOT DEFINED RSTUDIO_CRASHPAD_ENABLED OR RSTUDIO_CRASHPAD_ENABLED)
    if(UNIX)
       set(RSTUDIO_TOOLS_CRASHPAD "${RSTUDIO_TOOLS_ROOT}/crashpad")


### PR DESCRIPTION
### Intent

Allow RStudio Server (open source) to build on aarch64 Linux machines.

### Approach

- Disable RStudio Desktop builds on aarch64 by default
- Disable Crashpad on aarch64 by default (note: we could probably re-enable this in the future, but since this is not a supported configuration yet I don't believe it's worth collecting crash reports)
- Tweak dependency installation script (use dpkg architecture suffix)

### Automated Tests

None.

### QA Notes

None.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
