### PR TITLE
Allow only one login poll request at a time

### DIFF
--- a/src/gwt/www/js/signin.js
+++ b/src/gwt/www/js/signin.js
@@ -19,6 +19,8 @@ var responseURL = "";
 // Global variable; tracks whether an active sign-in is in progress
 var activeSignIn = false;
 
+var pollInProgress = false;
+
 /**
  * Ensure error region is spoken by a screen reader.
  */
@@ -170,8 +172,11 @@ function submitRealForm() {
  * Checks to see if the user has already signed in via another tab.
  */
 function pollForSignin() {
-  if (activeSignIn)
+  if (activeSignIn || pollInProgress)
      return;
+
+  pollInProgress = true;
+
   var xhr = new XMLHttpRequest();
   xhr.open("GET", "./", true);
   xhr.onreadystatechange = function() {
@@ -179,6 +184,7 @@ function pollForSignin() {
        return;
      try {
         if (xhr.readyState === 4) {
+           pollInProgress = false;
            if (xhr.status === 200) {
               var isSignIn = false;
               var url = xhr.responseURL.split('?')[0];

--- a/src/gwt/www/js/signin.js
+++ b/src/gwt/www/js/signin.js
@@ -19,8 +19,6 @@ var responseURL = "";
 // Global variable; tracks whether an active sign-in is in progress
 var activeSignIn = false;
 
-var pollInProgress = false;
-
 /**
  * Ensure error region is spoken by a screen reader.
  */
@@ -172,10 +170,8 @@ function submitRealForm() {
  * Checks to see if the user has already signed in via another tab.
  */
 function pollForSignin() {
-  if (activeSignIn || pollInProgress)
+  if (activeSignIn)
      return;
-
-  pollInProgress = true;
 
   var xhr = new XMLHttpRequest();
   xhr.open("GET", "./", true);
@@ -184,7 +180,7 @@ function pollForSignin() {
        return;
      try {
         if (xhr.readyState === 4) {
-           pollInProgress = false;
+           setTimeout(pollForSignin, 1000);
            if (xhr.status === 200) {
               var isSignIn = false;
               var url = xhr.responseURL.split('?')[0];
@@ -226,7 +222,7 @@ window.addEventListener("load", function() {
       userEle.focus();
    
       // Begin polling for sign-ins from other tabs (we only do this for interactive forms)
-      setInterval(pollForSignin, 1000);
+      setTimeout(pollForSignin, 1000);
    }
 
 


### PR DESCRIPTION
Do not start a new poll until the previous one finishes

If request latencies are longer than 1 second, and the login page is
left idle for a few seconds, these requests can pile up and create
problems with the login.

### Intent

Fixes intermittent problems when login-page has long-latencies. 

### Approach

Only allow one login poll request at a time. 

### Automated Tests

### QA Notes

Use chrome dev tools network throttling with long latency (5-15 secs)

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests



