### PR TITLE
include homebrew R in default script list

### DIFF
--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -111,6 +111,7 @@ FilePath systemDefaultRScript(std::string* pErrMsg)
       "/usr/local/bin/R",
       "/opt/local/bin/R",
    #ifdef __APPLE__
+      "/opt/homebrew/bin/R",
       "/Library/Frameworks/R.framework/Resources/bin/R",
    #endif
    };


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9265.

### Approach

Add Homebrew R to the list of R installations that will be tried. Note that R should only exist in this location on M1 machines, hence why we don't try to further screen based on the host architecture.

### Automated Tests

None.

### QA Notes

On an M1 macOS machine, install R via Homebrew, e.g.

```
brew install r
``` 

Then, try to launch RStudio. Assuming you don't already have a version of R installed at `/usr/bin/R`, `/usr/local/bin/R` or `/opt/local/bin/R`, then this version of R should be detected as the "default".

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
