### PR TITLE
various enhancements to python integration

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 ## RStudio 1.5 "Ghost Orchid" Release Notes
 
+### Python
+
+* Projects containing a Python environment in the '.venv' folder are now automatically activated (#9489)
+
+
 ### Logging
 
 * In an effort to help make the RStudio Team products more cohesive, logging has been changed significantly.
@@ -11,6 +16,7 @@
 * Logging can now be partially configured using environment variables (`RS_LOGGER_TYPE`, `RS_LOG_LEVEL`, `RS_LOG_MESSAGE_FORMAT`, and `RS_LOG_DIR`).
 * Log files will now rotate by time in addition to the existing rotation by file size. This can be controlled by the `rotate-days` parameter in `logging.conf`.
 * For more information, see section 2 of the Admin Guide.
+
 
 ### Bugfixes
 
@@ -24,6 +30,7 @@
 * Fixed issue where busy sessions can't be interrupted and block basic file operations (#2038)
 * Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
+
 
 ### Misc
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -180,6 +180,7 @@ struct RSuspendOptions;
 struct RCallbacks
 {
    boost::function<core::Error(const RInitInfo&)> init;
+   boost::function<void()> initComplete;
    boost::function<bool(const std::string&, bool, RConsoleInput*)> consoleRead;
    boost::function<void(const std::string&)> browseURL;
    boost::function<void(const core::FilePath&)> browseFile;

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -350,28 +350,29 @@ Error initialize()
    if (error)
       return error;
    
+   // set server options
+#ifdef __linux__
+   if (utils::isServerMode())
+   {
+      FilePath serverOptionsFilePath =
+            utils::rSourcePath().completePath("ServerOptions.R");
+      
+      Error error = r::sourceManager().sourceLocal(serverOptionsFilePath);
+      if (error)
+         return error;
+   }
+#endif
+   
+   // now run hooks for those waiting for session to be fully initialized
+   if (rCallbacks().initComplete)
+      rCallbacks().initComplete();
+   
    // run tests if configured to do so
    // (note that the callback will exit the process after tests have been run)
    if (rCallbacks().runTests)
-   {
       rCallbacks().runTests();
-   }
-
-   // server specific R options options
-   if (utils::isServerMode())
-   {
-#ifndef __APPLE__
-      FilePath serverOptionsFilePath = utils::rSourcePath().completePath(
-         "ServerOptions.R");
-      return r::sourceManager().sourceLocal(serverOptionsFilePath);
-#else
-      return Success();
-#endif
-   }
-   else
-   {
-      return Success();
-   }
+   
+   return Success();
 }
 
 void ensureDeserialized()

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -267,10 +267,10 @@ InternalCallbacks* stdInternalCallbacks()
    return &s_internalCallbacks;
 }
 
-int RReadConsole (const char *pmt,
-                  CONSOLE_BUFFER_CHAR* buf,
-                  int buflen,
-                  int hist)
+int RReadConsole(const char *pmt,
+                 CONSOLE_BUFFER_CHAR* buf,
+                 int buflen,
+                 int hist)
 {
    try
    {

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -746,6 +746,11 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
    return Success();
 }
 
+void rInitComplete()
+{
+   module_context::events().onInitComplete();
+}
+
 void notifyIfRVersionChanged()
 {
    using namespace rstudio::r::session::state;
@@ -2216,6 +2221,7 @@ int main (int argc, char * const argv[])
       // r callbacks
       rstudio::r::session::RCallbacks rCallbacks;
       rCallbacks.init = rInit;
+      rCallbacks.initComplete = rInitComplete;
       rCallbacks.consoleRead = console_input::rConsoleRead;
       rCallbacks.editFile = rEditFile;
       rCallbacks.showFile = rShowFile;

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -328,32 +328,29 @@ struct firstNonEmpty
 // session events
 struct Events : boost::noncopyable
 {
-   RSTUDIO_BOOST_SIGNAL<void (core::json::Object*)> onSessionInfo;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onClientInit;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onBeforeExecute;
-   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>   onConsolePrompt;
-   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>   onConsoleInput;
-   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)>  
-                                             onActiveConsoleChanged;
-   RSTUDIO_BOOST_SIGNAL<void (ConsoleOutputType, const std::string&)>
-                                             onConsoleOutput;
-   RSTUDIO_BOOST_SIGNAL<void()>                     onUserInterrupt;
-   RSTUDIO_BOOST_SIGNAL<void (ChangeSource)>        onDetectChanges;
-   RSTUDIO_BOOST_SIGNAL<void (core::FilePath)>      onSourceEditorFileSaved;
-   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onDeferredInit;
-   RSTUDIO_BOOST_SIGNAL<void(bool)>                 afterSessionInitHook;
-   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onBackgroundProcessing;
-   RSTUDIO_BOOST_SIGNAL<void(bool)>                 onShutdown;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onQuit;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onDestroyed;
-   RSTUDIO_BOOST_SIGNAL<void (const std::vector<std::string>&)>
-                                             onLibPathsChanged;
-   RSTUDIO_BOOST_SIGNAL<void (const std::string&)>  onPackageLoaded;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onPackageLibraryMutated;
-   RSTUDIO_BOOST_SIGNAL<void ()>                    onPreferencesSaved;
-   RSTUDIO_BOOST_SIGNAL<void (const core::DistributedEvent&)>
-                                             onDistributedEvent;
-   RSTUDIO_BOOST_SIGNAL<void (core::FilePath)>      onPermissionsChanged;
+   RSTUDIO_BOOST_SIGNAL<void(core::json::Object*)>                    onSessionInfo;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onClientInit;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onInitComplete;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onDeferredInit;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                                   afterSessionInitHook;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onBeforeExecute;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onConsolePrompt;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onConsoleInput;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&, const std::string&)> onActiveConsoleChanged;
+   RSTUDIO_BOOST_SIGNAL<void(ConsoleOutputType, const std::string&)>  onConsoleOutput;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onUserInterrupt;
+   RSTUDIO_BOOST_SIGNAL<void(ChangeSource)>                           onDetectChanges;
+   RSTUDIO_BOOST_SIGNAL<void(core::FilePath)>                         onSourceEditorFileSaved;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onBackgroundProcessing;
+   RSTUDIO_BOOST_SIGNAL<void(const std::vector<std::string>&)>        onLibPathsChanged;
+   RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onPackageLoaded;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onPackageLibraryMutated;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onPreferencesSaved;
+   RSTUDIO_BOOST_SIGNAL<void(const core::DistributedEvent&)>          onDistributedEvent;
+   RSTUDIO_BOOST_SIGNAL<void(core::FilePath)>                         onPermissionsChanged;
+   RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onShutdown;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onQuit;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onDestroyed;
 
    // signal for detecting extended type of documents
    RSTUDIO_BOOST_SIGNAL<std::string(boost::shared_ptr<source_database::SourceDocument>),

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -388,6 +388,7 @@ namespace prefs {
 #define kMemoryQueryIntervalSeconds "memory_query_interval_seconds"
 #define kTerminalPythonIntegration "terminal_python_integration"
 #define kSessionProtocolDebug "session_protocol_debug"
+#define kPythonProjectEnvironmentAutomaticActivate "python_project_environment_automatic_activate"
 
 class UserPrefValues: public Preferences
 {
@@ -1724,6 +1725,12 @@ public:
     */
    bool sessionProtocolDebug();
    core::Error setSessionProtocolDebug(bool val);
+
+   /**
+    * When enabled, if the active project contains a Python virtual environment located within the project's .venv folder, then RStudio will automatically activate this environment on startup.
+    */
+   bool pythonProjectEnvironmentAutomaticActivate();
+   core::Error setPythonProjectEnvironmentAutomaticActivate(bool val);
 
 };
 

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -57,12 +57,13 @@
    if (!identical(activate, TRUE))
       return()
    
-   # get path to configured version of python
-   pythonPath <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
-   if (is.na(pythonPath))
-      pythonPath <- .rs.python.projectInterpreterPath(projectDir)
+   # if the user has set RETICULATE_PYTHON, assume they're taking control
+   reticulatePython <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
+   if (!is.na(reticulatePython))
+      return()
    
-   # bail if it doesn't exist
+   # get path to project interpreter (bail if it doesn't exist)
+   pythonPath <- .rs.python.projectInterpreterPath(projectDir)
    if (!file.exists(pythonPath))
       return()
    

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -45,9 +45,9 @@
 
 .rs.addFunction("python.projectInterpreterPath", function(projectDir)
 {
-   suffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
    venvPath <- file.path(projectDir, ".venv")
-   file.path(venvPath, suffix)
+   pythonSuffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
+   file.path(venvPath, pythonSuffix)
 })
 
 .rs.addFunction("python.initialize", function(projectDir)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -181,6 +181,7 @@
 .rs.addFunction("python.findPythonInterpreters", function()
 {
    interpreters <- unname(c(
+      .rs.python.findPythonProjectInterpreters(),
       .rs.python.findPythonSystemInterpreters(),
       .rs.python.findPythonInterpretersInKnownLocations(),
       .rs.python.findPythonPyenvInterpreters(),
@@ -195,6 +196,24 @@
       default_interpreter = .rs.scalar(default)
    )
    
+})
+
+.rs.addFunction("python.findPythonProjectInterpreters", function()
+{
+   projectDir <- .rs.getProjectDirectory()
+   if (is.null(projectDir))
+      return(list())
+   
+   candidateDirs <- list.files(
+      path = projectDir,
+      all.files = TRUE,
+      full.names = TRUE
+   )
+   
+   pythonSuffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
+   candidatePaths <- file.path(candidateDirs, pythonSuffix)
+   pythonPaths <- Filter(file.exists, candidatePaths)
+   lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
 })
 
 .rs.addFunction("python.findPythonSystemInterpreters", function()

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -43,6 +43,55 @@
    .rs.python.describeInterpreter(pythonPath)
 })
 
+.rs.addFunction("python.projectInterpreterPath", function(projectDir)
+{
+   suffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
+   venvPath <- file.path(projectDir, ".venv")
+   file.path(venvPath, suffix)
+})
+
+.rs.addFunction("python.initialize", function(projectDir)
+{
+   # do nothing if the user hasn't opted in
+   activate <- .rs.readUiPref("python_project_environment_automatic_activate")
+   if (!identical(activate, TRUE))
+      return()
+   
+   # get path to configured version of python
+   pythonPath <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
+   if (is.na(pythonPath))
+      pythonPath <- .rs.python.projectInterpreterPath(projectDir)
+   
+   # bail if it doesn't exist
+   if (!file.exists(pythonPath))
+      return()
+   
+   # normalize path (avoid following symlinks)
+   pythonPath <- file.path(
+      normalizePath(dirname(pythonPath), winslash = "/", mustWork = FALSE),
+      basename(pythonPath)
+   )
+ 
+   # add the Python directory to the PATH
+   oldPath <- Sys.getenv("PATH")
+   pythonBin <- normalizePath(dirname(pythonPath))
+   newPath <- paste(pythonBin, oldPath, sep = .Platform$path.sep)
+   Sys.setenv(PATH = newPath)
+   
+   # if this is a virtual environment, set VIRTUAL_ENV
+   pythonInfo <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
+   if (identical(pythonInfo$type, "virtualenv")) {
+      envPath <- dirname(dirname(pythonPath))
+      Sys.setenv(VIRTUAL_ENV = envPath)
+   }
+   
+   # also set RETICULATE_PYTHON so this python is used by default
+   Sys.setenv(RETICULATE_PYTHON = pythonPath)
+   
+   # return path to python
+   invisible(pythonPath)
+})
+
 .rs.addFunction("python.execute", function(python, code)
 {
    python <- normalizePath(python, winslash = "/", mustWork = TRUE)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -57,6 +57,10 @@
    if (!identical(activate, TRUE))
       return()
    
+   # nothing to do if we don't have a project
+   if (is.null(projectDir) || !file.exists(projectDir))
+      return()
+   
    # if the user has set RETICULATE_PYTHON, assume they're taking control
    reticulatePython <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
    if (!is.na(reticulatePython))

--- a/src/cpp/session/modules/SessionPythonEnvironments.cpp
+++ b/src/cpp/session/modules/SessionPythonEnvironments.cpp
@@ -53,7 +53,7 @@ void onPrefsChanged(const std::string& /* layerName */,
    }
 }
 
-void onDeferredInit(bool)
+void onInitComplete()
 {
    if (!projects::projectContext().hasProject())
       return;
@@ -72,7 +72,7 @@ Error initialize()
 {
    using namespace module_context;
    
-   events().onDeferredInit.connect(onDeferredInit);
+   events().onInitComplete.connect(onInitComplete);
    
    prefs::userPrefs().onChanged.connect(onPrefsChanged);
 

--- a/src/cpp/session/modules/SessionPythonEnvironments.cpp
+++ b/src/cpp/session/modules/SessionPythonEnvironments.cpp
@@ -53,31 +53,32 @@ void onPrefsChanged(const std::string& /* layerName */,
    }
 }
 
+void onDeferredInit(bool)
+{
+   if (!projects::projectContext().hasProject())
+      return;
+   
+   Error error = r::exec::RFunction(".rs.python.initialize")
+         .addUtf8Param(projects::projectContext().directory())
+         .call();
+   
+   if (error)
+      LOG_ERROR(error);
+}
+
 } // end anonymous namespace
 
 Error initialize()
 {
    using namespace module_context;
    
+   events().onDeferredInit.connect(onDeferredInit);
+   
    prefs::userPrefs().onChanged.connect(onPrefsChanged);
 
    ExecBlock initBlock;
    initBlock.addFunctions()
       (bind(sourceModuleRFile, "SessionPythonEnvironments.R"));
-   
-   Error error = initBlock.execute();
-   if (error)
-      return error;
-   
-   if (projects::projectContext().hasProject())
-   {
-      projects::projectContext().directory();
-      Error error = r::exec::RFunction(".rs.python.initialize")
-            .addUtf8Param(projects::projectContext().directory())
-            .call();
-      if (error)
-         LOG_ERROR(error);
-   }
    
    return initBlock.execute();
 }

--- a/src/cpp/session/modules/SessionPythonEnvironments.cpp
+++ b/src/cpp/session/modules/SessionPythonEnvironments.cpp
@@ -21,6 +21,7 @@
 
 #include <session/prefs/UserPrefs.hpp>
 #include <session/prefs/UserPrefValues.hpp>
+#include <session/projects/SessionProjects.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -52,11 +53,26 @@ void onPrefsChanged(const std::string& /* layerName */,
    }
 }
 
+void onDeferredInit(bool)
+{
+   if (!projects::projectContext().hasProject())
+      return;
+   
+   Error error = r::exec::RFunction(".rs.python.initialize")
+         .addUtf8Param(projects::projectContext().directory())
+         .call();
+   
+   if (error)
+      LOG_ERROR(error);
+}
+
 } // end anonymous namespace
 
 Error initialize()
 {
    using namespace module_context;
+   
+   events().onDeferredInit.connect(onDeferredInit);
    
    prefs::userPrefs().onChanged.connect(onPrefsChanged);
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2909,6 +2909,19 @@ core::Error UserPrefValues::setSessionProtocolDebug(bool val)
    return writePref("session_protocol_debug", val);
 }
 
+/**
+ * When enabled, if the active project contains a Python virtual environment located within the project's .venv folder, then RStudio will automatically activate this environment on startup.
+ */
+bool UserPrefValues::pythonProjectEnvironmentAutomaticActivate()
+{
+   return readPref<bool>("python_project_environment_automatic_activate");
+}
+
+core::Error UserPrefValues::setPythonProjectEnvironmentAutomaticActivate(bool val)
+{
+   return writePref("python_project_environment_automatic_activate", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3134,6 +3147,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kMemoryQueryIntervalSeconds,
       kTerminalPythonIntegration,
       kSessionProtocolDebug,
+      kPythonProjectEnvironmentAutomaticActivate,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1510,6 +1510,12 @@
             "title": "Session protocol debug logging",
             "type": "boolean",
             "default": false
+        },
+        "python_project_environment_automatic_activate": {
+            "description": "When enabled, if the active project contains a Python virtual environment located within the project's .venv folder, then RStudio will automatically activate this environment on startup.",
+            "title": "Automatically activate project Python environments",
+            "type": "boolean",
+            "default": true
         }
     }
 }

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -156,6 +156,7 @@ public class ElementIds
    public final static String DIALOG_APPLY_BUTTON = "dlg_apply";
    public final static String DIALOG_RETRY_BUTTON = "dlg_retry";
    public final static String DIALOG_HOME_BUTTON = "dlg_home";
+   public final static String DIALOG_CLEAR_BUTTON = "dlg_clear";
    public final static String SELECT_ALL_BUTTON = "select_all";
    public final static String SELECT_NONE_BUTTON = "select_none";
    public final static String ABOUT_MANAGE_LICENSE_BUTTON = "about_manage_license";
@@ -253,6 +254,7 @@ public class ElementIds
    // TextBoxWithButton and subclasses -- prefixes for button/text/help, combined with suffixes
    public final static String TBB_TEXT = "tbb_text";
    public final static String TBB_BUTTON = "tbb_button";
+   public final static String TBB_CLEAR_BUTTON = "tbb_clear_button";
    public final static String TBB_HELP = "tbb_help";
 
    // TextBoxWithButton and subclasses -- unique suffix added to text field, button, and help link;

--- a/src/gwt/src/org/rstudio/core/client/widget/FileChooserTextBox.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/FileChooserTextBox.java
@@ -75,6 +75,7 @@ public class FileChooserTextBox extends TextBoxWithButton
             null, /* helpButton */
             uniqueId,
             true, /* readOnly */
+            false,
             null /* clickHandler */);
 
       if (buttonDisabled)

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.java
@@ -567,23 +567,30 @@ public abstract class ModalDialogBase extends DialogBox
          NativeEvent nativeEvent = event.getNativeEvent();
          switch (nativeEvent.getKeyCode())
          {
+         
          case KeyCodes.KEY_ENTER:
+         {
 
             if (enterDisabled_)
                break;
 
             // allow Enter on textareas, buttons, or anchors (including custom links)
             Element e = DomUtils.getActiveElement();
-            if (e.hasTagName("TEXTAREA") ||
+            
+            boolean enterAllowed =
+                  e.hasTagName("TEXTAREA") ||
                   e.hasTagName("A") ||
                   e.hasTagName("BUTTON") ||
                   e.hasClassName(ALLOW_ENTER_KEY_CLASS) ||
-                  (e.hasAttribute("role") && StringUtil.equals(e.getAttribute("role"), "link")))
+                  (e.hasAttribute("role") && StringUtil.equals(e.getAttribute("role"), "link"));
+            
+            if (enterAllowed)
                return;
 
             ThemedButton defaultButton = defaultOverrideButton_ == null
                   ? okButton_
                   : defaultOverrideButton_;
+            
             if ((defaultButton != null) && defaultButton.isEnabled())
             {
                nativeEvent.preventDefault();
@@ -591,14 +598,26 @@ public abstract class ModalDialogBase extends DialogBox
                event.cancel();
                defaultButton.click();
             }
+            
             break;
+         }
+            
          case KeyCodes.KEY_ESCAPE:
+         {
+            
             if (escapeDisabled_)
                break;
+            
+            Element e = DomUtils.getActiveElement();
+            if (e.hasClassName(ALLOW_ESCAPE_KEY_CLASS))
+               break;
+            
             onEscapeKeyDown(event);
             break;
-
+         }
+         
          case KeyCodes.KEY_TAB:
+         {
             if (nativeEvent.getShiftKey() && focus_.isFirst(DomUtils.getActiveElement()))
             {
                nativeEvent.preventDefault();
@@ -614,6 +633,8 @@ public abstract class ModalDialogBase extends DialogBox
                focusFirstControl();
             }
             break;
+         }
+         
          }
       }
    }
@@ -827,4 +848,5 @@ public abstract class ModalDialogBase extends DialogBox
    private final FocusHelper focus_;
    
    public static final String ALLOW_ENTER_KEY_CLASS = "__rstudio_modal_allow_enter_key";
+   public static final String ALLOW_ESCAPE_KEY_CLASS = "__rstudio_modal_allow_escape_key";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -15,6 +15,7 @@
 package org.rstudio.core.client.widget;
 
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -51,7 +52,7 @@ public class TextBoxWithButton extends Composite
                             boolean readOnly,
                             ClickHandler handler)
    {
-      this(label, null, emptyLabel, action, helpButton, uniqueId, readOnly, handler);
+      this(label, null, emptyLabel, action, helpButton, uniqueId, readOnly, false, handler);
    }
 
    /**
@@ -69,17 +70,18 @@ public class TextBoxWithButton extends Composite
                             boolean readOnly,
                             ClickHandler handler)
    {
-      this(null, existingLabel, emptyLabel, action, null, uniqueId, readOnly, handler);
+      this(null, existingLabel, emptyLabel, action, null, uniqueId, readOnly, false, handler);
    }
 
-   protected TextBoxWithButton(String label,
-                               FormLabel existingLabel,
-                               String emptyLabel,
-                               String action,
-                               HelpButton helpButton,
-                               ElementIds.TextBoxButtonId uniqueId,
-                               boolean readOnly,
-                               ClickHandler handler)
+   public TextBoxWithButton(String label,
+                            FormLabel existingLabel,
+                            String emptyLabel,
+                            String action,
+                            HelpButton helpButton,
+                            ElementIds.TextBoxButtonId uniqueId,
+                            boolean readOnly,
+                            boolean addClearButton,
+                            ClickHandler handler)
    {
       emptyLabel_ = StringUtil.isNullOrEmpty(emptyLabel) ? "" : emptyLabel;
       uniqueId_ = "_" + uniqueId;
@@ -97,10 +99,24 @@ public class TextBoxWithButton extends Composite
 
       // prevent button from triggering "submit" when hosted in a form, such as in FileUploadDialog
       themedButton_.getElement().setAttribute("type", "button");
+      
+      clearButton_ = new ThemedButton("Clear", (ClickEvent event) ->
+      {
+         setText("");
+      });
+      
+      clearButton_.getElement().getStyle().setMarginLeft(0, Unit.PX);
+      clearButton_.getElement().setAttribute("type", "button");
 
       inner_ = new HorizontalPanel();
       inner_.add(textBox_);
       inner_.add(themedButton_);
+      
+      if (addClearButton)
+      {
+         inner_.add(clearButton_);
+      }
+      
       inner_.setCellWidth(textBox_, "100%");
       inner_.setWidth("100%");
 
@@ -250,6 +266,7 @@ public class TextBoxWithButton extends Composite
       // prevent duplicates.
       ElementIds.assignElementId(textBox_, ElementIds.TBB_TEXT + uniqueId_);
       ElementIds.assignElementId(themedButton_, ElementIds.TBB_BUTTON + uniqueId_);
+      ElementIds.assignElementId(themedButton_, ElementIds.TBB_CLEAR_BUTTON + uniqueId_);
       if (helpButton_ != null)
          ElementIds.assignElementId(helpButton_, ElementIds.TBB_HELP + uniqueId_);
       if (lblCaption_ != null)
@@ -262,6 +279,7 @@ public class TextBoxWithButton extends Composite
    private final TextBox textBox_;
    private HelpButton helpButton_;
    private final ThemedButton themedButton_;
+   private final ThemedButton clearButton_;
    private final String emptyLabel_;
    private String useDefaultValue_;
    private String uniqueId_;

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPythonPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPythonPreferencesPane.java
@@ -30,7 +30,7 @@ public class ProjectPythonPreferencesPane extends PythonPreferencesPaneBase<RPro
    public ProjectPythonPreferencesPane(PythonDialogResources res,
                                        PythonServerOperations server)
    {
-      super("380px", "(Use default)");
+      super("380px", "(Use default)", true);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3147,6 +3147,18 @@ public class UserPrefsAccessor extends Prefs
          false);
    }
 
+   /**
+    * When enabled, if the active project contains a Python virtual environment located within the project's .venv folder, then RStudio will automatically activate this environment on startup.
+    */
+   public PrefValue<Boolean> pythonProjectEnvironmentAutomaticActivate()
+   {
+      return bool(
+         "python_project_environment_automatic_activate",
+         "Automatically activate project Python environments", 
+         "When enabled, if the active project contains a Python virtual environment located within the project's .venv folder, then RStudio will automatically activate this environment on startup.", 
+         true);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -3593,6 +3605,8 @@ public class UserPrefsAccessor extends Prefs
          terminalPythonIntegration().setValue(layer, source.getBool("terminal_python_integration"));
       if (source.hasKey("session_protocol_debug"))
          sessionProtocolDebug().setValue(layer, source.getBool("session_protocol_debug"));
+      if (source.hasKey("python_project_environment_automatic_activate"))
+         pythonProjectEnvironmentAutomaticActivate().setValue(layer, source.getBool("python_project_environment_automatic_activate"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -3819,6 +3833,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(memoryQueryIntervalSeconds());
       prefs.add(terminalPythonIntegration());
       prefs.add(sessionProtocolDebug());
+      prefs.add(pythonProjectEnvironmentAutomaticActivate());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPane.java
@@ -27,7 +27,7 @@ public class PythonPreferencesPane extends PythonPreferencesPaneBase<UserPrefs>
    public PythonPreferencesPane(PythonDialogResources res,
                                 PythonServerOperations server)
    {
-      super("420px", "(No interpreter selected)");
+      super("420px", "(No interpreter selected)", false);
       
       overrideLabel_ = new Label();
       add(overrideLabel_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -47,6 +47,7 @@ import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.SimplePanel;
 import com.google.inject.Inject;
@@ -54,7 +55,8 @@ import com.google.inject.Inject;
 public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPaneBase<T>
 {
    public PythonPreferencesPaneBase(String width,
-                                    String placeholderText)
+                                    String placeholderText,
+                                    boolean isProjectOptions)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -163,8 +165,22 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       tbPythonInterpreter_.setReadOnly(false);
       add(spaced(tbPythonInterpreter_));
       
-      add(container_);
+      add(interpreterDescription_);
       
+      if (!isProjectOptions)
+      {
+         cbAutoUseProjectInterpreter_ =
+               new CheckBox("Automatically activate project Python environments");
+         
+         cbAutoUseProjectInterpreter_.setValue(
+               prefs_.pythonProjectEnvironmentAutomaticActivate().getGlobalValue());
+         
+         cbAutoUseProjectInterpreter_.getElement().setTitle(
+               "When enabled, the Python environment in the active project's .venv folder " +
+               "(if any) will be automatically activated on startup.");
+
+         add(lessSpaced(cbAutoUseProjectInterpreter_));
+      }
    }
    
    @Inject
@@ -181,7 +197,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    
    protected void clearDescription()
    {
-      container_.setWidget(new FlowPanel());
+      interpreterDescription_.setWidget(new FlowPanel());
    }
    
    protected void updateDescription()
@@ -250,7 +266,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          
          InfoBar bar = new InfoBar(InfoBar.WARNING);
          bar.setText(reason);
-         container_.setWidget(bar);
+         interpreterDescription_.setWidget(bar);
       }
       else
       {
@@ -277,7 +293,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          }
          
          ui.getPath().setText("[" + type + "]");
-         container_.setWidget(ui);
+         interpreterDescription_.setWidget(ui);
       }
    }
    
@@ -431,7 +447,9 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    
    protected final InfoBar mismatchWarningBar_;
    protected final TextBoxWithButton tbPythonInterpreter_;
-   protected final SimplePanel container_ = new SimplePanel();
+   protected final SimplePanel interpreterDescription_ = new SimplePanel();
+   
+   protected CheckBox cbAutoUseProjectInterpreter_;
    
    protected String initialPythonPath_;
    protected PythonInterpreter interpreter_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.prefs.PreferencesDialogPaneBase;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.HelpButton;
 import org.rstudio.core.client.widget.InfoBar;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.OperationWithInput;
@@ -72,7 +73,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
             null,
             placeholderText_,
             "Select...",
-            null,
+            new HelpButton("using_python", "Using Python in RStudio"),
             ElementIds.TextBoxButtonId.PYTHON_PATH,
             true,
             true,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -35,9 +35,11 @@ import org.rstudio.studio.client.workbench.prefs.views.python.PythonInterpreterL
 import org.rstudio.studio.client.workbench.prefs.views.python.PythonInterpreterSelectionDialog;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
@@ -67,10 +69,12 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       
       tbPythonInterpreter_ = new TextBoxWithButton(
             "Python interpreter:",
+            null,
             placeholderText_,
             "Select...",
             null,
             ElementIds.TextBoxButtonId.PYTHON_PATH,
+            true,
             true,
             new ClickHandler()
             {
@@ -94,7 +98,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
                                        @Override
                                        public void execute(PythonInterpreter input)
                                        {
-                                          String path = input.getPath();
+                                          String path = input == null ? "" : input.getPath();
                                           tbPythonInterpreter_.setText(path);
                                        }
                                     });
@@ -129,6 +133,14 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
             event.preventDefault();
             tbPythonInterpreter_.blur();
          }
+         else if (event.getNativeKeyCode() == KeyCodes.KEY_ESCAPE)
+         {
+            event.stopPropagation();
+            event.preventDefault();
+            if (lastValue_ != null)
+               tbPythonInterpreter_.setText(lastValue_);
+            tbPythonInterpreter_.blur();
+         }
       }, KeyDownEvent.getType());
       
       tbPythonInterpreter_.addDomHandler((BlurEvent event) ->
@@ -136,8 +148,14 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          updateDescription();
       }, BlurEvent.getType());
       
-      tbPythonInterpreter_.getTextBox().getElement().addClassName(
-            ModalDialogBase.ALLOW_ENTER_KEY_CLASS);
+      tbPythonInterpreter_.getTextBox().addFocusHandler((FocusEvent event) ->
+      {
+         lastValue_ = tbPythonInterpreter_.getText();
+      });
+      
+      Element tbEl = tbPythonInterpreter_.getTextBox().getElement();
+      tbEl.addClassName(ModalDialogBase.ALLOW_ENTER_KEY_CLASS);
+      tbEl.addClassName(ModalDialogBase.ALLOW_ESCAPE_KEY_CLASS);
       
       tbPythonInterpreter_.setWidth(width);
       tbPythonInterpreter_.setText(placeholderText_);
@@ -423,6 +441,8 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    protected PythonServerOperations server_;
    protected Session session_;
    protected UserPrefs prefs_;
+   
+   private String lastValue_ = null;
    
    
    protected static Resources RES = GWT.create(Resources.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -172,7 +172,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       if (!isProjectOptions)
       {
          cbAutoUseProjectInterpreter_ =
-               new CheckBox("Automatically activate project Python environments");
+               new CheckBox("Automatically activate project-local Python environments");
          
          cbAutoUseProjectInterpreter_.setValue(
                prefs_.pythonProjectEnvironmentAutomaticActivate().getGlobalValue());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -151,6 +151,8 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          updateDescription();
       }, BlurEvent.getType());
       
+      // save the contents of the text box on focus
+      // (we'll restore the value if the user blurs via the Escape key)
       tbPythonInterpreter_.getTextBox().addFocusHandler((FocusEvent event) ->
       {
          lastValue_ = tbPythonInterpreter_.getText();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -17,11 +17,13 @@ package org.rstudio.studio.client.workbench.prefs.views.python;
 import org.rstudio.core.client.js.JsUtil;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.core.client.widget.WidgetListBox;
 import org.rstudio.studio.client.workbench.prefs.views.PythonInterpreter;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.user.client.ui.Widget;
 
 public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpreter>
@@ -39,12 +41,26 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
       for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))
          if (interpreter.isValid())
             widgets_.addItem(new PythonInterpreterListEntryUi(interpreter));
+ 
+      // allow double-click to select the requested interpreter
+      widgets_.addDoubleClickHandler((DoubleClickEvent event) ->
+      {
+         if (widgets_.getSelectedItem() != null)
+         {
+            clickOkButton();
+         }
+      });
+      
    }
    
    @Override
    protected PythonInterpreter collectInput()
    {
-      return widgets_.getSelectedItem().getInterpreter();
+      PythonInterpreterListEntryUi item = widgets_.getSelectedItem();
+      if (item == null)
+         return null;
+      
+      return item.getInterpreter();
    }
 
    @Override
@@ -54,4 +70,5 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
    }
    
    WidgetListBox<PythonInterpreterListEntryUi> widgets_;
+   ThemedButton useDefaultBtn_;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9489.

This PR brings some enhancements to RStudio's Python integration, including:

- Projects containing a Python environment within the `.venv` directory will be automatically activated,
- Some minor UI enhancements to our Python selection dialog.

<img width="606" alt="Screen Shot 2021-06-14 at 4 32 37 PM" src="https://user-images.githubusercontent.com/1976582/121971694-30738980-cd2e-11eb-835f-827853fa7733.png">

Hover text:

<img width="349" alt="Screen Shot 2021-06-14 at 4 32 42 PM" src="https://user-images.githubusercontent.com/1976582/121971692-2fdaf300-cd2e-11eb-9e95-7f2fc189cfea.png">

### Approach

Relatively straight-forward implementation.

### Automated Tests

TBA

### QA Notes

- In the Python selection dialog, double-clicking on a menu item suffices to select it (rather than just clicking the Select button),
- The 'Clear' button in the Python preferences pane resets the Python interpreter,
- If a project contains a Python environment in the `.venv` folder, then that version of Python is automatically placed on the PATH

(feel free to ask for more clarification if needed!)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
