### PR TITLE
tweak ordering of library() completion results

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 
 ### Misc
 
+* Improved ordering of completion results within `library()` calls (#9293)
 * Add option to synchronize the Files pane with the current working directory in R (#4615)
 * Add new *Set Working Directory* command to context menu for source files (#6781)
 * Local background jobs can now be replayed (#5548)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1548,7 +1548,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("listIndexedPackages", function()
 {
-   .Call("rs_listIndexedPackages")
+   .Call("rs_listIndexedPackages", PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("getCompletionsPackages", function(token,
@@ -1556,7 +1556,7 @@ assign(x = ".rs.acCompletionTypes",
                                                    excludeOtherCompletions = FALSE,
                                                    quote = !appendColons)
 {
-   allPackages <- basename(.rs.listIndexedPackages())
+   allPackages <- sort(basename(.rs.listIndexedPackages()))
    
    # In case indexing is disabled, include any loaded namespaces by default
    allPackages <- union(allPackages, loadedNamespaces())
@@ -1573,16 +1573,25 @@ assign(x = ".rs.acCompletionTypes",
    }
    
    # Construct our completions, and we're done
-   completions <- .rs.selectFuzzyMatches(allPackages, token)
-   .rs.makeCompletions(token = token,
-                       results = if (appendColons && length(completions))
-                          paste(completions, "::", sep = "")
-                       else
-                          completions,
-                       packages = completions,
-                       quote = quote,
-                       type = .rs.acCompletionTypes$PACKAGE,
-                       excludeOtherCompletions = excludeOtherCompletions)
+   matches <- .rs.selectFuzzyMatches(allPackages, token)
+   results <- if (appendColons && length(matches))
+      paste(matches, "::", sep = "")
+   else
+      matches
+   
+   completions <- .rs.makeCompletions(
+      token = token,
+      results = results,
+      packages = matches,
+      quote = quote,
+      type = .rs.acCompletionTypes$PACKAGE,
+      excludeOtherCompletions = excludeOtherCompletions
+   )
+   
+   .rs.sortCompletions(
+      completions   = completions,
+      token         = token
+   )
 })
 
 .rs.addFunction("getCompletionsData", function(token)


### PR DESCRIPTION
### Intent

This PR refines the completion ordering used for packages within a `library()` call.

Addresses https://github.com/rstudio/rstudio/issues/9293.

### Approach

The implementation here uses an indexed cache of packages; however, the ordering of that list does not seem to be defined. This leads to package completion results being in a seemingly random order; for example:

<img width="286" alt="Screen Shot 2021-06-24 at 2 42 58 PM" src="https://user-images.githubusercontent.com/1976582/123336267-7aacf580-d4fa-11eb-8e0c-f35472686c3b.png">

With this PR, completions are instead presented in alphabetical order.

<img width="285" alt="Screen Shot 2021-06-24 at 2 43 16 PM" src="https://user-images.githubusercontent.com/1976582/123336324-8ef0f280-d4fa-11eb-9d2f-2af3975ef381.png">

In addition, when presenting completion results, exact matches are now preferred; for example:

<img width="248" alt="Screen Shot 2021-06-24 at 2 43 53 PM" src="https://user-images.githubusercontent.com/1976582/123336376-a29c5900-d4fa-11eb-9777-71ac3115b44b.png">

which, most importantly, now matches the behavior of "fuzzy narrowing" when typing to narrow a completion list.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9293.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
