### PR TITLE
redirect stderr to stdout for Build pane actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ### Bugfixes
 
 * Fixed issue where .md, .py, .sql, and .stan files had duplicate event handlers (#9106)
+* Fixed issue where output when running tests could be emitted in wrong order in Build pane (#5126)
 
 ### Misc
 

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -305,9 +305,11 @@ bool ProcessSupervisor::hasRunningChildren()
 
 namespace {
 
-bool has_activity(const boost::shared_ptr<AsyncChildProcess>& childProc)
+bool hasActivity(const boost::shared_ptr<AsyncChildProcess>& childProc)
 {
-   return childProc->hasNonWhitelistSubprocess() || childProc->hasWhitelistSubprocess()||
+   return
+         childProc->hasNonWhitelistSubprocess() ||
+         childProc->hasWhitelistSubprocess() ||
          childProc->hasRecentOutput();
 }
 
@@ -315,7 +317,7 @@ bool has_activity(const boost::shared_ptr<AsyncChildProcess>& childProc)
 
 bool ProcessSupervisor::hasActiveChildren()
 {
-   return boost::algorithm::any_of(pImpl_->children, has_activity);
+   return boost::algorithm::any_of(pImpl_->children, hasActivity);
 }
 
 bool ProcessSupervisor::poll()

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -646,7 +646,7 @@ private:
                      const FilePath& packagePath,
                      const core::system::ProcessOptions& options,
                      const core::system::ProcessCallbacks& cb)
-   {      
+   {
 
       // if this action is going to INSTALL the package then on
       // windows we need to unload the library first
@@ -812,6 +812,10 @@ private:
       {
          if (useDevtools())
          {
+            // redirect stderr to stdout for certain build types
+            // see: https://github.com/rstudio/rstudio/issues/5126
+            pkgOptions.redirectStdErrToStdOut = true;
+            
             devtoolsCheckPackage(packagePath, pkgOptions, cb);
          }
          else
@@ -826,11 +830,18 @@ private:
 
       else if (type == kTestPackage)
       {
-
          if (useDevtools())
+         {
+            // redirect stderr to stdout for certain build types
+            // see: https://github.com/rstudio/rstudio/issues/5126
+            pkgOptions.redirectStdErrToStdOut = true;
+            
             devtoolsTestPackage(packagePath, pkgOptions, cb);
+         }
          else
+         {
             testPackage(packagePath, pkgOptions, cb);
+         }
       }
 
       else if (type == kTestFile)
@@ -998,7 +1009,7 @@ private:
 
       // execute within the package directory
       pkgOptions.workingDir = workingDir;
-
+      
       // build args
       std::vector<std::string> args;
       args.push_back("--slave");
@@ -1262,7 +1273,8 @@ private:
       cmd << "-e";
       std::vector<std::string> rSourceCommands;
       
-      if (type == kTestShiny) {
+      if (type == kTestShiny)
+      {
         boost::format fmt(
            "result <- shinytest::testApp('%1%');"
            "saveRDS(result, '%2%')"
@@ -1271,7 +1283,9 @@ private:
         cmd << boost::str(fmt %
                              shinyPath.getAbsolutePath() %
                           tempRdsFile.getAbsolutePath());
-      } else if (type == kTestShinyFile) {
+      }
+      else if (type == kTestShinyFile)
+      {
         boost::format fmt(
            "result <- shinytest::testApp('%1%', '%2%');"
            "saveRDS(result, '%3%')"
@@ -1281,7 +1295,9 @@ private:
                              shinyPath.getAbsolutePath() %
                           shinyTestName %
                           tempRdsFile.getAbsolutePath());
-      } else {
+      }
+      else
+      {
         terminateWithError("Shiny test type is unsupported.");
       }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/5126 -- avoid issues with standard output + standard error being incorrectly interleaved in Build pane.

### Approach

When running Build pane actions, redirect standard error to standard output. I believe this should be safe -- for Build actions (other than roxygenize), RStudio registers some filters on stdout / stderr, in order to figure out whether a Build action succeeded or failed. When such a filter is registered, it looks at both stdout and stderr without discriminating between each:

https://github.com/rstudio/rstudio/blob/495ce067873ffebaff44aef481dc4829b53fc84c/src/cpp/session/modules/build/SessionBuild.cpp#L1618-L1632

Technically, this is true of everything that goes through `buildPackage`, which appears to be everything except for a plain roxygenize call:

https://github.com/rstudio/rstudio/blob/669d964efd4606b153ed162ae912a636f79c7d2f/src/cpp/session/modules/build/SessionBuild.cpp#L425-L453

But given that this appears to only be an issue for tests, I targeted the change to specifically that case.

### Automated Tests

TBA

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5126.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
