### PR TITLE
fixups for Rtools 4.0

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -206,22 +206,27 @@ RToolsInfo::RToolsInfo(const std::string& name,
       // set clang args
 #ifdef _WIN64
       std::string baseDir = "mingw64";
-      std::string arch = "x86_64";
+      std::string triple = "x86_64-w64-mingw32";
 #else
       std::string baseDir = "mingw32";
-      std::string arch = "i686";
+      std::string triple = "i686-w64-mingw32";
 #endif
 
-      // path to mingw includes
-      boost::format mgwIncFmt("%1%/%2%-w64-mingw32/include");
-      std::string mingwIncludeSuffix = boost::str(mgwIncFmt % baseDir % arch);
-      FilePath mingwIncludePath = installPath.completeChildPath(mingwIncludeSuffix);
-      clangArgs.push_back("-I" + mingwIncludePath.getAbsolutePath());
+      std::vector<std::string> stems = {
+         "include/c++/8.3.0",
+         "include/c++/8.3.0/" + triple,
+         "include/c++/8.3.0/backward",
+         "lib/gcc/" + triple + "/8.3.0/include",
+         "include",
+         "lib/gcc/" + triple + "/8.3.0/include-fixed",
+         triple + "/include"
+      };
 
-      // path to C++ headers
-      std::string cppSuffix = "c++/8.3.0";
-      FilePath cppIncludePath = installPath.completeChildPath(cppSuffix);
-      clangArgs.push_back("-I" + cppIncludePath.getAbsolutePath());
+      for (auto&& stem : stems)
+      {
+         FilePath includePath = installPath.completeChildPath(baseDir + "/" + stem);
+         clangArgs.push_back("-I" + includePath.getAbsolutePath());
+      }
    }
    else
    {

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -979,13 +979,20 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp)
 {
    std::vector<std::string> args;
 
+
+#ifdef _WIN32
    // add built-in clang compiler headers
-   // (not required with Rtools40; libclang can just use those headers)
+   // built-in headers are not required with Rtools40 (used by R 4.0.x)
    if (r::version_info::currentRVersion().versionMajor() < 4)
    {
       auto clArgs = clang().compileArgs(isCpp);
       args.insert(args.end(), clArgs.begin(), clArgs.end());
    }
+#else
+   // add built-in clang compiler headers
+   auto clArgs = clang().compileArgs(isCpp);
+   args.insert(args.end(), clArgs.begin(), clArgs.end());
+#endif
 
 #ifdef _WIN32
    // disable inclusion of default system headers


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/4685.

### Approach

When building projects using Rtools 4.0, we:

- Disable the inclusion of our default libclang headers;
- Fix up the headers includes for Rtools 4.0;
- Instruct libclang not to find and use headers bundled with Visual Studio.

### Automated Tests

None included -- since this is a Windows-only issue, we don't have infrastructure for testing it.

### QA Notes

Test that C++ diagnostics, autocompletion etc. work as expected with the latest version of R as well as Rtools 4.0. (https://cran.r-project.org/bin/windows/Rtools/)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
