### PR TITLE
fixup for detaching completion handlers in Stan mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,7 @@
 * Fixed issue where C++ compilation database was not invalidated when compiler was updated (#8588)
 * Fixed issue where SQL chunks containing non-ASCII characters could fail to run on Windows (#8900)
 * Fixed issue where 'case:' statements were not outdented when rainbow parentheses were active. (#8846)
+* Fixed issue where Stan completion handlers were duplicated on save (#9106)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Fixed issue preventing R Notebook chunks from being queued for execution if they had never been previously run (#4238)
 * Fix various issues when the "Limit Console Output" performance setting was enabled, and enable it by default (#8544, #8504, #8529, #8552)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -259,6 +259,7 @@ public class StanCompletionManager extends CompletionManagerBase
    @Override
    public void detach()
    {
+      super.detach();
       sigTips_.detach();
    }
    


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/9106.

### Intent

On save, completion handlers in Stan mode were being duplicated.

### Approach

Unfortunate bug caused by our forgetting to call superclass method.

### Automated Tests

Not worth the effort for this fix.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9106.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
