### PR TITLE
Add command for editing code snippets

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/Workbench.java
@@ -74,6 +74,7 @@ import org.rstudio.studio.client.workbench.events.*;
 import org.rstudio.studio.client.workbench.events.ShowMainMenuEvent.Menu;
 import org.rstudio.studio.client.workbench.model.*;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.snippets.ui.EditSnippetsDialog;
 import org.rstudio.studio.client.workbench.views.choosefile.ChooseFile;
 import org.rstudio.studio.client.workbench.views.files.events.DirectoryNavigateEvent;
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
@@ -468,6 +469,12 @@ public class Workbench implements BusyEvent.Handler,
    public void onModifyKeyboardShortcuts()
    {
       new ModifyKeyboardShortcutsWidget().showModal();
+   }
+
+   @Handler
+   public void onEditCodeSnippets()
+   {
+      new EditSnippetsDialog().showModal();
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -515,6 +515,7 @@ well as menu structures (for main menu and popup menus).
          <separator/>
          <cmd refid="helpKeyboardShortcuts"/>
          <cmd refid="modifyKeyboardShortcuts"/>
+         <cmd refid="editCodeSnippets"/>
          <cmd refid="showCommandPalette"/>
          <separator/>
          <cmd refid="projectOptions"/>
@@ -3074,6 +3075,11 @@ well as menu structures (for main menu and popup menus).
    <cmd id="modifyKeyboardShortcuts"
         menuLabel="_Modify Keyboard Shortcuts..."
         desc="Modify keyboard shortcuts"
+        windowMode="main"/>
+
+   <cmd id="editCodeSnippets"
+        menuLabel="_Edit Code Snippets..."
+        desc="Edit code snippets"
         windowMode="main"/>
 
    <cmd id="checkForUpdates"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -443,6 +443,7 @@ public abstract class
    public abstract AppCommand showPublishingOptions();
    public abstract AppCommand showPythonOptions();
    public abstract AppCommand modifyKeyboardShortcuts();
+   public abstract AppCommand editCodeSnippets();
    public abstract AppCommand showCommandPalette();
    public abstract AppCommand clearCommandPaletteMru();
 


### PR DESCRIPTION
### Intent

Small, non-NEWS worthy change that makes it possible to edit code snippets (a very nifty feature) using the Command Palette or the menus, without having to dig through the Preferences dialog and figure out where the entry point is. 

### Approach

Create a new command, and put it in a menu slot next to Modify Keyboard Shortcuts. 

### Automated Tests

None, this only adds an entry point. Maybe helpful for automated tests of this dialog! 

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


