### PR TITLE
implement session startup (Posix-only)

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -28,7 +28,9 @@
     "ts-node": "^10.0.0",
     "typescript": "^4.3.2"
   },
-  "dependencies": {},
+  "dependencies": {
+    "uuid": "^8.3.2"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -35,6 +35,7 @@
     "package": "yarn run build && electron-packager ./ --prune --package-manager=yarn --out=./package --overwrite --ignore tsconfig.tsbuildinfo",
     "lint": "eslint ./src ./test",
     "start": "yarn run build && electron ./dist/main/main.js",
+    "start-diag": "yarn run build && electron ./dist/main/main.js --run-diagnostics",
     "show-version": "yarn run build && electron ./dist/main/main.js --version-json",
     "test": "electron-mocha -c --config ./test/unit/mocharc.json",
     "testcover": "nyc electron-mocha -c --config ./test/unit/mocharc.json",

--- a/src/node/desktop/src/core/environment.ts
+++ b/src/node/desktop/src/core/environment.ts
@@ -66,3 +66,10 @@ export function setVars(vars: Environment): void {
     setenv(name, vars[name]);
   } 
 }
+
+export function logEnvVar(name: string): void {
+  const value = getenv(name);
+  if (value) {
+    console.log(` . ${name} = ${value}`);
+  }
+}

--- a/src/node/desktop/src/main/activation-overlay.ts
+++ b/src/node/desktop/src/main/activation-overlay.ts
@@ -1,0 +1,62 @@
+/*
+ * activation-overlay.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { EventEmitter } from 'events';
+
+export enum ActivationEvents {
+  LAUNCH_FIRST_SESSION = 'launchFirstSession',
+  LAUNCH_ERROR = 'launchError'
+}
+
+/* eslint-disable @typescript-eslint/no-empty-function */
+export class DesktopActivation extends EventEmitter {
+
+  getInitialLicense(): void {
+    this.emitLaunchFirstSession();
+  }
+
+  allowProductUsage(): boolean {
+    return true;
+  }
+
+  editionName(): string {
+    return 'RStudio';
+  }
+
+  // license has been lost while using the program
+  emitLicenseLostSignal(): void {
+  }
+
+  // no longer need to show a license warning bar
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  emitUpdateLicenseWarningBarSignal(message: string): void {
+  }
+
+  // start a session after validating initial license
+  emitLaunchFirstSession(): void {
+    this.emit(ActivationEvents.LAUNCH_FIRST_SESSION);
+  }
+
+  // show a messagebox (if message is non-empty) then exit the program
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  emitLaunchError(message: string): void {
+    this.emit(ActivationEvents.LAUNCH_ERROR, message);
+  }
+
+  // detect (or re-detect) license status
+  emitDetectLicense(): void {
+  }
+
+}

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -25,6 +25,7 @@ import { Application } from './application';
 export interface AppState {
   mainWindow?: BrowserWindow;
   runDiagnostics: boolean;
+  sessionPath?: FilePath;
   scriptsPath?: FilePath;
   supportingFilePath(): FilePath;
 }

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow } from 'electron';
 
 import { FilePath } from '../core/file-path';
+import { DesktopActivation } from './activation-overlay';
 
 import { Application } from './application';
 
@@ -28,6 +29,7 @@ export interface AppState {
   sessionPath?: FilePath;
   scriptsPath?: FilePath;
   supportingFilePath(): FilePath;
+  activation(): DesktopActivation;
 }
 
 let rstudio: Application | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -107,7 +107,7 @@ export class Application implements AppState {
       }
     }
 
-    if (!prepareEnvironment()) {
+    if (!await prepareEnvironment()) {
       return exitFailure();
     }
 
@@ -117,20 +117,6 @@ export class Application implements AppState {
     // launch a local session
     this.sessionLauncher = new SessionLauncher(this.sessionPath, confPath, new FilePath(), this.appLaunch);
     this.sessionLauncher.launchFirstSession();
-
-    // TEMPORARY, show a window so starting the app does something visible
-    this.mainWindow = new BrowserWindow({
-      width: 1024,
-      height: 768,
-      backgroundColor: '#fff', // https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
-      webPreferences: {
-        enableRemoteModule: false,
-        nodeIntegration: false,
-        contextIsolation: true
-      }
-
-    });
-    this.mainWindow.loadURL('https://rstudio.com');
     return run();
   }
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -25,6 +25,8 @@ import { exitFailure, exitSuccess, run, ProgramStatus } from './program-status';
 import { ApplicationLaunch } from './application-launch';
 import { AppState } from './app-state';
 import { prepareEnvironment } from './detect_r';
+import { SessionLauncher } from './session-launcher';
+import { DesktopActivation } from './activation-overlay';
 
 // RStudio command-line switches
 export const kRunDiagnosticsOption = '--run-diagnostics';
@@ -45,6 +47,8 @@ export class Application implements AppState {
   supportPath?: FilePath;
 
   appLaunch?: ApplicationLaunch;
+  sessionLauncher?: SessionLauncher;
+  activationInst?: DesktopActivation;
 
   /**
    * Startup code run before app 'ready' event.
@@ -107,6 +111,13 @@ export class Application implements AppState {
       return exitFailure();
     }
 
+    // TODO: desktop pro session handling
+    // TODO: 'file/project' file open handling (e.g. launch by double-clicking a .R or .Rproj file)
+
+    // launch a local session
+    this.sessionLauncher = new SessionLauncher(this.sessionPath, confPath, new FilePath(), this.appLaunch);
+    this.sessionLauncher.launchFirstSession();
+
     // TEMPORARY, show a window so starting the app does something visible
     this.mainWindow = new BrowserWindow({
       width: 1024,
@@ -156,5 +167,12 @@ export class Application implements AppState {
       }
     }
     return this.supportPath;
+  }
+
+  activation(): DesktopActivation {
+    if (!this.activationInst) {
+      this.activationInst = new DesktopActivation();
+    }
+    return this.activationInst;
   }
 }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -41,6 +41,7 @@ export class Application implements AppState {
   mainWindow?: BrowserWindow;
   runDiagnostics = false;
   scriptsPath?: FilePath;
+  sessionPath?: FilePath;
   supportPath?: FilePath;
 
   appLaunch?: ApplicationLaunch;
@@ -87,6 +88,7 @@ export class Application implements AppState {
 
     // determine paths to config file, rsession, and desktop scripts
     const [confPath, sessionPath, scriptsPath] = findComponents();
+    this.sessionPath = sessionPath;
     this.scriptsPath = scriptsPath;
 
     if (!app.isPackaged) {
@@ -95,8 +97,8 @@ export class Application implements AppState {
         dialog.showErrorBox('Dev Mode Config', `conf: ${confPath.getAbsolutePath()} not found.'`);
         return exitFailure();
       }
-      if (!sessionPath.existsSync()) {
-        dialog.showErrorBox('Dev Mode Config', `rsession: ${sessionPath.getAbsolutePath()} not found.'`);
+      if (!this.sessionPath.existsSync()) {
+        dialog.showErrorBox('Dev Mode Config', `rsession: ${this.sessionPath.getAbsolutePath()} not found.'`);
         return exitFailure();
       }
     }

--- a/src/node/desktop/src/main/desktop-callback.ts
+++ b/src/node/desktop/src/main/desktop-callback.ts
@@ -1,0 +1,596 @@
+/*
+ * desktop-callback.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+// TODO clean this up
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+
+import { ipcMain, dialog, BrowserWindow } from 'electron';
+
+import { PendingWindow } from './pending-window';
+import { MainWindow } from './main-window';
+import { MessageBoxOptions, OpenDialogOptions } from 'electron/main';
+
+export const PendingQuit = {
+  'PendingQuitNone': 0,
+  'PendingQuitAndExit': 1,
+  'PendingQuitAndRestart': 2,
+  'PendingQuitRestartAndReload': 3
+};
+
+export class DesktopCallback {
+  pendingQuit: number = PendingQuit.PendingQuitNone;
+
+  constructor(public mainWindow: MainWindow,
+              public ownerWindow: MainWindow,
+              public isRemoteDesktop: boolean) {
+
+    ipcMain.on('desktop_browse_url', (event, url) => {
+      DesktopCallback.unimpl('desktop_browser_url');
+    });
+
+    ipcMain.handle('desktop_get_open_file_name',
+      (event, caption, label, dir, filter, canChooseDirectories, focusOwner) => {
+
+        // TODO: apply filter
+        const openDialogOptions: OpenDialogOptions =
+      {
+        properties: [canChooseDirectories ? 'openDirectory' : 'openFile'],
+        title: caption,
+        defaultPath: dir,
+        buttonLabel: label,
+      };
+
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (focusedWindow) {
+          return dialog.showOpenDialog(focusedWindow, openDialogOptions);
+        } else {
+          return dialog.showOpenDialog(openDialogOptions);
+        }
+      });
+
+    ipcMain.handle('desktop_get_save_file_name', (event,
+      caption,
+      label,
+      dir,
+      defaultExtension,
+      forceDefaultExtension,
+      focusOwner) => {
+      DesktopCallback.unimpl('desktop_get_save_file_name');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_existing_directory', (caption, label, dir, focusOwner) => {
+      DesktopCallback.unimpl('desktop_get_existing_directory');
+      return '';
+    });
+
+    ipcMain.on('desktop_on_clipboard_selection_changed', (event) => {
+      DesktopCallback.unimpl('desktop_on_clipboard_selection_changed');
+    });
+
+    ipcMain.on('desktop_undo', (event) => {
+      DesktopCallback.unimpl('desktop_undo');
+    });
+
+    ipcMain.on('desktop_redo', (event) => {
+      DesktopCallback.unimpl('desktop_redo');
+    });
+
+    ipcMain.on('desktop_clipboard_cut', (event) => {
+      DesktopCallback.unimpl('desktop_clipboard_cut');
+    });
+
+    ipcMain.on('desktop_clipboard_copy', (event) => {
+      DesktopCallback.unimpl('desktop_clipboard_copy');
+    });
+
+    ipcMain.on('desktop_clipboard_paste', (event) => {
+      DesktopCallback.unimpl('desktop_clipboard_paste');
+    });
+
+    ipcMain.on('desktop_set_clipboard_text', (event, text) => {
+      DesktopCallback.unimpl('desktop_set_clipboard_text');
+    });
+
+    ipcMain.handle('desktop_get_clipboard_text', (event) => {
+      DesktopCallback.unimpl('desktop_get_clipboard_text');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_clipboard_uris', (event) => {
+      DesktopCallback.unimpl('desktop_get_clipboard_uris');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_clipboard_image', (event) => {
+      DesktopCallback.unimpl('desktop_get_clipboard_image');
+      return '';
+    });
+
+    ipcMain.on('desktop_set_global_mouse_selection', (event, selection) => {
+      DesktopCallback.unimpl('desktop_set_global_mouse_selection');
+    });
+
+    ipcMain.handle('desktop_get_global_mouse_selection', (event) => {
+      DesktopCallback.unimpl('desktop_get_global_mouse_selection');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_cursor_position', (event) => {
+      DesktopCallback.unimpl('desktop_get_cursor_position');
+      return {x: 20, y: 20};
+    });
+
+    ipcMain.handle('desktop_does_window_exist_at_cursor_position', (event) => {
+      return false;
+    });
+
+    ipcMain.on('desktop_on_workbench_initialized', (event, scratchPath) => {
+      this.mainWindow.onWorkbenchInitialized();
+    });
+
+    ipcMain.on('desktop_show_folder', (event, path) => {
+      DesktopCallback.unimpl('desktop_show_folder');
+    });
+
+    ipcMain.on('desktop_show_file', (event, file) => {
+      DesktopCallback.unimpl('desktop_show_file');
+    });
+
+    ipcMain.on('desktop_show_word_doc', (event, wordDoc) => {
+      DesktopCallback.unimpl('desktop_show_word_doc');
+    });
+
+    ipcMain.on('desktop_show_ppt_presentation', (event, pptDoc) => {
+      DesktopCallback.unimpl('desktop_show_ppt_presentation');
+    });
+
+    ipcMain.on('desktop_show_pdf', (event, path, pdfPage) => {
+      DesktopCallback.unimpl('desktop_show_pdf');
+    });
+
+    ipcMain.on('desktop_prepare_show_word_doc', (event) => {
+      DesktopCallback.unimpl('desktop_prepare_show_word_doc');
+    });
+
+    ipcMain.on('desktop_prepare_show_ppt_presentation', (event) => {
+      DesktopCallback.unimpl('desktop_prepare_show_ppt_presentation');
+    });
+
+    ipcMain.handle('desktop_get_r_version', (event) => {
+      return '';
+    });
+
+    ipcMain.handle('desktop_choose_r_version', (event) => {
+      DesktopCallback.unimpl('desktop_choose_r_version');
+      return '';
+    });
+
+    ipcMain.handle('desktop_device_pixel_ratio', (event) => {
+      DesktopCallback.unimpl('desktop_device_pixel_ratio');
+      return 1.0;
+    });
+
+    ipcMain.on('desktop_open_minimal_window', (event, name, url, width, height) => {
+      DesktopCallback.unimpl('desktop_open_minimal_window');
+    });
+
+    ipcMain.on('desktop_activate_minimal_window', (event, name) => {
+      DesktopCallback.unimpl('desktop_activate_minimal_window');
+    });
+
+    ipcMain.on('desktop_activate_satellite_window', (event, name) => {
+      console.log(`activate_satellite_window ${name}`);
+    });
+
+    ipcMain.handle('desktop_prepare_for_satellite_window', (event, name, x, y, width, height) => {
+      this.mainWindow.prepareForWindow(new PendingWindow(name, x, y, width, height));
+    });
+
+    ipcMain.handle('desktop_prepare_for_named_window', (event, name, allowExternalNavigate, showToolbar) => {
+      console.log(`prepare_for_named_window ${name}`);
+    });
+
+    ipcMain.on('desktop_close_named_window', (event, name) => {
+      DesktopCallback.unimpl('desktop_close_named_window');
+    });
+
+    ipcMain.on('desktop_copy_page_region_to_clipboard', (event, left, top, width, height) => {
+      DesktopCallback.unimpl('desktop_copy_page_region_to_clipboard');
+    });
+
+    ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height) => {
+      DesktopCallback.unimpl('desktop_export_page_region_to_file');
+    });
+
+    ipcMain.on('desktop_print_text', (event, text) => {
+      DesktopCallback.unimpl('desktop_print_text');
+    });
+
+    ipcMain.on('desktop_paint_print_text', (event, printer) => {
+      DesktopCallback.unimpl('desktop_paint_print_text');
+    });
+
+    ipcMain.on('desktop_print_finished', (event, result) => {
+      DesktopCallback.unimpl('desktop_print_finished');
+    });
+
+    ipcMain.handle('desktop_supports_clipboard_metafile', (event) => {
+      return false;
+    });
+
+    ipcMain.handle('desktop_show_message_box', (event, type, caption, message, buttons, defaultButton, cancelButton) => {
+      const openDialogOptions: MessageBoxOptions =
+      {
+        type: this.convertMessageBoxType(type),
+        title: caption,
+        message: message,
+        buttons: this.convertButtons(buttons),
+      };
+
+      const focusedWindow = BrowserWindow.getFocusedWindow();
+      if (focusedWindow) {
+        return dialog.showMessageBox(focusedWindow, openDialogOptions);
+      } else {
+        return dialog.showMessageBox(openDialogOptions);
+      }
+    });
+
+    ipcMain.handle('desktop_prompt_for_text', (event, title, caption, defaultValue, type, 
+      rememberPasswordPrompt, rememberByDefault,
+      selectionStart, selectionLength, okButtonCaption) => {
+      DesktopCallback.unimpl('desktop_prompt_for_text');
+      return ''; 
+    });
+
+    ipcMain.on('desktop_bring_main_frame_to_front', (event) => {
+    });
+
+    ipcMain.on('desktop_bring_main_frame_behind_active', (event) => {
+      DesktopCallback.unimpl('desktop_bring_main_frame_behind_active');
+    });
+
+    ipcMain.handle('desktop_rendering_engine', (event) => {
+      return '';
+    });
+
+    ipcMain.on('desktop_set_desktop_rendering_engine', (event, engine) => {
+      DesktopCallback.unimpl('desktop_set_desktop_rendering_engine');
+    });
+
+    ipcMain.handle('desktop_filter_text', (event, text) => {
+      DesktopCallback.unimpl('desktop_filter_text');
+      return text;
+    });
+
+    ipcMain.on('desktop_clean_clipboard', (event, stripHtml) => {
+      DesktopCallback.unimpl('desktop_clean_clipboard');
+    });
+
+    ipcMain.on('desktop_set_pending_quit', (event, pendingQuit) => {
+      this.pendingQuit = pendingQuit;
+    });
+
+    ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
+      DesktopCallback.unimpl('desktop_open_project_in_new_window');
+    });
+
+    ipcMain.on('desktop_open_session_in_new_window', (event, workingDirectoryPath) => {
+      DesktopCallback.unimpl('desktop_open_session_in_new_window');
+    });
+
+    ipcMain.on('desktop_open_terminal', (event, terminalPath, workingDirectory, extraPathEntries, shellType) => {
+      DesktopCallback.unimpl('desktop_open_terminal');
+    });
+
+    ipcMain.handle('desktop_get_fixed_width_font_list', (event) => {
+      DesktopCallback.unimpl('desktop_get_fixed_width_font_list');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_fixed_width_font', (event) => {
+      DesktopCallback.unimpl('desktop_get_fixed_width_font');
+      return '';
+    });
+
+    ipcMain.on('desktop_set_fixed_width_font', (event, font) => {
+      DesktopCallback.unimpl('desktop_set_fixed_width_font');
+    });
+
+    ipcMain.handle('desktop_get_zoom_levels', (event) => {
+      DesktopCallback.unimpl('desktop_get_zoom_levels');
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_zoom_level', (event) => {
+      DesktopCallback.unimpl('desktop_get_zoom_level');
+      return 1.0;
+    });
+
+    ipcMain.on('desktop_set_zoom_level', (event, zoomLevel) => {
+      DesktopCallback.unimpl('desktop_set_zoom_level');
+    });
+
+    ipcMain.on('desktop_zoom_in', (event) => {
+      DesktopCallback.unimpl('desktop_zoom_in');
+    });
+
+    ipcMain.on('desktop_zoom_out', (event) => {
+      DesktopCallback.unimpl('desktop_zoom_out');
+    });
+
+    ipcMain.on('desktop_zoom_actual_size', (event) => {
+      DesktopCallback.unimpl('desktop_zoom_actual_size');
+    });
+
+    ipcMain.on('desktop_set_background_color', (event, rgbColor) => {
+    });
+
+    ipcMain.on('desktop_change_title_bar_color', (event, red, green, blue) => {
+    });
+
+    ipcMain.on('desktop_sync_to_editor_theme', (event, isDark) => {
+    });
+
+    ipcMain.handle('desktop_get_enable_accessibility', (event) => {
+      DesktopCallback.unimpl('desktop_get_enable_accessibility');
+      return true;
+    });
+
+    ipcMain.on('desktop_set_enable_accessibility', (event, enable) => {
+      DesktopCallback.unimpl('desktop_set_enable_accessibility');
+    });
+
+    ipcMain.handle('desktop_get_clipboard_monitoring', (event) => {
+      DesktopCallback.unimpl('desktop_get_clipboard_monitoring');
+      return false;
+    });
+
+    ipcMain.on('desktop_set_clipboard_monitoring', (event, monitoring) => {
+      DesktopCallback.unimpl('desktop_set_clipboard_monitoring');
+    });
+
+    ipcMain.handle('desktop_get_ignore_gpu_blacklist', (event, ignore) => {
+      return true;
+    });
+
+    ipcMain.on('desktop_set_ignore_gpu_blacklist', (event, ignore) => {
+      DesktopCallback.unimpl('desktop_set_ignore_gpu_blacklist');
+    });
+
+    ipcMain.handle('desktop_get_disable_gpu_driver_bug_workarounds', (event) => {
+      return false;
+    });
+
+    ipcMain.on('desktop_set_disable_gpu_driver_bug_workarounds', (event, disable) => {
+      DesktopCallback.unimpl('desktop_set_disable_gpu_driver_bug_workarounds');
+    });
+
+    ipcMain.on('desktop_show_license_dialog', (event) => {
+      DesktopCallback.unimpl('desktop_show_license_dialog');
+    });
+
+    ipcMain.on('desktop_show_session_server_options_dialog', (event) => {
+      DesktopCallback.unimpl('desktop_show_session_server_options_dialog');
+    });
+
+    ipcMain.handle('desktop_get_init_messages', (event) => {
+      return '';
+    });
+
+    ipcMain.handle('desktop_get_license_status_message', (event) => {
+      DesktopCallback.unimpl('desktop_get_license_status_messages');
+      return '';
+    });
+
+    ipcMain.handle('desktop_allow_product_usage', (event) => {
+      DesktopCallback.unimpl('desktop_allow_product_usage');
+      return true;
+    });
+
+    ipcMain.handle('desktop_get_desktop_synctex_viewer', (event) => {
+      DesktopCallback.unimpl('desktop_get_desktop_synctex_viewer');
+      return '';
+    });
+
+    ipcMain.on('desktop_external_synctex_preview', (event, pdfPath, page) => {
+      DesktopCallback.unimpl('desktop_external_synctex_preview');
+    });
+
+    ipcMain.on('desktop_external_synctex_view', (event, pdfFile, srcFile, line, column) => {
+      DesktopCallback.unimpl('desktop_external_synctex_view');
+    });
+
+    ipcMain.handle('desktop_supports_fullscreen_mode', (event) => {
+      DesktopCallback.unimpl('desktop_supports_fullscreen_mode');
+      return true;
+    });
+
+    ipcMain.on('desktop_toggle_fullscreen_mode', (event) => {
+      DesktopCallback.unimpl('desktop_toggle_fullscreen_mode');
+    });
+
+    ipcMain.on('desktop_show_keyboard_shortcut_help', (event) => {
+      DesktopCallback.unimpl('desktop_show_keyboard_shortcut_help');
+    });
+
+    ipcMain.on('desktop_launch_session', (event, reload) => {
+      DesktopCallback.unimpl('desktop_launch)_session');
+    });
+
+    ipcMain.on('desktop_reload_zoom_window', (event) => {
+    });
+
+    ipcMain.on('desktop_set_tutorial_url', (event, url) => {
+      DesktopCallback.unimpl('desktop_set_tutorial_url');
+    });
+  
+    ipcMain.on('desktop_set_viewer_url', (event, url) => {
+      DesktopCallback.unimpl('desktop_set_viewer_url');
+    });
+
+    ipcMain.on('desktop_reload_viewer_zoom_window', (event, url) => {
+      DesktopCallback.unimpl('desktop_reload_viewer_zoom_window');
+    });
+
+    ipcMain.on('desktop_set_shiny_dialog_url', (event, url) => {
+      DesktopCallback.unimpl('desktop_set_shiny_dialog_url');
+    });
+
+    ipcMain.handle('desktop_get_scrolling_compensation_type', (event) => {
+      DesktopCallback.unimpl('desktop_get_scrolling_compensation_type');
+      return '';
+    });
+
+    ipcMain.handle('desktop_is_macos', (event) => {
+      return true;
+    });
+
+    ipcMain.handle('desktop_is_centos', (event) => {
+      return false;
+    });
+
+    ipcMain.on('desktop_set_busy', (event, busy) => {
+    });
+
+    ipcMain.on('desktop_set_window_title', (event, title) => {
+      this.mainWindow.window?.setTitle(`${title} - RStudio`);
+    });
+
+    ipcMain.on('desktop_install_rtools', (event, version, installerPath) => {
+      DesktopCallback.unimpl('desktop_install_rtools');
+    });
+
+    ipcMain.handle('desktop_get_display_dpi', (event) => {
+      return '72';
+    });
+
+    ipcMain.on('desktop_on_session_quit', (event) => {
+      DesktopCallback.unimpl('desktop_on_session_quit');
+    });
+
+    ipcMain.handle('desktop_get_session_server', (event) => {
+      DesktopCallback.unimpl('desktop_get_session_server');
+      return {};
+    });
+
+    ipcMain.handle('desktop_get_session_servers', (event) => {
+      return [];
+    });
+
+    ipcMain.on('desktop_reconnect_to_session_server', (event, sessionServerJson) => {
+      DesktopCallback.unimpl('desktop_reconnect_to_session_server');
+    });
+
+    ipcMain.handle('desktop_set_launcher_server', (event, sessionServerJson) => {
+      DesktopCallback.unimpl('desktop_set_launcher_server');
+      return false;
+    });
+
+    ipcMain.on('desktop_connect_to_launcher_server', (event) => {
+      DesktopCallback.unimpl('desktop_connect_to_launcher_server');
+    });
+
+    ipcMain.handle('desktop_get_launcher_server', (event) => {
+      DesktopCallback.unimpl('desktop_get_launcher_server');
+      return {};
+    });
+
+    ipcMain.on('desktop_start_launcher_job_status_stream', (event, jobId) => {
+      DesktopCallback.unimpl('desktop_start_launcher_job_status_stream');
+    });
+
+    ipcMain.on('desktop_stop_launcher_job_status_stream', (event, jobId) => {
+      DesktopCallback.unimpl('desktop_stop_launcher_job_status_stream');
+    });
+
+    ipcMain.on('desktop_start_launcher_job_output_stream', (event, jobId) => {
+      DesktopCallback.unimpl('desktop_start_launcher_job_output_stream');
+    });
+
+    ipcMain.on('desktop_stop_launcher_job_output_stream', (event, jobId) => {
+      DesktopCallback.unimpl('desktop_stop_launcher_job_output_stream');
+    });
+
+    ipcMain.on('desktop_control_launcher_job', (event, jobId, operation) => {
+      DesktopCallback.unimpl('desktop_control_launcher_job');
+    });
+
+    ipcMain.on('desktop_submit_launcher_job', (event, job) => {
+      DesktopCallback.unimpl('desktop_submit_launcher_job');
+    });
+
+    ipcMain.on('desktop_get_job_container_user', (event) => {
+      DesktopCallback.unimpl('desktop_get_job_container_user');
+    });
+
+    ipcMain.on('desktop_validate_jobs_config', (event) => {
+      DesktopCallback.unimpl('desktop_validate_jobs_config');
+    });
+
+    ipcMain.handle('desktop_get_proxy_port_number', (event) => {
+      DesktopCallback.unimpl('desktop_get_proxy_port_number');
+      return -1;
+    });
+  }
+
+  static unimpl(ipcName: string) {
+
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    if (focusedWindow) {
+      dialog.showMessageBox(focusedWindow, {
+        title: 'Unimplemented',
+        message: `${ipcName} callback NYI`
+      });
+    } else {
+      dialog.showMessageBox({
+        title: 'Unimplemented',
+        message: `${ipcName} callback NYI`
+      });
+    }
+  }
+
+  collectPendingQuitRequest() {
+    if (this.pendingQuit != PendingQuit.PendingQuitNone) {
+      const currentPendingQuit = this.pendingQuit;
+      this.pendingQuit = PendingQuit.PendingQuitNone;
+      return currentPendingQuit;
+    } else {
+      return PendingQuit.PendingQuitNone;
+    }
+  }
+
+  convertMessageBoxType(type: number) {
+    // map QMessageBox types to Electron values
+    switch (type) {
+    case 1:
+      return 'info';
+    case 2:
+      return 'warning';
+    case 3:
+      return 'error';
+    default:
+    case 4:
+      return 'question';
+    }
+  }
+
+  convertButtons(buttons: string) {
+    return buttons.split('|');
+  }
+}
+
+module.exports = {PendingQuit, DesktopCallback};

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -56,7 +56,7 @@ export async function prepareEnvironment(): Promise<boolean> {
         rLdScriptPath = new FilePath(app.getAppPath()).completePath('r-ldpath');
       }
     } else {
-      rLdScriptPath = appState().scriptsPath?.completePath('../session/r-ldpath') ?? new FilePath();
+      rLdScriptPath = appState().sessionPath?.completePath('../r-ldpath') ?? new FilePath();
     }
   } else {
     // determine rLdPaths script location

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -22,6 +22,7 @@ import { existsSync } from 'fs';
 import { appState } from './app-state';
 import { Environment, getenv, setVars } from '../core/environment';
 import { FilePath } from '../core/file-path';
+import { assert } from 'console';
 
 const asyncExec = promisify(exec);
 
@@ -36,10 +37,15 @@ function showRNotFoundError(msg: string): void {
  */
 export async function prepareEnvironment(): Promise<boolean> {
   if (process.platform === 'win32') {
-    // TODO: current implementation in DesktopWin32DetectRHome.cpp
-    dialog.showErrorBox('NYI', 'R detection and environment setup NYI on Windows, cannot continue');
-    return false;
+    return await prepareEnvironmentWin32();
+  } else {
+    return await prepareEnvironmentPosix();
   }
+}
+
+async function prepareEnvironmentPosix(): Promise<boolean> {
+
+  assert((process.platform !== 'win32'));
 
   // check for which R override
   let rWhichRPath = new FilePath();
@@ -77,20 +83,36 @@ export async function prepareEnvironment(): Promise<boolean> {
     console.log(`Using R script: ${detectResult.rScriptPath}`);
   }
 
-  // set environment and return true
   setREnvironmentVars(detectResult.envVars ?? {});
+
+  if (process.platform === 'darwin') {
+    // TODO: deal with selection of x86_64 or arm64 build of R
+  }
+
   return true;
 }
 
-export async function scanForR(rstudioWhichR: FilePath): Promise<FilePath> {
+async function prepareEnvironmentWin32(): Promise<boolean> {
+  assert((process.platform === 'win32'));
+
+  dialog.showErrorBox('NYI', 'R detection and environment setup NYI on Windows, cannot continue');
+  return false;
+}
+
+async function scanForR(rstudioWhichR: FilePath): Promise<FilePath> {
+  if (process.platform === 'win32') {
+    return await scanForRWin32(rstudioWhichR);
+  } else {
+    return await scanForRPosix(rstudioWhichR);
+  }
+}
+
+async function scanForRPosix(rstudioWhichR: FilePath): Promise<FilePath> {
+  assert((process.platform !== 'win32'));
+
   // prefer RSTUDIO_WHICH_R
   if (!rstudioWhichR.isEmpty()) {
     return rstudioWhichR;
-  }
-
-  if (process.platform === 'win32') {
-    // For now must set env var to run on Windows
-    return new FilePath();
   }
 
   // first look for R on the PATH
@@ -119,6 +141,18 @@ export async function scanForR(rstudioWhichR: FilePath): Promise<FilePath> {
   }
 
   // nothing found
+  return new FilePath();
+}
+
+export async function scanForRWin32(rstudioWhichR: FilePath): Promise<FilePath> {
+  assert((process.platform === 'win32'));
+
+  // prefer RSTUDIO_WHICH_R
+  if (!rstudioWhichR.isEmpty()) {
+    return rstudioWhichR;
+  }
+
+  // For now must set env var to run on Windows
   return new FilePath();
 }
 
@@ -152,6 +186,8 @@ async function detectREnvironment(
     R_SHARE_DIR: `${rHome}/share`,
     R_DOC_DIR: `${rHome}/doc`
   };
+
+  // TODO: detect and return R version 
 
   return { success: true, rScriptPath: scanResult.getAbsolutePath(), envVars: rEnv };
 }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -1,0 +1,145 @@
+/*
+ * main-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { BrowserWindow, session } from 'electron';
+import path from 'path';
+
+import { DesktopCallback } from './desktop-callback';
+import { MenuCallback } from './menu-callback';
+import { PendingWindow } from './pending-window';
+import { RCommandEvaluator } from './r-command-evaluator';
+import { SessionLauncher } from './session-launcher';
+
+// corresponds to DesktopMainWindow.cpp/hpp
+export class MainWindow {
+  sessionLauncher_: SessionLauncher|null = null;
+  sessionProcess_: any = null;
+  window: BrowserWindow|null = null;
+  desktopCallback: DesktopCallback;
+  menuCallback: MenuCallback;
+  quitConfirmed = false;
+  workbenchInitialized_ = false;
+  pendingWindows = new Array<PendingWindow>();
+
+  constructor(public url: string, public isRemoteDesktop: boolean) {
+    this.desktopCallback = new DesktopCallback(this, this, isRemoteDesktop);
+    this.menuCallback = new MenuCallback(this);
+
+    RCommandEvaluator.setMainWindow(this);
+  }
+
+  set sessionLauncher(value) {
+    this.sessionLauncher_ = value;
+  }
+
+  get sessionLauncher() {
+    return this.sessionLauncher_;
+  }
+
+  set sessionProcess(value) {
+    this.sessionProcess_ = value;
+  }
+
+  get sessionProcess() {
+    return this.sessionProcess_;
+  }
+
+  load(url: string) {
+    // show the window
+    this.window = this.createWindow(1400, 1024);
+ 
+    // pass along the shared secret with every request
+    const filter = {
+      urls: [`${url}/*`]
+    };
+    session.defaultSession.webRequest.onBeforeSendHeaders(filter, (details, callback) => {
+      details.requestHeaders['X-Shared-Secret'] = process.env.RS_SHARED_SECRET ?? '';
+      callback({ requestHeaders: details.requestHeaders});
+    });
+
+    this.window.webContents.on('new-window',
+      (event, url, frameName, disposition, options, additionalFeatures, referrer, postBody) => {
+
+        event.preventDefault();
+
+        // check if we have a satellite window waiting to come up
+        const pendingWindow = this.pendingWindows.pop();
+        if (pendingWindow) {
+          const newWindow = this.createWindow(pendingWindow.width, pendingWindow.height);
+          newWindow.loadURL(url);
+          newWindow.webContents.openDevTools();
+        }
+      });
+
+    this.window.loadURL(url);
+    // this.window.webContents.openDevTools();
+  }
+
+  quit() {
+    RCommandEvaluator.setMainWindow(null);
+    this.quitConfirmed = true;
+    this.window?.close();
+  }
+
+  invokeCommand(cmdId: string) {
+    this.window?.webContents.executeJavaScript(`window.desktopHooks.invokeCommand("${cmdId}")`)
+      .catch(() => {
+        console.error(`Error: failed to execute desktopHooks.invokeCommand("${cmdId}")`);
+      });
+  }
+
+  onWorkbenchInitialized() {
+    this.workbenchInitialized_ = true;
+    this.window?.webContents.executeJavaScript('window.desktopHooks.getActiveProjectDir()')
+      .then(projectDir => {
+        if (projectDir.length > 0) {
+          this.window?.setTitle(`${projectDir} - RStudio`);
+        } else {
+          this.window?.setTitle('RStudio');
+        }
+      })
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      .catch(() => {
+      });
+  }
+
+  collectPendingQuitRequest() {
+    return this.desktopCallback.collectPendingQuitRequest();
+  }
+
+  get workbenchInitialized() {
+    return this.workbenchInitialized_;
+ 
+  }
+
+  createWindow(width: number, height: number) {
+    return new BrowserWindow({
+      width: width,
+      height: height,
+      // https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
+      backgroundColor: '#fff', 
+      webPreferences: {
+        enableRemoteModule: false,
+        nodeIntegration: false,
+        contextIsolation: true,
+        preload: path.join(__dirname, '../renderer/preload.js'),
+      },
+    });
+  }
+
+  prepareForWindow(pendingWindow: PendingWindow) {
+    this.pendingWindows.push(pendingWindow);
+  }
+}

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -1,0 +1,190 @@
+/*
+ * menu-callback.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+import { ipcMain, Menu, MenuItem } from 'electron';
+import { MenuItemConstructorOptions } from 'electron/main';
+import { MainWindow } from './main-window';
+
+export class MenuCallback {
+  mainMenu?: Menu|null = null;
+  menuStack: Menu[] = [];
+  actions = new Map();
+
+  lastWasTools = false;
+  lastWasDiagnostics = false;
+
+  constructor(public mainWindow: MainWindow) {
+
+    ipcMain.on('menu_begin_main', (event) => {
+      this.mainMenu = new Menu();
+      if (process.platform === 'darwin') {
+        this.mainMenu.append(new MenuItem({role: 'appMenu'}));
+      }
+    });
+
+    ipcMain.on('menu_begin', (event, label) => {
+      const subMenu = new Menu();
+      const opts: MenuItemConstructorOptions = {submenu: subMenu, label: label};
+      if (label === '&File') {
+        opts.role = 'fileMenu';
+      } else if (label === '&Edit') {
+        opts.role = 'editMenu';
+      } else if (label === '&View') {
+        opts.role = 'viewMenu';
+      } else if (label === '&Help') {
+        opts.role = 'help';
+      } else if (label === '&Tools') {
+        this.lastWasTools = true;
+      } else if (label === 'Dia&gnostics') {
+        this.lastWasDiagnostics = true;
+      }
+
+      const menuItem = new MenuItem(opts);
+      if (this.menuStack.length == 0) {
+        this.mainMenu?.append(menuItem);
+      } else {
+        this.addToCurrentMenu(menuItem);
+      }
+      this.menuStack.push(subMenu);
+    });
+
+    ipcMain.on('menu_add_command', (event, cmdId, label, tooltip, shortcut, checkable) => {
+      const menuItemOpts: MenuItemConstructorOptions = {label: label, id: cmdId, click: (menuItem, browserWindow, event) => {
+        this.actionInvoked(menuItem.id);
+      }};
+
+      if (checkable) {
+        menuItemOpts.checked = false;
+      }
+      if (shortcut.length > 0) {
+        menuItemOpts.accelerator = this.convertShortcut(shortcut);
+      }
+
+      // some shortcuts (namely, the Edit shortcuts) don't have bindings on the client side.
+      // populate those here when discovered
+      if (cmdId === 'zoomActualSize') {
+        menuItemOpts.role = 'resetZoom';
+      } else if (cmdId === 'zoomIn') {
+        menuItemOpts.role = 'zoomIn';
+      } else if (cmdId === 'zoomOut') {
+        menuItemOpts.role = 'zoomOut';
+      } else if (cmdId === 'cutDummy') {
+        menuItemOpts.role = 'cut';
+      } else if (cmdId === 'copyDummy') {
+        menuItemOpts.role = 'copy';
+      } else if (cmdId === 'pasteDummy') {
+        menuItemOpts.role = 'paste';
+      } else if (cmdId === 'pasteWithIndentDummy') {
+        menuItemOpts.role = 'pasteAndMatchStyle';
+      } else if (cmdId === 'undoDummy') {
+        menuItemOpts.role = 'undo';
+      } else if (cmdId === 'redoDummy') {
+        menuItemOpts.role = 'redo';
+      }
+
+      const menuItem = new MenuItem(menuItemOpts);
+      this.actions.set(cmdId, menuItem);
+      this.addToCurrentMenu(menuItem);
+    });
+
+    ipcMain.on('menu_add_separator', (event) => {
+      const separator = new MenuItem({type: 'separator'});
+      this.addToCurrentMenu(separator);
+    });
+
+    ipcMain.on('menu_end', (event) => {
+      if (this.lastWasDiagnostics) {
+        this.lastWasDiagnostics = false;
+        this.addToCurrentMenu(new MenuItem({role: 'toggleDevTools'}));
+      }
+
+      this.menuStack.pop();
+
+      if (this.lastWasTools) {
+        this.lastWasTools = false;
+
+        // add the Window menu on mac
+        if (process.platform === 'darwin') {
+          this.mainMenu?.append(new MenuItem({role: 'windowMenu'}));
+        }
+      }
+    });
+
+    ipcMain.on('menu_end_main', (event) => {
+      if (this.mainMenu)
+        Menu.setApplicationMenu(this.mainMenu);
+    });
+
+    ipcMain.on('menu_set_command_visible', (event, commandId, visible) => {
+      const item = this.getMenuItemById(commandId);
+      if (item) {
+        item.visible = visible;
+      }
+    });
+
+    ipcMain.on('menu_set_command_enabled', (event, commandId, enabled) => {
+      const item = this.getMenuItemById(commandId);
+      if (item) {
+        item.enabled = enabled;
+      }
+    });
+
+    ipcMain.on('menu_set_command_checked', (event, commandId, checked) => {
+      const item = this.getMenuItemById(commandId);
+      if (item) {
+        item.checked = checked;
+      }
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    ipcMain.on('menu_set_main_menu_enabled', (event, enabled) => {
+    });
+
+    ipcMain.on('menu_set_command_label', (event, commandId, label) => {
+      const item = this.getMenuItemById(commandId);
+      if (item) {
+        item.label = label;
+      }
+    });
+  }
+
+  addToCurrentMenu(menuItem: MenuItem): void {
+    if (this.menuStack.length > 0) {
+      this.menuStack[this.menuStack.length - 1].append(menuItem);
+    }
+  }
+
+  getMenuItemById(id: string) {
+    return this.actions.get(id);
+  }
+
+  /**
+   * Convert RStudio shortcut string to Electron Accelerator
+   */
+  convertShortcut(shortcut: string) {
+    return shortcut.split('+').map(key => {
+      if (key === 'Cmd') {
+        return 'CommandOrControl';
+      } else if (key === 'Meta') {
+        return 'Command';
+      } else {
+        return key;
+      }
+    }).join('+');
+  }
+
+  actionInvoked(commandId: string) {
+    this.mainWindow.invokeCommand(commandId);
+  }
+}

--- a/src/node/desktop/src/main/pending-window.ts
+++ b/src/node/desktop/src/main/pending-window.ts
@@ -1,0 +1,31 @@
+/*
+ * pending-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+export class PendingWindow {
+  isSatellite = true;
+  allowExternalNavigate = false; // for RDP
+  showToolbar = false;
+
+  constructor(public name: string,
+              public x: number,
+              public y: number,
+              public width: number,
+              public height: number) {
+  }
+
+  get isEmpty(): boolean {
+    return !this.name;
+  }
+}

--- a/src/node/desktop/src/main/r-command-evaluator.ts
+++ b/src/node/desktop/src/main/r-command-evaluator.ts
@@ -1,0 +1,36 @@
+/*
+ * r-command-evaluator.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { MainWindow } from './main-window';
+
+export class RCommandEvaluator {
+  static window: MainWindow|null;
+  
+  static setMainWindow(window: MainWindow|null): void {
+    RCommandEvaluator.window = window;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static evaluate(rCmd: string): void {
+    if (RCommandEvaluator.window === null) {
+      return;
+    }
+
+    //rCmd = core::string_utils::jsLiteralEscape(rCmd);
+    //std::string js = "window.desktopHooks.evaluateRCmd(\"" + rCmd + "\")";
+    //window_->webPage()->runJavaScript(QString::fromStdString(js));
+    console.log('RCommandEvaluator.evaluate NYI');
+  }
+}

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -41,8 +41,8 @@ export class SessionLauncher {
   ) { }
 
   launchFirstSession(): void {
-    appState().activation().on(ActivationEvents.LAUNCH_FIRST_SESSION, this.onLaunchFirstSession);
-    appState().activation().on(ActivationEvents.LAUNCH_ERROR, this.onLaunchError);
+    appState().activation().on(ActivationEvents.LAUNCH_FIRST_SESSION, this.onLaunchFirstSession.bind(this));
+    appState().activation().on(ActivationEvents.LAUNCH_ERROR, this.onLaunchError.bind(this));
     appState().activation().getInitialLicense();
   }
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -13,6 +13,182 @@
  *
  */
 
-export class SessionLauncher {
+import { spawn, ChildProcess } from 'child_process';
 
+import { FilePath } from '../core/file-path';
+import { ApplicationLaunch } from './application-launch';
+import { Err } from '../core/err';
+import { appState } from './app-state';
+import { ActivationEvents } from './activation-overlay';
+import { app, dialog } from 'electron';
+import { EXIT_FAILURE } from './program-status';
+import { getenv, logEnvVar, setenv } from '../core/environment';
+import { MainWindow } from './main-window';
+import { PendingQuit } from './desktop-callback';
+
+export class SessionLauncher {
+  host = '';
+  port = '40810'; // TODO: see DesktopOptions.cpp portNumber() for how to randomly generate
+  launcherToken = '7F83A8BD'; // TODO: generate short uuid
+  sessionProcess?: ChildProcess;
+  mainWindow?: MainWindow;
+
+  constructor(
+    private sessionPath: FilePath,
+    private confPath: FilePath,
+    private filename: FilePath,
+    private appLaunch: ApplicationLaunch
+  ) { }
+
+  launchFirstSession(): void {
+    appState().activation().on(ActivationEvents.LAUNCH_FIRST_SESSION, this.onLaunchFirstSession);
+    appState().activation().on(ActivationEvents.LAUNCH_ERROR, this.onLaunchError);
+    appState().activation().getInitialLicense();
+  }
+
+  private launchSession(argList: string[]): ChildProcess {
+    if (process.platform === 'darwin') {
+      // on macOS with the hardened runtime, we can no longer rely on dyld
+      // to lazy-load symbols from libR.dylib; to resolve this, we use
+      // DYLD_INSERT_LIBRARIES to inject the library we wish to use on
+      // launch 
+      const rHome = new FilePath(getenv('R_HOME'));
+      const rLib = rHome.completePath('lib/libR.dylib');
+      if (rLib.existsSync()) {
+        setenv('DYLD_INSERT_LIBRARIES', rLib.getAbsolutePath());
+      }
+    }
+
+    const sessionProc = spawn(this.sessionPath.getAbsolutePath(), argList);
+    sessionProc.stdout.on('data', (data) => {
+      console.log(`rsession stdout: ${data}`);
+    });
+    sessionProc.stderr.on('data', (data) => {
+      console.log(`rsession stderr: ${data}`);
+    });
+    sessionProc.on('exit', (code, signal) => {
+      if (code !== null) {
+        console.log(`rsession exited: code=${code}`);
+        if (code !== 0) {
+          console.log(`${this.sessionPath} ${argList}`);
+        }
+      } else {
+        console.log(`rsession terminated: signal=${signal}`);
+      }
+      this.onRSessionExited();
+    });
+
+    return sessionProc;
+  }
+
+  private onLaunchFirstSession(): void {
+    const launchContext = this.buildLaunchContext();
+
+    // show help home on first run
+    launchContext.argList.push('--show-help-home', '1');
+
+    if (appState().runDiagnostics) {
+      console.log('\nAttempting to launch R session...');
+      logEnvVar('RSTUDIO_WHICH_R');
+      logEnvVar('R_HOME');
+      logEnvVar('R_DOC_DIR');
+      logEnvVar('R_INCLUDE_DIR');
+      logEnvVar('R_SHARE_DIR');
+      logEnvVar('R_LIBS');
+      logEnvVar('R_LIBS_USER');
+      logEnvVar('DYLD_LIBRARY_PATH');
+      logEnvVar('DYLD_FALLBACK_LIBRARY_PATH');
+      logEnvVar('LD_LIBRARY_PATH');
+      logEnvVar('PATH');
+      logEnvVar('HOME');
+      logEnvVar('R_USER');
+    }
+
+    // launch the process
+    this.sessionProcess = this.launchSession(launchContext.argList);
+
+    this.mainWindow = new MainWindow(launchContext.url, false);
+    this.mainWindow.sessionLauncher = this;
+    this.mainWindow.sessionProcess = this.sessionProcess;
+
+    // show the window
+    this.mainWindow.load(launchContext.url);
+   
+  }
+
+  onLaunchError(message: string): void {
+    if (message) {
+      dialog.showErrorBox(appState().activation().editionName(), message);
+    }
+    if (appState().mainWindow) {
+      appState().mainWindow?.close();
+    } else {
+      app.exit(EXIT_FAILURE);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  launchNextSession(reload: boolean): Err {
+    return Error('launchNextSession NYI');
+  }
+
+  onRSessionExited(): void {
+    const pendingQuit = this.mainWindow?.collectPendingQuitRequest();
+
+    // if there was no pending quit set then this is a crash
+    if (pendingQuit === PendingQuit.PendingQuitNone) {
+
+      // closeAllSatellites();
+
+      this.mainWindow?.window?.webContents.executeJavaScript('window.desktopHooks.notifyRCrashed()')
+        .catch(() => {
+          // The above can throw if the window has no desktop hooks; this is normal
+          // if we haven't loaded the initial session.
+        });
+
+      if (!this.mainWindow?.workbenchInitialized) {
+        // If the R session exited without initializing the workbench, treat it as
+        // a boot failure.
+        this.showLaunchErrorPage(); 
+      }
+
+    // quit and exit means close the main window
+    } else if (pendingQuit === PendingQuit.PendingQuitAndExit) {
+      this.mainWindow?.quit();
+    }
+
+    // otherwise this is a restart so we need to launch the next session
+    else {
+      const reload = (pendingQuit === PendingQuit.PendingQuitRestartAndReload);
+      if (reload) {
+        this.closeAllSatellites();
+      }
+
+      // launch next session
+      this.launchNextSession(reload);
+    }
+  }
+
+  buildLaunchContext(): {host: string, port: string, url: string, argList: string[]} {
+    this.host = '127.0.0.1';
+    return {
+      host: this.host,
+      port: `${this.port}`,
+      url: `http://${this.host}:${this.port}`,
+      argList: [
+        '--config-file', this.confPath.getAbsolutePath(),
+        '--program-mode', 'desktop',
+        '--www-port', this.port,
+        '--launcher-token', this.launcherToken,
+      ],
+    };
+  }
+
+  showLaunchErrorPage(): void {
+    console.log('Launch error page not implemented');
+  }
+
+  closeAllSatellites(): void {
+    console.log('CloseAllSatellites not implemented');
+  }
 }

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -1,0 +1,746 @@
+/*
+ * desktop-bridge.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { ipcRenderer } from 'electron';
+
+interface VoidCallback<Type> {
+  (result: Type): void;
+}
+
+interface CursorPosition {
+  x: number,
+  y: number
+}
+
+export interface DesktopBridge {
+  browseUrl(url: string): void;
+  getOpenFileName(
+    caption: string, label: string, dir: string, filter: string, canChooseDirectories: boolean,
+    focusOwner: boolean, callback: VoidCallback<string>): void;
+  getSaveFileName(
+    caption: string, label: string, dir: string, defaultExtension: string,
+    forceDefaultExtension: boolean, focusOwner: boolean, callback: VoidCallback<string>): void;
+  getExistingDirectory(
+    caption: string, label: string, dir: string, focusOwner: boolean, callback: VoidCallback<string>): void;
+  onClipboardSelectionChanged(): void;
+  undo(): void;
+  redo(): void;
+  clipboardCut(): void;
+  clipboardCopy(): void;
+  clipboardPaste(): void;
+  setClipboardText(text: string): void;
+  getClipboardText(callback: VoidCallback<string>): void;
+  getClipboardUris(callback: VoidCallback<string>): void;
+  getClipboardImage(callback: VoidCallback<string>): void;
+  setGlobalMouseSelection(selection: string): void;
+  getGlobalMouseSelection(callback: VoidCallback<string>): void;
+  getCursorPosition(callback: VoidCallback<CursorPosition>): void;
+  doesWindowExistAtCursorPosition(callback: VoidCallback<boolean>): void;
+  onWorkbenchInitialized(scratchPath: string): void;
+  showFolder(path: string): void;
+  showFile(file: string): void;
+  showWordDoc(wordDoc: string): void;
+  showPptPresentation(pptDoc: string): void;
+  showPDF(path: string, pdfPage: string): void;
+  prepareShowWordDoc(): void;
+  prepareShowPptPresentation(): void;
+  getRVersion(callback: VoidCallback<string>): void;
+  chooseRVersion(callback: VoidCallback<string>): void;
+  devicePixelRatio(callback: VoidCallback<number>): void;
+  openMinimalWindow(name: string, url: string, width: number, height: number): void;
+  activateMinimalWindow(name: string): void;
+  activateSatelliteWindow(name: string): void;
+  prepareForSatelliteWindow(name: string, x: number, y: number, width: number, height: number, callback: () => void): void;
+  prepareForNamedWindow(name: string, allowExternalNavigate: boolean, showToolbar: boolean, callback: () => void): void;
+  closeNamedWindow(name: string): void;
+  copyPageRegionToClipboard(left: number, top: number, width: number, height: number): void;
+  exportPageRegionToFile(targetPath: string, format: string, left: number, top: number, width: number, height: number): void;
+  printText(text: string): void;
+  paintPrintText(printer: string): void;
+  printFinished(result: number): void;
+  supportsClipboardMetafile(callback: VoidCallback<boolean>): void;
+  showMessageBox(type: number, caption: string, message: string, buttons: string, defaultButton: number,
+    cancelButton: number, callback: VoidCallback<number>): void;
+  promptForText(title: string, caption: string, defaultValue: string, type: number, rememberPasswordPrompt: boolean,
+    rememberByDefault: boolean, selectionStart: number, selectionLength: number, okButtonCaption: string,
+    callback: VoidCallback<string>): void;
+  bringMainFrameToFront(): void;
+  bringMainFrameBehindActive(): void;
+  desktopRenderingEngine(callback: VoidCallback<string>): void;
+  setDesktopRenderingEngine(engine: string): void;
+  filterText(text: string, callback: VoidCallback<string>): void;
+  cleanClipboard(stripHtml: boolean): void;
+  setPendingQuit(pendingQuit: number): void;
+  openProjectInNewWindow(projectFilePath: string): void;
+  openSessionInNewWindow(workingDirectoryPath: string): void;
+  openTerminal(terminalPath: string, workingDirectory: string, extraPathEntries: string, shellType: string): void;
+  getFixedWidthFontList(callback: VoidCallback<string>): void;
+  getFixedWidthFont(callback: VoidCallback<string>): void;
+  setFixedWidthFont(font: string): void;
+  getZoomLevels(callback: VoidCallback<string>): void;
+  getZoomLevel(callback: VoidCallback<number>): void;
+  setZoomLevel(zoomLevel: number): void;
+  zoomIn(): void;
+  zoomOut(): void;
+  zoomActualSize(): void;
+  setBackgroundColor(rgbColor: Record<string, unknown>[]): void;
+  changeTitleBarColor(red: number, green: number, blue: number): void;
+  syncToEditorTheme(isDark: boolean): void;
+  getEnableAccessibility(callback: VoidCallback<boolean>): void;
+  setEnableAccessibility(enable: boolean): void;
+  getClipboardMonitoring(callback: VoidCallback<boolean>): void;
+  setClipboardMonitoring(monitoring: boolean): void;
+  getIgnoreGpuBlacklist(callback: VoidCallback<boolean>): void;
+  setIgnoreGpuBlacklist(ignore: boolean): void;
+  getDisableGpuDriverBugWorkarounds(callback: VoidCallback<boolean>): void;
+  setDisableGpuDriverBugWorkarounds(disable: boolean): void;
+  showLicenseDialog(): void;
+  showSessionServerOptionsDialog(): void;
+  getInitMessages(callback: VoidCallback<string>): void;
+  getLicenseStatusMessage(callback: VoidCallback<string>): void;
+  allowProductUsage(callback: VoidCallback<boolean>): void;
+  getDesktopSynctexViewer(callback: VoidCallback<string>): void;
+  externalSynctexPreview(pdfPath: string, page: number): void;
+  externalSynctexView(pdfFile: string, srcFile: string, line: number, column: number): void;
+  supportsFullscreenMode(callback: VoidCallback<boolean>): void;
+  toggleFullscreenMode(): void;
+  showKeyboardShortcutHelp(): void;
+  launchSession(reload: boolean): void;
+  reloadZoomWindow(): void;
+  setTutorialUrl(url: string): void;
+  setViewerUrl(url: string): void;
+  reloadViewerZoomWindow(url: string): void;
+  setShinyDialogUrl(url: string): void;
+  getScrollingCompensationType(callback: VoidCallback<string>): void;
+  isMacOS(callback: VoidCallback<boolean>): void;
+  isCentOS(callback: VoidCallback<boolean>): void;
+  setBusy(busy: boolean): void;
+  setWindowTitle(title: string): void;
+  installRtools(version: string, installerPath: string): void;
+  getDisplayDpi(callback: VoidCallback<string>): void;
+  onSessionQuit(): void;
+  getSessionServer(callback: VoidCallback<Record<string, unknown>>): void;
+  getSessionServers(callback: VoidCallback<Record<string, unknown>[]>): void;
+  reconnectToSessionServer(sessionServerJson: Record<string, unknown>): void;
+  setLauncherServer(sessionServerJson: Record<string, unknown>, callback: VoidCallback<boolean>): void;
+  connectToLauncherServer(): void;
+  getLauncherServer(callback: VoidCallback<string>): void;
+  startLauncherJobStatusStream(jobId: string): void;
+  stopLauncherJobStatusStream(jobId: string): void;
+  startLauncherJobOutputStream(jobId: string): void;
+  stopLauncherJobOutputStream(jobId: string): void;
+  controlLauncherJob(jobId: string, operation: string): void;
+  submitLauncherJob(job: Record<string, unknown>): void;
+  getJobContainerUser(): void;
+  validateJobsConfig(): void;
+  getProxyPortNumber(callback: VoidCallback<number>): void;
+  signOut(): void;
+}
+
+export function getDesktopBridge(): DesktopBridge {
+  return {
+    browseUrl: (url: string) => {
+      ipcRenderer.send('desktop_browse_url', url);
+    },
+
+    getOpenFileName: (caption: string,
+      label: string,
+      dir: string,
+      filter: string,
+      canChooseDirectories: boolean,
+      focusOwner: boolean,
+      callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_open_file_name', caption,
+          label,
+          dir,
+          filter,
+          canChooseDirectories,
+          focusOwner)
+        .then(result => {
+          if (result.canceled) {
+            callback('');
+          } else {
+            callback(result.filePaths[0]);
+          }
+        });
+    },
+
+    getSaveFileName: (caption: string,
+      label: string,
+      dir: string,
+      defaultExtension: string,
+      forceDefaultExtension: boolean,
+      focusOwner: boolean,
+      callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_save_file_name', caption,
+          label,
+          dir,
+          defaultExtension,
+          forceDefaultExtension,
+          focusOwner)
+        .then(filename => callback(filename));
+    },
+
+    getExistingDirectory: (caption: string,
+      label: string,
+      dir: string,
+      focusOwner: boolean,
+      callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_existing_directory', caption,
+          label,
+          dir,
+          focusOwner)
+        .then(directory => callback(directory));
+    },
+
+    onClipboardSelectionChanged: () => {
+      ipcRenderer.send('desktop_on_clipboard_selection_changed');
+    },
+
+    undo: () => {
+      ipcRenderer.send('desktop_undo');
+    },
+
+    redo: () => {
+      ipcRenderer.send('desktop_redo');
+    },
+
+    clipboardCut: () => {
+      ipcRenderer.send('desktop_clipboard_cut');
+    },
+
+    clipboardCopy: () => {
+      ipcRenderer.send('desktop_clipboard_copy');
+    },
+
+    clipboardPaste: () => {
+      ipcRenderer.send('desktop_clipboard_paste');
+    },
+
+    setClipboardText: (text: string) => {
+      ipcRenderer.send('desktop_set_clipboard_text', text);
+    },
+
+    getClipboardText: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_clipboard_text')
+        .then(text => callback(text));
+    },
+
+    getClipboardUris: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_clipboard_uris')
+        .then(text => callback(text));
+    },
+
+    getClipboardImage: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_clipboard_image')
+        .then(text => callback(text));
+    },
+
+    setGlobalMouseSelection: (selection: string) => {
+      ipcRenderer.send('desktop_set_global_mouse_selection', selection);
+    },
+
+    getGlobalMouseSelection: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_global_mouse_selection')
+        .then(selection => callback(selection));
+    },
+
+    getCursorPosition: (callback: VoidCallback<CursorPosition>) => {
+      ipcRenderer
+        .invoke('desktop_get_cursor_position')
+        .then(position => callback(position));
+    },
+
+    doesWindowExistAtCursorPosition: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_does_window_exist_at_cursor_position')
+        .then(exists => callback(exists));
+    },
+
+    onWorkbenchInitialized: (scratchPath: string) => {
+      ipcRenderer.send('desktop_on_workbench_initialized', scratchPath);
+    },
+
+    showFolder: (path: string) => {
+      ipcRenderer.send('desktop_show_folder', path);
+    },
+
+    showFile: (file: string) => {
+      ipcRenderer.send('desktop_show_file', file);
+    },
+
+    showWordDoc: (wordDoc: string) => {
+      ipcRenderer.send('desktop_show_word_doc', wordDoc);
+    },
+
+    showPptPresentation: (pptDoc: string) => {
+      ipcRenderer.send('desktop_show_ppt_presentation', pptDoc);
+    },
+
+    showPDF: (path: string, pdfPage: string) => {
+      ipcRenderer.send('desktop_show_pdf', path, pdfPage);
+    },
+
+    prepareShowWordDoc: () => {
+      ipcRenderer.send('desktop_prepare_show_word_doc');
+    },
+
+    prepareShowPptPresentation: () => {
+      ipcRenderer.send('desktop_prepare_show_ppt_presentation');
+    },
+
+    // R version selection currently Win32 only
+    getRVersion: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_r_version')
+        .then(rver => callback(rver));
+    },
+
+    chooseRVersion: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_choose_r_version')
+        .then(rver => callback(rver));
+    },
+
+    devicePixelRatio: (callback: VoidCallback<number>) => {
+      ipcRenderer
+        .invoke('desktop_device_pixel_ratio')
+        .then(ratio => callback(ratio));
+    },
+
+    openMinimalWindow: (name: string, url: string, width: number, height: number) => {
+      ipcRenderer.send('desktop_open_minimal_window', name, url, width, height);
+    },
+
+    activateMinimalWindow: (name: string) => {
+      ipcRenderer.send('desktop_activate_minimal_window', name);
+    },
+
+    activateSatelliteWindow: (name: string) => {
+      ipcRenderer.send('desktop_activate_satellite_window', name);
+    },
+
+    prepareForSatelliteWindow: (name: string, x: number, y: number, width: number, height: number, callback: () => void) => {
+      ipcRenderer.invoke('desktop_prepare_for_satellite_window', name, x, y, width, height)
+        .then(() => callback());
+    },
+
+    prepareForNamedWindow: (name: string, allowExternalNavigate: boolean, showToolbar: boolean, callback: () => void) => {
+      ipcRenderer.invoke('desktop_prepare_for_named_window', name, allowExternalNavigate, showToolbar)
+        .then(() => callback());
+    },
+
+    closeNamedWindow: (name: string) => {
+      ipcRenderer.send('desktop_close_named_window', name);
+    },
+
+    copyPageRegionToClipboard: (left: number, top: number, width: number, height: number) => {
+      ipcRenderer.send('desktop_copy_page_region_to_clipboard', left, top, width, height);
+    },
+
+    exportPageRegionToFile: (targetPath: string, format: string, left: number, top: number, width: number, height: number) => {
+      ipcRenderer.send('desktop_export_page_region_to_file', targetPath, format, left, top, width, height);
+    },
+
+    printText: (text: string) => {
+      ipcRenderer.send('desktop_print_text', text);
+    },
+
+    paintPrintText: (printer: string) => {
+      ipcRenderer.send('desktop_paint_print_text', printer);
+    },
+
+    printFinished: (result: number) => {
+      ipcRenderer.send('desktop_print_finished', result);
+    },
+
+    supportsClipboardMetafile: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_supports_clipboard_metafile')
+        .then(metafilesupport => callback(metafilesupport));
+    },
+
+    showMessageBox: (type: number,
+      caption: string,
+      message: string,
+      buttons: string,
+      defaultButton: number,
+      cancelButton: number,
+      callback: VoidCallback<number>) => {
+      ipcRenderer
+        .invoke('desktop_show_message_box', type, caption, message, buttons, defaultButton, cancelButton)
+        .then(result => callback(result.response));
+    },
+
+    promptForText: (title: string,
+      caption: string,
+      defaultValue: string,
+      type: number,
+      rememberPasswordPrompt: boolean,
+      rememberByDefault: boolean,
+      selectionStart: number,
+      selectionLength: number,
+      okButtonCaption: string,
+      callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_prompt_for_text', title, caption, defaultValue, type,
+          rememberPasswordPrompt, rememberByDefault,
+          selectionStart, selectionLength, okButtonCaption)
+        .then(text => callback(text));
+    },
+
+    bringMainFrameToFront: () => {
+      ipcRenderer.send('desktop_bring_main_frame_to_front');
+    },
+
+    bringMainFrameBehindActive: () => {
+      ipcRenderer.send('desktop_bring_main_frame_behind_active');
+    },
+
+    desktopRenderingEngine: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_rendering_engine')
+        .then(engine => callback(engine));
+    },
+
+    setDesktopRenderingEngine: (engine: string) => {
+      ipcRenderer.send('desktop_set_desktop_rendering_engine', engine);
+    },
+
+    filterText: (text: string, callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_filter_text', text)
+        .then(filtered => callback(text));
+    },
+
+    cleanClipboard: (stripHtml: boolean) => {
+      ipcRenderer.send('desktop_clean_clipboard', stripHtml);
+    },
+
+    setPendingQuit: (pendingQuit: number) => {
+      ipcRenderer.send('desktop_set_pending_quit', pendingQuit);
+    },
+
+    openProjectInNewWindow: (projectFilePath: string) => {
+      ipcRenderer.send('desktop_open_project_in_new_window', projectFilePath);
+    },
+
+    openSessionInNewWindow: (workingDirectoryPath: string) => {
+      ipcRenderer.send('desktop_open_session_in_new_window', workingDirectoryPath);
+    },
+
+    openTerminal: (terminalPath: string, workingDirectory: string, extraPathEntries: string, shellType: string) => {
+      ipcRenderer.send('desktop_open_terminal', terminalPath, workingDirectory, extraPathEntries, shellType);
+    },
+
+    getFixedWidthFontList: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_fixed_width_font_list')
+        .then(fonts => callback(fonts));
+    },
+
+    getFixedWidthFont: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_fixed_width_font')
+        .then(font => callback(font));
+    },
+
+    setFixedWidthFont: (font: string) => {
+      ipcRenderer.send('desktop_set_fixed_width_font', font);
+    },
+
+    getZoomLevels: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_zoom_levels')
+        .then(levels => callback(levels));
+    },
+
+    getZoomLevel: (callback: VoidCallback<number>) => {
+      ipcRenderer
+        .invoke('desktop_get_zoom_level')
+        .then(zoomLevel => callback(zoomLevel));
+    },
+
+    setZoomLevel: (zoomLevel: number) => {
+      ipcRenderer.send('desktop_set_zoom_level', zoomLevel);
+    },
+
+    zoomIn: () => {
+      ipcRenderer.send('desktop_zoom_in');
+    },
+
+    zoomOut: () => {
+      ipcRenderer.send('desktop_zoom_out');
+    },
+
+    zoomActualSize: () => {
+      ipcRenderer.send('desktop_zoom_actual_size');
+    },
+
+    setBackgroundColor: (rgbColor: Record<string, unknown>[]) => {
+      ipcRenderer.send('desktop_set_background_color', rgbColor);
+    },
+
+    changeTitleBarColor: (red: number, green: number, blue: number) => {
+      ipcRenderer.send('desktop_change_title_bar_color', red, green, blue);
+    },
+
+    syncToEditorTheme: (isDark: boolean) => {
+      ipcRenderer.send('desktop_sync_to_editor_theme', isDark);
+    },
+
+    getEnableAccessibility: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_get_enable_accessibility')
+        .then(enabled => callback(enabled));
+    },
+
+    setEnableAccessibility: (enable: boolean) => {
+      ipcRenderer.send('desktop_set_enable_accessibility', enable);
+    },
+
+    getClipboardMonitoring: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_get_clipboard_monitoring')
+        .then(monitoring => callback(monitoring));
+    },
+
+    setClipboardMonitoring: (monitoring: boolean) => {
+      ipcRenderer.send('desktop_set_clipboard_monitoring', monitoring);
+    },
+
+    getIgnoreGpuBlacklist: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_get_ignore_gpu_blacklist')
+        .then(ignore => callback(ignore));
+    },
+
+    setIgnoreGpuBlacklist: (ignore: boolean) => {
+      ipcRenderer.send('desktop_set_ignore_gpu_blacklist', ignore);
+    },
+
+    getDisableGpuDriverBugWorkarounds: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_get_disable_gpu_driver_bug_workarounds')
+        .then(disabled => callback(disabled));
+    },
+
+    setDisableGpuDriverBugWorkarounds: (disable: boolean) => {
+      ipcRenderer.send('desktop_set_disable_gpu_driver_bug_workarounds', disable);
+    },
+
+    showLicenseDialog: () => {
+      ipcRenderer.send('desktop_show_license_dialog');
+    },
+
+    showSessionServerOptionsDialog: () => {
+      ipcRenderer.send('desktop_show_session_server_options_dialog');
+    },
+
+    getInitMessages: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_init_messages')
+        .then(messages => callback(messages));
+    },
+
+    getLicenseStatusMessage: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_license_status_message')
+        .then(message => callback(message));
+    },
+
+    allowProductUsage: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_allow_product_usage')
+        .then(allow => callback(allow));
+    },
+
+    getDesktopSynctexViewer: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_desktop_synctex_viewer')
+        .then(viewer => callback(viewer));
+    },
+
+    externalSynctexPreview: (pdfPath: string, page: number) => {
+      ipcRenderer.send('desktop_external_synctex_preview', pdfPath, page);
+    },
+
+    externalSynctexView: (pdfFile: string,
+      srcFile: string,
+      line: number,
+      column: number) => {
+      ipcRenderer.send('desktop_external_synctex_view', pdfFile, srcFile, line, column);
+    },
+
+    supportsFullscreenMode: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_supports_fullscreen_mode')
+        .then(supportsFullScreen => callback(supportsFullScreen));
+    },
+
+    toggleFullscreenMode: () => {
+      ipcRenderer.send('desktop_toggle_fullscreen_mode');
+    },
+
+    showKeyboardShortcutHelp: () => {
+      ipcRenderer.send('desktop_show_keyboard_shortcut_help');
+    },
+
+    launchSession: (reload: boolean) => {
+      ipcRenderer.send('desktop_launch_session', reload);
+    },
+
+    reloadZoomWindow: () => {
+      ipcRenderer.send('desktop_reload_zoom_window');
+    },
+
+    setTutorialUrl: (url: string) => {
+      ipcRenderer.send('desktop_set_tutorial_url', url);
+    },
+
+    setViewerUrl: (url: string) => {
+      ipcRenderer.send('desktop_set_viewer_url', url);
+    },
+
+    reloadViewerZoomWindow: (url: string) => {
+      ipcRenderer.send('desktop_reload_viewer_zoom_window', url);
+    },
+
+    setShinyDialogUrl: (url: string) => {
+      ipcRenderer.send('desktop_set_shiny_dialog_url', url);
+    },
+
+    getScrollingCompensationType: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_scrolling_compensation_type')
+        .then(compensationType => callback(compensationType));
+    },
+
+    isMacOS: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_is_macos')
+        .then(isMac => callback(isMac));
+    },
+
+    isCentOS: (callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_is_centos')
+        .then(isCentOS => callback(isCentOS));
+    },
+
+    setBusy: (busy: boolean) => {
+      ipcRenderer.send('desktop_set_busy', busy);
+    },
+
+    setWindowTitle: (title: string) => {
+      ipcRenderer.send('desktop_set_window_title', title);
+    },
+
+    installRtools: (version: string, installerPath: string) => {
+      ipcRenderer.send('desktop_install_rtools', version, installerPath);
+    },
+
+    getDisplayDpi: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_display_dpi')
+        .then(dpi => callback(dpi));
+    },
+
+    onSessionQuit: () => {
+      ipcRenderer.send('desktop_on_session_quit');
+    },
+
+    getSessionServer: (callback: VoidCallback<Record<string, unknown>>) => {
+      ipcRenderer
+        .invoke('desktop_get_session_server')
+        .then(server => callback(server));
+    },
+
+    getSessionServers: (callback: VoidCallback<Record<string, unknown>[]>) => {
+      ipcRenderer
+        .invoke('desktop_get_session_servers')
+        .then(servers => callback(servers));
+    },
+
+    reconnectToSessionServer: (sessionServerJson: Record<string, unknown>) => {
+      ipcRenderer.send('desktop_reconnect_to_session_server', sessionServerJson);
+    },
+
+    setLauncherServer: (sessionServerJson: Record<string, unknown>, callback: VoidCallback<boolean>) => {
+      ipcRenderer
+        .invoke('desktop_set_launcher_server', sessionServerJson)
+        .then(result => callback(result));
+    },
+
+    connectToLauncherServer: () => {
+      ipcRenderer.send('desktop_connect_to_launcher_server');
+    },
+
+    getLauncherServer: (callback: VoidCallback<string>) => {
+      ipcRenderer
+        .invoke('desktop_get_launcher_server')
+        .then(server => callback(server));
+    },
+
+    startLauncherJobStatusStream: (jobId: string) => {
+      ipcRenderer.send('desktop_start_launcher_job_status_stream', jobId);
+    },
+
+    stopLauncherJobStatusStream: (jobId: string) => {
+      ipcRenderer.send('desktop_stop_launcher_job_status_stream', jobId);
+    },
+
+    startLauncherJobOutputStream: (jobId: string) => {
+      ipcRenderer.send('desktop_start_launcher_job_output_stream', jobId);
+    },
+
+    stopLauncherJobOutputStream: (jobId: string) => {
+      ipcRenderer.send('desktop_stop_launcher_job_output_stream', jobId);
+    },
+
+    controlLauncherJob: (jobId: string, operation: string) => {
+      ipcRenderer.send('desktop_control_launcher_job', jobId, operation);
+    },
+
+    submitLauncherJob: (job: Record<string, unknown>) => {
+      ipcRenderer.send('desktop_submit_launcher_job', job);
+    },
+
+    getJobContainerUser: () => {
+      ipcRenderer.send('desktop_get_job_container_user');
+    },
+
+    validateJobsConfig: () => {
+      ipcRenderer.send('desktop_validate_jobs_config');
+    },
+
+    getProxyPortNumber: (callback: VoidCallback<number>) => {
+      ipcRenderer
+        .invoke('desktop_get_proxy_port_number')
+        .then(port => callback(port));
+    },
+
+    signOut: () => {
+      ipcRenderer.send('desktop_sign_out');
+    },
+  };
+}

--- a/src/node/desktop/src/renderer/desktop-info-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-info-bridge.ts
@@ -1,0 +1,102 @@
+/*
+ * desktop-info-bridge.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+export interface DesktopInfoBridge {
+  platform: string;
+  version: string;
+  scrollingCompensationType: string;
+  fixedWidthFontList: string;
+  fixedWidthFont: string;
+  proportionalFont: string;
+  desktopSynctexViewer: string;
+  zoomLevel: number;
+  chromiumDevtoolsPort: number;
+}
+
+export function getDesktopInfoBridge(): DesktopInfoBridge {
+  if (process.platform === 'win32') {
+    return {
+      platform: '',
+      version: '',
+      scrollingCompensationType: '',
+      fixedWidthFontList: `BIZ UDGothic
+BIZ UDMincho Medium
+Cascadia Code
+Cascadia Code ExtraLight
+Cascadia Code Light
+Cascadia Code SemiBold
+Cascadia Code SemiLight
+Cascadia Mono
+Cascadia Mono ExtraLight
+Cascadia Mono Light
+Cascadia Mono SemiBold
+Cascadia Mono SemiLight
+Consolas
+Courier
+Courier New
+Lucida Console
+Lucida Sans Typewriter
+MingLiU-ExtB
+MingLiU_HKSCS-ExtB
+MS Gothic
+MS Mincho
+NSimSun
+OCR A Extended
+SimSun
+SimSun-ExtB
+UD Digi Kyokasho N-B
+UD Digi Kyokasho N-R`,
+      fixedWidthFont: 'Lucida Console',
+      proportionalFont: 'Segoe UI',
+      desktopSynctexViewer: '',
+      zoomLevel: 1.0,
+      chromiumDevtoolsPort: 0,
+    };
+  } else {
+    return {
+      platform: '',
+      version: '',
+      scrollingCompensationType: '',
+      fixedWidthFontList: `AndaleMono
+AppleBraille-Outline6Dot
+AppleBraille-Outline8Dot
+AppleBraille-Pinpoint6Dot
+AppleBraille-Pinpoint8Dot
+AppleBraille
+AppleColorEmoji
+Courier
+Courier-Oblique
+Courier-Bold
+Courier-BoldOblique
+CourierNewPSMT
+CourierNewPS-ItalicMT
+CourierNewPS-BoldMT
+CourierNewPS-BoldItalicMT
+Menlo-Regular
+Menlo-Italic
+Menlo-Bold
+Menlo-BoldItalic
+Monaco
+PTMono-Regular
+PTMono-Bold`,
+      fixedWidthFont: 'Monaco',
+      proportionalFont: 'Lucida Grande',
+      desktopSynctexViewer: '',
+      zoomLevel: 1.0,
+      chromiumDevtoolsPort: 0,
+    };
+
+  }
+}

--- a/src/node/desktop/src/renderer/menu-bridge.ts
+++ b/src/node/desktop/src/renderer/menu-bridge.ts
@@ -1,0 +1,78 @@
+/*
+ * menu-bridge.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { ipcRenderer } from 'electron';
+
+export interface MenuBridge {
+  beginMainMenu(): void;
+  beginMenu(label: string): void;
+  addCommand(cmdId: string, label: string, tooltip: string, shortcut: string, isChecked: boolean): void;
+  addSeparator(): void;
+  endMenu(): void;
+  endMainMenu(): void;
+  setCommandVisible(commandId: string, visible: boolean): void;
+  setCommandEnabled(commandId: string, enabled: boolean): void;
+  setCommandChecked(commandId: string, checked: boolean): void;
+  setMainMenuEnabled(enabled: boolean): void;
+  setCommandLabel(commandId: string, label: string): void;
+}
+
+export function getMenuBridge(): MenuBridge {
+  return {
+    beginMainMenu: () => {
+      ipcRenderer.send('menu_begin_main');
+    },
+
+    beginMenu: (label: string) => {
+      ipcRenderer.send('menu_begin', label);
+    },
+
+    addCommand: (cmdId: string, label: string, tooltip: string, shortcut: string, isChecked: boolean) => {
+      ipcRenderer.send('menu_add_command', cmdId, label, tooltip, shortcut, isChecked);
+    },
+
+    addSeparator: () => {
+      ipcRenderer.send('menu_add_separator');
+    },
+
+    endMenu: () => {
+      ipcRenderer.send('menu_end');
+    },
+
+    endMainMenu: () => {
+      ipcRenderer.send('menu_end_main');
+    },
+
+    setCommandVisible: (commandId: string, visible: boolean) => {
+      ipcRenderer.send('menu_set_command_visible', commandId, visible);
+    },
+
+    setCommandEnabled: (commandId: string, enabled: boolean) => {
+      ipcRenderer.send('menu_set_command_enabled', commandId, enabled);
+    },
+
+    setCommandChecked: (commandId: string, checked: boolean) => {
+      ipcRenderer.send('menu_set_command_checked', commandId, checked);
+    },
+
+    setMainMenuEnabled: (enabled: boolean) => {
+      ipcRenderer.send('menu_set_main_menu_enabled', enabled);
+    },
+
+    setCommandLabel: (commandId: string, label: string) => {
+      ipcRenderer.send('menu_set_command_label', commandId, label);
+    },
+  };
+}

--- a/src/node/desktop/src/renderer/preload.ts
+++ b/src/node/desktop/src/renderer/preload.ts
@@ -12,12 +12,10 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-// import { contextBridge } from 'electron';
-// import getMenuBridge from './menu-bridge';
-// import getDesktopBridge from './desktop-bridge';
-// import getDesktopInfoBridge from './desktop-info-bridge';
-
-// Bring over this stuff from the prototype when needed
+import { contextBridge } from 'electron';
+import { getMenuBridge } from './menu-bridge';
+import { getDesktopBridge } from './desktop-bridge';
+import { getDesktopInfoBridge } from './desktop-info-bridge';
 
 /**
  * The preload script is run in the renderer before our GWT code and enables
@@ -33,9 +31,9 @@
  * Actual implementation happens in the main process, reached via ipcRenderer.
  */
 
-// contextBridge.exposeInMainWorld('desktop', getDesktopBridge());
-// contextBridge.exposeInMainWorld('desktopInfo', getDesktopInfoBridge());
-// contextBridge.exposeInMainWorld('desktopMenuCallback', getMenuBridge());
+contextBridge.exposeInMainWorld('desktop', getDesktopBridge());
+contextBridge.exposeInMainWorld('desktopInfo', getDesktopInfoBridge());
+contextBridge.exposeInMainWorld('desktopMenuCallback', getMenuBridge());
 
 // RDP-only
-// contextBridge.exposeInMainWorld('remoteDesktop', {});
+//contextBridge.exposeInMainWorld('remoteDesktop', {});

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -3356,6 +3356,11 @@ uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"


### PR DESCRIPTION
### Intent

Be able to load the rsession and display the real UI, including menu population and some callbacks (essentially equivalent to where the prototype was but with somewhat less hardcoding).

Currently Posix (Mac/Linux) only, and only for dev builds; some additional Win32-specific work needed to get that standing up again, as well as work specific to package builds. 

### Approach

Location of `src/cpp` build output (on a dev machine) must be specified in `RSTUDIO_CPP_BUILD_OUTPUT` environment variable. For example, `RSTUDIO_CPP_BUILD_OUTPUT=/Users/gary/rstudio/src/cpp/build`.

R detection (Posix only) is partially implemented (Kevin did some work on this in the prototype and I have pulled it over and tweaked it a bit. It should handle common cases).

First use of node.js events (replacing the Qt signal/slots used in the existing desktop code).

The `--run-diagnostics` command-line switch is now supported, and some of the output is hooked up; you can use `yarn start-diag` to see it.

Note that quite a few changes related to this work went in separately via https://github.com/rstudio/rstudio/pull/9511.

### Automated Tests

This is getting into integration testing territory (which we don't currently have a mechanism for), but additional unit testing will also be added; wanted to get this in ASAP to unblock others.

### QA Notes

Still only building in a dev environment.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


