### PR TITLE
read system root certificates from keychain for SSL connections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
 RStudio 1.4 "Trampled Dandelion"
 
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server
+* Fixed an issue where RStudio Desktop Pro could fail when connecting to remote sessions via https (Pro, #2651)
+

--- a/src/cpp/core/http/Keychain.mm
+++ b/src/cpp/core/http/Keychain.mm
@@ -20,51 +20,86 @@
 
 #import <AppKit/NSApplication.h>
 
+#define kRootCertsKeychainPath "/System/Library/Keychains/SystemRootCertificates.keychain"
+
 namespace rstudio {
 namespace core {
 namespace http {
 
 std::vector<KeychainCertificateData> getKeychainCertificates()
 {
+   // some up-front declarations
+   OSStatus status;
    std::vector<KeychainCertificateData> certificates;
-
-   NSDictionary* query =
-         @{static_cast<id>(kSecClass): static_cast<id>(kSecClassCertificate),
-           static_cast<id>(kSecMatchLimit): static_cast<id>(kSecMatchLimitAll),
-           static_cast<id>(kSecReturnRef): @YES};
-
-   NSArray* certs = nil;
-   OSStatus result = SecItemCopyMatching(static_cast<CFDictionaryRef>(query),
-                                         (CFTypeRef*)&certs); // C-Style cast required here
+ 
+   // root certificates are not included by default in SecItemCopyMatching searches,
+   // so we need to explicitly add that keychain to the search list
+   SecKeychainRef rootCertsKeychain;
+   status = SecKeychainOpen(kRootCertsKeychainPath, &rootCertsKeychain);
+   if (status != errSecSuccess)
+   {
+      LOG_ERROR_MESSAGE("Could not open system root certificate store");
+      return certificates;
+   }
+   
+   // read current (default) search list
+   CFArrayRef currentSearchList;
+   SecKeychainCopySearchList(&currentSearchList);
+   
+   // copy to mutable array (so we can append root certs)
+   NSMutableArray* searchList = [(NSArray*) currentSearchList mutableCopy];
+   [searchList addObject: (id) rootCertsKeychain];
+   
+   // build our query
+   NSDictionary* query = @{
+      (id) kSecMatchSearchList: (id) searchList,
+      (id) kSecClass:           (id) kSecClassCertificate,
+      (id) kSecMatchLimit:      (id) kSecMatchLimitAll,
+      (id) kSecReturnRef:       @YES
+   };
+   
+   // execute the query
+   CFArrayRef certs;
+   OSStatus result = SecItemCopyMatching((CFDictionaryRef) query, (CFTypeRef*) &certs);
+   
+   // release values required by the query
+   [searchList release];
+   CFRelease(currentSearchList);
+   CFRelease(rootCertsKeychain);
+   
+   // check for and bail on failure
    if (result != errSecSuccess)
    {
-       LOG_ERROR_MESSAGE("Could not search keychains: error code " + safe_convert::numberToString(result));
-       return certificates;
+      LOG_ERROR_MESSAGE("Could not search keychains: error code " + safe_convert::numberToString(result));
+      return certificates;
    }
-
-   for (unsigned int i = 0; i < [certs count]; ++i)
+   
+   // iterate and copy certificate data
+   for (CFIndex i = 0; i < CFArrayGetCount(certs); ++i)
    {
-      SecCertificateRef cert = reinterpret_cast<SecCertificateRef>([certs objectAtIndex:i]);
+      // copy the certificate data into a raw byte representation
+      // (these will be converted by OpenSSL appropriately later)
+      SecCertificateRef cert = (SecCertificateRef) CFArrayGetValueAtIndex(certs, i);
       CFDataRef certData = SecCertificateCopyData(cert);
-
+      
       CFRange range;
       range.location = 0;
       range.length = CFDataGetLength(certData);
-
+      
       struct KeychainCertificateData keychainCertData;
       keychainCertData.size = range.length;
       keychainCertData.data = boost::shared_ptr<unsigned char>(new unsigned char[range.length]);
-
+      
       CFDataGetBytes(certData, range, keychainCertData.data.get());
-
+      CFRelease(certData);
+      
       certificates.push_back(keychainCertData);
    }
 
-   [certs release];
+   CFRelease(certs);
    return certificates;
 }
 
 } // namespace http
 } // namespace core
 } // namespace rstudio
-


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2651.

On macOS, the current `getKeychainCertificates()` implementation unfortunately does not read system root certificates, which implies that SSL connections (unless we get lucky and OpenSSL finds a `certs.pem` file) will fail to connect.

### Approach

Explicitly include the root certificate keychain when searching for certificates, and disable the default OpenSSL `cert.pem` lookup on Windows + macOS (since it will point to a Homebrew-specific location that is not useful on these platforms).

### Automated Tests

Not included.

### QA Notes

Test that RDP -> RSP connections work on macOS.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
