### PR TITLE
Set explicit height for column button toolbar

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -199,6 +199,7 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
 
       Toolbar columnToolbar = new Toolbar("Manage Column Display");
       columnToolbar.setStyleName(res_.styles().newSection());
+      columnToolbar.setHeight("20px");
 
       ToolbarButton addButton = new ToolbarButton(
          "Add Column",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9165.

### Approach

Due to a recent change, all toolbars are capable of emitting resize events. However, due to the inscrutable ways of GWT, they now also must have a height assigned, so assign a height. 

### Automated Tests

None, style only change.

### QA Notes

Visual change only.

### Checklist

No NEWS update since this is a regression in Juliet Rose.

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests



