### PR TITLE
scope Sys.setlocale() workaround to R < 3.5.2

### DIFF
--- a/NEWS-v1.4-juliet-rose.md
+++ b/NEWS-v1.4-juliet-rose.md
@@ -154,6 +154,7 @@
 * Fixed issue where Open File dialog would fail to open files whose names were explicitly typed (#4059)
 * Fixed issue causing Project Sharing to fail to set Access Control Lists when using NFS v4 and `username@domain` security principals (Pro #2415)
 * Fixed issue where dialog boxes [e.g. Git commit, Installing Pro Database drivers] could fail to show output with Limit Console Output turned on (Pro #2284)
-* Fixed issue where uploading a .zip archive when unzip was not on PATH would cause a cryptic error. (#9151)
+* Fixed issue where uploading a .zip archive when unzip was not on PATH would cause a cryptic error (#9151)
+* Fixed issue where RStudio occasionally reset the locale to the "default" locale on Windows (#9350)
 * Errors that occur when R packages update the Connections pane are now better handled and reported (#9219)
 * Fixed an issue where login page could fail intermittently with slow network connections (Pro #2551)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2214,7 +2214,9 @@
       # https://bugs.r-project.org/bugzilla3/show_bug.cgi?id=17484
       # https://github.com/rstudio/rstudio/issues/3658
       #
-      Sys.setlocale()
+      if (getRversion() < "3.5.2")
+         Sys.setlocale()
+      
       return(character())
 
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9350.

### Approach

Scope our fix to the versions of R affected by the associated bug.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9350.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
