### PR TITLE
Allow comment toggling and comment reflow for C files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/CppFileType.java
@@ -67,11 +67,11 @@ public class CppFileType extends TextFileType
       HashSet<AppCommand> result = super.getSupportedCommands(commands);
       if (isCpp())
       {
-         result.add(commands.commentUncomment());
-         result.add(commands.reflowComment());
          result.add(commands.sourceActiveDocument());
          result.add(commands.sourceActiveDocumentWithEcho());
       }
+      result.add(commands.commentUncomment());
+      result.add(commands.reflowComment());
       result.add(commands.goToDefinition());
       result.add(commands.codeCompletion());
       result.add(commands.findUsages());


### PR DESCRIPTION
### Intent

Allow the comment toggling shortcut (Ctrl + Shift + c) on `.c` files, just like it exists for `.h`, `.hpp`, and `.cpp` files. See issue #4109

### Approach

C and CPP files are handled by the same java CppFiletype class. The option enabling comment toggling was only enabled for CPP files. Simply moving it out of a check for CPP-type (specifically `.h`, `.hpp`, `.cc`, and `.cpp` extensions) files allows comment toggling for both C and CPP files.

 I also noticed an option for enabling comment reflow, and included that for C files as well, since functionally it would be the same for C and CPP files

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


