### PR TITLE
fix separate console output in same line

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
@@ -10,6 +10,7 @@
       overflow: hidden;
       margin: 5px 5px 5px 0px;
       padding: 5px 0px 5px 10px;
+      white-space: pre-line;
    }
 
    .consoleErrorCommands {


### PR DESCRIPTION
### Intent

Currently, the multi-line output of an R Markdown document are placed on the same line.
![Pasted image 20210625203139](https://user-images.githubusercontent.com/1218851/123426971-9eedfc80-d5f6-11eb-93c2-5d3ab69905de.png)

With this pull request, the two lines of output are placed on separate lines.
![Pasted image 20210625203220](https://user-images.githubusercontent.com/1218851/123427297-060bb100-d5f7-11eb-9a0d-cc55ec4714d5.png)

As it is done in the R console.
![Pasted image 20210625205029](https://user-images.githubusercontent.com/1218851/123427344-1754bd80-d5f7-11eb-976a-d6d35942fb7c.png)

Addresses #8992 

### Approach

We now use `white-space` to handle the white space inside the element. 
From the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space): 

> With `pre-line` the sequences of white spaced are colapsed. Lines are broken at newline characters, at `<br>`, and as necessary to fill line boxes

### Automated Tests

N/A

### QA Notes

Tested with running:

    ---
    title: "Untitled"
    output: html_document
    ---
    ```{r}
    library(tidyverse)
    
    mpg %>%
    filter(cyl == 4) %>%
    ggplot(mpg, aes(x = cty, y = hwy)) +
    geom_point()
    ```   



### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


