### PR TITLE
create basic interface for logging and a simple console logger

### DIFF
--- a/src/node/desktop/src/core/console-logger.ts
+++ b/src/node/desktop/src/core/console-logger.ts
@@ -1,0 +1,54 @@
+/*
+ * logger.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { getenv } from './environment';
+import { Logger } from './logger';
+
+/**
+ * A Logger using console.log()
+ */
+export class ConsoleLogger implements Logger {
+
+  logError(err: Error): void {
+    console.log(err);
+  }
+
+  logErrorMessage(message: string): void {
+    console.log(message);
+  }
+
+  logInfo(message: string): void {
+    console.log(message);
+  }
+
+  logWarning(warning: string): void {
+    console.log(warning);
+  }
+
+  logDebug(message: string): void {
+    console.log(message);
+  }
+
+  logDiagnostic(message: string): void {
+    console.log(message);
+  }
+
+  logDiagnosticEnvVar(name: string): void {
+    const value = getenv(name);
+    if (value) {
+      this.logDiagnostic(` . ${name} = ${value}`);
+    }
+  }
+}

--- a/src/node/desktop/src/core/core-state.ts
+++ b/src/node/desktop/src/core/core-state.ts
@@ -1,0 +1,53 @@
+/*
+ * core-state.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { Logger } from './logger';
+
+/**
+ * Global singleton containing state for 'core' routines
+ */
+export interface CoreState {
+  logger?: Logger;
+  instance: number; // for unit-testing
+}
+
+let core: CoreState | null = null;
+let coreStateInstanceCounter = 0;
+
+/**
+ * @returns Global core state
+ */
+export function coreState(): CoreState {
+  if (!core) {
+    core = new CoreStateImpl;
+  }
+  return core;
+}
+
+/**
+ * Clear core singleton; intended for unit tests only
+ */
+export function clearCoreSingleton(): void {
+  core = null;
+}
+
+class CoreStateImpl implements CoreState {
+  logger?: Logger;
+  instance: number;
+
+  constructor() {
+    this.instance = coreStateInstanceCounter++;
+  }
+}

--- a/src/node/desktop/src/core/environment.ts
+++ b/src/node/desktop/src/core/environment.ts
@@ -67,9 +67,3 @@ export function setVars(vars: Environment): void {
   } 
 }
 
-export function logEnvVar(name: string): void {
-  const value = getenv(name);
-  if (value) {
-    console.log(` . ${name} = ${value}`);
-  }
-}

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -16,6 +16,7 @@
 import fs from 'fs';
 import fsPromises from 'fs/promises';
 
+import { logger } from './logger';
 import path from 'path';
 import { Err, Success } from './err';
 import { userHomePath } from './user';
@@ -104,7 +105,7 @@ export class FilePath {
     try {
       return fs.existsSync(p);
     } catch (err) {
-      FilePath.logErrorWithPath(p, err);
+      logger().logError(err);
       return false;
     }
   }
@@ -122,7 +123,7 @@ export class FilePath {
       await fsPromises.access(p);
       return true;
     } catch (err) {
-      FilePath.logErrorWithPath(p, err);
+      logger().logError(err);
       return false;
     }
   }
@@ -180,7 +181,7 @@ export class FilePath {
     try {
       return new FilePath(process.cwd());
     } catch (err) {
-      FilePath.logError(err);
+      logger().logError(err);
     }
 
     // revert to the specified path if it exists, otherwise
@@ -192,7 +193,7 @@ export class FilePath {
 
     const error = safePath.makeCurrentPath();
     if (error) {
-      FilePath.logError(error);
+      logger().logError(error);
     }
 
     return safePath;
@@ -207,7 +208,7 @@ export class FilePath {
     try {
       return new FilePath(process.cwd());
     } catch (err) {
-      FilePath.logError(err);
+      logger().logError(err);
     }
 
     // revert to the specified path if it exists, otherwise
@@ -219,7 +220,7 @@ export class FilePath {
 
     const error = safePath.makeCurrentPath();
     if (error) {
-      FilePath.logError(error);
+      logger().logError(error);
     }
 
     return safePath;
@@ -273,7 +274,7 @@ export class FilePath {
   completeChildPath(filePath: string): FilePath {
     const result = this.completeChildPathWithErrorResult(filePath);
     if (result.err) {
-      FilePath.logError(result.err);
+      logger().logError(result.err);
     }
     return result.path;
   }
@@ -317,7 +318,7 @@ export class FilePath {
     try {
       return new FilePath(normalizeSeparators(path.resolve(this.path, stem)));
     } catch (err) {
-      FilePath.logError(err);
+      logger().logError(err);
       return this;
     }
   }
@@ -411,7 +412,7 @@ export class FilePath {
     try {
       return !this.isEmpty() && fs.existsSync(this.path);
     } catch (err) {
-      FilePath.logErrorWithPath(this.path, err);
+      logger().logError(err);
       return false;
     }
   }
@@ -427,7 +428,7 @@ export class FilePath {
       await fsPromises.access(this.path);
       return true;
     } catch (err) {
-      FilePath.logErrorWithPath(this.path, err);
+      logger().logError(err);
       return false;
     }
   }
@@ -458,7 +459,7 @@ export class FilePath {
     try {
       return normalizeSeparators(fs.realpathSync(this.path));
     } catch (err) {
-      FilePath.logErrorWithPath(this.path, err);
+      logger().logError(err);
     }
     return '';
   }
@@ -476,7 +477,7 @@ export class FilePath {
     try {
       return await fsPromises.realpath(this.path);
     } catch (err) {
-      FilePath.logErrorWithPath(this.path, err);
+      logger().logError(err);
     }
 
     return '';
@@ -807,21 +808,4 @@ export class FilePath {
   testWritePermissions(): Err {
     throw Error('testWritePermissions is NYI');
   }
-
-  // -------------------------
-  // Internal helper functions
-  // -------------------------
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static logErrorWithPath(path: string, error: Error): void {
-    // TODO logging
-    // console.error(error.message + ": " + path);
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  static logError(error: Error): void {
-    // TODO logging
-    // console.error(error.message);
-  }
-
 }

--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -1,0 +1,38 @@
+/*
+ * log.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { coreState } from './core-state';
+
+export interface Logger {
+  logError(err: Error): void;
+  logErrorMessage(message: string): void;
+  logInfo(message: string): void;
+  logWarning(warning: string): void;
+  logDebug(message: string): void;
+  logDiagnostic(message: string): void;
+  logDiagnosticEnvVar(name: string): void;
+}
+
+export function logger(): Logger {
+  const logger = coreState().logger;
+  if (!logger) {
+    throw Error('Logger not set');
+  }
+  return logger;
+}
+
+export function setLogger(logger: Logger): void {
+  coreState().logger = logger;
+}

--- a/src/node/desktop/src/core/xdg.ts
+++ b/src/node/desktop/src/core/xdg.ts
@@ -33,6 +33,8 @@
  */
 
 import os from 'os';
+
+import { logger } from './logger';
 import { Environment, expandEnvVars, getenv } from './environment';
 import { username, userHomePath } from './user';
 import { FilePath } from './file-path';
@@ -122,8 +124,7 @@ function resolveXdgDir(
       if (path) {
         xdgHome = new FilePath(path);
       } else {
-        // TODO: LOG_ERROR_MESSAGE
-        // console.error(`Unable to retrieve app settings path (${windowsFolderId}).`);
+        logger().logError(new Error(`Unable to retrieve app settings path (${windowsFolderId}).`));
       }
     }
     if (xdgHome.isEmpty()) {

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -34,7 +34,7 @@ export interface AppState {
   generateNewPort(): void;
 }
 
-let rstudio: Application | null = null;
+let rstudio: AppState | null = null;
 
 /**
  * @returns Global application state

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -62,3 +62,4 @@ export function setApplication(app: Application): void {
 export function clearApplicationSingleton(): void {
   rstudio = null;
 }
+

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -18,6 +18,7 @@ import { app, dialog, BrowserWindow } from 'electron';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 import { generateRandomPort } from '../core/system';
+import { logger } from '../core/logger';
 
 import { getRStudioVersion } from './product-info';
 import { findComponents, initializeSharedSecret } from './utils';
@@ -65,7 +66,7 @@ export class Application implements AppState {
     try {
       removeStaleOptionsLockfile();
     } catch (error) {
-      console.error(error);
+      logger().logError(error);
       return exitFailure();
     }
 
@@ -125,13 +126,13 @@ export class Application implements AppState {
   initCommandLine(argv: string[]): ProgramStatus {
     // look for a version check request; if we have one, just do that and exit
     if (argv.indexOf(kVersion) > -1) {
-      console.log(getRStudioVersion());
+      logger().logInfo(getRStudioVersion());
       return exitSuccess();
     }
 
     // report extended version info and exit
     if (argv.indexOf(kVersionJson) > -1) {
-      console.log(getComponentVersions());
+      logger().logInfo(getComponentVersions());
       return exitSuccess();
     }
 

--- a/src/node/desktop/src/main/desktop-callback.ts
+++ b/src/node/desktop/src/main/desktop-callback.ts
@@ -45,13 +45,12 @@ export class DesktopCallback {
       (event, caption, label, dir, filter, canChooseDirectories, focusOwner) => {
 
         // TODO: apply filter
-        const openDialogOptions: OpenDialogOptions =
-      {
-        properties: [canChooseDirectories ? 'openDirectory' : 'openFile'],
-        title: caption,
-        defaultPath: dir,
-        buttonLabel: label,
-      };
+        const openDialogOptions: OpenDialogOptions = {
+          properties: [canChooseDirectories ? 'openDirectory' : 'openFile'],
+          title: caption,
+          defaultPath: dir,
+          buttonLabel: label,
+        };
 
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -14,15 +14,16 @@
  */
 
 import { app, dialog } from 'electron';
-
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { existsSync } from 'fs';
 import { assert } from 'console';
 
-import { appState } from './app-state';
+import { logger } from '../core/logger';
 import { Environment, getenv, setVars } from '../core/environment';
 import { FilePath } from '../core/file-path';
+
+import { appState } from './app-state';
 
 const asyncExec = promisify(exec);
 
@@ -80,7 +81,7 @@ async function prepareEnvironmentPosix(): Promise<boolean> {
   }
 
   if (appState().runDiagnostics) {
-    console.log(`Using R script: ${detectResult.rScriptPath}`);
+    logger().logDiagnostic(`Using R script: ${detectResult.rScriptPath}`);
   }
 
   setREnvironmentVars(detectResult.envVars ?? {});

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -17,6 +17,8 @@ import { BrowserWindow, session } from 'electron';
 import path from 'path';
 import { ChildProcess } from 'child_process';
 
+import { logger } from '../core/logger';
+
 import { DesktopCallback } from './desktop-callback';
 import { MenuCallback } from './menu-callback';
 import { PendingWindow } from './pending-window';
@@ -81,7 +83,7 @@ export class MainWindow {
   invokeCommand(cmdId: string): void {
     this.window?.webContents.executeJavaScript(`window.desktopHooks.invokeCommand("${cmdId}")`)
       .catch(() => {
-        console.error(`Error: failed to execute desktopHooks.invokeCommand("${cmdId}")`);
+        logger().logErrorMessage(`Error: failed to execute desktopHooks.invokeCommand("${cmdId}")`);
       });
   }
 

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -15,6 +15,9 @@
 
 import { app, dialog } from 'electron';
 
+import { ConsoleLogger } from '../core/console-logger';
+import { setLogger } from '../core/logger';
+
 import { Application } from './application';
 import { setApplication } from './app-state';
 import { parseStatus } from './program-status';
@@ -31,12 +34,13 @@ class RStudioMain {
       if (!app.isPackaged) {
         dialog.showErrorBox('Unhandled exception', error.message);
       }
-      console.error(error.message);
+      console.error(error.message); // logging possibly not available this early in startup
       app.exit(1);
     }
   }
 
   private async startup(): Promise<void> {
+    setLogger(new ConsoleLogger());
     const rstudio = new Application();
     setApplication(rstudio);
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -16,10 +16,11 @@
 import { app, dialog } from 'electron';
 import { spawn, ChildProcess } from 'child_process';
 
+import { logger } from '../core/logger';
 import { FilePath } from '../core/file-path';
 import { generateShortenedUuid, localPeer } from '../core/system';
 import { Err } from '../core/err';
-import { getenv, logEnvVar, setenv } from '../core/environment';
+import { getenv, setenv } from '../core/environment';
 
 import { ApplicationLaunch } from './application-launch';
 import { appState } from './app-state';
@@ -96,20 +97,20 @@ export class SessionLauncher {
     launchContext.argList.push('--show-help-home', '1');
 
     if (appState().runDiagnostics) {
-      console.log('\nAttempting to launch R session...');
-      logEnvVar('RSTUDIO_WHICH_R');
-      logEnvVar('R_HOME');
-      logEnvVar('R_DOC_DIR');
-      logEnvVar('R_INCLUDE_DIR');
-      logEnvVar('R_SHARE_DIR');
-      logEnvVar('R_LIBS');
-      logEnvVar('R_LIBS_USER');
-      logEnvVar('DYLD_LIBRARY_PATH');
-      logEnvVar('DYLD_FALLBACK_LIBRARY_PATH');
-      logEnvVar('LD_LIBRARY_PATH');
-      logEnvVar('PATH');
-      logEnvVar('HOME');
-      logEnvVar('R_USER');
+      logger().logDiagnostic('\nAttempting to launch R session...');
+      logger().logDiagnosticEnvVar('RSTUDIO_WHICH_R');
+      logger().logDiagnosticEnvVar('R_HOME');
+      logger().logDiagnosticEnvVar('R_DOC_DIR');
+      logger().logDiagnosticEnvVar('R_INCLUDE_DIR');
+      logger().logDiagnosticEnvVar('R_SHARE_DIR');
+      logger().logDiagnosticEnvVar('R_LIBS');
+      logger().logDiagnosticEnvVar('R_LIBS_USER');
+      logger().logDiagnosticEnvVar('DYLD_LIBRARY_PATH');
+      logger().logDiagnosticEnvVar('DYLD_FALLBACK_LIBRARY_PATH');
+      logger().logDiagnosticEnvVar('LD_LIBRARY_PATH');
+      logger().logDiagnosticEnvVar('PATH');
+      logger().logDiagnosticEnvVar('HOME');
+      logger().logDiagnosticEnvVar('R_USER');
     }
 
     // launch the process

--- a/src/node/desktop/test/unit/core/console-logger.test.ts
+++ b/src/node/desktop/test/unit/core/console-logger.test.ts
@@ -1,0 +1,61 @@
+/*
+ * console-logger.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { ConsoleLogger } from '../../../src/core/console-logger';
+
+describe('Console-logger', () => {
+  it('can be created', () => {
+    const logger = new ConsoleLogger();
+    assert.isNotNull(logger);
+  });
+  it('logError', () => {
+    const logger = new ConsoleLogger();
+    logger.logError(new Error('test Errormessage'));
+    assert.isTrue(true);
+  });
+  it('logErrorMessage', () => {
+    const logger = new ConsoleLogger();
+    logger.logErrorMessage('test error message');
+    assert.isTrue(true);
+  });
+  it('logInfo', () => {
+    const logger = new ConsoleLogger();
+    logger.logInfo('test info message');
+    assert.isTrue(true);
+  });
+  it('logWarning', () => {
+    const logger = new ConsoleLogger();
+    logger.logWarning('test warning message');
+    assert.isTrue(true);
+  });
+  it('logDebug', () => {
+    const logger = new ConsoleLogger();
+    logger.logDebug('test debug message');
+    assert.isTrue(true);
+  });
+  it('logDiagnostic', () => {
+    const logger = new ConsoleLogger();
+    logger.logDiagnostic('test diagnostic message');
+    assert.isTrue(true);
+  });
+  it('logDiagnosticEnvVar', () => {
+    const logger = new ConsoleLogger();
+    logger.logDiagnosticEnvVar('PATH');
+    assert.isTrue(true);
+  });
+});

--- a/src/node/desktop/test/unit/core/core-state.test.ts
+++ b/src/node/desktop/test/unit/core/core-state.test.ts
@@ -1,0 +1,41 @@
+/*
+ * core-state.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { coreState, clearCoreSingleton } from '../../../src/core/core-state';
+
+describe('core-state', () => {
+  afterEach(() => {
+    clearCoreSingleton();
+  });
+
+  it('creates and stores singleton', () => {
+    const state1 = coreState();
+    const state2 = coreState();
+    assert.isNotEmpty(state1);
+    assert.isNotEmpty(state2);
+    assert.deepEqual(state1, state2);
+  });
+  it('creates new singleton after clearing', () => {
+    const state1 = coreState();
+    assert.isNotEmpty(state1);
+    clearCoreSingleton();
+    const state2 = coreState();
+    assert.isNotEmpty(state2);
+    assert.notDeepEqual(state1, state2);
+  });
+});

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -23,6 +23,9 @@ import os from 'os';
 
 import { FilePath } from '../../../src/core/file-path';
 import { userHomePath } from '../../../src/core/user';
+import { setLogger } from '../../../src/core/logger';
+import { ConsoleLogger } from '../../../src/core/console-logger';
+import { clearCoreSingleton } from '../../../src/core/core-state';
 
 function randomString() {
   return Math.trunc(Math.random() * 2147483647).toString();
@@ -46,6 +49,13 @@ const cannotCreatePath = process.platform === 'win32' ? 'C:\\Program Files\\a_te
 const absolutePath = process.platform === 'win32' ? 'C:/Users/human/documents' : '/users/human/documents';
 
 describe('FilePath', () => {
+  before(() => {
+    setLogger(new ConsoleLogger());
+  });
+  after(() => {
+    clearCoreSingleton();
+  });
+
   afterEach(() => {
     // make sure we leave cwd in a valid place
     process.chdir(__dirname);

--- a/src/node/desktop/test/unit/core/logger.test.ts
+++ b/src/node/desktop/test/unit/core/logger.test.ts
@@ -1,0 +1,58 @@
+/*
+ * logger.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { Logger, logger, setLogger } from '../../../src/core/logger';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+class FakeLogger implements Logger {
+  uniqueId = 123;
+  logError(err: Error): void {
+    throw new Error('Method not implemented.');
+  }
+  logErrorMessage(message: string): void {
+    throw new Error('Method not implemented.');
+  }
+  logInfo(message: string): void {
+    throw new Error('Method not implemented.');
+  }
+  logWarning(warning: string): void {
+    throw new Error('Method not implemented.');
+  }
+  logDebug(message: string): void {
+    throw new Error('Method not implemented.');
+  }
+  logDiagnostic(message: string): void {
+    throw new Error('Method not implemented.');
+  }
+  logDiagnosticEnvVar(name: string): void {
+    throw new Error('Method not implemented.');
+  }
+}
+
+describe('Logger', () => {
+  it('throws if unset', () => {
+    assert.throws(() => { logger(); });
+  });
+  it('can be set and fetched', () => {
+    const f = new FakeLogger();
+    setLogger(f);
+    const fetched = logger();
+    assert.exists(logger());
+    assert.deepEqual(f, fetched);
+  });
+});


### PR DESCRIPTION
### Intent

Provide a logging interface and an initial implementation that uses `console.log`. We can revisit logging in more detail "later", but in the meantime want something other than raw `console.log` calls throughout the code.

### Approach

Create `Logger` interface with methods similar to our C++ LOG_ERROR-style macros, and an implementation in `ConsoleLogger`.

Give `core` a place to set and retrieve global state (`CoreState`), including the global logger.

### Automated Tests

Added unit tests for the new code.

### QA Notes

Nothing specifically to test here even if you had a build.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


