### PR TITLE
support running dev desktop build (qt) with cmake generation from repo root

### DIFF
--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -795,6 +795,18 @@ int main(int argc, char* argv[])
          scriptsPath = currentPath.completePath("desktop");
          devMode = true;
       }
+
+      // alternate debug config where cmake generation was run at root of repo; the
+      // config files will be in src/cpp relative to the current directory set earlier
+      // to location of CMakeCache.txt
+      else if (currentPath.completePath("src/cpp/conf/rdesktop-dev.conf").exists())
+      {
+         confPath = currentPath.completePath("src/cpp/conf/rdesktop-dev.conf");
+         sessionPath = currentPath.completePath("src/cpp/session/rsession");
+         scriptsPath = currentPath.completePath("src/cpp/desktop");
+         devMode = true;
+      }
+
       // Sometimes boost is returning the wrong current path, which leads to not discovering the conf files correctly.
       // This falls back to checking under the install path. If this file is present there, we probably want to be
       // running in developer mode.


### PR DESCRIPTION
### Intent

I'm using vscode to work on IDE source (C++ and Java) in a single window, as part of that running cmake generation from root of repo versus our usual approach of running it in src/cpp.

Currently the Qt-based desktop fails to find the generated conf files (rdesktop-dev.conf, etc) in this arrangement, thus applies wrong logic to find "stuff" and fails to fully load. This makes it harder to debug the Qt desktop, which is handy to do occasionally when porting code over to Electron.

### Approach

Add another "debug mode" detection step that handles this arrangement properly.

### Automated Tests

None, purely a dev environment thing (and we don't have tests for Qt desktop code, anyway).

### QA Notes

Nothing to test other than making sure the IDE still launches.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


