### PR TITLE
avoid using py_run_string(..., local = TRUE)

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1268,30 +1268,44 @@
    #
    # TODO: this might fit more naturally as a helper class
    # in the reticulate package
-   pydoc <- reticulate::import("pydoc", convert = TRUE)
-   objects <- reticulate::py_run_string("
+   #
+   # NOTE: we explicitly use `py_run_string(..., local = FALSE)` to avoid
+   # issues with reticulate 1.20 -- normally we'd just update the version
+   # of reticulate on CRAN, but because R 4.1.0 was just published a number
+   # of people will only be able to install the reticulate 1.20 binary and
+   # so it behooves us to support that version for now
+   reticulate::py_run_string("
 
 # Create HTML documentation object
-import pydoc
-html = pydoc.HTMLDoc()
+def _rstudio_html_generator_():
+   import pydoc
+   html = pydoc.HTMLDoc()
 
-# Override the heading function
-def _heading(title, fgcol, bgcol, extra = ''):
-   return '''
-<table width=\"100%%\" cellspacing=0 cellpadding=2 border=0 summary=\"heading\">
-<tr><td><h2>%s</h2></td></tr>
-</table>
-   ''' % (title)
-
-html.heading = _heading
-", local = TRUE)
+   # Override the heading function
+   def _heading(title, fgcol, bgcol, extra = ''):
+      return '''
+   <table width=\"100%%\" cellspacing=0 cellpadding=2 border=0 summary=\"heading\">
+   <tr><td><h2>%s</h2></td></tr>
+   </table>
+      ''' % (title)
    
-   html <- objects$html
+   html.heading = _heading
+   return html
+", local = FALSE)
    
-   if (inherits(resolved, "numpy.ufunc"))
-      page <- html$page(paste("numpy function", name), html$docroutine(resolved, name))
-   else
-      page <- html$page(pydoc$describe(resolved), html$document(resolved, name))
+   # create html object, then remove generator function
+   main <- reticulate::import_main(convert = TRUE)
+   generator <- reticulate::py_to_r(reticulate::py_get_attr(main, "_rstudio_html_generator_"))
+   html <- generator()
+   reticulate::py_del_attr(main, "_rstudio_html_generator_")
+   
+   # generate page (handle numpy specially)
+   page <- if (inherits(resolved, "numpy.ufunc")) {
+      html$page(paste("numpy function", name), html$docroutine(resolved, name))
+   } else {
+      pydoc <- reticulate::import("pydoc", convert = TRUE)
+      html$page(pydoc$describe(resolved), html$document(resolved, name))
+   }
    
    # remove hard-coded background colors for rows
    page <- gsub("\\s?bgcolor=\"#[0-9a-fA-F]{6}\"", "", page, perl = TRUE)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9311.

### Approach

Avoid using `reticulate::py_run_string(..., local = TRUE)`; instead, use the global version and then pick up after ourselves later.

### Automated Tests

None included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9311. Note that testing needs to be done with the current CRAN release of reticulate, 1.20.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
