### PR TITLE
Moved location of Python global and project options to make it more prominent

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -81,12 +81,12 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                   general,
                   editing,
                   rMarkdown, 
+                  python,
                   compilePdf,
                   spelling,
                   build,
                   source,
                   renv,
-                  python,
                   sharing));
 
       pSession_ = session;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
@@ -80,13 +80,13 @@ public class PreferencesDialog extends PreferencesDialogBase<UserPrefs>
                   paneLayout,
                   packages,
                   rmarkdown,
+                  python,
                   compilePdf,
                   spelling,
                   sourceControl,
                   publishing,
                   terminal,
-                  accessibility,
-                  python));
+                  accessibility));
       
       session_ = session;
       server_ = server;


### PR DESCRIPTION
### Intent

Addresses #9345. The “Python" global and project options in the menu are moved up for increased prominence, under “R Markdown."

### Approach

Move the references to the “Python” options.

### Automated Tests

Check that the Python options are still reachable.

### QA Notes

1. Verify in Global Options that “Python” is between “R Markdown” and “Sweave.”
2. Verify in Project Options that “Python” is between “R Markdown” and “Sweave.”
3. Verify that the “Python” options continue to work.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests **I compiled RStudio Server and tested the UI—does that count?**