### PR TITLE
implement basic support for LogLevels

### DIFF
--- a/src/node/desktop/src/core/console-logger.ts
+++ b/src/node/desktop/src/core/console-logger.ts
@@ -14,7 +14,7 @@
  */
 
 import { getenv } from './environment';
-import { Logger } from './logger';
+import { Logger, LogLevel, logLevel } from './logger';
 
 /**
  * A Logger using console.log()
@@ -22,33 +22,47 @@ import { Logger } from './logger';
 export class ConsoleLogger implements Logger {
 
   logError(err: Error): void {
-    console.log(err);
+    if (logLevel() >= LogLevel.ERR) {
+      console.log(err);
+    }
   }
 
   logErrorMessage(message: string): void {
-    console.log(message);
-  }
-
-  logInfo(message: string): void {
-    console.log(message);
+    if (logLevel() >= LogLevel.ERR) {
+      console.log(message);
+    }
   }
 
   logWarning(warning: string): void {
-    console.log(warning);
+    if (logLevel() >= LogLevel.WARN) {
+      console.log(warning);
+    }
+  }
+
+  logInfo(message: string): void {
+    if (logLevel() >= LogLevel.INFO) {
+      console.log(message);
+    }
   }
 
   logDebug(message: string): void {
-    console.log(message);
+    if (logLevel() >= LogLevel.DEBUG) {
+      console.log(message);
+    }
   }
 
   logDiagnostic(message: string): void {
-    console.log(message);
+    if (logLevel() >= LogLevel.OFF) {
+      console.log(message);
+    }
   }
 
   logDiagnosticEnvVar(name: string): void {
-    const value = getenv(name);
-    if (value) {
-      this.logDiagnostic(` . ${name} = ${value}`);
+    if (logLevel() >= LogLevel.OFF) {
+      const value = getenv(name);
+      if (value) {
+        this.logDiagnostic(` . ${name} = ${value}`);
+      }
     }
   }
 }

--- a/src/node/desktop/src/core/core-state.ts
+++ b/src/node/desktop/src/core/core-state.ts
@@ -13,13 +13,13 @@
  *
  */
 
-import { Logger } from './logger';
+import { LogOptions, LogLevel } from './logger';
 
 /**
  * Global singleton containing state for 'core' routines
  */
 export interface CoreState {
-  logger?: Logger;
+  logOptions: LogOptions;
   instance: number; // for unit-testing
 }
 
@@ -44,10 +44,11 @@ export function clearCoreSingleton(): void {
 }
 
 class CoreStateImpl implements CoreState {
-  logger?: Logger;
+  logOptions: LogOptions;
   instance: number;
 
   constructor() {
     this.instance = coreStateInstanceCounter++;
+    this.logOptions = { logLevel: LogLevel.ERR};
   }
 }

--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -15,24 +15,54 @@
 
 import { coreState } from './core-state';
 
+/**
+ * Enum representing logging detail level
+ */
+export enum LogLevel {
+  OFF = 0,       // No messages will be logged
+  ERR = 1,       // Error messages will be logged
+  WARN = 2,      // Warning and error messages will be logged
+  INFO = 3,      // Info, warning, and error messages will be logged
+  DEBUG = 4      // All messages will be logged
+}
+
 export interface Logger {
   logError(err: Error): void;
   logErrorMessage(message: string): void;
-  logInfo(message: string): void;
   logWarning(warning: string): void;
+  logInfo(message: string): void;
   logDebug(message: string): void;
   logDiagnostic(message: string): void;
   logDiagnosticEnvVar(name: string): void;
 }
 
+export interface LogOptions {
+  logger?: Logger;
+  logLevel: LogLevel;
+}
+
 export function logger(): Logger {
-  const logger = coreState().logger;
+  const logger = coreState().logOptions.logger;
   if (!logger) {
     throw Error('Logger not set');
   }
   return logger;
 }
 
+/**
+ * @returns Current logging level
+ */
+export function logLevel(): LogLevel {
+  return coreState().logOptions.logLevel;
+}
+
 export function setLogger(logger: Logger): void {
-  coreState().logger = logger;
+  coreState().logOptions.logger = logger;
+}
+
+/**
+ * @param level minimum logging level
+ */
+export function setLoggerLevel(level: LogLevel): void {
+  coreState().logOptions.logLevel = level;
 }

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -16,7 +16,7 @@
 import { app, dialog } from 'electron';
 
 import { ConsoleLogger } from '../core/console-logger';
-import { setLogger } from '../core/logger';
+import { LogLevel, setLogger, setLoggerLevel } from '../core/logger';
 
 import { Application } from './application';
 import { setApplication } from './app-state';
@@ -41,6 +41,7 @@ class RStudioMain {
 
   private async startup(): Promise<void> {
     setLogger(new ConsoleLogger());
+    setLoggerLevel(LogLevel.ERR);
     const rstudio = new Application();
     setApplication(rstudio);
 

--- a/src/node/desktop/test/unit/core/console-logger.test.ts
+++ b/src/node/desktop/test/unit/core/console-logger.test.ts
@@ -18,6 +18,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 
 import { ConsoleLogger } from '../../../src/core/console-logger';
+import { setLoggerLevel, LogLevel } from '../../../src/core/logger';
 
 describe('Console-logger', () => {
   let fakeConsoleLog = sinon.fake();
@@ -31,34 +32,81 @@ describe('Console-logger', () => {
   });
 
   it('logError writes error', () => {
+    setLoggerLevel(LogLevel.ERR);
+    const logger = new ConsoleLogger();
+    const err = new Error('test Errormessage');
+    logger.logError(err);
+    assert.isTrue(fakeConsoleLog.calledWithMatch(err));
+  });
+  it('logError output suppressed when LogLevel = OFF', () => {
+    setLoggerLevel(LogLevel.OFF);
+    const logger = new ConsoleLogger();
+    const err = new Error('test Errormessage');
+    logger.logError(err);
+    assert.isFalse(fakeConsoleLog.called);
+  });
+  it('logError writes error when LogLevel = DEBUG', () => {
+    setLoggerLevel(LogLevel.DEBUG);
     const logger = new ConsoleLogger();
     const err = new Error('test Errormessage');
     logger.logError(err);
     assert.isTrue(fakeConsoleLog.calledWithMatch(err));
   });
   it('logErrorMessage', () => {
+    setLoggerLevel(LogLevel.ERR);
     const logger = new ConsoleLogger();
     const msg = 'test error message';
     logger.logErrorMessage(msg);
     assert.isTrue(fakeConsoleLog.calledWith(msg));
   });
+  it('logErrorMessage suppressed when LogLevel = OFF', () => {
+    setLoggerLevel(LogLevel.OFF);
+    const logger = new ConsoleLogger();
+    const msg = 'test error message';
+    logger.logErrorMessage(msg);
+    assert.isFalse(fakeConsoleLog.called);
+  });
   it('logInfo', () => {
+    setLoggerLevel(LogLevel.INFO);
     const logger = new ConsoleLogger();
     const msg = 'test info message';
     logger.logInfo(msg);
     assert.isTrue(fakeConsoleLog.calledWith(msg));
   });
+  it('logInfo suppressed when LogLevel = WARN', () => {
+    setLoggerLevel(LogLevel.WARN);
+    const logger = new ConsoleLogger();
+    const msg = 'test info message';
+    logger.logInfo(msg);
+    assert.isFalse(fakeConsoleLog.called);
+  });
   it('logWarning', () => {
+    setLoggerLevel(LogLevel.WARN);
     const logger = new ConsoleLogger();
     const msg = 'test warning message';
     logger.logWarning(msg);
     assert.isTrue(fakeConsoleLog.calledWith(msg));
   });
+  it('logWarning suppressed when LogLevel = ERR', () => {
+    setLoggerLevel(LogLevel.ERR);
+    const logger = new ConsoleLogger();
+    const msg = 'test warning message';
+    logger.logWarning(msg);
+    assert.isFalse(fakeConsoleLog.called);
+  });
   it('logDebug', () => {
+    setLoggerLevel(LogLevel.DEBUG);
     const logger = new ConsoleLogger();
     const msg = 'test debug message';
     logger.logDebug(msg);
     assert.isTrue(fakeConsoleLog.calledWith(msg));
+  });
+  it('logDebug suppressed whebn LogLevel = INFO', () => {
+    setLoggerLevel(LogLevel.INFO);
+    const logger = new ConsoleLogger();
+    const msg = 'test debug message';
+    logger.logDebug(msg);
+    assert.isFalse(fakeConsoleLog.called);
   });
   it('logDiagnostic', () => {
     const logger = new ConsoleLogger();

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -23,7 +23,7 @@ import os from 'os';
 
 import { FilePath } from '../../../src/core/file-path';
 import { userHomePath } from '../../../src/core/user';
-import { setLogger } from '../../../src/core/logger';
+import { logLevel, setLogger, setLoggerLevel, LogLevel } from '../../../src/core/logger';
 import { ConsoleLogger } from '../../../src/core/console-logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 
@@ -51,6 +51,7 @@ const absolutePath = process.platform === 'win32' ? 'C:/Users/human/documents' :
 describe('FilePath', () => {
   before(() => {
     setLogger(new ConsoleLogger());
+    setLoggerLevel(LogLevel.OFF);
   });
   after(() => {
     clearCoreSingleton();

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -51,6 +51,8 @@ const absolutePath = process.platform === 'win32' ? 'C:/Users/human/documents' :
 describe('FilePath', () => {
   before(() => {
     setLogger(new ConsoleLogger());
+
+    // some tests trigger ERR logging; this is expected and don't want to see it during tests
     setLoggerLevel(LogLevel.OFF);
   });
   after(() => {


### PR DESCRIPTION
### Intent

Implement logging levels so logging verbosity can be controlled (Electron desktop).

### Approach

Using same LogLevel enum as the C++ code (OFF | ERR | WARN | INFO | DEBUG), provided a way to set it, and made the various logError, logWarning, etc. methods pay attention to it.

The default setting is `LogLevel.ERR` same as the C++ desktop.

We may decide later to simplify this (maybe just ERR and DEBUG?), but for now matching the existing code.

### Automated Tests

Added/updated unit tests to cover this new scenario. Also used it to suppress logging of expected errors thrown inside the FilePath class during unit tests.

### QA Notes

Internal functionality.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


