### PR TITLE
Add option to upload an unzipped archive if unzip is not on PATH

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -127,3 +127,4 @@
 * Fixed issue causing Project Sharing to fail to set Access Control Lists when using NFS v4 and `username@domain` security principals (Pro #2415)
 * Fixed issue where dialog boxes [e.g. Git commit, Installing Pro Database drivers] could fail to show output with Limit Console Output turned on (Pro #2284)
 * Fixed issue preventing Kubernetes sessions from starting due to incorrect SSL certificate checking on websocket connections; make websocket connections support the `verify-ssl-certs` option (Pro #2463)
+* Fixed issue where uploading a .zip archive when unzip was not on PATH would cause a cryptic error. (#9151)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesUpload.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/FilesUpload.java
@@ -67,9 +67,9 @@ public class FilesUpload
          new OperationWithInput<PendingFileUpload>() {
             public void execute(PendingFileUpload pendingUpload)
             {
-               Boolean unzipFound = pendingUpload.getUnzipFound();
-               Boolean isZip = pendingUpload.getIsZip();
                FileUploadToken token = pendingUpload.getToken();
+               Boolean unzipFound = token.getUnzipFound();
+               Boolean isZip = token.getIsZip();
 
                // confirm unzip is installed
                if (unzipFound == Boolean.FALSE && isZip == Boolean.TRUE)
@@ -77,15 +77,16 @@ public class FilesUpload
                   // Warn user unzip is not installed
                   globalDisplay_.showYesNoMessage(
                           MessageDialog.WARNING,
-                          "Unzip not found on PATH",
-                          "Unzip was not found on users PATH. Would you like to upload the zip archive without unzipping?",
+                          "unzip not found",
+                          "The unzip system utility could not be found. unzip is required for decompressing .zip archives after upload.\n\nWould you like to upload the zip archive without unzipping?",
                           false,
                           checkForFileUploadOverwrite(pendingUpload, token),
-                          () -> {},
+                          completeFileUploadOperation(token, false),
                           true
                           );
                }
-               else {
+               else
+               {
                   // Upload and warn of overwrites, if any
                   checkForFileUploadOverwrite(pendingUpload, token).execute();
                }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FileUploadToken.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FileUploadToken.java
@@ -21,4 +21,24 @@ public class FileUploadToken extends JavaScriptObject
    protected FileUploadToken()
    {
    }
+
+   public final native String getFilename() /*-{
+      return this.filename;
+   }-*/;
+
+   public final native String getUploadTempFile() /*-{
+      return this.uploadedTempFile;
+   }-*/;
+
+   public final native String geTargetDirectory() /*-{
+      return this.targetDirectory;
+   }-*/;
+
+   public final native Boolean getUnzipFound() /*-{
+      return this.unzipFound;
+   }-*/;
+
+   public final native Boolean getIsZip() /*-{
+      return this.isZip;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/PendingFileUpload.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/PendingFileUpload.java
@@ -31,12 +31,4 @@ public class PendingFileUpload extends JavaScriptObject
    public final native JsArray<FileSystemItem> getOverwrites() /*-{
       return this.overwrites;
    }-*/;
-
-   public final native Boolean getUnzipFound() /*-{
-      return this.unzipFound;
-   }-*/;
-
-   public final native Boolean getIsZip() /*-{
-      return this.isZip;
-   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/PendingFileUpload.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/PendingFileUpload.java
@@ -31,4 +31,12 @@ public class PendingFileUpload extends JavaScriptObject
    public final native JsArray<FileSystemItem> getOverwrites() /*-{
       return this.overwrites;
    }-*/;
+
+   public final native Boolean getUnzipFound() /*-{
+      return this.unzipFound;
+   }-*/;
+
+   public final native Boolean getIsZip() /*-{
+      return this.isZip;
+   }-*/;
 }


### PR DESCRIPTION
### Intent

When uploading a zip archive, if unzip is not located on a user's PATH, offer to upload the zip archive without extracting instead of crashing or causing errors.

Addresses #9151 

### Approach

This adds a couple features:

1. If unzip is not on PATH, try `/usr/bin/unzip` as well. Adding other paths to check is easy
2. If unzip cannot be found, display a message asking if uploading the archive, without extracting, is okay
<img width="393" alt="Upload without unzipping" src="https://user-images.githubusercontent.com/56326543/114609393-9c187800-9c53-11eb-9bb1-235377fd13a0.png">

3. Play nicely with the overwrite message, which will display normally if uploading the archive will overwrite an already existing archive in the same directory
<img width="393" alt="Upload zip confirming override" src="https://user-images.githubusercontent.com/56326543/114609481-b6525600-9c53-11eb-888f-2f2faff29a8f.png">

### Automated Tests

I think some automated tests that do something like this would be more than enough:

- Sanity Check: 
  - Uploading a zip archive when `unzip` is on PATH should upload and extract the zip normally
- Backup Path Check: 
  - Uploading a zip archive when `unzip` is not on PATH, but is in `/usr/bin/unzip`, should upload and extract the zip normally
- Upload w/o Extracting Check: 
  - Uploading a zip archive when `unzip` is not on PATH or in `/usr/bin/unzip` should display a prompt asking the user if uploading without extracting is okay
    - Yes -> archive gets uploaded, but not extracted
    - No -> archive does not get uploaded
- Overwrite Compatibility Check: 
  - If uploading a zip archive will overwrite an already existing zip archive, the user should be warned, as usual

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


