### PR TITLE
Clean up New Project preferences

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 * High DPI ("Retina") plots are now supported on RStudio Server (#3896)
 * The "auto-detect indentation" preference is now off by default (#9211) 
 * Prevent user preferences from setting CRAN repos when `allow-cran-repos-edit=0` (Pro #1301)
+* Make the *Use renv with this project* option sticky, and allow setting by admins (Pro #2671)
 * Updated embedded nginx in Server Pro to 1.20.1 (Pro #2676)
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 * Added AWS Cognito support to openid integration (Pro #2313)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -281,6 +281,7 @@ namespace prefs {
 #define kGitDiffIgnoreWhitespace "git_diff_ignore_whitespace"
 #define kConsoleDoubleClickSelect "console_double_click_select"
 #define kNewProjGitInit "new_proj_git_init"
+#define kNewProjUseRenv "new_proj_use_renv"
 #define kRootDocument "root_document"
 #define kShowUserHomePage "show_user_home_page"
 #define kShowUserHomePageAlways "always"
@@ -1316,6 +1317,12 @@ public:
     */
    bool newProjGitInit();
    core::Error setNewProjGitInit(bool val);
+
+   /**
+    * Whether an renv environment should be created inside new projects by default.
+    */
+   bool newProjUseRenv();
+   core::Error setNewProjUseRenv(bool val);
 
    /**
     * The root document to use when compiling PDF documents.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -169,7 +169,6 @@ namespace prefs {
 #define kToolbarVisible "toolbar_visible"
 #define kDefaultProjectLocation "default_project_location"
 #define kSourceWithEcho "source_with_echo"
-#define kNewProjectGitInit "new_project_git_init"
 #define kDefaultSweaveEngine "default_sweave_engine"
 #define kDefaultLatexProgram "default_latex_program"
 #define kUseRoxygen "use_roxygen"
@@ -933,12 +932,6 @@ public:
     */
    bool sourceWithEcho();
    core::Error setSourceWithEcho(bool val);
-
-   /**
-    * Whether to initialize new projects with a Git repo by default.
-    */
-   bool newProjectGitInit();
-   core::Error setNewProjectGitInit(bool val);
 
    /**
     * The default engine to use when processing Sweave documents.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1194,19 +1194,6 @@ core::Error UserPrefValues::setSourceWithEcho(bool val)
 }
 
 /**
- * Whether to initialize new projects with a Git repo by default.
- */
-bool UserPrefValues::newProjectGitInit()
-{
-   return readPref<bool>("new_project_git_init");
-}
-
-core::Error UserPrefValues::setNewProjectGitInit(bool val)
-{
-   return writePref("new_project_git_init", val);
-}
-
-/**
  * The default engine to use when processing Sweave documents.
  */
 std::string UserPrefValues::defaultSweaveEngine()
@@ -3015,7 +3002,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kToolbarVisible,
       kDefaultProjectLocation,
       kSourceWithEcho,
-      kNewProjectGitInit,
       kDefaultSweaveEngine,
       kDefaultLatexProgram,
       kUseRoxygen,

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2026,6 +2026,19 @@ core::Error UserPrefValues::setNewProjGitInit(bool val)
 }
 
 /**
+ * Whether an renv environment should be created inside new projects by default.
+ */
+bool UserPrefValues::newProjUseRenv()
+{
+   return readPref<bool>("new_proj_use_renv");
+}
+
+core::Error UserPrefValues::setNewProjUseRenv(bool val)
+{
+   return writePref("new_proj_use_renv", val);
+}
+
+/**
  * The root document to use when compiling PDF documents.
  */
 std::string UserPrefValues::rootDocument()
@@ -3066,6 +3079,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kGitDiffIgnoreWhitespace,
       kConsoleDoubleClickSelect,
       kNewProjGitInit,
+      kNewProjUseRenv,
       kRootDocument,
       kShowUserHomePage,
       kReuseSessionsForProjectLinks,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1054,6 +1054,12 @@
             "title": "Create a Git repo in new projects",
             "description": "Whether a git repo should be initialized inside new projects by default."
         },
+        "new_proj_use_renv": {
+            "type": "boolean",
+            "default": false,
+            "title": "Create an renv environment in new projects",
+            "description": "Whether an renv environment should be created inside new projects by default."
+        },
         "root_document": {
             "type": "string",
             "default": "",

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -635,12 +635,6 @@
             "title": "Source with echo by default",
             "description": "Whether to echo R code when sourcing it."
         },
-        "new_project_git_init": {
-            "type": "boolean",
-            "default": false,
-            "title": "Initialize new projects with Git",
-            "description": "Whether to initialize new projects with a Git repo by default."
-        },
         "default_sweave_engine": {
             "type": "string",
             "default": "Sweave",

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -389,8 +389,9 @@ public class Projects implements OpenProjectFileEvent.Handler,
 
             // update default project location pref if necessary
             if ((newProject.getNewDefaultProjectLocation() != null) ||
-                (newProject.getCreateGitRepo() !=
-                 userPrefs.newProjGitInit().getValue()))
+                (newProject.getCreateGitRepo() != userPrefs.newProjGitInit().getValue()) ||
+                (newProject.getUseRenv() != userPrefs.newProjUseRenv().getValue()))
+
             {
                indicator.onProgress("Saving defaults...");
 
@@ -405,6 +406,13 @@ public class Projects implements OpenProjectFileEvent.Handler,
                {
                   userPrefs.newProjGitInit().setGlobalValue(
                                           newProject.getCreateGitRepo());
+               }
+
+               if (newProject.getUseRenv() !=
+                  userPrefs.newProjUseRenv().getValue())
+               {
+                  userPrefs.newProjUseRenv().setGlobalValue(
+                     newProject.getUseRenv());
                }
 
                // call the server -- in all cases continue on with

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewDirectoryPage.java
@@ -146,6 +146,7 @@ public class NewDirectoryPage extends NewProjectWizardPage
       
       // Initialize project with renv
       chkRenvInit_ = new CheckBox("Use renv with this project");
+      chkRenvInit_.setValue(userState.newProjUseRenv().getValue());
       ElementIds.assignElementId(chkRenvInit_,
          ElementIds.idWithPrefix(getTitle(), ElementIds.NEW_PROJECT_RENV));
       chkRenvInit_.addValueChangeHandler((ValueChangeEvent<Boolean> event) -> {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1303,18 +1303,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Whether to initialize new projects with a Git repo by default.
-    */
-   public PrefValue<Boolean> newProjectGitInit()
-   {
-      return bool(
-         "new_project_git_init",
-         "Initialize new projects with Git", 
-         "Whether to initialize new projects with a Git repo by default.", 
-         false);
-   }
-
-   /**
     * The default engine to use when processing Sweave documents.
     */
    public PrefValue<String> defaultSweaveEngine()
@@ -3341,8 +3329,6 @@ public class UserPrefsAccessor extends Prefs
          defaultProjectLocation().setValue(layer, source.getString("default_project_location"));
       if (source.hasKey("source_with_echo"))
          sourceWithEcho().setValue(layer, source.getBool("source_with_echo"));
-      if (source.hasKey("new_project_git_init"))
-         newProjectGitInit().setValue(layer, source.getBool("new_project_git_init"));
       if (source.hasKey("default_sweave_engine"))
          defaultSweaveEngine().setValue(layer, source.getString("default_sweave_engine"));
       if (source.hasKey("default_latex_program"))
@@ -3701,7 +3687,6 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(toolbarVisible());
       prefs.add(defaultProjectLocation());
       prefs.add(sourceWithEcho());
-      prefs.add(newProjectGitInit());
       prefs.add(defaultSweaveEngine());
       prefs.add(defaultLatexProgram());
       prefs.add(useRoxygen());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2212,6 +2212,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether an renv environment should be created inside new projects by default.
+    */
+   public PrefValue<Boolean> newProjUseRenv()
+   {
+      return bool(
+         "new_proj_use_renv",
+         "Create an renv environment in new projects", 
+         "Whether an renv environment should be created inside new projects by default.", 
+         false);
+   }
+
+   /**
     * The root document to use when compiling PDF documents.
     */
    public PrefValue<String> rootDocument()
@@ -3457,6 +3469,8 @@ public class UserPrefsAccessor extends Prefs
          consoleDoubleClickSelect().setValue(layer, source.getBool("console_double_click_select"));
       if (source.hasKey("new_proj_git_init"))
          newProjGitInit().setValue(layer, source.getBool("new_proj_git_init"));
+      if (source.hasKey("new_proj_use_renv"))
+         newProjUseRenv().setValue(layer, source.getBool("new_proj_use_renv"));
       if (source.hasKey("root_document"))
          rootDocument().setValue(layer, source.getString("root_document"));
       if (source.hasKey("show_user_home_page"))
@@ -3751,6 +3765,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(gitDiffIgnoreWhitespace());
       prefs.add(consoleDoubleClickSelect());
       prefs.add(newProjGitInit());
+      prefs.add(newProjUseRenv());
       prefs.add(rootDocument());
       prefs.add(showUserHomePage());
       prefs.add(reuseSessionsForProjectLinks());


### PR DESCRIPTION
### Intent

Small housekeeping change to remove an unused pref and replace it with a more useful one.

Addresses https://github.com/rstudio/rstudio-pro/issues/2670
Addresses https://github.com/rstudio/rstudio-pro/issues/2671

### Approach

- Remove the unused user preference `new_project_git_init`
- Add a useful user preference `new_proj_use_renv`

### Automated Tests

None, effectively a UI only change.

### QA Notes

- It is not an error to have unrecognized keys in the preferences JSON file, so if the `new_project_git_init` preference was somehow written in the past, it will be silently ignored after this change.
- This change makes the "Use renv with this project" checkbox value sticky; that is, once you've checked it, it will stay checked for future projects until you uncheck it again. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


