### PR TITLE
find system Python installations on Windows

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -281,7 +281,10 @@
    roots <- c(roots, getOption("rstudio.python.installationPath"))
       
    # check and see if any of these roots point directly
-   # to a particular version of Python. note that on Windows,
+   # to a particular version of Python.
+   #
+   # on Windows, Python is typically installed in 'Scripts/python.exe'
+   # for regular installations, and 'python.exe' for Anaconda installations
    suffixes <- if (.rs.platform.isWindows) {
       c("Scripts/python.exe", "python.exe")
    } else {

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -247,9 +247,24 @@
    # Python root paths we'll search in
    roots <- if (.rs.platform.isWindows) {
       
+      # find path to Windows local app data folder
+      localAppData <- local({
+         
+         path <- Sys.getenv("LOCALAPPDATA", unset = NA)
+         if (!is.na(path))
+            return(path)
+         
+         profile <- Sys.getenv("USERPROFILE", unset = NA)
+         if (!is.na(profile))
+            return(file.path(profile, "AppData\\Local"))
+         
+         ""
+         
+      })
+      
       c(
-         paste0(Sys.getenv("SYSTEMDRIVE"), "/"),
-         file.path(Sys.getenv("LOCALAPPDATA"), "Programs/Python")
+         paste0(Sys.getenv("SYSTEMDRIVE", unset = "C:"), "/"),
+         file.path(localAppData, "Programs/Python")
       )
       
    } else {

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -284,7 +284,7 @@
    # to a particular version of Python.
    #
    # on Windows, Python is typically installed in 'Scripts/python.exe'
-   # for regular installations, and 'python.exe' for Anaconda installations
+   # for virtual environments, and 'python.exe' for Anaconda + standalone
    suffixes <- if (.rs.platform.isWindows) {
       c("Scripts/python.exe", "python.exe")
    } else {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9379.

### Approach

We had a routine intended to find "system" installations of Python, which lacked the Windows-specific pieces necessary. This PR adds those bits.

### Automated Tests

None included (no infrastructure for Windows tests yet).

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9379.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
