### PR TITLE
more tests, eslint cleanup

### DIFF
--- a/src/node/desktop/.mocharc.json
+++ b/src/node/desktop/.mocharc.json
@@ -1,6 +1,5 @@
 {
   "extension": ["ts"],
-  "spec": "./test/**/*.spec.ts",
+  "spec": "./test/**/*.test.ts",
   "require": "ts-node/register"
 }
- 

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
-    "lint": "eslint ./src",
+    "lint": "eslint ./src ./test",
     "start": "yarn run build && electron ./dist/main/app.js",
     "show-version": "yarn run build && electron ./dist/main/app.js --version-json",
     "test": "electron-mocha -c",

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -57,6 +57,7 @@ export class FilePath {
   /**
    * Creates a path in which the user home path will be replaced by the ~ alias.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static createAliasedPath(filePath: FilePath, userHomePath: FilePath): string {
     throw Error('createAliasedPath is NYI');
   }
@@ -100,6 +101,7 @@ export class FilePath {
    * Checks whether the two provided files are equal, ignoring case. Two files are equal 
    * if their absolute paths are equal.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static isEqualCaseInsensitive(filePath1: FilePath, filePath2: FilePath): boolean {
     throw Error('isEqualCaseInsensitive is NYI');
   }
@@ -107,6 +109,7 @@ export class FilePath {
   /**
    * Checks whether the specified path is a root path or a relative path.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static isRootPath(filePath: string): boolean {
     throw Error('isRootPath is NYI');
   }
@@ -114,6 +117,7 @@ export class FilePath {
   /**
    * Changes the current working directory to the specified path.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static makeCurrent(filePath: string): Err {
     throw Error('makeCurrent (static) is NYI');
   }
@@ -194,6 +198,7 @@ export class FilePath {
   /**
    * Creates a randomly named file in the temp directory.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static tempFilePath(extension?: string): FilePathWithError {
     throw Error('tempFilePath is NYI');
   }
@@ -201,6 +206,7 @@ export class FilePath {
   /**
    * Creates a file with a random name in the specified directory.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static uniqueFilePath(basePath: string, extension?: string): FilePathWithError {
     throw Error('uniqueFilePath is NYI');
   }
@@ -209,6 +215,7 @@ export class FilePath {
    * Changes the file mode to the specified file mode (Posix-only). Pass in the posix file mode
    * string, e.g. rwxr-xr-x
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   changeFileMode(fileModeStr: string, setStickyBit = false): Err {
     if (process.platform === 'win32')
       return Success(); // no-op on Windows
@@ -287,6 +294,7 @@ export class FilePath {
   /**
    * Copies this file path to the specified location.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   copy(targetPath: FilePath, overwrite = false): Err {
     throw Error('copy is NYI');
   }
@@ -294,6 +302,7 @@ export class FilePath {
   /**
    * Copies this directory recursively to the specified location.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   copyDirectoryRecursive(targetPath: FilePath, overwrite = false): Err {
     throw Error('copyDirectoryRecursive is NYI');
   }
@@ -446,6 +455,7 @@ export class FilePath {
   /**
    * Gets the children of this directory. Sub-directories will not be traversed.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getChildren(filePaths: Array<FilePath>): Err {
     throw Error('getChildren is NYI');
   }
@@ -504,6 +514,7 @@ export class FilePath {
   /**
    * Gets the mime content type of this file.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getMimeContentType(defaultType = 'text/plain'): string {
     throw Error('getMimeContentType is NYI');
   }
@@ -526,6 +537,7 @@ export class FilePath {
   /**
    * Gets the representation of this path, relative to the provided path.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   getRelativePath(parentPath: FilePath): string {
     throw Error('getRelativePath is NYI');
   }
@@ -554,6 +566,7 @@ export class FilePath {
   /**
    * Checks whether this file has the specified extension.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hasExtension(extension: string): boolean {
     throw Error('hasExtension is NYI');
   }
@@ -561,6 +574,7 @@ export class FilePath {
   /**
    * Checks whether this file has the specified extension when it is converted to lower case.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   hasExtensionLowerCase(extension: string): boolean {
     throw Error('hasExtensionLowerCase is NYI');
   }
@@ -582,7 +596,7 @@ export class FilePath {
   /**
    * Checks whether this file path contains a path or not.
    */
-  isEmpty() {
+  isEmpty(): boolean {
     return !this.path;
   }
 
@@ -590,6 +604,7 @@ export class FilePath {
    * Checks whether this file path points to the same location in the filesystem as 
    * the specified file path.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   isEquivalentTo(other: FilePath): boolean {
     throw Error('isEquivalentTo is NYI');
   }
@@ -718,6 +733,7 @@ export class FilePath {
   /**
    * Performs an indirect move by copying this directory to the target and then deleting this directory.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   moveIndirect(targetPath: FilePath, overwrite = false): Err {
     throw Error('moveIndirect is NYI');
   }
@@ -732,6 +748,7 @@ export class FilePath {
   /**
    * Opens this file for write.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   openForWrite(/*std:: shared_ptr<std:: ostream>& out_stream,*/ truncate = true): Err {
     throw Error('openForWrite is NYI');
   }
@@ -783,11 +800,13 @@ export class FilePath {
   // Internal helper functions
   // -------------------------
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static logErrorWithPath(path: string, error: Error): void {
     // TODO logging
     // console.error(error.message + ": " + path);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   static logError(error: Error): void {
     // TODO logging
     // console.error(error.message);

--- a/src/node/desktop/src/core/log-options.ts
+++ b/src/node/desktop/src/core/log-options.ts
@@ -20,28 +20,28 @@ export class StdErrLogOptions {}
 export class SysLogOptions {}
 export type LoggerOptions = StdErrLogOptions | SysLogOptions | FileLogOptions
 
-const kLogLevel          = 'log-level';
-const kLoggerType        = 'logger-type';
-const kLogDir            = 'log-dir';
-const kLogFileMode       = 'log-file-mode';
-const kLogFileIncludePid = 'log-file-include-pid';
-const kRotate            = 'rotate';
-const kMaxSizeMb         = 'max-size-mb';
-const kLogConfFile       = 'logging.conf';
-const kLogConfEnvVar     = 'RS_LOG_CONF_FILE';
+// const kLogLevel          = 'log-level';
+// const kLoggerType        = 'logger-type';
+// const kLogDir            = 'log-dir';
+// const kLogFileMode       = 'log-file-mode';
+// const kLogFileIncludePid = 'log-file-include-pid';
+// const kRotate            = 'rotate';
+// const kMaxSizeMb         = 'max-size-mb';
+// const kLogConfFile       = 'logging.conf';
+// const kLogConfEnvVar     = 'RS_LOG_CONF_FILE';
 
-const kFileLogger        = 'file';
-const kStdErrLogger      = 'stderr';
-const kSysLogger         = 'syslog';
+// const kFileLogger        = 'file';
+// const kStdErrLogger      = 'stderr';
+// const kSysLogger         = 'syslog';
 
-const kLoggingLevelDebug = 'debug';
-const kLoggingLevelInfo  = 'info';
-const kLoggingLevelWarn  = 'warn';
-const kLoggingLevelError = 'error';
+// const kLoggingLevelDebug = 'debug';
+// const kLoggingLevelInfo  = 'info';
+// const kLoggingLevelWarn  = 'warn';
+// const kLoggingLevelError = 'error';
 
-const kBaseLevel         = 0;
-const kBinaryLevel       = 1;
-const kLogSectionLevel   = 2;
+// const kBaseLevel         = 0;
+// const kBinaryLevel       = 1;
+// const kLogSectionLevel   = 2;
 
 export class LogOptions
 {

--- a/src/node/desktop/src/core/system.ts
+++ b/src/node/desktop/src/core/system.ts
@@ -49,6 +49,7 @@ export function initializeLog(
   programIdentity: string,
   logLevel: log.LogLevel,
   logDir: FilePath,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   enableConfigReload = true
 ): Err {
   // // create default file logger options

--- a/src/node/desktop/src/main/app.ts
+++ b/src/node/desktop/src/main/app.ts
@@ -14,10 +14,19 @@
  */
 
 import { app } from 'electron';
-
 import Main from './main';
+import * as Init from './init';
 
-// Where it all begins
-app.whenReady().then(() => {
-  new Main().run();
-});
+/**
+ * Handlers for `app` events go here; otherwise do as little as possible in this
+ * file (it cannot be unit-tested).
+ */
+
+// Code to run before app 'ready' event
+if (!Init.beforeAppReadyEvent()) {
+  app.exit(0);
+} else {
+  app.whenReady().then(() => {
+    new Main().run();
+  });
+}

--- a/src/node/desktop/src/main/desktop-utils.ts
+++ b/src/node/desktop/src/main/desktop-utils.ts
@@ -34,6 +34,10 @@ export function devicePixelRatio(/*QMainWindow * pMainWindow*/): number {
   return 1.0;
 }
 
+export function randomString(): string {
+  return Math.trunc(Math.random() * 2147483647).toString();
+}
+
 export function initializeLang(): void {
   if (process.platform !== 'darwin') {
     return;

--- a/src/node/desktop/src/main/init.ts
+++ b/src/node/desktop/src/main/init.ts
@@ -1,0 +1,114 @@
+/*
+ * init.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { app } from 'electron';
+
+import { getenv } from '../core/environment';
+import { getRStudioVersion } from './product-info';
+
+/**
+ * Startup code run before app 'ready' event. Return 0 (zero) to continue 
+ * launching, non-zero to exit process with that value.
+ */
+export function beforeAppReadyEvent(): number {
+  // look for a version check request; if we have one, just do that and exit
+  if (app.commandLine.hasSwitch('version')) {
+    console.log(getRStudioVersion());
+    return 1;
+  }
+
+  // report extended version info and exit
+  if (app.commandLine.hasSwitch('version-json')) {
+    console.log(getComponentVersions());
+    return 1;
+  }
+
+  // attempt to remove stale lockfiles, as they can impede application startup
+  try {
+    removeStaleOptionsLockfile();
+  } catch (error) {
+    console.error(error);
+    return 1;
+  }
+
+  // allow users to supply extra command-line arguments
+  augmentCommandLineArguments();
+
+  return 0;
+}
+
+export interface VersionInfo  {
+  electron: string;
+  rstudio?: string;
+  node: string;
+  v8: string;
+}
+
+export function getComponentVersions(): string {
+  const componentVers: VersionInfo = process.versions;
+  componentVers['rstudio'] = getRStudioVersion();
+  return JSON.stringify(componentVers, null, 2);
+}
+
+/**
+ * Pass additional Chromium arguments set by user via RSTUDIO_CHROMIUM_ARGUMENTS
+ * environment variable.
+ */
+export function augmentCommandLineArguments(): void {
+  const user = getenv('RSTUDIO_CHROMIUM_ARGUMENTS');
+  if (!user) {
+    return;
+  }
+
+  const pieces = user.split(' ');
+  pieces.forEach((piece) => {
+    if (piece.startsWith('-')) {
+      app.commandLine.appendSwitch(piece);
+    } else {
+      app.commandLine.appendArgument(piece);
+    }
+  });
+}
+
+/**
+ * Attempt to remove stale lockfiles that might inhibit
+ * RStudio startup (currently Windows only). Throws
+ * an error only when a stale lockfile exists, but
+ * we could not successfully remove it
+ */
+export function removeStaleOptionsLockfile(): void {
+  if (process.platform !== 'win32') {
+    return;
+  }
+
+  const appData = getenv('APPDATA');
+  if (!appData) {
+    return;
+  }
+
+  const lockFilePath = path.join(appData, 'RStudio/desktop.ini.lock');
+  if (!fs.existsSync(lockFilePath)) {
+    return;
+  }
+
+  const diff = (Date.now() - fs.statSync(lockFilePath).mtimeMs) / 1000;
+  if (diff < 10) {
+    return;
+  }
+
+  fs.unlinkSync(lockFilePath);
+}

--- a/src/node/desktop/test/core/environment.test.ts
+++ b/src/node/desktop/test/core/environment.test.ts
@@ -1,5 +1,5 @@
 /*
- * environment.spec.ts
+ * environment.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *

--- a/src/node/desktop/test/core/err.test.ts
+++ b/src/node/desktop/test/core/err.test.ts
@@ -1,5 +1,5 @@
 /*
- * log.spec.ts
+ * err.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -16,15 +16,25 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import fs from 'fs';
+import { Err, Success } from '../../src/core/err';
 
-import { FileLogOptions } from '../../src/core/log';
+function beSuccessful(): Err {
+  return Success();
+}
 
-describe('Log', () => {
-  describe('Constructions', () => {
-    it('FileLogOptions construction works', () => {
-      const flo = new FileLogOptions('/somewhere');
-      expect(flo.directory).to.equal('/somewhere');
+function beUnsuccessful(): Err {
+  return new Error('Some error');
+}
+
+describe('Err', () => {
+  describe('Success helper', () => {
+    it('Success return should be falsy', () => {
+      expect(!!beSuccessful()).is.false;
+      expect(beSuccessful() == null);
+    });
+    it('Error return should be truthy', () => {
+      expect(!!beUnsuccessful()).is.true;
+      expect(beUnsuccessful() instanceof Error);
     });
   });
 });

--- a/src/node/desktop/test/core/file-path.test.ts
+++ b/src/node/desktop/test/core/file-path.test.ts
@@ -1,5 +1,5 @@
 /*
- * file-path.spec.ts
+ * file-path.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *

--- a/src/node/desktop/test/core/log.test.ts
+++ b/src/node/desktop/test/core/log.test.ts
@@ -1,5 +1,5 @@
 /*
- * desktop-utils.spec.ts
+ * log.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -16,17 +16,14 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import * as Utils from '../../src/main/desktop-utils';
+import { FileLogOptions } from '../../src/core/log';
 
-describe('DesktopUtils', () => {
-  describe('Static helpers', () => {
-    it('isMacOS detects... macOS', () => {
-      const result = Utils.isMacOS();
-      if (process.platform === 'darwin') {
-        expect(result).is.true;
-      } else {
-        expect(result).is.false;
-      }
+describe('Log', () => {
+  describe('Constructions', () => {
+    it('FileLogOptions construction works', () => {
+      const flo = new FileLogOptions('/somewhere');
+      expect(flo.directory).to.equal('/somewhere');
     });
   });
 });
+ 

--- a/src/node/desktop/test/core/system.test.ts
+++ b/src/node/desktop/test/core/system.test.ts
@@ -1,5 +1,5 @@
 /*
- * system.spec.ts
+ * system.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *

--- a/src/node/desktop/test/core/user.test.ts
+++ b/src/node/desktop/test/core/user.test.ts
@@ -1,5 +1,5 @@
 /*
- * app.spec.ts
+ * user.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -16,11 +16,16 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import Main from '../../src/main/main';
+import fs from 'fs';
 
-// IMPORTANT: Cannot unit-test app.ts, because it will cause app.WhenReady() to
-// start up RStudio, instead of the tests!
-describe('App', () => {
-  // eslint-disable-next-line @typescript-eslint/no-empty-function
-  describe('No tests (by design)', () => {});
+import { User } from '../../src/core/user';
+
+describe('User', () => {
+  describe('Static helpers', () => {
+    it('getUserHomePath returns a valid path', () => {
+      const path = User.getUserHomePath();
+      expect(fs.existsSync(path.getAbsolutePath())).is.true;
+    });
+  });
 });
+ 

--- a/src/node/desktop/test/core/xdg.test.ts
+++ b/src/node/desktop/test/core/xdg.test.ts
@@ -1,5 +1,5 @@
 /*
- * xdg.spec.ts
+ * xdg.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *

--- a/src/node/desktop/test/main/app.test.ts
+++ b/src/node/desktop/test/main/app.test.ts
@@ -1,5 +1,5 @@
 /*
- * err.spec.ts
+ * app.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -14,28 +14,10 @@
  */
 
 import { describe } from 'mocha';
-import { expect } from 'chai';
 
-import { Err, Success } from '../../src/core/err';
-
-function beSuccessful(): Err {
-  return Success();
-}
-
-function beUnsuccessful(): Err {
-  return new Error('Some error');
-}
-
-describe('Err', () => {
-  describe('Success helper', () => {
-    it('Success return should be falsy', () => {
-      expect(!!beSuccessful()).is.false;
-      expect(beSuccessful() == null);
-    });
-    it('Error return should be truthy', () => {
-      expect(!!beUnsuccessful()).is.true;
-      expect(beUnsuccessful() instanceof Error);
-    });
-  });
+// IMPORTANT: Cannot unit-test app.ts, because it will cause app.WhenReady() to
+// start up RStudio, instead of the tests!
+describe('App', () => {
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  describe('No tests (by design)', () => {});
 });
- 

--- a/src/node/desktop/test/main/desktop-utils.test.ts
+++ b/src/node/desktop/test/main/desktop-utils.test.ts
@@ -1,0 +1,61 @@
+/*
+ * desktop-utils.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { expect } from 'chai';
+
+import * as Utils from '../../src/main/desktop-utils';
+
+describe('DesktopUtils', () => {
+  describe('Static helpers', () => {
+    it('reattachConsoleIfNecessary does... something', () => {
+      Utils.reattachConsoleIfNecessary();
+      if (process.platform === 'win32') {
+        // TODO 
+      }
+    });
+    it('userLogPath returns a non-empty string', () => {
+      expect(Utils.userLogPath()).to.not.be.empty;
+    });
+    it('usereWebCachePath returns a non-empty string', () => {
+      expect(Utils.userWebCachePath()).to.not.be.empty;
+    });
+    it('devicePixelRatio returns 1.0', () => {
+      expect(Utils.devicePixelRatio()).equals(1.0);
+    });
+    it('initializeLang does... something', () => {
+      Utils.initializeLang();
+      if (process.platform === 'darwin') {
+        // TODO
+      }
+    });
+    it('isMacOS detects... macOS', () => {
+      const result = Utils.isMacOS();
+      if (process.platform === 'darwin') {
+        expect(result).is.true;
+      } else {
+        expect(result).is.false;
+      }
+    });
+    it('randomString genereates a random string', () => {
+      const str1 = Utils.randomString();
+      const str2 = Utils.randomString();
+      const str3 = Utils.randomString();
+      expect(str1).not.equal(str2);
+      expect(str1).not.equal(str3);
+      expect(str2).not.equal(str3);
+    });
+  });
+});

--- a/src/node/desktop/test/main/init.test.ts
+++ b/src/node/desktop/test/main/init.test.ts
@@ -1,5 +1,5 @@
 /*
- * main.spec.ts
+ * init.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -16,24 +16,33 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import Main from '../../src/main/main';
+import * as Init from '../../src/main/init';
+import { app } from 'electron';
+import * as env from '../../src/core/environment';
 
-interface Versions  {
-  electron: string;
-  rstudio: string;
-  node: string;
-  v8: string;
-}
-
-describe('Main', () => {
+describe('Init', () => {
   describe('Static helpers', () => {
     it('getComponentVersions returns expected JSON', () => {
-      const result = Main.getComponentVersions();
-      const json: Versions = JSON.parse(result);
+      const result = Init.getComponentVersions();
+      const json: Init.VersionInfo = JSON.parse(result);
       expect(json.electron).length.is.greaterThan(0);
       expect(json.rstudio).length.is.greaterThan(0);
       expect(json.node).length.is.greaterThan(0);
       expect(json.v8).length.is.greaterThan(0);
+    });
+    it('removeStaleOptionsLockfile does... something', () => {
+      Init.removeStaleOptionsLockfile();
+      if (process.platform === 'win32') {
+        // TODO
+      }
+    });
+    it('augmentCommandLineArguments adds contents of env var', () => {
+      expect(app.commandLine.hasSwitch('disable-gpu')).is.false;
+      expect(env.getenv('RSTUDIO_CHROMIUM_ARGUMENTS')).is.empty;
+      env.setenv('RSTUDIO_CHROMIUM_ARGUMENTS', '--disable-gpu');
+      Init.augmentCommandLineArguments();
+      expect(app.commandLine.hasSwitch('disable-gpu')).is.true;
+      env.unsetenv('RSTUDIO_CHROMIUM_ARGUMENTS');
     });
   });
 });

--- a/src/node/desktop/test/main/main.test.ts
+++ b/src/node/desktop/test/main/main.test.ts
@@ -1,5 +1,5 @@
 /*
- * user.spec.ts
+ * main.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -16,16 +16,16 @@
 import { describe } from 'mocha';
 import { expect } from 'chai';
 
-import fs from 'fs';
+import { getenv } from '../../src/core/environment';
+import Main from '../../src/main/main';
 
-import { User } from '../../src/core/user';
-
-describe('User', () => {
+describe('Main', () => {
   describe('Static helpers', () => {
-    it('getUserHomePath returns a valid path', () => {
-      const path = User.getUserHomePath();
-      expect(fs.existsSync(path.getAbsolutePath())).is.true;
+    it('initializeSharedSecret generates a random string in RS_SHARED_SECRET envvar_', () => {
+      const envvar = 'RS_SHARED_SECRET';
+      expect(getenv(envvar)).has.lengthOf(0);
+      Main.initializeSharedSecret();
+      expect(getenv(envvar).length).is.greaterThan(0);
     });
   });
 });
- 

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -321,14 +321,14 @@
   integrity sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==
 
 "@types/node@^14.6.2":
-  version "14.17.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.1.tgz#5e07e0cb2ff793aa7a1b41deae76221e6166049f"
-  integrity sha512-/tpUyFD7meeooTRwl3sYlihx2BrJE7q9XF71EguPFIySj9B7qgnRtHsHTho+0AUm4m1SvWGm6uSncrR94q6Vtw==
+  version "14.17.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.17.2.tgz#1e94476db57ec93a372c7f7d29aa5707cfb92339"
+  integrity sha512-sld7b/xmFum66AAKuz/rp/CUO8+98fMpyQ3SBfzzBNGMd/1iHBTAg9oyAvcYlAj46bpc74r91jSw2iFdnx29nw==
 
 "@types/node@^15.6.1":
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.6.1.tgz#32d43390d5c62c5b6ec486a9bc9c59544de39a08"
-  integrity sha512-7EIraBEyRHEe7CH+Fm1XvgqU6uwZN8Q7jppJGcqjROMT29qhAuuOxYB1uEY5UMYQKEmA5D+5tBnhdaPXSsLONA==
+  version "15.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.9.0.tgz#0b7f6c33ca5618fe329a9d832b478b4964d325a8"
+  integrity sha512-AR1Vq1Ei1GaA5FjKL5PBqblTZsL5M+monvGSZwe6sSIdGiuu7Xr/pNwWJY+0ZQuN8AapD/XMB5IzBAyYRFbocA==
 
 "@typescript-eslint/eslint-plugin@^4.25.0":
   version "4.26.0"
@@ -652,9 +652,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001232"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001232.tgz#2ebc8b6a77656fd772ab44a82a332a26a17e9527"
-  integrity sha512-e4Gyp7P8vqC2qV2iHA+cJNf/yqUKOShXQOJHQt81OHxlIZl/j/j3soEA0adAQi8CPUQgvOdDENyQ5kd6a6mNSg==
+  version "1.0.30001233"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001233.tgz#b7cb4a377a4b12ed240d2fa5c792951a06e5f2c4"
+  integrity sha512-BmkbxLfStqiPA7IEzQpIk0UFZFf3A4E6fzjPJ6OR+bFC2L8ES9J8zGA/asoi47p8XDVkev+WJo2I2Nc8c/34Yg==
 
 chai@^4.3.4:
   version "4.3.4"
@@ -947,9 +947,9 @@ electron-mocha@^10.0.0:
     yargs "^16.1.1"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.743"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.743.tgz#fcec24d6d647cb84fd796b42caa1b4039a180894"
-  integrity sha512-K2wXfo9iZQzNJNx67+Pld0DRF+9bYinj62gXCdgPhcu1vidwVuLPHQPPFnCdO55njWigXXpfBiT90jGUPbw8Zg==
+  version "1.3.744"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.744.tgz#34e0da7babb325e18b50d3a0214504b12045ca85"
+  integrity sha512-o/vep/PvSXg+7buwCbVJXHY3zbjYVmFPwnMMnchESXgAzrfcasvbX/hQZHCFGG7YdZgdtwt1KTMyK9CyBxPbLA==
 
 electron-window@^0.8.0:
   version "0.8.1"


### PR DESCRIPTION
### Intent

Assorted minor tweaks.

### Approach

- renamed test files from `*.spec.ts` to `*.test.ts` to better match our usual scheme
- make `yarn eslint` run against both `src` and `test` sources
- cleanup all eslint warnings
- create and invoke `beforeAppReadyEvent()` for operations that can or must happen before app 'ready' event (one example is passing additional arguments to Chromium; according to docs this must happen before app 'ready'
- fix `augmentCommandLineArguments()`; discovered bug when writing unit test
- a few more unit tests

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


