### PR TITLE
use activate script if available to activate Python in terminal

### DIFF
--- a/src/cpp/session/resources/terminal/hooks
+++ b/src/cpp/session/resources/terminal/hooks
@@ -1,5 +1,17 @@
 #!/usr/bin/env sh
 
 if [ -f "${RETICULATE_PYTHON}" ]; then
-	PATH="$(dirname "${RETICULATE_PYTHON}"):${PATH}"
+
+	# check for an activate script in the same directory
+	# as the configured version of Python; if it exists,
+	# use that to activate Python
+	_RS_PYTHON_BIN=$(dirname "${RETICULATE_PYTHON}")
+	if [ -f "${_RS_PYTHON_BIN}/activate" ]; then
+		. "${_RS_PYTHON_BIN}/activate"
+	else
+		PATH="${_RS_PYTHON_BIN}:${PATH}"
+	fi
+	unset _RS_PYTHON_BIN
+
 fi
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9188. For Python virtual environments, rather than only adding Python to the PATH, we use the environment's `activate` script (if any) to activate Python.

### Approach

Check if the Python executable used has a sibling `activate` script; if it exists, source it.

### Automated Tests

None included.

### QA Notes

Test that the activate script associated with a Python virtual environment is sourced when RStudio has been configured to use a virtual environment.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


