### PR TITLE
add NOTICE.electron to track new components added for Electron desktop

### DIFF
--- a/src/node/desktop/NOTICE.electron
+++ b/src/node/desktop/NOTICE.electron
@@ -1,0 +1,34 @@
+Open source software components used by the Electron-based desktop 
+are listed here. Once we determine which RStudio release will 
+replace Qt with Electron, we will merge this list with the NOTICE
+at root of the repo.
+
+RStudio includes other open source software components. The following
+is a list of these components (full copies of the license agreements
+used by these components are included below):
+
+- Electron
+
+Electron License
+----------------------------------------------------------------------
+Copyright (c) Electron contributors
+Copyright (c) 2013-2020 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
### Intent

Electron desktop project incorporates new components requiring attribution in NOTICE. Until we decide which RStudio release will make the switchover from Qt to Electron, this is being tracked in `rstudio/src/node/desktop/NOTICE.electron`; once we have made the decision, it should be merged into `rstudio/NOTICE` then deleted (tracked by #9429)

### Approach

Created Electron-specific NOTICE file.

### Automated Tests

None

### QA Notes

Nothing to test here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


