### PR TITLE
install R 3.6.3 (up from 3.5) via PowerShell bootstrapper

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -42,17 +42,17 @@ try {
 
 # install R
 if (-Not (Test-Path -Path "C:\R")) {
-    $RSetupPackage = "C:\R-3.5.0-win.exe"
+    $RSetupPackage = "C:\R-3.6.3-win.exe"
     if (-Not (Test-Path -Path $RSetupPackage)) {
-        Write-Host "Downloading R 3.5.0..."
-        Download-File https://cran.rstudio.com/bin/windows/base/old/3.5.0/R-3.5.0-win.exe $RSetupPackage
+        Write-Host "Downloading R 3.6.3..."
+        Download-File https://cran.rstudio.com/bin/windows/base/old/3.6.3/R-3.6.3-win.exe $RSetupPackage
     } else {
         Write-Host "Using previously downloaded R installer"
     }
     Write-Host "Installing R..."
-    Start-Process $RSetupPackage -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-3.5.0\"'
+    Start-Process $RSetupPackage -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-3.6.3\"'
     if ($DeleteDownloads) { Remove-Item $RSetupPackage -Force }
-    $env:path += ';C:\R\R-3.5.0\bin\i386\'
+    $env:path += ';C:\R\R-3.6.3\bin\i386\'
     [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 } else {
     Write-Host "C:\R already exists, skipping R installation"


### PR DESCRIPTION
### Intent

One of @AndrewMcClain or @cm421 mentioned this a couple weeks ago, can't remember who so including both as potential reviewers!

The Windows dev bootstrapper script installs an old version of R that can make it hard to work on Tidyverse tutorials and such. No particular reason for it installing such an old version other than wanting to have a reasonable baseline if dev hasn't already installed R.

Note that the official build uses a REALLY old version (3.0.3 currently) to ensure compatibility with oldest supported version, but this isn't necessary on a dev machine.

https://github.com/rstudio/rstudio/blob/19c6fe31d25b7b3cb8ec8f51be42cc7f2d21e4b5/docker/jenkins/Dockerfile.windows#L46

### Approach

Increase to 3.6.3. Could have gone to a 4.x version, I suppose, but decided to be conservative and install latest 3.x.

### Automated Tests
### QA Notes

None; this script is purely a dev-machine convenience thing, and optional at that. The official build for Windows uses Dockerfile to install R, not this bootstrapper script.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


