### PR TITLE
support autocompletion for native pipe

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2058,7 +2058,7 @@ assign(x = ".rs.acCompletionTypes",
    dropFirstArgument <- FALSE
    if (length(string))
    {
-      pipes <- c("%>%", "%<>%", "%T>%", "%>>%", "|>")
+      pipes <- c("%>%", "%<>%", "%T>%", "%>>%", "\\|>")
       pattern <- paste(pipes, collapse = "|")
       
       stringPipeMatches <- gregexpr(

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2058,7 +2058,7 @@ assign(x = ".rs.acCompletionTypes",
    dropFirstArgument <- FALSE
    if (length(string))
    {
-      pipes <- c("%>%", "%<>%", "%T>%", "%>>%")
+      pipes <- c("%>%", "%<>%", "%T>%", "%>>%", "|>")
       pattern <- paste(pipes, collapse = "|")
       
       stringPipeMatches <- gregexpr(

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -216,7 +216,7 @@ var RCodeModel = function(session, tokenizer,
 
    function pInfix(token)
    {
-      return /\binfix\b/.test(token.type);
+      return /\binfix\b/.test(token.type) || token.value === "|>";
    }
 
    this.getDplyrJoinContextFromInfixChain = function(cursor)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9385.

<img width="258" alt="Screen Shot 2021-05-20 at 7 55 00 PM" src="https://user-images.githubusercontent.com/1976582/119075240-51ea8b00-b9a5-11eb-9291-2b53bae4c963.png">

### Approach

Add support for the `|>` native pipe in places relevant to our autocompletion code.

### Automated Tests

None included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9385.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
