### PR TITLE
Rerun lint on doc blur

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1813,6 +1813,9 @@ public class TextEditingTarget implements
             // in a collaborative editing session so we can get delete
             // notifications
             checkForExternalEdit(500);
+
+            // relint on blur
+            lintManager_.relintAfterDelay(100);
          }
       });
 


### PR DESCRIPTION
### Intent

Ensure that spellcheck (and linting in general) is done whenever the document gets focus.

Addresses #9074 

### Approach

Just call the linter on focus.

### Automated Tests

Very minor change. Everything passes.

### QA Notes

Just click from Visual back to Source and see that the squigglies are there immedaitely.

### Checklist

- [ x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


