### PR TITLE
Fix electron unit tests on Windows

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -20,10 +20,6 @@ module.exports = {
       "error",
       2
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
-    ],
     "quotes": [
       "error",
       "single"

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -33,7 +33,8 @@
     "lint": "eslint ./src",
     "start": "yarn run build && electron ./dist/main/app.js",
     "show-version": "yarn run build && electron ./dist/main/app.js --version-json",
-    "test": "nyc electron-mocha -c",
+    "test": "electron-mocha -c",
+    "testcover": "nyc electron-mocha -c",
     "testwip": "electron-mocha -c -g WIP"
   }
 }

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -33,6 +33,7 @@
     "lint": "eslint ./src",
     "start": "yarn run build && electron ./dist/main/app.js",
     "show-version": "yarn run build && electron ./dist/main/app.js --version-json",
-    "test": "MOCHA_COLORS=1 nyc electron-mocha"
+    "test": "nyc electron-mocha -c",
+    "testwip": "electron-mocha -c -g WIP"
   }
 }

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -36,14 +36,14 @@ export class FilePath {
   static homePathLeafAlias = '~';
 
   constructor(path = '') {
-    this.path = FilePath.fromString(path);
+    this.path = path;
   }
 
   /**
    * Get string representation of object, for debugging purposes
    */
   toString(): string {
-    return this.path;
+    return this.getAbsolutePath();
   }
 
   /**
@@ -51,7 +51,7 @@ export class FilePath {
    * path (exact match).
    */
   equals(filePath: FilePath): boolean {
-    return this.path == filePath.path;
+    return FilePath.boost_fs_path2str(this.path) == FilePath.boost_fs_path2str(filePath.path);
   }
 
   /**
@@ -69,7 +69,7 @@ export class FilePath {
       return false;
     }
 
-    const p = FilePath.fromString(filePath);
+    const p = filePath;
     try {
       return fs.existsSync(p);
     } catch (err) {
@@ -86,7 +86,7 @@ export class FilePath {
       return false;
     }
 
-    const p = FilePath.fromString(filePath);
+    const p = filePath;
     try {
       await fsPromises.access(p);
       return true;
@@ -255,7 +255,7 @@ export class FilePath {
       }
 
       // confirm this is a relative path
-      const relativePath = FilePath.fromString(filePath);
+      const relativePath = filePath;
       if (path.isAbsolute(relativePath)) {
         throw Error('absolute path not permitted');
       }
@@ -278,7 +278,7 @@ export class FilePath {
    */
   completePath(filePath: string): FilePath {
     try {
-      return new FilePath(FilePath.fs_path2str(FilePath.fs_complete(filePath, this.path)));
+      return new FilePath(FilePath.boost_fs_path2str(FilePath.fs_complete(filePath, this.path)));
     } catch (err) {
       FilePath.logError(err);
       return this;
@@ -396,15 +396,15 @@ export class FilePath {
   /**
    * Gets the full absolute representation of this file path.
    */
-  getAbsolutePath() {
-    return FilePath.fs_path2str(this.path);
+  getAbsolutePath(): string {
+    return FilePath.boost_fs_path2str(this.path);
   }
 
   /**
    * Gets the full absolute representation of this file path in native format.
    */
   getAbsolutePathNative(): string {
-    throw Error('getAbsolutePathNative is NYI');
+    return FilePath.boost_fs_path2strnative(this.path);
   }
 
   /**
@@ -417,7 +417,7 @@ export class FilePath {
     }
 
     try {
-      return FilePath.fs_path2str(fs.realpathSync(this.path));
+      return FilePath.boost_fs_path2str(fs.realpathSync(this.path));
     }
     catch (err) {
       FilePath.logErrorWithPath(this.path, err);
@@ -435,7 +435,7 @@ export class FilePath {
     }
 
     try {
-      return FilePath.fs_path2str(await fsPromises.realpath(this.path));
+      return FilePath.boost_fs_path2str(await fsPromises.realpath(this.path));
     }
     catch (err) {
       FilePath.logErrorWithPath(this.path, err);
@@ -520,7 +520,7 @@ export class FilePath {
    * components resolved and/or removed.
    */
   getLexicallyNormalPath() {
-    return FilePath.fs_path2str(path.normalize(this.path));
+    return FilePath.boost_fs_path2str(path.normalize(this.path));
   }
 
   /**
@@ -793,24 +793,27 @@ export class FilePath {
     // console.error(error.message);
   }
 
+  /**
+   * Return generic form of stored path (akin to boost's path.generic_string method)
+   */
+  static generic_string(p: string): string {
+    if (process.platform !== 'win32') {
+      return p;
+    } else {
+      return p.split(path.sep).join(path.posix.sep);
+    }
+  }
+
   // Analogous to BOOST_FS_COMPLETE in FilePath.cpp
-  static fs_complete(p: string, base: string) {
+  static fs_complete(p: string, base: string): string {
     return path.resolve(base, p);
   }
 
-  // Analogous to BOOST_FS_PATH2STR
-  static fs_path2str(p: string): string {
-    // TODO do we need this (i.e. on Windows?)
-    return p;
+  static boost_fs_path2str(p: string): string {
+    return FilePath.generic_string(p);
   }
 
-  static fromString(value: string): string {
-    // TODO do we need this (i.e. on Windows?)
-    return value;
-  }
-
-  static toString(value: string): string {
-    // TODO do we need this (i.e. on Windows?)
-    return value;
+  static boost_fs_path2strnative(p: string): string {
+    return FilePath.generic_string(p);
   }
 }

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -519,7 +519,7 @@ export class FilePath {
    * Gets the lexically normal representation of this file path, with . and ..
    * components resolved and/or removed.
    */
-  getLexicallyNormalPath() {
+  getLexicallyNormalPath(): string {
     return FilePath.boost_fs_path2str(path.normalize(this.path));
   }
 
@@ -783,12 +783,12 @@ export class FilePath {
   // Internal helper functions
   // -------------------------
 
-  static logErrorWithPath(path: string, error: Error) {
+  static logErrorWithPath(path: string, error: Error): void {
     // TODO logging
     // console.error(error.message + ": " + path);
   }
 
-  static logError(error: Error) {
+  static logError(error: Error): void {
     // TODO logging
     // console.error(error.message);
   }

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -15,6 +15,7 @@
 
 import fs from 'fs';
 import fsPromises from 'fs/promises';
+import { platform } from 'os';
 
 import path from 'path';
 import { Err, Success } from './err';
@@ -814,6 +815,10 @@ export class FilePath {
   }
 
   static boost_fs_path2strnative(p: string): string {
-    return FilePath.generic_string(p);
+    if (process.platform === 'win32') {
+      return p;
+    } else {
+      return FilePath.generic_string(p);
+    }
   }
 }

--- a/src/node/desktop/src/core/system.ts
+++ b/src/node/desktop/src/core/system.ts
@@ -19,7 +19,7 @@ import { Err, Success } from './err';
 import { User } from './user';
 import { FilePath } from './file-path';
 
-export function initHook() {
+export function initHook(): void {
   if (process.platform !== 'win32' ) {
     return;
   }
@@ -33,7 +33,7 @@ export const s_programIdentity = '';
 // logging options representing the latest state of the logging configuration file
 // export let s_logOptions: LogOptions;
 
-function initLog() {
+function initLog(): Err {
   // requires prior synchronization
 
   // Error error = s_logOptions.read();
@@ -68,11 +68,11 @@ export function initializeLog(
   return Success();
 }
 
-export function username() {
+export function username(): string {
   const userVar = process.platform === 'win32' ? 'USERNAME' : 'USER';
   return getenv(userVar);
 }
 
-export function userHomePath() {
+export function userHomePath(): FilePath {
   return User.getUserHomePath();
 }

--- a/src/node/desktop/src/core/xdg.ts
+++ b/src/node/desktop/src/core/xdg.ts
@@ -33,7 +33,7 @@
  */
 
 import os from 'os';
-import { Environment, expandEnvVars, getenv, setenv } from './environment';
+import { Environment, expandEnvVars, getenv } from './environment';
 import { username, userHomePath } from './system';
 import { FilePath } from './file-path';
 
@@ -141,7 +141,7 @@ function resolveXdgDir(
     'HOME': homeDir ? homeDir.getAbsolutePath() : userHomePath().getAbsolutePath(),
     'USER': user ? user : username()
   };
-
+  
   // check for manually specified hostname in environment variable
   let hostname = getenv('HOSTNAME');
 
@@ -173,7 +173,7 @@ export class Xdg {
    * On Unix-alikes, this is `~/.config/rstudio`, or `XDG_CONFIG_HOME`.
    * On Windows, this is `FOLDERID_RoamingAppData` (typically `AppData/Roaming`).
    */
-  static userConfigDir(user?: string, homeDir?: FilePath) {
+  static userConfigDir(user?: string, homeDir?: FilePath): FilePath {
     return resolveXdgDir(
       'RSTUDIO_CONFIG_HOME',
       'XDG_CONFIG_HOME',
@@ -190,7 +190,7 @@ export class Xdg {
    * On Unix-alikes, this is `~/.local/share/rstudio`, or `XDG_DATA_HOME`.
    * On Windows, this is `FOLDERID_LocalAppData` (typically `AppData/Local`).
    */
-  static userDataDir(user?: string, homeDir?: FilePath) {
+  static userDataDir(user?: string, homeDir?: FilePath): FilePath {
     return resolveXdgDir(
       'RSTUDIO_DATA_HOME',
       'XDG_DATA_HOME',
@@ -209,9 +209,11 @@ export class Xdg {
    * session log.
    */
   static verifyUserDirs(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     user?: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     homeDir?: FilePath
-  ) {
+  ): void {
     throw Error('Xdg.verifyUserDirs is NYI');
   }
 
@@ -223,7 +225,6 @@ export class Xdg {
    * On Windows, this is `FOLDERID_ProgramData` (typically `C:/ProgramData`).
    */
   static systemConfigDir(): FilePath {
-    const result = '';
     if (process.platform !== 'win32') {
       if (!getenv('RSTUDIO_CONFIG_DIR')) {
         // On POSIX operating systems, it's possible to specify multiple config
@@ -284,7 +285,8 @@ export class Xdg {
   /**
    * Sets relevant XDG environment variables
    */
-  static forwardXdgEnvVars(pEnvironment: Environment) {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static forwardXdgEnvVars(pEnvironment: Environment): void {
     throw Error('forwardXdgEnvVars is NYI');
   }
 }

--- a/src/node/desktop/src/main/desktop-utils.ts
+++ b/src/node/desktop/src/main/desktop-utils.ts
@@ -15,16 +15,17 @@
 
 import { Xdg } from '../core/xdg';
 import { getenv } from '../core/environment';
+import { FilePath } from '../core/file-path';
 
-export function reattachConsoleIfNecessary() {
+export function reattachConsoleIfNecessary(): void {
   // TODO Windows-only
 }
 
-export function userLogPath() {
+export function userLogPath(): FilePath {
   return Xdg.userDataDir().completeChildPath('log');
 }
 
-export function userWebCachePath() {
+export function userWebCachePath(): FilePath {
   return Xdg.userDataDir().completeChildPath('web-cache');
 }
 
@@ -33,7 +34,7 @@ export function devicePixelRatio(/*QMainWindow * pMainWindow*/): number {
   return 1.0;
 }
 
-export function initializeLang() {
+export function initializeLang(): void {
   if (process.platform !== 'darwin') {
     return;
   }

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -29,7 +29,7 @@ import * as desktop from './desktop-utils';
 
 export default class Main {
 
-  run() {
+  run(): void {
     initHook();
 
     // TODO: how do we know if this is a package build or not?
@@ -653,7 +653,7 @@ export default class Main {
   // Static helper functions
   // -------------------------
 
-  static augmentCommandLineArguments() {
+  static augmentCommandLineArguments(): void {
     const user = getenv('RSTUDIO_CHROMIUM_ARGUMENTS');
     if (!user) {
       return;
@@ -694,7 +694,7 @@ export default class Main {
     return Math.trunc(Math.random() * 2147483647).toString();
   }
 
-  static initializeSharedSecret() {
+  static initializeSharedSecret(): void {
     const sharedSecret = Main.randomString() + Main.randomString() + Main.randomString();
     setenv('RS_SHARED_SECRET', sharedSecret);
   }

--- a/src/node/desktop/test/core/file-path.spec.ts
+++ b/src/node/desktop/test/core/file-path.spec.ts
@@ -68,11 +68,12 @@ describe('FilePath', () => {
       expect(path.getAbsolutePath().length).to.equal(0);
       expect(path.isEmpty());
     });
-    it('getAbsolutePathNative should convert generic path to Windows path', () => {
-      const expectedPath = 'C:\\Windows\\Was\\Here';
-      const fp1 = new FilePath(expectedPath);
+    it('getAbsolutePathNative should return raw path on Windows', () => {
+      const originalPath = 'C:\\Windows\\Was\\Here';
+      const expectedPosix = 'C:/Windows/Was/Here';
+      const fp1 = new FilePath(originalPath);
       const native = fp1.getAbsolutePathNative();
-      expect(native).equals(expectedPath);
+      expect(native).equals(process.platform === 'win32' ? originalPath : expectedPosix);
     });
   });
 

--- a/src/node/desktop/test/core/file-path.spec.ts
+++ b/src/node/desktop/test/core/file-path.spec.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import { describe, utils } from 'mocha';
-import { expect, assert } from 'chai';
+import { describe } from 'mocha';
+import { expect } from 'chai';
 
 import fs from 'fs';
 import fsPromises from 'fs/promises';
@@ -36,7 +36,11 @@ async function realpath(path: string): Promise<string> {
   return fsPromises.realpath(path);
 }
 
+// A path that should never exist
 const bogusPath = '/super/bogus/path/42';
+
+// A path that a non-elevated user cannot create
+const cannotCreatePath = process.platform === 'win32' ? '\\Program Files\\a_test_folder' : '/foo/bar/crazy';
 
 describe('FilePath', () => {
   afterEach(() => {
@@ -189,7 +193,6 @@ describe('FilePath', () => {
     });
     it('safeCurrentPathSync should change to supplied safe path if it exists if cwd doesn\'t exist', () => {
       const origDir = new FilePath(process.cwd());
-
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
@@ -198,13 +201,24 @@ describe('FilePath', () => {
       fs.mkdirSync(testDir);
       process.chdir(testDir);
       testDir = realpathSync(testDir);
-      fs.rmdirSync(testDir);
+      try {
+        fs.rmdirSync(testDir);
+      }
+      catch (error) {
+        // On Windows, trying to remove current-working-directory may fail so can't 
+        // execute rest of this test case; cleanup and exit
+        expect(process.platform === 'win32').is.true;
+        expect(() => process.chdir(origDir.getAbsolutePath())).to.not.throw();
+        expect(() => fs.rmdirSync(testDir)).to.not.throw();
+        return;
+      }
 
       const currentPath = FilePath.safeCurrentPathSync(origDir);
       expect(realpathSync(origDir.getAbsolutePath())).to.equal(realpathSync(process.cwd()));
       expect(realpathSync(currentPath.getAbsolutePath())).to.equal(realpathSync(process.cwd()));
     });
     it('safeCurrentPathSync should change to home folder when both cwd and revert paths don\'t exist', () => {
+      const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
@@ -213,7 +227,17 @@ describe('FilePath', () => {
       fs.mkdirSync(testDir);
       process.chdir(testDir);
       testDir = realpathSync(testDir);
-      fs.rmdirSync(testDir);
+      try {
+        fs.rmdirSync(testDir);
+      }
+      catch (error) {
+        // On Windows, trying to remove current-working-directory may fail so can't 
+        // execute rest of this test case; cleanup and exit
+        expect(process.platform === 'win32').is.true;
+        expect(() => process.chdir(origDir.getAbsolutePath())).to.not.throw();
+        expect(() => fs.rmdirSync(testDir)).to.not.throw();
+        return;
+      }
 
       const currentPath = FilePath.safeCurrentPathSync(new FilePath(bogusPath));
       expect(realpathSync(currentPath.getAbsolutePath())).to.equal(realpathSync(os.homedir()));
@@ -227,7 +251,6 @@ describe('FilePath', () => {
     });
     it('safeCurrentPath should change to supplied safe path if it exists if cwd doesn\'t exist', async () => {
       const origDir = new FilePath(process.cwd());
-
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
@@ -236,13 +259,24 @@ describe('FilePath', () => {
       await fsPromises.mkdir(testDir);
       process.chdir(testDir);
       testDir = await realpath(testDir);
-      await fsPromises.rmdir(testDir);
+      try {
+        await fsPromises.rmdir(testDir);
+      }
+      catch (error) {
+        // On Windows, trying to remove current-working-directory may fail so can't 
+        // execute rest of this test case; cleanup and exit
+        expect(process.platform === 'win32').is.true;
+        expect(() => process.chdir(origDir.getAbsolutePath())).to.not.throw();
+        expect(() => fs.rmdirSync(testDir)).to.not.throw();
+        return;
+      }
 
       const currentPath = await FilePath.safeCurrentPath(origDir);
       expect(await realpath(origDir.getAbsolutePath())).to.equal(await realpath(process.cwd()));
       expect(await realpath(currentPath.getAbsolutePath())).to.equal(await realpath(process.cwd()));
     });
     it('safeCurrentPath should change to home folder when both cwd and revert paths don\'t exist', async () => {
+      const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = path.join(
         os.tmpdir(),
@@ -251,7 +285,17 @@ describe('FilePath', () => {
       await fsPromises.mkdir(testDir);
       process.chdir(testDir);
       testDir = await realpath(testDir);
-      await fsPromises.rmdir(testDir);
+      try {
+        await fsPromises.rmdir(testDir);
+      }
+      catch (error) {
+        // On Windows, trying to remove current-working-directory may fail so can't 
+        // execute rest of this test case; cleanup and exit
+        expect(process.platform === 'win32').is.true;
+        expect(() => process.chdir(origDir.getAbsolutePath())).to.not.throw();
+        expect(() => fs.rmdirSync(testDir)).to.not.throw();
+        return;
+      }
 
       const currentPath = await FilePath.safeCurrentPath(new FilePath(bogusPath));
       expect(await realpath(currentPath.getAbsolutePath())).to.equal(await realpath(os.homedir()));
@@ -348,14 +392,16 @@ describe('FilePath', () => {
       fs.rmdirSync(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
     it('createDirectorySync should fail when it cannot create the directory', () => {
-      const fp = new FilePath('/foo/bar/crazy');
+      const fp = new FilePath(cannotCreatePath);
+      expect(fp.existsSync()).is.false;
       let result = fp.createDirectorySync('');
       expect(!!result).is.true;
       result = fp.createDirectorySync('stuff');
       expect(!!result).is.true;
     });
     it('createDirectorySync should ignore base when given an absolute path', () => {
-      const fp = new FilePath('/foo/bar/crazy');
+      const fp = new FilePath(cannotCreatePath);
+      expect(fp.existsSync()).is.false;
       const target = path.join(os.tmpdir(), randomString());
       const result = fp.createDirectorySync(target);
       expect(!!result).is.false;
@@ -442,14 +488,14 @@ describe('FilePath', () => {
       await fsPromises.rmdir(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
     it('createDirectory should fail when it cannot create the directory', async () => {
-      const fp = new FilePath('/foo/bar/crazy');
+      const fp = new FilePath(cannotCreatePath);
       let result = await fp.createDirectory('');
       expect(!!result).is.true;
       result = await fp.createDirectory('stuff');
       expect(!!result).is.true;
     });
     it('createDirectory should ignore base when given an absolute path', async () => {
-      const fp = new FilePath('/foo/bar/crazy');
+      const fp = new FilePath(cannotCreatePath);
       const target = path.join(os.tmpdir(), randomString());
       const result = await fp.createDirectory(target);
       expect(!!result).is.false;
@@ -480,30 +526,34 @@ describe('FilePath', () => {
       expect(process.cwd()).equals(cwd);
     });
     it('makeCurrentPath with autocreate should create and change cwd to non-existent folder', () => {
+      const origCwd = process.cwd();
       const newFolder = path.join(os.tmpdir(), randomString());
       const f1 = new FilePath(newFolder);
       expect(fs.existsSync(newFolder)).is.false;
       const result = f1.makeCurrentPath(true);
       expect(!!result).is.false;
       expect(realpathSync(process.cwd())).equals(realpathSync(newFolder));
+      process.chdir(origCwd);
       fs.rmdirSync(newFolder);
     });
   });
 
-  describe('Path resolutions', () => {
-    it('resolveAliasedPath should return home if empty path provided', () => {
+  describe('WIP Path resolutions', () => {
+    it('resolveAliasedPathSync should return home if empty path provided', () => {
       const home = User.getUserHomePath();
       const result = FilePath.resolveAliasedPathSync('', home);
       expect(result.getAbsolutePath()).equals(home.getAbsolutePath());
     });
-    it('resolveAliasedPath should resolve \'~\' as home', () => {
+    it('resolveAliasedPathSync should resolve \'~\' as home', () => {
       const home = User.getUserHomePath();
       const result = FilePath.resolveAliasedPathSync('~', home);
       expect(result.getAbsolutePath()).equals(home.getAbsolutePath());
     });
-    it('resolveAliasedPath should replace \'~\' in path', () => {
+    it('resolveAliasedPathSync should replace \'~\' in path', () => {
       const start = '~/foo/bar';
+      console.log(`getUserHomePath returns ${User.getUserHomePath()}`);
       const result = FilePath.resolveAliasedPathSync(start, User.getUserHomePath());
+      console.log(`result is ${result}`);
       const resultStr = result.getAbsolutePath();
       expect(resultStr.length).is.greaterThanOrEqual(start.length);
       expect(resultStr.charAt(0)).is.not.equals('~');
@@ -552,7 +602,7 @@ describe('FilePath', () => {
       expect(() => FilePath.tempFilePath()).to.throw();
       expect(() => FilePath.uniqueFilePath('/')).to.throw();
       if (process.platform === 'win32') {
-        expect(fp1.changeFileMode('')).is.false;
+        expect(fp1.changeFileMode('')).to.not.throw();
       } else {
         expect(() => fp1.changeFileMode('')).to.throw();
       }

--- a/src/node/desktop/test/core/file-path.spec.ts
+++ b/src/node/desktop/test/core/file-path.spec.ts
@@ -70,10 +70,9 @@ describe('FilePath', () => {
     });
     it('getAbsolutePathNative should return raw path on Windows', () => {
       const originalPath = 'C:\\Windows\\Was\\Here';
-      const expectedPosix = 'C:/Windows/Was/Here';
       const fp1 = new FilePath(originalPath);
       const native = fp1.getAbsolutePathNative();
-      expect(native).equals(process.platform === 'win32' ? originalPath : expectedPosix);
+      expect(native).equals(originalPath);
     });
   });
 

--- a/src/node/desktop/test/core/xdg.spec.ts
+++ b/src/node/desktop/test/core/xdg.spec.ts
@@ -35,8 +35,13 @@ function randomString() {
   return Math.trunc(Math.random() * 2147483647).toString();
 }
 
-const onceUponAPath = process.platform === 'win32' ?
-  'C:/once/upon/a/time/rstudio' : '/once/upon/a/time/rstudio';
+function addDrive(path: string): string {
+  if (process.platform === 'win32') {
+    return 'C:' + path;
+  } else {
+    return path;
+  }
+}
 
 describe('Xdg', () => {
   // store env values at start of each test so we can restore them
@@ -78,28 +83,23 @@ describe('Xdg', () => {
       expect(result.getAbsolutePath().length).is.greaterThan(folder().length);
     });
     it('userConfigDir returns path set with RSTUDIO_CONFIG_HOME', () => {
-      const p = onceUponAPath;
+      const p = addDrive('/once/upon/a/time/rstudio');
       process.env.RSTUDIO_CONFIG_HOME = p;
       const result = Xdg.userConfigDir();
       expect(result.getAbsolutePath()).equals(p);
     });
     it('userConfigDir returns path set with XDG_CONFIG_HOME', () => {
-      const p = onceUponAPath;
+      const p = addDrive('/once/upon/a/time/rstudio');
       process.env.XDG_CONFIG_HOME = p;
       const result = Xdg.userConfigDir();
       expect(result.getAbsolutePath().startsWith(p)).is.true;
       expect(hasExpectedEnding(result)).is.true;
     });
-    it('WIP userConfigDir expands placeholders', () => {
-      let p = '${HOME}/a/$USER/stuff';
+    it('userConfigDir expands placeholders', () => {
+      const p = '${HOME}/a/$USER/stuff';
       const user = 'fred';
-      let home = '/somewhere/nifty';
-      let expected = '/somewhere/nifty/a/fred/stuff';
-      if (process.platform === 'win32') {
-        p = 'C:' + p;
-        home = 'C:' + home;
-        expected = 'C:' + expected;
-      }
+      const home = addDrive('/somewhere/nifty');
+      const expected = addDrive('/somewhere/nifty/a/fred/stuff');
       process.env.XDG_CONFIG_HOME = p;
       const result = Xdg.userConfigDir(user, new FilePath(home));
       expect(result.getAbsolutePath().startsWith(expected)).is.true;
@@ -112,13 +112,13 @@ describe('Xdg', () => {
       expect(result.getAbsolutePath().length).is.greaterThan(folder().length);
     });
     it('userDataDir returns path set with RSTUDIO_DATA_HOME', () => {
-      const p = '/once/upon/a/time/rstudio';
+      const p = addDrive('/once/upon/a/time/rstudio');
       process.env.RSTUDIO_DATA_HOME = p;
       const result = Xdg.userDataDir();
       expect(result.getAbsolutePath()).equals(p);
     });
     it('userDataDir returns path set with XDG_DATA_HOME', () => {
-      const p = '/once/upon/a/time';
+      const p = addDrive('/once/upon/a/time');
       process.env.XDG_DATA_HOME = p;
       const result = Xdg.userDataDir();
       expect(result.getAbsolutePath().startsWith(p)).is.true;
@@ -127,8 +127,8 @@ describe('Xdg', () => {
     it('userDataDir expands placeholders', () => {
       const p = '${HOME}/a/$USER/stuff';
       const user = 'fred';
-      const home = '/somewhere/nifty';
-      const expected = '/somewhere/nifty/a/fred/stuff';
+      const home = addDrive('/somewhere/nifty');
+      const expected = addDrive('/somewhere/nifty/a/fred/stuff');
       process.env.XDG_DATA_HOME = p;
       const result = Xdg.userDataDir(user, new FilePath(home));
       expect(result.getAbsolutePath().startsWith(expected)).is.true;
@@ -141,13 +141,13 @@ describe('Xdg', () => {
       expect(result.getAbsolutePath().length).is.greaterThan(folder().length);
     });
     it('systemConfigDir returns path set with RSTUDIO_CONFIG_DIR', () => {
-      const p = '/config/goes/here';
+      const p = addDrive('/config/goes/here');
       process.env.RSTUDIO_CONFIG_DIR = p;
       const result = Xdg.systemConfigDir();
       expect(result.getAbsolutePath()).equals(p);
     });
     it('systemConfigDir returns path set with single-path XDG_CONFIG_DIRS', () => {
-      const p = '/once/upon/a/time';
+      const p = addDrive('/once/upon/a/time');
       process.env.XDG_CONFIG_DIRS = p;
       const result = Xdg.systemConfigDir();
       expect(result.getAbsolutePath().startsWith(p)).is.true;

--- a/src/node/desktop/test/core/xdg.spec.ts
+++ b/src/node/desktop/test/core/xdg.spec.ts
@@ -35,6 +35,9 @@ function randomString() {
   return Math.trunc(Math.random() * 2147483647).toString();
 }
 
+const onceUponAPath = process.platform === 'win32' ?
+  'C:/once/upon/a/time/rstudio' : 'C:/once/upon/a/time/rstudio';
+
 describe('Xdg', () => {
   // store env values at start of each test so we can restore them
   const xdgVars: Record<string, string> = {
@@ -75,23 +78,28 @@ describe('Xdg', () => {
       expect(result.getAbsolutePath().length).is.greaterThan(folder().length);
     });
     it('userConfigDir returns path set with RSTUDIO_CONFIG_HOME', () => {
-      const p = '/once/upon/a/time/rstudio';
+      const p = onceUponAPath;
       process.env.RSTUDIO_CONFIG_HOME = p;
       const result = Xdg.userConfigDir();
       expect(result.getAbsolutePath()).equals(p);
     });
     it('userConfigDir returns path set with XDG_CONFIG_HOME', () => {
-      const p = '/once/upon/a/time';
+      const p = onceUponAPath;
       process.env.XDG_CONFIG_HOME = p;
       const result = Xdg.userConfigDir();
       expect(result.getAbsolutePath().startsWith(p)).is.true;
       expect(hasExpectedEnding(result)).is.true;
     });
-    it('userConfigDir expands placeholders', () => {
-      const p = '${HOME}/a/$USER/stuff';
+    it('WIP userConfigDir expands placeholders', () => {
+      let p = '${HOME}/a/$USER/stuff';
       const user = 'fred';
-      const home = '/somewhere/nifty';
-      const expected = '/somewhere/nifty/a/fred/stuff';
+      let home = '/somewhere/nifty';
+      let expected = '/somewhere/nifty/a/fred/stuff';
+      if (process.platform === 'win32') {
+        p = 'C:' + p;
+        home = 'C:' + home;
+        expected = 'C:' + expected;
+      }
       process.env.XDG_CONFIG_HOME = p;
       const result = Xdg.userConfigDir(user, new FilePath(home));
       expect(result.getAbsolutePath().startsWith(expected)).is.true;

--- a/src/node/desktop/test/core/xdg.spec.ts
+++ b/src/node/desktop/test/core/xdg.spec.ts
@@ -36,7 +36,7 @@ function randomString() {
 }
 
 const onceUponAPath = process.platform === 'win32' ?
-  'C:/once/upon/a/time/rstudio' : 'C:/once/upon/a/time/rstudio';
+  'C:/once/upon/a/time/rstudio' : '/once/upon/a/time/rstudio';
 
 describe('Xdg', () => {
   // store env values at start of each test so we can restore them

--- a/src/node/desktop/test/main/app.spec.ts
+++ b/src/node/desktop/test/main/app.spec.ts
@@ -21,5 +21,6 @@ import Main from '../../src/main/main';
 // IMPORTANT: Cannot unit-test app.ts, because it will cause app.WhenReady() to
 // start up RStudio, instead of the tests!
 describe('App', () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   describe('No tests (by design)', () => {});
 });

--- a/src/node/desktop/test/main/desktop-utils.spec.ts
+++ b/src/node/desktop/test/main/desktop-utils.spec.ts
@@ -21,7 +21,7 @@ import * as Utils from '../../src/main/desktop-utils';
 describe('DesktopUtils', () => {
   describe('Static helpers', () => {
     it('isMacOS detects... macOS', () => {
-      let result = Utils.isMacOS();
+      const result = Utils.isMacOS();
       if (process.platform === 'darwin') {
         expect(result).is.true;
       } else {

--- a/src/node/desktop/test/main/main.spec.ts
+++ b/src/node/desktop/test/main/main.spec.ts
@@ -28,8 +28,8 @@ interface Versions  {
 describe('Main', () => {
   describe('Static helpers', () => {
     it('getComponentVersions returns expected JSON', () => {
-      let result = Main.getComponentVersions();
-      let json: Versions = JSON.parse(result);
+      const result = Main.getComponentVersions();
+      const json: Versions = JSON.parse(result);
       expect(json.electron).length.is.greaterThan(0);
       expect(json.rstudio).length.is.greaterThan(0);
       expect(json.node).length.is.greaterThan(0);

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -305,7 +305,7 @@
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.18.tgz#0c8e298dbff8205e2266606c1ea5fbdba29b46e4"
   integrity sha512-rS27+EkB/RE1Iz3u0XtVL5q36MGDWbgYe7zWiodyKNUnthxY0rukK5V36eiUCtCisB7NN8zKYH6DO2M37qxFEQ==
 
-"@types/json-schema@^7.0.3":
+"@types/json-schema@^7.0.7":
   version "7.0.7"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
   integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
@@ -331,73 +331,73 @@
   integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
 
 "@typescript-eslint/eslint-plugin@^4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.25.0.tgz#d82657b6ab4caa4c3f888ff923175fadc2f31f2a"
-  integrity sha512-Qfs3dWkTMKkKwt78xp2O/KZQB8MPS1UQ5D3YW2s6LQWBE1074BE+Rym+b1pXZIX3M3fSvPUDaCvZLKV2ylVYYQ==
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.26.0.tgz#12bbd6ebd5e7fabd32e48e1e60efa1f3554a3242"
+  integrity sha512-yA7IWp+5Qqf+TLbd8b35ySFOFzUfL7i+4If50EqvjT6w35X8Lv0eBHb6rATeWmucks37w+zV+tWnOXI9JlG6Eg==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.25.0"
-    "@typescript-eslint/scope-manager" "4.25.0"
-    debug "^4.1.1"
+    "@typescript-eslint/experimental-utils" "4.26.0"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
-    lodash "^4.17.15"
-    regexpp "^3.0.0"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    lodash "^4.17.21"
+    regexpp "^3.1.0"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.25.0.tgz#b2febcfa715d2c1806fd5f0335193a6cd270df54"
-  integrity sha512-f0doRE76vq7NEEU0tw+ajv6CrmPelw5wLoaghEHkA2dNLFb3T/zJQqGPQ0OYt5XlZaS13MtnN+GTPCuUVg338w==
+"@typescript-eslint/experimental-utils@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.26.0.tgz#ba7848b3f088659cdf71bce22454795fc55be99a"
+  integrity sha512-TH2FO2rdDm7AWfAVRB5RSlbUhWxGVuxPNzGT7W65zVfl8H/WeXTk1e69IrcEVsBslrQSTDKQSaJD89hwKrhdkw==
   dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/scope-manager" "4.25.0"
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/typescript-estree" "4.25.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
+    "@types/json-schema" "^7.0.7"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/typescript-estree" "4.26.0"
+    eslint-scope "^5.1.1"
+    eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.25.0.tgz#6b2cb6285aa3d55bfb263c650739091b0f19aceb"
-  integrity sha512-OZFa1SKyEJpAhDx8FcbWyX+vLwh7OEtzoo2iQaeWwxucyfbi0mT4DijbOSsTgPKzGHr6GrF2V5p/CEpUH/VBxg==
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.26.0.tgz#31b6b732c9454f757b020dab9b6754112aa5eeaf"
+  integrity sha512-b4jekVJG9FfmjUfmM4VoOItQhPlnt6MPOBUL0AQbiTmm+SSpSdhHYlwayOm4IW9KLI/4/cRKtQCmDl1oE2OlPg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.25.0"
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/typescript-estree" "4.25.0"
-    debug "^4.1.1"
+    "@typescript-eslint/scope-manager" "4.26.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/typescript-estree" "4.26.0"
+    debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.25.0.tgz#9d86a5bcc46ef40acd03d85ad4e908e5aab8d4ca"
-  integrity sha512-2NElKxMb/0rya+NJG1U71BuNnp1TBd1JgzYsldsdA83h/20Tvnf/HrwhiSlNmuq6Vqa0EzidsvkTArwoq+tH6w==
+"@typescript-eslint/scope-manager@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.26.0.tgz#60d1a71df162404e954b9d1c6343ff3bee496194"
+  integrity sha512-G6xB6mMo4xVxwMt5lEsNTz3x4qGDt0NSGmTBNBPJxNsrTXJSm21c6raeYroS2OwQsOyIXqKZv266L/Gln1BWqg==
   dependencies:
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/visitor-keys" "4.25.0"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/visitor-keys" "4.26.0"
 
-"@typescript-eslint/types@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.25.0.tgz#0e444a5c5e3c22d7ffa5e16e0e60510b3de5af87"
-  integrity sha512-+CNINNvl00OkW6wEsi32wU5MhHti2J25TJsJJqgQmJu3B3dYDBcmOxcE5w9cgoM13TrdE/5ND2HoEnBohasxRQ==
+"@typescript-eslint/types@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.26.0.tgz#7c6732c0414f0a69595f4f846ebe12616243d546"
+  integrity sha512-rADNgXl1kS/EKnDr3G+m7fB9yeJNnR9kF7xMiXL6mSIWpr3Wg5MhxyfEXy/IlYthsqwBqHOr22boFbf/u6O88A==
 
-"@typescript-eslint/typescript-estree@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.25.0.tgz#942e4e25888736bff5b360d9b0b61e013d0cfa25"
-  integrity sha512-1B8U07TGNAFMxZbSpF6jqiDs1cVGO0izVkf18Q/SPcUAc9LhHxzvSowXDTvkHMWUVuPpagupaW63gB6ahTXVlg==
+"@typescript-eslint/typescript-estree@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.26.0.tgz#aea17a40e62dc31c63d5b1bbe9a75783f2ce7109"
+  integrity sha512-GHUgahPcm9GfBuy3TzdsizCcPjKOAauG9xkz9TR8kOdssz2Iz9jRCSQm6+aVFa23d5NcSpo1GdHGSQKe0tlcbg==
   dependencies:
-    "@typescript-eslint/types" "4.25.0"
-    "@typescript-eslint/visitor-keys" "4.25.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
+    "@typescript-eslint/types" "4.26.0"
+    "@typescript-eslint/visitor-keys" "4.26.0"
+    debug "^4.3.1"
+    globby "^11.0.3"
     is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
+    semver "^7.3.5"
+    tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.25.0":
-  version "4.25.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.25.0.tgz#863e7ed23da4287c5b469b13223255d0fde6aaa7"
-  integrity sha512-AmkqV9dDJVKP/TcZrbf6s6i1zYXt5Hl8qOLrRDTFfRNae4+LB8A4N3i+FLZPW85zIxRy39BgeWOfMS3HoH5ngg==
+"@typescript-eslint/visitor-keys@4.26.0":
+  version "4.26.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.26.0.tgz#26d2583169222815be4dcd1da4fe5459bc3bcc23"
+  integrity sha512-cw4j8lH38V1ycGBbF+aFiLUls9Z0Bw8QschP3mkth50BbWzgFS33ISIgBzUMuQ2IdahoEv/rXstr8Zhlz4B1Zg==
   dependencies:
-    "@typescript-eslint/types" "4.25.0"
+    "@typescript-eslint/types" "4.26.0"
     eslint-visitor-keys "^2.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -560,9 +560,9 @@ binary-extensions@^2.0.0:
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
 boolean@^3.0.1:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.0.4.tgz#aa1df8749af41d7211b66b4eee584722ff428c27"
-  integrity sha512-5pyOr+w2LNN72F2mAq6J0ckHUfJYSgRKma7e/wlcMMhgOLV9OI0ERhERYXxUqo+dPyVxcbXKy9n+wg13+LpNnA==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/boolean/-/boolean-3.1.0.tgz#a245080649ebb80e7c0ea218a480e4e913136336"
+  integrity sha512-K6r5tvO1ykeYerI7jIyTvSFw2l6D6DzqkljGj2E2uyYAAdDo2SV4qGJIV75cHIQpTFyb6BB0BEHiDdDrFsNI+g==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -652,9 +652,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001230"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz#8135c57459854b2240b57a4a6786044bdc5a9f71"
-  integrity sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==
+  version "1.0.30001232"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001232.tgz#2ebc8b6a77656fd772ab44a82a332a26a17e9527"
+  integrity sha512-e4Gyp7P8vqC2qV2iHA+cJNf/yqUKOShXQOJHQt81OHxlIZl/j/j3soEA0adAQi8CPUQgvOdDENyQ5kd6a6mNSg==
 
 chai@^4.3.4:
   version "4.3.4"
@@ -823,7 +823,7 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+debug@4.3.1, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.1.tgz#f0d229c505e0c6d8c49ac553d1b13dc183f6b2ee"
   integrity sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
@@ -947,9 +947,9 @@ electron-mocha@^10.0.0:
     yargs "^16.1.1"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.742"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.742.tgz#7223215acbbd3a5284962ebcb6df85d88b95f200"
-  integrity sha512-ihL14knI9FikJmH2XUIDdZFWJxvr14rPSdOhJ7PpS27xbz8qmaRwCwyg/bmFwjWKmWK9QyamiCZVCvXm5CH//Q==
+  version "1.3.743"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.743.tgz#fcec24d6d647cb84fd796b42caa1b4039a180894"
+  integrity sha512-K2wXfo9iZQzNJNx67+Pld0DRF+9bYinj62gXCdgPhcu1vidwVuLPHQPPFnCdO55njWigXXpfBiT90jGUPbw8Zg==
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -1121,7 +1121,7 @@ eslint-plugin-promise@^5.1.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-5.1.0.tgz#fb2188fb734e4557993733b41aa1a688f46c6f24"
   integrity sha512-NGmI6BH5L12pl7ScQHbg7tvtk4wPxxj8yPHH47NvSmMtFneC077PSeY3huFj06ZWZvtbfxSPt3RuOQD5XcR4ng==
 
-eslint-scope@^5.0.0, eslint-scope@^5.1.1:
+eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
   integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
@@ -1135,6 +1135,13 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-3.0.0.tgz#8aebaface7345bb33559db0a1f13a1d2d48c3672"
+  integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
+  dependencies:
+    eslint-visitor-keys "^2.0.0"
 
 eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
@@ -1524,7 +1531,7 @@ globalthis@^1.0.1:
   dependencies:
     define-properties "^1.1.3"
 
-globby@^11.0.1:
+globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==
@@ -2015,7 +2022,7 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.10, lodash@^4.17.15:
+lodash@^4.17.10, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2654,7 +2661,7 @@ semver@^6.0.0, semver@^6.1.0, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.2.1, semver@^7.3.2:
+semver@^7.2.1, semver@^7.3.2, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -2948,7 +2955,7 @@ tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tsutils@^3.17.1:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==


### PR DESCRIPTION
### Intent

Unit tests had numerous failures on Windows.

### Approach

Fix them; mostly involved adding behavior to FilePath class to mimic the C++ behavior with regards to "native" versus "generic" paths.

Also created additional commands for yarn:

- `yarn test` runs all unit tests without producing coverage report
- `yarn testcover` runs all unit tests and gives a coverage report
- `yarn testwip` only runs tests containing `WIP` (case sensitive) in their description

### Automated Tests

This is work on automated tests.

### QA Notes

Nothing to test here, just unit test fixes on Windows.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


