### PR TITLE
tell 7z to overwrite without prompting when extracting soci.tar.gz

### DIFF
--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -66,8 +66,8 @@ if (!file.exists(normalizePath(file.path(soci_build_dir, "x64\\lib\\Release\\lib
       section("Downloading SOCI sources")
       download(soci_url, destfile = "soci.tar.gz")
 	  section("Unzipping SOCI sources")
-	  exec("7z.exe", "e", "soci.tar.gz")
-	  exec("7z.exe", "x", "soci.tar")
+	  exec("7z.exe", "-aoa", "e", "soci.tar.gz")
+	  exec("7z.exe", "-aoa", "x", "soci.tar")
    }
 
    # create build directories


### PR DESCRIPTION
### Intent

We have a long-standing "weird" thing on Windows build where sometimes `soci.tar.gz` fails to extract, and from there the build ultimately fails. Replaying the build has never seemed to help.

See #9497 (not saying this fixes it, but might help understand what's going on)

Noticed that if you run `7z e soci.tar.gz` as the install-soci.R script does, and there's already an existing `soci.tar`, then 7z interactively asks if you want to overview, skip, etc. For example:

```bat
C:\Users\gtritchie\rstudio\dependencies\windows\install-soci>7z e soci.tar.gz
7-Zip 19.00 (x64) : Copyright (c) 1999-2018 Igor Pavlov : 2019-02-21
Scanning the drive for archives:
1 file, 60992753 bytes (59 MiB)
Extracting archive: soci.tar.gz
--
Path = soci.tar.gz
Type = gzip
Headers Size = 10
Would you like to replace the existing file:
  Path:     .\soci.tar
  Size:     64102400 bytes (62 MiB)
  Modified: 2020-03-11 09:21:22
with the file from archive:
  Path:     soci.tar
  Size:     64102400 bytes (62 MiB)
  Modified: 2020-03-11 09:21:22
? (Y)es / (N)o / (A)lways / (S)kip all / A(u)to rename all / (Q)uit?
```

This _might_ explain some of the weird behavior and, perhaps, why re-running the build doesn't ever fix it.


### Approach

Use command-line switch to 7z that tells it to just overwrite. Also did this on the subsequent `7z x soci.tar`, just in case (though that shouldn't be a problem since both calls should only happen if the resulting `soci` folder doesn't exist).

### Automated Tests

The builds are the test. How dramatic.

### QA Notes

None. Purely build logic.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


