### PR TITLE
hookup eslint and fix all errors in Electron project sources

### DIFF
--- a/src/node/desktop/.eslintignore
+++ b/src/node/desktop/.eslintignore
@@ -1,0 +1,2 @@
+.eslintrc.js
+

--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -1,0 +1,36 @@
+module.exports = {
+  "env": {
+    "es2020": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 11,
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  }
+};

--- a/src/node/desktop/.npmrc
+++ b/src/node/desktop/.npmrc
@@ -1,0 +1,3 @@
+package-lock=false
+save=false
+

--- a/src/node/desktop/.prettierrc
+++ b/src/node/desktop/.prettierrc
@@ -1,7 +1,0 @@
-{
-  "tabWidth": 2,
-  "printWidth": 120,
-  "trailingComma": "all",
-  "singleQuote": true,
-  "semi": true
-}

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -17,16 +17,20 @@
     "electron": "^13.0.1",
     "electron-mocha": "^10.0.0",
     "eslint": "^7.27.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.3",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0",
     "ts-node": "^10.0.0",
-    "typescript": "^4.2.4"
+    "typescript": "^4.3.2"
   },
   "dependencies": {},
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint -c .eslintrc --ext .ts ./src",
+    "lint": "eslint ./src",
     "start": "yarn run build && electron ./dist/main/app.js",
     "show-version": "yarn run build && electron ./dist/main/app.js --version-json",
     "test": "MOCHA_COLORS=1 nyc electron-mocha"

--- a/src/node/desktop/src/core/environment.ts
+++ b/src/node/desktop/src/core/environment.ts
@@ -20,21 +20,21 @@ export type Environment = Record<string, string>;
 /**
  * Get value of process environment variable; returns empty string it not found.
  */
-export function getenv(name: string) {
+export function getenv(name: string): string {
   return process.env[name] ?? '';
 }
 
 /**
  * Add given name=value to process environment.
  */
-export function setenv(name: string, value: string) {
+export function setenv(name: string, value: string): void {
   process.env[name] = value;
 }
 
 /**
  * Unset given environment variable in process environment.
  */
-export function unsetenv(name: string) {
+export function unsetenv(name: string): void {
   delete process.env[name];
 }
 
@@ -42,15 +42,15 @@ export function unsetenv(name: string) {
  * Expand environment variables in a string; for example /$USER/foo to
  * /bob/foo when USER=bob
  */
-export function expandEnvVars(environment: Environment, str: string) {
+export function expandEnvVars(environment: Environment, str: string): string {
   let result = str;
-  for (let name in environment) {
+  for (const name in environment) {
     // replace bare forms (/home/$USER)
-    let reVar = new RegExp('\\$\\b' + name + '\\b', 'g');
+    const reVar = new RegExp('\\$\\b' + name + '\\b', 'g');
     result = result.replace(reVar, environment[name]);
 
     // replace curly brace forms (/home/${USER})
-    let reBraceVar = new RegExp('\\${' + name + '}', 'g');
+    const reBraceVar = new RegExp('\\${' + name + '}', 'g');
     result = result.replace(reBraceVar, environment[name]);
   }
   return result;

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -35,7 +35,7 @@ export class FilePath {
   static homePathAlias = '~/';
   static homePathLeafAlias = '~';
 
-  constructor(path: string = '') {
+  constructor(path = '') {
     this.path = FilePath.fromString(path);
   }
 
@@ -58,7 +58,7 @@ export class FilePath {
    * Creates a path in which the user home path will be replaced by the ~ alias.
    */
   static createAliasedPath(filePath: FilePath, userHomePath: FilePath): string {
-    throw Error("createAliasedPath is NYI");
+    throw Error('createAliasedPath is NYI');
   }
 
   /**
@@ -69,7 +69,7 @@ export class FilePath {
       return false;
     }
 
-    let p = FilePath.fromString(filePath);
+    const p = FilePath.fromString(filePath);
     try {
       return fs.existsSync(p);
     } catch (err) {
@@ -86,7 +86,7 @@ export class FilePath {
       return false;
     }
 
-    let p = FilePath.fromString(filePath);
+    const p = FilePath.fromString(filePath);
     try {
       await fsPromises.access(p);
       return true;
@@ -101,21 +101,21 @@ export class FilePath {
    * if their absolute paths are equal.
    */
   static isEqualCaseInsensitive(filePath1: FilePath, filePath2: FilePath): boolean {
-    throw Error("isEqualCaseInsensitive is NYI");
+    throw Error('isEqualCaseInsensitive is NYI');
   }
 
   /**
    * Checks whether the specified path is a root path or a relative path.
    */
   static isRootPath(filePath: string): boolean {
-    throw Error("isRootPath is NYI");
+    throw Error('isRootPath is NYI');
   }
 
   /**
    * Changes the current working directory to the specified path.
    */
   static makeCurrent(filePath: string): Err {
-    throw Error("makeCurrent (static) is NYI");
+    throw Error('makeCurrent (static) is NYI');
   }
 
   /**
@@ -156,7 +156,7 @@ export class FilePath {
       safePath = User.getUserHomePath();
     }
 
-    let error = safePath.makeCurrentPath();
+    const error = safePath.makeCurrentPath();
     if (error) {
       FilePath.logError(error);
     }
@@ -183,7 +183,7 @@ export class FilePath {
       safePath = User.getUserHomePath();
     }
 
-    let error = safePath.makeCurrentPath();
+    const error = safePath.makeCurrentPath();
     if (error) {
       FilePath.logError(error);
     }
@@ -195,25 +195,25 @@ export class FilePath {
    * Creates a randomly named file in the temp directory.
    */
   static tempFilePath(extension?: string): FilePathWithError {
-    throw Error("tempFilePath is NYI");
+    throw Error('tempFilePath is NYI');
   }
 
   /**
    * Creates a file with a random name in the specified directory.
    */
   static uniqueFilePath(basePath: string, extension?: string): FilePathWithError {
-    throw Error("uniqueFilePath is NYI");
+    throw Error('uniqueFilePath is NYI');
   }
 
   /**
    * Changes the file mode to the specified file mode (Posix-only). Pass in the posix file mode
    * string, e.g. rwxr-xr-x
    */
-  changeFileMode(fileModeStr: string, setStickyBit: boolean = false): Err {
+  changeFileMode(fileModeStr: string, setStickyBit = false): Err {
     if (process.platform === 'win32')
       return Success(); // no-op on Windows
 
-    throw Error("changeFileMode is NYI");
+    throw Error('changeFileMode is NYI');
   }
 
   /**
@@ -234,8 +234,8 @@ export class FilePath {
    * refers to a path strictly within this one (i.e. ".." isn't allowed).
    */
   completeChildPath(filePath: string): FilePath {
-    let result = this.completeChildPathWithErrorResult(filePath);
-    if (!!result.err) {
+    const result = this.completeChildPathWithErrorResult(filePath);
+    if (result.err) {
       FilePath.logError(result.err);
     }
     return result.path;
@@ -255,12 +255,12 @@ export class FilePath {
       }
 
       // confirm this is a relative path
-      let relativePath = FilePath.fromString(filePath);
+      const relativePath = FilePath.fromString(filePath);
       if (path.isAbsolute(relativePath)) {
         throw Error('absolute path not permitted');
       }
 
-      let childPath = this.completePath(filePath);
+      const childPath = this.completePath(filePath);
 
       if (!childPath.isWithin(this)) {
         return { err: new Error('child path must be inside parent path'), path: this };
@@ -288,20 +288,20 @@ export class FilePath {
    * Copies this file path to the specified location.
    */
   copy(targetPath: FilePath, overwrite = false): Err {
-    throw Error("copy is NYI");
+    throw Error('copy is NYI');
   }
 
   /**
    * Copies this directory recursively to the specified location.
    */
   copyDirectoryRecursive(targetPath: FilePath, overwrite = false): Err {
-    throw Error("copyDirectoryRecursive is NYI");
+    throw Error('copyDirectoryRecursive is NYI');
   }
 
   /**
    * Creates the specified directory, relative to this directory.
    */
-  createDirectorySync(filePath: string = ''): Err {
+  createDirectorySync(filePath = ''): Err {
     let targetDirectory: string;
     if (!filePath) {
       targetDirectory = this.path;
@@ -320,7 +320,7 @@ export class FilePath {
   /**
    * Creates the specified directory, relative to this directory.
    */
-  async createDirectory(filePath: string = ''): Promise<Err> {
+  async createDirectory(filePath = ''): Promise<Err> {
     let targetDirectory: string;
     if (!filePath) {
       targetDirectory = this.path;
@@ -404,7 +404,7 @@ export class FilePath {
    * Gets the full absolute representation of this file path in native format.
    */
   getAbsolutePathNative(): string {
-    throw Error("getAbsolutePathNative is NYI");
+    throw Error('getAbsolutePathNative is NYI');
   }
 
   /**
@@ -413,7 +413,7 @@ export class FilePath {
    */
   getCanonicalPathSync(): string {
     if (this.isEmpty()) {
-      return "";
+      return '';
     }
 
     try {
@@ -422,7 +422,7 @@ export class FilePath {
     catch (err) {
       FilePath.logErrorWithPath(this.path, err);
     }
-    return "";
+    return '';
   }
 
   /**
@@ -431,7 +431,7 @@ export class FilePath {
    */
   async getCanonicalPath(): Promise<string> {
     if (this.isEmpty()) {
-      return "";
+      return '';
     }
 
     try {
@@ -440,21 +440,21 @@ export class FilePath {
     catch (err) {
       FilePath.logErrorWithPath(this.path, err);
     }
-    return "";
+    return '';
   }
 
   /**
    * Gets the children of this directory. Sub-directories will not be traversed.
    */
   getChildren(filePaths: Array<FilePath>): Err {
-    throw Error("getChildren is NYI");
+    throw Error('getChildren is NYI');
   }
 
   /**
    * Gets the children of this directory recursively. Sub-directories will be traversed.
    */
   getChildrenRecursive(/*iterationFunction: RecursiveIterationFunction*/): Err {
-    throw Error("getChildrenRecursive is NYI");
+    throw Error('getChildrenRecursive is NYI');
   }
 
   /**
@@ -477,7 +477,7 @@ export class FilePath {
    * Gets the posix file mode of this file or directory (Posix-only)
    */
   getFileMode(/*fileMode: FileMode*/): Err {
-    throw Error("getFileMode is NYI");
+    throw Error('getFileMode is NYI');
   }
 
   /**
@@ -504,15 +504,15 @@ export class FilePath {
   /**
    * Gets the mime content type of this file.
    */
-  getMimeContentType(defaultType = "text/plain"): string {
-    throw Error("getMimeContentType is NYI");
+  getMimeContentType(defaultType = 'text/plain'): string {
+    throw Error('getMimeContentType is NYI');
   }
 
   /**
    * Gets the parent directory of this file path.
    */
   getParent(): FilePath {
-    throw Error("getParent is NYI");
+    throw Error('getParent is NYI');
   }
 
   /**
@@ -527,56 +527,56 @@ export class FilePath {
    * Gets the representation of this path, relative to the provided path.
    */
   getRelativePath(parentPath: FilePath): string {
-    throw Error("getRelativePath is NYI");
+    throw Error('getRelativePath is NYI');
   }
 
   /**
    * Gets the size of this file path in bytes.
    */
   getSize(): number {
-    throw Error("getSize is NYI");
+    throw Error('getSize is NYI');
   }
 
   /**
    * Gets the size of this file path and all sub-directories and files in it, in bytes.
    */
   getSizeRecursive(): number {
-    throw Error("getSizeRecursive is NYI");
+    throw Error('getSizeRecursive is NYI');
   }
 
   /**
    * Gets only the name of the file, excluding the extension.
    */
   getStem(): string {
-    throw Error("getStem is NYI");
+    throw Error('getStem is NYI');
   }
 
   /**
    * Checks whether this file has the specified extension.
    */
   hasExtension(extension: string): boolean {
-    throw Error("hasExtension is NYI");
+    throw Error('hasExtension is NYI');
   }
 
   /**
    * Checks whether this file has the specified extension when it is converted to lower case.
    */
   hasExtensionLowerCase(extension: string): boolean {
-    throw Error("hasExtensionLowerCase is NYI");
+    throw Error('hasExtensionLowerCase is NYI');
   }
 
   /**
    * Checks whether this file has a text mime content type.
    */
   hasTextMimeType(): boolean {
-    throw Error("hasTextMimeType is NYI");
+    throw Error('hasTextMimeType is NYI');
   }
 
   /**
    * Checks whether this file path is a directory.
    */
   isDirectory(): boolean {
-    throw Error("isDirectory is NYI");
+    throw Error('isDirectory is NYI');
   }
 
   /**
@@ -591,14 +591,14 @@ export class FilePath {
    * the specified file path.
    */
   isEquivalentTo(other: FilePath): boolean {
-    throw Error("isEquivalentTo is NYI");
+    throw Error('isEquivalentTo is NYI');
   }
 
   /**
    * Checks whether this file path is a hidden file or directory.
    */
   isHidden(): boolean {
-    throw Error("isHidden is NYI");
+    throw Error('isHidden is NYI');
   }
 
   /**
@@ -607,7 +607,7 @@ export class FilePath {
    * @return True if this file path is a Windows junction; false otherwise.
    */
   isJunction(): boolean {
-    throw Error("isJunction is NYI");
+    throw Error('isJunction is NYI');
   }
 
   /**
@@ -619,21 +619,21 @@ export class FilePath {
    * @return Success if the readability of this file could be checked; Error otherwise. (e.g. EACCES).
    */
   isReadable(): Error | boolean {
-    throw Error("isReadable is NYI");
+    throw Error('isReadable is NYI');
   }
 
   /**
    * Checks whether this file path is a regular file.
    */
   isRegularFile(): boolean {
-    throw Error("isRegularFile is NYI");
+    throw Error('isRegularFile is NYI');
   }
 
   /**
    * Checks whether this file path is a symbolic link.
    */
   isSymlink(): boolean {
-    throw Error("isSymLink is NYI");
+    throw Error('isSymLink is NYI');
   }
 
   /**
@@ -651,8 +651,8 @@ export class FilePath {
     }
 
     // Make the paths lexically normal so that e.g. foo/../bar isn't considered a child of foo.
-    let child = new FilePath(this.getLexicallyNormalPath());
-    let parent = new FilePath(scopePath.getLexicallyNormalPath());
+    const child = new FilePath(this.getLexicallyNormalPath());
+    const parent = new FilePath(scopePath.getLexicallyNormalPath());
 
     // Easy test: We can't possibly be in this scope path if it has more components than we do
     if (parent.path.length > child.path.length) {
@@ -667,8 +667,8 @@ export class FilePath {
 
     // Find the first path element that differs. Stop when we reach the end of the parent
     // path, or a "." path component, which signifies the end of a directory (/foo/bar/.)
-    const childDirs = childDetail.dir.split(/[\/\\]/);
-    const parentDirs = parentDetail.dir.split(/[\/\\]/);
+    const childDirs = childDetail.dir.split(/[/\\]/);
+    const parentDirs = parentDetail.dir.split(/[/\\]/);
     childDirs.push(childDetail.base);
     parentDirs.push(parentDetail.base);
     for (let i = 0; i < parentDirs.length; i++) {
@@ -688,7 +688,7 @@ export class FilePath {
    * Checks whether this file path is writeable.
    */
   isWriteable(): boolean | Error {
-    throw Error("isWriteable is NYI");
+    throw Error('isWriteable is NYI');
   }
 
   /**
@@ -712,49 +712,49 @@ export class FilePath {
    * Moves the current directory to the specified directory.
    */
   move(/*targetPath: FilePath, type: MoveType = MoveCrossDevice, overwrite = false*/): Err {
-    throw Error("move is NYI");
+    throw Error('move is NYI');
   }
 
   /**
    * Performs an indirect move by copying this directory to the target and then deleting this directory.
    */
   moveIndirect(targetPath: FilePath, overwrite = false): Err {
-    throw Error("moveIndirect is NYI");
+    throw Error('moveIndirect is NYI');
   }
 
   /**
    * Opens this file for read.
    */
   openForRead(/*std:: shared_ptr<std:: istream>& out_stream*/): Err {
-    throw Error("openForRead is NYI");
+    throw Error('openForRead is NYI');
   }
 
   /**
    * Opens this file for write.
    */
   openForWrite(/*std:: shared_ptr<std:: ostream>& out_stream,*/ truncate = true): Err {
-    throw Error("openForWrite is NYI");
+    throw Error('openForWrite is NYI');
   }
 
   /**
    * Removes this file or directory from the filesystem.
    */
   remove(): Err {
-    throw Error("remove is NYI");
+    throw Error('remove is NYI');
   }
 
   /**
    * Removes this file or directory from the filesystem, if it exists.
    */
   removeIfExists(): Err {
-    throw Error("removeIfExists is NYI");
+    throw Error('removeIfExists is NYI');
   }
 
   /**
    * Removes the directory represented by this FilePath, if it exists, and recreates it.
    */
   resetDirectory(): Err {
-    throw Error("resetDirectory is NYI");
+    throw Error('resetDirectory is NYI');
   }
 
   /**
@@ -762,21 +762,21 @@ export class FilePath {
    * is not a symbolic link, the original FilePath is returned.
    */
   resolveSymlink(): FilePath {
-    throw Error("resolveSymlink is NYI");
+    throw Error('resolveSymlink is NYI');
   }
 
   /**
    * Sets the last time that this file was modified to the specified time.
    */
   setLastWriteTime(/*std::time_t in_time = ::time(nullptr)*/): void {
-    throw Error("setLastWriteTime is NYI");
+    throw Error('setLastWriteTime is NYI');
   }
 
   /**
    * Checks if a file can be written to by opening the file.
    */
   testWritePermissions(): Err {
-    throw Error("testWritePermissions is NYI");
+    throw Error('testWritePermissions is NYI');
   }
 
   // -------------------------

--- a/src/node/desktop/src/core/log-options.ts
+++ b/src/node/desktop/src/core/log-options.ts
@@ -13,35 +13,35 @@
  *
  */
 
-import { Err, Success } from "./err";
-import { LogLevel, LoggerType, FileLogOptions } from "./log";
+import { Err, Success } from './err';
+import { LogLevel, LoggerType, FileLogOptions } from './log';
 
 export class StdErrLogOptions {}
 export class SysLogOptions {}
 export type LoggerOptions = StdErrLogOptions | SysLogOptions | FileLogOptions
 
-const kLogLevel          = "log-level"
-const kLoggerType        = "logger-type"
-const kLogDir            = "log-dir"
-const kLogFileMode       = "log-file-mode"
-const kLogFileIncludePid = "log-file-include-pid"
-const kRotate            = "rotate"
-const kMaxSizeMb         = "max-size-mb"
-const kLogConfFile       = "logging.conf"
-const kLogConfEnvVar     = "RS_LOG_CONF_FILE"
+const kLogLevel          = 'log-level';
+const kLoggerType        = 'logger-type';
+const kLogDir            = 'log-dir';
+const kLogFileMode       = 'log-file-mode';
+const kLogFileIncludePid = 'log-file-include-pid';
+const kRotate            = 'rotate';
+const kMaxSizeMb         = 'max-size-mb';
+const kLogConfFile       = 'logging.conf';
+const kLogConfEnvVar     = 'RS_LOG_CONF_FILE';
 
-const kFileLogger        = "file"
-const kStdErrLogger      = "stderr"
-const kSysLogger         = "syslog"
+const kFileLogger        = 'file';
+const kStdErrLogger      = 'stderr';
+const kSysLogger         = 'syslog';
 
-const kLoggingLevelDebug = "debug"
-const kLoggingLevelInfo  = "info"
-const kLoggingLevelWarn  = "warn"
-const kLoggingLevelError = "error"
+const kLoggingLevelDebug = 'debug';
+const kLoggingLevelInfo  = 'info';
+const kLoggingLevelWarn  = 'warn';
+const kLoggingLevelError = 'error';
 
-const kBaseLevel         = 0
-const kBinaryLevel       = 1
-const kLogSectionLevel   = 2 
+const kBaseLevel         = 0;
+const kBinaryLevel       = 1;
+const kLogSectionLevel   = 2;
 
 export class LogOptions
 {
@@ -54,7 +54,7 @@ export class LogOptions
     this.initProfile();
   }
 
-  initProfile() {
+  initProfile(): void {
     // base level - * (applies to all loggers/binaries)
     // first override - @ (specific binary)
     // second override - (logger name)
@@ -71,7 +71,7 @@ export class LogOptions
     // // add logger-specific params
     // LoggerOptionsVisitor visitor(profile_);
     // boost::apply_visitor(visitor, defaultLoggerOptions_);
-   }
+  }
    
   read(): Err {
     return Success();
@@ -125,34 +125,34 @@ export class LogOptions
     //  }
   }
    
-   // gets the current log level
-   //LogLevel logLevel(const std::string& loggerName = std::string()) const;
+  // gets the current log level
+  //LogLevel logLevel(const std::string& loggerName = std::string()) const;
 
-   // gets the lowest log level defined
-   //LogLevel lowestLogLevel() const;
+  // gets the lowest log level defined
+  //LogLevel lowestLogLevel() const;
 
-   // gets the current logger type
-   //LoggerType loggerType(const std::string& loggerName = std::string()) const;
+  // gets the current logger type
+  //LoggerType loggerType(const std::string& loggerName = std::string()) const;
 
-   // gets the current logger's specific options
-   //LoggerOptions loggerOptions(const std::string& loggerName = std::string()) const;
+  // gets the current logger's specific options
+  //LoggerOptions loggerOptions(const std::string& loggerName = std::string()) const;
 
-   //std::vector<std::string> loggerOverrides() const;
+  //std::vector<std::string> loggerOverrides() const;
 
-//private:
-   //void initProfile();
+  //private:
+  //void initProfile();
 
-   //void setLowestLogLevel();
+  //void setLowestLogLevel();
 
-   //std::vector<ConfigProfile::Level> getLevels(const std::string& loggerName) const;
+  //std::vector<ConfigProfile::Level> getLevels(const std::string& loggerName) const;
 
-   //std::string executableName_;
+  //std::string executableName_;
 
-   //std::string defaultLogLevel_;
-   //std::string defaultLoggerType_;
-   //LoggerOptions defaultLoggerOptions_;
+  //std::string defaultLogLevel_;
+  //std::string defaultLoggerType_;
+  //LoggerOptions defaultLoggerOptions_;
 
-   //LogLevel lowestLogLevel_;
+  //LogLevel lowestLogLevel_;
 
-   //ConfigProfile profile_;
-};
+  //ConfigProfile profile_;
+}

--- a/src/node/desktop/src/core/system.ts
+++ b/src/node/desktop/src/core/system.ts
@@ -28,7 +28,7 @@ export function initHook() {
 }
 
 // logger's program identity (this process's binary name)
-export let s_programIdentity = "";
+export const s_programIdentity = '';
 
 // logging options representing the latest state of the logging configuration file
 // export let s_logOptions: LogOptions;
@@ -57,7 +57,7 @@ export function initializeLog(
   // s_logOptions = new LogOptions(programIdentity, logLevel, log.LoggerType.kFile, options);
   // s_programIdentity = programIdentity;
 
-  let error = initLog();
+  const error = initLog();
   if (error) {
     return error;
   }
@@ -74,5 +74,5 @@ export function username() {
 }
 
 export function userHomePath() {
-   return User.getUserHomePath();
+  return User.getUserHomePath();
 }

--- a/src/node/desktop/src/core/user.ts
+++ b/src/node/desktop/src/core/user.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import os from "os";
-import { FilePath } from "./file-path";
+import os from 'os';
+import { FilePath } from './file-path';
 
 /**
  * Class which represents a system user.

--- a/src/node/desktop/src/core/xdg.ts
+++ b/src/node/desktop/src/core/xdg.ts
@@ -48,33 +48,31 @@ export enum WinFolderID {
  * variables.
  */
 export function SHGetKnownFolderPath(folderId: WinFolderID): string {
-  let envVar = "";
+  let envVar = '';
   switch (folderId) {
-    case WinFolderID.FOLDERID_RoamingAppData:
-      envVar = "APPDATA";
-      break;
-    case WinFolderID.FOLDERID_LocalAppData:
-      envVar = "LOCALAPPDATA";
-      break;
-    case WinFolderID.FOLDERID_ProgramData:
-      envVar = "ProgramData";
-      break;
+  case WinFolderID.FOLDERID_RoamingAppData:
+    envVar = 'APPDATA';
+    break;
+  case WinFolderID.FOLDERID_LocalAppData:
+    envVar = 'LOCALAPPDATA';
+    break;
+  case WinFolderID.FOLDERID_ProgramData:
+    envVar = 'ProgramData';
+    break;
   }
   return getenv(envVar);
 }
+
+// Store the hostname so we don't have to look it up multiple times
+let hostname = '';
 
 /**
  * Returns the hostname from the operating system
  */
 function getHostname(): string {
-  if (!getHostname.hostname)
-    getHostname.hostname = os.hostname();
-  return getHostname.hostname;
-}
-namespace getHostname {
-   // Use a static string to store the hostname so we don't have to look it up
-   // multiple times
-  export let hostname = "";
+  if (!hostname)
+    hostname = os.hostname();
+  return hostname;
 }
 
 /**
@@ -107,7 +105,7 @@ function resolveXdgDir(
   let xdgHome = new FilePath();
   let finalPath = true;
 
-   // Look for the RStudio-specific environment variable
+  // Look for the RStudio-specific environment variable
   let env = getenv(rstudioEnvVar);
   if (!env) {
     // The RStudio environment variable specifies the final path; if it isn't
@@ -120,7 +118,7 @@ function resolveXdgDir(
     // No root specified for xdg home; we will need to generate one.
     if (process.platform === 'win32') {
       // On Windows, the default path is in Application Data/Roaming.
-      let path = SHGetKnownFolderPath(windowsFolderId);
+      const path = SHGetKnownFolderPath(windowsFolderId);
       if (path) {
         xdgHome = new FilePath(path);
       } else {
@@ -139,13 +137,13 @@ function resolveXdgDir(
   }
 
   // expand HOME, USER, and HOSTNAME if given
-  let environment: Environment = {
-    "HOME": homeDir ? homeDir.getAbsolutePath() : userHomePath().getAbsolutePath(),
-    "USER": user ? user : username()
+  const environment: Environment = {
+    'HOME': homeDir ? homeDir.getAbsolutePath() : userHomePath().getAbsolutePath(),
+    'USER': user ? user : username()
   };
 
   // check for manually specified hostname in environment variable
-  let hostname = getenv("HOSTNAME");
+  let hostname = getenv('HOSTNAME');
 
   // when omitted, look up the hostname using a system call
   if (!hostname)
@@ -177,10 +175,10 @@ export class Xdg {
    */
   static userConfigDir(user?: string, homeDir?: FilePath) {
     return resolveXdgDir(
-      "RSTUDIO_CONFIG_HOME",
-      "XDG_CONFIG_HOME",
+      'RSTUDIO_CONFIG_HOME',
+      'XDG_CONFIG_HOME',
       WinFolderID.FOLDERID_RoamingAppData,
-      "~/.config",
+      '~/.config',
       user,
       homeDir
     );
@@ -194,10 +192,10 @@ export class Xdg {
    */
   static userDataDir(user?: string, homeDir?: FilePath) {
     return resolveXdgDir(
-      "RSTUDIO_DATA_HOME",
-      "XDG_DATA_HOME",
+      'RSTUDIO_DATA_HOME',
+      'XDG_DATA_HOME',
       WinFolderID.FOLDERID_LocalAppData,
-      "~/.local/share",
+      '~/.local/share',
       user,
       homeDir
     );
@@ -214,7 +212,7 @@ export class Xdg {
     user?: string,
     homeDir?: FilePath
   ) {
-    throw Error("Xdg.verifyUserDirs is NYI");
+    throw Error('Xdg.verifyUserDirs is NYI');
   }
 
 
@@ -225,17 +223,17 @@ export class Xdg {
    * On Windows, this is `FOLDERID_ProgramData` (typically `C:/ProgramData`).
    */
   static systemConfigDir(): FilePath {
-    let result = "";
+    const result = '';
     if (process.platform !== 'win32') {
-      if (!getenv("RSTUDIO_CONFIG_DIR")) {
+      if (!getenv('RSTUDIO_CONFIG_DIR')) {
         // On POSIX operating systems, it's possible to specify multiple config
         // directories. We have to select one, so read the list and take the first
         // one that contains an "rstudio" folder.
-        const env = getenv("XDG_CONFIG_DIRS");
-        if (env.indexOf(":") >= 0) {
-          const dirs = env.split(":");
-          for (let dir of dirs) {
-            let resolved = new FilePath(dir).completePath("rstudio");
+        const env = getenv('XDG_CONFIG_DIRS');
+        if (env.indexOf(':') >= 0) {
+          const dirs = env.split(':');
+          for (const dir of dirs) {
+            const resolved = new FilePath(dir).completePath('rstudio');
             if (resolved.existsSync()) {
               return resolved;
             }
@@ -244,10 +242,10 @@ export class Xdg {
       }
     }
     return resolveXdgDir(
-      "RSTUDIO_CONFIG_DIR",
-      "XDG_CONFIG_DIRS",
+      'RSTUDIO_CONFIG_DIR',
+      'XDG_CONFIG_DIRS',
       WinFolderID.FOLDERID_ProgramData,
-      "/etc",
+      '/etc',
       undefined,  // no specific user
       undefined   // no home folder resolution
     );
@@ -263,14 +261,14 @@ export class Xdg {
       // Passthrough on Windows
       return Xdg.systemConfigDir().completeChildPath(filename);
     }
-    if (!getenv("RSTUDIO_CONFIG_DIR")) {
+    if (!getenv('RSTUDIO_CONFIG_DIR')) {
       // On POSIX, check for a search path.
-      const env = getenv("XDG_CONFIG_DIRS");
-      if (env.indexOf(":") >= 0) {
+      const env = getenv('XDG_CONFIG_DIRS');
+      if (env.indexOf(':') >= 0) {
         // This is a search path; check each element for the file.
-        const dirs = env.split(":");
-        for (let dir of dirs) {
-          let resolved = new FilePath(dir).completePath("rstudio").completeChildPath(filename);
+        const dirs = env.split(':');
+        for (const dir of dirs) {
+          const resolved = new FilePath(dir).completePath('rstudio').completeChildPath(filename);
           if (resolved.existsSync()) {
             return resolved;
           }
@@ -287,6 +285,6 @@ export class Xdg {
    * Sets relevant XDG environment variables
    */
   static forwardXdgEnvVars(pEnvironment: Environment) {
-    throw Error("forwardXdgEnvVars is NYI");
+    throw Error('forwardXdgEnvVars is NYI');
   }
 }

--- a/src/node/desktop/src/main/app.ts
+++ b/src/node/desktop/src/main/app.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app } from "electron";
+import { app } from 'electron';
 
 import Main from './main';
 

--- a/src/node/desktop/src/main/desktop-utils.ts
+++ b/src/node/desktop/src/main/desktop-utils.ts
@@ -62,7 +62,7 @@ export function initializeLang() {
 
   // Next highest precedence: LANG environment variable.
   if (!lang) {
-    let envLang = getenv('LANG');
+    const envLang = getenv('LANG');
     if (!envLang) {
       lang = envLang;
     }
@@ -180,7 +180,7 @@ export function initializeLang() {
 // }
 
 export function isMacOS(): boolean {
-  return process.platform === "darwin";
+  return process.platform === 'darwin';
 }
 
 // bool isCentOS()

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -28,7 +28,6 @@ import * as desktop from './desktop-utils';
 // QString sharedSecret;
 
 export default class Main {
-  constructor() {}
 
   run() {
     initHook();
@@ -1064,8 +1063,8 @@ export default class Main {
   }
 
   static getComponentVersions(): string {
-    let componentVers: any = process.versions;
-    componentVers["rstudio"] = getRStudioVersion();
+    const componentVers: any = process.versions;
+    componentVers['rstudio'] = getRStudioVersion();
     return JSON.stringify(componentVers, null, 2);
   }
 }

--- a/src/node/desktop/src/main/product-info.ts
+++ b/src/node/desktop/src/main/product-info.ts
@@ -13,7 +13,7 @@
  *
  */
 
-export function getRStudioVersion() {
+export function getRStudioVersion(): string {
   // TODO: need to figure out how to consume build numbers for package build, etc.
-  return "1.5.0";
+  return '1.5.0';
 }

--- a/src/node/desktop/test/core/environment.spec.ts
+++ b/src/node/desktop/test/core/environment.spec.ts
@@ -13,86 +13,86 @@
  *
  */
 
-import { describe } from "mocha";
-import { expect } from "chai";
-import * as env from "../../src/core/environment";
+import { describe } from 'mocha';
+import { expect } from 'chai';
+import * as env from '../../src/core/environment';
 
-const envVarName = "BOGUS_FAKE_ENVIRONMENT_VARIABLE_FOR_ENV_TESTS";
-const envValue = "Value used for testing environment variables";
+const envVarName = 'BOGUS_FAKE_ENVIRONMENT_VARIABLE_FOR_ENV_TESTS';
+const envValue = 'Value used for testing environment variables';
 
-describe("Environment", () => {
-  describe("Get global environment variable", () => {
-    it("Should return zero length string for non-existent variable", () => {
-      let result = env.getenv(envVarName);
-      expect(result).to.equal("");
+describe('Environment', () => {
+  describe('Get global environment variable', () => {
+    it('Should return zero length string for non-existent variable', () => {
+      const result = env.getenv(envVarName);
+      expect(result).to.equal('');
     });
-    it("Should return value of a variable that exists", () => {
-      let result = env.getenv("PATH");
+    it('Should return value of a variable that exists', () => {
+      const result = env.getenv('PATH');
       expect(result).to.not.be.empty;
     });
   });
-  describe("Set and unset global environment variable", () => {
-    it("Should set a variable, fetch, then remove it", () => {
+  describe('Set and unset global environment variable', () => {
+    it('Should set a variable, fetch, then remove it', () => {
       let result = env.getenv(envVarName);
-      expect(result).to.equal("");
+      expect(result).to.equal('');
       env.setenv(envVarName, envValue);
       result = env.getenv(envVarName);
       expect(result).to.equal(envValue);
       env.unsetenv(envVarName);
       result = env.getenv(envVarName);
-      expect(result).to.equal("");
+      expect(result).to.equal('');
     });
   });
-  describe("Expand variables in a string using environment", () => {
-    it("Should return original string if it contained no variables", () => {
-      const environment = { "FOO": "bar", "ZOOM": "car" };
-      const input = "~/.local/share";
+  describe('Expand variables in a string using environment', () => {
+    it('Should return original string if it contained no variables', () => {
+      const environment = { 'FOO': 'bar', 'ZOOM': 'car' };
+      const input = '~/.local/share';
       const result = env.expandEnvVars(environment, input);
       expect(result).to.equal(input);
     });
-    it("Should return original string if environment contains no matching variables", () => {
-      const environment = { "FOO": "bar", "ZOOM": "car" };
-      const input = "$HOME/.local/share";
+    it('Should return original string if environment contains no matching variables', () => {
+      const environment = { 'FOO': 'bar', 'ZOOM': 'car' };
+      const input = '$HOME/.local/share';
       const result = env.expandEnvVars(environment, input);
       expect(result).to.equal(input);
     });
-    it("Should substitute value from environment using bare form ($FOO)", () => {
-      const environment = { "FOO": "bar", "ZOOM": "car" };
+    it('Should substitute value from environment using bare form ($FOO)', () => {
+      const environment = { 'FOO': 'bar', 'ZOOM': 'car' };
 
-      const input = "C:\\HELLO\\$FOO";
+      const input = 'C:\\HELLO\\$FOO';
       const result = env.expandEnvVars(environment, input);
-      expect(result).to.equal("C:\\HELLO\\bar");
+      expect(result).to.equal('C:\\HELLO\\bar');
     });
-    it("Should substitute multiple values from environment using bare form ($FOO)", () => {
-      const environment = { "FOO": "bar", "ZOOM": "car" };
-      const input = "/usr/HELLO/$ZOOM/misc/$FOO/etc/";
+    it('Should substitute multiple values from environment using bare form ($FOO)', () => {
+      const environment = { 'FOO': 'bar', 'ZOOM': 'car' };
+      const input = '/usr/HELLO/$ZOOM/misc/$FOO/etc/';
       const result = env.expandEnvVars(environment, input);
-      expect(result).to.equal("/usr/HELLO/car/misc/bar/etc/");
+      expect(result).to.equal('/usr/HELLO/car/misc/bar/etc/');
     });
-    it("Should substitute value from environment using curly brace form (${FOO})", () => {
-      const environment = { "FOO": "bar", "ZOOM": "car" };
-      const input = "C:\\HELLO\\${FOO}";
+    it('Should substitute value from environment using curly brace form (${FOO})', () => {
+      const environment = { 'FOO': 'bar', 'ZOOM': 'car' };
+      const input = 'C:\\HELLO\\${FOO}';
       const result = env.expandEnvVars(environment, input);
-      expect(result).to.equal("C:\\HELLO\\bar");
+      expect(result).to.equal('C:\\HELLO\\bar');
     });
-    it("Should expand all instances of a variable", () => {
+    it('Should expand all instances of a variable', () => {
       const environment = {
-        "VAR1": "foo",
-        "VAR2": "bar",
-        "VAR3": "baz",
+        'VAR1': 'foo',
+        'VAR2': 'bar',
+        'VAR3': 'baz',
       };
       const input =
-        "Metasyntactic variables include $VAR1, $VAR2, and $VAR3, " +
-        "but $VAR1 is used most often.";
+        'Metasyntactic variables include $VAR1, $VAR2, and $VAR3, ' +
+        'but $VAR1 is used most often.';
       const expanded =
-        "Metasyntactic variables include foo, bar, and baz, " + "but foo is used most often.";
+        'Metasyntactic variables include foo, bar, and baz, ' + 'but foo is used most often.';
       const result = env.expandEnvVars(environment, input);
       expect(result).to.equal(expanded);
     });
-    it("Should not expand partially matching variables", () => {
-      const environment = { "VAR": "foo" };
-      const input = "I think $VAR is a nice name for a $VARIABLE.";
-      const expanded = "I think foo is a nice name for a $VARIABLE.";
+    it('Should not expand partially matching variables', () => {
+      const environment = { 'VAR': 'foo' };
+      const input = 'I think $VAR is a nice name for a $VARIABLE.';
+      const expanded = 'I think foo is a nice name for a $VARIABLE.';
       const result = env.expandEnvVars(environment, input);
       expect(result).to.equal(expanded);
     });

--- a/src/node/desktop/test/core/err.spec.ts
+++ b/src/node/desktop/test/core/err.spec.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import { describe } from "mocha";
-import { expect } from "chai";
+import { describe } from 'mocha';
+import { expect } from 'chai';
 
 import { Err, Success } from '../../src/core/err';
 
@@ -23,19 +23,19 @@ function beSuccessful(): Err {
 }
 
 function beUnsuccessful(): Err {
-  return new Error("Some error");
+  return new Error('Some error');
 }
 
-describe("Err", () => {
-  describe("Success helper", () => {
-      it("Success return should be falsy", () => {
-        expect(!!beSuccessful()).is.false;
-        expect(beSuccessful() == null);
-      });
-      it("Error return should be truthy", () => {
-        expect(!!beUnsuccessful()).is.true;
-        expect(beUnsuccessful() instanceof Error);
-      });
+describe('Err', () => {
+  describe('Success helper', () => {
+    it('Success return should be falsy', () => {
+      expect(!!beSuccessful()).is.false;
+      expect(beSuccessful() == null);
+    });
+    it('Error return should be truthy', () => {
+      expect(!!beUnsuccessful()).is.true;
+      expect(beUnsuccessful() instanceof Error);
+    });
   });
 });
  

--- a/src/node/desktop/test/core/file-path.spec.ts
+++ b/src/node/desktop/test/core/file-path.spec.ts
@@ -13,16 +13,16 @@
  *
  */
 
-import { describe, utils } from "mocha";
-import { expect, assert } from "chai";
+import { describe, utils } from 'mocha';
+import { expect, assert } from 'chai';
 
-import fs from "fs";
+import fs from 'fs';
 import fsPromises from 'fs/promises';
-import path from "path";
-import os from "os";
+import path from 'path';
+import os from 'os';
 
-import { FilePath } from "../../src/core/file-path";
-import { User } from "../../src/core/user";
+import { FilePath } from '../../src/core/file-path';
+import { User } from '../../src/core/user';
 
 function randomString() {
   return Math.trunc(Math.random() * 2147483647).toString();
@@ -36,164 +36,164 @@ async function realpath(path: string): Promise<string> {
   return fsPromises.realpath(path);
 }
 
-const bogusPath = "/super/bogus/path/42";
+const bogusPath = '/super/bogus/path/42';
 
-describe("FilePath", () => {
+describe('FilePath', () => {
   afterEach(() => {
     // make sure we leave cwd in a valid place
     process.chdir(__dirname);
   });
 
-  describe("Constructor checks", () => {
-    it("Should store and return the supplied path", () => {
-      const path1= "hello/world";
-      const path2 = "~/foo";
-      const path3 = "/once/upon/a/time";
-      const path4 = "~";
+  describe('Constructor checks', () => {
+    it('Should store and return the supplied path', () => {
+      const path1= 'hello/world';
+      const path2 = '~/foo';
+      const path3 = '/once/upon/a/time';
+      const path4 = '~';
       expect(new FilePath(path1).getAbsolutePath()).to.equal(path1);
       expect(new FilePath(path2).getAbsolutePath()).to.equal(path2);
       expect(new FilePath(path3).getAbsolutePath()).to.equal(path3);
       expect(new FilePath(path4).getAbsolutePath()).to.equal(path4);
       expect(new FilePath(path3).toString()).to.equal(path3);
     });
-    it("Should create empty path when given no arguments", () => {
+    it('Should create empty path when given no arguments', () => {
       const path = new FilePath();
       expect(path.getAbsolutePath().length).to.equal(0);
       expect(path.isEmpty());
     });
-   });
+  });
 
-  describe("Comparisons", () => {
-    it("equals should return true if storing exact same path string", () => {
-      const path1 = new FilePath("/hello/world");
-      const path2 = new FilePath("/hello/world");
+  describe('Comparisons', () => {
+    it('equals should return true if storing exact same path string', () => {
+      const path1 = new FilePath('/hello/world');
+      const path2 = new FilePath('/hello/world');
       expect(path1.equals(path2)).is.true;
     });
-    it("equals should return false if they are storing different path strings", () => {
-      const path1 = new FilePath("/hello/world");
-      const path2 = new FilePath("/hello/../hello/world");
+    it('equals should return false if they are storing different path strings', () => {
+      const path1 = new FilePath('/hello/world');
+      const path2 = new FilePath('/hello/../hello/world');
       expect(path1.equals(path2)).is.false;
     });
-    it("isWithin should handle detect simple path containment checks", () => {
-      const pPath = new FilePath("/path/to");
-      const aPath = new FilePath("/path/to/a");
-      const bPath = new FilePath("/path/to/b");
+    it('isWithin should handle detect simple path containment checks', () => {
+      const pPath = new FilePath('/path/to');
+      const aPath = new FilePath('/path/to/a');
+      const bPath = new FilePath('/path/to/b');
       expect(aPath.isWithin(pPath)).is.true;
       expect(bPath.isWithin(pPath)).is.true;
       expect(aPath.isWithin(bPath)).is.false;
     });
-    it("isWithin should not be fooled by directory traversal", () => {
+    it('isWithin should not be fooled by directory traversal', () => {
       // the first path is not inside the second even though it appears to be lexically
-      let aPath = new FilePath("/path/to/a/../b");
-      let bPath = new FilePath("path/to/a");
+      const aPath = new FilePath('/path/to/a/../b');
+      const bPath = new FilePath('path/to/a');
       expect(!!aPath.isWithin(bPath)).is.false;
     });
-    it("isWithin should not be fooled by substrings", () => {
-      let cPath = new FilePath("/path/to/foo");
-      let dPath = new FilePath("path/to/foobar");
+    it('isWithin should not be fooled by substrings', () => {
+      const cPath = new FilePath('/path/to/foo');
+      const dPath = new FilePath('path/to/foobar');
       expect(dPath.isWithin(cPath)).is;
     });
   });
 
-  describe("Retrieval methods", () => {
-    it("getCanonicalPathSync should return empty results for empty path", () => {
+  describe('Retrieval methods', () => {
+    it('getCanonicalPathSync should return empty results for empty path', () => {
       const f = new FilePath();
       expect(f.existsSync()).is.false;
       expect(!!f.getAbsolutePath()).is.false;
       expect(!!f.isEmpty()).is.true;
       expect(!!f.isWithin(f)).is.true;
-      expect(!!f.isWithin(new FilePath("/some/path"))).is.false;
+      expect(!!f.isWithin(new FilePath('/some/path'))).is.false;
       expect(f.getCanonicalPathSync()).is.empty;
       expect(f.getExtension()).is.empty;
       expect(f.getExtensionLowerCase()).is.empty;
       expect(f.getFilename()).is.empty;
     });
-    it("getCanonicalPathSync should return a non-empty path for a path that exists", () => {
+    it('getCanonicalPathSync should return a non-empty path for a path that exists', () => {
       const f = new FilePath(os.tmpdir());
       expect(f.existsSync()).is.true;
       const result = f.getCanonicalPathSync();
       expect(result).length.is.greaterThan(0);
     });
-    it("getCanonicalPathSync should return an empty path for a path that doesn't exist", () => {
-      const f = new FilePath("/some/really/bogus/path");
+    it('getCanonicalPathSync should return an empty path for a path that doesn\'t exist', () => {
+      const f = new FilePath('/some/really/bogus/path');
       expect(f.existsSync()).is.false;
       const result = f.getCanonicalPathSync();
       expect(result).length.lessThanOrEqual(0);
     });
-    it("getCanonicalPath should return empty results for empty path", async () => {
+    it('getCanonicalPath should return empty results for empty path', async () => {
       const f = new FilePath();
       expect(await f.exists()).is.false;
       expect(!!f.getAbsolutePath()).is.false;
       expect(!!f.isEmpty()).is.true;
       expect(!!f.isWithin(f)).is.true;
-      expect(!!f.isWithin(new FilePath("/some/path"))).is.false;
+      expect(!!f.isWithin(new FilePath('/some/path'))).is.false;
       expect(await f.getCanonicalPath()).is.empty;
     });
-    it("getCanonicalPath should return a non-empty path for a path that exists", async () => {
+    it('getCanonicalPath should return a non-empty path for a path that exists', async () => {
       const f = new FilePath(os.tmpdir());
       expect(await f.exists()).is.true;
       const result = await f.getCanonicalPath();
       expect(result).length.is.greaterThan(0);
     });
-    it("getCanonicalPath should return an empty path for a path that doesn't exist", async () => {
-      const f = new FilePath("/some/really/bogus/path");
+    it('getCanonicalPath should return an empty path for a path that doesn\'t exist', async () => {
+      const f = new FilePath('/some/really/bogus/path');
       expect(await f.exists()).is.false;
       const result = await f.getCanonicalPath();
       expect(result).length.lessThanOrEqual(0);
     });
-    it("getExtension should return the extension including leading period", () => {
-      const f = new FilePath("/some/stuff/hello.tXt");
-      expect(f.getExtension()).equals(".tXt");
+    it('getExtension should return the extension including leading period', () => {
+      const f = new FilePath('/some/stuff/hello.tXt');
+      expect(f.getExtension()).equals('.tXt');
     });
-    it("getExtension should return no extension for extension-only filename", () => {
-      const f = new FilePath("/some/stuff/.foo");
+    it('getExtension should return no extension for extension-only filename', () => {
+      const f = new FilePath('/some/stuff/.foo');
       expect(f.getExtension()).is.empty;
     });
-    it("getExtension should return blank extension for file without extension", () => {
-      const f = new FilePath("/some/stuff/hello");
+    it('getExtension should return blank extension for file without extension', () => {
+      const f = new FilePath('/some/stuff/hello');
       expect(f.getExtension()).is.empty;
     });
-    it("getExtensionLowerCase should return the extension in lowercase", () => {
-      const f = new FilePath("/some/stuff/hello.tXt");
-      expect(f.getExtensionLowerCase()).equals(".txt");
+    it('getExtensionLowerCase should return the extension in lowercase', () => {
+      const f = new FilePath('/some/stuff/hello.tXt');
+      expect(f.getExtensionLowerCase()).equals('.txt');
     });
-    it("getExtensionLowerCase should return blank extension for file without extension", () => {
-      const f = new FilePath("/some/stuff/hello");
+    it('getExtensionLowerCase should return blank extension for file without extension', () => {
+      const f = new FilePath('/some/stuff/hello');
       expect(f.getExtension()).is.empty;
     });
-    it("getFilename should return filename including extension", () => {
-      const f = new FilePath("/etc/foo/hello.txt.world");
-      expect(f.getFilename()).equals("hello.txt.world");
+    it('getFilename should return filename including extension', () => {
+      const f = new FilePath('/etc/foo/hello.txt.world');
+      expect(f.getFilename()).equals('hello.txt.world');
     });
-    it("getFilename should return filename when there is no extension", () => {
-      const f = new FilePath("/etc/foo/hello");
-      expect(f.getFilename()).equals("hello");
+    it('getFilename should return filename when there is no extension', () => {
+      const f = new FilePath('/etc/foo/hello');
+      expect(f.getFilename()).equals('hello');
     });
-    it("getFilename should return filename for extension-only filename", () => {
-      const f = new FilePath("/etc/foo/.hello");
-      expect(f.getFilename()).equals(".hello");
+    it('getFilename should return filename for extension-only filename', () => {
+      const f = new FilePath('/etc/foo/.hello');
+      expect(f.getFilename()).equals('.hello');
     });
-    it("getLastWriteTimeSync should return zero for non-existent file", () => {
-      const f = new FilePath("/some/file/that/will/not/exist");
+    it('getLastWriteTimeSync should return zero for non-existent file', () => {
+      const f = new FilePath('/some/file/that/will/not/exist');
       expect(f.getLastWriteTimeSync()).equals(0);
-    })
+    });
   });
 
-  describe("Get a safe current path", () => {
-    it("safeCurrentPathSync should return current working directory if it exists", () => {
+  describe('Get a safe current path', () => {
+    it('safeCurrentPathSync should return current working directory if it exists', () => {
       const cwd = new FilePath(process.cwd());
-      const rootPath = new FilePath("/");
+      const rootPath = new FilePath('/');
       const currentPath = FilePath.safeCurrentPathSync(rootPath);
       expect(currentPath.getAbsolutePath()).to.equal(cwd.getAbsolutePath());
       expect(realpathSync(cwd.getAbsolutePath())).to.equal(realpathSync(process.cwd()));
     });
-    it("safeCurrentPathSync should change to supplied safe path if it exists if cwd doesn't exist", () => {
+    it('safeCurrentPathSync should change to supplied safe path if it exists if cwd doesn\'t exist', () => {
       const origDir = new FilePath(process.cwd());
 
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
-        "temp-folder-for-FilePath-tests-" + randomString()
+        'temp-folder-for-FilePath-tests-' + randomString()
       );
       fs.mkdirSync(testDir);
       process.chdir(testDir);
@@ -204,11 +204,11 @@ describe("FilePath", () => {
       expect(realpathSync(origDir.getAbsolutePath())).to.equal(realpathSync(process.cwd()));
       expect(realpathSync(currentPath.getAbsolutePath())).to.equal(realpathSync(process.cwd()));
     });
-    it("safeCurrentPathSync should change to home folder when both cwd and revert paths don't exist", () => {
+    it('safeCurrentPathSync should change to home folder when both cwd and revert paths don\'t exist', () => {
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
-        "temp-folder-for-FilePath-tests-" + randomString()
+        'temp-folder-for-FilePath-tests-' + randomString()
       );
       fs.mkdirSync(testDir);
       process.chdir(testDir);
@@ -218,20 +218,20 @@ describe("FilePath", () => {
       const currentPath = FilePath.safeCurrentPathSync(new FilePath(bogusPath));
       expect(realpathSync(currentPath.getAbsolutePath())).to.equal(realpathSync(os.homedir()));
     });
-    it("safeCurrentPath should return current working directory if it exists", async () => {
+    it('safeCurrentPath should return current working directory if it exists', async () => {
       const cwd = new FilePath(process.cwd());
-      const rootPath = new FilePath("/");
+      const rootPath = new FilePath('/');
       const currentPath = await FilePath.safeCurrentPath(rootPath);
       expect(currentPath.getAbsolutePath()).to.equal(cwd.getAbsolutePath());
       expect(await realpath(cwd.getAbsolutePath())).to.equal(await realpath(process.cwd()));
     });
-    it("safeCurrentPath should change to supplied safe path if it exists if cwd doesn't exist", async () => {
+    it('safeCurrentPath should change to supplied safe path if it exists if cwd doesn\'t exist', async () => {
       const origDir = new FilePath(process.cwd());
 
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
-        "temp-folder-for-FilePath-tests-" + randomString()
+        'temp-folder-for-FilePath-tests-' + randomString()
       );
       await fsPromises.mkdir(testDir);
       process.chdir(testDir);
@@ -242,11 +242,11 @@ describe("FilePath", () => {
       expect(await realpath(origDir.getAbsolutePath())).to.equal(await realpath(process.cwd()));
       expect(await realpath(currentPath.getAbsolutePath())).to.equal(await realpath(process.cwd()));
     });
-    it("safeCurrentPath should change to home folder when both cwd and revert paths don't exist", async () => {
+    it('safeCurrentPath should change to home folder when both cwd and revert paths don\'t exist', async () => {
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
-        "temp-folder-for-FilePath-tests-" + randomString()
+        'temp-folder-for-FilePath-tests-' + randomString()
       );
       await fsPromises.mkdir(testDir);
       process.chdir(testDir);
@@ -256,60 +256,60 @@ describe("FilePath", () => {
       const currentPath = await FilePath.safeCurrentPath(new FilePath(bogusPath));
       expect(await realpath(currentPath.getAbsolutePath())).to.equal(await realpath(os.homedir()));
     });
- });
+  });
 
-  describe("Path existence checks", () => {
-    it("isEmpty should detect if this object's path is empty", () => {
+  describe('Path existence checks', () => {
+    it('isEmpty should detect if this object\'s path is empty', () => {
       expect(new FilePath().isEmpty()).is.true;
     });
-    it("existsSync should detect when object's path exists", () => {
+    it('existsSync should detect when object\'s path exists', () => {
       expect(new FilePath(os.tmpdir()).existsSync()).is.true;
     });
-    it("existsSync should return false for empty path", () => {
-      expect(new FilePath("").existsSync()).is.false;
+    it('existsSync should return false for empty path', () => {
+      expect(new FilePath('').existsSync()).is.false;
     });
-    it("existsSync should detect when object's path doesn't exist", () => {
+    it('existsSync should detect when object\'s path doesn\'t exist', () => {
       expect(new FilePath(bogusPath).existsSync()).is.false;
     });
-    it("existsSync should detect when a supplied path exists", () => {
+    it('existsSync should detect when a supplied path exists', () => {
       expect(FilePath.existsSync(os.tmpdir())).is.true;
     });
-    it("existsSync should detect when a supplied path doesn't exist", () => {
+    it('existsSync should detect when a supplied path doesn\'t exist', () => {
       expect(FilePath.existsSync(bogusPath)).is.false;
     });
-    it("existsSync should return false for existence of a null path", () => {
+    it('existsSync should return false for existence of a null path', () => {
       expect(new FilePath().existsSync()).is.false;
     });
-    it("exists should return false for empty path", async () => {
+    it('exists should return false for empty path', async () => {
       expect(await new FilePath().exists()).is.false;
     });
-    it("exists should detect when object's path exists", async () => {
+    it('exists should detect when object\'s path exists', async () => {
       expect(await new FilePath(os.tmpdir()).exists()).is.true;
     });
-    it("exists should detect when object's path doesn't exist", async () => {
+    it('exists should detect when object\'s path doesn\'t exist', async () => {
       expect(await new FilePath(bogusPath).exists()).is.false;
     });
-    it("exists should detect when a supplied path exists", async () => {
+    it('exists should detect when a supplied path exists', async () => {
       expect(await FilePath.exists(os.tmpdir())).is.true;
     });
-    it("exists should detect when a supplied path doesn't exist", async () => {
+    it('exists should detect when a supplied path doesn\'t exist', async () => {
       expect(await FilePath.exists(bogusPath)).is.false;
     });
-    it("exists should return false for existence of a null path", async () => {
+    it('exists should return false for existence of a null path', async () => {
       expect(await new FilePath().exists()).is.false;
     });
- });
+  });
 
-  describe("Synchronous Directory creation", () => {
-    it("createDirectorySync should create directory stored in FilePath", () => {
+  describe('Synchronous Directory creation', () => {
+    it('createDirectorySync should create directory stored in FilePath', () => {
       const target = path.join(os.tmpdir(), randomString());
       const fp = new FilePath(target);
       const result = fp.createDirectorySync();
       expect(!!result).is.false;
       expect(fp.existsSync()).is.true;
       fs.rmdirSync(target);
-   });
-   it("createDirectorySync should succeed if directory in FilePath already exists", () => {
+    });
+    it('createDirectorySync should succeed if directory in FilePath already exists', () => {
       const target = path.join(os.tmpdir(), randomString());
       const fp = new FilePath(target);
       let result = fp.createDirectorySync();
@@ -319,7 +319,7 @@ describe("FilePath", () => {
       expect(fp.existsSync()).is.true;
       fs.rmdirSync(target);
     });
-    it("createDirectorySync should create directory relative to path in FilePath", () => {
+    it('createDirectorySync should create directory relative to path in FilePath', () => {
       const target = randomString();
       const fp = new FilePath(os.tmpdir());
       const result = fp.createDirectorySync(target);
@@ -328,7 +328,7 @@ describe("FilePath", () => {
       expect(fs.existsSync(newPath)).is.true;
       fs.rmdirSync(newPath);
     });
-    it("createDirectorySync should recursively create directories", () => {
+    it('createDirectorySync should recursively create directories', () => {
       const target = path.join(os.tmpdir(), randomString(), randomString());
       const fp = new FilePath(target);
       const result = fp.createDirectorySync();
@@ -336,39 +336,39 @@ describe("FilePath", () => {
       expect(fp.existsSync()).is.true;
       fs.rmdirSync(target);
     });
-    it("createDirectorySync should recursively create directories relative to path in FilePath", () => {
+    it('createDirectorySync should recursively create directories relative to path in FilePath', () => {
       const firstLevel = randomString();
       const extraFolder = randomString();
       const target = path.join(os.tmpdir(), firstLevel, randomString());
       const fp = new FilePath(target);
       const result = fp.createDirectorySync(extraFolder);
       expect(!!result).is.false;
-      let newPath = path.join(target, extraFolder);
+      const newPath = path.join(target, extraFolder);
       expect(fs.existsSync(newPath)).is.true;
       fs.rmdirSync(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
-    it("createDirectorySync should fail when it cannot create the directory", () => {
-      const fp = new FilePath("/foo/bar/crazy");
-      let result = fp.createDirectorySync("");
+    it('createDirectorySync should fail when it cannot create the directory', () => {
+      const fp = new FilePath('/foo/bar/crazy');
+      let result = fp.createDirectorySync('');
       expect(!!result).is.true;
-      result = fp.createDirectorySync("stuff");
+      result = fp.createDirectorySync('stuff');
       expect(!!result).is.true;
     });
-    it("createDirectorySync should ignore base when given an absolute path", () => {
-      const fp = new FilePath("/foo/bar/crazy");
+    it('createDirectorySync should ignore base when given an absolute path', () => {
+      const fp = new FilePath('/foo/bar/crazy');
       const target = path.join(os.tmpdir(), randomString());
-      let result = fp.createDirectorySync(target);
+      const result = fp.createDirectorySync(target);
       expect(!!result).is.false;
       expect(fs.existsSync(target));
       fs.rmdirSync(target);
     });
-    it("ensureDirectorySync should return success when asked to ensure existing directory exists", () => {
+    it('ensureDirectorySync should return success when asked to ensure existing directory exists', () => {
       const existingFolder = new FilePath(os.homedir());
       expect(existingFolder.existsSync()).is.true;
       const result = existingFolder.ensureDirectorySync();
       expect(!!result).is.false;
     });
-    it("ensureDirectorySync should create directory when asked to ensure it exists", () => {
+    it('ensureDirectorySync should create directory when asked to ensure it exists', () => {
       const newFolder = path.join(os.tmpdir(), randomString());
       const newFilePath = new FilePath(newFolder);
       expect(fs.existsSync(newFolder)).is.false;
@@ -377,13 +377,13 @@ describe("FilePath", () => {
       expect(fs.existsSync(newFolder)).is.true;
       fs.rmdirSync(newFolder);
     });
-    it("ensureDirectory should return success when asked to ensure existing directory exists", async () => {
+    it('ensureDirectory should return success when asked to ensure existing directory exists', async () => {
       const existingFolder = new FilePath(os.homedir());
       expect(await existingFolder.exists()).is.true;
       const result = await existingFolder.ensureDirectory();
       expect(!!result).is.false;
     });
-    it("ensureDirectory should create directory when asked to ensure it exists", async () => {
+    it('ensureDirectory should create directory when asked to ensure it exists', async () => {
       const newFolder = path.join(os.tmpdir(), randomString());
       const newFilePath = new FilePath(newFolder);
       expect(await FilePath.exists(newFolder)).is.false;
@@ -391,11 +391,11 @@ describe("FilePath", () => {
       expect(!!result).is.false;
       expect(await FilePath.exists(newFolder)).is.true;
       await fsPromises.rmdir(newFolder);
-   });
- });
+    });
+  });
 
-  describe("Async Directory creation", () => {
-    it("createDirectory should create directory stored in FilePath", async () => {
+  describe('Async Directory creation', () => {
+    it('createDirectory should create directory stored in FilePath', async () => {
       const target = path.join(os.tmpdir(), randomString());
       const fp = new FilePath(target);
       const result = await fp.createDirectory();
@@ -403,7 +403,7 @@ describe("FilePath", () => {
       expect(await fp.exists()).is.true;
       await fsPromises.rmdir(target);
     });
-    it("createDirectory should succeed if directory in FilePath already exists", async () => {
+    it('createDirectory should succeed if directory in FilePath already exists', async () => {
       const target = path.join(os.tmpdir(), randomString());
       const fp = new FilePath(target);
       let result = await fp.createDirectory();
@@ -413,7 +413,7 @@ describe("FilePath", () => {
       expect(await fp.exists()).is.true;
       await fsPromises.rmdir(target);
     });
-    it("createDirectory should create directory relative to path in FilePath", async () => {
+    it('createDirectory should create directory relative to path in FilePath', async () => {
       const target = randomString();
       const fp = new FilePath(os.tmpdir());
       const result = await fp.createDirectory(target);
@@ -422,7 +422,7 @@ describe("FilePath", () => {
       expect(await FilePath.exists(newPath)).is.true;
       await fsPromises.rmdir(newPath);
     });
-    it("createDirectory should recursively create directories", async () => {
+    it('createDirectory should recursively create directories', async () => {
       const target = path.join(os.tmpdir(), randomString(), randomString());
       const fp = new FilePath(target);
       const result = await fp.createDirectory();
@@ -430,36 +430,36 @@ describe("FilePath", () => {
       expect(await fp.exists()).is.true;
       await fsPromises.rmdir(target);
     });
-    it("createDirectory should recursively create directories relative to path in FilePath", async () => {
+    it('createDirectory should recursively create directories relative to path in FilePath', async () => {
       const firstLevel = randomString();
       const extraFolder = randomString();
       const target = path.join(os.tmpdir(), firstLevel, randomString());
       const fp = new FilePath(target);
       const result = await fp.createDirectory(extraFolder);
       expect(!!result).is.false;
-      let newPath = path.join(target, extraFolder);
+      const newPath = path.join(target, extraFolder);
       expect(await FilePath.exists(newPath)).is.true;
       await fsPromises.rmdir(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
-    it("createDirectory should fail when it cannot create the directory", async () => {
-      const fp = new FilePath("/foo/bar/crazy");
-      let result = await fp.createDirectory("");
+    it('createDirectory should fail when it cannot create the directory', async () => {
+      const fp = new FilePath('/foo/bar/crazy');
+      let result = await fp.createDirectory('');
       expect(!!result).is.true;
-      result = await fp.createDirectory("stuff");
+      result = await fp.createDirectory('stuff');
       expect(!!result).is.true;
     });
-    it("createDirectory should ignore base when given an absolute path", async () => {
-      const fp = new FilePath("/foo/bar/crazy");
+    it('createDirectory should ignore base when given an absolute path', async () => {
+      const fp = new FilePath('/foo/bar/crazy');
       const target = path.join(os.tmpdir(), randomString());
-      let result = await fp.createDirectory(target);
+      const result = await fp.createDirectory(target);
       expect(!!result).is.false;
       expect(await FilePath.exists(target));
       await fsPromises.rmdir(target);
     });
   });
 
-  describe("Manipulate current working directory", () => {
-    it("makeCurrentPath should change cwd to existing folder", () => {
+  describe('Manipulate current working directory', () => {
+    it('makeCurrentPath should change cwd to existing folder', () => {
       const cwd = new FilePath(process.cwd());
       const newFolder = path.join(os.tmpdir(), randomString());
       fs.mkdirSync(newFolder);
@@ -470,7 +470,7 @@ describe("FilePath", () => {
       process.chdir(cwd.getAbsolutePath());
       fs.rmdirSync(newFolder);
     });
-    it("makeCurrentPath with false autocreate flag should fail to change cwd to non-existent folder", () => {
+    it('makeCurrentPath with false autocreate flag should fail to change cwd to non-existent folder', () => {
       const cwd = process.cwd();
       const newFolder = path.join(os.tmpdir(), randomString());
       const f1 = new FilePath(newFolder);
@@ -479,7 +479,7 @@ describe("FilePath", () => {
       expect(!!result).is.true;
       expect(process.cwd()).equals(cwd);
     });
-    it("makeCurrentPath with autocreate should create and change cwd to non-existent folder", () => {
+    it('makeCurrentPath with autocreate should create and change cwd to non-existent folder', () => {
       const newFolder = path.join(os.tmpdir(), randomString());
       const f1 = new FilePath(newFolder);
       expect(fs.existsSync(newFolder)).is.false;
@@ -490,71 +490,71 @@ describe("FilePath", () => {
     });
   });
 
-  describe("Path resolutions", () => {
-    it("resolveAliasedPath should return home if empty path provided", () => {
+  describe('Path resolutions', () => {
+    it('resolveAliasedPath should return home if empty path provided', () => {
       const home = User.getUserHomePath();
-      const result = FilePath.resolveAliasedPathSync("", home);
+      const result = FilePath.resolveAliasedPathSync('', home);
       expect(result.getAbsolutePath()).equals(home.getAbsolutePath());
     });
-    it("resolveAliasedPath should resolve '~' as home", () => {
+    it('resolveAliasedPath should resolve \'~\' as home', () => {
       const home = User.getUserHomePath();
-      const result = FilePath.resolveAliasedPathSync("~", home);
+      const result = FilePath.resolveAliasedPathSync('~', home);
       expect(result.getAbsolutePath()).equals(home.getAbsolutePath());
     });
-    it("resolveAliasedPath should replace '~' in path", () => {
-      const start = "~/foo/bar";
+    it('resolveAliasedPath should replace \'~\' in path', () => {
+      const start = '~/foo/bar';
       const result = FilePath.resolveAliasedPathSync(start, User.getUserHomePath());
       const resultStr = result.getAbsolutePath();
       expect(resultStr.length).is.greaterThanOrEqual(start.length);
-      expect(resultStr.charAt(0)).is.not.equals("~");
-      expect(resultStr.lastIndexOf("/foo/bar")).is.greaterThan(-1);
+      expect(resultStr.charAt(0)).is.not.equals('~');
+      expect(resultStr.lastIndexOf('/foo/bar')).is.greaterThan(-1);
     });
-    it("completePath should return absolute path as-is ignoring base", () => {
+    it('completePath should return absolute path as-is ignoring base', () => {
       const f1 = User.getUserHomePath();
-      const result = f1.completePath("/from/the/root");
-      expect(result.getAbsolutePath()).equals("/from/the/root");
+      const result = f1.completePath('/from/the/root');
+      expect(result.getAbsolutePath()).equals('/from/the/root');
     });
-    it("completePath should resolve relative path to cwd when no base", () => {
+    it('completePath should resolve relative path to cwd when no base', () => {
       const f1 = new FilePath();
-      const result = f1.completePath("some/path");
-      expect(result.getAbsolutePath()).equals(path.join(process.cwd(), "some/path"));
+      const result = f1.completePath('some/path');
+      expect(result.getAbsolutePath()).equals(path.join(process.cwd(), 'some/path'));
     });
-    it("completeChildPath should return same path when no child provided", () => {
-      const aPath = new FilePath("/path/to/a");
-      const result = aPath.completeChildPath("");
+    it('completeChildPath should return same path when no child provided', () => {
+      const aPath = new FilePath('/path/to/a');
+      const result = aPath.completeChildPath('');
       expect(result.equals(aPath)).is.true;
     });
-    it("completeChildPath should correct handle a simple request", () => {
-      const aPath = new FilePath("/path/to/a");
-      const bPath = new FilePath("/path/to/a/b");
-      const result = aPath.completeChildPath("b");
+    it('completeChildPath should correct handle a simple request', () => {
+      const aPath = new FilePath('/path/to/a');
+      const bPath = new FilePath('/path/to/a/b');
+      const result = aPath.completeChildPath('b');
       expect(result.equals(bPath)).is.true;
     });
-    it("completeChildPath should not complete a path outside and instead return original path", () => {
-      const cPath = new FilePath("/path/to/foo");
-      expect(cPath.completeChildPath("../bar").equals(cPath)).is.true;
-      expect(cPath.completeChildPath("/path/to/quux").equals(cPath));
+    it('completeChildPath should not complete a path outside and instead return original path', () => {
+      const cPath = new FilePath('/path/to/foo');
+      expect(cPath.completeChildPath('../bar').equals(cPath)).is.true;
+      expect(cPath.completeChildPath('/path/to/quux').equals(cPath));
     });
   });
-  describe("Static helpers", () => {
-    it("toString should return the string", () => {
-      expect(FilePath.toString("hello world")).equals("hello world");
+  describe('Static helpers', () => {
+    it('toString should return the string', () => {
+      expect(FilePath.toString('hello world')).equals('hello world');
     });
   });
-  describe("NYI placeholders", () => {
-    it("sync methods should throw exception", () => {
+  describe('NYI placeholders', () => {
+    it('sync methods should throw exception', () => {
       const fp1 = new FilePath();
       const fp2 = new FilePath();
       expect(() => FilePath.createAliasedPath(fp1, fp2)).to.throw();
       expect(() => FilePath.isEqualCaseInsensitive(fp1, fp2)).to.throw();
-      expect(() => FilePath.isRootPath("/")).to.throw();
-      expect(() =>FilePath.makeCurrent("/")).to.throw();
+      expect(() => FilePath.isRootPath('/')).to.throw();
+      expect(() =>FilePath.makeCurrent('/')).to.throw();
       expect(() => FilePath.tempFilePath()).to.throw();
-      expect(() => FilePath.uniqueFilePath("/")).to.throw();
+      expect(() => FilePath.uniqueFilePath('/')).to.throw();
       if (process.platform === 'win32') {
-        expect(fp1.changeFileMode("")).is.false;
+        expect(fp1.changeFileMode('')).is.false;
       } else {
-        expect(() => fp1.changeFileMode("")).to.throw();
+        expect(() => fp1.changeFileMode('')).to.throw();
       }
       expect(() => fp1.copy(fp2)).to.throw();
       expect(() => fp1.copyDirectoryRecursive(fp2)).to.throw();
@@ -569,8 +569,8 @@ describe("FilePath", () => {
       expect(() => fp1.getSize()).to.throw();
       expect(() => fp1.getSizeRecursive()).to.throw();
       expect(() => fp1.getStem()).to.throw();
-      expect(() => fp1.hasExtension(".txt")).to.throw();
-      expect(() => fp1.hasExtensionLowerCase(".txt")).to.throw();
+      expect(() => fp1.hasExtension('.txt')).to.throw();
+      expect(() => fp1.hasExtensionLowerCase('.txt')).to.throw();
       expect(() => fp1.hasTextMimeType()).to.throw();
       expect(() => fp1.isDirectory()).to.throw();
       expect(() => fp1.isEquivalentTo(fp2)).to.throw();

--- a/src/node/desktop/test/core/log.spec.ts
+++ b/src/node/desktop/test/core/log.spec.ts
@@ -13,18 +13,18 @@
  *
  */
 
-import { describe } from "mocha";
-import { expect } from "chai";
+import { describe } from 'mocha';
+import { expect } from 'chai';
 
 import fs from 'fs';
 
 import { FileLogOptions } from '../../src/core/log';
 
-describe("Log", () => {
-  describe("Constructions", () => {
-    it("FileLogOptions construction works", () => {
-      const flo = new FileLogOptions("/somewhere");
-      expect(flo.directory).to.equal("/somewhere");
+describe('Log', () => {
+  describe('Constructions', () => {
+    it('FileLogOptions construction works', () => {
+      const flo = new FileLogOptions('/somewhere');
+      expect(flo.directory).to.equal('/somewhere');
     });
   });
 });

--- a/src/node/desktop/test/core/system.spec.ts
+++ b/src/node/desktop/test/core/system.spec.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import { describe } from "mocha";
-import { expect } from "chai";
+import { describe } from 'mocha';
+import { expect } from 'chai';
 
 import fs from 'fs';
 import os from 'os';
@@ -23,21 +23,21 @@ import { FilePath } from '../../src/core/file-path';
 import { initHook, initializeLog, userHomePath, username } from '../../src/core/system';
 import * as log from '../../src/core/log';
 
-describe("System", () => {
-  describe("User info", () => {
-    it("getUserHomePath returns a valid path", () => {
+describe('System', () => {
+  describe('User info', () => {
+    it('getUserHomePath returns a valid path', () => {
       expect(fs.existsSync(userHomePath().getAbsolutePath())).is.true;
     });
-    it("username returns a non-empty string", () => {
+    it('username returns a non-empty string', () => {
       expect(username().length).is.greaterThan(0);
     });
   });
-  describe("Assorted helper functions", () => {
-    it("initHook does something", () => {
+  describe('Assorted helper functions', () => {
+    it('initHook does something', () => {
       initHook();
       // TODO: once this does something, test it!
     });
-    it("initializeLog succeeds", () => {
+    it('initializeLog succeeds', () => {
       const err = initializeLog('rdesktop', log.LogLevel.WARN, new FilePath(os.tmpdir()));
       expect(!!err).is.false;
     });

--- a/src/node/desktop/test/core/user.spec.ts
+++ b/src/node/desktop/test/core/user.spec.ts
@@ -13,16 +13,16 @@
  *
  */
 
-import { describe } from "mocha";
-import { expect } from "chai";
+import { describe } from 'mocha';
+import { expect } from 'chai';
 
 import fs from 'fs';
 
 import { User } from '../../src/core/user';
 
-describe("User", () => {
-  describe("Static helpers", () => {
-    it("getUserHomePath returns a valid path", () => {
+describe('User', () => {
+  describe('Static helpers', () => {
+    it('getUserHomePath returns a valid path', () => {
       const path = User.getUserHomePath();
       expect(fs.existsSync(path.getAbsolutePath())).is.true;
     });

--- a/src/node/desktop/test/core/xdg.spec.ts
+++ b/src/node/desktop/test/core/xdg.spec.ts
@@ -37,7 +37,7 @@ function randomString() {
 
 describe('Xdg', () => {
   // store env values at start of each test so we can restore them
-  let xdgVars: Record<string, string> = {
+  const xdgVars: Record<string, string> = {
     RSTUDIO_CONFIG_HOME: '',
     RSTUDIO_CONFIG_DIR: '',
     RSTUDIO_DATA_HOME: '',
@@ -50,7 +50,7 @@ describe('Xdg', () => {
 
   // save and clear any XDG-related env vars
   beforeEach(() => {
-    for (let name in xdgVars) {
+    for (const name in xdgVars) {
       xdgVars[name] = process.env[name] ?? '';
       delete process.env[name];
     }
@@ -58,7 +58,7 @@ describe('Xdg', () => {
 
   // put back the original XDG env vars
   afterEach(() => {
-    for (let name in xdgVars) {
+    for (const name in xdgVars) {
       if (xdgVars[name]) {
         process.env[name] = xdgVars[name];
         xdgVars[name] = '';
@@ -149,8 +149,8 @@ describe('Xdg', () => {
       if (process.platform === 'win32') return; // not supported on Windows
 
       // path must end with 'rstudio' and exist to be returned
-      let baseDir = path.join(os.tmpdir(), randomString());
-      let fullDir = path.join(baseDir, 'rstudio');
+      const baseDir = path.join(os.tmpdir(), randomString());
+      const fullDir = path.join(baseDir, 'rstudio');
       fs.mkdirSync(fullDir, { recursive: true });
       expect(fs.existsSync(fullDir)).is.true;
       const p = `/once/upon/a/time:${baseDir}:/something/else/rstudio`;
@@ -173,20 +173,20 @@ describe('Xdg', () => {
       expect(result.getAbsolutePath().endsWith('fake-config-file.foo')).is.true;
     });
   });
-  describe("Misc helpers", () => {
-    it("SHGetKnownFolderPath returns a string", () => {
+  describe('Misc helpers', () => {
+    it('SHGetKnownFolderPath returns a string', () => {
       if (process.platform === 'win32') {
         // TODO, actually check results?
       } else {
-        let result = SHGetKnownFolderPath(WinFolderID.FOLDERID_LocalAppData);
+        const result = SHGetKnownFolderPath(WinFolderID.FOLDERID_LocalAppData);
         expect(result).equals('');
       }
     });
   });
-  describe("NYI placeholders", () => {
-    it("sync methods should throw exception", () => {
+  describe('NYI placeholders', () => {
+    it('sync methods should throw exception', () => {
       expect(() => Xdg.verifyUserDirs()).to.throw();
-      expect(() => Xdg.forwardXdgEnvVars({"FOO": "bar"})).to.throw();
+      expect(() => Xdg.forwardXdgEnvVars({'FOO': 'bar'})).to.throw();
     });
   });
- });
+});

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -310,6 +310,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
 
+"@types/json5@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
+  integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
 "@types/mocha@^8.2.2":
   version "8.2.2"
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.2.tgz#91daa226eb8c2ff261e6a8cbf8c7304641e095e0"
@@ -504,10 +509,30 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-includes@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.3.tgz#c7f619b382ad2afaf5326cddfdc0afc61af7690a"
+  integrity sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
+    get-intrinsic "^1.1.1"
+    is-string "^1.0.5"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array.prototype.flat@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz#6ef638b43312bd401b4c6199fdec7e2dc9e9a123"
+  integrity sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.1"
 
 assertion-error@^1.1.0:
   version "1.1.0"
@@ -602,6 +627,14 @@ caching-transform@^4.0.0:
     make-dir "^3.0.0"
     package-hash "^4.0.0"
     write-file-atomic "^3.0.0"
+
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -767,9 +800,9 @@ convert-source-map@^1.7.0:
     safe-buffer "~5.1.1"
 
 core-js@^3.6.5:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.13.0.tgz#58ca436bf01d6903aee3d364089868d0d89fe58d"
-  integrity sha512-iWDbiyha1M5vFwPFmQnvRv+tJzGbFAm6XimJUT0NgHYW3xZEs1SkCAcasWSVFxpI2Xb/V1DDJckq3v90+bQnog==
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.13.1.tgz#30303fabd53638892062d8b4e802cac7599e9fb7"
+  integrity sha512-JqveUc4igkqwStL2RTRn/EPFGBOfEZHxJl/8ej1mXJR75V3go2mFF4bmUYkEIT1rveHKnkUlcJX/c+f1TyIovQ==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -803,6 +836,13 @@ debug@^2.6.9:
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
   dependencies:
     ms "2.0.0"
+
+debug@^3.2.7:
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.7.tgz#72580b7e9145fb39b6676f9c5e5fb100b934179a"
+  integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+  dependencies:
+    ms "^2.1.1"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -874,6 +914,13 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
+doctrine@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"
+  integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
+  dependencies:
+    esutils "^2.0.2"
+
 doctrine@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
@@ -900,9 +947,9 @@ electron-mocha@^10.0.0:
     yargs "^16.1.1"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.741"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.741.tgz#dc1024b19b31e27fb2c8c0a1f120cb05fc6ca695"
-  integrity sha512-4i3T0cwnHo1O4Mnp9JniEco8bZiXoqbm3PhW5hv7uu8YLg35iajYrRnNyKFaN8/8SSTskU2hYqVTeYVPceSpUA==
+  version "1.3.742"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.742.tgz#7223215acbbd3a5284962ebcb6df85d88b95f200"
+  integrity sha512-ihL14knI9FikJmH2XUIDdZFWJxvr14rPSdOhJ7PpS27xbz8qmaRwCwyg/bmFwjWKmWK9QyamiCZVCvXm5CH//Q==
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -949,6 +996,44 @@ env-paths@^2.2.0:
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-2.2.1.tgz#420399d416ce1fbe9bc0a07c62fa68d67fd0f8f2"
   integrity sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==
 
+error-ex@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.2.tgz#b4ac40648107fdcdcfae242f428bea8a14d4f1bf"
+  integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+  dependencies:
+    is-arrayish "^0.2.1"
+
+es-abstract@^1.18.0-next.1, es-abstract@^1.18.0-next.2, es-abstract@^1.18.2:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.3.tgz#25c4c3380a27aa203c44b2b685bba94da31b63e0"
+  integrity sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==
+  dependencies:
+    call-bind "^1.0.2"
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.3"
+    is-string "^1.0.6"
+    object-inspect "^1.10.3"
+    object-keys "^1.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
+
+es-to-primitive@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
+  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+  dependencies:
+    is-callable "^1.1.4"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.2"
+
 es6-error@^4.0.1, es6-error@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/es6-error/-/es6-error-4.1.1.tgz#9e3af407459deed47e9a91f9b885a84eb05c561d"
@@ -968,6 +1053,73 @@ escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
+eslint-config-standard@^16.0.3:
+  version "16.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz#6c8761e544e96c531ff92642eeb87842b8488516"
+  integrity sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==
+
+eslint-import-resolver-node@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz#85ffa81942c25012d8231096ddf679c03042c717"
+  integrity sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
+eslint-module-utils@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz#b51be1e473dd0de1c5ea638e22429c2490ea8233"
+  integrity sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==
+  dependencies:
+    debug "^3.2.7"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-es@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz#75a7cdfdccddc0589934aeeb384175f221c57893"
+  integrity sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-import@^2.23.3:
+  version "2.23.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz#8a1b073289fff03c4af0f04b6df956b7d463e191"
+  integrity sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==
+  dependencies:
+    array-includes "^3.1.3"
+    array.prototype.flat "^1.2.4"
+    debug "^2.6.9"
+    doctrine "^2.1.0"
+    eslint-import-resolver-node "^0.3.4"
+    eslint-module-utils "^2.6.1"
+    find-up "^2.0.0"
+    has "^1.0.3"
+    is-core-module "^2.4.0"
+    minimatch "^3.0.4"
+    object.values "^1.1.3"
+    pkg-up "^2.0.0"
+    read-pkg-up "^3.0.0"
+    resolve "^1.20.0"
+    tsconfig-paths "^3.9.0"
+
+eslint-plugin-node@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.1.0.tgz#c95544416ee4ada26740a30474eefc5402dc671d"
+  integrity sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
+eslint-plugin-promise@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz#fb2188fb734e4557993733b41aa1a688f46c6f24"
+  integrity sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==
 
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
@@ -1164,6 +1316,13 @@ find-up@5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -1232,6 +1391,11 @@ fsevents@~2.3.1:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
+function-bind@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
+  integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
@@ -1251,6 +1415,15 @@ get-func-name@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-package-type@^0.1.0:
   version "0.1.0"
@@ -1380,7 +1553,7 @@ got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
@@ -1389,6 +1562,11 @@ growl@1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
+
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1399,6 +1577,18 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.3.tgz#722d7cbfc1f6aa8241f16dd814e011e1f41e8796"
+  integrity sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+  dependencies:
+    function-bind "^1.1.1"
 
 hasha@^5.0.0:
   version "5.2.2"
@@ -1412,6 +1602,11 @@ he@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
+hosted-git-info@^2.1.4:
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 html-escaper@^2.0.0:
   version "2.0.2"
@@ -1428,7 +1623,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.4:
+ignore@^5.1.1, ignore@^5.1.4:
   version "5.1.8"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
@@ -1469,12 +1664,46 @@ ini@^1.3.4:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
+is-arrayish@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+  integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-bigint@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
+  integrity sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==
+
 is-binary-path@~2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
   integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
   dependencies:
     binary-extensions "^2.0.0"
+
+is-boolean-object@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.1.tgz#3c0878f035cb821228d350d2e1e36719716a3de8"
+  integrity sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==
+  dependencies:
+    call-bind "^1.0.2"
+
+is-callable@^1.1.4, is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
+
+is-core-module@^2.2.0, is-core-module@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
+  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
+  dependencies:
+    has "^1.0.3"
+
+is-date-object@^1.0.1:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
+  integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
 
 is-electron-renderer@^2.0.0:
   version "2.0.1"
@@ -1503,6 +1732,16 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.5.tgz#6edfaeed7950cff19afedce9fbfca9ee6dd289eb"
+  integrity sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==
+
 is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
@@ -1513,10 +1752,30 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-regex@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
+  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
+  dependencies:
+    call-bind "^1.0.2"
+    has-symbols "^1.0.2"
+
 is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
+is-string@^1.0.5, is-string@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
+  integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
+  dependencies:
+    has-symbols "^1.0.2"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -1634,6 +1893,11 @@ json-buffer@3.0.0:
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
 
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
+  integrity sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -1653,6 +1917,13 @@ json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
+json5@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
+  dependencies:
+    minimist "^1.2.0"
 
 json5@^2.1.2:
   version "2.2.0"
@@ -1691,6 +1962,24 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+load-json-file@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-4.0.0.tgz#2f5f45ab91e33216234fd53adab668eb4ec0993b"
+  integrity sha1-L19Fq5HjMhYjT9U62rZo607AmTs=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^4.0.0"
+    pify "^3.0.0"
+    strip-bom "^3.0.0"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -1807,7 +2096,7 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -1860,7 +2149,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@2.1.3:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
@@ -1886,6 +2175,16 @@ node-releases@^1.1.71:
   version "1.1.72"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.72.tgz#14802ab6b1039a79a0c7d662b610a5bbd76eacbe"
   integrity sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==
+
+normalize-package-data@^2.3.2:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
+  integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+  dependencies:
+    hosted-git-info "^2.1.4"
+    resolve "^1.10.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1938,10 +2237,34 @@ nyc@^15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-object-keys@^1.0.12:
+object-inspect@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
+  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
+
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+  dependencies:
+    call-bind "^1.0.0"
+    define-properties "^1.1.3"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.values@^1.1.3:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.1.4.tgz#0d273762833e816b693a637d30073e7051535b30"
+  integrity sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.2"
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"
@@ -1967,6 +2290,13 @@ p-cancelable@^1.0.0:
   resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-1.1.0.tgz#d078d15a3af409220c886f1d9a0ca2e441ab26cc"
   integrity sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -1980,6 +2310,13 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -2001,6 +2338,11 @@ p-map@^3.0.0:
   integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
   dependencies:
     aggregate-error "^3.0.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -2024,6 +2366,19 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-json@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-4.0.0.tgz#be35f5425be1f7f6c747184f98a788cb99477ee0"
+  integrity sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+  dependencies:
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -2038,6 +2393,18 @@ path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-parse@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -2064,12 +2431,26 @@ pify@^3.0.0:
   resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
   integrity sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
 
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
+
 pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
+  integrity sha1-yBmscoBZpGHKscOImivjxJoATX8=
+  dependencies:
+    find-up "^2.1.0"
 
 prelude-ls@^1.2.1:
   version "1.2.1"
@@ -2128,6 +2509,23 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
+read-pkg-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-3.0.0.tgz#3ed496685dba0f8fe118d0691dc51f4a1ff96f07"
+  integrity sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^3.0.0"
+
+read-pkg@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
+  integrity sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=
+  dependencies:
+    load-json-file "^4.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^3.0.0"
+
 readable-stream@^2.2.2:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
@@ -2185,6 +2583,14 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.20.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+  dependencies:
+    is-core-module "^2.2.0"
+    path-parse "^1.0.6"
+
 responselike@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
@@ -2238,7 +2644,12 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+"semver@2 || 3 || 4 || 5":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+
+semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -2330,6 +2741,32 @@ spawn-wrap@^2.0.0:
     signal-exit "^3.0.2"
     which "^2.0.1"
 
+spdx-correct@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
+  integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
+  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz#8a595135def9592bda69709474f1cbeea7c2467f"
+  integrity sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==
+
 sprintf-js@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
@@ -2357,6 +2794,22 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -2377,6 +2830,11 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
 strip-bom@^4.0.0:
   version "4.0.0"
@@ -2475,6 +2933,16 @@ ts-node@^10.0.0:
     source-map-support "^0.5.17"
     yn "3.1.1"
 
+tsconfig-paths@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz#098547a6c4448807e8fcb8eae081064ee9a3c90b"
+  integrity sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==
+  dependencies:
+    "@types/json5" "^0.0.29"
+    json5 "^1.0.1"
+    minimist "^1.2.0"
+    strip-bom "^3.0.0"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
@@ -2531,10 +2999,20 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.2.4:
+typescript@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
   integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -2574,6 +3052,25 @@ v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
+
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
 
 which-module@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Intent

We should leverage tooling to enforce some basic styles and best practices in our TypeScript.

### Approach

#### Configured ESLint
- install [ESLint](https://eslint.org/) and related packages (via `yarn add`)
- create config for typescript by running `eslint --init` and answering questions
- tweak to match our target environment (node 14, which translates to es2020 / ecmaVersion11)
- set to indentation of two spaces
- pick single quotes as our preferred syntax for string literals, this seems most common in other TypeScript projects such as vscode; note can still use double quotes if string contains single quote(s)
- beyond those tweaks, we're using the "eslint:recommended" settings for TypeScript as our starting point; I'm sure we'll find something we agree to tweak as we write more code, but let's start here and see how close we can stick to it

#### Use ESLint
- you can run `yarn lint` to get a list of errors and warnings, but...
- more usefully, use the ESLint VSCode plugin, configure ESLint as the "Editor Default Formatter" to prevent battles with other formatters
- you can configure VSCode to format on save and paste, if you'd like, or when you see them in the editor; use "ESLint fix all auto-fixable problems" to fix everything in a file, or editor popup for same, etc.

#### Other tweaks
- let ESLint fix all errors it found in source files; left warnings alone for now, those are almost all to do with unused parameters due to stubbed code that will either get unstubbed or go away)
- created `.npmrc` to prevent creation of `npm` lock files if somebody (or some tool, such as `eslint --init`) runs `npm` to install packages (we're using yarn)
- delete `.prettierrc` (config for another formatter I had played with); let's try and just use ESLint (though you can configure them to cooperate if we find a reason to do do: https://prettier.io/docs/en/integrating-with-linters.html

### Automated Tests

No new code, all tests still pass.

### QA Notes

Purely dev-side tooling to establish source code formatting rules, and best-practices.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


