### PR TITLE
Fix issue where unit tests running as sudo will not run correctly on CentOS 7 due to weird sudo and escaping issue

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -98,7 +98,7 @@ runWatchdogProcess() {
       PRELOAD="LD_PRELOAD=${RSESSION_DIAGNOSTICS_LIBSEGFAULT}"
    fi
 
-   FULL_COMMAND="env SEGFAULT_SIGNALS='abrt segv' ${PRELOAD} ${command} $*; exit"
+   FULL_COMMAND="env SEGFAULT_SIGNALS=\"abrt segv\" ${PRELOAD} ${command} $*; exit"
 
    # centos6 doesn't support the --foreground option for timeout
    if [ "${OPERATING_SYSTEM}" = "centos_6" ] || [ -z "${TIMEOUT_CMD}" ]; then


### PR DESCRIPTION


### Intent

Unit tests run with `sudo` on CentOS 7 don't actually run and instead immediately exit. See the running Launcher tests for pro builds as an example.

### Approach

Fix this. See https://github.com/rstudio/launcher/pull/100 for more details.

### Automated Tests

None necessary.

### QA Notes

Launcher tests should start running for CentOS 7. Already verified in new Launcher repo.



