### PR TITLE
Add recursion guard for notebook console output

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -82,7 +82,7 @@ public:
    void disconnect();
 
 private:
-   void onConsoleText(int type, const std::string& output, bool truncate);
+   void onConsoleText(int type, const std::string& output, bool truncate, bool pending);
    void onConsolePrompt(const std::string&);
    void onFileOutput(const core::FilePath& file, const core::FilePath& sidecar,
         const core::json::Value& metadata, ChunkOutputType outputType, 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9155. 

### Approach

We don't have a repro for this issue, so this fix is speculative. It makes a stronger guarantee that the method that processes R output in notebooks cannot recurse indefinitely. The method can recurse in order to process previously queued output; we now avoid any further recursion by discarding pending output if we are already in the process of handling it. 

### Automated Tests

None, this change does not materially impact behavior.

### QA Notes

Sanity test R console (plain text) output persistence in R notebooks. It'd be great if we could reproduce the original issue, too; there are some ideas on doing that in the original issue (i.e., deleting the notebook output directory during runtime).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

