### PR TITLE
ensure Python installations can be discovered when no Python on PATH

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -262,8 +262,12 @@
          
       })
       
+      # system-installs of Python might be in one of these folders
+      drive <- Sys.getenv("SYSTEMDRIVE", unset = "C:")
+      suffixes <- c("/", "/Program Files", "/Program Files (x86)")
+
       c(
-         paste0(Sys.getenv("SYSTEMDRIVE", unset = "C:"), "/"),
+         paste0(drive, suffixes),
          file.path(localAppData, "Programs/Python")
       )
       

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -180,13 +180,13 @@
 
 .rs.addFunction("python.findPythonInterpreters", function()
 {
-   interpreters <- c(
+   interpreters <- unname(c(
       .rs.python.findPythonSystemInterpreters(),
       .rs.python.findPythonInterpretersInKnownLocations(),
       .rs.python.findPythonPyenvInterpreters(),
       .rs.python.findPythonVirtualEnvironments(),
       .rs.python.findPythonCondaEnvironments()
-   )
+   ))
    
    default <- Sys.getenv("RETICULATE_PYTHON", unset = "")
    


### PR DESCRIPTION
### Intent

Resolves https://github.com/rstudio/rstudio/issues/9379#issuecomment-847345034.

### Approach

Ensure the list of Python interpreters returned is un-named, so that it's serialized as a Javascript array.

### Automated Tests

N/A (cannot yet test on Windows)

### QA Notes

See https://github.com/rstudio/rstudio/issues/9379#issuecomment-847345034.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
