### PR TITLE
use separate tabs for different Python types

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -379,7 +379,8 @@
    paths <- strsplit(Sys.getenv("PATH"), split = .Platform$path.sep, fixed = TRUE)[[1]]
    paths <- unique(normalizePath(paths, winslash = "/", mustWork = FALSE))
    
-   for (path in paths) {
+   for (path in paths)
+   {
       
       # skip fake broken Windows Python interpreters
       skip <-
@@ -402,9 +403,20 @@
          full.names = TRUE
       )
       
-      # loop over interpreters and add
+      # loop over interpreters and add them
       for (python in pythons)
       {
+         # skip simple symlinks. the intention here is to avoid adding
+         # all of python, python3, and python3.9 if they all ultimately
+         # resolve to the same python executable
+         if (!.rs.platform.isWindows)
+         {
+            link <- Sys.readlink(python)
+            if (grepl(pattern, link))
+               next
+         }
+         
+         # add the interpreter
          info <- .rs.python.getPythonInfo(python, strict = TRUE)
          interpreters[[length(interpreters) + 1]] <- info
       }

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -17,8 +17,6 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.KeyDownEvent;
-import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
@@ -188,6 +186,10 @@ public class TextBoxWithButton extends Composite
       {
          textBox_.setText(text);
       }
+      else if (useNativePlaceholder_)
+      {
+         textBox_.setText("");
+      }
       else
       {
          textBox_.setText(emptyLabel_);
@@ -201,7 +203,9 @@ public class TextBoxWithButton extends Composite
       String text = textBox_.getText();
       
       if (StringUtil.equals(text, emptyLabel_))
+      {
          return "";
+      }
       
       if (text.startsWith(USE_DEFAULT_PREFIX))
       {
@@ -258,48 +262,12 @@ public class TextBoxWithButton extends Composite
       textBox_.setFocus(false);
    }
    
-   public void autosize()
+   public void useNativePlaceholder()
    {
-      textBox_.addKeyDownHandler((KeyDownEvent event) ->
-      {
-         updateFontSize();
-      });
-      
-      textBox_.addKeyUpHandler((KeyUpEvent event) ->
-      {
-         updateFontSize();
-      });
-      
-      textBox_.addValueChangeHandler((ValueChangeEvent<String> event) ->
-      {
-         updateFontSize();
-      });
-      
-      updateFontSize();
-   }
-
-   private void updateFontSize()
-   {
-      String value = textBox_.getText();
-
-      double fontSize = -1;
-      if (value.length() > 60)
-      {
-         fontSize = 7;
-      }
-      else if (value.length() > 40)
-      {
-         fontSize = 7.5;
-      }
-      else
-      {
-         fontSize = 8;
-      }
-
-      textBox_.getElement().getStyle().setFontSize(fontSize, Unit.PT);
+      useNativePlaceholder_ = true;
+      textBox_.getElement().setAttribute("placeholder", emptyLabel_);
    }
    
-
    @Override
    protected void onAttach()
    {
@@ -327,6 +295,7 @@ public class TextBoxWithButton extends Composite
    private final String emptyLabel_;
    private String useDefaultValue_;
    private String uniqueId_;
+   private boolean useNativePlaceholder_;
    
    private static final String USE_DEFAULT_PREFIX = "[Use Default]";
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -17,6 +17,8 @@ package org.rstudio.core.client.widget;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.KeyDownEvent;
+import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
@@ -255,6 +257,48 @@ public class TextBoxWithButton extends Composite
    {
       textBox_.setFocus(false);
    }
+   
+   public void autosize()
+   {
+      textBox_.addKeyDownHandler((KeyDownEvent event) ->
+      {
+         updateFontSize();
+      });
+      
+      textBox_.addKeyUpHandler((KeyUpEvent event) ->
+      {
+         updateFontSize();
+      });
+      
+      textBox_.addValueChangeHandler((ValueChangeEvent<String> event) ->
+      {
+         updateFontSize();
+      });
+      
+      updateFontSize();
+   }
+
+   private void updateFontSize()
+   {
+      String value = textBox_.getText();
+
+      double fontSize = -1;
+      if (value.length() > 60)
+      {
+         fontSize = 7;
+      }
+      else if (value.length() > 40)
+      {
+         fontSize = 7.5;
+      }
+      else
+      {
+         fontSize = 8;
+      }
+
+      textBox_.getElement().getStyle().setFontSize(fontSize, Unit.PT);
+   }
+   
 
    @Override
    protected void onAttach()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -123,6 +123,8 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
                }
             });
       
+      tbPythonInterpreter_.autosize();
+      
       tbPythonInterpreter_.addValueChangeHandler((ValueChangeEvent<String> event) ->
       {
          updateDescription();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -60,8 +60,6 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
-      placeholderText_ = placeholderText;
-      
       add(headerLabel("Python"));
       
       mismatchWarningBar_ = new InfoBar(InfoBar.WARNING);
@@ -73,7 +71,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       tbPythonInterpreter_ = new TextBoxWithButton(
             "Python interpreter:",
             null,
-            placeholderText_,
+            placeholderText,
             "Select...",
             new HelpButton("using_python", "Using Python in RStudio"),
             ElementIds.TextBoxButtonId.PYTHON_PATH,
@@ -123,7 +121,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
                }
             });
       
-      tbPythonInterpreter_.autosize();
+      tbPythonInterpreter_.useNativePlaceholder();
       
       tbPythonInterpreter_.addValueChangeHandler((ValueChangeEvent<String> event) ->
       {
@@ -165,7 +163,6 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       tbEl.addClassName(ModalDialogBase.ALLOW_ESCAPE_KEY_CLASS);
       
       tbPythonInterpreter_.setWidth(width);
-      tbPythonInterpreter_.setText(placeholderText_);
       tbPythonInterpreter_.setReadOnly(false);
       add(spaced(tbPythonInterpreter_));
       
@@ -228,14 +225,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       // reset to default when empty
       if (StringUtil.isNullOrEmpty(path))
       {
-         tbPythonInterpreter_.setText(placeholderText_);
-         clearDescription();
-         return;
-      }
-      
-      // clear description when using default
-      if (StringUtil.equals(path, placeholderText_))
-      {
+         tbPythonInterpreter_.setText("");
          clearDescription();
          return;
       }
@@ -266,7 +256,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       {
          String reason = info.getInvalidReason();
          if (StringUtil.isNullOrEmpty(reason))
-            reason = "The selected Python interpreter appears to be invalid.";
+            reason = "The selected Python interpreter does not appear to be valid.";
          
          InfoBar bar = new InfoBar(InfoBar.WARNING);
          bar.setText(reason);
@@ -312,9 +302,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       
       // nothing to do if the user hasn't changed the configured Python
       String requestedPath = tbPythonInterpreter_.getText();
-      boolean isSet =
-            !StringUtil.isNullOrEmpty(requestedPath) &&
-            !StringUtil.equals(requestedPath, placeholderText_);
+      boolean isSet = !StringUtil.isNullOrEmpty(requestedPath);
       
       if (!isSet)
       {
@@ -386,10 +374,8 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    {
       RestartRequirement requirement = new RestartRequirement();
       
-      // read current Python path (normalize placeholder text if set)
+      // read current Python path
       String newValue = tbPythonInterpreter_.getText().trim();
-      if (StringUtil.equals(newValue, placeholderText_))
-         newValue = "";
       
       // for project preferences, use project-relative path to interpreter
       if (isProjectPrefs)
@@ -447,8 +433,6 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
       Styles styles();
    }
 
-   protected final String placeholderText_;
-   
    protected final InfoBar mismatchWarningBar_;
    protected final TextBoxWithButton tbPythonInterpreter_;
    protected final SimplePanel interpreterDescription_ = new SimplePanel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterListEntryUi.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterListEntryUi.java
@@ -66,7 +66,7 @@ public class PythonInterpreterListEntryUi extends Composite
    
    private final Label createUiPath()
    {
-      return new Label("[" + interpreter_.getPath() + "]");
+      return new Label(interpreter_.getPath());
    }
    
    public final Image getIcon()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -14,7 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views.python;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
+import org.rstudio.core.client.theme.DialogTabLayoutPanel;
+import org.rstudio.core.client.theme.VerticalTabPanel;
 import org.rstudio.core.client.widget.ModalDialog;
 import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -23,52 +29,105 @@ import org.rstudio.studio.client.workbench.prefs.views.PythonInterpreter;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.user.client.ui.Widget;
 
 public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpreter>
 {
+   private static final String LABEL_SYSTEM  = "System";
+   private static final String LABEL_VIRTUAL = "Virtual Environments";
+   private static final String LABEL_CONDA   = "Conda Environments";
+   
    public PythonInterpreterSelectionDialog(final JsArray<PythonInterpreter> interpreters,
                                            final OperationWithInput<PythonInterpreter> operation)
    {
       super("Python Interpreters", Roles.getDialogRole(), operation);
       setOkButtonCaption("Select");
       
-      widgets_ = new WidgetListBox<>();
-      widgets_.setHeight("420px");
-      widgets_.setAriaLabel("Python Interpreters");
-      
-      for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))
-         if (interpreter.isValid())
-            widgets_.addItem(new PythonInterpreterListEntryUi(interpreter));
- 
-      // allow double-click to select the requested interpreter
-      widgets_.addDoubleClickHandler((DoubleClickEvent event) ->
+      // initialize widget list boxes
+      widgets_ = new HashMap<>();
+      for (String label : new String[] { LABEL_SYSTEM, LABEL_VIRTUAL, LABEL_CONDA })
       {
-         if (widgets_.getSelectedItem() != null)
+         WidgetListBox<PythonInterpreterListEntryUi> listBox = new WidgetListBox<>();
+         listBox.setSize("598px", "468px");
+         listBox.setAriaLabel(label);
+         
+         listBox.setEmptyText("(None available)");
+         
+         // allow double-click to select the requested interpreter
+         listBox.addDoubleClickHandler((DoubleClickEvent event) ->
          {
-            clickOkButton();
-         }
-      });
+            if (listBox.getSelectedItem() != null)
+            {
+               selectedItem_ = listBox.getSelectedItem();
+               clickOkButton();
+            }
+         });
+         
+         listBox.addChangeHandler((ChangeEvent event) ->
+         {
+            selectedItem_ = listBox.getSelectedItem();
+         });
+         
+         widgets_.put(label, listBox);
+      }
       
+      // add interpreters to their appropriate buckets
+      for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))
+      {
+         if (!interpreter.isValid())
+            continue;
+         
+         String type = interpreter.getType();
+         if (type == null)
+            continue;
+         
+         if (StringUtil.equals(type, "system"))
+         {
+            widgets_.get(LABEL_SYSTEM).addItem(new PythonInterpreterListEntryUi(interpreter));
+         }
+         else if (StringUtil.equals(type, "virtualenv"))
+         {
+            widgets_.get(LABEL_VIRTUAL).addItem(new PythonInterpreterListEntryUi(interpreter));
+         }
+         else if (StringUtil.equals(type, "conda"))
+         {
+            widgets_.get(LABEL_CONDA).addItem(new PythonInterpreterListEntryUi(interpreter));
+         }
+      }
+ 
+      // initialize tab panel
+      tabPanel_ = new DialogTabLayoutPanel("General");
+      tabPanel_.setSize("620px", "520px");
+      for (Map.Entry<String, WidgetListBox<PythonInterpreterListEntryUi>> entry : widgets_.entrySet())
+      {
+         VerticalTabPanel panel = new VerticalTabPanel(entry.getKey());
+         panel.add(entry.getValue());
+         tabPanel_.add(panel, entry.getKey(), panel.getBasePanelId());
+      }
+      
+      tabPanel_.selectTab(0);
    }
    
    @Override
    protected PythonInterpreter collectInput()
    {
-      PythonInterpreterListEntryUi item = widgets_.getSelectedItem();
-      if (item == null)
+      if (selectedItem_ == null)
          return null;
       
-      return item.getInterpreter();
+      return selectedItem_.getInterpreter();
    }
 
    @Override
    protected Widget createMainWidget()
    {
-      return widgets_;
+      return tabPanel_;
    }
    
-   WidgetListBox<PythonInterpreterListEntryUi> widgets_;
+   final DialogTabLayoutPanel tabPanel_;
+   final Map<String, WidgetListBox<PythonInterpreterListEntryUi>> widgets_;
+   
+   PythonInterpreterListEntryUi selectedItem_;
    ThemedButton useDefaultBtn_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/python/PythonInterpreterSelectionDialog.java
@@ -76,11 +76,15 @@ public class PythonInterpreterSelectionDialog extends ModalDialog<PythonInterpre
       // add interpreters to their appropriate buckets
       for (PythonInterpreter interpreter : JsUtil.asIterable(interpreters))
       {
-         if (!interpreter.isValid())
+         if (interpreter == null || !interpreter.isValid())
             continue;
          
          String type = interpreter.getType();
          if (type == null)
+            continue;
+         
+         String version = interpreter.getVersion();
+         if (version == null || version.startsWith("2"))
             continue;
          
          if (StringUtil.equals(type, "system"))


### PR DESCRIPTION
### Intent

Improve the overall usability of the Python interpreter selection dialog.

### Approach

Separate each Python "type" into its own tab, with tabs for system / virtual / conda environments.

<img width="681" alt="Screen Shot 2021-06-22 at 4 19 29 PM" src="https://user-images.githubusercontent.com/1976582/123011646-a94d9380-d375-11eb-9a45-119b91a847d1.png">

<img width="651" alt="Screen Shot 2021-06-22 at 4 42 04 PM" src="https://user-images.githubusercontent.com/1976582/123013303-d485b200-d378-11eb-9946-7318118a0db9.png">

### Automated Tests

Not included.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
