### PR TITLE
Avoid setting mime type handler for text/html

### DIFF
--- a/src/cpp/desktop/resources/freedesktop/rstudio.desktop.in
+++ b/src/cpp/desktop/resources/freedesktop/rstudio.desktop.in
@@ -5,4 +5,4 @@ Type=Application
 Terminal=false
 Name=RStudio
 Categories=Development;IDE;
-MimeType=text/x-r-source;text/x-r;text/x-R;text/x-r-doc;text/x-r-sweave;text/x-r-markdown;text/x-r-html;text/x-r-presentation;application/x-r-data;application/x-r-project;application/x-rdp-rsp;text/x-r-history;text/x-r-profile;text/x-tex;text/x-markdown;text/html;text/css;text/javascript;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;
+MimeType=text/x-r-source;text/x-r;text/x-R;text/x-r-doc;text/x-r-sweave;text/x-r-markdown;text/x-r-html;text/x-r-presentation;application/x-r-data;application/x-r-project;application/x-rdp-rsp;text/x-r-history;text/x-r-profile;text/x-tex;text/x-markdown;text/css;text/javascript;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;


### PR DESCRIPTION
**Problem:**

After installing RStudio Desktop 1.4.1106 for Ubuntu 18 from [here](https://www.rstudio.com/products/rstudio/download/) on Ubuntu 20.04, when other applications attempted to open HTTP and HTTPS URLs, the URLs would open in the RStudio Desktop IDE as editable files instead of being displayed in my default browser.

This came as a surprise :smile:

**One Possible Solution:**

I found that RStudio Desktop was advertising itself as being a handler for `text/html` in `/usr/share/applications/rstudio.desktop`.  After that removing that mime type from the list HTTP(s) URLs once again opened in my default browser.

**Notes:**

- I do not know what the intention behind advertising the RStudio Desktop IDE as a `text/html` mime type handler was (also the same with `text/css` and `text/javascript`).
    - perhaps `text/css` and `text/javascript` should also be removed
- In my case, removing the `text/html` mime type was sufficient.
- Perhaps a less invasive way exists whereby the IDE can register itself as a secondary handler instead.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
    - I am unsure if this needs an entry in `NEWS.md`
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
    - N/A
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
    - N/A