### PR TITLE
prefer cout, cerr when reporting messages

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -149,8 +149,19 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("restoreGlobalEnvFromFile", function(path)
 {
    Encoding(path) <- "UTF-8"
-
-   status <- try(load(path, envir = .GlobalEnv), silent = TRUE)
+   
+   # avoid path encoding issues by moving to directory first
+   if (!file.exists(path))
+      return(paste(path, "does not exist"))
+   
+   owd <- setwd(dirname(path))
+   on.exit(setwd(owd), add = TRUE)
+   
+   status <- try(
+      load(basename(path), envir = .GlobalEnv),
+      silent = TRUE
+   )
+   
    if (!inherits(status, "try-error"))
       return("")
    

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -137,10 +137,10 @@ void deferredRestoreNewSession()
       Error error = restoreGlobalEnvFromFile(path, &errMessage);
       if (error)
       {
-         ::REprintf(
-                  "WARNING: Failed to restore workspace from '%s' "
-                  "(an internal error occurred)\n",
-                  aliasedPath.c_str());
+         std::cerr << "WARNING: Failed to restore workspace from "
+                   << "'" << aliasedPath << "'"
+                   << " (an internal error occurred)"
+                   << std::endl;
          LOG_ERROR(error);
       }
       else if (!errMessage.empty())
@@ -150,14 +150,15 @@ void deferredRestoreNewSession()
             << "'" << aliasedPath << "'" << std::endl
             << "Reason: " << errMessage << std::endl;
          std::string message = ss.str();
-         
-         ::REprintf("%s\n", message.c_str());
+
+         std::cerr << message << std::endl;
          LOG_ERROR_MESSAGE(message);
       }
       else
       {
-         const char* fmt = "[Workspace loaded from %s]\n\n";
-         Rprintf(fmt, aliasedPath.c_str());
+         std::cout << "[Workspace loaded from " << aliasedPath << "]"
+                   << std::endl
+                   << std::endl;
       }
    }
 


### PR DESCRIPTION
### Intent

Fixes a [mojibake](https://en.wikipedia.org/wiki/Mojibake) on Windows when the current path uses non-ASCII characters.

Part of https://github.com/rstudio/rstudio/issues/8321.

<img width="411" alt="Screen Shot 2021-03-05 at 4 27 34 PM" src="https://user-images.githubusercontent.com/1976582/110188172-b303b900-7dcf-11eb-8267-5d450171617c.png">

<img width="382" alt="Screen Shot 2021-03-05 at 4 35 38 PM" src="https://user-images.githubusercontent.com/1976582/110188524-d5e29d00-7dd0-11eb-8d33-f16303d5d70b.png">


### Approach

`Rprintf()` and `REprintf()` expect their inputs to be in the native encoding, so prefer instead writing to `cout` and `cerr` directly.

### Automated Tests

None.

### QA Notes

None.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
