### PR TITLE
launch rsession-arm64 via /usr/bin/arch -arm64

### DIFF
--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -520,6 +520,7 @@ Error SessionLauncher::launchSession(const QStringList& argList,
    {
       QStringList archArgList;
       archArgList.append(QStringLiteral("-arm64"));
+      archArgList.append(sessionPath_.getAbsolutePath());
       archArgList.append(argList);
       
       return parent_process_monitor::wrapFork(

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -518,6 +518,7 @@ Error SessionLauncher::launchSession(const QStringList& argList,
    // we need indirection through arch to handle arm64
    if (sessionPath_.getFilename() == "rsession-arm64")
    {
+      QStringList archArgList;
       archArgList.append("-arm64");
       archArgList.append(argList);
       

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -512,12 +512,39 @@ Error SessionLauncher::launchSession(const QStringList& argList,
    Error error = abendLogPath().removeIfExists();
    if (error)
       LOG_ERROR(error);
+   
+#ifdef __APPLE__
+   
+   // we need indirection through arch to handle arm64
+   if (sessionPath_.getFilename() == "rsession-arm64")
+   {
+      archArgList.append("-arm64");
+      archArgList.append(argList);
+      
+      return parent_process_monitor::wrapFork(
+               boost::bind(launchProcess,
+                           "/usr/bin/arch",
+                           archArgList,
+                           ppRSessionProcess));
+   }
+   else
+   {
+      return parent_process_monitor::wrapFork(
+               boost::bind(launchProcess,
+                           sessionPath_.getAbsolutePath(),
+                           argList,
+                           ppRSessionProcess));
+   }
+   
+#else
 
    return parent_process_monitor::wrapFork(
          boost::bind(launchProcess,
                      sessionPath_.getAbsolutePath(),
                      argList,
                      ppRSessionProcess));
+   
+#endif
 }
 
 void SessionLauncher::onLaunchError(QString message)

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -519,7 +519,7 @@ Error SessionLauncher::launchSession(const QStringList& argList,
    if (sessionPath_.getFilename() == "rsession-arm64")
    {
       QStringList archArgList;
-      archArgList.append("-arm64");
+      archArgList.append(QStringLiteral("-arm64"));
       archArgList.append(argList);
       
       return parent_process_monitor::wrapFork(


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9223.

### Approach

Launches our `rsession-arm64` binary via `arch -arm64`, so that the rest of the process context (including newly-launched child processes) are launched using arm64.

### Automated Tests

None added.

### QA Notes

Test that `system("uname -m")` reports `arm64` when using an M1 macOS machine with an arm64 build of R.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
