### PR TITLE
catch errors when invoking connectionsObserver methods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -127,3 +127,4 @@
 * Fixed issue causing Project Sharing to fail to set Access Control Lists when using NFS v4 and `username@domain` security principals (Pro #2415)
 * Fixed issue where dialog boxes [e.g. Git commit, Installing Pro Database drivers] could fail to show output with Limit Console Output turned on (Pro #2284)
 * Fixed issue preventing Kubernetes sessions from starting due to incorrect SSL certificate checking on websocket connections; make websocket connections support the `verify-ssl-certs` option (Pro #2463)
+* Errors that occur when R packages update the Connections pane are now better handled and reported (#9219)

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -61,18 +61,99 @@ assign(".rs.activeConnections",
 # given a connection type and host, find an active connection object, or NULL if
 # no connection was found
 .rs.addFunction("findActiveConnection", function(type, host) {
+   
    name <- .rs.findConnectionName(type, host)
    if (is.null(name))
       return(NULL)
-   return(get(name, envir = .rs.activeConnections))
+   
+   if (exists(name, envir = .rs.activeConnections))
+      get(name, envir = .rs.activeConnections)
+   
 })
 
-options(connectionObserver = list(
-   connectionOpened = function(type, host, displayName, icon = NULL, 
-                               connectCode, disconnect, listObjectTypes,
-                               listObjects, listColumns, previewObject, 
-                               connectionObject, actions = NULL) {
+.rs.addFunction("connectionsObserver.traceback", function()
+{
+   .rs.getVar("connectionsObserver.lastTraceback")
+})
 
+.rs.addFunction("connectionObserver.connectionError", function(error) {
+   
+   # save the error and calls
+   .rs.setVar("connectionsObserver.lastTraceback", sys.calls())
+   
+   # be quiet if requested
+   suppressed <- getOption("rstudio.connectionsObserver.errorsSuppressed", default = FALSE)
+   if (suppressed)
+      return()
+   
+   # try to figure out what the offending package is
+   package <- NULL
+   
+   frames <- sys.frames()
+   for (frame in rev(frames)) {
+      
+      parent <- parent.env(frame)
+      if (identical(parent, baseenv()) || identical(parent, .BaseNamespaceEnv))
+         next
+      
+      if (isNamespace(parent)) {
+         spec <- getNamespaceInfo(parent, "spec")
+         package <- spec[["name"]]
+         break
+      }
+      
+   }
+   
+   # make header
+   header <- if (is.null(package)) {
+      "An error occurred while updating the RStudio Connections pane:"
+   } else {
+      fmt <- "An error occurred while '%s' attempted to update the RStudio Connections pane:"
+      sprintf(fmt, package)
+   } 
+   
+   # make body
+   fmt <- "Error in %s: %s"
+   body <- sprintf(fmt, format(error$call), format(error$message))
+   
+   # make footer
+   footer <- "If necessary, these warnings can be squelched by setting `options(rstudio.connectionsObserver.errorsSuppressed = TRUE)`."
+   
+   # notify user as message
+   all <- paste(c(header, body, footer), collapse = "\n")
+   message(all)
+   
+})
+
+.rs.addFunction(
+   "connectionObserver.connectionOpened",
+   function(type, host, displayName, icon = NULL, 
+            connectCode, disconnect, listObjectTypes,
+            listObjects, listColumns, previewObject, 
+            connectionObject, actions = NULL)
+   {
+      tryCatch(
+         
+         .rs.connectionObserver.connectionOpenedImpl(
+            type, host, displayName, icon, 
+            connectCode, disconnect, listObjectTypes,
+            listObjects, listColumns, previewObject, 
+            connectionObject, actions
+         ),
+         
+         error = .rs.connectionObserver.connectionError
+         
+      )
+   }
+)
+
+.rs.addFunction(
+   "connectionObserver.connectionOpenedImpl",
+   function(type, host, displayName, icon = NULL, 
+            connectCode, disconnect, listObjectTypes,
+            listObjects, listColumns, previewObject, 
+            connectionObject, actions = NULL)
+   {
       # execute the object types function once to get the list of known 
       # object types; this is presumed to be static over the lifetime of the
       # connection
@@ -80,27 +161,29 @@ options(connectionObserver = list(
          stop("listObjectTypes must be a function returning a list of object types", 
               call. = FALSE)
       }
-
+      
       # function to flatten the tree of object types for more convenient storage
       promote <- function(name, l) {
-        if (length(l) == 0)
-          return(list())
-        if (is.null(l$contains)) {
-          # plain data
-          return(list(list(name = name,
-                      icon = l$icon,
-                      contains = "data")))
-        } else {
-          # subtypes
-          return(unlist(append(list(list(list(
+         
+         if (length(l) == 0)
+            return(list())
+         
+         if (is.null(l$contains)) {
+            # plain data
+            return(list(list(name = name,
+                             icon = l$icon,
+                             contains = "data")))
+         } 
+         
+         # subtypes
+         return(unlist(append(list(list(list(
             name = name, 
             icon = l$icon, 
             contains = names(l$contains)))),
             lapply(names(l$contains), function(name) {
-              promote(name, l$contains[[name]])
+               promote(name, l$contains[[name]])
             })), recursive = FALSE))
-        }
-        return(list())
+         
       }
       
       # apply tree flattener to provided object tree
@@ -126,32 +209,72 @@ options(connectionObserver = list(
       )
       class(connection) <- "rstudioConnection"
       .rs.validateConnection(connection)
-
-      # generate an internal key for this connection in the local cache 
-      cacheKey <- paste(connection$type, connection$host, 
-                        .Call("rs_generateShortUuid"), 
-                        sep = "_")
+      
+      # generate an internal key for this connection in the local cache
+      uuid <- .Call("rs_generateShortUuid", PACKAGE = "(embedding)")
+      cacheKey <- paste(connection$type, connection$host, uuid, sep = "_")
       assign(cacheKey, value = connection, envir = .rs.activeConnections)
-
+      
       # serialize and generate client events
-      invisible(.Call("rs_connectionOpened", connection))
-   },
-   connectionClosed = function(type, host, ...) {
-      .rs.validateCharacterParams(list(type = type, host = host))
+      invisible(.Call("rs_connectionOpened", connection, PACKAGE = "(embedding)"))
+   }
+)
 
+.rs.addFunction(
+   "connectionObserver.connectionClosed",
+   function(type, host, ...)
+   {
+      tryCatch(
+         .rs.connectionObserver.connectionClosedImpl(type, host, ...),
+         error = .rs.connectionObserver.connectionError
+      )
+   }
+)
+
+.rs.addFunction(
+   "connectionObserver.connectionClosedImpl",
+   function(type, host, ...)
+   {
+      .rs.validateCharacterParams(list(type = type, host = host))
+      
       # clean up reference in environment
       name <- .rs.findConnectionName(type, host)
       if (!is.null(name))
          rm(list = name, envir = .rs.activeConnections)
-
-      invisible(.Call("rs_connectionClosed", type, host))
-   },
-   connectionUpdated = function(type, host, hint, ...) {
-      .rs.validateCharacterParams(list(type = type, host = host, hint = hint))
-      invisible(.Call("rs_connectionUpdated", type, host, hint))
+      
+      invisible(.Call("rs_connectionClosed", type, host, PACKAGE = "(embedding)"))
    }
-))
+)
 
+.rs.addFunction(
+   "connectionObserver.connectionUpdated",
+   function(type, host, hint, ...)
+   {
+      tryCatch(
+         .rs.connectionObserver.connectionUpdatedImpl(type, host, hint, ...),
+         error = .rs.connectionObserver.connectionError
+      )
+   }
+)
+
+
+.rs.addFunction(
+   "connectionObserver.connectionUpdatedImpl",
+   function(type, host, hint, ...)
+   {
+      .rs.validateCharacterParams(list(type = type, host = host, hint = hint))
+      invisible(.Call("rs_connectionUpdated", type, host, hint, PACKAGE = "(embedding)"))
+   }
+)
+
+
+options(
+   connectionObserver = list(
+      connectionOpened  = .rs.connectionObserver.connectionOpened,
+      connectionClosed  = .rs.connectionObserver.connectionClosed,
+      connectionUpdated = .rs.connectionObserver.connectionUpdated
+   )
+)
 
 .rs.addFunction("getConnectionObjectName", function(finder, host) {
    finderFunc <- eval(parse(text = finder))

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -108,7 +108,7 @@ assign(".rs.activeConnections",
    header <- if (is.null(package)) {
       "An error occurred while updating the RStudio Connections pane:"
    } else {
-      fmt <- "An error occurred while '%s' attempted to update the RStudio Connections pane:"
+      fmt <- "An error occurred while the '%s' package was updating the RStudio Connections pane:"
       sprintf(fmt, package)
    } 
    


### PR DESCRIPTION
### Intent

Packages can update the Connections pane via the [Connections Contract](https://rstudio.github.io/rstudio-extensions/connections-contract.html). However, it's possible that R errors can occur if the associated R package violates the Connections contract in some way. These errors should not be fatal, since they only imply that the Connections pane will fail to update -- the underlying connection will likely still work without issue.

Addresses https://github.com/rstudio/rstudio/issues/9219.

### Approach

Wrap any connectionObserver methods with `tryCatch()`, and report errors to the user in a minimally-actionable way. At least, they can learn the offending package, and suppress these errors later.

<img width="887" alt="Screen Shot 2021-04-13 at 12 28 33 PM" src="https://user-images.githubusercontent.com/1976582/114609540-c5d19f00-9c53-11eb-9f54-2f8b894cd0ae.png">



### Automated Tests

None included.

### QA Notes

Install the latest release of RSQLite (2.2.6), and then try running the following in RStudio:

```
BiocManager::install("org.Hs.eg.db")
DBI::dbConnect(
   RSQLite::SQLite(),
   dbname = system.file("extdata/org.Hs.eg.sqlite", package = "org.Hs.eg.db"),
   cache_size = 64000L, 
   synchronous = "off",
   flags = RSQLite:::SQLITE_RO,
   vfs = "unix-none"
)
```

You should see an error like the following:

<img width="904" alt="Screen Shot 2021-04-13 at 12 29 46 PM" src="https://user-images.githubusercontent.com/1976582/114609763-ff0a0f00-9c53-11eb-91a7-e1170be28318.png">


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
