### PR TITLE
Import Authors from Datasets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -101,4 +101,5 @@
 * Fixed issue where Pro database drivers will not install if `~/odbcinst.ini` is missing (Pro #2284)
 * Fixed issue causing the mouse cursor to become too small in certain areas on Linux Desktop (#8781)
 * Fixed issue causing Run Tests command to do nothing unless the Build tab was available (#8775)
+* Fixed issue importing dataset author data from DOIs in the Visual Editor (#9059)
 

--- a/src/gwt/panmirror/src/editor/src/api/bibliography/bibDB.ts
+++ b/src/gwt/panmirror/src/editor/src/api/bibliography/bibDB.ts
@@ -220,6 +220,13 @@ function cslToBibDB(id: string, csl: CSL): BibDB | undefined {
 // For a given type, we filter out any fields that aren't required,
 // eitheror, or optional.
 function shouldIncludeField(bibDBFieldName: string, bibType: BibType) {
+  // Special case:
+  // For datasets, allow author 
+  // Fixes https://github.com/rstudio/rstudio/issues/9059
+  if (bibType.csl === 'dataset' && bibDBFieldName === 'author') {
+    return true;
+  }
+
   return (
     bibType.required.includes(bibDBFieldName) ||
     bibType.optional.includes(bibDBFieldName) ||


### PR DESCRIPTION
The ‘dataset’ CSL defintion really wants to have editors instead of authors, but author is frequently used instead. Allow that field to be processed

Fixes @rstudio/rstudio#9059


### Intent
Resolves issue where dataset citation data imported from DOIs failed to include authors.

### Approach
To minimize the impact (and not require changing the CSL schema definition from biblatex-csl-converter, I merely added a special case.

### Automated Tests
Does not include tests.

### QA Notes
No other behavior change is expected other than authors being imported for datasets. Bug has good repro cases.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


