### PR TITLE
Add session-suspend-on-incomplete-statement option

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 * **BREAKING:** RStudio when served via `http` erroneously reported its own address as `https` during redirects if the header `X-Forwarded-Proto` was defined by a proxy. That could lead to a confusing proxy setup. That has been fixed, but existing proxy installations with redirect rewite settings matching for `https` may have to be adjusted.
 * **BREAKING:** RStudio Workbench's Linux packages have new file names, `rstudio-workbench-*` instead of `rstudio-server-pro-*`. The operating system package name remains `rstudio-server`, so installs and upgrades will work correctly. Scripts which refer to the `.deb` or `.rpm` file names directly will need to be updated.
 * **BREAKING:** RStudio Server no longer supports Internet Explorer 11. 
+* Added `session-suspend-on-incomplete-statement` option to enable more aggressive session suspension behavior (Pro #1934)
 
 ### Visual Editor
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -72,7 +72,8 @@ struct ROptions
          disableRProfileOnStart(false),
          rProfileOnResume(false),
          restoreEnvironmentOnResume(true),
-         packratEnabled(false)
+         packratEnabled(false),
+         suspendOnIncompleteStatement(false)
    {
    }
    core::FilePath userHomePath;
@@ -101,6 +102,7 @@ struct ROptions
    bool restoreEnvironmentOnResume;
    core::r_util::SessionScope sessionScope;
    bool packratEnabled;
+   bool suspendOnIncompleteStatement;
 };
       
 struct RInitInfo

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -472,13 +472,26 @@ bool isSuspendable(const std::string& currentPrompt)
    // NOTE: active file graphics devices (e.g. png or pdf) are wiped out
    // during a suspend as are open connections. there may or may not be a
    // way to make this more robust.
-
-   // are we not at the default prompt?
-   std::string defaultPrompt = r::options::getOption<std::string>("prompt");
-   if (currentPrompt != defaultPrompt)
-      return false;
-   else
+   
+   if (s_options.suspendOnIncompleteStatement)
+   {
+      // Always allow suspending, even if the statement is not complete.
       return true;
+   }
+   else
+   {
+      // Avoid suspending when the prompt is not at its default value.  This mostly prevents us from
+      // suspending if the user hasn't finished an R statement, since R's prompt changes from > to +
+      // when a statement is incomplete. It is an option since some environments prefer more
+      // aggressive suspension behavior.
+      std::string defaultPrompt = r::options::getOption<std::string>("prompt");
+      if (currentPrompt != defaultPrompt)
+      {
+         return false;
+      }
+   }
+    
+   return true;
 }
    
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2174,6 +2174,7 @@ int main (int argc, char * const argv[])
       rOptions.packratEnabled = persistentState().settings().getBool("packratEnabled");
       rOptions.sessionScope = options.sessionScope();
       rOptions.runScript = options.runScript();
+      rOptions.suspendOnIncompleteStatement = options.suspendOnIncompleteStatement();
 
       // r callbacks
       rstudio::r::session::RCallbacks rCallbacks;

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -76,6 +76,7 @@
 #define kWwwPortSessionOption             "www-port"
 #define kWwwResusePorts                   "www-reuse-ports"
 #define kTerminalPortOption               "terminal-port"
+#define kSessionSuspendOnIncompleteStatement "session-suspend-on-incomplete-statement"
 
 #define kLauncherSessionOption            "launcher-session"
 

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -205,7 +205,10 @@ protected:
       "Specifies a list of directories exempt from directory view restrictions, separated by a colon character (:).")
       (kSessionEnvVarSaveBlacklist,
       value<std::string>(&envVarSaveBlacklist_)->default_value(std::string()),
-      "Specifies a list of environment variables that will not be saved when sessions suspend, separated by a colon character (:).");
+      "Specifies a list of environment variables that will not be saved when sessions suspend, separated by a colon character (:).")
+      (kSessionSuspendOnIncompleteStatement,
+      value<bool>(&suspendOnIncompleteStatement_)->default_value(false),
+      "Specifies whether the session should be allowed to suspend when a user has entered a partial R statement.");
 
    pAllow->add_options()
       ("allow-vcs-executable-edit",
@@ -432,6 +435,7 @@ public:
    bool restrictDirectoryView() const { return restrictDirectoryView_; }
    std::string directoryViewWhitelist() const { return directoryViewWhitelist_; }
    std::string envVarSaveBlacklist() const { return envVarSaveBlacklist_; }
+   bool suspendOnIncompleteStatement() const { return suspendOnIncompleteStatement_; }
    bool allowVcsExecutableEdit() const { return allowVcsExecutableEdit_; }
    bool allowCRANReposEdit() const { return allowCRANReposEdit_; }
    bool allowVcs() const { return allowVcs_; }
@@ -528,6 +532,7 @@ protected:
    bool restrictDirectoryView_;
    std::string directoryViewWhitelist_;
    std::string envVarSaveBlacklist_;
+   bool suspendOnIncompleteStatement_;
    bool allowVcsExecutableEdit_;
    bool allowCRANReposEdit_;
    bool allowVcs_;

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -339,6 +339,13 @@
             "type": "string",
             "memberName": "envVarSaveBlacklist_",
             "description": "Specifies a list of environment variables that will not be saved when sessions suspend, separated by a colon character (:)."
+         },
+         {
+            "name": {"constant": "kSessionSuspendOnIncompleteStatement", "value": "session-suspend-on-incomplete-statement"},
+            "type": "bool",
+            "memberName": "suspendOnIncompleteStatement_",
+            "defaultValue": false,
+            "description": "Specifies whether the session should be allowed to suspend when a user has entered a partial R statement."
          }
       ],
       "allow": [


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/1934, which is becoming a major issue for rstudio.cloud. 

### Approach

The current behavior is very much intentional; we avoid suspending sessions wherein R is waiting for you to finish writing a statement because we can't restore that state. When we resume after suspend you will lose the partial statement and be returned to the R prompt. 

This PR makes the current behavior optional, trading the possibility for minor data loss (your partial statement) for more reliable suspension. 

### Automated Tests

None, suspension currently isn't testable.

### QA Notes

Note that you can set sessions to suspend after 1 minute of inactivity to test this quickly. You will also notice that the partial statement entered prior to suspension will be lost; that's expected. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

