### PR TITLE
re-enable unit tests for macOS

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -65,13 +65,17 @@ pipeline {
 
     stage('tests') {
 
+      environment {
+        PATH = "${env.HOME}/opt/bin:${env.PATH}"
+      }
+
       steps {
         script {
           try {
             // attempt to run cpp unit tests
             // problems with rsession finding openssl, so those tests
             // are disabled until we solve it (#6890)
-            sh "cd package/osx/build/src/cpp && ./rstudio-tests --scope core"
+            sh "cd package/osx/build/src/cpp && ./rstudio-tests"
           } catch(err) {
              currentBuild.result = "UNSTABLE"
           }

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -609,6 +609,9 @@ else()
       # test runner script
       if(NOT WIN32)
          configure_file(rstudio-tests.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-tests @ONLY)
+         if(EXISTS rstudio-pro-tests.in)
+            configure_file(rstudio-pro-tests.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-pro-tests @ONLY)
+         endif()
       endif()
 
       # add desktop subprojects if we aren't building in server only mode

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -608,7 +608,7 @@ else()
 
       # test runner script
       if(NOT WIN32)
-         configure_file(rstudio-tests.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-tests)
+         configure_file(rstudio-tests.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-tests @ONLY)
       endif()
 
       # add desktop subprojects if we aren't building in server only mode

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -124,10 +124,9 @@ runWatchdogProcess() {
 }
 
 has-scope () {
-   [ -z "${TEST_SCOPE}" ] || "${TEST_SCOPE}" = "$1"
+   [ -z "${TEST_SCOPE}" ] || [ "${TEST_SCOPE}" = "$1" ]
 }
 
-TEST_SCOPE=
 case "$1" in
 
 "--scope")
@@ -159,11 +158,6 @@ esac
 
 # try to find libSegFault if available
 findLibSegFault
-
-# help our build machine find the appropriate version of R
-if [ "$(uname)" = "Darwin" ] && [ -n "${JENKINS_URL}" ]; then
-   PATH="$HOME/homebrew/x86_64/bin:$PATH"
-fi
 
 ## On a Debug Mac IDE build via xcodebuild, the executables
 ## will be in a Debug folder

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -96,13 +96,13 @@ runWatchdogProcess() {
 
    # centos6 doesn't support the --foreground option for timeout
    if [ "${OPERATING_SYSTEM}" = "centos_6" ] || [ -z "${TIMEOUT_CMD}" ]; then
-      if [ "$privileged" = true ]; then
-         sudo /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} $*; exit"
+      if [ "${privileged}" = "true" ]; then
+         sudo /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
       else
-         /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} $*; exit"
+         /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
       fi
    else
-      if [ "$privileged" = true ]; then
+      if [ "${privileged}" = "true" ]; then
          sudo "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
       else
          "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -52,7 +52,7 @@ findLibSegFault() {
    for CANDIDATE in "${CANDIDATES[@]}"; do
       if [ -e "${CANDIDATE}" ]; then
          RSESSION_DIAGNOSTICS_LIBSEGFAULT="${CANDIDATE}"
-         break
+         return 0
       fi
    done
 

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -1,132 +1,173 @@
 #!/usr/bin/env bash
 
-# help our build machine find the appropriate version of R
-if [ "$(uname)" = "Darwin" ] && [ -n "$JENKINS_URL" ]; then
-   PATH="$HOME/homebrew/x86_64/bin:$PATH"
-fi
+read -r -d '' USAGE <<- EOF
+Run RStudio unit tests. Available flags:
+
+--help    Show this help.
+--scope   Run only tests wtih the given scope (core, rserver, rsession, r).
+--filter  Run a subset of R tests, matching the requested filter.
+EOF
+
+section () {
+    echo -e "\033[1;94m==>\033[0m \033[1;97m$1\033[0m"
+}
+
+error () {
+    echo -e "\033[1;91mERROR: $1\033[0m";
+    exit 1
+}
 
 checkUnitTestFailure() {
-   RET_CODE=$?
-   if [ $RET_CODE != 0 ]; then
+   RETCODE="$?"
+   if [ "${RETCODE}" = "0" ]; then
       UNIT_TEST_FAILURE=true
    fi
 }
 
 checkRUnitTestFailure() {
-    FAILURES=$(cat "${CMAKE_CURRENT_BINARY_DIR}/testthat-failures.log")
-    if [[ $FAILURES != 0 ]]; then
-        UNIT_TEST_FAILURE=true
-    fi
+   FAILURES=$(cat "@CMAKE_CURRENT_BINARY_DIR@/testthat-failures.log")
+   if [ "${FAILURES}" != "0" ]; then
+      UNIT_TEST_FAILURE=true
+   fi
 }
 
-findLibSegFault()
-{
-   # if the libsegfault location has not explicitly been set
-   # try to find it in common distribution locations
-   if [[ -z "$${EMPTY}{RSESSION_DIAGNOSTICS_LIBSEGFAULT}" ]]; then
-      if [[ -e /lib/x86_64-linux-gnu/libSegFault.so ]]; then
-         RSESSION_DIAGNOSTICS_LIBSEGFAULT=/lib/x86_64-linux-gnu/libSegFault.so
-      elif [[ -e /lib/i386-linux-gnu/libSegFault.so ]]; then
-         RSESSION_DIAGNOSTICS_LIBSEGFAULT=/lib/i386-linux-gnu/libSegFault.so
-      elif [[ -e /lib64/libSegFault.so ]]; then
-         RSESSION_DIAGNOSTICS_LIBSEGFAULT=/lib64/libSegFault.so
-      elif [[ -e /lib/libSegFault.so ]]; then
-         RSESSION_DIAGNOSTICS_LIBSEGFAULT=/lib/libSegFault.so
+# finds libSegFault.so, and sets RSESSION_DIAGNOSTICS_LIBSEGFAULT
+# as a side effect
+findLibSegFault() {
+
+   # not available on macOS
+   if [ "$(uname)" = "Darwin" ]; then
+      return 0
+   fi
+
+   # if already set, nothign to do
+   if [ -n "${RSESSION_DIAGNOSTICS_LIBSEGFAULT}" ]; then
+      return 0
+   fi
+
+   # look in common locations
+   CANDIDATES=(
+      /lib/x86_64-linux-gnu/libSegFault.so
+      /lib/i386-linux-gnu/libSegFault.so
+      /lib64/libSegFault.so
+      /lib/libSegFault.so
+   )
+
+   for CANDIDATE in "${CANDIDATES[@]}"; do
+      if [ -e "${CANDIDATE}" ]; then
+         RSESSION_DIAGNOSTICS_LIBSEGFAULT="${CANDIDATE}"
+         break
       fi
-   fi
+   done
+
+   echo "WARNING: Could not find libSegFault.so"
+
 }
 
-runWatchdogProcess()
-{
-   if [[ "$OSTYPE" == "darwin"* ]]; then
-      # requires brew install coreutils
-      TIMEOUT_CMD=gtimeout
-   else
-      TIMEOUT_CMD=timeout
+runWatchdogProcess() {
+
+   TIMEOUTS=(gtimeout timeout)
+   for TIMEOUT in "${TIMEOUTS[@]}"; do
+      if command -v "${TIMEOUT}" &> /dev/null; then
+         TIMEOUT_CMD="${TIMEOUT}"
+         break
+      fi
+   done
+
+   if [ -z "${TIMEOUT_CMD}" ]; then
+      echo "WARNING: 'timeout' utility is not available; hangs will not be diagnosed"
    fi
-   timeout=$1
-   privileged=$2
-   command=$3
-   arg1=$4
-   arg2=$5
-   arg3=$6
-   arg4=$7
-   arg5=$8
+
+   timeout="$1"
+   shift
+
+   privileged="$1"
+   shift
+
+   command="$1"
+   shift
+
+   local PRELOAD
+   if [ "$(uname)" = "Darwin" ]; then
+      PRELOAD="DYLD_INSERT_LIBRARIES=${DYLD_INSERT_LIBRARIES}"
+   else
+      PRELOAD="LD_PRELOAD=${RSESSION_DIAGNOSTICS_LIBSEGFAULT}"
+   fi
 
    # centos6 doesn't support the --foreground option for timeout
-   if [ "$OPERATING_SYSTEM" = "centos_6" ]; then
+   if [ "${OPERATING_SYSTEM}" = "centos_6" ] || [ -z "${TIMEOUT_CMD}" ]; then
       if [ "$privileged" = true ]; then
-         sudo /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         sudo /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} $*; exit"
       else
-         /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} $*; exit"
       fi
    else
       if [ "$privileged" = true ]; then
-         sudo $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         sudo "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
       else
-         $TIMEOUT_CMD --foreground $timeout /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' LD_PRELOAD=$RSESSION_DIAGNOSTICS_LIBSEGFAULT  DYLD_INSERT_LIBRARIES=$DYLD_INSERT_LIBRARIES $VALGRIND $command $arg1 $arg2 $arg3 $arg4 $arg5;exit"
+         "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
       fi
    fi
 
    RETCODE=$?
-   if [ $RETCODE == 124 ]; then
+   if [ "${RETCODE}" = "124" ]; then
       # process is hanging - use gdb to collect a stack trace to find out why
       echo "Hang detected. Dumping backtrace..."
-      if [[ "$OSTYPE" == "darwin"* ]]; then
-         # pidof on Mac doesn't support fully qualified process names
-         commandbase="$(basename $command)"
-      else
-         commandbase=$command
-      fi
-      sudo gdb -q -batch -ex 'thread apply all backtrace' -p "$(pidof $commandbase)"
-      sudo kill -9 "$(pidof $commandbase)"
+      PID=$(pgrep -nf "${command}")
+      sudo gdb -q -batch -ex 'thread apply all backtrace' -p "${PID}"
+      sudo kill -9 "${PID}"
       UNIT_TEST_FAILURE=true
-   elif [ $RETCODE != 0 ]; then
+   elif [ "${RETCODE}" != "0" ]; then
       UNIT_TEST_FAILURE=true
    fi
+
 }
 
-findLibSegFault
+has-scope () {
+   [ -z "${TEST_SCOPE}" ] || "${TEST_SCOPE}" = "$1"
+}
 
 TEST_SCOPE=
-if [ "$1" == "--scope" ]; then
-   if [ "$#" == 1 ]; then
-      printf "Specify scope (core, rserver, rsession, or r).\n"
+case "$1" in
+
+"--scope")
+
+   if [ -z "$2" ]; then
+      echo "Usage: ./rstudio-tests --scope [core|rserver|rsession|r]"
       exit 1
    fi
 
-   # Remember test scope
    TEST_SCOPE="$2"
-
-   # Remove the option and argument we just read
    shift 2
-elif [ "$1" == "--filter" ]; then
+
+;;
+
+"--filter")
 
    # used for filtering to a subset of R testthat tests
    TEST_SCOPE="r"
    TEST_FILTER="$2"
    shift 2
 
-elif [ "$1" == "--help" ]; then
-   printf "%s\n\n" "Runs RStudio unit tests. Available flags: "
-   printf "%s\n" "--help    Show this help"
-   printf "%s\n" "--scope   Run only tests with the given scope (core, rsession, or r)"
-   printf "%s\n\n" "--filter  Used instead of --scope to run a subset of R tests"
-   printf "%s\n" "Any other options are passed to Valgrind."
-   exit 0
-fi
+;;
 
-## Any remaining arguments passed in are considered arguments to valgrind
-if [ "$#" -eq 0 ]; then
-   VALGRIND=
-else
-   VALGRIND="valgrind --dsymutil=yes $@"
+"--help")
+   echo "${USAGE}"
+   exit 0
+
+esac
+
+# try to find libSegFault if available
+findLibSegFault
+
+# help our build machine find the appropriate version of R
+if [ "$(uname)" = "Darwin" ] && [ -n "${JENKINS_URL}" ]; then
+   PATH="$HOME/homebrew/x86_64/bin:$PATH"
 fi
 
 ## On a Debug Mac IDE build via xcodebuild, the executables
 ## will be in a Debug folder
-if [ ! -e "${CMAKE_CURRENT_BINARY_DIR}/core/rstudio-core-tests" ]
-then
+if [ ! -e "@CMAKE_CURRENT_BINARY_DIR@/core/rstudio-core-tests" ]; then
     RSTUDIO_CORETEST_BIN="Debug/rstudio-core-tests"
     RSTUDIO_SESSION_BIN="Debug/rsession"
 else
@@ -135,84 +176,98 @@ else
 fi
 
 # set R environment variables needed by rsession tests
-export R_HOME=$(R --slave --vanilla -e "cat(paste(R.home('home'),sep=':'))")
-export R_DOC_DIR=$(R --slave --vanilla -e "cat(paste(R.home('doc'),sep=':'))")
-export R_LIB_DIR=$(R --slave --vanilla -e "cat(paste(R.home('lib'),sep=':'))")
+export R_HOME=$(R RHOME)
+export R_DOC_DIR=$(R --vanilla -s -e "cat(paste(R.home('doc'), sep=':'))")
+export R_LIB_DIR=$(R --vanilla -s -e "cat(paste(R.home('lib'), sep=':'))")
 
 # On macOS, we need to tell the rsession executable where to look for libR.dylib
 if [ "$(uname)" = "Darwin" ]; then
-   export DYLD_INSERT_LIBRARIES="$R_LIB_DIR/libR.dylib"
+   export DYLD_INSERT_LIBRARIES="${R_LIB_DIR}/libR.dylib"
 fi
 
 UNIT_TEST_FAILURE=false
 
 # Run core tests
-if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "core" ]; then
-    echo Running 'core' tests...
-    runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/core/$RSTUDIO_CORETEST_BIN"
+if has-scope "core"; then
 
-    if [ -e ${CMAKE_CURRENT_BINARY_DIR}/server_core/rstudio-server-core-tests ]
-    then
-        echo Running 'server_core' tests...
-        runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/server_core/rstudio-server-core-tests"
-    fi
+   section "Running 'core' tests"
+   runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN}"
 
-    if [ -e ${CMAKE_CURRENT_BINARY_DIR}/shared_core/rstudio-shared-core-tests ]
-    then
-        echo Running 'shared_core' tests...
-        runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/shared_core/rstudio-shared-core-tests"
-    fi
+   if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server_core/rstudio-server-core-tests" ]; then
+      section "Running 'server_core' tests"
+      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server_core/rstudio-server-core-tests"
+   fi
+
+   if [ -e "@CMAKE_CURRENT_BINARY_DIR@/shared_core/rstudio-shared-core-tests" ]; then
+      section "Running 'shared_core' tests"
+      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/shared_core/rstudio-shared-core-tests"
+   fi
+
 fi
 
 # Run server tests
-if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "rserver" ]; then
-    echo Running 'rserver' tests...
-    if [ -e ${CMAKE_CURRENT_BINARY_DIR}/server/rserver-tests ]
-    then
-        echo Running 'rserver' tests...
-        runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/server/rserver-tests" -s
-    fi
+if has-scope "rserver"; then
+
+   if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" ]; then
+      section "Running 'rserver' tests..."
+      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" -s
+   fi
+
 fi
 
 # Setup for rsession tests
-if [ -e ${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf ]; then
-   SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf
+if [ -e "@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf" ]; then
+   SESSION_CONF_FILE="@CMAKE_CURRENT_BINARY_DIR@/conf/rsession-dev.conf"
 else
-   SESSION_CONF_FILE=${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf
+   SESSION_CONF_FILE="@CMAKE_CURRENT_BINARY_DIR@/conf/rdesktop-dev.conf"
 fi
 
-if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "rsession" ]; then
-    echo Running 'rsession' tests...
+if has-scope "rsession"; then
 
-    export RS_CRASH_HANDLER_PATH="${CMAKE_CURRENT_BINARY_DIR}/server/crash-handler-proxy/crash-handler-proxy"
-    export RS_CRASHPAD_HANDLER_PATH="${RSTUDIO_TOOLS_ROOT}/crashpad/crashpad/out/Default/crashpad_handler"
-    runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN" --run-tests --config-file="$SESSION_CONF_FILE"
+   section "Running 'rsession' tests"
+
+   export RS_CRASH_HANDLER_PATH="@CMAKE_CURRENT_BINARY_DIR@/server/crash-handler-proxy/crash-handler-proxy"
+   export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
+   runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}" --run-tests --config-file="${SESSION_CONF_FILE}"
+
 fi
 
-if [ -z "$TEST_SCOPE" ] || [ "$TEST_SCOPE" == "r" ]; then
-    echo Running 'r' tests...
+if has-scope "r"; then
 
-    if [ ! -z "$TEST_FILTER" ]; then
-        TESTTHAT_FILTER=", filter = '$TEST_FILTER'"
-    fi
+   section "Running 'r' tests"
 
-    # Establish temporary folders for user state and data; this prevents the state/config on the 
-    # machine from affecting the tests
-    RSTUDIO_FOLDER=$(mktemp -d -t rstudio-tests-XXXXXXXXXX)
-    export RSTUDIO_DATA_HOME="$RSTUDIO_FOLDER/data"
-    export RSTUDIO_CONFIG_HOME="$RSTUDIO_FOLDER/config"
-    export RS_CRASH_HANDLER_PATH="${CMAKE_CURRENT_BINARY_DIR}/server/crash-handler-proxy/crash-handler-proxy"
-    export RS_CRASHPAD_HANDLER_PATH="${RSTUDIO_TOOLS_ROOT}/crashpad/crashpad/out/Default/crashpad_handler"
-    runWatchdogProcess 5m false "${CMAKE_CURRENT_BINARY_DIR}/session/$RSTUDIO_SESSION_BIN" \
-        --run-script "\"source('${CMAKE_CURRENT_SOURCE_DIR}/tests/testthat/run-tests.R'); runAllTests('${CMAKE_CURRENT_SOURCE_DIR}', '${CMAKE_CURRENT_BINARY_DIR}'$TESTTHAT_FILTER)\"" \
-        --config-file="$SESSION_CONF_FILE"
-    checkRUnitTestFailure
+   # tell testthat our source dir, binary dir
+   export TESTTHAT_TESTS_DIR="@CMAKE_CURRENT_SOURCE_DIR@/tests/testthat"
+   export TESTTHAT_OUTPUT_DIR="@CMAKE_CURRENT_BINARY_DIR@"
+
+   # set TESTTHAT_FILTER if a filter was provided
+   if [ -n "${TEST_FILTER}" ]; then
+      TESTTHAT_FILTER="${TEST_FILTER}"
+      export TESTTHAT_FILTER
+   fi
+
+   # Establish temporary folders for user state and data; this prevents the state/config on the
+   # machine from affecting the tests
+   RSTUDIO_FOLDER=$(mktemp -d -t rstudio-tests-XXXXXXXXXX)
+   export RSTUDIO_DATA_HOME="${RSTUDIO_FOLDER}/data"
+   export RSTUDIO_CONFIG_HOME="${RSTUDIO_FOLDER}/config"
+   export RS_CRASH_HANDLER_PATH="@CMAKE_CURRENT_BINARY_DIR@/server/crash-handler-proxy/crash-handler-proxy"
+   export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
+
+   runWatchdogProcess 5m false                                                   \
+      "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}"                \
+      --run-script "\"source('${TESTTHAT_TESTS_DIR}/run-tests.R'); runTests()\"" \
+      --config-file="${SESSION_CONF_FILE}"
+
+   checkRUnitTestFailure
+
 fi
 
 # return an error exit code if any unit tests failed
-if [ "$UNIT_TEST_FAILURE" = true ]; then
-    exit 1
+if [ "${UNIT_TEST_FAILURE}" = "true" ]; then
+   error "One or more test suites had failures."
+   exit 1
 fi
 
-# otherwise, return success
+# success!
 exit 0

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+SCRIPT="${BASH_SOURCE[0]}"
+DIR="$(dirname "${SCRIPT}")"
+
 read -r -d '' USAGE <<- EOF
 Run RStudio unit tests. Available flags:
 
@@ -253,6 +256,12 @@ if has-scope "r"; then
 
    checkRUnitTestFailure
 
+fi
+
+# if Pro unit tests are available, run those
+PRO_TESTS="${DIR}/rstudio-pro-tests"
+if [ -e "${PRO_TESTS}" ]; then
+   source "${PRO_TESTS}"
 fi
 
 # return an error exit code if any unit tests failed

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -17,13 +17,6 @@ error () {
     exit 1
 }
 
-checkUnitTestFailure() {
-   RETCODE="$?"
-   if [ "${RETCODE}" = "0" ]; then
-      UNIT_TEST_FAILURE=true
-   fi
-}
-
 checkRUnitTestFailure() {
    FAILURES=$(cat "@CMAKE_CURRENT_BINARY_DIR@/testthat-failures.log")
    if [ "${FAILURES}" != "0" ]; then
@@ -94,22 +87,24 @@ runWatchdogProcess() {
       PRELOAD="LD_PRELOAD=${RSESSION_DIAGNOSTICS_LIBSEGFAULT}"
    fi
 
+   FULL_COMMAND="env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+
    # centos6 doesn't support the --foreground option for timeout
    if [ "${OPERATING_SYSTEM}" = "centos_6" ] || [ -z "${TIMEOUT_CMD}" ]; then
       if [ "${privileged}" = "true" ]; then
-         sudo /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+         sudo /bin/bash -c "${FULL_COMMAND}"
       else
-         /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+         /bin/bash -c "${FULL_COMMAND}"
       fi
    else
       if [ "${privileged}" = "true" ]; then
-         sudo "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+         sudo "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "${FULL_COMMAND}"
       else
-         "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+         "${TIMEOUT_CMD}" --foreground "${timeout}" /bin/bash -c "${FULL_COMMAND}"
       fi
    fi
 
-   RETCODE=$?
+   RETCODE="$?"
    if [ "${RETCODE}" = "124" ]; then
       # process is hanging - use gdb to collect a stack trace to find out why
       echo "Hang detected. Dumping backtrace..."
@@ -204,7 +199,7 @@ if has-scope "rserver"; then
 
    if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" ]; then
       section "Running 'rserver' tests..."
-      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" -s
+      runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests"
    fi
 
 fi
@@ -222,7 +217,10 @@ if has-scope "rsession"; then
 
    export RS_CRASH_HANDLER_PATH="@CMAKE_CURRENT_BINARY_DIR@/server/crash-handler-proxy/crash-handler-proxy"
    export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
-   runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}" --run-tests --config-file="${SESSION_CONF_FILE}"
+   runWatchdogProcess 5m false                                    \
+      "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}" \
+      --run-tests                                                 \
+      --config-file="${SESSION_CONF_FILE}"
 
 fi
 

--- a/src/cpp/tests/testthat/run-tests.R
+++ b/src/cpp/tests/testthat/run-tests.R
@@ -1,14 +1,17 @@
 library(testthat)
 
-runAllTests <- function(sourceDir, outputDir, filter = NULL)
-{
-   # get path to testthat tests
-   testsRoot <- file.path(sourceDir, "tests/testthat")
+runTests <- function(testDir = NULL, outputDir = NULL, filter = NULL) {
+ 
+   "%||%" <- function(x, y) if (is.null(x)) y else x
+   
+   testDir   <- testDir   %||% Sys.getenv("TESTTHAT_TESTS_DIR",  unset = NA)
+   outputDir <- outputDir %||% Sys.getenv("TESTTHAT_OUTPUT_DIR", unset = NA)
+   filter    <- filter    %||% Sys.getenv("TESTTHAT_FILTER",     unset = "")
    
    # run tests
    results <- testthat::test_dir(
-      path = testsRoot,
-      filter = filter,
+      path            = testDir,
+      filter          = filter,
       stop_on_failure = FALSE,
       stop_on_warning = FALSE
    )
@@ -19,4 +22,5 @@ runAllTests <- function(sourceDir, outputDir, filter = NULL)
    
    # write to file
    cat(failures, file = file.path(outputDir, "testthat-failures.log"))
+   
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6890.

### Approach

Refactors the `rstudio-tests` script (for easier future maintenance), and re-enables all tests on Jenkins.

### Automated Tests

There are the automated tests. :-)

### QA Notes

No QA required; this is just getting unit tests running on macOS CI.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
