### PR TITLE
use install_name_tool to fix paths at install time

### DIFF
--- a/package/osx/cmake/fix-library-paths.cmake
+++ b/package/osx/cmake/fix-library-paths.cmake
@@ -42,7 +42,15 @@ if(EXISTS "@RSESSION_ARM64_PATH@")
 		COMMAND
 		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
 		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64"
-		"@executable_path/../Frameworks/arm64")
+		"@executable_path/../Frameworks/arm64"
+		"*.dylib")
+
+	execute_process(
+		COMMAND
+			"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+			"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
+			"@executable_path/../Frameworks/arm64"
+			"rsession-arm64")
 
 else()
 
@@ -53,8 +61,16 @@ endif()
 # fix library paths on x86_64 components
 execute_process(
 	COMMAND
-	"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
-	"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks"
-	"@executable_path/../Frameworks")
+		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks"
+		"@executable_path/../Frameworks"
+		"*.dylib")
+
+execute_process(
+	COMMAND
+		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
+		"@executable_path/../Frameworks"
+		"RStudio diagnostics rpostback rsession")
 
 

--- a/package/osx/cmake/fix-library-paths.cmake
+++ b/package/osx/cmake/fix-library-paths.cmake
@@ -1,76 +1,76 @@
 
 # CMake's message is suppressed during install stage so just use echo here
 function(echo MESSAGE)
-	execute_process(COMMAND echo "-- ${MESSAGE}")
+   execute_process(COMMAND echo "-- ${MESSAGE}")
 endfunction()
 
 if(EXISTS "@RSESSION_ARM64_PATH@")
 
-	echo("Found arm64 rsession binary: '@RSESSION_ARM64_PATH@'")
+   echo("Found arm64 rsession binary: '@RSESSION_ARM64_PATH@'")
 
-	# find out where arm64 homebrew lives
-	if(EXISTS "$ENV{HOME}/homebrew/arm64")
-		set(HOMEBREW_ARM64_PREFIX "$ENV{HOME}/homebrew/arm64")
-	else()
-		set(HOMEBREW_ARM64_PREFIX "/opt/homebrew")
-	endif()
+   # find out where arm64 homebrew lives
+   if(EXISTS "$ENV{HOME}/homebrew/arm64")
+      set(HOMEBREW_ARM64_PREFIX "$ENV{HOME}/homebrew/arm64")
+   else()
+      set(HOMEBREW_ARM64_PREFIX "/opt/homebrew")
+   endif()
 
-	echo("Homebrew prefix: '${HOMEBREW_ARM64_PREFIX}'")
+   echo("Homebrew prefix: '${HOMEBREW_ARM64_PREFIX}'")
 
-	# copy arm64 rsession binary
-	configure_file(
-		"@RSESSION_ARM64_PATH@"
-		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS/rsession-arm64"
-		COPYONLY)
+   # copy arm64 rsession binary
+   configure_file(
+      "@RSESSION_ARM64_PATH@"
+      "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS/rsession-arm64"
+      COPYONLY)
 
-	# copy required Homebrew libraries
-	set(HOMEBREW_LIBS gettext krb5 libpq openssl sqlite3)
-	
-	file(MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64")
-	foreach(LIB ${HOMEBREW_LIBS})
-		set(LIBPATH "${HOMEBREW_ARM64_PREFIX}/opt/${LIB}/lib")
-		file(GLOB LIBFILES "${LIBPATH}/*.dylib")
-		foreach(LIBFILE ${LIBFILES})
-			file(
-				COPY "${LIBFILE}"
-				DESTINATION "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64")
-		endforeach()
-	endforeach()
+   # copy required Homebrew libraries
+   set(HOMEBREW_LIBS gettext krb5 libpq openssl sqlite3)
 
-	# fix library paths on arm64 components
-	execute_process(
-		COMMAND
-		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
-		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64"
-		"@executable_path/../Frameworks/arm64"
-		"*.dylib")
+   file(MAKE_DIRECTORY "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64")
+   foreach(LIB ${HOMEBREW_LIBS})
+      set(LIBPATH "${HOMEBREW_ARM64_PREFIX}/opt/${LIB}/lib")
+      file(GLOB LIBFILES "${LIBPATH}/*.dylib")
+      foreach(LIBFILE ${LIBFILES})
+         file(
+            COPY "${LIBFILE}"
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64")
+      endforeach()
+   endforeach()
 
-	execute_process(
-		COMMAND
-			"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
-			"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
-			"@executable_path/../Frameworks/arm64"
-			"rsession-arm64")
+   # fix library paths on arm64 components
+   execute_process(
+      COMMAND
+         "@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+         "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks/arm64"
+         "@executable_path/../Frameworks/arm64"
+         "*.dylib")
+
+   execute_process(
+      COMMAND
+         "@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+         "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
+         "@executable_path/../Frameworks/arm64"
+         "rsession-arm64")
 
 else()
 
-	echo("No arm64 rsession binary available at '@RSESSION_ARM64_PATH@'")
+   echo("No arm64 rsession binary available at '@RSESSION_ARM64_PATH@'")
 
 endif()
 
 # fix library paths on x86_64 components
 execute_process(
-	COMMAND
-		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
-		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks"
-		"@executable_path/../Frameworks"
-		"*.dylib")
+   COMMAND
+      "@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+      "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/Frameworks"
+      "@executable_path/../Frameworks"
+      "*.dylib")
 
 execute_process(
-	COMMAND
-		"@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
-		"${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
-		"@executable_path/../Frameworks"
-		"RStudio diagnostics rpostback rsession")
+   COMMAND
+      "@CMAKE_CURRENT_SOURCE_DIR@/fix-library-paths.sh"
+      "${CMAKE_INSTALL_PREFIX}/RStudio.app/Contents/MacOS"
+      "@executable_path/../Frameworks"
+      "RStudio diagnostics rpostback rsession")
 
 

--- a/package/osx/fix-library-paths.sh
+++ b/package/osx/fix-library-paths.sh
@@ -16,15 +16,16 @@
 #
 
 if [ "$#" = "0" ]; then
-   echo "Usage: $0 [frameworks directory] [prefix]"
+   echo "Usage: $0 [frameworks directory] [prefix] [files]"
    exit 0
 fi
 
 DIR="$1"
 PREFIX="$2"
+FILES="$3"
 
 cd "$DIR"
-for FILE in *.dylib; do
+for FILE in ${FILES}; do
 
    install_name_tool -id "${FILE}" "${FILE}" &> /dev/null
 
@@ -33,7 +34,7 @@ for FILE in *.dylib; do
       tail -n+2 | \
       cut -d' ' -f1 | \
       sed 's|\t||g' | \
-      grep 'homebrew'
+      grep -E 'homebrew|local'
    )
 
    for LIBPATH in ${LIBPATHS}; do

--- a/src/cpp/diagnostics/CMakeLists.txt
+++ b/src/cpp/diagnostics/CMakeLists.txt
@@ -58,37 +58,8 @@ add_stripped_executable(diagnostics
 target_link_libraries(diagnostics
    rstudio-core
 )
+
 if(NOT RSTUDIO_SESSION_WIN32)
    install(TARGETS diagnostics DESTINATION ${RSTUDIO_INSTALL_BIN})
 endif()
-
-# if doing a package build on MacOS, reroute depdendent libraries to our bundled copies
-if(APPLE AND RSTUDIO_PACKAGE_BUILD)
-
-   find_package(OpenSSL REQUIRED QUIET)
-   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-      # get the real path to the library (with all symlinks resolved) and filename
-      get_filename_component(LIB_PATH "${lib}" REALPATH)
-      get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
-      # this command does the following:
-      # 1. runs otool -L to find the path at which the OpenSSL library is
-      #    linked into the executable (this path is unfortunately not canonical
-      #    and includes layers of both resolved and unresolved symlinks)
-      # 2. extracts the path from the output using grep and awk
-      # 3. runs install_name_tool and tells it to replace the path with one that
-      #    points to a bundled copy of the same file
-      add_custom_command (TARGET diagnostics POST_BUILD
-         COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/diagnostics | grep ${LIB_FILE} | awk '{ print $$1 }'` @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/diagnostics)
-   endforeach()
-
-   # do something similar to the above to fix paths to SOCI libraries
-   foreach(lib ${SOCI_DEPENDENCIES})
-      get_filename_component(LIB_NAME "${lib}" NAME_WE)
-      add_custom_command (TARGET diagnostics POST_BUILD
-          COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/diagnostics | grep ${LIB_NAME} | awk '{ print $$1 }'` @executable_path/../Frameworks/$$\(otool -L ${CMAKE_CURRENT_BINARY_DIR}/diagnostics | grep ${LIB_NAME} | awk '{ print $$1 }' | xargs basename\) ${CMAKE_CURRENT_BINARY_DIR}/diagnostics)
-   endforeach()
-
-endif()
-
-
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -691,31 +691,4 @@ if(APPLE)
       set(RSESSION_DYLIB_PREFIX "@executable_path/../Frameworks")
    endif()
 
-   # if doing a package build on MacOS, reroute dependent libraries to our bundled copies
-   if (RSTUDIO_PACKAGE_BUILD)
-      find_package(OpenSSL REQUIRED QUIET)
-      foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-         # get the real path to the library (with all symlinks resolved) and filename
-         get_filename_component(LIB_PATH "${lib}" REALPATH)
-         get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
-         # this command does the following:
-         # 1. runs otool -L to find the path at which the OpenSSL library is
-         #    linked into the executable (this path is unfortunately not canonical
-         #    and includes layers of both resolved and unresolved symlinks)
-         # 2. extracts the path from the output using grep and awk
-         # 3. runs install_name_tool and tells it to replace the path with one that
-         #    points to a bundled copy of the same file
-         add_custom_command(TARGET rsession POST_BUILD
-            COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rsession | grep ${LIB_FILE} | awk '{ print $$1 }'` ${RSESSION_DYLIB_PREFIX}/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rsession)
-      endforeach()
-
-      # do something similar to the above to fix paths to SOCI libraries
-      foreach(lib ${SOCI_DEPENDENCIES})
-         get_filename_component(LIB_NAME "${lib}" NAME_WE)
-         add_custom_command(TARGET rsession POST_BUILD
-            COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rsession | grep ${LIB_NAME} | awk '{ print $$1 }'` ${RSESSION_DYLIB_PREFIX}/$$\(otool -L ${CMAKE_CURRENT_BINARY_DIR}/rsession | grep ${LIB_NAME} | awk '{ print $$1 }' | xargs basename\) ${CMAKE_CURRENT_BINARY_DIR}/rsession)
-      endforeach()
-
-   endif()
-
 endif()

--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -68,31 +68,3 @@ if(NOT RSTUDIO_SESSION_WIN32)
            DESTINATION ${RSTUDIO_INSTALL_BIN}/postback)
 endif()
 
-# if doing a package build on MacOS, reroute dependent libraries to our bundled copies
-if(APPLE AND RSTUDIO_PACKAGE_BUILD)
-
-   find_package(OpenSSL REQUIRED QUIET)
-   foreach(lib ${OPENSSL_CRYPTO_LIBRARY} ${OPENSSL_SSL_LIBRARY})
-      # get the real path to the library (with all symlinks resolved) and filename
-      get_filename_component(LIB_PATH "${lib}" REALPATH)
-      get_filename_component(LIB_FILE "${LIB_PATH}" NAME)
-      # this command does the following:
-      # 1. runs otool -L to find the path at which the OpenSSL library is
-      #    linked into the executable (this path is unfortunately not canonical
-      #    and includes layers of both resolved and unresolved symlinks)
-      # 2. extracts the path from the output using grep and awk
-      # 3. runs install_name_tool and tells it to replace the path with one that
-      #    points to a bundled copy of the same file
-      add_custom_command (TARGET rpostback POST_BUILD
-         COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rpostback | grep ${LIB_FILE} | awk '{ print $$1 }'` @executable_path/../Frameworks/${LIB_FILE} ${CMAKE_CURRENT_BINARY_DIR}/rpostback)
-   endforeach()
-
-   # do something similar to the above to fix paths to SOCI libraries
-   foreach(lib ${SOCI_DEPENDENCIES})
-      get_filename_component(LIB_NAME "${lib}" NAME_WE)
-      add_custom_command (TARGET rpostback POST_BUILD
-          COMMAND install_name_tool -change `otool -L ${CMAKE_CURRENT_BINARY_DIR}/rpostback | grep ${LIB_NAME} | awk '{ print $$1 }'` @executable_path/../Frameworks/$$\(otool -L ${CMAKE_CURRENT_BINARY_DIR}/rpostback | grep ${LIB_NAME} | awk '{ print $$1 }' | xargs basename\) ${CMAKE_CURRENT_BINARY_DIR}/rpostback)
-   endforeach()
-
-endif()
-


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9190.
Addresses https://github.com/rstudio/rstudio/issues/6890.

Previously, we were running `install_name_tool` for package builds at build time, rather than install time. This causes problems when we try to run unit tests with built-but-not-yet-installed RStudio components, as the processes will end up looking for libraries in the wrong locations.

This PR removes those build-time `install_name_tool` usages, and instead just fixes the library paths at install time for the requisite components.

### Approach

Relatively straight-forward switch from using post-build CMake commands to install-time CMake commands (with existing tools).

### Automated Tests

These are the automated tests!

### QA Notes

Nothing for QA.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
