### PR TITLE
Bugfix/bibpath

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -103,4 +103,5 @@
 * Fixed issue causing Run Tests command to do nothing unless the Build tab was available (#8775)
 * Fixed issue importing dataset author data from DOIs in the Visual Editor (#9059)
 * Fixed issue where the Insert Citation dialog in the visual editor would clear selected citation when typeahead searching (#8521)
+* Fixed issue where the bibliography path is assumed to be document relative when inserting citations in the visual editor (#8847)
 

--- a/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography-provider_zotero.ts
+++ b/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography-provider_zotero.ts
@@ -28,6 +28,7 @@ import {
 import { EditorUI } from '../ui';
 import { CSL } from '../csl';
 import { toBibTeX } from './bibDB';
+import { Editor } from '../../editor/editor';
 
 export const kZoteroProviderKey = '2509FBBE-5BB0-44C4-B119-6083A81ED673';
 
@@ -50,6 +51,7 @@ export class BibliographyDataProviderZotero implements BibliographyDataProvider 
   public requiresWritable: boolean = true;
 
   public async load(
+    _ui: EditorUI,
     docPath: string,
     _resourcePath: string,
     yamlBlocks: ParsedYaml[],

--- a/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography.ts
+++ b/src/gwt/panmirror/src/editor/src/api/bibliography/bibliography.ts
@@ -24,8 +24,8 @@ import { CSL } from '../csl';
 import { ZoteroServer } from '../zotero';
 import { BibliographyDataProviderLocal, kLocalBiliographyProviderKey } from './bibliography-provider_local';
 import { BibliographyDataProviderZotero } from './bibliography-provider_zotero';
-import { toBibLaTeX, toBibTeX } from './bibDB';
-import { joinPaths } from '../path';
+import { toBibTeX } from './bibDB';
+import { joinPaths, isAbsolute } from '../path';
 
 export interface BibliographyFile {
   displayPath: string;
@@ -37,7 +37,7 @@ export interface BibliographyFile {
 export function bibliographyFileForPath(path: string, ui: EditorUI): BibliographyFile {
   return {
     displayPath: path,
-    fullPath: joinPaths(ui.context.getDefaultResourceDir(), path),
+    fullPath: isAbsolute(path, ui.context.isWindowsDesktop()) ? path : joinPaths(ui.context.getDefaultResourceDir(), path),
     isProject: false,
     writable: true,
   };
@@ -78,6 +78,7 @@ export interface BibliographyDataProvider {
 
   isEnabled(): boolean;
   load(
+    ui: EditorUI,
     docPath: string | null,
     resourcePath: string,
     yamlBlocks: ParsedYaml[],
@@ -159,7 +160,7 @@ export class BibliographyManager {
     // Load each provider
     const providersNeedUpdate = await Promise.all(
       this.providers.map(provider =>
-        provider.load(docPath, ui.context.getDefaultResourceDir(), parsedYamlNodes, refreshCollectionData),
+        provider.load(ui, docPath, ui.context.getDefaultResourceDir(), parsedYamlNodes, refreshCollectionData),
       ),
     );
 

--- a/src/gwt/panmirror/src/editor/src/api/path.ts
+++ b/src/gwt/panmirror/src/editor/src/api/path.ts
@@ -24,6 +24,37 @@ export function joinPaths(root: string, path: string) {
   return mergedPath.replace(/\/\//g, '/');
 }
 
+// Ported from
+// https://github.com/denoland/deno_std/tree/main/path
+export function isAbsolute(path: string, isWindows: boolean) {
+
+  if (isWindows) {
+    // Win32 implementation
+    const len = path.length;
+    if (len === 0) {
+      return false;
+    }
+
+    const code = path.charCodeAt(0);
+    if (isWinPathSeparator(code)) {
+      return true;
+    } else if (isWindowsDeviceRoot(code)) {
+      // Possible device root
+
+      if (len > 2 && path.charCodeAt(1) === CHAR_COLON) {
+        if (isWinPathSeparator(path.charCodeAt(2))) {
+          return true;
+        }
+      }
+    }
+    return false;
+
+  } else {
+    // posix implementation
+    return path.length > 0 && path.charCodeAt(0) === CHAR_FORWARD_SLASH;
+  }
+}
+
 export function getExtension(path: string) {
   // Get the file out of the path
   const fileName = path.split(/[\\/]/).pop();
@@ -40,4 +71,23 @@ export function changeExtension(path: string, extension: string) {
   const lastDot = path.lastIndexOf('.');
   const pathNoExtension = path.substr(0, lastDot + 1);
   return pathNoExtension + extension;
+}
+
+const CHAR_UPPERCASE_A = 65; /* A */
+const CHAR_LOWERCASE_A = 97; /* a */
+const CHAR_UPPERCASE_Z = 90; /* Z */
+const CHAR_LOWERCASE_Z = 122; /* z */
+const CHAR_FORWARD_SLASH = 47; /* / */
+const CHAR_BACKWARD_SLASH = 92; /* \ */
+const CHAR_COLON = 58; /* : */
+
+function isWinPathSeparator(code: number) {
+  return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
+}
+
+function isWindowsDeviceRoot(code: number): boolean {
+  return (
+    (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z) ||
+    (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z)
+  );
 }


### PR DESCRIPTION
### Intent
A user reported a problem accessing bibliographies on a network mounted drive on windows (this requires an absolute path). The underlying issue was an assumption in our bibliography manage that paths were always document relative (or project paths). Instead, we need to permit absolute paths if specified.

fixes rstudio/rstudio#8847

### Approach
Implement a function for testing whether a path is absolute given platform (win vs posix) and use that to test whether a path is absolute before we assume it is relative.

### Automated Tests
None

### QA Notes
The 'bibliography' front matter of an RMarkdown document should now support a single (or array of) bibliography paths that are either relative to the document or are absolute (including permitting drive letters on Windows).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


