### PR TITLE
improve handling of malformed data.frame in viewer

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 * Fixed issue where .md, .py, .sql, and .stan files had duplicate event handlers (#9106)
 * Fixed issue where output when running tests could be emitted in wrong order in Build pane (#5126)
+* Fixed issue where RStudio could crash when viewing a malformed data.frame (#9364)
 
 ### Misc
 

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -799,6 +799,44 @@ std::string formatDouble(const double d, const int precision)
    return out.str();
 }
 
+std::string sprintf(const char* fmt, ...)
+{
+   // note: the semantics for vsnprintf are slightly awkward... when vsnprintf
+   // is called with a null pointer, it returns the number of characters that
+   // would be written, not including the null terminator. however, when called
+   // with a buffer, vsnprintf will write a maximum of n - 1 characters, and
+   // will always write a null terminator at the end! so we need to ensure we
+   // add 1 character to the size returned by vsnprintf(nullptr) to get the
+   // full size of the C string we want to generate
+   std::size_t n = 0;
+   {
+      va_list args;
+      va_start(args, fmt);
+      n = std::vsnprintf(nullptr, 0, fmt, args);
+      va_end(args);
+   }
+   
+   if (n == 0)
+   {
+      return std::string();
+   }
+   
+   // allocate buffer of required size
+   // (include space for null pointer)
+   std::vector<char> buffer(n + 1);
+   
+   // write formatted string to buffer
+   {
+      va_list args;
+      va_start(args, fmt);
+      std::vsnprintf(&buffer[0], buffer.size(), fmt, args);
+      va_end(args);
+   }
+   
+   // return as string
+   return std::string(&buffer[0], n);
+}
+
 } // namespace string_utils
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/core/StringUtilsTests.cpp
+++ b/src/cpp/core/StringUtilsTests.cpp
@@ -155,6 +155,20 @@ test_context("Comment extraction")
    }
 }
 
+test_context("String formatting")
+{
+   test_that("Some simple strings can be formatted")
+   {
+      std::string s;
+      
+      s = string_utils::sprintf("%s, %s!", "Hello", "world");
+      expect_true(s == "Hello, world!");
+      
+      s = string_utils::sprintf("%i + %i == %i", 2, 2, 2 + 2);
+      expect_true(s == "2 + 2 == 4");
+   }
+}
+
 } // end namespace string_utils
 } // end namespace core
 } // end namespace rstudio

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -16,8 +16,9 @@
 #ifndef CORE_STRING_UTILS_HPP
 #define CORE_STRING_UTILS_HPP
 
-#include <string>
 #include <cctype>
+#include <cstdio>
+#include <string>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -293,6 +294,8 @@ bool extractCommentHeader(const std::string& contents,
 std::string extractIndent(const std::string& line);
 
 std::string formatDouble(const double d, const int precision);
+
+std::string sprintf(const char* fmt, ...);
 
 } // namespace string_utils
 

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -532,6 +532,7 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
       std::string emptyStr = "";
       filters.push_back(emptyStr);
    }
+   
    for (int i = 1; i <= ncol; i++)
    {
       std::string filterVal = http::util::urlDecode(
@@ -550,18 +551,17 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    bool hasTransform = false;
 
    // check to see if we have an ordered/filtered view we can build from
-   std::map<std::string, CachedFrame>::iterator cachedFrame = 
-      s_cachedFrames.find(cacheKey);
+   auto cachedFrame =  s_cachedFrames.find(cacheKey);
    if (needsTransform)
    {
       if (cachedFrame != s_cachedFrames.end())
       {
          // do we have a previously ordered/filtered view?
-         SEXP workingDataSEXP = nullptr;
+         SEXP workingDataSEXP = R_NilValue;
          r::exec::RFunction(".rs.findWorkingData", cacheKey)
             .call(&workingDataSEXP, &protect);
-         if (workingDataSEXP != nullptr && TYPEOF(workingDataSEXP) != NILSXP &&
-             !Rf_isNull(workingDataSEXP))
+         
+         if (workingDataSEXP != R_NilValue)
          {
             if (cachedFrame->second.workingSearch == search &&
                 cachedFrame->second.workingFilters == filters && 
@@ -601,8 +601,7 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
 
       // check to see if we've accidentally transformed ourselves into nothing
       // (this shouldn't generally happen without a specific error)
-      if (dataSEXP == nullptr || TYPEOF(dataSEXP) == NILSXP || 
-          Rf_isNull(dataSEXP)) 
+      if (dataSEXP == R_NilValue)
       {
          throw r::exec::RErrorException("Failure to sort or filter data");
       }
@@ -620,9 +619,9 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    }
 
    // apply new row count if we've transformed the data (or need to)
-   filteredNRow = needsTransform || hasTransform ?
-      safeDim(dataSEXP, DIM_ROWS) : 
-      nrow;
+   filteredNRow = needsTransform || hasTransform
+      ? safeDim(dataSEXP, DIM_ROWS)
+      : nrow;
 
    // return the lesser of the rows available and rows requested
    length = std::min(length, filteredNRow - start);
@@ -638,14 +637,23 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    int initialIndex = 0 + columnOffset;
    for (int i = initialIndex; i < initialIndex + numFormattedColumns; i++)
    {
-      SEXP columnSEXP = VECTOR_ELT(dataSEXP, i);
-      if (columnSEXP == nullptr || TYPEOF(columnSEXP) == NILSXP ||
-          Rf_isNull(columnSEXP))
+      if (i >= r::sexp::length(dataSEXP))
       {
-         throw r::exec::RErrorException("No data in column " +
-               boost::lexical_cast<std::string>(i));
+         throw r::exec::RErrorException(
+                  string_utils::sprintf(
+                     "Internal error: attempted to access column %i in vector of size %i",
+                     i,
+                     r::sexp::length(dataSEXP)));
       }
-      SEXP formattedColumnSEXP;
+      
+      SEXP columnSEXP = VECTOR_ELT(dataSEXP, i);
+      if (columnSEXP == nullptr || columnSEXP == R_NilValue)
+      {
+         throw r::exec::RErrorException(
+                  string_utils::sprintf("No data in column %i", i));
+      }
+      
+      SEXP formattedColumnSEXP = R_NilValue;
       r::exec::RFunction formatFx(".rs.formatDataColumn");
       formatFx.addParam(columnSEXP);
       formatFx.addParam(gsl::narrow_cast<int>(start));
@@ -653,33 +661,40 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
       error = formatFx.call(&formattedColumnSEXP, &protect);
       if (error)
          throw r::exec::RErrorException(error.getSummary());
+      
       SET_VECTOR_ELT(formattedDataSEXP, i - initialIndex, formattedColumnSEXP);
    }
 
    // format the row names
-   SEXP rownamesSEXP;
+   SEXP rownamesSEXP = R_NilValue;
    r::exec::RFunction(".rs.formatRowNames", dataSEXP, start, length)
       .call(&rownamesSEXP, &protect);
    
    // create the result grid as JSON
+   
    json::Array data;
    for (int row = 0; row < length; row++)
    {
+      // first, handle row names
       json::Array rowData;
-      if (rownamesSEXP != nullptr &&
-          TYPEOF(rownamesSEXP) != NILSXP &&
-          !Rf_isNull(rownamesSEXP) )
+      if (rownamesSEXP != nullptr && TYPEOF(rownamesSEXP) == STRSXP)
       {
          SEXP nameSEXP = STRING_ELT(rownamesSEXP, row);
-         if (nameSEXP != nullptr &&
-             nameSEXP != NA_STRING &&
-             r::sexp::length(nameSEXP) > 0)
+         if (nameSEXP == nullptr)
          {
-            rowData.push_back(Rf_translateCharUTF8(nameSEXP));
+            rowData.push_back(row + start);
+         }
+         else if (nameSEXP == NA_STRING)
+         {
+            rowData.push_back(SPECIAL_CELL_NA);
+         }
+         else if (r::sexp::length(nameSEXP) == 0)
+         {
+            rowData.push_back(row + start);
          }
          else
          {
-            rowData.push_back(row + start);
+            rowData.push_back(Rf_translateCharUTF8(nameSEXP));
          }
       }
       else
@@ -687,34 +702,51 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
          rowData.push_back(row + start);
       }
 
-      for (int col = 0; col<Rf_length(formattedDataSEXP); col++)
+      // now, handle remaining columns in formatted data
+      for (int col = 0, ncol = r::sexp::length(formattedDataSEXP); col < ncol; col++)
       {
+         // NOTE: it is possible for malformed data.frames to have columns with
+         // differing number of elements; this is rare in practice but needs
+         // to be handled to avoid crashes
+         // https://github.com/rstudio/rstudio/issues/9364
          SEXP columnSEXP = VECTOR_ELT(formattedDataSEXP, col);
-         if (columnSEXP != nullptr &&
-             TYPEOF(columnSEXP) == STRSXP &&
-             !Rf_isNull(columnSEXP))
+         if (row >= r::sexp::length(columnSEXP))
          {
-            SEXP stringSEXP = STRING_ELT(columnSEXP, row);
-            if (stringSEXP != nullptr &&
-                stringSEXP != NA_STRING &&
-                r::sexp::length(stringSEXP) > 0)
-            {
-               rowData.push_back(Rf_translateCharUTF8(stringSEXP));
-            }
-            else if (stringSEXP == NA_STRING)
-            {
-               rowData.push_back(SPECIAL_CELL_NA);
-            }
-            else
-            {
-               rowData.push_back("");
-            }
+            // because R's default print method pads with NAs in this case,
+            // we replicate that with our own padded NAs
+            rowData.push_back(SPECIAL_CELL_NA);
+            continue;
          }
-         else
+         
+         // validate that we have a character vector
+         if (columnSEXP == nullptr || TYPEOF(columnSEXP) != STRSXP)
+         {
+            rowData.push_back("");
+            continue;
+         }
+         
+         // we have a valid character vector; access the string element
+         // and push back data as appropriate
+         SEXP stringSEXP = STRING_ELT(columnSEXP, row);
+         if (stringSEXP == nullptr)
          {
             rowData.push_back("");
          }
+         else if (stringSEXP == NA_STRING)
+         {
+            rowData.push_back(SPECIAL_CELL_NA);
+         }
+         else if (r::sexp::length(stringSEXP) == 0)
+         {
+            rowData.push_back("");
+         }
+         else
+         {
+            rowData.push_back(Rf_translateCharUTF8(stringSEXP));
+         }
       }
+      
+      // all done, add row data
       data.push_back(rowData);
    }
 

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -551,7 +551,7 @@ json::Value getData(SEXP dataSEXP, const http::Fields& fields)
    bool hasTransform = false;
 
    // check to see if we have an ordered/filtered view we can build from
-   auto cachedFrame =  s_cachedFrames.find(cacheKey);
+   auto cachedFrame = s_cachedFrames.find(cacheKey);
    if (needsTransform)
    {
       if (cachedFrame != s_cachedFrames.end())


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9364.

Also adds in a simple `sprintf()` implementation, for cases where `boost::format` is too heavy-weight and we just want a quick format-to-string implementation.

### Approach

Explicitly check the number of rows against the length of the vector being formatted; if the number of rows is less than the vector length, then format with `NA`.

### Automated Tests

TBA

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9364.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
