### PR TITLE
Emit unit test failure details

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,13 +41,13 @@ def compile_package(os, type, flavor, variant) {
   }
 }
 
-def run_tests(type, flavor, variant) {
+def run_tests(os, type, flavor) {
   try {
     // attempt to run ant (gwt) unit tests
     sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/gwt && ./gwt-unit-tests.sh"
   } catch(err) {
     // mark build as unstable if it fails unit tests
-    currentBuild.result = "UNSTABLE"
+    unstable("GWT unit tests failed (${flavor.capitalize()} ${type} on ${os})")
   }
 
 
@@ -55,7 +55,7 @@ def run_tests(type, flavor, variant) {
     // attempt to run cpp unit tests
     sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ./rstudio-tests"
   } catch(err) {
-    currentBuild.result = "UNSTABLE"
+    unstable("C++ unit tests failed (${flavor.capitalize()} ${type} on ${os})")
   }
 }
 
@@ -312,7 +312,7 @@ try {
                                 compile_package(current_container.package_os, get_type_from_os(current_container.os), current_container.flavor, current_container.variant)
                             }
                             stage('run tests') {
-                                run_tests(get_type_from_os(current_container.os), current_container.flavor, current_container.variant)
+                                run_tests(current_container.os, get_type_from_os(current_container.os), current_container.flavor)
                             }
                             stage('sentry upload') {
                                 sentry_upload(get_type_from_os(current_container.os), current_container.flavor)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2510.

### Approach

Instead of simply marking the build as unstable, emit information about which test failed on which platform. 

### Automated Tests

None, not product code.

### QA Notes

No QA necessary.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

