### PR TITLE
avoid changing languages when sending code to console from History pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -113,4 +113,5 @@
 * Fixed issue where paging in the DataViewer would throw errors and current columns wouldn't update (#9078)
 * Fixed issue causing RStudio Server to create `.local/share/rstudio` folder with incorrect permissions when `session-timeout-kill-hours` is set (Pro #2388)
 * Fixed issue causing `verify-installation` to exit without showing the error that caused it to do so (Pro #2399)
+* Fixed issue where sending code from Python History pane would switch Console to R mode (#8693)
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
@@ -54,7 +54,10 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
    
    public SendToConsoleEvent(String code, String language, boolean execute)
    {
-      this(code, language, execute, 
+      this(
+            code,
+            language,
+            execute,
             true,   /* raise */
             false,  /* focus */
             false); /* animate */

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -418,7 +418,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    public void onSendToConsole(final SendToConsoleEvent event)
    {
-      if (event.getLanguage().equals("Python"))
+      if (StringUtil.equals(event.getLanguage(), "Python"))
       {
          dependencyManager_.withReticulate(
                "Executing Python code",
@@ -435,10 +435,18 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    private void onSendToConsoleImpl(final SendToConsoleEvent event)
    {
-      languageTracker_.adaptToLanguage(
-            event.getLanguage(),
-            () -> { sendToConsoleImpl(event); }
-            );
+      String language = event.getLanguage();
+      
+      if (StringUtil.isNullOrEmpty(language))
+      {
+         sendToConsoleImpl(event);
+      }
+      else
+      {
+         languageTracker_.adaptToLanguage(
+               language,
+               () -> sendToConsoleImpl(event));
+      }
    }
 
    private void sendToConsoleImpl(final SendToConsoleEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/History.java
@@ -430,7 +430,7 @@ public class History extends BasePresenter implements SelectionCommitEvent.Handl
       String commandString = getSelectedCommands();
       commandString = StringUtil.chomp(commandString);
       if (commandString.length() > 0 )
-         events_.fireEvent(new SendToConsoleEvent(commandString, false));
+         events_.fireEvent(new SendToConsoleEvent(commandString, null, false));
    }
 
    @Handler


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8693.

### Approach

Provide a mechanism for sending code to the Console, keeping the current Console language mode as-is.

### Automated Tests

None.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8693.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
