### PR TITLE
ensure DYLD_INSERT_LIBRARIES set in arch call

### DIFF
--- a/package/osx/fix-library-paths.sh
+++ b/package/osx/fix-library-paths.sh
@@ -27,7 +27,7 @@ FILES="$3"
 cd "$DIR"
 for FILE in ${FILES}; do
 
-   install_name_tool -id "${FILE}" "${FILE}" &> /dev/null
+   install_name_tool -id "${FILE}" "${FILE}"
 
    LIBPATHS=$( \
       otool -L "${FILE}" | \
@@ -40,7 +40,7 @@ for FILE in ${FILES}; do
    for LIBPATH in ${LIBPATHS}; do
       OLD="${LIBPATH}"
       NEW="${PREFIX}/$(basename "${OLD}")"
-      install_name_tool -change "${OLD}" "${NEW}" "${FILE}" &> /dev/null
+      install_name_tool -change "${OLD}" "${NEW}" "${FILE}"
    done
 
 done

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -51,13 +51,6 @@ fi
 
 RSTUDIO_BUNDLE_NAME="RStudio${RSTUDIO_PRO_SUFFIX}-${RSTUDIO_VERSION_FULL}"
 
-# use RStudio credentials for builds on Jenkins
-if [ -n "${JENKINS_URL}" ]; then
-   USE_CREDS=1
-else
-   USE_CREDS=0
-fi
-
 # use Ninja if available
 if has-program ninja; then
    export CMAKE_GENERATOR=Ninja
@@ -78,9 +71,16 @@ fi
 # default build options
 build_gwt=1
 build_package=1
+build_dmg=1
 clean=0
 copy_gwt=1
 install=0
+use_creds=0
+
+# by default, use RStudio credentials for builds on Jenkins
+if [ -n "${JENKINS_URL}" ]; then
+   use_creds=1
+fi
 
 # read command line arguments
 for arg in "$@"; do
@@ -93,6 +93,8 @@ for arg in "$@"; do
    --build-gwt=*)     build_gwt=${arg#*=} ;;
    --copy-gwt=*)      copy_gwt=${arg#*=} ;;
    --build-package=*) build_package=${arg#*=} ;;
+   --build-dmg=*)     build_dmg=${arg#*=} ;;
+   --use-creds=*)     use_creds=${arg#*=} ;;
    esac
 
 done
@@ -154,7 +156,7 @@ if [ -n "${build_x86_64}" ]; then
       -DRSTUDIO_PACKAGE_BUILD=1                              \
       -DRSTUDIO_CRASHPAD_ENABLED=0                           \
       -DRSTUDIO_TOOLS_ROOT="${RSTUDIO_TOOLS_ROOT}/../x86_64" \
-      -DRSTUDIO_CODESIGN_USE_CREDENTIALS="${USE_CREDS}"      \
+      -DRSTUDIO_CODESIGN_USE_CREDENTIALS="${use_creds}"      \
       -DGWT_BUILD="${build_gwt}"                             \
       -DGWT_COPY="${copy_gwt}"                               \
       -DGWT_BIN_DIR="${BUILD_DIR_X86_64}/gwt/bin"            \
@@ -224,29 +226,33 @@ if [ "${build_package}" = "1" ]; then
    # install target
    cd "${BUILD_DIR_X86_64}"
 
-   "${CMAKE}" --build . --target install > /dev/null
+   "${CMAKE}" --build . --target install
 
-   # move to target directory
-   cd "${INSTALL_DIR}"
+   if [ "${build_dmg}" = "1" ]; then
 
-   # create 'Applications' symlink
-   ln -nfs /Applications Applications
+      # move to target directory
+      cd "${INSTALL_DIR}"
 
-   # package into dmg
-   info "Creating '${RSTUDIO_BUNDLE_NAME}.dmg ...'"
+      # create 'Applications' symlink
+      ln -nfs /Applications Applications
 
-   cd ..
+      # package into dmg
+      info "Creating '${RSTUDIO_BUNDLE_NAME}.dmg ...'"
 
-   hdiutil create                       \
-      -fs "APFS"                        \
-      -volname "${RSTUDIO_BUNDLE_NAME}" \
-      -srcfolder "install"              \
-      -ov                               \
-      -format "UDZO"                    \
-      "${RSTUDIO_BUNDLE_NAME}.dmg"
+      cd ..
 
-   # move to expected location in build folder
-   mv "${RSTUDIO_BUNDLE_NAME}.dmg" "${BUILD_DIR_X86_64}/"
+      hdiutil create                       \
+         -fs "APFS"                        \
+         -volname "${RSTUDIO_BUNDLE_NAME}" \
+         -srcfolder "install"              \
+         -ov                               \
+         -format "UDZO"                    \
+         "${RSTUDIO_BUNDLE_NAME}.dmg"
+
+      # move to expected location in build folder
+      mv "${RSTUDIO_BUNDLE_NAME}.dmg" "${BUILD_DIR_X86_64}/"
+
+   fi
 
    info "Done!"
 

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -516,11 +516,31 @@ Error SessionLauncher::launchSession(const QStringList& argList,
 #ifdef __APPLE__
    
    // we need indirection through arch to handle arm64
-   if (false && sessionPath_.getFilename() == "rsession-arm64")
+   if (sessionPath_.getFilename() == "rsession-arm64")
    {
       QStringList archArgList;
+
+      // run rsession-arm64 with arm64 context
       archArgList.append(QStringLiteral("-arm64"));
+
+      // on macOS with the hardened runtime, we can no longer rely on dyld
+      // to lazy-load symbols from libR.dylib; to resolve this, we use
+      // DYLD_INSERT_LIBRARIES to inject the library we wish to use on
+      // launch 
+      FilePath rHome = FilePath(core::system::getenv("R_HOME"));
+      FilePath rLib = rHome.completeChildPath("lib/libR.dylib");
+      if (rLib.exists())
+      {
+         std::string dyldInsertLibraries("DYLD_INSERT_LIBRARIES=");
+         dyldInsertLibraries.append(rLib.getAbsolutePath());
+         archArgList.append(QStringLiteral("-e"));
+         archArgList.append(QString::fromStdString(dyldInsertLibraries));
+      }
+
+      // add rsession-arm64 path
       archArgList.append(QString::fromStdString(sessionPath_.getAbsolutePath()));
+      
+      // forward remaining arguments
       archArgList.append(argList);
       
       return parent_process_monitor::wrapFork(


### PR DESCRIPTION
### Intent

Addreses https://github.com/rstudio/rstudio/issues/9223.

### Approach

Launch `rsession-arm64` via `/usr/bin/arch`, explicitly setting `-arm64` and also passing along `DYLD_INSERT_LIBRARIES` explicitly.

### Automated Tests

None.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9223.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
