### PR TITLE
avoid executing reticulate package load hook too early

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -371,9 +371,3 @@
    info <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    .rs.scalarListFromList(info)
 })
-
-.rs.registerPackageLoadHook("reticulate", function(...)
-{
-   python <- .rs.readUiPref("python_path")
-   .rs.reticulate.usePython(python)
-})

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -113,6 +113,14 @@
    engine <- tolower(Sys.getenv("MPLENGINE"))
    if (engine %in% c("", "qt5agg"))
       Sys.setenv(MPLENGINE = "tkAgg")
+   
+   # update default version of Python to be used when reticulate is laoded
+   .rs.registerPackageLoadHook("reticulate", function(...)
+   {
+      python <- .rs.readUiPref("python_path")
+      .rs.reticulate.usePython(python)
+   })
+   
 })
 
 .rs.addFunction("reticulate.onPythonInitialized", function()


### PR DESCRIPTION
### Intent

RStudio could crash on load if the `reticulate` package was loaded too early. This was caused by us registering a package load hook that was run immediately, with that load hook also having been run _before_ our R FFI code had finished initialization -- that is, the code that registers the native R routines used by RStudio.

Addresses https://github.com/rstudio/rstudio/issues/9253.

### Approach

Use the `.rs.reticulate.initialized()` hook to add this hook, since that hook will be run on deferred init appropriately:

https://github.com/rstudio/rstudio/blob/102989cb285ed1544d961d88ac011efcfb60db5f/src/cpp/session/modules/SessionReticulate.cpp#L58-L63

### Automated Tests

None included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9253.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
