### PR TITLE
Don’t lose citation state in debounced function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -102,4 +102,5 @@
 * Fixed issue causing the mouse cursor to become too small in certain areas on Linux Desktop (#8781)
 * Fixed issue causing Run Tests command to do nothing unless the Build tab was available (#8775)
 * Fixed issue importing dataset author data from DOIs in the Visual Editor (#9059)
+* Fixed issue where the Insert Citation dialog in the visual editor would clear selected citation when typeahead searching (#8521)
 

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
@@ -441,18 +441,20 @@ export const InsertCitationPanel: React.FC<InsertCitationPanelProps> = props => 
       (
         searchTerm: string,
         panelProvider: CitationSourcePanelProvider,
-        selectedNode: NavigationTreeNode,
         existingIds: string[],
+        existingState: InsertCitationPanelState
       ) => {
-        const searchResult = panelProvider.typeAheadSearch(searchTerm, selectedNode, existingIds);
+        const searchResult = panelProvider.typeAheadSearch(searchTerm, existingState.selectedNode, existingIds);
         if (searchResult) {
-          updateState({
-            searchTerm,
-            citations: searchResult?.citations,
-            status: searchResult?.status,
-            statusMessage: searchResult?.statusMessage,
-            selectedNode,
-          });
+          setInsertCitationPanelState(
+            {
+              ...existingState,
+              searchTerm,
+              citations: searchResult?.citations,
+              status: searchResult?.status,
+              statusMessage: searchResult?.statusMessage,
+            }
+          );
         }
       },
       30,
@@ -470,8 +472,9 @@ export const InsertCitationPanel: React.FC<InsertCitationPanelProps> = props => 
     citationsToAdd: mergedCitationsToAdd,
     searchTerm: insertCitationPanelState.searchTerm,
     onSearchTermChanged: (term: string) => {
-      updateState({ searchTerm: term });
-      memoizedTypeaheadSearch(term, selectedPanelProvider, insertCitationPanelState.selectedNode, existingCitationIds);
+      const updatedState = { ...insertCitationPanelState, searchTerm: term };
+      updateState(updatedState);
+      memoizedTypeaheadSearch(term, selectedPanelProvider, existingCitationIds, updatedState);
     },
     onExecuteSearch: (searchTerm: string) => {
       searchCanceled.current = false;


### PR DESCRIPTION

### Intent
Typeahead searching would clear any selected citation because the function was capturing empty state and using that state when performing the search (rather than reflecting the correct up to date state).

Fixes @rstudio/rstudio#8521

### Approach
Pass state rather than capturing it.

### Automated Tests
No tests

### QA Notes
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


