### PR TITLE
Report verify-installation failure to stderr

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -104,4 +104,5 @@
 * Fixed issue importing dataset author data from DOIs in the Visual Editor (#9059)
 * Fixed issue where the Insert Citation dialog in the visual editor would clear selected citation when typeahead searching (#8521)
 * Fixed issue where the bibliography path is assumed to be document relative when inserting citations in the visual editor (#8847)
+* Fixed issue causing `verify-installation` to stop early without reporting a reason (Pro #2399)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -108,4 +108,5 @@
 * Fixed issue causing the mouse cursor to become too small in certain areas on Linux Desktop (#8781)
 * Fixed issue causing Run Tests command to do nothing unless the Build tab was available (#8775)
 * Fixed issue causing RStudio Server to create `.local/share/rstudio` folder with incorrect permissions when `session-timeout-kill-hours` is set (Pro #2388)
+* Fixed issue causing `verify-installation` to exit without showing the error that caused it to do so (Pro #2399)
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -768,7 +768,10 @@ int main(int argc, char * const argv[])
       {
          Error error = session_proxy::runVerifyInstallationSession();
          if (error)
+         {
+            std::cerr << "Verify Installation Failed: " << error << std::endl;
             return core::system::exitFailure(error, ERROR_LOCATION);
+         }
 
          return EXIT_SUCCESS;
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2399. This issue appears to be at the root of a lot of the "verify-installation just exits without returning any output" reports we have gotten from customers.

### Approach

When verify-installation encounters an error that causes it to exit `main()`, have it print that error to stderr before terminating.

### Automated Tests

None, this change just improves logging. 

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2399.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


