### PR TITLE
Disable console virtualization by default

### DIFF
--- a/NEWS-v1.4-juliet-rose.md
+++ b/NEWS-v1.4-juliet-rose.md
@@ -134,7 +134,7 @@
 * Fixed issue where Stan completion handlers were duplicated on save (#9106)
 * Improved checks for non-writable R library paths on startup (Pro #2184)
 * Fixed issue preventing R Notebook chunks from being queued for execution if they had never been previously run (#4238)
-* Fix various issues when the "Limit Console Output" performance setting was enabled, and enable it by default (#8544, #8504, #8529, #8552)
+* Fix various issues when the "Limit Console Output" performance setting was enabled (#8544, #8504, #8529, #8552)
 * Fix display of condition messages (errors and warnings) in some character encodings (#8546)
 * Fix out-of-date tooltip when renaming files (#8490, #8491)
 * Fix incorrect keyboard shortcuts shown in some places in the Command Palette (#8735)

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -559,7 +559,7 @@
         },
         "limit_visible_console": {
             "type": "boolean",
-            "default": true,
+            "default": false,
             "title": "Limit visible console output",
             "description": "Whether to only show a limited window of the total console output"
         },

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1155,7 +1155,7 @@ public class UserPrefsAccessor extends Prefs
          "limit_visible_console",
          "Limit visible console output", 
          "Whether to only show a limited window of the total console output", 
-         true);
+         false);
    }
 
    /**


### PR DESCRIPTION
### Intent

Disables the "Limit visible console output" setting by default. 

Addresses https://github.com/rstudio/rstudio/issues/9376. 

This setting is intended to improve performance of the console when it contains a lot of output, but empirically it has the exact opposite effect in some situations. Were we not literally days away from releasing, it would be worth trying to figure out whether this is something we could make a targeted fix for, but this code is very sensitive (see e.g., https://github.com/rstudio/rstudio/pull/8623), so it's safer to just make it opt-in, as it was in all previous releases. 

### Approach

Set the default to false in the preference schema. 

### Automated Tests

None, schema default change only.

### QA Notes

Ensure that:

1. The preference is now off by default in a fresh install, and
2. in a fresh install, issue https://github.com/rstudio/rstudio/issues/9376 does not reproduce.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


