### PR TITLE
fix issue with opening file with explicitly typed name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -120,4 +120,4 @@
 * Fixed issue causing `verify-installation` to exit without showing the error that caused it to do so (Pro #2399)
 * Fixed issue causing spurious "Failed to reset ACL permission mask" errors to be logged outside shared projects on some filesystems (Pro #2406)
 * Fixed issue where sending code from Python History pane would switch Console to R mode (#8693)
-
+* Fixed issue where Open File dialog would fail to open files whose names were explicitly typed (#4059)

--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/OpenFileDialog.java
@@ -71,7 +71,7 @@ public class OpenFileDialog extends FileDialog
    @Override
    protected FileSystemItem getSelectedItem()
    {
-      FileSystemItem item = browser_.getSelectedItem();
+      FileSystemItem item = super.getSelectedItem();
       if (item == null)
          item = browser_.getCurrentDirectory();
       return item;


### PR DESCRIPTION
### Intent

When a user attempts to open a file by explicitly typing the name of that file (rather than selecting an entry from the file-list widget), the attempt to open that file fails. This PR intends to fix that.

Addresses https://github.com/rstudio/rstudio/issues/4059.

### Approach

The underlying issue here is that there are two notions of the "active" file:

- The current selection, if any, in the Files list widget;
- What the user has typed in the filename at the top of the widget.

Because selecting an item always updates the filename at the top of the widget, that should be taken as the correct filename to open.

### Automated Tests

https://github.com/rstudio/rstudio-ide-automation/issues/279

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/4059. The change should only effect RStudio Server, but it's worth verifying in RStudio Desktop as well.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
