### PR TITLE
add "indices" to spellcheck domain wordlist

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
@@ -165,6 +165,7 @@ ides
 ietf
 iframe
 igraph
+indices
 inode
 installable
 instapaper


### PR DESCRIPTION
Both _indexes_ and _indices_ are acceptable English pluralizations of index, but "[_indices_ is generally preferred in mathematical, financial, and technical contexts](https://grammarist.com/usage/indexes-indices/)," such as in, say, a statistical computing application.

