### PR TITLE
Avoid creating multiple background Shiny jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 * Fixed issue where help requests for Python objects would fail with reticulate 1.20 (#9311)
 * Fixed issue where busy sessions can't be interrupted and block basic file operations (#2038)
 * Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
+* Fixed issues causing multiple background jobs to be created when running Shiny applications in the background (#8746, #6904)
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
 
 

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -166,9 +166,9 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
                            stopShinyBackgroundJob(params.getId(), null);
                         }
                      }
-                  }
 
-                  break;
+                     break;
+                  }
                }
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/ShinyApplication.java
@@ -17,7 +17,9 @@ package org.rstudio.studio.client.shiny;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.gwt.event.shared.HandlerRegistration;
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
@@ -30,6 +32,7 @@ import org.rstudio.studio.client.application.ApplicationInterrupt.InterruptHandl
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.RestartStatusEvent;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.Value;
 import org.rstudio.studio.client.common.dependencies.DependencyManager;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
 import org.rstudio.studio.client.common.satellite.events.WindowClosedEvent;
@@ -47,6 +50,10 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.console.events.ConsoleBusyEvent;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 import org.rstudio.studio.client.workbench.views.environment.events.DebugModeChangedEvent;
+import org.rstudio.studio.client.workbench.views.jobs.events.JobUpdatedEvent;
+import org.rstudio.studio.client.workbench.views.jobs.model.Job;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobConstants;
+import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobsServerOperations;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerClearedEvent;
 
@@ -77,6 +84,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
                            JobsServerOperations jobsServer,
                            GlobalDisplay display,
                            DependencyManager dependencyManager,
+                           JobManager jobManager,
                            ApplicationInterrupt interrupt)
    {
       eventBus_ = eventBus;
@@ -89,6 +97,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       isBusy_ = false;
       currentViewType_ = UserPrefs.SHINY_VIEWER_TYPE_NONE;
       dependencyManager_ = dependencyManager;
+      jobManager_ = jobManager;
       interrupt_ = interrupt;
       params_ = new ArrayList<>();
       
@@ -132,6 +141,29 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       }
       else if (event.getParams().getState() == ShinyApplicationParams.STATE_STOPPED)
       {
+         Debug.devlog("received notification that shiny application stopped");
+         // If this Shiny application was running in the background, we're responsible for ending the job.
+         if (event.getParams().isBackgroundApp())
+         {
+            for (ShinyApplicationParams params: params_)
+            {
+               if (StringUtil.equals(params.getId(), event.getParams().getId()))
+               {
+                  // If we got here, the Shiny application that was stopped corresponds to a background job. If the job
+                  // is still running, stop it.
+                  Job job = jobManager_.getJob(params.getId());
+                  if (job != null)
+                  {
+                     if (job.state == JobConstants.STATE_RUNNING)
+                     {
+                        Debug.devlog("stopping running shiny background job (was running)");
+                        stopShinyBackgroundJob(params.getId(), null);
+                        break;
+                     }
+                  }
+               }
+            }
+         }
          params_.removeIf(params -> params.getId() == event.getParams().getId());
       }
    }
@@ -292,6 +324,43 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
             });
             return;
          }
+         else if (StringUtil.equals(destination, BACKGROUND_APP) && params.isBackgroundApp())
+         {
+            // This app is running in the background; stop and then replay the background job
+
+            // Stop the background job -- this returns immediately (it's an async call)
+            Debug.devlog("stopping running shiny background job (for replay)");
+            stopShinyBackgroundJob(params.getId(), () ->
+            {
+               Debug.devlog("stop complete, waiting for job status update");
+               // Now wait for a JobUpdatedEvent that tells us that the job has actually stopped.
+               final Value<HandlerRegistration> reg = new Value<>(null);
+               reg.setValue(eventBus_.addHandler(JobUpdatedEvent.TYPE, evt ->
+               {
+                  if (StringUtil.equals(params.getId(), evt.getData().job.id) &&
+                     evt.getData().job.state != JobConstants.STATE_RUNNING)
+                  {
+                     Debug.devlog("replaying!");
+                     // The job is now stopped; replay it
+                     jobsServer_.executeJobAction(params.getId(), JobConstants.ACTION_REPLAY,
+                        new VoidServerRequestCallback()
+                        {
+                           @Override
+                           public void onError(ServerError error)
+                           {
+                              display_.showErrorMessage("Failed to reload",
+                                 "Could not reload the Shiny application.\n\n" +
+                                    error.getMessage());
+                           }
+                        });
+                     // Clean up event handler
+                     reg.getValue().removeHandler();
+                  }
+               }));
+            });
+
+            return;
+         }
       }
       
       // Nothing else running, start this app.
@@ -308,6 +377,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
    private void notifyShinyAppDisconnected(JavaScriptObject params)
    {
       ShinyApplicationParams appState = params.cast();
+      Debug.devlog("got shiny disconnect notification: " + appState.getId() + " @ " + appState.getPath());
       if (params_ == null || params_.isEmpty())
          return;
       
@@ -374,31 +444,45 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
       {
          if (appState.getId() == ShinyApplicationParams.ID_FOREGROUND)
          {
-            // Foreground apps: interrupt R itself
-            if (commands_.interruptR().isEnabled()) 
+            // If this app is running in the foreground, stop it now. Background jobs will be stopped when we fire the
+            // status event (below).
+            if (commands_.interruptR().isEnabled())
                commands_.interruptR().execute();
-         }
-         else
-         {
-            // Background apps: stop the associated job
-            jobsServer_.executeJobAction(appState.getId(), "stop", 
-                  new VoidServerRequestCallback()
-            {
-               @Override
-               public void onError(ServerError error)
-               {
-                  display_.showErrorMessage("Failed to Stop", 
-                        "Could not stop the Shiny application.\n\n" + 
-                        error.getMessage());
-               }
-            });
          }
          appState.setState(ShinyApplicationParams.STATE_STOPPED);
       }
       eventBus_.fireEvent(new ShinyApplicationStatusEvent(
             (ShinyApplicationParams) params.cast()));
    }
-   
+
+   /**
+    * Stops the Shiny background job associated with the given ID
+    */
+   private void stopShinyBackgroundJob(String id, Command onSuccess)
+   {
+      Debug.devlog("stopping shiny background job");
+      jobsServer_.executeJobAction(id, JobConstants.ACTION_STOP,
+         new VoidServerRequestCallback()
+         {
+            @Override
+            public void onSuccess()
+            {
+               if (onSuccess != null)
+               {
+                  onSuccess.execute();
+               }
+            }
+
+            @Override
+            public void onError(ServerError error)
+            {
+               display_.showErrorMessage("Failed to Stop",
+                  "Could not stop the Shiny application.\n\n" +
+                     error.getMessage());
+            }
+         });
+   }
+
    private final native void exportShinyAppClosedCallback()/*-{
       var registry = this;     
       $wnd.notifyShinyAppClosed = $entry(
@@ -560,6 +644,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
    
    private final EventBus eventBus_;
    private final SatelliteManager satelliteManager_;
+   private final JobManager jobManager_;
    private final DependencyManager dependencyManager_;
    private final Commands commands_;
    private final Provider<UserPrefs> pPrefs_;
@@ -574,7 +659,7 @@ public class ShinyApplication implements ShinyApplicationStatusEvent.Handler,
    private boolean stopOnNextClose_ = true;
    private String satelliteClosePath_ = null;
    private String currentViewType_;
-   
+
    public static final String FOREGROUND_APP = "foreground";
    public static final String BACKGROUND_APP = "background";
 }

--- a/src/gwt/src/org/rstudio/studio/client/shiny/model/ShinyApplicationParams.java
+++ b/src/gwt/src/org/rstudio/studio/client/shiny/model/ShinyApplicationParams.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.shiny.model;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsObject;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -77,4 +78,14 @@ public class ShinyApplicationParams extends JavaScriptObject
    public final native void setViewerType(String viewerType) /*-{
       this.viewer = viewerType;
    }-*/;
+
+   public final boolean isBackgroundApp()
+   {
+      return !isForegroundApp();
+   }
+
+   public final boolean isForegroundApp()
+   {
+      return StringUtil.equals(getId(), ID_FOREGROUND);
+   }
 }


### PR DESCRIPTION
### Intent

Addresses a couple of Ghost Orchid issues that cause usability problems when running Shiny applications in the background. 

Addresses #8706
Addresses #6904

### Approach

- Use the new job replay mechanism, introduced in https://github.com/rstudio/rstudio/pull/9393, when Shiny apps are reloaded. 
- Rework how we stop Shiny jobs so that they're also stopped when the Viewer pane is cleared. 

### Automated Tests

None included, it is not possible to run Shiny applications with the current unit test infrastructure.

### QA Notes

In addition to ensuring that the bugs are addressed (relatively straightforward), check that stopping Shiny jobs when the associated window closes hasn't regressed. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


