### PR TITLE
Ignore user CRAN preference when allow-cran-repos-edit=0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,5 +15,6 @@
 * Add new *Set Working Directory* command to context menu for source files (#6781)
 * Improved display of R stack traces in R functions invoked internally by RStudio (#9307)
 * The "auto-detect indentation" preference is now off by default. (#9211) 
+* Prevent user preferences from setting CRAN repos when `allow-cran-repos-edit=0` (Pro #1301)
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2120,11 +2120,11 @@ int main (int argc, char * const argv[])
       // 1. The user's personal preferences file (rstudio-prefs.json), if CRAN repo editing is
       //    permitted by policy
       // 2. The system-wide preferences file (rstudio-prefs.json)
-      // 2. The repo settings specified in the loaded version of R
-      // 3. The session's repo settings (in rsession.conf/repos.conf)
-      // 4. The server's repo settings
-      // 5. The default repo settings from the preferences schema (user-prefs-schema.json)
-      // 6. If all else fails, cran.rstudio.com
+      // 3. The repo settings specified in the loaded version of R
+      // 4. The session's repo settings (in rsession.conf/repos.conf)
+      // 5. The server's repo settings
+      // 6. The default repo settings from the preferences schema (user-prefs-schema.json)
+      // 7. If all else fails, cran.rstudio.com
       std::string layerName;
       auto val = prefs::userPrefs().readValue(kCranMirror, &layerName);
       if (val && ((options.allowCRANReposEdit() && layerName == kUserPrefsUserLayer) ||

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2112,10 +2112,14 @@ int main (int argc, char * const argv[])
       if (!desktopMode) // ignore r-libs-user in desktop mode
          rOptions.rLibsUser = options.rLibsUser();
 
+      // name of the source of the CRAN repo value (for logging)
+      std::string source;
+
       // CRAN repos configuration follows; order of precedence is:
       //
-      // 1. The user's personal preferences file (rstudio-prefs.json) or system-level version of
-      //    same
+      // 1. The user's personal preferences file (rstudio-prefs.json), if CRAN repo editing is
+      //    permitted by policy
+      // 2. The system-wide preferences file (rstudio-prefs.json)
       // 2. The repo settings specified in the loaded version of R
       // 3. The session's repo settings (in rsession.conf/repos.conf)
       // 4. The server's repo settings
@@ -2123,12 +2127,14 @@ int main (int argc, char * const argv[])
       // 6. If all else fails, cran.rstudio.com
       std::string layerName;
       auto val = prefs::userPrefs().readValue(kCranMirror, &layerName);
-      if (val && (layerName == kUserPrefsUserLayer ||
+      if (val && ((options.allowCRANReposEdit() && layerName == kUserPrefsUserLayer) ||
                   layerName == kUserPrefsSystemLayer))
       {
-         // There is a user-scoped value, so use it
+         // If we got here, either (a) there is a user value and the user is allowed to set their
+         // own CRAN repos, or (b) there's a system value, which we always respect
          rOptions.rCRANUrl = prefs::userPrefs().getCRANMirror().url;
          rOptions.rCRANSecondary = prefs::userPrefs().getCRANMirror().secondary;
+         source = layerName + "-level preference file";
       }
       else if (!core::system::getenv("RSTUDIO_R_REPO").empty())
       {
@@ -2141,34 +2147,43 @@ int main (int argc, char * const argv[])
          {
             std::string reposConfig = Options::parseReposConfig(reposFile);
             loadCranRepos(reposConfig, &rOptions);
+            source = reposFile.getAbsolutePath() + " via RSTUDIO_R_REPO environment variable";
          }
          else
          {
             rOptions.rCRANUrl = repo;
+            source = "RSTUDIO_R_REPO environment variable";
          }
       }
       else if (!options.rCRANMultipleRepos().empty())
       {
          // repo was specified in a repos file
          loadCranRepos(options.rCRANMultipleRepos(), &rOptions);
+         source = "repos file";
       }
       else if (!options.rCRANUrl().empty())
       {
          // Global server option
          rOptions.rCRANUrl = options.rCRANUrl();
+         source = "global session option";
       }
       else if (val && layerName == kUserPrefsDefaultLayer)
       {
          // If we found defaults in the prefs schema, use them.
          rOptions.rCRANUrl = prefs::userPrefs().getCRANMirror().url;
          rOptions.rCRANSecondary = prefs::userPrefs().getCRANMirror().secondary;
+         source = "preference defaults";
       }
       else
       {
          // Hard-coded repo of last resort so we don't wind up without a repo setting (users will
          // not be able to install packages without one)
          rOptions.rCRANUrl = "https://cran.rstudio.com/";
+         source = "hard-coded default";
       }
+
+      LOG_INFO_MESSAGE("Set CRAN URL for session to '" + rOptions.rCRANUrl + "' (source: " +
+            source + ")");
 
       rOptions.useInternet2 = prefs::userPrefs().useInternet2();
       rOptions.rCompatibleGraphicsEngineVersion =

--- a/src/cpp/session/modules/SessionCRANMirrors.cpp
+++ b/src/cpp/session/modules/SessionCRANMirrors.cpp
@@ -26,6 +26,7 @@
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionAsyncRProcess.hpp>
+#include <session/SessionOptions.hpp>
 #include <session/prefs/UserPrefs.hpp>
 
 using namespace rstudio::core;
@@ -252,6 +253,12 @@ void onUserSettingsChanged(const std::string& layer, const std::string& pref)
 {
    if (pref != kCranMirror)
       return;
+
+   if (!options().allowCRANReposEdit() && layer == kUserPrefsUserLayer)
+   {
+      // if admin has disallowed CRAN mirror editing, ignore this change
+      return;
+   }
 
    // extract the CRAN mirror option
    auto mirror = prefs::userPrefs().getCRANMirror();


### PR DESCRIPTION
### Intent

The Pro option `allow-cran-repos-edit` is intended to prevent users from changing the CRAN repo option away from one the admin has supplied through some other mechanism. It *does* make the UI non-editable, but doesn't actually prevent user preferences from taking precedence. This is a problem when e.g., many users have *already* changed their repo, after which admins setting `allow-cran-repos-edit=0` doesn't do much because it doesn't remove user settings. 

Addresses (part of) https://github.com/rstudio/rstudio-pro/issues/1301.

### Approach

Ignore user preferences for CRAN settings when `allow-cran-repos-edit=0`. Also, add a new `INFO` level log statement explaining where the CRAN repo option is being set from.

### Automated Tests

None included.

### QA Notes

Turning off CRAN repo editing will disable the UI, but you can still set the preference through the API or by hand-editing `rstudio-prefs.json`. It is not an error to set the CRAN repo this way, but it should be ignored if `allow-cran-repos-edit=0`. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


