### PR TITLE
don't allow repl_python banner to enter notebook output

### DIFF
--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -32,6 +32,7 @@
 
 #include <r/RCntxtUtils.hpp>
 #include <r/RInterface.hpp>
+#include <r/ROptions.hpp>
 #include <r/RExec.hpp>
 #include <r/RJson.hpp>
 #include <r/RSexp.hpp>
@@ -69,6 +70,7 @@ class NotebookQueue : boost::noncopyable
 public:
    NotebookQueue() 
    {
+      prevReticulateReplQuiet_ = false;
       // launch a thread to process console input
       pInput_ = 
          boost::make_shared<core::thread::ThreadsafeQueue<std::string> >();
@@ -290,6 +292,7 @@ private:
       {
          // if we're switching the console between languages, call the
          // appropriate R code to make that happen
+         const char * const kReplQuietOption = "reticulate.repl.quiet";
          std::string prefix;
 
          bool isPythonActive = module_context::isPythonReplActive();
@@ -297,11 +300,18 @@ private:
          {
             // switching from Python -> R: deactivate the Python REPL
             prefix = "quit\n";
+
+            // reverse out changes to the banner option
+            r::options::setOption(kReplQuietOption, prevReticulateReplQuiet_);
          }
          else if (!isPythonActive && execContext_ && execContext_->engine() == "python")
          {
             // switching from R -> Python: activate the Python REPL
             prefix = "reticulate::repl_python()\n";
+
+            // suppress the banner
+            prevReticulateReplQuiet_ = r::options::getOption<bool>(kReplQuietOption, false, false);
+            r::options::setOption(kReplQuietOption, true);
          }
 
          // send code to console 
@@ -680,6 +690,9 @@ private:
          }
       }
    }
+
+   // previous value for reticulate.repl.quiet
+   bool prevReticulateReplQuiet_;
 
    // the documents with active queues
    std::list<boost::shared_ptr<NotebookDocQueue> > queue_;


### PR DESCRIPTION
@kevinushey I think this is the right approach to suppressing the banner, LMK what you think.

Perhaps as annoying is that a bunch of transient objects get printed in an "R Console" output block:

<img width="591" alt="Screen Shot 2021-06-09 at 10 04 07 AM" src="https://user-images.githubusercontent.com/104391/121369670-0c691000-c90a-11eb-85cb-7aa371c35f31.png">

These do not get displayed when executed in JupyterLab:

<img width="815" alt="Screen Shot 2021-06-09 at 10 05 52 AM" src="https://user-images.githubusercontent.com/104391/121369964-4d612480-c90a-11eb-87ef-815acdeed8e1.png">

We need to figure out the right logic for suppressing that output. It seems as if JupyterLab can and does print multiple set of output, but they have some criteria that allows them to exclude that output.