### PR TITLE
check for both '.rmd' and '.Rmd' when finding R Markdown templates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Fixed issue where completion tooltip was erroneously shown in multi-line strings in some cases (#8677)
 * Fixed issue with autocompletion of column names within native-piped R expressions (#9385)
 * Fixed issue where help requests for Python objects would fail with reticulate 1.20 (#9311)
+* Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
 
 ### Misc
 

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -250,7 +250,8 @@
 
 # given a path to a folder on disk, return information about the R Markdown
 # template in that folder.
-.rs.addFunction("getTemplateYamlFile", function(path) {
+.rs.addFunction("getTemplateYamlFile", function(path)
+{
    # check for required files
    templateYaml <- file.path(path, "template.yaml")
    skeletonPath <- file.path(path, "skeleton")
@@ -260,11 +261,13 @@
          return(NULL)
    }
 
-   if (!file.exists(file.path(skeletonPath, "skeleton.Rmd")))
+   # validate that a skeleton.Rmd file exists
+   paths <- file.path(skeletonPath, c("skeleton.rmd", "skeleton.Rmd"))
+   if (!any(file.exists(paths)))
       return(NULL)
 
    # will need to enforce create_dir if there are multiple files in /skeleton/
-   multiFile = length(list.files(skeletonPath)) > 1 
+   multiFile <- length(list.files(skeletonPath)) > 1
 
    # return metadata; we won't parse until the client requests template files
    list(
@@ -272,7 +275,6 @@
       multi_file    = .rs.scalar(multiFile)
    )
 })
-
 
 .rs.addFunction("evaluateRmdParams", function(contents) {
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1304,9 +1304,9 @@ Error getRmdTemplate(const json::JsonRpcRequest& request,
    // locate the template skeleton on disk
    // (return empty string if none found)
    std::string templateContent;
-   for (auto&& path : { "skeleton/skeleton.Rmd", "skeleton/skeleton.rmd" })
+   for (auto&& suffix : { "skeleton/skeleton.Rmd", "skeleton/skeleton.rmd" })
    {
-      FilePath skeletonPath = FilePath(path).completePath(path);
+      FilePath skeletonPath = FilePath(path).completePath(suffix);
       if (skeletonPath.exists())
       {
          error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1301,19 +1301,27 @@ Error getRmdTemplate(const json::JsonRpcRequest& request,
 
    json::Object jsonResult;
 
-   // locate the template skeleton on disk (if it doesn't exist we'll just
-   // return an empty string)
-   FilePath skeletonPath = FilePath(path).completePath("skeleton/skeleton.Rmd");
+   // locate the template skeleton on disk
+   // (return empty string if none found)
    std::string templateContent;
-   if (skeletonPath.exists())
+   for (auto&& path : { "skeleton/skeleton.Rmd", "skeleton/skeleton.rmd" })
    {
-      error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);
-      if (error)
-         return error;
-   }
-   jsonResult["content"] = templateContent;
-   pResponse->setResult(jsonResult);
+      FilePath skeletonPath = FilePath(path).completePath(path);
+      if (skeletonPath.exists())
+      {
+         error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);
+         if (error)
+         {
+            LOG_ERROR(error);
+            continue;
+         }
+      }
 
+      jsonResult["content"] = templateContent;
+      break;
+   }
+
+   pResponse->setResult(jsonResult);
    return Success();
 }
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1307,20 +1307,20 @@ Error getRmdTemplate(const json::JsonRpcRequest& request,
    for (auto&& suffix : { "skeleton/skeleton.Rmd", "skeleton/skeleton.rmd" })
    {
       FilePath skeletonPath = FilePath(path).completePath(suffix);
-      if (skeletonPath.exists())
+      if (!skeletonPath.exists())
+         continue;
+
+      Error error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);
+      if (error)
       {
-         error = readStringFromFile(skeletonPath, &templateContent, string_utils::LineEndingPosix);
-         if (error)
-         {
-            LOG_ERROR(error);
-            continue;
-         }
+         LOG_ERROR(error);
+         continue;
       }
 
-      jsonResult["content"] = templateContent;
       break;
    }
 
+   jsonResult["content"] = templateContent;
    pResponse->setResult(jsonResult);
    return Success();
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/1607.

### Approach

Check for both `skeleton.rmd` and `skeleton.Rmd` when scanning for R Markdown templates.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/1607#issuecomment-614279186.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


