### PR TITLE
show "Interrupt Python" text for interrupt button when Python active

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.ui.WorkbenchPane;
+import org.rstudio.studio.client.workbench.views.console.Console.Language;
 import org.rstudio.studio.client.workbench.views.console.shell.Shell;
 import org.rstudio.studio.client.workbench.views.jobs.JobProgressPresenter;
 import org.rstudio.studio.client.workbench.views.jobs.model.LocalJobProgress;
@@ -54,7 +55,7 @@ public class ConsolePane extends WorkbenchPane
    @Inject
    public ConsolePane(Provider<Shell> consoleProvider,
                       Provider<JobProgressPresenter> progressProvider,
-                      final EventBus events,
+                      EventBus events,
                       Commands commands,
                       Session session)
    {
@@ -83,7 +84,7 @@ public class ConsolePane extends WorkbenchPane
       // is always created during startup
       ensureWidget();
 
-      new Console(this, events, commands);
+      new Console(this, events, session, commands);
    }
 
    public void setWorkingDirectory(String directory)
@@ -267,7 +268,20 @@ public class ConsolePane extends WorkbenchPane
          progress_.showProgress(progress);
       lastProgress_ = progress;
    }
-
+   
+   @Override
+   public void adaptToLanguage(Language language)
+   {
+      if (language == Language.R)
+      {
+         consoleInterruptButton_.setTitle("Interrupt R");
+      }
+      else if (language == Language.PYTHON)
+      {
+         consoleInterruptButton_.setTitle("Interrupt Python");
+      }
+   }
+   
    private void syncSecondaryToolbar()
    {      
       // show the toolbar if we're not in normal mode


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8838.

### Approach

Let Console listen to reticulate events, and adapt view as appropriate.

### Automated Tests

None included.

### QA Notes

When R is active, try executing `Sys.sleep(60)`, and verify that the Stop button shows "Interrupt R" on hover; when Python is active, try executing `import time; time.sleep(60)`, and verify that the Stop button shows "Interrupt Python" on hover.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
