### PR TITLE
avoid deparsing excessively large calls

### DIFF
--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -154,5 +154,8 @@ options(profvis.keep_output = TRUE)
 # indicate that we're not in a notebook by default
 options(rstudio.notebook.executing = FALSE)
 
+# avoid exceedingly-large deparsed line output
+.rs.setOptionDefault("deparse.max.lines", 20L)
+
 # provide a custom HTTP user agent
 .rs.initHttpUserAgent()

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2068,9 +2068,24 @@
  
 })
 
-.rs.addFunction("deparse", function(object)
+# like deparse(), but always deparsed to a length-one character vector
+.rs.addFunction("deparse", function(object,
+                                    width.cutoff = 500L,
+                                    nlines       = -1L,
+                                    collapse     = " ")
 {
-   paste(deparse(object, width.cutoff = 500L), collapse = " ")
+   # deparse the call
+   deparsed <- deparse(
+      expr         = object,
+      width.cutoff = width.cutoff,
+      nlines       = nlines
+   )
+   
+   # un-escape our inline R objects
+   deparsed <- gsub("`<(.*?)>`", "<\\1>", deparsed, perl = TRUE)
+   
+   # paste to return as length-one character vector
+   paste(deparsed, collapse = collapse)
 })
 
 .rs.addFunction("ensureScalarCharacter", function(object)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -656,17 +656,14 @@
       #
       # https://github.com/rstudio/rstudio/issues/5158
       sanitized <- .rs.sanitizeCall(obj)
-      val1 <- deparse(sanitized, nlines = 1L)
-      val2 <- deparse(sanitized, nlines = 2L)
+      val1 <- .rs.deparse(sanitized, nlines = 1L)
+      val2 <- .rs.deparse(sanitized, nlines = 2L)
       
       # indicate if there is more output
       val <- if (!identical(val1, val2))
          paste(val1, "<...>")
       else
          val1
-      
-      # remove backticks on our embedded summaries
-      val <- gsub("`<(.*?)>`", "<\\1>", val, perl = TRUE)
 
    }
    else if (!hasNullPtr)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -649,8 +649,11 @@
    {
       # defend against very large calls; e.g. those with R objects inlined
       # as part of the call (can happen in do.call contexts)
-      # note that we only show the first line of the call in the Environment
-      # pane anyhow
+      #
+      # this is primarily used for the Environment pane, where we try to display
+      # a single-line summary of an R object -- so we can enforce that when
+      # deparsing calls here as well
+      #
       # https://github.com/rstudio/rstudio/issues/5158
       sanitized <- .rs.sanitizeCall(obj)
       val1 <- deparse(sanitized, nlines = 1L)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -230,7 +230,8 @@
       return(.rs.valueDescription(expr))
    
    # we have a call; try to deparse it
-   .rs.deparse(call)
+   sanitized <- .rs.sanitizeCall(call)
+   .rs.deparse(sanitized)
 })
 
 # used to create descriptions for language objects and symbols
@@ -308,7 +309,7 @@
      # the below number of lines, but in practice such a large highlight
      # would be unlikely to be useful
      # https://github.com/rstudio/rstudio/issues/5158
-     calltext <- deparse(call, nlines = 200L)
+     calltext <- .rs.deparse(call, nlines = 200L)
   }
   else
   {
@@ -404,7 +405,7 @@
    .rs.deparse(call[[1L]])
 })
 
-.rs.addFunction("sanitizeCallSummary", function(object)
+.rs.addFunction("sanitizeCall", function(object)
 {
    if (missing(object))
    {
@@ -427,7 +428,7 @@
       {
          # assigning NULL to object will remove that entry
          # https://github.com/rstudio/rstudio/issues/9299
-         sanitized <- .rs.sanitizeCallSummary(object[[i]])
+         sanitized <- .rs.sanitizeCall(object[[i]])
          if (!missing(sanitized) && !is.null(sanitized))
             object[[i]] <- sanitized
       }
@@ -480,9 +481,11 @@
    # where 'object' is something very large when deparsed. we avoid
    # issues by replacing such objects with a short identifier of their
    # type / class
-   call <- .rs.sanitizeCallSummary(call)
+   call <- .rs.sanitizeCall(call)
    
+   # deparse call
    .rs.deparse(call)
+   
 })
 
 .rs.addFunction("valueDescription", function(obj)
@@ -649,7 +652,7 @@
       # note that we only show the first line of the call in the Environment
       # pane anyhow
       # https://github.com/rstudio/rstudio/issues/5158
-      sanitized <- .rs.sanitizeCallSummary(obj)
+      sanitized <- .rs.sanitizeCall(obj)
       val1 <- deparse(sanitized, nlines = 1L)
       val2 <- deparse(sanitized, nlines = 2L)
       

--- a/src/cpp/tests/testthat/test-debugger.R
+++ b/src/cpp/tests/testthat/test-debugger.R
@@ -19,16 +19,24 @@ context("debugger")
 
 test_that("deparsing large calls is not overly expensive", {
    
+   # call including large data.frame
    big <- data.frame(x = as.numeric(1:1E5))
    cl <- call("dummy", big)
    summary <- .rs.callSummary(cl)
    expect_true(nchar(summary) < 1000)
    
+   # call including large vector
    data <- as.list(0:200)
    data[[1L]] <- as.name("c")
    cl <- as.call(data)
    summary <- .rs.callSummary(cl)
    expect_equal(summary, "c(...)")
+   
+   # call including large data.frame should be described quickly
+   big <- mtcars[rep.int(1, 1E5)]
+   bigcall <- call("dummy", x = big)
+   time <- system.time(.rs.describeObject(environment(), "bigcall"))
+   expect_true(time[1] < 1)
    
 })
 
@@ -48,7 +56,7 @@ test_that("we successfully parse the function name from different calls", {
 test_that("function calls are not mangled into something un-printable", {
    
    cl <- call("function", pairlist(a = 1, b = 2, c = 3), quote({}))
-   sanitized <- .rs.sanitizeCallSummary(cl)
+   sanitized <- .rs.sanitizeCall(cl)
    expect_equal(cl, sanitized)
    
 })


### PR DESCRIPTION
### Intent

Currently, RStudio can hang when large call objects are defined in the global environment. This is caused by us attempting to deparse the call object, which can be excessively slow when that call contained large inlined R objects.

Addresses https://github.com/rstudio/rstudio/issues/5158.

### Approach

This PR seeks to avoid IDE slowness when attempting to deparse excessively large calls -- especially, those with large inlined R objects.

### Automated Tests

Unit tests are included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5158.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

