### PR TITLE
execute shared_core unit tests on Windows via rstudio-tests.bat

### DIFF
--- a/src/cpp/rstudio-tests.bat.in
+++ b/src/cpp/rstudio-tests.bat.in
@@ -4,6 +4,9 @@ set "PATH=@LIBR_BIN_DIR@;%PATH%"
 echo Running 'core' tests...
 "@CMAKE_CURRENT_BINARY_DIR@/core/rstudio-core-tests.exe"
 
+echo Running 'shared_core' tests...
+"@CMAKE_CURRENT_BINARY_DIR@/shared_core/rstudio-shared-core-tests.exe"
+
 echo Running 'rsession' tests...
 set "RS_CRASH_HANDLER_PATH=@CMAKE_SOURCE_DIR@/../../dependencies/windows/crashpad-release/bin/crashpad_handler.com"
 "@CMAKE_CURRENT_BINARY_DIR@/session/rsession.exe" ^


### PR DESCRIPTION
### Intent

Unit-test running script on Windows isn't running the `shared_core` tests; these are run for Linux and Mac.

### Approach

Add this to the script.

### Automated Tests

Existing unit tests for `shared_core` will now run on Windows during builds, and on Windows dev machines via `rstudio-tests.bat`

### QA Notes

No code change, just running existing unit tests on Windows.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


