### PR TITLE
avoid crashes when logging default-constructed error objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,6 +77,7 @@
 
 ### Bugfixes
 
+* Fixed an issue that could cause RStudio to crash when generating plots on Windows (#9113)
 * Fix Windows Desktop installer to support running from path with characters from other codepages (#8421)
 * Fixed issue where R code input could be executed in the wrong order in some cases (#8837)
 * Fixed issue where debugger could hang when debugging functions called via do.call() (#5158)

--- a/src/cpp/core/MiscellaneousTests.cpp
+++ b/src/cpp/core/MiscellaneousTests.cpp
@@ -29,6 +29,7 @@
 #include <core/system/Types.hpp>
 
 namespace rstudio {
+namespace core {
 namespace unit_tests {
 
 using namespace core::collection;
@@ -52,6 +53,16 @@ private:
    std::streambuf* pCoutBuf_;
    std::streambuf* pCerrBuf_;
 };
+
+test_context("Errors")
+{
+   test_that("Success() can be logged")
+   {
+      Error error;
+      LOG_ERROR(error);
+      LOG_ERROR(Success());
+   }
+}
 
 test_context("Position")
 {
@@ -277,4 +288,5 @@ test_context("Options")
 }
 
 } // namespace unit_tests
+} // namespace core
 } // namespace rstudio

--- a/src/cpp/core/MiscellaneousTests.cpp
+++ b/src/cpp/core/MiscellaneousTests.cpp
@@ -58,6 +58,8 @@ test_context("Errors")
 {
    test_that("Success() can be logged")
    {
+      // attempts to log default-constructed Error objects could segfault
+      // https://github.com/rstudio/rstudio/issues/9113
       Error error;
       LOG_ERROR(error);
       LOG_ERROR(Success());

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -519,7 +519,7 @@ void PlotManager::render(boost::function<void(DisplayState)> outputFunction)
       {
          // no such file error expected in the case of an invalid graphics
          // context (because generation of the PNG would have failed)
-         bool pngNotFound = error.getCause() && isPathNotFoundError(error.getCause());
+         bool pngNotFound = error.hasCause() && isPathNotFoundError(error.getCause());
 
          // only log if this wasn't png not found
          if (!pngNotFound)

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -28,6 +28,8 @@
 #include <shared_core/Logger.hpp>
 #include <shared_core/SafeConvert.hpp>
 
+#include <boost/optional.hpp>
+
 #ifdef _WIN32
 #include <boost/system/windows_error.hpp>
 #endif
@@ -177,10 +179,15 @@ struct Error::Impl
    std::string Name;
    std::string Message;
    ErrorProperties Properties;
-   Error Cause;
+   boost::optional<Error> Cause;
    ErrorLocation Location;
    bool Expected = false;
 };
+
+Error::Error() :
+   m_impl(new Impl())
+{
+}
 
 // This is a shallow copy because deep copy will only be performed on a write.
 Error::Error(const Error& in_other) :
@@ -362,7 +369,7 @@ std::string Error::asString() const
    ostr << log::s_delim << " " << s_occurredAt << " "
         << log::cleanDelimiters(getLocation().asString());
 
-   if (getCause())
+   if (hasCause())
    {
       ostr << log::s_delim << " " << s_causedBy << ": " << getCause().asString();
    }
@@ -370,9 +377,17 @@ std::string Error::asString() const
    return ostr.str();
 }
 
+bool Error::hasCause() const
+{
+   if (impl().Cause)
+      return true;
+   else
+      return false;
+}
+
 const Error& Error::getCause() const
 {
-   return impl().Cause;
+   return *impl().Cause;
 }
 
 int Error::getCode() const

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -174,9 +174,9 @@ class Error : public virtual ErrorLock
 {
 public:
    /**
-    * @brief Default constructor.
+    * @brief Constructor.
     */
-   Error() = default;
+   Error();
 
    /**
     * @brief Copy constructor.
@@ -427,6 +427,13 @@ public:
     */
    std::string asString() const;
 
+   /**
+    * @brief Checks whether this error was caused by a separate error.
+    *
+    * @return True if the error has an associated cause.
+    */
+   bool hasCause() const;
+   
    /**
     * @brief Gets the error which caused this error.
     *


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9113.

### Approach

Give the default-constructed Error object an empty Impl.

### Automated Tests

Simple automated test verifying that we can indeed log such default-constructed error objects.

### QA Notes

Since we haven't been able to reproduce this in the wild, I don't think there's any testing to be done. All testing is captured by the unit tests in this PR.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

