### PR TITLE
Add option to report R session version

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -74,6 +74,7 @@
 * Add support for non-CRAN repositories when installing R packages in the background (#8946)
 * Add server homepage link and retry options to mitigate "Unable to connect to service" errors (Pro #2066)
 * Add support for commenting and uncommenting code in C (`.c` and `.h`) files (#4109, thanks to @cm421)
+* The R session binary (`rsession`) now has a `--version` option for reporting its version (Pro #2410)
 
 ### Bugfixes
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1799,6 +1799,15 @@ int main (int argc, char * const argv[])
       if (status.exit())
          return status.exitCode();
 
+      // print version if requested
+      if (options.version())
+      {
+         std::cout << RSTUDIO_VERSION ", \"" RSTUDIO_RELEASE_NAME "\" "
+                      "( " RSTUDIO_GIT_COMMIT ", " RSTUDIO_BUILD_DATE ")"
+                      "for " RSTUDIO_PACKAGE_OS << std::endl;
+         return 0;
+      }
+
       // convenience flags for server and desktop mode
       bool desktopMode = options.programMode() == kSessionProgramModeDesktop;
       bool serverMode = options.programMode() == kSessionProgramModeServer;

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1802,8 +1802,9 @@ int main (int argc, char * const argv[])
       // print version if requested
       if (options.version())
       {
+         std::string gitCommit(RSTUDIO_GIT_COMMIT);
          std::cout << RSTUDIO_VERSION ", \"" RSTUDIO_RELEASE_NAME "\" "
-                      "( " RSTUDIO_GIT_COMMIT ", " RSTUDIO_BUILD_DATE ")"
+                      "(" << gitCommit.substr(0, 8) << ", " RSTUDIO_BUILD_DATE ") "
                       "for " RSTUDIO_PACKAGE_OS << std::endl;
          return 0;
       }

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -112,6 +112,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    options_description runTests("tests");
    options_description runScript("script");
    options_description verify("verify");
+   options_description version("version");
    options_description program("program");
    options_description log("log");
    options_description docs("docs");
@@ -128,13 +129,14 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    int sameSite;
 
    program_options::OptionsDescription optionsDesc =
-         buildOptions(&runTests, &runScript, &verify, &program, &log, &docs, &www,
+         buildOptions(&runTests, &runScript, &verify, &version, &program, &log, &docs, &www,
                       &session, &allow, &r, &limits, &external, &git, &user, &misc,
                       &saveActionDefault, &sameSite);
 
    addOverlayOptions(&misc);
 
    optionsDesc.commandLine.add(verify);
+   optionsDesc.commandLine.add(version);
    optionsDesc.commandLine.add(runTests);
    optionsDesc.commandLine.add(runScript);
    optionsDesc.commandLine.add(program);

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -63,6 +63,8 @@
 #define kRunTestsSessionOption            "run-tests"
 #define kRunScriptSessionOption           "run-script"
 
+#define kVersionSessionOption             "version"
+
 #define kLimitSessionOption               "session-limit"
 #define kTimeoutSessionOption             "session-timeout-minutes"
 #define kTimeoutSuspendSessionOption      "session-timeout-suspend"

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -44,6 +44,7 @@ protected:
    buildOptions(boost::program_options::options_description* pTests,
                 boost::program_options::options_description* pScript,
                 boost::program_options::options_description* pVerify,
+                boost::program_options::options_description* pVersion,
                 boost::program_options::options_description* pProgram,
                 boost::program_options::options_description* pLog,
                 boost::program_options::options_description* pDocs,
@@ -76,6 +77,11 @@ protected:
       (kVerifyInstallationSessionOption,
       value<bool>(&verifyInstallation_)->default_value(false),
       "Verifies that the session installation is working correctly and exits.");
+
+   pVersion->add_options()
+      (kVersionSessionOption,
+      value<bool>(&version_)->default_value(false)->implicit_value(true),
+      "Prints the version number and exits.");
 
    pProgram->add_options()
       (kProgramModeSessionOption,
@@ -387,6 +393,7 @@ public:
    bool runTests() const { return runTests_; }
    std::string runScript() const { return runScript_; }
    bool verifyInstallation() const { return verifyInstallation_; }
+   bool version() const { return version_; }
    std::string programMode() const { return programMode_; }
    bool logStderr() const { return logStderr_; }
    std::string docsURL() const { return docsURL_; }
@@ -482,6 +489,7 @@ protected:
    bool runTests_;
    std::string runScript_;
    bool verifyInstallation_;
+   bool version_;
    std::string programMode_;
    bool logStderr_;
    std::string docsURL_;

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -44,6 +44,16 @@
             "description": "Verifies that the session installation is working correctly and exits."
          }
       ],
+      "version": [
+         {
+            "name": {"constant": "kVersionSessionOption", "value": "version"},
+            "memberName": "version_",
+            "type": "bool",
+            "defaultValue": false,
+            "implicitValue": true,
+            "description": "Prints the version number and exits."
+         }
+      ],
       "program": [
          {
             "name": {"constant": "kProgramModeSessionOption", "value": "program-mode"},


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2410.

### Approach

Add a `--version` option that prints the version of the R session binary and exits.

### Automated Tests

None, this option is for validating config of standalone binaries. 

### QA Notes

You can find the `rsession` binary in `/usr/lib/rstudio-server/bin`. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


