### PR TITLE
fix diagnostics logging, other Electron WIP

### DIFF
--- a/src/node/desktop/src/core/console-logger.ts
+++ b/src/node/desktop/src/core/console-logger.ts
@@ -14,7 +14,7 @@
  */
 
 import { getenv } from './environment';
-import { Logger, LogLevel, logLevel } from './logger';
+import { Logger, LogLevel, logLevel, showDiagnosticsOutput } from './logger';
 
 /**
  * A Logger using console.log()
@@ -52,13 +52,13 @@ export class ConsoleLogger implements Logger {
   }
 
   logDiagnostic(message: string): void {
-    if (logLevel() >= LogLevel.OFF) {
+    if (showDiagnosticsOutput()) {
       console.log(message);
     }
   }
 
   logDiagnosticEnvVar(name: string): void {
-    if (logLevel() >= LogLevel.OFF) {
+    if (showDiagnosticsOutput()) {
       const value = getenv(name);
       if (value) {
         this.logDiagnostic(` . ${name} = ${value}`);

--- a/src/node/desktop/src/core/core-state.ts
+++ b/src/node/desktop/src/core/core-state.ts
@@ -49,6 +49,6 @@ class CoreStateImpl implements CoreState {
 
   constructor() {
     this.instance = coreStateInstanceCounter++;
-    this.logOptions = { logLevel: LogLevel.ERR};
+    this.logOptions = { logLevel: LogLevel.ERR, showDiagnostics: false };
   }
 }

--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -39,6 +39,7 @@ export interface Logger {
 export interface LogOptions {
   logger?: Logger;
   logLevel: LogLevel;
+  showDiagnostics: boolean;
 }
 
 export function logger(): Logger {
@@ -58,6 +59,14 @@ export function logLevel(): LogLevel {
 
 export function setLogger(logger: Logger): void {
   coreState().logOptions.logger = logger;
+}
+
+export function enableDiagnosticsOutput(): void {
+  coreState().logOptions.showDiagnostics = true;
+}
+
+export function showDiagnosticsOutput(): boolean {
+  return coreState().logOptions.showDiagnostics;
 }
 
 /**

--- a/src/node/desktop/src/main/activation-overlay.ts
+++ b/src/node/desktop/src/main/activation-overlay.ts
@@ -13,6 +13,7 @@
  *
  */
 
+import { BrowserWindow } from 'electron';
 import { EventEmitter } from 'events';
 
 export enum ActivationEvents {
@@ -31,32 +32,68 @@ export class DesktopActivation extends EventEmitter {
     return true;
   }
 
+  /**
+   * @returns License state description if expired or within certain time window before
+   * expiring, otherwise empty string.
+   */
+  currentLicenseStateMessage(): string {
+    // TODO - reimplement
+    return '';
+  }
+
+  /**
+   * @returns Description of license state
+   */
+  licenseStatus(): string {
+    // TODO - reimplement
+    return '';
+  }
+
+  /** 
+    * Set main window, so we can supply it as default parent of message boxes
+    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setMainWindow(window?: BrowserWindow): void {
+  }
+
+  /**
+   * @returns Name of product edition, for use in UI
+   */
   editionName(): string {
     return 'RStudio';
   }
 
-  // license has been lost while using the program
+  /**
+   * license has been lost while using the program
+   */
   emitLicenseLostSignal(): void {
   }
 
-  // no longer need to show a license warning bar
+  /**
+   * no longer need to show a license warning bar
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   emitUpdateLicenseWarningBarSignal(message: string): void {
   }
 
-  // start a session after validating initial license
+  /**
+   * start a session after validating initial license
+   */
   emitLaunchFirstSession(): void {
     this.emit(ActivationEvents.LAUNCH_FIRST_SESSION);
   }
 
-  // show a messagebox (if message is non-empty) then exit the program
+  /**
+   * show a messagebox (if message is non-empty) then exit the program
+   */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   emitLaunchError(message: string): void {
     this.emit(ActivationEvents.LAUNCH_ERROR, message);
   }
 
-  // detect (or re-detect) license status
+  /**
+   * detect (or re-detect) license status
+   */
   emitDetectLicense(): void {
   }
-
 }

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -13,13 +13,24 @@
  *
  */
 
+import { MainWindow } from './main-window';
+
 /**
  * Not clear yet if we'll need this class from the Qt implementation, but keeping
  * it for now. If it ends up being useful, probably need to create an interface
  * describing behavior (for easier unit testing).
  */
 export class ApplicationLaunch {
+  mainWindow?: MainWindow;
   static init(): ApplicationLaunch {
     return new ApplicationLaunch();
+  }
+
+  setActivationWindow(window: MainWindow): void {
+    this.mainWindow = window;
+  }
+
+  activateWindow(): void {
+    // TODO - reimplement (if needed at all)
   }
 }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -18,7 +18,7 @@ import { app, dialog, BrowserWindow } from 'electron';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 import { generateRandomPort } from '../core/system';
-import { logger } from '../core/logger';
+import { logger, enableDiagnosticsOutput } from '../core/logger';
 
 import { getRStudioVersion } from './product-info';
 import { findComponents, initializeSharedSecret } from './utils';
@@ -138,6 +138,7 @@ export class Application implements AppState {
 
     if (argv.indexOf(kRunDiagnosticsOption) > -1) {
       this.runDiagnostics = true;
+      enableDiagnosticsOutput();
     }
 
     return run();

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -80,9 +80,7 @@ async function prepareEnvironmentPosix(): Promise<boolean> {
     return false;
   }
 
-  if (appState().runDiagnostics) {
-    logger().logDiagnostic(`Using R script: ${detectResult.rScriptPath}`);
-  }
+  logger().logDiagnostic(`Using R script: ${detectResult.rScriptPath}`);
 
   setREnvironmentVars(detectResult.envVars ?? {});
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -1,5 +1,5 @@
 /*
- * desktop-callback.ts
+ * gwt-callback.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -30,15 +30,15 @@ export const PendingQuit = {
   'PendingQuitRestartAndReload': 3
 };
 
-export class DesktopCallback {
+export class GwtCallback {
   pendingQuit: number = PendingQuit.PendingQuitNone;
 
-  constructor(public mainWindow: MainWindow,
-              public ownerWindow: MainWindow,
-              public isRemoteDesktop: boolean) {
-
+  constructor(
+    public mainWindow: MainWindow,
+    public isRemoteDesktop: boolean
+  ) {
     ipcMain.on('desktop_browse_url', (event, url) => {
-      DesktopCallback.unimpl('desktop_browser_url');
+      GwtCallback.unimpl('desktop_browser_url');
     });
 
     ipcMain.handle('desktop_get_open_file_name',
@@ -67,69 +67,69 @@ export class DesktopCallback {
       defaultExtension,
       forceDefaultExtension,
       focusOwner) => {
-      DesktopCallback.unimpl('desktop_get_save_file_name');
+      GwtCallback.unimpl('desktop_get_save_file_name');
       return '';
     });
 
     ipcMain.handle('desktop_get_existing_directory', (caption, label, dir, focusOwner) => {
-      DesktopCallback.unimpl('desktop_get_existing_directory');
+      GwtCallback.unimpl('desktop_get_existing_directory');
       return '';
     });
 
     ipcMain.on('desktop_on_clipboard_selection_changed', (event) => {
-      DesktopCallback.unimpl('desktop_on_clipboard_selection_changed');
+      GwtCallback.unimpl('desktop_on_clipboard_selection_changed');
     });
 
     ipcMain.on('desktop_undo', (event) => {
-      DesktopCallback.unimpl('desktop_undo');
+      GwtCallback.unimpl('desktop_undo');
     });
 
     ipcMain.on('desktop_redo', (event) => {
-      DesktopCallback.unimpl('desktop_redo');
+      GwtCallback.unimpl('desktop_redo');
     });
 
     ipcMain.on('desktop_clipboard_cut', (event) => {
-      DesktopCallback.unimpl('desktop_clipboard_cut');
+      GwtCallback.unimpl('desktop_clipboard_cut');
     });
 
     ipcMain.on('desktop_clipboard_copy', (event) => {
-      DesktopCallback.unimpl('desktop_clipboard_copy');
+      GwtCallback.unimpl('desktop_clipboard_copy');
     });
 
     ipcMain.on('desktop_clipboard_paste', (event) => {
-      DesktopCallback.unimpl('desktop_clipboard_paste');
+      GwtCallback.unimpl('desktop_clipboard_paste');
     });
 
     ipcMain.on('desktop_set_clipboard_text', (event, text) => {
-      DesktopCallback.unimpl('desktop_set_clipboard_text');
+      GwtCallback.unimpl('desktop_set_clipboard_text');
     });
 
     ipcMain.handle('desktop_get_clipboard_text', (event) => {
-      DesktopCallback.unimpl('desktop_get_clipboard_text');
+      GwtCallback.unimpl('desktop_get_clipboard_text');
       return '';
     });
 
     ipcMain.handle('desktop_get_clipboard_uris', (event) => {
-      DesktopCallback.unimpl('desktop_get_clipboard_uris');
+      GwtCallback.unimpl('desktop_get_clipboard_uris');
       return '';
     });
 
     ipcMain.handle('desktop_get_clipboard_image', (event) => {
-      DesktopCallback.unimpl('desktop_get_clipboard_image');
+      GwtCallback.unimpl('desktop_get_clipboard_image');
       return '';
     });
 
     ipcMain.on('desktop_set_global_mouse_selection', (event, selection) => {
-      DesktopCallback.unimpl('desktop_set_global_mouse_selection');
+      GwtCallback.unimpl('desktop_set_global_mouse_selection');
     });
 
     ipcMain.handle('desktop_get_global_mouse_selection', (event) => {
-      DesktopCallback.unimpl('desktop_get_global_mouse_selection');
+      GwtCallback.unimpl('desktop_get_global_mouse_selection');
       return '';
     });
 
     ipcMain.handle('desktop_get_cursor_position', (event) => {
-      DesktopCallback.unimpl('desktop_get_cursor_position');
+      GwtCallback.unimpl('desktop_get_cursor_position');
       return {x: 20, y: 20};
     });
 
@@ -142,31 +142,31 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_show_folder', (event, path) => {
-      DesktopCallback.unimpl('desktop_show_folder');
+      GwtCallback.unimpl('desktop_show_folder');
     });
 
     ipcMain.on('desktop_show_file', (event, file) => {
-      DesktopCallback.unimpl('desktop_show_file');
+      GwtCallback.unimpl('desktop_show_file');
     });
 
     ipcMain.on('desktop_show_word_doc', (event, wordDoc) => {
-      DesktopCallback.unimpl('desktop_show_word_doc');
+      GwtCallback.unimpl('desktop_show_word_doc');
     });
 
     ipcMain.on('desktop_show_ppt_presentation', (event, pptDoc) => {
-      DesktopCallback.unimpl('desktop_show_ppt_presentation');
+      GwtCallback.unimpl('desktop_show_ppt_presentation');
     });
 
     ipcMain.on('desktop_show_pdf', (event, path, pdfPage) => {
-      DesktopCallback.unimpl('desktop_show_pdf');
+      GwtCallback.unimpl('desktop_show_pdf');
     });
 
     ipcMain.on('desktop_prepare_show_word_doc', (event) => {
-      DesktopCallback.unimpl('desktop_prepare_show_word_doc');
+      GwtCallback.unimpl('desktop_prepare_show_word_doc');
     });
 
     ipcMain.on('desktop_prepare_show_ppt_presentation', (event) => {
-      DesktopCallback.unimpl('desktop_prepare_show_ppt_presentation');
+      GwtCallback.unimpl('desktop_prepare_show_ppt_presentation');
     });
 
     ipcMain.handle('desktop_get_r_version', (event) => {
@@ -174,21 +174,21 @@ export class DesktopCallback {
     });
 
     ipcMain.handle('desktop_choose_r_version', (event) => {
-      DesktopCallback.unimpl('desktop_choose_r_version');
+      GwtCallback.unimpl('desktop_choose_r_version');
       return '';
     });
 
     ipcMain.handle('desktop_device_pixel_ratio', (event) => {
-      DesktopCallback.unimpl('desktop_device_pixel_ratio');
+      GwtCallback.unimpl('desktop_device_pixel_ratio');
       return 1.0;
     });
 
     ipcMain.on('desktop_open_minimal_window', (event, name, url, width, height) => {
-      DesktopCallback.unimpl('desktop_open_minimal_window');
+      GwtCallback.unimpl('desktop_open_minimal_window');
     });
 
     ipcMain.on('desktop_activate_minimal_window', (event, name) => {
-      DesktopCallback.unimpl('desktop_activate_minimal_window');
+      GwtCallback.unimpl('desktop_activate_minimal_window');
     });
 
     ipcMain.on('desktop_activate_satellite_window', (event, name) => {
@@ -204,27 +204,27 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_close_named_window', (event, name) => {
-      DesktopCallback.unimpl('desktop_close_named_window');
+      GwtCallback.unimpl('desktop_close_named_window');
     });
 
     ipcMain.on('desktop_copy_page_region_to_clipboard', (event, left, top, width, height) => {
-      DesktopCallback.unimpl('desktop_copy_page_region_to_clipboard');
+      GwtCallback.unimpl('desktop_copy_page_region_to_clipboard');
     });
 
     ipcMain.on('desktop_export_page_region_to_file', (event, targetPath, format, left, top, width, height) => {
-      DesktopCallback.unimpl('desktop_export_page_region_to_file');
+      GwtCallback.unimpl('desktop_export_page_region_to_file');
     });
 
     ipcMain.on('desktop_print_text', (event, text) => {
-      DesktopCallback.unimpl('desktop_print_text');
+      GwtCallback.unimpl('desktop_print_text');
     });
 
     ipcMain.on('desktop_paint_print_text', (event, printer) => {
-      DesktopCallback.unimpl('desktop_paint_print_text');
+      GwtCallback.unimpl('desktop_paint_print_text');
     });
 
     ipcMain.on('desktop_print_finished', (event, result) => {
-      DesktopCallback.unimpl('desktop_print_finished');
+      GwtCallback.unimpl('desktop_print_finished');
     });
 
     ipcMain.handle('desktop_supports_clipboard_metafile', (event) => {
@@ -251,7 +251,7 @@ export class DesktopCallback {
     ipcMain.handle('desktop_prompt_for_text', (event, title, caption, defaultValue, type, 
       rememberPasswordPrompt, rememberByDefault,
       selectionStart, selectionLength, okButtonCaption) => {
-      DesktopCallback.unimpl('desktop_prompt_for_text');
+      GwtCallback.unimpl('desktop_prompt_for_text');
       return ''; 
     });
 
@@ -259,7 +259,7 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_bring_main_frame_behind_active', (event) => {
-      DesktopCallback.unimpl('desktop_bring_main_frame_behind_active');
+      GwtCallback.unimpl('desktop_bring_main_frame_behind_active');
     });
 
     ipcMain.handle('desktop_rendering_engine', (event) => {
@@ -267,16 +267,16 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_set_desktop_rendering_engine', (event, engine) => {
-      DesktopCallback.unimpl('desktop_set_desktop_rendering_engine');
+      GwtCallback.unimpl('desktop_set_desktop_rendering_engine');
     });
 
     ipcMain.handle('desktop_filter_text', (event, text) => {
-      DesktopCallback.unimpl('desktop_filter_text');
+      GwtCallback.unimpl('desktop_filter_text');
       return text;
     });
 
     ipcMain.on('desktop_clean_clipboard', (event, stripHtml) => {
-      DesktopCallback.unimpl('desktop_clean_clipboard');
+      GwtCallback.unimpl('desktop_clean_clipboard');
     });
 
     ipcMain.on('desktop_set_pending_quit', (event, pendingQuit) => {
@@ -284,55 +284,55 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
-      DesktopCallback.unimpl('desktop_open_project_in_new_window');
+      GwtCallback.unimpl('desktop_open_project_in_new_window');
     });
 
     ipcMain.on('desktop_open_session_in_new_window', (event, workingDirectoryPath) => {
-      DesktopCallback.unimpl('desktop_open_session_in_new_window');
+      GwtCallback.unimpl('desktop_open_session_in_new_window');
     });
 
     ipcMain.on('desktop_open_terminal', (event, terminalPath, workingDirectory, extraPathEntries, shellType) => {
-      DesktopCallback.unimpl('desktop_open_terminal');
+      GwtCallback.unimpl('desktop_open_terminal');
     });
 
     ipcMain.handle('desktop_get_fixed_width_font_list', (event) => {
-      DesktopCallback.unimpl('desktop_get_fixed_width_font_list');
+      GwtCallback.unimpl('desktop_get_fixed_width_font_list');
       return '';
     });
 
     ipcMain.handle('desktop_get_fixed_width_font', (event) => {
-      DesktopCallback.unimpl('desktop_get_fixed_width_font');
+      GwtCallback.unimpl('desktop_get_fixed_width_font');
       return '';
     });
 
     ipcMain.on('desktop_set_fixed_width_font', (event, font) => {
-      DesktopCallback.unimpl('desktop_set_fixed_width_font');
+      GwtCallback.unimpl('desktop_set_fixed_width_font');
     });
 
     ipcMain.handle('desktop_get_zoom_levels', (event) => {
-      DesktopCallback.unimpl('desktop_get_zoom_levels');
+      GwtCallback.unimpl('desktop_get_zoom_levels');
       return '';
     });
 
     ipcMain.handle('desktop_get_zoom_level', (event) => {
-      DesktopCallback.unimpl('desktop_get_zoom_level');
+      GwtCallback.unimpl('desktop_get_zoom_level');
       return 1.0;
     });
 
     ipcMain.on('desktop_set_zoom_level', (event, zoomLevel) => {
-      DesktopCallback.unimpl('desktop_set_zoom_level');
+      GwtCallback.unimpl('desktop_set_zoom_level');
     });
 
     ipcMain.on('desktop_zoom_in', (event) => {
-      DesktopCallback.unimpl('desktop_zoom_in');
+      GwtCallback.unimpl('desktop_zoom_in');
     });
 
     ipcMain.on('desktop_zoom_out', (event) => {
-      DesktopCallback.unimpl('desktop_zoom_out');
+      GwtCallback.unimpl('desktop_zoom_out');
     });
 
     ipcMain.on('desktop_zoom_actual_size', (event) => {
-      DesktopCallback.unimpl('desktop_zoom_actual_size');
+      GwtCallback.unimpl('desktop_zoom_actual_size');
     });
 
     ipcMain.on('desktop_set_background_color', (event, rgbColor) => {
@@ -345,21 +345,21 @@ export class DesktopCallback {
     });
 
     ipcMain.handle('desktop_get_enable_accessibility', (event) => {
-      DesktopCallback.unimpl('desktop_get_enable_accessibility');
+      GwtCallback.unimpl('desktop_get_enable_accessibility');
       return true;
     });
 
     ipcMain.on('desktop_set_enable_accessibility', (event, enable) => {
-      DesktopCallback.unimpl('desktop_set_enable_accessibility');
+      GwtCallback.unimpl('desktop_set_enable_accessibility');
     });
 
     ipcMain.handle('desktop_get_clipboard_monitoring', (event) => {
-      DesktopCallback.unimpl('desktop_get_clipboard_monitoring');
+      GwtCallback.unimpl('desktop_get_clipboard_monitoring');
       return false;
     });
 
     ipcMain.on('desktop_set_clipboard_monitoring', (event, monitoring) => {
-      DesktopCallback.unimpl('desktop_set_clipboard_monitoring');
+      GwtCallback.unimpl('desktop_set_clipboard_monitoring');
     });
 
     ipcMain.handle('desktop_get_ignore_gpu_blacklist', (event, ignore) => {
@@ -367,7 +367,7 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_set_ignore_gpu_blacklist', (event, ignore) => {
-      DesktopCallback.unimpl('desktop_set_ignore_gpu_blacklist');
+      GwtCallback.unimpl('desktop_set_ignore_gpu_blacklist');
     });
 
     ipcMain.handle('desktop_get_disable_gpu_driver_bug_workarounds', (event) => {
@@ -375,15 +375,15 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_set_disable_gpu_driver_bug_workarounds', (event, disable) => {
-      DesktopCallback.unimpl('desktop_set_disable_gpu_driver_bug_workarounds');
+      GwtCallback.unimpl('desktop_set_disable_gpu_driver_bug_workarounds');
     });
 
     ipcMain.on('desktop_show_license_dialog', (event) => {
-      DesktopCallback.unimpl('desktop_show_license_dialog');
+      GwtCallback.unimpl('desktop_show_license_dialog');
     });
 
     ipcMain.on('desktop_show_session_server_options_dialog', (event) => {
-      DesktopCallback.unimpl('desktop_show_session_server_options_dialog');
+      GwtCallback.unimpl('desktop_show_session_server_options_dialog');
     });
 
     ipcMain.handle('desktop_get_init_messages', (event) => {
@@ -391,66 +391,66 @@ export class DesktopCallback {
     });
 
     ipcMain.handle('desktop_get_license_status_message', (event) => {
-      DesktopCallback.unimpl('desktop_get_license_status_messages');
+      GwtCallback.unimpl('desktop_get_license_status_messages');
       return '';
     });
 
     ipcMain.handle('desktop_allow_product_usage', (event) => {
-      DesktopCallback.unimpl('desktop_allow_product_usage');
+      GwtCallback.unimpl('desktop_allow_product_usage');
       return true;
     });
 
     ipcMain.handle('desktop_get_desktop_synctex_viewer', (event) => {
-      DesktopCallback.unimpl('desktop_get_desktop_synctex_viewer');
+      GwtCallback.unimpl('desktop_get_desktop_synctex_viewer');
       return '';
     });
 
     ipcMain.on('desktop_external_synctex_preview', (event, pdfPath, page) => {
-      DesktopCallback.unimpl('desktop_external_synctex_preview');
+      GwtCallback.unimpl('desktop_external_synctex_preview');
     });
 
     ipcMain.on('desktop_external_synctex_view', (event, pdfFile, srcFile, line, column) => {
-      DesktopCallback.unimpl('desktop_external_synctex_view');
+      GwtCallback.unimpl('desktop_external_synctex_view');
     });
 
     ipcMain.handle('desktop_supports_fullscreen_mode', (event) => {
-      DesktopCallback.unimpl('desktop_supports_fullscreen_mode');
+      GwtCallback.unimpl('desktop_supports_fullscreen_mode');
       return true;
     });
 
     ipcMain.on('desktop_toggle_fullscreen_mode', (event) => {
-      DesktopCallback.unimpl('desktop_toggle_fullscreen_mode');
+      GwtCallback.unimpl('desktop_toggle_fullscreen_mode');
     });
 
     ipcMain.on('desktop_show_keyboard_shortcut_help', (event) => {
-      DesktopCallback.unimpl('desktop_show_keyboard_shortcut_help');
+      GwtCallback.unimpl('desktop_show_keyboard_shortcut_help');
     });
 
     ipcMain.on('desktop_launch_session', (event, reload) => {
-      DesktopCallback.unimpl('desktop_launch)_session');
+      GwtCallback.unimpl('desktop_launch)_session');
     });
 
     ipcMain.on('desktop_reload_zoom_window', (event) => {
     });
 
     ipcMain.on('desktop_set_tutorial_url', (event, url) => {
-      DesktopCallback.unimpl('desktop_set_tutorial_url');
+      GwtCallback.unimpl('desktop_set_tutorial_url');
     });
   
     ipcMain.on('desktop_set_viewer_url', (event, url) => {
-      DesktopCallback.unimpl('desktop_set_viewer_url');
+      GwtCallback.unimpl('desktop_set_viewer_url');
     });
 
     ipcMain.on('desktop_reload_viewer_zoom_window', (event, url) => {
-      DesktopCallback.unimpl('desktop_reload_viewer_zoom_window');
+      GwtCallback.unimpl('desktop_reload_viewer_zoom_window');
     });
 
     ipcMain.on('desktop_set_shiny_dialog_url', (event, url) => {
-      DesktopCallback.unimpl('desktop_set_shiny_dialog_url');
+      GwtCallback.unimpl('desktop_set_shiny_dialog_url');
     });
 
     ipcMain.handle('desktop_get_scrolling_compensation_type', (event) => {
-      DesktopCallback.unimpl('desktop_get_scrolling_compensation_type');
+      GwtCallback.unimpl('desktop_get_scrolling_compensation_type');
       return '';
     });
 
@@ -470,7 +470,7 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_install_rtools', (event, version, installerPath) => {
-      DesktopCallback.unimpl('desktop_install_rtools');
+      GwtCallback.unimpl('desktop_install_rtools');
     });
 
     ipcMain.handle('desktop_get_display_dpi', (event) => {
@@ -478,11 +478,11 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_on_session_quit', (event) => {
-      DesktopCallback.unimpl('desktop_on_session_quit');
+      GwtCallback.unimpl('desktop_on_session_quit');
     });
 
     ipcMain.handle('desktop_get_session_server', (event) => {
-      DesktopCallback.unimpl('desktop_get_session_server');
+      GwtCallback.unimpl('desktop_get_session_server');
       return {};
     });
 
@@ -491,57 +491,57 @@ export class DesktopCallback {
     });
 
     ipcMain.on('desktop_reconnect_to_session_server', (event, sessionServerJson) => {
-      DesktopCallback.unimpl('desktop_reconnect_to_session_server');
+      GwtCallback.unimpl('desktop_reconnect_to_session_server');
     });
 
     ipcMain.handle('desktop_set_launcher_server', (event, sessionServerJson) => {
-      DesktopCallback.unimpl('desktop_set_launcher_server');
+      GwtCallback.unimpl('desktop_set_launcher_server');
       return false;
     });
 
     ipcMain.on('desktop_connect_to_launcher_server', (event) => {
-      DesktopCallback.unimpl('desktop_connect_to_launcher_server');
+      GwtCallback.unimpl('desktop_connect_to_launcher_server');
     });
 
     ipcMain.handle('desktop_get_launcher_server', (event) => {
-      DesktopCallback.unimpl('desktop_get_launcher_server');
+      GwtCallback.unimpl('desktop_get_launcher_server');
       return {};
     });
 
     ipcMain.on('desktop_start_launcher_job_status_stream', (event, jobId) => {
-      DesktopCallback.unimpl('desktop_start_launcher_job_status_stream');
+      GwtCallback.unimpl('desktop_start_launcher_job_status_stream');
     });
 
     ipcMain.on('desktop_stop_launcher_job_status_stream', (event, jobId) => {
-      DesktopCallback.unimpl('desktop_stop_launcher_job_status_stream');
+      GwtCallback.unimpl('desktop_stop_launcher_job_status_stream');
     });
 
     ipcMain.on('desktop_start_launcher_job_output_stream', (event, jobId) => {
-      DesktopCallback.unimpl('desktop_start_launcher_job_output_stream');
+      GwtCallback.unimpl('desktop_start_launcher_job_output_stream');
     });
 
     ipcMain.on('desktop_stop_launcher_job_output_stream', (event, jobId) => {
-      DesktopCallback.unimpl('desktop_stop_launcher_job_output_stream');
+      GwtCallback.unimpl('desktop_stop_launcher_job_output_stream');
     });
 
     ipcMain.on('desktop_control_launcher_job', (event, jobId, operation) => {
-      DesktopCallback.unimpl('desktop_control_launcher_job');
+      GwtCallback.unimpl('desktop_control_launcher_job');
     });
 
     ipcMain.on('desktop_submit_launcher_job', (event, job) => {
-      DesktopCallback.unimpl('desktop_submit_launcher_job');
+      GwtCallback.unimpl('desktop_submit_launcher_job');
     });
 
     ipcMain.on('desktop_get_job_container_user', (event) => {
-      DesktopCallback.unimpl('desktop_get_job_container_user');
+      GwtCallback.unimpl('desktop_get_job_container_user');
     });
 
     ipcMain.on('desktop_validate_jobs_config', (event) => {
-      DesktopCallback.unimpl('desktop_validate_jobs_config');
+      GwtCallback.unimpl('desktop_validate_jobs_config');
     });
 
     ipcMain.handle('desktop_get_proxy_port_number', (event) => {
-      DesktopCallback.unimpl('desktop_get_proxy_port_number');
+      GwtCallback.unimpl('desktop_get_proxy_port_number');
       return -1;
     });
   }
@@ -591,5 +591,3 @@ export class DesktopCallback {
     return buttons.split('|');
   }
 }
-
-module.exports = {PendingQuit, DesktopCallback};

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -1,0 +1,20 @@
+/*
+ * gwt-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { RStudioBrowserWindow } from './rstudio-browser-window';
+
+export class GwtWindow extends RStudioBrowserWindow {
+
+}

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -19,25 +19,29 @@ import { ChildProcess } from 'child_process';
 
 import { logger } from '../core/logger';
 
-import { DesktopCallback } from './desktop-callback';
+import { GwtCallback } from './gwt-callback';
 import { MenuCallback } from './menu-callback';
 import { PendingWindow } from './pending-window';
 import { RCommandEvaluator } from './r-command-evaluator';
 import { SessionLauncher } from './session-launcher';
+import { ApplicationLaunch } from './application-launch';
+import { GwtWindow } from './gwt-window';
 
 // corresponds to DesktopMainWindow.cpp/hpp
-export class MainWindow {
+export class MainWindow extends GwtWindow {
   sessionLauncher?: SessionLauncher;
   sessionProcess?: ChildProcess;
+  appLauncher?: ApplicationLaunch;
   window?: BrowserWindow;
-  desktopCallback: DesktopCallback;
+  desktopCallback: GwtCallback;
   menuCallback: MenuCallback;
   quitConfirmed = false;
   workbenchInitialized = false;
   pendingWindows = new Array<PendingWindow>();
 
   constructor(public url: string, public isRemoteDesktop: boolean) {
-    this.desktopCallback = new DesktopCallback(this, this, isRemoteDesktop);
+    super();
+    this.desktopCallback = new GwtCallback(this, isRemoteDesktop);
     this.menuCallback = new MenuCallback(this);
 
     RCommandEvaluator.setMainWindow(this);

--- a/src/node/desktop/src/main/rstudio-browser-window.ts
+++ b/src/node/desktop/src/main/rstudio-browser-window.ts
@@ -1,0 +1,20 @@
+/*
+ * rstudio-browser-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { BrowserWindow } from 'electron';
+
+export class RStudioBrowserWindow {
+  window?: BrowserWindow;
+}

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -1,0 +1,20 @@
+/*
+ * satellite-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { GwtWindow } from './gwt-window';
+
+export class SatelliteWindow extends GwtWindow {
+
+}

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -1,0 +1,21 @@
+
+/*
+ * secondary-window.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { RStudioBrowserWindow } from './rstudio-browser-window';
+
+export class SecondaryWindow extends RStudioBrowserWindow {
+
+}

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -22,6 +22,7 @@ import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 
 import { getRStudioVersion } from './product-info';
+import { MainWindow } from './main-window';
 
 export function initializeSharedSecret(): void {
   const sharedSecret = randomString() + randomString() + randomString();
@@ -135,4 +136,9 @@ export function findComponents(): [FilePath, FilePath, FilePath] {
     sessionPath = buildRoot.completePath(`session/${rsessionExeName()}`);
   }
   return [confPath, sessionPath, new FilePath(app.getAppPath())];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function finalPlatformInitialize(mainWindow: MainWindow): void {
+  // TODO - reimplement for each platform
 }

--- a/src/node/desktop/test/unit/core/console-logger.test.ts
+++ b/src/node/desktop/test/unit/core/console-logger.test.ts
@@ -18,7 +18,7 @@ import { assert } from 'chai';
 import sinon from 'sinon';
 
 import { ConsoleLogger } from '../../../src/core/console-logger';
-import { setLoggerLevel, LogLevel } from '../../../src/core/logger';
+import { setLoggerLevel, LogLevel, enableDiagnosticsOutput } from '../../../src/core/logger';
 
 describe('Console-logger', () => {
   let fakeConsoleLog = sinon.fake();
@@ -108,14 +108,27 @@ describe('Console-logger', () => {
     logger.logDebug(msg);
     assert.isFalse(fakeConsoleLog.called);
   });
-  it('logDiagnostic', () => {
+  it('logDiagnostic silent by default', () => {
     const logger = new ConsoleLogger();
+    const msg = 'test diagnostic message';
+    logger.logDiagnostic(msg);
+    assert.isFalse(fakeConsoleLog.called);
+  });
+  it('logDiagnosticEnvVar silent by default', () => {
+    const logger = new ConsoleLogger();
+    logger.logDiagnosticEnvVar('PATH');
+    assert.isFalse(fakeConsoleLog.called);
+  });
+  it('logDiagnostic obeys setting', () => {
+    const logger = new ConsoleLogger();
+    enableDiagnosticsOutput();
     const msg = 'test diagnostic message';
     logger.logDiagnostic(msg);
     assert.isTrue(fakeConsoleLog.calledWith(msg));
   });
-  it('logDiagnosticEnvVar', () => {
+  it('logDiagnosticEnvVar obeys setting', () => {
     const logger = new ConsoleLogger();
+    enableDiagnosticsOutput();
     logger.logDiagnosticEnvVar('PATH');
     assert.isTrue(fakeConsoleLog.calledOnce);
   });

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -23,7 +23,7 @@ import os from 'os';
 
 import { FilePath } from '../../../src/core/file-path';
 import { userHomePath } from '../../../src/core/user';
-import { logLevel, setLogger, setLoggerLevel, LogLevel } from '../../../src/core/logger';
+import { setLogger, setLoggerLevel, LogLevel } from '../../../src/core/logger';
 import { ConsoleLogger } from '../../../src/core/console-logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 

--- a/src/node/desktop/test/unit/main/activation-overlay.test.ts
+++ b/src/node/desktop/test/unit/main/activation-overlay.test.ts
@@ -1,0 +1,26 @@
+/*
+ * application-overlay.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { DesktopActivation } from '../../../src/main/activation-overlay';
+
+describe('DesktopActivation', () => {
+  it('returns product edition name', () => {
+    const activation = new DesktopActivation();
+    assert.isNotEmpty(activation.editionName());
+  });
+});

--- a/src/node/desktop/test/unit/main/application-launch.test.ts
+++ b/src/node/desktop/test/unit/main/application-launch.test.ts
@@ -1,0 +1,26 @@
+/*
+ * application-launch.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { ApplicationLaunch } from '../../../src/main/application-launch';
+
+describe('ApplicationLaunch', () => {
+  it('static init returns new instance', () => {
+    const appLaunch = ApplicationLaunch.init();
+    assert.isObject(appLaunch);
+  });
+});

--- a/src/node/desktop/test/unit/main/gwt-callback.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-callback.test.ts
@@ -1,0 +1,30 @@
+/*
+ * gwt-callback.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import { GwtCallback } from '../../../src/main/gwt-callback';
+import { MainWindow } from '../../../src/main/main-window';
+
+describe('DesktopCallback', () => {
+  it('can be constructed', () => {
+    const isRemoteDesktop = false;
+    const mainWindowStub = sinon.createStubInstance(MainWindow);
+    const callback = new GwtCallback(mainWindowStub, isRemoteDesktop);
+    assert.equal(callback.isRemoteDesktop, isRemoteDesktop);
+  });
+});

--- a/src/node/desktop/test/unit/main/main-window.test.ts
+++ b/src/node/desktop/test/unit/main/main-window.test.ts
@@ -1,0 +1,23 @@
+/*
+ * main-window.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+//import { assert } from 'chai';
+
+//import { MainWindow } from '../../../src/main/main-window';
+
+describe('MainWindow', () => {
+  // currently can't instantiate a MainWindow during unit tests due to problems with GwtCallback
+});

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -1,0 +1,30 @@
+/*
+ * menu-callback.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import sinon from 'sinon';
+
+import { MenuCallback } from '../../../src/main/menu-callback';
+import { MainWindow } from '../../../src/main/main-window';
+
+describe('MenuCallback', () => {
+  it('can be constructed', () => {
+    const mainWindowStub = sinon.createStubInstance(MainWindow);
+    const callback = new MenuCallback(mainWindowStub);
+    assert.isNull(callback.mainMenu);
+    assert.equal(callback.mainWindow, mainWindowStub);
+  });
+});

--- a/src/node/desktop/test/unit/main/pending-window.test.ts
+++ b/src/node/desktop/test/unit/main/pending-window.test.ts
@@ -1,0 +1,36 @@
+/*
+ * pending-window.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { PendingWindow } from '../../../src/main/pending-window';
+
+describe('PendingWindow', () => {
+  it('can be constructed', () => {
+    const name = 'foo';
+    const x = 1;
+    const y = 2;
+    const width = 3;
+    const height = 4;
+    const pw = new PendingWindow(name, x, y, width, height);
+    assert.equal(pw.name, name);
+    assert.equal(pw.x, x);
+    assert.equal(pw.y, y);
+    assert.equal(pw.width, width);
+    assert.equal(pw.height, height);
+    assert.isFalse(pw.isEmpty);
+  });
+});


### PR DESCRIPTION
### Intent

The diagnostics logging routines shouldn't display output on console unless the --run-diagnostics flag was provided.

### Approach

Fixed that.

This also includes a bunch of additional work-in-progress on more detailed porting of the current window creation and session launching behavior, including stubs for the various window classes we have in the Qt app. Specifically, the Qt desktop has this class hierarchy (showing both the Qt classes and the RStudio classes):

![Qt Desktop Window Classes](https://user-images.githubusercontent.com/10569626/123353652-d1c0c380-d516-11eb-932d-1f1f626f824f.png)

For Electron, I'm currently leaning towards having the basic window class (`BrowserWindow` in Qt, but `RStudioBrowserWindow` in Electron) contain the Electron `BrowserWindow` instead of inheriting from it.

So added in stubs for this:

![Electron Desktop Window Classes](https://user-images.githubusercontent.com/10569626/123353848-4b58b180-d517-11eb-8711-98a2407cbb8a.png)

These diagrams are made with PlantUML, sources in the `docs` folder, along with a readme.

### Automated Tests

Added additional unit tests.

### QA Notes

Internal details.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


