### PR TITLE
clean-rstudio script missing some folders

### DIFF
--- a/scripts/clean-rstudio
+++ b/scripts/clean-rstudio
@@ -14,6 +14,7 @@ rm -f ~/.Rhistory
 
 # global options
 rm -rf ~/.config/rstudio
+rm -rf ~/.config/RStudio
 rm -rf ~/.r/rstudio
 
 # settings and session state
@@ -30,13 +31,13 @@ rm -f ~/.r/crash-handler-permission
 rm -f ~/.r/crash-handler.conf
 
 if [ "${PLATFORM}" = "Darwin" ]; then
+  # Mac session state
+  rm -rf ~/Library/Application\ Support/RStudio
+
   # macOS desktop settings
   defaults delete com.rstudio.desktop > /dev/null 2>&1 || true
   defaults delete com.RStudio.desktop > /dev/null 2>&1 || true
   defaults delete org.rstudio.RStudio > /dev/null 2>&1 || true
-else
-  # Linux desktop settings
-  rm -rf ~/.config/RStudio
 fi
 
 echo Done cleaning RStudio settings and state


### PR DESCRIPTION
### Intent

The `rstudio/scripts/clean-rstudio` bash script is intended as a blunt instrument for resetting RStudio desktop and server to a clean state on Mac/Linux. Primarily intended for dev and testing. There's a corresponding `clean-rstudio.bat` for Windows, not changed as part of this PR.

Anyway, I noticed it was missing some folders.

### Approach

Added those folders.

### Automated Tests

No automated tests, this is a utility script not used by the product in any way.

### QA Notes

Nothing here requires testing; if you have your own copy of this script somewhere, you'll want to update it!

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


