### PR TITLE
Update CRANMirror.CRANMirror to centralize display logic

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/ChooseMirrorDialog.java
@@ -74,8 +74,7 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
          CRANMirror cranMirror = CRANMirror.empty();
          cranMirror.setURL(customTextBox_.getText());
 
-         cranMirror.setHost("Custom");
-         cranMirror.setName("Custom");
+         cranMirror.setAsCustom();
 
          return cranMirror;
       }
@@ -113,7 +112,7 @@ public class ChooseMirrorDialog extends ModalDialog<CRANMirror>
          return;
       }
       
-      if (input.getHost().equals("Custom"))
+      if (input.isCustom())
       {
          progressIndicator_.onProgress("Validating CRAN repository...");
          

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -111,8 +111,48 @@ public class CRANMirror extends UserPrefs.CranMirror
       return repos;
    }
 
+   /**
+    * Sets Name and Host as a "custom" CRAN repo defined by URL alone
+    */
+   public final void setAsCustom()
+   {
+      setName(getCustomEnumValue());
+      setHost(getCustomEnumValue());
+   }
+
+   /**
+    * Returns whether this is a "custom" CRAN repo (eg: defined by URL alone)
+    */
+   public final boolean isCustom()
+   {
+      return getHost().equals(getCustomEnumValue());
+   }
+
+   /**
+    * Returns a formatted display name for this CRANMirror.
+    *
+    * Returned name includes Name and Host if a standard host, and simply the URL of a custom host from the user
+    */
    public final String getDisplay()
    {
-      return getName() + " - " + getHost();
+      if (isCustom()) {
+         // Host is Custom with no standard Name/Host info.  Identify by URL
+         return getURL();
+      } else {
+         return getName() + " - " + getHost();
+      }
    }
+
+   // Implement enumerators as functions because this extends a JavaScriptObject
+   // A cleaner way might be to wrap this in a wrapper class, but this gets the job done
+   public final static String getCustomEnumValue()
+   {
+      return "Custom"; //$NON-NLS-1$
+   }
+
+   public final static String getSecondaryEnumValue()
+   {
+      return "Secondary"; //$NON-NLS-1$
+   }
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/mirrors/model/CRANMirror.java
@@ -135,7 +135,8 @@ public class CRANMirror extends UserPrefs.CranMirror
     */
    public final String getDisplay()
    {
-      if (isCustom()) {
+      if (isCustom()) 
+      {
          // Host is Custom with no standard Name/Host info.  Identify by URL
          return getURL();
       } else {

--- a/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/repos/SecondaryReposDialog.java
@@ -81,14 +81,14 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
          cranMirror.setName(nameTextBox_.getText());
          cranMirror.setURL(urlTextBox_.getText());
 
-         cranMirror.setHost("Custom");
+         cranMirror.setHost(cranMirror.getCustomEnumValue());
 
          return cranMirror;
       }
       else if (listBox_ != null && listBox_.getSelectedIndex() >= 0)
       {
          CRANMirror cranMirror = repos_.get(listBox_.getSelectedIndex());
-         cranMirror.setHost("Secondary");
+         cranMirror.setHost(cranMirror.getSecondaryEnumValue());
          return cranMirror;
       }
       else
@@ -136,7 +136,7 @@ public class SecondaryReposDialog extends ModalDialog<CRANMirror>
          return;
       }
 
-      if (input.getHost().equals("Custom"))
+      if (input.isCustom())
       {
          progressIndicator_.onProgress("Validating CRAN repository...");
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -82,18 +82,9 @@ public class PackagesPreferencesPane extends PreferencesPane
             cranMirror_ = cranMirror;
             cranMirrorTextBox_.setText(cranMirror_.getDisplay());
 
-            if (cranMirror_.getHost().equals("Custom"))
-            {
-               cranMirrorTextBox_.setText(cranMirror_.getURL());
-            }
-            else
-            {
-               cranMirrorTextBox_.setText(cranMirror_.getDisplay());
-            }
-
             secondaryReposWidget_.setCranRepoUrl(
                   cranMirror_.getURL(),
-                  cranMirror_.getHost().equals("Custom")
+                  cranMirror_.isCustom()
             );
          });
       };
@@ -247,17 +238,10 @@ public class PackagesPreferencesPane extends PreferencesPane
 
          secondaryReposWidget_.setCranRepoUrl(
             cranMirror_.getURL(),
-            cranMirror_.getHost().equals("Custom")
+            cranMirror_.isCustom()
          );
 
-         if (cranMirror_.getHost().equals("Custom"))
-         {
-            cranMirrorTextBox_.setText(cranMirror_.getURL());
-         }
-         else
-         {
-            cranMirrorTextBox_.setText(cranMirror_.getDisplay());
-         }
+         cranMirrorTextBox_.setText(cranMirror_.getDisplay());
 
          cranMirrorStored_ = cranMirrorTextBox_.getTextBox().getText();
 
@@ -364,6 +348,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       String mirrorTextValue = cranMirrorTextBox_.getTextBox().getText();
 
       boolean cranRepoChanged = !mirrorTextValue.equals(cranMirrorStored_);
+      // TODO: Is this correct?  Custom doesn't require a leading http://, so this wont always match
       boolean cranRepoChangedToUrl = cranRepoChanged &&
                                       mirrorTextValue.startsWith("http");
 
@@ -373,8 +358,7 @@ public class PackagesPreferencesPane extends PreferencesPane
          {
             cranMirror_.setURL(mirrorTextValue);
 
-            cranMirror_.setHost("Custom");
-            cranMirror_.setName("Custom");
+            cranMirror_.setAsCustom();
          }
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -348,7 +348,6 @@ public class PackagesPreferencesPane extends PreferencesPane
       String mirrorTextValue = cranMirrorTextBox_.getTextBox().getText();
 
       boolean cranRepoChanged = !mirrorTextValue.equals(cranMirrorStored_);
-      // TODO: Is this correct?  Custom doesn't require a leading http://, so this wont always match
       boolean cranRepoChangedToUrl = cranRepoChanged &&
                                       mirrorTextValue.startsWith("http");
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Update to CRANMirror that makes logic around how to display it to users, as well as whether it is a standard CRAN Mirror or if it is user defined by URL.  Change should not affect function, only make things more maintainable.  This was done while working on internationalizing RStudio and trying to simplify where hardcoded strings are located in the code.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

CRANMirror implements a .getDisplay() method for showing a human readable representation of itself.  PackagesPreferencesPane.java and ChooseMirrorDialog.java both use this, but only when CRANMirror.host != "Custom".  CRANMirror.host is treated as an enumeration when =="Custom".  When CRANMirror.host == "Custom", they both show CRANMirror.url instead of the host and name. 
* These two references are the only usages of getDisplay(), and are direct copies of each other.  Both apply the same logic in whether to use getDisplay() or create their own displayed text, and when creating their own displayed text they produce the same result (using the URL as the display value
* Determining whether a CRANMirror is "Custom" depends on the somewhat brittle fact that .host=="Custom" when a mirror is defined by URL alone.  This is hard for the CRANMirror maintain if it was ever updated (need to find hard coded strings of "Custom" in the codebase and update them)

Proposed changes here address the above by centralizing the display logic of PackagesPreferencesPane.java and ChooseMirrorDialog.java in CRANMirror.  The following added/changed methods are provided in CRANMirror:
* .getCustomEnumValue(): Serves as an enumerator to specify the string label that denotes a custom object.  This would be more cleanly implemented as an enumerator string, but CRANMirror extends JavaScriptObject which cannot have class-level attributes
* .getSecondaryEnumValue(): Similar to Custom, but implements another enumerator for a "Secondary" mirror
* .setAsCustom(): This sets the object as a "Custom" (url-only) object, replacing the previous pattern where the user of the object would set .host="Custom" and .name="Custom" themselves
* .isCustom(): API for public to assess whether a CRANMirror is or is not "Custom".  Implemented by testing `host==getCustomEnumValue()` (eg: host=="Custom"), which is how consumers of this object previously performed the test themselves
* .getDisplay(): Implements the logic used by PackagesPreferencesPane.java and ChooseMirrorDialog.java, where the display text will be the URL if this is a custom CRANMirror.



### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

No addition to the test suite made.  Function of the code should be the same as prior to the change

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

Can see this working in Global Options -> Packages -> display text for CRAN Mirror

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
Contributor agreement signed and sending later today

