### PR TITLE
Add barebones internationalization support

### DIFF
--- a/src/gwt/.gitignore
+++ b/src/gwt/.gitignore
@@ -9,3 +9,5 @@ war/
 javac.*
 /*.log
 
+# ignore development properties file
+*_dev.properties

--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -137,4 +137,15 @@
 
    <!-- work around incompatibility between GWT 2.8 and Gin 2.1.2 -->
    <set-configuration-property name="gin.classloading.exceptedPackages" value="com.google.gwt.core.client"/>
+
+   <!-- internationalization -->
+   <inherits name="com.google.gwt.i18n.I18N"/>
+   <set-configuration-property name="locale.useragent" value="Y"/>
+   <!-- Set order of precidence for locale settings -->
+   <set-configuration-property name="locale.searchorder" value="queryparam,cookie,useragent,meta"/>
+   <!-- Set only locale and default locale to en to ensure English content only -->
+   <extend-property name="locale" values="en"/>
+   <set-property name="locale" value="en"/>
+   <set-property-fallback name="locale" value="en"/>
+
 </module>

--- a/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioDesktopSuperDevMode.gwt.xml
@@ -4,6 +4,7 @@
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
    <set-property name="rstudio.desktop" value="true"/>
-   <set-property name="locale" value="default"/>
+   <!-- dev language for i18n development -->
+   <extend-property name="locale" values="dev"/>
 </module>
 

--- a/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
@@ -5,5 +5,6 @@
    <set-property name="compiler.stackMode" value="native"/>
    <set-property name="rstudio.desktop" value="false"/>
    <set-property name="user.agent" value="safari"/>
-   <set-property name="locale" value="default"/>
+   <!-- dev language for i18n development -->
+   <extend-property name="locale" values="dev"/>
 </module>

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.application.ui;
 import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -33,13 +34,13 @@ public class AboutDialog extends ModalDialogBase
       super(Roles.getDialogRole());
       RStudioGinjector.INSTANCE.injectMembers(this);
 
-      setText("About " + editionInfo_.editionName());
-      ThemedButton OKButton = new ThemedButton("OK", (ClickEvent) -> closeDialog());
+      setText(messages_.title(editionInfo_.editionName()));
+      ThemedButton OKButton = new ThemedButton(constants_.okBtn(), (ClickEvent) -> closeDialog());
       addOkButton(OKButton);
 
       if (editionInfo_.proLicense() && Desktop.hasDesktopFrame())
       {
-         ThemedButton licenseButton = new ThemedButton("Manage License...", (ClickEvent) ->  {
+         ThemedButton licenseButton = new ThemedButton(constants_.manageLicenseBtn(), (ClickEvent) ->  {
             closeDialog();
             editionInfo_.showLicense();
          });
@@ -47,7 +48,7 @@ public class AboutDialog extends ModalDialogBase
       }
       contents_ = new AboutDialogContents(info, editionInfo_);
       setARIADescribedBy(contents_.getDescriptionElement());
-      setWidth("600px");
+      setWidth("600px"); //$NON-NLS-1$
    }
 
    @Override
@@ -70,4 +71,7 @@ public class AboutDialog extends ModalDialogBase
 
    private AboutDialogContents contents_;
    private ProductEditionInfo editionInfo_;
+
+   private AboutDialogConstants constants_ = GWT.create(AboutDialogConstants.class);
+   private AboutDialogMessages messages_ = GWT.create(AboutDialogMessages.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants.java
@@ -1,11 +1,25 @@
+/*
+ * AboutDialogConstants.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.application.ui;
 
 import com.google.gwt.i18n.client.Constants;
 
 public interface AboutDialogConstants extends Constants {
-    @DefaultStringValue("|OK")
+    @DefaultStringValue("OK")
     String okBtn();
 
-    @DefaultStringValue("|Manage License...")
+    @DefaultStringValue("Manage License...")
     String manageLicenseBtn();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants.java
@@ -1,0 +1,11 @@
+package org.rstudio.studio.client.application.ui;
+
+import com.google.gwt.i18n.client.Constants;
+
+public interface AboutDialogConstants extends Constants {
+    @DefaultStringValue("|OK")
+    String okBtn();
+
+    @DefaultStringValue("|Manage License...")
+    String manageLicenseBtn();
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogConstants_en.properties
@@ -1,0 +1,2 @@
+okBtn = Ok
+manageLicenseBtn = Manage License

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages.java
@@ -1,8 +1,22 @@
+/*
+ * AboutDialogMessages.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 package org.rstudio.studio.client.application.ui;
 
 import com.google.gwt.i18n.client.Messages;
 
 public interface AboutDialogMessages extends Messages {
-    @DefaultMessage("|About {0}")
+    @DefaultMessage("About {0}")
     String title(String version);
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages.java
@@ -1,0 +1,8 @@
+package org.rstudio.studio.client.application.ui;
+
+import com.google.gwt.i18n.client.Messages;
+
+public interface AboutDialogMessages extends Messages {
+    @DefaultMessage("|About {0}")
+    String title(String version);
+}

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogMessages_en.properties
@@ -1,0 +1,1 @@
+title = About {0}

--- a/src/gwt/tools/i18n-helpers/README.md
+++ b/src/gwt/tools/i18n-helpers/README.md
@@ -1,0 +1,43 @@
+# Summary
+
+This README describes the internationalization (i18n) development workflow and helper tools available.
+
+# i18n in RStudio
+
+## Implementation Details
+
+i18n is implemented using GWT's [i18n](http://www.gwtproject.org/doc/latest/DevGuideI18n.html) features, typically through static string internationalization.  Until i18n has been enabled across RStudio, non-English locales are enabled only when running `ant` in `SuperDevMode`.  
+
+To localize part of the codebase, define interfaces that extend `com.google.gwt.i18n.client.Constants` and `.Messages`.  Include `String`s with `@DefaultStringValue`s in the interfaces for all localized text, and cite these `String` objects in your code to get their text values.  To add locales to your application, add properties files called `INTERFACENAME_LOCALE.properties`.  An example of this implemented is available in `src/org/rstudio/studio/client/application/ui/AboutDialog.java`, which cites:
+* `AboutDialogConstants.java` (interface for constants)
+* `AboutDialogConstants_en.properties` (English locale for constants)
+* `AboutDialogConstants.java` (interface for messages)
+* `AboutDialogMessages_en.properties` (English locale for messages)
+
+When debugging, access non-English locales from `SuperDevMode` by adding `?locale=yourLocale` to the RStudio URL (for example, `http://localhost:8787/?locale=yourLocale`).
+
+When serving localized content, GWT will serve it in the following order:
+* Locale matching the locale selected, if available (if `?locale=en`, serve `*_en.properties` if it is available)
+* Default locale (defined in `RStudio.gwt.xml` or other XML files), if available
+* The `@DefaultStringValue` text
+
+GWT suggests you always include both a `@DefaultStringValue` and at least one `.properties` file.
+
+## Development Workflow 
+
+When implementing i18n and going from hard-coded English text to text from an English properties file, it can be hard to know what is/is not translated and whether your translations are actually working because you are "translating" without changing the visible content.  One workflow to help with this problem is to use a "dev" locale which applies easily visible changes to the text for development purposes.  The "dev" locale is:
+* a copy of the current English locale's `.properties` files, with "@" prepended to all constants and messages to make them clearly visible in the UI
+* enabled when in SuperDevMode (server or desktop) and accessible at `http://localhost:8787/?locale=dev`, but not accessible during production use (see `RStudioSuperDevMode.gwt.xml`/`RStudioDesktopSuperDevMode.gwt.xml`)
+* intended to be generated when needed during development and to be committed with the codebase (files are ignored in `.gitignore`)
+
+For example, below shows a "dev" locale where menus and commands have i18n support but other text does not:
+
+![Example of partly-translated dev locale](./rstudio-dev-locale-example.png)
+
+# Tools
+
+## create_dev_locale.sh
+
+Useful for debugging i18n and visually confirming what is/is not i18n-enabled by creating `*_dev.properties` files from existing `*_en.properties` files.  The script copies the English properties files and prefixes their texts with `@`. 
+
+Run this script from `/src/gwt/src` with syntax `./create_dev_locale.sh`

--- a/src/gwt/tools/i18n-helpers/create_dev_locale.sh
+++ b/src/gwt/tools/i18n-helpers/create_dev_locale.sh
@@ -1,4 +1,6 @@
-# Creates a "_dev" locale, which is a copy of the _en locale with PREFIX prepended 
+#!/usr/bin/env bash
+
+# Creates a "_dev" locale, which is a copy of the _en locale with PREFIX prepended
 # onto all strings for easy spotting in the UI
 # 
 # Running this script will result in a "XXX_dev.properties" file for each 
@@ -9,7 +11,7 @@
 
 PREFIX="@"
 
-for src in $(find -name "*en.properties"); do
+for src in $(find . -name "*en.properties"); do
   tgt=$(echo "$src" | sed -e 's/_en.properties$/_dev.properties/')
   echo "Copying $src -> $tgt"
   if [ -f "$tgt" ]; then

--- a/src/gwt/tools/i18n-helpers/create_dev_locale.sh
+++ b/src/gwt/tools/i18n-helpers/create_dev_locale.sh
@@ -17,7 +17,11 @@ for src in $(find . -name "*en.properties"); do
   if [ -f "$tgt" ]; then
   	echo "WARNING: Target $tgt already exists - skipping"
   else
-  	# "copy" src with sed, replacing all lines of "X = Y" with "X = {PREFIX}Y"
-	sed -E "s/^([^\n=]*)=([ ]*)([^\n]*)\$/\1=\2${PREFIX}\3/" $src > $tgt
+    # "copy" src with sed, replacing all lines of "X = Y" with "X = {PREFIX}Y"
+    if [[ "$OSTYPE" = "darwin"* ]]; then
+      sed -E "s/^([^\x0D=]*)=([ ]*)([^\x0D]*)/\1=\2${PREFIX}\3/" $src > $tgt
+    else
+      sed -E "s/^([^\n=]*)=([ ]*)([^\n]*)\$/\1=\2${PREFIX}\3/" $src > $tgt
+    fi
   fi
 done

--- a/src/gwt/tools/i18n-helpers/create_dev_locale.sh
+++ b/src/gwt/tools/i18n-helpers/create_dev_locale.sh
@@ -1,0 +1,21 @@
+# Creates a "_dev" locale, which is a copy of the _en locale with PREFIX prepended 
+# onto all strings for easy spotting in the UI
+# 
+# Running this script will result in a "XXX_dev.properties" file for each 
+# "XXX_en.properties" file in this directory and its subdirectories
+
+# Note: run this from /src/gwt/src, otherwise you'll create extra properties files
+# from places that are generated code rather than input code
+
+PREFIX="@"
+
+for src in $(find -name "*en.properties"); do
+  tgt=$(echo "$src" | sed -e 's/_en.properties$/_dev.properties/')
+  echo "Copying $src -> $tgt"
+  if [ -f "$tgt" ]; then
+  	echo "WARNING: Target $tgt already exists - skipping"
+  else
+  	# "copy" src with sed, replacing all lines of "X = Y" with "X = {PREFIX}Y"
+	sed -E "s/^([^\n=]*)=([ ]*)([^\n]*)\$/\1=\2${PREFIX}\3/" $src > $tgt
+  fi
+done


### PR DESCRIPTION
### Intent

See #9083 for more context on i18n efforts.

This PR enables i18n in RStudio development and "translates" some content of the AboutDialog in a backwards compatable way.

### Approach

* Enable i18n features by modifying RStudio.gwt.xml to accept only "en" locale and redirect all other locales to "en" by default.  This allows any available translations to be live without changing function for the user.  
* To make development easier, add "dev" locale to RStudioSuperDevMode.gwt.xml and RStudioDesktopSuperDevMode.gwt.xml.  This lets developers add `*_dev.properties` files with obvious changes to see if i18n changes worked without exposing them to and real users
* Add create_dev_locale.sh which creates a "dev" locale from any existing "en" properties files.  The "dev" locale is a copy of "en" properties files with "@" prepended to the strings to make it easy to see if i18n features worked during development
* Add i18n for part of the AboutDialog as a non-breaking proof of concept.  Frame Title, "OK" button, and license message are  "translated" using GWT i18n features to English as proof-of-concept translation.  AboutDialogConstants.java and AboutDialogMessages.java provide the interfaces for translation
* Add "*_dev.properties" to .gitignore to avoid committing any development locales

### Automated Tests

No additional testing is added.  I'm interested in feedback on what testing would be appropriate.

### QA Notes

This change is believed to be fully working without changing the user experience, but feedback is welcome as I am not an expert RStudio or GWT.  To confirm i18n is working for AboutDialog, while running RStudio in devmode you can do one of:
* Modify AboutDialogConstants_en.properties and AboutDialogMessages_en.properties and refresh RStudio with ant in devmode.  The following fields should change (if you have a license, the license message should also change)
![image](https://user-images.githubusercontent.com/48125859/121401389-aa6ad380-c926-11eb-9d39-b4bbd196201d.png)
* Run `create_dev_locale.sh` to clone all `_en` properties files, adding a prefix of "@" to each constant and message.  Then open RStudio using `http://localhost:8787/?locale=dev` and browse to the AboutDialog

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

cc @gtritchie 