### PR TITLE
automatically activate .condaenv environments; fixes for reticulate binding to Anaconda

### DIFF
--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -825,17 +825,30 @@ std::string rLibraryPath(const FilePath& rHomePath,
    
    // pass along default (inheritted) library paths
    std::string defaultLibraryPaths = core::system::getenv(kLibraryPathEnvVariable);
+ 
+   // on macOS, we need to initialize with a default set of library paths
+   // if the path was already empty
+#ifdef __APPLE__
    if (defaultLibraryPaths.empty())
    {
-#ifdef __APPLE__
       // if this isn't set explicitly then initalize it with the default
       // of $HOME/lib:/usr/local/lib:/usr/lib. See documentation here:
       // http://developer.apple.com/library/ios/#documentation/system/conceptual/manpages_iphoneos/man3/dlopen.3.html
+      //
+      // NOTE (kevin): the above documentation now appears to be old; 'man dyld' has:
+      // 
+      // DYLD_FALLBACK_LIBRARY_PATH This is a colon separated list of
+      // directories that contain libraries. If a dylib is not found at its
+      // install path, dyld uses this as a list of directories to search for
+      // the dylib. By default, it is set to /usr/local/lib:/usr/lib.
+      //
+      // we keep $HOME/lib on the path for backwards compatibility, just in case
       boost::format fmt("%1%/lib:/usr/local/lib:/usr/lib");
       defaultLibraryPaths = boost::str(fmt % core::system::getenv("HOME"));
-#endif
    }
+#endif
    
+   // now add our default library paths
    if (!defaultLibraryPaths.empty())
       libraryPaths.push_back(defaultLibraryPaths);
    

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1247,7 +1247,7 @@ Error writeProjectFile(const FilePath& projectFilePath,
       contents.append(boost::str(pythonConfig));
    }
 
-   // add spelling dictioanry if present
+   // add spelling dictionary if present
    if (!config.spellingDictionary.empty())
    {
       boost::format fmt("\nSpellingDictionary: %1%\n");

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -88,10 +88,6 @@ void launchProcess(const std::string& absPath,
             QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"),
             dyldFallbackLibraryPath);
    
-   environment.insert(
-            QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
-            QString::fromStdString(libraryPath));
-   
    process->setProcessEnvironment(environment);
    
 #endif

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -79,8 +79,15 @@ void launchProcess(const std::string& absPath,
       
    }
    
-   // similarly, we need to set a fallback library path for conda
+   // create fallback library path
    std::string libraryPath = tempnam("/tmp", "rstudio-fallback-library-");
+   
+   // set it in environment variable (to be used by R)
+   environment.insert(
+            QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
+            QString::fromStdString(libraryPath));
+   
+   // and ensure it's placed on the fallback library path
    QString dyldFallbackLibraryPath = environment.value(QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"));
    dyldFallbackLibraryPath.append(QStringLiteral(":"));
    dyldFallbackLibraryPath.append(QString::fromStdString(libraryPath));

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -53,6 +53,37 @@ namespace {
 
 std::string s_launcherToken;
 
+#ifdef Q_OS_DARWIN
+
+std::string fallbackLibraryPathImpl()
+{
+   // The macOS documentation for tempnam state:
+   //
+   //    The tempnam() function is similar to tmpnam(), but provides the ability
+   //    to specify the directory which will contain the temporary file and the
+   //    file name prefix.
+   //
+   //    The environment variable TMPDIR (if set), the argument dir (if non-NULL),
+   //    the directory P_tmpdir, and the directory /tmp are tried, in the listed
+   //    order, as directories in which to store the temporary file.
+   //
+   // but that does not appear to actually be true (TMPDIR is ignored)
+   // so we explicitly read it and use it here.
+   const char* dir = ::getenv("TMPDIR");
+   if (dir == nullptr)
+      dir = P_tmpdir;
+   
+   return tempnam(dir, "rstudio-fallback-library-path-");
+}
+
+std::string fallbackLibraryPath()
+{
+   static std::string instance = fallbackLibraryPathImpl();
+   return instance;
+}
+
+#endif
+
 void launchProcess(const std::string& absPath,
                    const QStringList& argList,
                    QProcess** ppProc)
@@ -79,29 +110,21 @@ void launchProcess(const std::string& absPath,
       
    }
    
-   // create fallback library path
-   Error error = FilePath("/tmp/rstudio-desktop").ensureDirectory();
-   if (error)
-   {
-      LOG_ERROR(error);
-   }
-   else
-   {
-      std::string libraryPath = tempnam("/tmp/rstudio-desktop", "rstudio-fallback-library-");
+   // create fallback library path (use TMPDIR so it's user-specific)
+   std::string libraryPath = fallbackLibraryPath();
 
-      // set it in environment variable (to be used by R)
-      environment.insert(
-               QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
-               QString::fromStdString(libraryPath));
+   // set it in environment variable (to be used by R)
+   environment.insert(
+            QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
+            QString::fromStdString(libraryPath));
 
-      // and ensure it's placed on the fallback library path
-      QString dyldFallbackLibraryPath = environment.value(QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"));
-      dyldFallbackLibraryPath.append(QStringLiteral(":"));
-      dyldFallbackLibraryPath.append(QString::fromStdString(libraryPath));
-      environment.insert(
-               QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"),
-               dyldFallbackLibraryPath);
-   }
+   // and ensure it's placed on the fallback library path
+   QString dyldFallbackLibraryPath = environment.value(QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"));
+   dyldFallbackLibraryPath.append(QStringLiteral(":"));
+   dyldFallbackLibraryPath.append(QString::fromStdString(libraryPath));
+   environment.insert(
+            QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"),
+            dyldFallbackLibraryPath);
    
    process->setProcessEnvironment(environment);
    

--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -80,20 +80,28 @@ void launchProcess(const std::string& absPath,
    }
    
    // create fallback library path
-   std::string libraryPath = tempnam("/tmp", "rstudio-fallback-library-");
-   
-   // set it in environment variable (to be used by R)
-   environment.insert(
-            QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
-            QString::fromStdString(libraryPath));
-   
-   // and ensure it's placed on the fallback library path
-   QString dyldFallbackLibraryPath = environment.value(QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"));
-   dyldFallbackLibraryPath.append(QStringLiteral(":"));
-   dyldFallbackLibraryPath.append(QString::fromStdString(libraryPath));
-   environment.insert(
-            QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"),
-            dyldFallbackLibraryPath);
+   Error error = FilePath("/tmp/rstudio-desktop").ensureDirectory();
+   if (error)
+   {
+      LOG_ERROR(error);
+   }
+   else
+   {
+      std::string libraryPath = tempnam("/tmp/rstudio-desktop", "rstudio-fallback-library-");
+
+      // set it in environment variable (to be used by R)
+      environment.insert(
+               QStringLiteral("RSTUDIO_FALLBACK_LIBRARY_PATH"),
+               QString::fromStdString(libraryPath));
+
+      // and ensure it's placed on the fallback library path
+      QString dyldFallbackLibraryPath = environment.value(QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"));
+      dyldFallbackLibraryPath.append(QStringLiteral(":"));
+      dyldFallbackLibraryPath.append(QString::fromStdString(libraryPath));
+      environment.insert(
+               QStringLiteral("DYLD_FALLBACK_LIBRARY_PATH"),
+               dyldFallbackLibraryPath);
+   }
    
    process->setProcessEnvironment(environment);
    

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -486,6 +486,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    }
 })
 
+.rs.addFunction("canonicalizePath", function(path, winslash = "/")
+{
+   file.path(
+      normalizePath(dirname(path), winslash = winslash, mustWork = FALSE),
+      basename(path),
+      fsep = winslash
+   )
+})
+
 # alias for normalizePath function
 .rs.addFunction("normalizePath", normalizePath)
 
@@ -1215,6 +1224,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       action   = "append"
    )
       
+})
+
+.rs.addFunction("prependToPath", function(entry)
+{
+   oldPath <- Sys.getenv("PATH")
+   newPath <- paste(normalizePath(entry), oldPath, sep = .Platform$path.sep)
+   Sys.setenv(PATH = newPath)
 })
 
 .rs.addFunction("initTools", function()

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -243,15 +243,7 @@ namespace {
 
 std::string s_fallbackLibraryPath;
 
-void onExit()
-{
-   if (!s_fallbackLibraryPath.empty())
-   {
-      ::remove(s_fallbackLibraryPath.c_str());
-   }
-}
-
-}
+} // end anonymous namespace
 
 bool disableExecuteRprofile()
 {
@@ -473,6 +465,7 @@ void exitEarly(int status)
 {
    stopMonitorWorkerThread();
    FileLock::cleanUp();
+   FilePath(s_fallbackLibraryPath).removeIfExists();
    ::exit(status);
 }
 
@@ -1768,9 +1761,6 @@ int main(int argc, char * const argv[])
    {
       // save fallback library path
       s_fallbackLibraryPath = core::system::getenv("RSTUDIO_FALLBACK_LIBRARY_PATH");
-      
-      // set up exit hooks
-      ::atexit(onExit);
       
       // sleep on startup if requested (mainly for debugging)
       std::string sleepOnStartup = core::system::getenv("RSTUDIO_SESSION_SLEEP_ON_STARTUP");

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1903,7 +1903,7 @@ int main (int argc, char * const argv[])
       // Mirror the R getOptions("width") value in an environment variable
       core::system::setenv("RSTUDIO_CONSOLE_WIDTH",
                safe_convert::numberToString(rstudio::r::options::kDefaultWidth));
-
+ 
       // set the rstudio user identity environment variable (can differ from
       // username in debug configurations). this is provided so that
       // rpostback knows what local stream to connect back to

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -239,6 +239,20 @@ using namespace rsession::client_events;
 namespace rstudio {
 namespace session {
 
+namespace {
+
+std::string s_fallbackLibraryPath;
+
+void onExit()
+{
+   if (!s_fallbackLibraryPath.empty())
+   {
+      ::remove(s_fallbackLibraryPath.c_str());
+   }
+}
+
+}
+
 bool disableExecuteRprofile()
 {
    // check for session-specific override
@@ -1748,10 +1762,16 @@ void initMonitorClient()
 } // anonymous namespace
 
 // run session
-int main (int argc, char * const argv[])
+int main(int argc, char * const argv[])
 {
    try
    {
+      // save fallback library path
+      s_fallbackLibraryPath = core::system::getenv("RSTUDIO_FALLBACK_LIBRARY_PATH");
+      
+      // set up exit hooks
+      ::atexit(onExit);
+      
       // sleep on startup if requested (mainly for debugging)
       std::string sleepOnStartup = core::system::getenv("RSTUDIO_SESSION_SLEEP_ON_STARTUP");
       if (!sleepOnStartup.empty())

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -113,8 +113,15 @@
       c("Scripts/python.exe", "python.exe")
    else
       c("bin/python", "bin/python3")
-      
-   for (envName in c("env", ".venv", ".virtualenv", ".condaenv"))
+   
+   # look within all top-level directories for an environment
+   envNames <- list.dirs(
+      path = projectDir,
+      full.names = TRUE,
+      recursive = FALSE
+   )
+   
+   for (envName in envNames)
    {
       envPath <- file.path(projectDir, envName)
       if (!file.exists(envPath))

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -108,27 +108,28 @@
 
 .rs.addFunction("python.projectInterpreterPath", function(projectDir)
 {
-   # check for .venv
-   venvPath <- file.path(projectDir, ".venv")
-   if (file.exists(venvPath))
+   # check for virtual environments / conda environments
+   for (envName in c("env", ".venv", ".virtualenv", ".condaenv"))
    {
-      pythonSuffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
-      pythonPath <- file.path(venvPath, pythonSuffix)
-      return(pythonPath)
-   }
-   
-   # check for .condaenv
-   condaenvPath <- file.path(projectDir, ".condaenv")
-   if (file.exists(condaenvPath))
-   {
-      pythonSuffix <- if (.rs.platform.isWindows) "python.exe" else "bin/python"
-      pythonPath <- file.path(condaenvPath, pythonSuffix)
-      return(pythonPath)
+      envPath <- file.path(projectDir, envName)
+      if (!file.exists(envPath))
+         next
+      
+      pythonSuffixes <- if (.rs.platform.isWindows)
+         c("Scripts/python.exe", "python.exe")
+      else
+         c("bin/python", "bin/python3")
+      
+      for (pythonSuffix in pythonSuffixes)
+      {
+         pythonPath <- file.path(envPath, pythonSuffix)
+         if (file.exists(pythonPath))
+            return(pythonPath)
+      }
    }
    
    # nothing found
    ""
-   
 })
 
 .rs.addFunction("python.initialize", function(projectDir)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -109,16 +109,16 @@
 .rs.addFunction("python.projectInterpreterPath", function(projectDir)
 {
    # check for virtual environments / conda environments
+   pythonSuffixes <- if (.rs.platform.isWindows)
+      c("Scripts/python.exe", "python.exe")
+   else
+      c("bin/python", "bin/python3")
+      
    for (envName in c("env", ".venv", ".virtualenv", ".condaenv"))
    {
       envPath <- file.path(projectDir, envName)
       if (!file.exists(envPath))
          next
-      
-      pythonSuffixes <- if (.rs.platform.isWindows)
-         c("Scripts/python.exe", "python.exe")
-      else
-         c("bin/python", "bin/python3")
       
       for (pythonSuffix in pythonSuffixes)
       {

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -674,6 +674,12 @@ Error writeProjectConfig(const json::Object& configJson)
    
    if (error)
       return error;
+   
+   // ensure Python path is project-relative
+   FilePath projectDir = s_projectContext.directory();
+   FilePath pythonPath = module_context::resolveAliasedPath(config.pythonPath);
+   if (pythonPath.isWithin(projectDir))
+      config.pythonPath = pythonPath.getRelativePath(projectDir);
 
    // read spelling options
    error = json::readObject(configJson,


### PR DESCRIPTION
### Intent

This PR contains two main changes:

1. If the project contains a Conda environment within the `.condaenv` directory, RStudio will now automatically activate that environment on startup.

2. Add some extra glue to ensure that `reticulate` can bind to Anaconda installations on macOS. See https://github.com/ContinuumIO/anaconda-issues/issues/12478 for more details.

### Approach

The Anaconda glue is the more interesting part of the PR. Currently, Anaconda installations rely on the process rpath when discovering libraries. This unfortunately doesn't work for us, since we attempt to load Python as a library (and so don't have the rpath entries set that Anaconda is expecting).

The workaround is to set `DYLD_FALLBACK_LIBRARY_PATH` to include the Anaconda library path, but this is challenging for a couple reasons:

1. The `DYLD_FALLBACK_LIBRARY_PATH` cannot be changed after a process has already been launched. (You can change the value of the environment variable, but it will not affect future library load attempts in the current process.)
2. When RStudio launches the `rsession` process, we have no idea if the user plans to use Python, or even Anaconda Python. We also don't know where Anaconda might be installed.

The solution is to instead have RStudio place a special fallback library path in the `DYLD_FALLBACK_LIBRARY_PATH`, and have R initialize the library path when necessary. See https://github.com/rstudio/reticulate/commit/08f145b0d2f13c8f8c242ea788359406d139467d for an example.

### Automated Tests

N/A

### QA Notes

Verify, on macOS, that the following works:

1. Install Anaconda: https://www.anaconda.com/products/individual#macos
2. Install the development version of `reticulate`: `remotes::install_github("rstudio/reticulate")`
3. Try to load that environment: `reticulate::use_python("~/opt/anaconda3/bin/python", required = TRUE); reticulate::py_config()`

If all is well, you should see `reticulate::py_config()` print without issue.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
