### PR TITLE
render '\' as lower-case lambda for anonymous functions

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -183,14 +183,8 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
 
   var RHighlightRules = function()
   {
-    // NOTE: The backslash character is an experimental alias
-    // for the 'function' symbol, and can be used for defining
-    // short-hand functions, e.g.
-    //
-    //     \(x) x + 1
-    //
     var keywords = lang.arrayToMap([
-      "\\", "function", "if", "else", "in",
+      "function", "if", "else", "in",
       "break", "next", "repeat", "for", "while"
     ]);
 
@@ -207,9 +201,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       "NA_complex_"
     ]);
 
-    // NOTE: We accept '\' as a standalone identifier here
-    // so that it can be parsed as the 'function' alias symbol
-    var reIdentifier = "(?:\\\\|[a-zA-Z.][a-zA-Z0-9._]*)";
+    var reIdentifier = "[a-zA-Z.][a-zA-Z0-9._]*";
 
     var $complements = {
       "{" : "}",
@@ -325,6 +317,20 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         regex : "[`](?:(?:\\\\.)|(?:[^`\\\\]))*?[`]",
         merge : false,
         next  : "start"
+      }
+    ];
+
+    rules["#lambda"] = [
+      {
+        token : "keyword",
+        regex : "\\\\",
+        next  : "start",
+        onMatch : function(value, state, stack, line) {
+          return [{
+            type: this.token,
+            value: "λ"
+          }];
+        }
       }
     ];
 
@@ -462,7 +468,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
 
     // Construct rules from previously defined blocks.
     rules["start"] = include([
-      "#comment", "#string", "#number",
+      "#comment", "#string", "#number", "#lambda",
       "#package-access", "#quoted-identifier",
       "#function-call-or-keyword", "#keyword-or-identifier",
       "#knitr-embed", "#operator", "#text"


### PR DESCRIPTION
Just for fun...

### Intent

Render the `\` keyword as `λ`, for definitions of anonymous functions.

<img width="353" alt="Screen Shot 2021-03-05 at 3 24 24 PM" src="https://user-images.githubusercontent.com/1976582/110185459-42f13500-7dc7-11eb-8cbf-4effe40a1cde.png">

Note that if we eventually merge this, we'd probably want to allow users to toggle the behavior as `λ` may not be rendered as a monospace character in all fonts (and so could mess up rendering in Ace).

### Approach

Relatively straightforward application of special Ace `onMatch` tokenization rule.

### Automated Tests

None.

### QA Notes

None.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
