### PR TITLE
Bugfix/rstan duplicate save

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -140,3 +140,4 @@
 * Fixed issue preventing Kubernetes sessions from starting due to incorrect SSL certificate checking on websocket connections; make websocket connections support the `verify-ssl-certs` option (Pro #2463)
 * Fixed issue where uploading a .zip archive when unzip was not on PATH would cause a cryptic error. (#9151)
 * Errors that occur when R packages update the Connections pane are now better handled and reported (#9219)
+* Fixed issue where .md, .py, .sql, and .stan files had duplicate event handlers (#9106)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -67,7 +67,7 @@ public abstract class CompletionManagerBase
       public void onToken(TokenIterator it, Token token);
    }
    
-   public CompletionManagerBase(CompletionPopupDisplay popup,
+   protected CompletionManagerBase(CompletionPopupDisplay popup,
                                 DocDisplay docDisplay,
                                 CodeToolsServerOperations server,
                                 CompletionContext context)
@@ -84,10 +84,6 @@ public abstract class CompletionManagerBase
       helpTimer_ = new HelpTimer();
       handlers_ = new ArrayList<>();
       snippets_ = new SnippetHelper((AceEditor) docDisplay, context.getId());
-      
-      // deferred so that handlers are toggled after subclasses have finished
-      // construction
-      Scheduler.get().scheduleDeferred(() -> toggleHandlers(true));
    }
    
    @Inject
@@ -825,7 +821,7 @@ public abstract class CompletionManagerBase
       helpTimer_.schedule(completion);
    }
    
-   private void toggleHandlers(boolean enable)
+   protected void toggleHandlers(boolean enable)
    {
       if (enable)
          addHandlers();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/MarkdownCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/MarkdownCompletionManager.java
@@ -24,8 +24,22 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Token;
 public class MarkdownCompletionManager extends CompletionManagerBase
                                        implements CompletionManager
 {
+   // Use a funstructor to create an instance in order to ensure toggleHandlers()
+   // is invoked after the object is fully instantiated
+   public static MarkdownCompletionManager create(DocDisplay docDisplay,
+                                                  CompletionPopupDisplay popup,
+                                                  CodeToolsServerOperations server,
+                                                  CompletionContext context)
+   {
+      MarkdownCompletionManager retVal = new MarkdownCompletionManager(docDisplay, popup, server, context);
 
-   public MarkdownCompletionManager(DocDisplay docDisplay,
+      retVal.toggleHandlers(true);
+
+      return retVal;
+   }
+
+   // Use the create() funstructor above instead of invoking this constructor directly
+   private MarkdownCompletionManager(DocDisplay docDisplay,
                                     CompletionPopupDisplay popup,
                                     CodeToolsServerOperations server,
                                     CompletionContext context)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PythonCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PythonCompletionManager.java
@@ -35,8 +35,23 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.CompletionC
 
 public class PythonCompletionManager extends CompletionManagerBase
                                      implements CompletionManager
-{  
-   public PythonCompletionManager(DocDisplay docDisplay,
+{
+   // Use a funstructor to create an instance in order to ensure toggleHandlers()
+   // is invoked after the object is fully instantiated
+   public static PythonCompletionManager create(DocDisplay docDisplay,
+                                                CompletionPopupDisplay popup,
+                                                CodeToolsServerOperations server,
+                                                CompletionContext context)
+   {
+      PythonCompletionManager retVal = new PythonCompletionManager(docDisplay, popup, server, context);
+
+      retVal.toggleHandlers(true);
+
+      return retVal;
+   }
+
+   // Use the create() funstructor above instead of invoking this constructor directly
+   private PythonCompletionManager(DocDisplay docDisplay,
                                   CompletionPopupDisplay popup,
                                   CodeToolsServerOperations server,
                                   CompletionContext context)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/SqlCompletionManager.java
@@ -32,7 +32,22 @@ import com.google.gwt.core.client.JsArray;
 public class SqlCompletionManager extends CompletionManagerBase
                                   implements CompletionManager
 {
-   public SqlCompletionManager(DocDisplay docDisplay,
+   // Use a funstructor to create an instance in order to ensure toggleHandlers()
+   // is invoked after the object is fully instantiated
+   public static SqlCompletionManager create(DocDisplay docDisplay,
+                                             CompletionPopupDisplay popup,
+                                             CodeToolsServerOperations server,
+                                             CompletionContext context)
+   {
+      SqlCompletionManager retVal = new SqlCompletionManager(docDisplay, popup, server, context);
+
+      retVal.toggleHandlers(true);
+
+      return retVal;
+   }
+
+   // Use the create() funstructor above instead of invoking this constructor directly
+   private SqlCompletionManager(DocDisplay docDisplay,
                                CompletionPopupDisplay popup,
                                CodeToolsServerOperations server,
                                CompletionContext context)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -45,7 +45,22 @@ import com.google.gwt.event.shared.HandlerRegistration;
 public class StanCompletionManager extends CompletionManagerBase
                                    implements CompletionManager
 {
-   public StanCompletionManager(DocDisplay docDisplay,
+   // Use a funstructor to create an instance in order to ensure toggleHandlers()
+   // is invoked after the object is fully instantiated
+   public static StanCompletionManager create(DocDisplay docDisplay,
+                                             CompletionPopupDisplay popup,
+                                             CodeToolsServerOperations server,
+                                             CompletionContext context)
+   {
+      StanCompletionManager retVal = new StanCompletionManager(docDisplay, popup, server, context);
+
+      retVal.toggleHandlers(true);
+
+      return retVal;
+   }
+
+   // Use the create() funstructor above instead of invoking this constructor directly
+   private StanCompletionManager(DocDisplay docDisplay,
                                 CompletionPopupDisplay popup,
                                 CodeToolsServerOperations server,
                                 CompletionContext context)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -843,7 +843,7 @@ public class AceEditor implements DocDisplay,
                // Markdown completion manager
                if (fileType_.isMarkdown() || fileType_.isRmd())
                {
-                  managers.put(DocumentMode.Mode.MARKDOWN, new MarkdownCompletionManager(
+                  managers.put(DocumentMode.Mode.MARKDOWN, MarkdownCompletionManager.create(
                         editor,
                         new CompletionPopupPanel(),
                         server_,
@@ -853,7 +853,7 @@ public class AceEditor implements DocDisplay,
                // Python completion manager
                if (fileType_.isPython() || fileType_.isRmd())
                {
-                  managers.put(DocumentMode.Mode.PYTHON, new PythonCompletionManager(
+                  managers.put(DocumentMode.Mode.PYTHON, PythonCompletionManager.create(
                         editor,
                         new CompletionPopupPanel(),
                         server_,
@@ -872,7 +872,7 @@ public class AceEditor implements DocDisplay,
                // SQL completion manager
                if (fileType_.isSql() || fileType_.isRmd())
                {
-                  managers.put(DocumentMode.Mode.SQL, new SqlCompletionManager(
+                  managers.put(DocumentMode.Mode.SQL, SqlCompletionManager.create(
                         editor,
                         new CompletionPopupPanel(),
                         server_,
@@ -882,7 +882,7 @@ public class AceEditor implements DocDisplay,
                // Stan completion manager
                if (fileType_.isStan() || fileType_.isRmd())
                {
-                  managers.put(DocumentMode.Mode.STAN, new StanCompletionManager(
+                  managers.put(DocumentMode.Mode.STAN, StanCompletionManager.create(
                         editor,
                         new CompletionPopupPanel(),
                         server_,


### PR DESCRIPTION
### Intent

Completion managers that extend the `CompletionManagerBase` class have duplicated handlers that fire twice for every one event they're registered for. This was noticed in #9106 specifically for `.stan` files when saving, but it's been occurring for all file types that use `CompletionManagerBase`, including:
- Markdown files
- Python files
- SQL files
- Stan files

### Approach

The handlers need to be registered after the completion manager objects are fully instantiated. Completion mangers now take a factory-ish approach using a "funstructor" `create()` method in place of the, now private, constructor to:
1. create the object
2. register the handlers
3. return the created object.

### Automated Tests

Probably not needed

### QA Notes

#9106 describes how to check the autosave handler for `.stan` files. Saves (and autosaves) should increment `count` by one. Clicking inside the editor of a `.stan` file for the first time should also trigger a single `OnFocus` event

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests