### PR TITLE
'--slave' => '-s'

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -32,7 +32,7 @@ if(APPLE)
       get_filename_component(_LIBR_LIBRARIES_DIR "${_LIBR_LIBRARIES}" PATH)
       set(LIBR_EXECUTABLE "${_LIBR_LIBRARIES_DIR}/../bin/R")
       execute_process(
-         COMMAND ${LIBR_EXECUTABLE} "--slave" "--vanilla" "-e" "cat(R.home())"
+         COMMAND ${LIBR_EXECUTABLE} "--vanilla" "-s" "-e" "cat(R.home())"
                    OUTPUT_VARIABLE LIBR_HOME
       )
       set(LIBR_HOME ${LIBR_HOME} CACHE PATH "R home directory")
@@ -57,7 +57,7 @@ else()
       # ask R for the home path
       if(NOT LIBR_HOME)
          execute_process(
-            COMMAND ${LIBR_EXECUTABLE} "--slave" "--vanilla" "-e" "cat(R.home())"
+            COMMAND ${LIBR_EXECUTABLE} "--vanilla" "-s" "-e" "cat(R.home())"
                       OUTPUT_VARIABLE LIBR_HOME
          )
          if(LIBR_HOME)
@@ -68,7 +68,7 @@ else()
       # ask R for the include dir
       if(NOT LIBR_INCLUDE_DIRS)
          execute_process(
-            COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(R.home('include'))"
+            COMMAND ${LIBR_EXECUTABLE} "--no-save" "-s" "-e" "cat(R.home('include'))"
             OUTPUT_VARIABLE LIBR_INCLUDE_DIRS
          )
          if(LIBR_INCLUDE_DIRS)
@@ -79,7 +79,7 @@ else()
       # ask R for the doc dir
       if(NOT LIBR_DOC_DIR)
          execute_process(
-            COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(R.home('doc'))"
+            COMMAND ${LIBR_EXECUTABLE} "--no-save" "-s" "-e" "cat(R.home('doc'))"
             OUTPUT_VARIABLE LIBR_DOC_DIR
          )
          if(LIBR_DOC_DIR)
@@ -90,7 +90,7 @@ else()
       # ask R for the lib dir
       if(NOT LIBR_LIB_DIR)
          execute_process(
-            COMMAND ${LIBR_EXECUTABLE} "--slave" "--no-save" "-e" "cat(R.home('lib'))"
+            COMMAND ${LIBR_EXECUTABLE} "--no-save" "-s" "-e" "cat(R.home('lib'))"
             OUTPUT_VARIABLE LIBR_LIB_DIR
          )
       endif()

--- a/dependencies/windows/install-boost.cmd
+++ b/dependencies/windows/install-boost.cmd
@@ -6,8 +6,8 @@ set PATH=%CD%\tools;%PATH%
 
 REM Build Boost.
 cd install-boost
-R --vanilla --slave -f install-boost.R --args debug static
-R --vanilla --slave -f install-boost.R --args release static
+R --vanilla -s -f install-boost.R --args debug static
+R --vanilla -s -f install-boost.R --args release static
 cd ..
 
 REM Build the Boost archive for upload to S3.

--- a/dependencies/windows/install-crashpad.cmd
+++ b/dependencies/windows/install-crashpad.cmd
@@ -1,4 +1,4 @@
 @echo off
 cd install-crashpad
-R --vanilla --slave -f install-crashpad.R
+R --vanilla -s -f install-crashpad.R
 cd ..

--- a/dependencies/windows/install-openssl.cmd
+++ b/dependencies/windows/install-openssl.cmd
@@ -1,5 +1,5 @@
 @echo off
 
 cd install-openssl
-R --vanilla --slave -f install-openssl.R
+R --vanilla -s -f install-openssl.R
 cd ..

--- a/dependencies/windows/install-soci.cmd
+++ b/dependencies/windows/install-soci.cmd
@@ -1,4 +1,4 @@
 @echo off
 cd install-soci
-R --vanilla --slave -f install-soci.R
+R --vanilla -s -f install-soci.R
 cd ..

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -593,7 +593,7 @@ else()
       if(LIBR_FOUND AND RSTUDIO_VERIFY_R_VERSION)
          set(CMAKE_REQUIRED_INCLUDES ${LIBR_INCLUDE_DIRS})
          execute_process(
-             COMMAND "${LIBR_EXECUTABLE}" "--vanilla" "--slave" "-e" "cat(as.character(getRversion()))"
+             COMMAND "${LIBR_EXECUTABLE}" "--vanilla" "-s" "-e" "cat(as.character(getRversion()))"
              OUTPUT_VARIABLE LIBR_VERSION)
          if (LIBR_VERSION VERSION_LESS "3.0.1")
             message(FATAL_ERROR "Minimum R version (${RSTUDIO_R_MAJOR_VERSION_REQUIRED}.${RSTUDIO_R_MINOR_VERSION_REQUIRED}.${RSTUDIO_R_PATCH_VERSION_REQUIRED}) not found; detected version is ${LIBR_VERSION}")

--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -507,7 +507,7 @@ bool detectRLocationsUsingR(const std::string& rScriptPath,
    // only be the case when a module is specified
    std::string rCommand = !rScriptPath.empty() ? rScriptPath : "R";
    std::string command =  rCommand +
-     " --slave --vanilla -e \"cat(paste("
+     " --vanilla -s -e \"cat(paste("
             "R.home('home'),"
             "R.home('share'),"
             "R.home('include'),"
@@ -887,7 +887,7 @@ Error rVersion(const FilePath& rHomePath,
    core::system::ProcessResult result;
 
    std::string rCommand = !rScriptPath.isEmpty() ? rScriptPath.getAbsolutePath() : "R";
-   std::string command = rCommand + " --slave --vanilla -e 'cat(R.Version()$major,R.Version()$minor, sep=\".\")'";
+   std::string command = rCommand + " --vanilla -s -e 'cat(R.Version()$major,R.Version()$minor, sep=\".\")'";
    std::string fullCommand = createSourcedCommand(prelaunchScript,
                                                   module,
                                                   moduleBinaryPath,

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -76,14 +76,16 @@ void AsyncRProcess::start(const char* rCommand,
 
    // args
    std::vector<std::string> args;
-   args.push_back("--slave");
+
    if (rOptions & R_PROCESS_VANILLA)
       args.push_back("--vanilla");
+
    if (rOptions & R_PROCESS_NO_RDATA)
    {
       args.push_back("--no-save");
       args.push_back("--no-restore");
    }
+
 
    // for windows we need to forward setInternet2
 #ifdef _WIN32
@@ -91,6 +93,7 @@ void AsyncRProcess::start(const char* rCommand,
       args.push_back("--internet2");
 #endif
 
+   args.push_back("-s");
    args.push_back("-e");
    
    bool needsQuote = false;

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1899,8 +1899,8 @@ Error sourceModuleRFileWithResult(const std::string& rSourceFile,
 
    // vanilla execution of a single expression
    std::vector<std::string> args;
-   args.push_back("--slave");
    args.push_back("--vanilla");
+   args.push_back("-s");
    args.push_back("-e");
 
    // build source command

--- a/src/cpp/session/modules/SessionRPubs.cpp
+++ b/src/cpp/session/modules/SessionRPubs.cpp
@@ -146,9 +146,9 @@ private:
 
       // args
       std::vector<std::string> args;
-      args.push_back("--slave");
       args.push_back("--no-save");
       args.push_back("--no-restore");
+      args.push_back("-s");
       args.push_back("-e");
 
       boost::format fmt(

--- a/src/cpp/session/modules/SessionTests.cpp
+++ b/src/cpp/session/modules/SessionTests.cpp
@@ -127,8 +127,8 @@ Error installShinyTestDependencies(const json::JsonRpcRequest& request,
 
    // build args
    std::vector<std::string> args;
-   args.push_back("--slave");
    args.push_back("--vanilla");
+   args.push_back("-s");
 
    // for windows we need to forward setInternet2
 #ifdef _WIN32

--- a/src/cpp/session/modules/SessionUpdates.cpp
+++ b/src/cpp/session/modules/SessionUpdates.cpp
@@ -79,14 +79,16 @@ void beginUpdateCheck(bool manual,
 
    // Arguments
    std::vector<std::string> args;
-   args.push_back("--slave");
    args.push_back("--vanilla");
+
 #if defined(_WIN32)
    if (prefs::userPrefs().useInternet2())
    {
       args.push_back("--internet2");
    }
 #endif
+
+   args.push_back("-s");
    args.push_back("-e");
    
    // Build the command to send to R

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -582,8 +582,8 @@ private:
       
       // build the roxygenize command
       shell_utils::ShellCommand cmd(rScriptPath);
-      cmd << "--slave";
       cmd << "--vanilla";
+      cmd << "-s";
       cmd << "-e";
       cmd << buildRoxygenizeCall();
 
@@ -1001,9 +1001,10 @@ private:
 
       // build args
       std::vector<std::string> args;
-      args.push_back("--slave");
       if (vanilla)
          args.push_back("--vanilla");
+
+      args.push_back("-s");
       args.push_back("-e");
       args.push_back(command);
 
@@ -1130,8 +1131,8 @@ private:
 
       // construct a shell command to execute
       shell_utils::ShellCommand cmd(rScriptPath);
-      cmd << "--slave";
       cmd << "--vanilla";
+      cmd << "-s";
       cmd << "-e";
       std::vector<std::string> rSourceCommands;
       
@@ -1139,7 +1140,7 @@ private:
          "setwd('%1%');"
          "files <- list.files(pattern = '[.][rR]$');"
          "invisible(lapply(files, function(x) {"
-         "    system(paste(shQuote('%2%'), '--vanilla --slave -f', shQuote(x)))"
+         "    system(paste(shQuote('%2%'), '--vanilla -s -f', shQuote(x)))"
          "}))"
       );
 
@@ -1170,8 +1171,8 @@ private:
 
       // construct a shell command to execute
       shell_utils::ShellCommand cmd(rScriptPath);
-      cmd << "--slave";
       cmd << "--vanilla";
+      cmd << "-s";
       cmd << "-e";
       std::vector<std::string> rSourceCommands;
       
@@ -1257,8 +1258,8 @@ private:
 
       // construct a shell command to execute
       shell_utils::ShellCommand cmd(rScriptPath);
-      cmd << "--slave";
       cmd << "--vanilla";
+      cmd << "-s";
       cmd << "-e";
       std::vector<std::string> rSourceCommands;
       

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -619,7 +619,7 @@ Error RCompilationDatabase::executeSourceCpp(
 
    // always run as a slave
    std::vector<std::string> args;
-   args.push_back("--slave");
+   args.push_back("-s");
 
    // for packrat projects we execute the profile and set the working
    // directory to the project directory; for other contexts we just

--- a/src/cpp/session/modules/connections/SessionConnections.cpp
+++ b/src/cpp/session/modules/connections/SessionConnections.cpp
@@ -653,8 +653,8 @@ Error installOdbcDriver(const json::JsonRpcRequest& request,
 
    // build args
    std::vector<std::string> args;
-   args.push_back("--slave");
    args.push_back("--vanilla");
+   args.push_back("-s");
 
    // for windows we need to forward setInternet2
 #ifdef _WIN32

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -310,9 +310,9 @@ bool performKnit(const FilePath& rmdPath,
 
    // args
    std::vector<std::string> args;
-   args.push_back("--slave");
    args.push_back("--no-save");
    args.push_back("--no-restore");
+   args.push_back("-s");
    args.push_back("-e");
    boost::format fmt("library(knitr); "
                      "opts_chunk$set(cache.path='%1%-cache/', "

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -102,9 +102,9 @@ public:
                                        const std::string& driver) const
    {
       std::vector<std::string> args;
-      args.push_back("--slave");
       args.push_back("--no-save");
       args.push_back("--no-restore");
+      args.push_back("-s");
       args.push_back("-e");
       std::string cmd = "grDevices::pdf.options(useDingbats = FALSE); "
                         + weaveCommand(file, encoding, driver);


### PR DESCRIPTION
### Intent

Prefer using `-s` as a backwards-compatible alias for the deprecated `--slave` flag (whose long form is now `--no-echo`). Note that because this doesn't change any externally-facing behavior I don't think it merits a NEWS update.

### Approach

Straightforward find and replace.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
