### PR TITLE
ensure R session is initialized before running tests

### DIFF
--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -425,7 +425,6 @@ Error RFunction::call(SEXP evalNS, bool safely, SEXP* pResultSEXP,
    // verify the function
    if (functionSEXP_ == R_UnboundValue)
    {
-      LOG_ERROR_MESSAGE("Failed to find function: '" + functionName_ + "'");
       Error error(errc::SymbolNotFoundError, ERROR_LOCATION);
       if (!functionName_.empty())
          error.addProperty("symbol", functionName_);

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -180,14 +180,14 @@ struct RSuspendOptions;
 struct RCallbacks
 {
    boost::function<core::Error(const RInitInfo&)> init;
-   boost::function<bool(const std::string&,bool,RConsoleInput*)> consoleRead;
+   boost::function<bool(const std::string&, bool, RConsoleInput*)> consoleRead;
    boost::function<void(const std::string&)> browseURL;
    boost::function<void(const core::FilePath&)> browseFile;
    boost::function<void(const std::string&)> showHelp;
    boost::function<void(const std::string&, core::FilePath&, bool)> showFile;
    boost::function<void(const std::string&, int)> consoleWrite;
    boost::function<void()> consoleHistoryReset;
-   boost::function<bool(double*,double*)> locator;
+   boost::function<bool(double*, double*)> locator;
    boost::function<core::FilePath(bool)> chooseFile;
    boost::function<int(const std::string&)> editFile;
    boost::function<void(const std::string&)> showMessage;
@@ -199,7 +199,8 @@ struct RCallbacks
    boost::function<void()> quit;
    boost::function<void(const std::string&)> suicide;
    boost::function<void(bool)> cleanup;
-   boost::function<void(int,const core::FilePath&)> serialization;
+   boost::function<void(int, const core::FilePath&)> serialization;
+   boost::function<void()> runTests;
 };
 
 // run the session   

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -349,6 +349,13 @@ Error initialize()
    error = r::sourceManager().sourceLocal(optionsFilePath);
    if (error)
       return error;
+   
+   // run tests if configured to do so
+   // (note that the callback will exit the process after tests have been run)
+   if (rCallbacks().runTests)
+   {
+      rCallbacks().runTests();
+   }
 
    // server specific R options options
    if (utils::isServerMode())

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -649,13 +649,6 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       exitEarly(exitCode);
    }
 
-   // run unit tests
-   if (rsession::options().runTests())
-   {
-      int result = tests::run();
-      exitEarly(result);
-   }
-
    // register all of the json rpc methods implemented in R
    json::JsonRpcMethods rMethods;
    error = rstudio::r::json::getRpcMethods(&rMethods);
@@ -725,7 +718,10 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    // set flag indicating we had an abnormal end (if this doesn't get
    // unset by the time we launch again then we didn't terminate normally
    // i.e. either the process dying unexpectedly or a call to R_Suicide)
-   rsession::persistentState().setAbend(true);
+   if (!rsession::options().runTests())
+   {
+      rsession::persistentState().setAbend(true);
+   }
 
    // begin session
    using namespace module_context;
@@ -1282,6 +1278,17 @@ void rSerialization(int action, const FilePath& targetPath)
    rsession::clientEventQueue().add(event);
 }
 
+void rRunTests()
+{
+   // run tests
+   int status = tests::run();
+   
+   // try to clean up session
+   rCleanup(true);
+   
+   // exit if we haven't already
+   exitEarly(status);
+}
 
 void ensureRProfile()
 {
@@ -2199,6 +2206,10 @@ int main (int argc, char * const argv[])
       rCallbacks.showHelp = rShowHelp;
       rCallbacks.showMessage = rShowMessage;
       rCallbacks.serialization = rSerialization;
+      
+      // set test callback if enabled
+      if (options.runTests())
+         rCallbacks.runTests = rRunTests;
 
       // run r (does not return, terminates process using exit)
       error = rstudio::r::session::run(rOptions, rCallbacks);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9331.

### Approach

Use a separate `runTests()` callback that can be triggered at an appropriate point after RStudio has finished initializing R.

Note that some parts of initialization (specifically, deferred init) is not run at this point -- should we consider running that for tests too?

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
