### PR TITLE
ensure configured copy of Python is placed on PATH for render

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -568,13 +568,23 @@ private:
       // pass along the current Python environment, if any
       std::string reticulatePython;
       error = r::exec::RFunction(".rs.inferReticulatePython").call(&reticulatePython);
-      if (error) {
+      if (error)
          LOG_ERROR(error);
-      }
+      
+      // pass along current PATH
+      std::string currentPath = core::system::getenv("PATH");
+      core::system::setenv(&environment, "PATH", currentPath);
+      
       if (!reticulatePython.empty())
       {
          // we found a Python version; forward it
-         environment.push_back(std::make_pair("RETICULATE_PYTHON", reticulatePython));
+         environment.push_back({"RETICULATE_PYTHON", reticulatePython});
+         
+         // also update the PATH so this version of Python is visible
+         core::system::addToPath(
+                  &environment,
+                  FilePath(reticulatePython).getParent().getAbsolutePath(),
+                  true);
       }
 
       // render unless we were handed an existing output file


### PR DESCRIPTION
### Intent

Users might configure RStudio to use a particular version of Python, via Global Options or Project Options. While the selected version of Python is visible to reticulate via `RETICULATE_PYTHON`, it's also useful for the requested copy of Python to be available on the PATH as well.

Addresses https://github.com/rstudio/rstudio/issues/9116.

### Approach

Relatively straightforward munging of PATH in our render code.

### Automated Tests

None included.

### QA Notes

Configure RStudio to use a particular copy of Python, then create an R Markdown document and check the output of `Sys.getenv("PATH")` from an R chunk. You should see something like:

<img width="934" alt="Screen Shot 2021-03-29 at 4 35 52 PM" src="https://user-images.githubusercontent.com/1976582/112912639-dbb85f00-90ac-11eb-935c-b7c09e9ceb89.png">

where the first PATH entry corresponds to the directory name of the configured version of Python.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
