### PR TITLE
don't auto-detect indentation by default

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,5 +12,6 @@
 * Add option to synchronize the Files pane with the current working directory in R (#4615)
 * Add new *Set Working Directory* command to context menu for source files (#6781)
 * Improved display of R stack traces in R functions invoked internally by RStudio (#9307)
+* The "auto-detect indentation" preference is now off by default. (#9211) 
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -230,8 +230,8 @@
         },
         "auto_detect_indentation": {
             "type": "boolean",
-            "default": true,
-            "title": "Autodetect indentation in files",
+            "default": false,
+            "title": "Auto-detect indentation in files",
             "description": "Whether to automatically detect indentation settings from file contents."
         },
         "show_margin": {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -449,9 +449,9 @@ public class UserPrefsAccessor extends Prefs
    {
       return bool(
          "auto_detect_indentation",
-         "Autodetect indentation in files", 
+         "Auto-detect indentation in files", 
          "Whether to automatically detect indentation settings from file contents.", 
-         true);
+         false);
    }
 
    /**


### PR DESCRIPTION
### Intent

The auto-detect indentation feature has caused a fair amount of confusion, as it causes pre-existing documents to potentially be indented in a way different from the global / project settings. It would be better for us to have users opt-in to this behavior, since having them opt-in forces them to be cognizant of the consequences.

Addresses https://github.com/rstudio/rstudio/issues/9211.

### Approach

Flipped the switch.

### Automated Tests

Not necessary for this PR.

### QA Notes

Check via notes in https://github.com/rstudio/rstudio/issues/9211.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
