### PR TITLE
disable null external pointer checks for environment pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 
 ### Python
 
-* Projects containing a Python environment in the '.venv' folder are now automatically activated (#9489)
+* Projects containing a Python environment are now automatically activated (#9489)
 
 
 ### Logging
@@ -35,6 +35,7 @@
 
 ### Misc
 
+* **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 * Add option to synchronize the Files pane with the current working directory in R (#4615)
 * Add new *Set Working Directory* command to context menu for source files (#6781)
 * Local background jobs can now be replayed (#5548)
@@ -44,7 +45,7 @@
 * Prevent user preferences from setting CRAN repos when `allow-cran-repos-edit=0` (Pro #1301)
 * Make the *Use renv with this project* option sticky, and allow setting by admins (Pro #2671)
 * Updated embedded nginx in Server Pro to 1.20.1 (Pro #2676)
-* **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 * Added AWS Cognito support to openid integration (Pro #2313)
 * Add file uploads and downloads to session audit log (Pro #2226)
+* RStudio no longer treats R objects containing null external pointers specially when building Environment pane (#5546)
 * Make Cmd+Shift+0 the shortcut for restarting session on MacOS (#7695)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -389,6 +389,7 @@ namespace prefs {
 #define kTerminalPythonIntegration "terminal_python_integration"
 #define kSessionProtocolDebug "session_protocol_debug"
 #define kPythonProjectEnvironmentAutomaticActivate "python_project_environment_automatic_activate"
+#define kCheckNullExternalPointers "check_null_external_pointers"
 
 class UserPrefValues: public Preferences
 {
@@ -1731,6 +1732,12 @@ public:
     */
    bool pythonProjectEnvironmentAutomaticActivate();
    core::Error setPythonProjectEnvironmentAutomaticActivate(bool val);
+
+   /**
+    * When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.
+    */
+   bool checkNullExternalPointers();
+   core::Error setCheckNullExternalPointers(bool val);
 
 };
 

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -361,7 +361,7 @@ bool isInstalled(bool refresh)
    if (refresh)
    {
       Error error = core::system::findProgramOnPath("quarto", &s_quartoPath);
-      if (error)
+      if (error && !isFileNotFoundError(error))
          LOG_ERROR(error);
    }
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2922,6 +2922,19 @@ core::Error UserPrefValues::setPythonProjectEnvironmentAutomaticActivate(bool va
    return writePref("python_project_environment_automatic_activate", val);
 }
 
+/**
+ * When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.
+ */
+bool UserPrefValues::checkNullExternalPointers()
+{
+   return readPref<bool>("check_null_external_pointers");
+}
+
+core::Error UserPrefValues::setCheckNullExternalPointers(bool val)
+{
+   return writePref("check_null_external_pointers", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3148,6 +3161,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kTerminalPythonIntegration,
       kSessionProtocolDebug,
       kPythonProjectEnvironmentAutomaticActivate,
+      kCheckNullExternalPointers,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1516,6 +1516,12 @@
             "title": "Automatically activate project Python environments",
             "type": "boolean",
             "default": true
+        },
+        "check_null_external_pointers": {
+            "description": "When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.",
+            "title": "Examine R objects for null external pointers",
+            "type": "boolean",
+            "default": false
         }
     }
 }

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1519,7 +1519,7 @@
         },
         "check_null_external_pointers": {
             "description": "When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.",
-            "title": "Examine R objects for null external pointers",
+            "title": "Check values in the Environment pane for null external pointers",
             "type": "boolean",
             "default": false
         }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3159,6 +3159,18 @@ public class UserPrefsAccessor extends Prefs
          true);
    }
 
+   /**
+    * When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.
+    */
+   public PrefValue<Boolean> checkNullExternalPointers()
+   {
+      return bool(
+         "check_null_external_pointers",
+         "Examine R objects for null external pointers", 
+         "When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.", 
+         false);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -3607,6 +3619,8 @@ public class UserPrefsAccessor extends Prefs
          sessionProtocolDebug().setValue(layer, source.getBool("session_protocol_debug"));
       if (source.hasKey("python_project_environment_automatic_activate"))
          pythonProjectEnvironmentAutomaticActivate().setValue(layer, source.getBool("python_project_environment_automatic_activate"));
+      if (source.hasKey("check_null_external_pointers"))
+         checkNullExternalPointers().setValue(layer, source.getBool("check_null_external_pointers"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -3834,6 +3848,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(terminalPythonIntegration());
       prefs.add(sessionProtocolDebug());
       prefs.add(pythonProjectEnvironmentAutomaticActivate());
+      prefs.add(checkNullExternalPointers());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3166,7 +3166,7 @@ public class UserPrefsAccessor extends Prefs
    {
       return bool(
          "check_null_external_pointers",
-         "Examine R objects for null external pointers", 
+         "Check values in the Environment pane for null external pointers", 
          "When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.", 
          false);
    }


### PR DESCRIPTION
### Intent

RStudio normally screens for objects containing null external pointers when building the Environment pane, primarily to fix crashes that occurred when introspecting certain objects in older versions of R.

This has caused a fair amount of user confusion, and in addition this workaround no longer appears to be necessary with the newer versions of R / igraph.

Addresses https://github.com/rstudio/rstudio/issues/5546.

### Approach

We now no longer search for null external pointers by default, but allow users to opt-in via a user preference if necessary.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/5546#issuecomment-567646350. Also confirm that you can set the "Check Null External Pointers" preference to toggle the behavior.

<img width="631" alt="Screen Shot 2021-06-24 at 4 48 27 PM" src="https://user-images.githubusercontent.com/1976582/123345939-0713e400-d50c-11eb-8fcf-f3639d59c720.png">


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


