### PR TITLE
fix call to onResponseReceived

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetSpelling.java
@@ -118,14 +118,16 @@ public class TextEditingTargetSpelling extends SpellingContext
 
                   lint.push(LintItem.create(wordStart.getRow(), wordStart.getColumn(), wordEnd.getRow(), wordEnd.getColumn(), "Spellcheck", "spelling"));
                }
-
-               request.onResponseReceived(lint);
             }
+
+            request.onResponseReceived(lint);
+
          }
 
          @Override
          public void onError(ServerError error)
          {
+            Debug.logError(error);
          }
       });
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9297.

### Approach

Suspect call to `onResponseReceived()` had accidentally been placed in body of for loop; moved outside.

### Automated Tests

None included for this PR.

### QA Notes

See https://github.com/rstudio/rstudio/issues/9297.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
