### PR TITLE
install reticulate before running Python chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 
 ### Bugfixes
 
+* Fixed issue where running Python chunk in notebook did not validate reticulate was installed (#9471)
 * Fixed issue where .md, .py, .sql, and .stan files had duplicate event handlers (#9106)
 * Fixed issue where output when running tests could be emitted in wrong order in Build pane (#5126)
 * Fixed issue where RStudio could crash when viewing a malformed data.frame (#9364)

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookDocQueue.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookDocQueue.java
@@ -96,7 +96,7 @@ public class NotebookDocQueue extends JavaScriptObject
    }-*/;
 
    public final native JsArray<NotebookQueueUnit> getUnits() /*-{
-      return this.units;
+      return this.units || [];
    }-*/;
    
    public final native JsArray<NotebookQueueUnit> getCompletedUnits() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -592,7 +592,11 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
          if (StringUtil.isNullOrEmpty(code))
             continue;
          
-         String header = code.substring(0, code.indexOf('\n'));
+         int newlineIndex = code.indexOf('\n');
+         if (newlineIndex == -1)
+            continue;
+         
+         String header = code.substring(0, newlineIndex);
          Map<String, String> chunkOptions = RChunkHeaderParser.parse(header);
          if (!chunkOptions.containsKey("engine"))
             continue;


### PR DESCRIPTION
### Intent

Currently, when executing a Python chunk within an R Markdown document, we fail to check if the `reticulate` package is available, which is required in order to execute those chunks. This PR rectifies that.

Addresses https://github.com/rstudio/rstudio/issues/9471.

### Approach

Add a helper function that tries to validate queue dependencies in the front-end before attempting execution of the queue.

### Automated Tests

https://github.com/rstudio/rstudio-ide-automation/issues/347

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9471.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
