### PR TITLE
show component info when IDE launched with --version switch

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -26,7 +26,7 @@
     "watch": "tsc -w",
     "lint": "eslint -c .eslintrc --ext .ts ./src",
     "start": "yarn run build && electron ./dist/main/main.js",
-    "show-version": "yarn run build && electron ./dist/main/main.js --version",
+    "show-version": "yarn run build && electron ./dist/main/main.js --version-json",
     "test": "nyc ./node_modules/.bin/mocha --require ts-node/register ./test/**/*.spec.ts"
   }
 }

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -55,7 +55,7 @@ export default class Main {
 
     // look for a version check request; if we have one, just do that and exit
     if (app.commandLine.hasSwitch('version')) {
-      console.log(getRStudioVersion());
+      console.log(Main.getVersion());
       app.exit(0);
       return;
     }
@@ -1058,5 +1058,11 @@ export default class Main {
     //   return desktop::optionsPro().getSessionUrl();
     // #else // OPEN_SOURCE
     return '';
+  }
+
+  static getVersion(): string {
+    let componentVers: any = process.versions;
+    componentVers["rstudio"] = getRStudioVersion();
+    return componentVers;
   }
 }

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -55,10 +55,18 @@ export default class Main {
 
     // look for a version check request; if we have one, just do that and exit
     if (app.commandLine.hasSwitch('version')) {
-      console.log(Main.getVersion());
+      console.log(getRStudioVersion());
       app.exit(0);
       return;
     }
+
+    // report extended version info and exit
+    if (app.commandLine.hasSwitch('version-json')) {
+      console.log(Main.getComponentVersions());
+      app.exit(0);
+      return;
+    }
+
 
     desktop.initializeLang();
     Main.initializeRenderingEngine();
@@ -1060,7 +1068,7 @@ export default class Main {
     return '';
   }
 
-  static getVersion(): string {
+  static getComponentVersions(): string {
     let componentVers: any = process.versions;
     componentVers["rstudio"] = getRStudioVersion();
     return componentVers;

--- a/src/node/desktop/tsconfig.json
+++ b/src/node/desktop/tsconfig.json
@@ -3,20 +3,17 @@
     "incremental": true,
     "target": "es2020",
     "module": "commonjs",
-    "sourceMap": true,                              /* Generates corresponding '.map' file. */
-    "outDir": "dist",                               /* Redirect output structure to the directory. */
-    "removeComments": true,                      /* Do not emit comments to output. */
-
-    "strict": true,                                 /* Enable all strict type-checking options. */
-
-    "baseUrl": ".",                                 /* Base directory to resolve non-absolute module names. */
-    "paths": {                                      /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    "sourceMap": true,
+    "outDir": "dist",
+    "removeComments": true,
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {
       "*": ["node_modules/*"]
     },
-    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-
-    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
-    "forceConsistentCasingInFileNames": true        /* Disallow inconsistently-cased references to the same file. */
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
### Intent

The desktop IDE has always had a command-line argument (`--version`) to show the RStudio version. Extending that in Electron to include a new switch `--version-json` that shows versions of major components (electron, node, chrome, etc), returning results as JSON.

Also some unrelated no-op cleanup of tsconfig.json (removing comments and extra blank lines).

### Approach
Use node's `process.version` to get json blob of version info and add rstudio version to it. Can use `yarn show-version` in a dev environment to run it.

```
$ yarn show-version
{
  node: '14.16.0',
  v8: '9.1.269.28-electron.0',
  uv: '1.40.0',
  zlib: '1.2.11',
  brotli: '1.0.9',
  ares: '1.16.1',
  modules: '89',
  nghttp2: '1.41.0',
  napi: '7',
  llhttp: '2.1.3',
  openssl: '1.1.1',
  icu: '68.1',
  unicode: '13.0',
  electron: '13.0.1',
  chrome: '91.0.4472.69',
  rstudio: '1.5.0'
}
✨  Done in 1.95s.
```

### Automated Tests

None at the moment, still hammering out problems with unit testing Electron-aware code.

### QA Notes

Once there are builds run rstudio with `--version` command-line argument and confirm it just shows product version. Run again with `--version-json` and should see output as shown above.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


