### PR TITLE
make GWT detect both Electron and QtWebEngine desktop user agents

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -4,9 +4,9 @@
 
    <!-- GWT module dependencies                                    -->
    <inherits name='com.google.gwt.user.User'/>
-   
+
    <inherits name='com.google.gwt.widgetideas.SliderBar'/>
-    
+
    <inherits name='com.sksamuel.gwt.GwtWebsockets'/>
 
    <!-- Gin module dependencies                                    -->
@@ -26,8 +26,9 @@
       if (window.desktop)
          return "true";
 
-      // also true when run under QtWebEngine, which defers hook injection
-      return window.navigator.userAgent.indexOf("QtWebEngine") > 0 ? "true" : "false";
+      // also true when run under Electron or QtWebEngine, which defer hook injection
+      return ((window.navigator.userAgent.indexOf("Electron") > 0) ||
+              (window.navigator.userAgent.indexOf("QtWebEngine") > 0)) ? "true" : "false";
    ]]></property-provider>
 
    <define-property name="rstudio.remoteDesktop" values="true,false"/>
@@ -36,7 +37,7 @@
       if (window.remoteDesktop)
          return "true";
 
-      // also true when run under QtWebEngine, which defers hook injection
+      // also true when run under Electron or QtWebEngine, which defer hook injection
       return window.navigator.userAgent.indexOf("RStudio Remote Desktop") > 0 ? "true" : "false";
    ]]></property-provider>
 
@@ -44,13 +45,13 @@
       <when-property-is name="rstudio.desktop" value="true"/>
    </set-property>
    <collapse-property name="rstudio.desktop" values="*"/>
-    
+
    <define-property name="rstudio.unittests" values="true,false"/>
    <set-property name="rstudio.unittests" value="false"/>
 
    <!-- RStudio module dependencies                                -->
    <inherits name='org.rstudio.core.Core' />
-   
+
    <!-- Specify the app entry point class.                         -->
    <entry-point class='org.rstudio.studio.client.RStudio'/>
 
@@ -75,7 +76,7 @@
          <when-property-is name="rstudio.remoteDesktop" value="false"/>
       </all>
    </replace-with>
- 
+
    <replace-with class="org.rstudio.studio.client.application.ui.impl.WebApplicationHeader">
       <when-type-is class="org.rstudio.studio.client.application.ui.ApplicationHeader" />
    </replace-with>
@@ -118,7 +119,7 @@
       <when-type-is class="org.rstudio.studio.client.common.dialog.DialogBuilderFactory"/>
       <when-property-is name="rstudio.desktop" value="true"/>
    </replace-with>
-  
+
    <replace-with class="org.rstudio.studio.client.common.impl.WebTextInput">
       <when-type-is class="org.rstudio.studio.client.common.TextInput"/>
    </replace-with>


### PR DESCRIPTION
### Intent

First non-prototype Electron commit!

During development of the Electron-based desktop, want the GWT code (i.e. the user interface) to detect and function with both the QtWebEngine-based desktop, and the Electron desktop.

Addresses #9082

### Approach

Detect desktop mode both via the QtWebEngine user agent and the Electron user agent.

### Automated Tests

N/A

### QA Notes

Test that the existing desktop app (Qt) still loads the desktop variation of the UI. Most obvious symptom is whether the main menu is displayed as part of the HTML (server) or the native menus are populated (desktop).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


