### PR TITLE
avoid showing tooltips in strings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Fixed issue where .md, .py, .sql, and .stan files had duplicate event handlers (#9106)
 * Fixed issue where output when running tests could be emitted in wrong order in Build pane (#5126)
 * Fixed issue where RStudio could crash when viewing a malformed data.frame (#9364)
+* Fixed issue where completion tooltip was erroneously shown in multi-line strings in some cases (#8677)
 
 ### Misc
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -787,29 +787,28 @@ public class RCompletionManager implements CompletionManager
          boolean canAutoPopup = checkCanAutoPopup(c, userPrefs_.codeCompletionCharacters().getValue() - 1);
          
          // Attempt to pop up completions immediately after a function call.
-         Token currentToken = docDisplay_.getTokenAt(docDisplay_.getCursorPosition());
-         boolean isFormingFunctionCall =
-               c == '(' &&
-               !isLineInComment(docDisplay_.getCurrentLine()) &&
-               currentToken != null &&
-               currentToken.hasType("identifier");
-         
-         if (isFormingFunctionCall)
+         if (c == '(' && !isLineInComment(docDisplay_.getCurrentLine()))
          {
-            String token = StringUtil.getToken(
-                  docDisplay_.getCurrentLine(),
-                  input_.getCursorPosition().getColumn(),
-                  "[" + RegexUtil.wordCharacter() + "._]",
-                  false,
-                  true);
-            
-            if (token.matches("^(library|require|requireNamespace|data)\\s*$"))
-               canAutoPopup = true;
-            
-            Scheduler.get().scheduleDeferred(() ->
+            // further validate that we're not working within a string
+            // https://github.com/rstudio/rstudio/issues/8677
+            Token currentToken = docDisplay_.getTokenAt(docDisplay_.getCursorPosition());
+            if (currentToken != null && currentToken.hasType("identifier"))
             {
-               sigTipManager_.resolveActiveFunctionAndDisplayToolTip();
-            });
+               String token = StringUtil.getToken(
+                     docDisplay_.getCurrentLine(),
+                     input_.getCursorPosition().getColumn(),
+                     "[" + RegexUtil.wordCharacter() + "._]",
+                     false,
+                     true);
+               
+               if (token.matches("^(library|require|requireNamespace|data)\\s*$"))
+                  canAutoPopup = true;
+               
+               Scheduler.get().scheduleDeferred(() -> 
+               {
+                  sigTipManager_.resolveActiveFunctionAndDisplayToolTip();
+               });
+            }
          }
          
          if (

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -787,7 +787,14 @@ public class RCompletionManager implements CompletionManager
          boolean canAutoPopup = checkCanAutoPopup(c, userPrefs_.codeCompletionCharacters().getValue() - 1);
          
          // Attempt to pop up completions immediately after a function call.
-         if (c == '(' && !isLineInComment(docDisplay_.getCurrentLine()))
+         Token currentToken = docDisplay_.getTokenAt(docDisplay_.getCursorPosition());
+         boolean isFormingFunctionCall =
+               c == '(' &&
+               !isLineInComment(docDisplay_.getCurrentLine()) &&
+               currentToken != null &&
+               currentToken.hasType("identifier");
+         
+         if (isFormingFunctionCall)
          {
             String token = StringUtil.getToken(
                   docDisplay_.getCurrentLine(),
@@ -799,7 +806,10 @@ public class RCompletionManager implements CompletionManager
             if (token.matches("^(library|require|requireNamespace|data)\\s*$"))
                canAutoPopup = true;
             
-            Scheduler.get().scheduleDeferred(() -> sigTipManager_.resolveActiveFunctionAndDisplayToolTip());
+            Scheduler.get().scheduleDeferred(() ->
+            {
+               sigTipManager_.resolveActiveFunctionAndDisplayToolTip();
+            });
          }
          
          if (


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8677.

### Approach

Validate that the token preceding the newly-inserted `(` character is an identifier, not a string.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8677. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
