### PR TITLE
Do not attempt to recursively chown() RStudio state folders

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -84,6 +84,7 @@
 ### Bugfixes
 
 * Fixed an issue that could cause RStudio to crash when generating plots on Windows (#9113)
+* Fixed an issue causing slow session startup and "Unable to connect to service" errors on RStudio Server (#9152)
 * Fix Windows Desktop installer to support running from path with characters from other codepages (#8421)
 * Fixed issue where R code input could be executed in the wrong order in some cases (#8837)
 * Fixed issue where debugger could hang when debugging functions called via `do.call()` (#5158)

--- a/src/cpp/core/FilePathTests.cpp
+++ b/src/cpp/core/FilePathTests.cpp
@@ -140,6 +140,38 @@ TEST_CASE("file paths")
       CHECK(aPath.getRelativePath(pPath) == "a");
    }
 
+#else
+
+   // Non-Windows tests
+
+   SECTION("directory write testing")
+   {
+      // create temporary directory
+      FilePath tempDir;
+      Error error = FilePath::tempFilePath(tempDir);
+      CHECK(!error);
+
+      error = tempDir.ensureDirectory();
+      CHECK(!error);
+
+      // ensure it's writeable
+      error = tempDir.changeFileMode(FileMode::USER_READ_WRITE_ALL_READ);
+      CHECK(!error);
+
+      // it should now report as writeable
+      bool writeable = false;
+      error = tempDir.isWriteable(writeable);
+      CHECK(!error);
+      CHECK(writeable);
+
+      // however, it should be an error to test write permissions (that's only for files)
+      error = tempDir.testWritePermissions();
+      CHECK(error);
+
+      // clean up
+      tempDir.remove();
+   }
+
 #endif /* _WIN32 */
 
 }

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -223,7 +223,7 @@ void verifyUserDirs(
    const boost::optional<FilePath>& homeDir)
 {
 #ifndef _WIN32
-   auto testDir = [](const FilePath& dir)
+   auto testDir = [](const FilePath& dir, const ErrorLocation& errorLoc)
    {
       Error error, permError;
       if (dir.exists())
@@ -235,23 +235,25 @@ void verifyUserDirs(
          if (error)
          {
             // We couldn't even read the directory's access bits
-            LOG_WARNING_MESSAGE("Could not access " + dir.getAbsolutePath() + " to check write "
-                  "permissions. Some features may not work correctly.");
-            LOG_ERROR(error);
+            rstudio::core::log::logWarningMessage("Could not access " + dir.getAbsolutePath() + 
+                  " to check write " "permissions. Some features may not work correctly.",
+                  errorLoc);
+            rstudio::core::log::logError(error, errorLoc);
          }
          else if (!writeable)
          {
             // We determined that the directory was not writable. There's nothing we can do to
             // correct this, so just log a warning to help diagnose downstream failures (which are
             // virtually guaranteed).
-            LOG_WARNING_MESSAGE("Missing write permissions to " + dir.getAbsolutePath() + 
-                  ". Some features may not work correctly.");
+            rstudio::core::log::logWarningMessage("Missing write permissions to " + 
+                  dir.getAbsolutePath() + ". Some features may not work correctly.",
+                  errorLoc);
          }
       }
    };
 
-   testDir(userConfigDir(user, homeDir));
-   testDir(userDataDir(user, homeDir));
+   testDir(userConfigDir(user, homeDir), ERROR_LOCATION);
+   testDir(userDataDir(user, homeDir), ERROR_LOCATION);
 #endif
 }
 

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1570,6 +1570,14 @@ void FilePath::setLastWriteTime(std::time_t in_time) const
 
 Error FilePath::testWritePermissions() const
 {
+   // This check only works on ordinary files; it is an error to use it on directories.
+   if (isDirectory())
+   {
+      Error error = systemError(boost::system::errc::is_a_directory, ERROR_LOCATION);
+      error.addProperty("path", getAbsolutePath());
+      return error;
+   }
+
    std::ostream* pStream = nullptr;
    try
    {

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -723,7 +723,9 @@ public:
    /**
     * @brief Checks if a file can be written to by opening the file.
     *
-    * To be successful, the file must already exist on the system.
+    * To be successful, the file must be a regular file (not a directory, etc.) and already exist on
+    * the system.
+    *
     * If write access is not absolutely necessary, use isWriteable instead.
     *
     * @return Success if file can be written to; system error otherwise (e.g. EPERM, ENOENT, etc.)


### PR DESCRIPTION
### Intent

Fix a regression in 1.4 that causes RStudio sessions to recursively `chown()` RStudio state folders at startup, resulting in performance and connectivity issues. Addresses https://github.com/rstudio/rstudio/issues/9152.

### Approach

As noted in #9152 comments, the primary issue here is that we are trying to test a directory for writeability the wrong way, with the result that we never think it's writeable and always try to fix permissions. So the primary fix is to do the correct test for writeability.

To further reduce risk I've made two other changes:

- Documentation, an explicit error, and unit tests have been added to ensure that future usage of `testWritePermissions` against a directory doesn't occur.
- I have completely removed the recursive `chown()` to eliminate the possibility it will cause trouble in the future. No one is aware of a circumstance in which it will actually fix a permissions issue (there is some discussion of this in the PR that introduced it, https://github.com/rstudio/rstudio/pull/7742). Since permissions issues can't be fixed by the user who is experiencing them, we just log an error now so that downstream trouble will be easier to diagnose. 

### Automated Tests

New unit tests added to be sure that directory writeability related `FilePath` methods return what we expect.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9152; there are also a couple of support tickets attached that show customer configurations that demonstrate the problem. Might also be worth taking a look at https://github.com/rstudio/rstudio/issues/4505, which https://github.com/rstudio/rstudio/pull/7742 was intended to fix.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

