### PR TITLE
Allow to specify resources directory as cmake parameter

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -234,8 +234,12 @@ else()
    else()
      set(RSTUDIO_INSTALL_BIN bin)
    endif()
-   set(RSTUDIO_INSTALL_SUPPORTING .)
+   if(NOT RSTUDIO_INSTALL_SUPPORTING)
+       set(RSTUDIO_INSTALL_SUPPORTING .)
+   endif()
 endif()
+
+add_compile_definitions(RSTUDIO_RESOURCES_DIR="${RSTUDIO_INSTALL_SUPPORTING}")
 
 # if the install prefix is /usr/local then tweak as appropriate
 if(NOT DEFINED CMAKE_INSTALL_PREFIX)

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -87,7 +87,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    core::system::unsetenv(kMonitorSharedSecretEnvVar);
 
    // compute the resource path
-   Error error = core::system::installPath("..", argv[0], &resourcePath_);
+   Error error = core::system::installPath(RSTUDIO_RESOURCES_DIR, argv[0], &resourcePath_);
    if (error)
    {
       LOG_ERROR_MESSAGE("Unable to determine install path: "+error.getSummary());


### PR DESCRIPTION
Signed-off-by: Wolfgang E. Sanyer <WolfgangESanyer@gmail.com>


### Intent

This will allow to specify the r-resources-path at compile-time via 
`cmake -DRSTUDIO_INSTALL_SUPPORTING`, and ensures that this value is respected
at runtime

### Approach

A cmake `add_compile_definitions` is used, along with some logic it
`CMakeGlobals.txt`.

### Automated Tests

n/a

### QA Notes

n/a

### Checklist

- <n/a> If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- <n/a> If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
    - I cannot get unit tests to work on my system

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
Contributor agreement has been signed and mailed in.

