### PR TITLE
show memory usage as mebibytes

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.java
@@ -40,7 +40,7 @@ public class MemoryUsageSummary extends Composite
 {
    interface Style extends CssResource
    {
-      String kbCell();
+      String mbCell();
       String stats();
       String header();
       String swatch();
@@ -202,12 +202,12 @@ public class MemoryUsageSummary extends Composite
 
       TableCellElement kbCell = Document.get().createTDElement();
       Element kbVal = Document.get().createElement("strong");
-      kbVal.setInnerText(StringUtil.prettyFormatNumber(kb));
+      kbVal.setInnerText(StringUtil.prettyFormatNumber(kb / 1024));
       kbCell.appendChild(kbVal);
       Element kbLabel = Document.get().createSpanElement();
-      kbLabel.setInnerText(" KiB");
+      kbLabel.setInnerText(" MiB");
       kbCell.appendChild(kbLabel);
-      kbCell.setClassName(style.kbCell());
+      kbCell.setClassName(style.mbCell());
       row.appendChild(kbCell);
 
       TableCellElement sourceCell = Document.get().createTDElement();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/MemoryUsageSummary.ui.xml
@@ -43,7 +43,7 @@
             padding: 4px;
         }
 
-        .kbCell {
+        .mbCell {
             text-align: right;
         }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9351.

### Approach

Display memory in MiB instead of KiB.

![image](https://user-images.githubusercontent.com/470418/118322560-2dc61000-b4b4-11eb-8392-8281005a9d40.png)

### Automated Tests

None, display change only.

### QA Notes

Test via notes in #9351.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


