### PR TITLE
Add support for high DPI plots on RStudio Server

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 * Add new *Set Working Directory* command to context menu for source files (#6781)
 * Local background jobs can now be replayed (#5548)
 * Improved display of R stack traces in R functions invoked internally by RStudio (#9307)
+* High DPI ("Retina") plots are now supported on RStudio Server (#3896)
 * The "auto-detect indentation" preference is now off by default. (#9211) 
 * Prevent user preferences from setting CRAN repos when `allow-cran-repos-edit=0` (Pro #1301)
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)

--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -158,8 +158,6 @@ public class BrowseCap
 
    public static double devicePixelRatio()
    {
-      // TODO: validate that we can rely on browser to report even
-      // on desktop clients
       return getDevicePixelRatio();
    }
 
@@ -195,6 +193,7 @@ public class BrowseCap
    private static native final double getDevicePixelRatio() /*-{
       try
       {
+         // use explicitly declared device pixel ratio if present
          if ('devicePixelRatio' in $wnd)
             return $wnd.devicePixelRatio;
          else

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/WorkbenchScreen.java
@@ -277,14 +277,11 @@ public class WorkbenchScreen extends Composite
                Math.max(deckPanelSize.width, 0),
                Math.max(deckPanelSize.height - Toolbar.DEFAULT_HEIGHT, 0));
 
-      double devicePixelRatio = 1.0;
-      if (BrowseCap.isMacintoshDesktop())
-         devicePixelRatio = BrowseCap.devicePixelRatio();
-      WorkbenchMetrics metrics = WorkbenchMetrics.create(consoleWidth,
+     WorkbenchMetrics metrics = WorkbenchMetrics.create(consoleWidth,
                                                          buildConsoleWidth,
                                                          plotsSize.width,
                                                          plotsSize.height,
-                                                         devicePixelRatio);
+                                                         BrowseCap.devicePixelRatio());
 
       // make sure we don't send very similar metrics values twice (it is
       // an expensive operation since it involves at least 2 http requests)


### PR DESCRIPTION
### Intent

Adds high DPI plot support for RStudio Server; addresses https://github.com/rstudio/rstudio/issues/3896.

### Approach

We've always had a way to test for high DPI support using `Window.devicePixelRatio`, but it was turned off since it wasn't widely supported. Fast-forward a bunch of years: now our desktop clients all use Chromium and all our supported browsers support it too, so we can feel good about relying on it.

https://caniuse.com/devicepixelratio

### Automated Tests

None, this doesn't add new code paths.

### QA Notes

The macOS desktop is unaffected by this change, but high DPI plots should be tested on Linux and Windows desktops as well as RStudio Server. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


