### PR TITLE
Add working directory/Files Pane conveniences

### DIFF
--- a/NEWS-1.5-ghost-orchid
+++ b/NEWS-1.5-ghost-orchid
@@ -7,5 +7,6 @@
 
 ### Misc
 
-* Placeholder
+* Add option to synchronize the Files pane with the current working directory in R (#4615)
+* Add new *Set Working Directory* command to context menu for source files (#6781)
 

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -248,6 +248,7 @@ namespace prefs {
 #define kAlwaysShownFiles "always_shown_files"
 #define kAlwaysShownExtensions "always_shown_extensions"
 #define kSortFileNamesNaturally "sort_file_names_naturally"
+#define kSyncFilesPaneWorkingDir "sync_files_pane_working_dir"
 #define kJobsTabVisibility "jobs_tab_visibility"
 #define kJobsTabVisibilityClosed "closed"
 #define kJobsTabVisibilityShown "shown"
@@ -1235,6 +1236,12 @@ public:
     */
    bool sortFileNamesNaturally();
    core::Error setSortFileNamesNaturally(bool val);
+
+   /**
+    * Whether to change the directory in the Files pane automatically when the working directory in R changes.
+    */
+   bool syncFilesPaneWorkingDir();
+   core::Error setSyncFilesPaneWorkingDir(bool val);
 
    /**
     * The visibility of the Jobs tab.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1857,6 +1857,19 @@ core::Error UserPrefValues::setSortFileNamesNaturally(bool val)
 }
 
 /**
+ * Whether to change the directory in the Files pane automatically when the working directory in R changes.
+ */
+bool UserPrefValues::syncFilesPaneWorkingDir()
+{
+   return readPref<bool>("sync_files_pane_working_dir");
+}
+
+core::Error UserPrefValues::setSyncFilesPaneWorkingDir(bool val)
+{
+   return writePref("sync_files_pane_working_dir", val);
+}
+
+/**
  * The visibility of the Jobs tab.
  */
 std::string UserPrefValues::jobsTabVisibility()
@@ -3014,6 +3027,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kAlwaysShownFiles,
       kAlwaysShownExtensions,
       kSortFileNamesNaturally,
+      kSyncFilesPaneWorkingDir,
       kJobsTabVisibility,
       kShowLauncherJobsTab,
       kLauncherJobsSort,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -973,6 +973,12 @@
             "title": "Sort file names naturally in Files pane",
             "description": "Whether to sort file names naturally, so that e.g., file10.R comes after file9.R"
         },
+        "sync_files_pane_working_dir": {
+            "type": "boolean",
+            "default": false,
+            "title": "Synchronize the Files pane with the current working directory",
+            "description": "Whether to change the directory in the Files pane automatically when the working directory in R changes."
+        },
         "jobs_tab_visibility": {
             "type": "string",
             "enum": ["closed", "shown", "default"],

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -617,6 +617,8 @@ public class ElementIds
    public final static String TAB_CLOSE = "tab_close";
    public final static String TAB_RENAME_FILE = "tab_rename_file";
    public final static String TAB_COPY_PATH = "tab_copy_path";
+   public final static String TAB_SET_WORKING_DIR = "tab_set_working_dir";
+   public final static String TAB_SET_FILES_PANE = "tab_set_files_pane";
    public final static String TAB_CLOSE_ALL = "tab_close_all";
    public final static String TAB_CLOSE_OTHERS = "tab_close_others";
 

--- a/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/DocTabLayoutPanel.java
@@ -21,6 +21,7 @@ import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ClassIds;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
+import org.rstudio.core.client.RUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.NodePredicate;
@@ -33,6 +34,7 @@ import org.rstudio.core.client.events.TabCloseEvent;
 import org.rstudio.core.client.events.TabClosedEvent;
 import org.rstudio.core.client.events.TabClosingEvent;
 import org.rstudio.core.client.events.TabReorderEvent;
+import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
@@ -47,6 +49,8 @@ import org.rstudio.studio.client.common.filetypes.events.RenameSourceFileEvent;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.server.model.DocumentCloseEvent;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+import org.rstudio.studio.client.workbench.views.files.events.DirectoryNavigateEvent;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.events.CloseAllSourceDocsExceptEvent;
@@ -227,6 +231,13 @@ public class DocTabLayoutPanel
                menu.addItem(ElementIds.TAB_COPY_PATH, new MenuItem("Copy Path", () ->
                {
                   events_.fireEvent(new CopySourcePathEvent(filePath));
+               }));
+               menu.addItem(ElementIds.TAB_SET_WORKING_DIR, new MenuItem("Set Working Directory", () ->
+               {
+                  FileSystemItem targetPath = FileSystemItem.createFile(filePath);
+                  events_.fireEvent(new SendToConsoleEvent(
+                     "setwd(" + RUtil.asStringLiteral(targetPath.getParentPathString()) + ")", true));
+                  events_.fireEvent(new DirectoryNavigateEvent(targetPath.getParentPath(), false));
                }));
                menu.addSeparator();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1995,6 +1995,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to change the directory in the Files pane automatically when the working directory in R changes.
+    */
+   public PrefValue<Boolean> syncFilesPaneWorkingDir()
+   {
+      return bool(
+         "sync_files_pane_working_dir",
+         "Synchronize the Files pane with the current working directory", 
+         "Whether to change the directory in the Files pane automatically when the working directory in R changes.", 
+         false);
+   }
+
+   /**
     * The visibility of the Jobs tab.
     */
    public PrefValue<String> jobsTabVisibility()
@@ -3395,6 +3407,8 @@ public class UserPrefsAccessor extends Prefs
          alwaysShownExtensions().setValue(layer, source.getObject("always_shown_extensions"));
       if (source.hasKey("sort_file_names_naturally"))
          sortFileNamesNaturally().setValue(layer, source.getBool("sort_file_names_naturally"));
+      if (source.hasKey("sync_files_pane_working_dir"))
+         syncFilesPaneWorkingDir().setValue(layer, source.getBool("sync_files_pane_working_dir"));
       if (source.hasKey("jobs_tab_visibility"))
          jobsTabVisibility().setValue(layer, source.getString("jobs_tab_visibility"));
       if (source.hasKey("show_launcher_jobs_tab"))
@@ -3696,6 +3710,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(alwaysShownFiles());
       prefs.add(alwaysShownExtensions());
       prefs.add(sortFileNamesNaturally());
+      prefs.add(syncFilesPaneWorkingDir());
       prefs.add(jobsTabVisibility());
       prefs.add(showLauncherJobsTab());
       prefs.add(launcherJobsSort());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -55,6 +55,9 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addSeparator();
       moreMenu.addItem(commands.setAsWorkingDir().createMenuItem(false));
       moreMenu.addItem(commands.goToWorkingDir().createMenuItem(false));
+      moreMenu.addItem(new UserPrefMenuItem<>(prefs.syncFilesPaneWorkingDir(), true,
+         "Synchronize Working Directory", prefs));
+      moreMenu.addSeparator();
       moreMenu.addItem(commands.openNewTerminalAtFilePaneLocation().createMenuItem(false));
       moreMenu.addSeparator();
       moreMenu.addItem(commands.showFolder().createMenuItem(false));


### PR DESCRIPTION
### Intent

Adds a couple of small features to make managing the working directory more convenient. First, there's a new context menu option which gives one-click access to setting the working directory to that of the chosen tab (addresses #6781).

![image](https://user-images.githubusercontent.com/470418/116319078-b762a780-a76a-11eb-9c0e-56f46ec6d9c3.png)

Second, there's a new option in the Files pane that causes it to automatically start tracking your working directory. When enabled, it will update the Files pane when you change the working directory in R (addresses #6781)

![image](https://user-images.githubusercontent.com/470418/116319167-e11bce80-a76a-11eb-9a93-cdc004db5fcb.png)


### Approach

Very straightforward client-only changes. 

### Automated Tests

None, unit tests don't currently support front end changes driven by back end events.

### QA Notes

1. The "Set Working Directory" command should update both the R working directory and the Files pane.
2. Turning on the "Synchronize Working Directory" setting should cause the working directory to synchronize immediately. This setting can also be toggled from the Command Palette. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


