### PR TITLE
don't eagerly resolve R functions in RFunction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,5 +9,6 @@
 
 * Add option to synchronize the Files pane with the current working directory in R (#4615)
 * Add new *Set Working Directory* command to context menu for source files (#6781)
+* Improved display of R stack traces in R functions invoked internally by RStudio (#9307)
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9307.

Currently, stack traces including functions called by RStudio are often large and ugly, including the deparsed representation of the function called by RStudio. This PR seeks to remedy that.

### Approach

For the `RFunction` class, instead of explicitly resolving the R function class in the constructor, construct the equivalent R call to reference that function.

### Automated Tests

None included (R function evaluation is covered extensively by existing parts of unit tests / code base)

### QA Notes

Execute the following code:

```
debugonce(.rs.rpc.get_completions)
```

Then, do something to trigger RStudio's R completions; e.g. type `mtcars$<TAB>`. The RStudio debugger should open. Then, try entering:

```
sys.calls()
```

You should see something like:

```
Browse[2]> sys.calls()
[[1]]
.rs.rpc.get_completions("", list("mtcars"), list(6L), list(0L), 
    "", "", list(), list(), FALSE, "", "5D44D828", "mtcars$", 
    FALSE)
```

In particular, the name of the function being called (as opposed to the function definition itself) should be shown, instead of a (very large) deparsed representation of the called function.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
