### PR TITLE
wire MainWindow into window class hierarchy (Electron)

### DIFF
--- a/src/node/desktop/src/main/activation-overlay.ts
+++ b/src/node/desktop/src/main/activation-overlay.ts
@@ -53,7 +53,7 @@ export class DesktopActivation extends EventEmitter {
     * Set main window, so we can supply it as default parent of message boxes
     */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  setMainWindow(window?: BrowserWindow): void {
+  setMainWindow(window: BrowserWindow): void {
   }
 
   /**

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -15,7 +15,6 @@
 
 import { BrowserWindow, WebContents } from 'electron';
 
-import { URL } from 'url';
 import path from 'path';
 
 /**
@@ -37,14 +36,13 @@ export class DesktopBrowserWindow {
   constructor(
     private adjustTitle: boolean,
     private name: string,
-    private baseUrl?: URL,
+    private baseUrl?: string,
     private parent?: DesktopBrowserWindow,
     private opener?: WebContents,
     private allowExternalNavigate = false,
     addApiKeys: string[] = []
   ) {
-    const apiKeys = ['desktopInfo', ...addApiKeys];
-
+    const apiKeys = [['desktopInfo', ...addApiKeys].join('|')];
     this.window = new BrowserWindow({
       // https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
       backgroundColor: '#fff', 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -188,7 +188,7 @@ export class GwtCallback {
     ) => {
       const minimalWindow = openMinimalWindow(name, url, width, height, this.mainWindow);
       minimalWindow.window.once('ready-to-show', () => {
-        minimalWindow.window?.show();
+        minimalWindow.window.show();
       });
     });
 
@@ -478,7 +478,7 @@ export class GwtCallback {
     });
 
     ipcMain.on('desktop_set_window_title', (event, title: string) => {
-      this.mainWindow.window?.setTitle(`${title} - RStudio`);
+      this.mainWindow.window.setTitle(`${title} - RStudio`);
     });
 
     ipcMain.on('desktop_install_rtools', (event, version, installerPath) => {

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -14,7 +14,6 @@
  */
 
 import { WebContents } from 'electron';
-import { URL } from 'url';
 
 import { DesktopBrowserWindow } from './desktop-browser-window';
 
@@ -23,7 +22,7 @@ export class GwtWindow extends DesktopBrowserWindow {
   constructor(
     adjustTitle: boolean,
     name: string,
-    baseUrl?: URL,
+    baseUrl?: string,
     parent?: DesktopBrowserWindow,
     opener?: WebContents,
     isRemoteDesktop = false,

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -26,7 +26,6 @@ export function openMinimalWindow(
   mainWindow: MainWindow
 ): DesktopBrowserWindow {
 
-  const urlStr = url.toString();
   const named = !!name && name !== '_blank';
 
   let browser: DesktopBrowserWindow|undefined = undefined;
@@ -65,7 +64,7 @@ export function openMinimalWindow(
     }
   }
 
-  browser.window.loadURL(urlStr);
+  browser.window.loadURL(url);
   browser.window.setSize(width, height);
   return browser;
 }

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -15,13 +15,12 @@
  */
 
 import { WebContents } from 'electron';
-import { URL } from 'url';
 import { DesktopBrowserWindow } from './desktop-browser-window';
 
 export class SecondaryWindow extends DesktopBrowserWindow {
   constructor(
     name: string,
-    baseUrl?: URL,
+    baseUrl?: string,
     parent?: DesktopBrowserWindow,
     opener?: WebContents,
     allowExternalNavigate = false

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -100,7 +100,8 @@ export class SessionLauncher {
     this.appLaunch.setActivationWindow(this.mainWindow);
 
     // TODO - reimplement
-    // desktop::options().restoreMainWindowBounds(pMainWindow_);
+    // desktop::options().restoreMainWindowBounds(this.mainWindow);
+    this.mainWindow.window.setSize(1200, 900); // TEMP
 
     logger().logDiagnostic('\nConnected to R session, attempting to initialize...\n');
 
@@ -137,11 +138,16 @@ export class SessionLauncher {
     // show the window (but don't if we are doing a --run-diagnostics)
     if (!appState().runDiagnostics) {
       finalPlatformInitialize(this.mainWindow);
-      this.mainWindow.window?.show(); // TODO - don't show until 'ready-to-show' event to avoid flashing?
+      this.mainWindow.window.once('ready-to-show', () => {
+        this.mainWindow?.window.show();
+      });
       appState().activation().setMainWindow(this.mainWindow.window);
       this.appLaunch.activateWindow();
-      this.mainWindow.load(launchContext.url);
+      this.mainWindow.loadUrl(launchContext.url);
     }
+
+    // TODO
+    // qApp->setQuitOnLastWindowClosed(true);
     return Success();
   }
 
@@ -217,7 +223,7 @@ export class SessionLauncher {
 
       // closeAllSatellites();
 
-      this.mainWindow?.window?.webContents.executeJavaScript('window.desktopHooks.notifyRCrashed()')
+      this.mainWindow?.window.webContents.executeJavaScript('window.desktopHooks.notifyRCrashed()')
         .catch(() => {
           // The above can throw if the window has no desktop hooks; this is normal
           // if we haven't loaded the initial session.

--- a/src/node/desktop/src/main/window-tracker.ts
+++ b/src/node/desktop/src/main/window-tracker.ts
@@ -27,7 +27,7 @@ export class WindowTracker {
 
   addWindow(key: string, browserWindow: DesktopBrowserWindow): void {
     this.nameMap.set(key, browserWindow);
-    browserWindow.window?.addListener('closed', () => {
+    browserWindow.window.addListener('closed', () => {
       this.onWindowDestroyed(key);
     });
   }

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -23,6 +23,6 @@ describe('DesktopBrowserWindow', () => {
     const win = new DesktopBrowserWindow(false, '_blank');
     assert.isObject(win);
     assert.isObject(win.window);
-    assert.isFalse(win.window?.isVisible());
+    assert.isFalse(win.window.isVisible());
   });
 });

--- a/src/node/desktop/test/unit/main/gwt-callback.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-callback.test.ts
@@ -16,15 +16,20 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { createSinonStubInstance } from '../unit-utils';
 
 import { GwtCallback } from '../../../src/main/gwt-callback';
 import { MainWindow } from '../../../src/main/main-window';
 
 describe('DesktopCallback', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('can be constructed', () => {
     const isRemoteDesktop = false;
-    const mainWindowStub = sinon.createStubInstance(MainWindow);
-    const callback = new GwtCallback(mainWindowStub, isRemoteDesktop);
+    const mainWindow = createSinonStubInstance(MainWindow);
+    const callback = new GwtCallback(mainWindow, isRemoteDesktop);
     assert.equal(callback.isRemoteDesktop, isRemoteDesktop);
   });
 });

--- a/src/node/desktop/test/unit/main/gwt-window.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-window.test.ts
@@ -23,6 +23,6 @@ describe('GwtWindow', () => {
     const gwtWin = new GwtWindow(false, 'some name');
     assert.isObject(gwtWin);
     assert.isObject(gwtWin.window);
-    assert.isFalse(gwtWin.window?.isVisible());
+    assert.isFalse(gwtWin.window.isVisible());
   });
 });

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -16,13 +16,18 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { createSinonStubInstance } from '../unit-utils';
 
 import { MenuCallback } from '../../../src/main/menu-callback';
 import { MainWindow } from '../../../src/main/main-window';
 
 describe('MenuCallback', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('can be constructed', () => {
-    const mainWindowStub = sinon.createStubInstance(MainWindow);
+    const mainWindowStub = createSinonStubInstance(MainWindow);
     const callback = new MenuCallback(mainWindowStub);
     assert.isNull(callback.mainMenu);
     assert.equal(callback.mainWindow, mainWindowStub);

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -16,6 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { createSinonStubInstance } from '../unit-utils';
 
 import { MainWindow } from '../../../src/main/main-window';
 import { openMinimalWindow } from '../../../src/main/minimal-window';
@@ -26,10 +27,14 @@ describe('minimal-window', () => {
   beforeEach(() => {
     clearApplicationSingleton();
   });
+  afterEach(() => {
+    sinon.restore();
+  });
+
 
   it('can be constructed', () => {
     setApplication(new Application());
-    const mainWindowStub = sinon.createStubInstance(MainWindow);
+    const mainWindowStub = createSinonStubInstance(MainWindow);
     const minWin = openMinimalWindow('test-win', 'about:blank', 640, 480, mainWindowStub);
     assert.isObject(minWin);
   });

--- a/src/node/desktop/test/unit/main/satellite-window.test.ts
+++ b/src/node/desktop/test/unit/main/satellite-window.test.ts
@@ -16,6 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { createSinonStubInstance } from '../unit-utils';
 
 import { BrowserWindow } from 'electron';
 
@@ -23,12 +24,16 @@ import { SatelliteWindow } from '../../../src/main/satellite-window';
 import { MainWindow } from '../../../src/main/main-window';
 
 describe('SatelliteWindow', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
   it('construction creates a hidden BrowserWindow', () => {
-    const mainWindowStub = sinon.createStubInstance(MainWindow);
+    const mainWindowStub = createSinonStubInstance(MainWindow);
     const browserWin = new BrowserWindow({show: false});
     const win = new SatelliteWindow(mainWindowStub, 'satellite window', browserWin.webContents);
     assert.isObject(win);
     assert.isObject(win.window);
-    assert.isFalse(win.window?.isVisible());
+    assert.isFalse(win.window.isVisible());
   });
 });

--- a/src/node/desktop/test/unit/main/secondary-window.test.ts
+++ b/src/node/desktop/test/unit/main/secondary-window.test.ts
@@ -23,6 +23,6 @@ describe('SecondaryWindow', () => {
     const win = new SecondaryWindow('some name');
     assert.isObject(win);
     assert.isObject(win.window);
-    assert.isFalse(win.window?.isVisible());
+    assert.isFalse(win.window.isVisible());
   });
 });

--- a/src/node/desktop/test/unit/main/window-tracker.test.ts
+++ b/src/node/desktop/test/unit/main/window-tracker.test.ts
@@ -60,7 +60,7 @@ describe('window-tracker', () => {
     const tracker = new WindowTracker();
     const oneWin = new DesktopBrowserWindow(false, 'some name');
     tracker.addWindow('one', oneWin);
-    oneWin.window?.close();
+    oneWin.window.close();
     assert.equal(tracker.length(), 0);
   });
 });

--- a/src/node/desktop/test/unit/unit-utils.ts
+++ b/src/node/desktop/test/unit/unit-utils.ts
@@ -13,6 +13,8 @@
  *
  */
 
+import { createStubInstance, StubbableType, SinonStubbedInstance, SinonStubbedMember } from 'sinon';
+
 /**
  * save and clear specific env vars
  */
@@ -35,4 +37,16 @@ export function restore(vars: Record<string, string>): void {
       delete process.env[name];
     }
   }
+}
+
+// From: https://github.com/sinonjs/sinon/issues/1963
+// Sinon can't stub members marked with TypeScript "private" or "protected"
+export type StubbedClass<T> = SinonStubbedInstance<T> & T;
+
+export function createSinonStubInstance<T>(
+  constructor: StubbableType<T>,
+  overrides?: { [K in keyof T]?: SinonStubbedMember<T[K]> },
+): StubbedClass<T> {
+  const stub = createStubInstance<T>(constructor, overrides);
+  return stub as unknown as StubbedClass<T>;
 }

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -377,9 +377,9 @@
   integrity sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==
 
 "@types/node@*", "@types/node@^15.6.1":
-  version "15.12.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.4.tgz#e1cf817d70a1e118e81922c4ff6683ce9d422e26"
-  integrity sha512-zrNj1+yqYF4WskCMOHwN+w9iuD12+dGm0rQ35HLl9/Ouuq52cEtd0CH9qMgrdNmi5ejC1/V7vKEXYubB+65DkA==
+  version "15.12.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
+  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
 
 "@types/node@^14.6.2":
   version "14.17.4"
@@ -406,72 +406,72 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^4.25.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.0.tgz#1a66f03b264844387beb7dc85e1f1d403bd1803f"
-  integrity sha512-KcF6p3zWhf1f8xO84tuBailV5cN92vhS+VT7UJsPzGBm9VnQqfI9AsiMUFUCYHTYPg1uCCo+HyiDnpDuvkAMfQ==
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.1.tgz#c045e440196ae45464e08e20c38aff5c3a825947"
+  integrity sha512-9yfcNpDaNGQ6/LQOX/KhUFTR1sCKH+PBr234k6hI9XJ0VP5UqGxap0AnNwBnWFk1MNyWBylJH9ZkzBXC+5akZQ==
   dependencies:
-    "@typescript-eslint/experimental-utils" "4.28.0"
-    "@typescript-eslint/scope-manager" "4.28.0"
+    "@typescript-eslint/experimental-utils" "4.28.1"
+    "@typescript-eslint/scope-manager" "4.28.1"
     debug "^4.3.1"
     functional-red-black-tree "^1.0.1"
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/experimental-utils@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.0.tgz#13167ed991320684bdc23588135ae62115b30ee0"
-  integrity sha512-9XD9s7mt3QWMk82GoyUpc/Ji03vz4T5AYlHF9DcoFNfJ/y3UAclRsfGiE2gLfXtyC+JRA3trR7cR296TEb1oiQ==
+"@typescript-eslint/experimental-utils@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.1.tgz#3869489dcca3c18523c46018b8996e15948dbadc"
+  integrity sha512-n8/ggadrZ+uyrfrSEchx3jgODdmcx7MzVM2sI3cTpI/YlfSm0+9HEUaWw3aQn2urL2KYlWYMDgn45iLfjDYB+Q==
   dependencies:
     "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.28.0"
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/typescript-estree" "4.28.0"
+    "@typescript-eslint/scope-manager" "4.28.1"
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/typescript-estree" "4.28.1"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
 "@typescript-eslint/parser@^4.25.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.0.tgz#2404c16751a28616ef3abab77c8e51d680a12caa"
-  integrity sha512-7x4D22oPY8fDaOCvkuXtYYTQ6mTMmkivwEzS+7iml9F9VkHGbbZ3x4fHRwxAb5KeuSkLqfnYjs46tGx2Nour4A==
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.1.tgz#5181b81658414f47291452c15bf6cd44a32f85bd"
+  integrity sha512-UjrMsgnhQIIK82hXGaD+MCN8IfORS1CbMdu7VlZbYa8LCZtbZjJA26De4IPQB7XYZbL8gJ99KWNj0l6WD0guJg==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.28.0"
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/typescript-estree" "4.28.0"
+    "@typescript-eslint/scope-manager" "4.28.1"
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/typescript-estree" "4.28.1"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.0.tgz#6a3009d2ab64a30fc8a1e257a1a320067f36a0ce"
-  integrity sha512-eCALCeScs5P/EYjwo6se9bdjtrh8ByWjtHzOkC4Tia6QQWtQr3PHovxh3TdYTuFcurkYI4rmFsRFpucADIkseg==
+"@typescript-eslint/scope-manager@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.1.tgz#fd3c20627cdc12933f6d98b386940d8d0ce8a991"
+  integrity sha512-o95bvGKfss6705x7jFGDyS7trAORTy57lwJ+VsYwil/lOUxKQ9tA7Suuq+ciMhJc/1qPwB3XE2DKh9wubW8YYA==
   dependencies:
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/visitor-keys" "4.28.0"
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/visitor-keys" "4.28.1"
 
-"@typescript-eslint/types@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.0.tgz#a33504e1ce7ac51fc39035f5fe6f15079d4dafb0"
-  integrity sha512-p16xMNKKoiJCVZY5PW/AfILw2xe1LfruTcfAKBj3a+wgNYP5I9ZEKNDOItoRt53p4EiPV6iRSICy8EPanG9ZVA==
+"@typescript-eslint/types@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.1.tgz#d0f2ecbef3684634db357b9bbfc97b94b828f83f"
+  integrity sha512-4z+knEihcyX7blAGi7O3Fm3O6YRCP+r56NJFMNGsmtdw+NCdpG5SgNz427LS9nQkRVTswZLhz484hakQwB8RRg==
 
-"@typescript-eslint/typescript-estree@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.0.tgz#e66d4e5aa2ede66fec8af434898fe61af10c71cf"
-  integrity sha512-m19UQTRtxMzKAm8QxfKpvh6OwQSXaW1CdZPoCaQuLwAq7VZMNuhJmZR4g5281s2ECt658sldnJfdpSZZaxUGMQ==
+"@typescript-eslint/typescript-estree@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.1.tgz#af882ae41740d1f268e38b4d0fad21e7e8d86a81"
+  integrity sha512-GhKxmC4sHXxHGJv8e8egAZeTZ6HI4mLU6S7FUzvFOtsk7ZIDN1ksA9r9DyOgNqowA9yAtZXV0Uiap61bIO81FQ==
   dependencies:
-    "@typescript-eslint/types" "4.28.0"
-    "@typescript-eslint/visitor-keys" "4.28.0"
+    "@typescript-eslint/types" "4.28.1"
+    "@typescript-eslint/visitor-keys" "4.28.1"
     debug "^4.3.1"
     globby "^11.0.3"
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/visitor-keys@4.28.0":
-  version "4.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.0.tgz#255c67c966ec294104169a6939d96f91c8a89434"
-  integrity sha512-PjJyTWwrlrvM5jazxYF5ZPs/nl0kHDZMVbuIcbpawVXaDPelp3+S9zpOz5RmVUfS/fD5l5+ZXNKnWhNYjPzCvw==
+"@typescript-eslint/visitor-keys@4.28.1":
+  version "4.28.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.1.tgz#162a515ee255f18a6068edc26df793cdc1ec9157"
+  integrity sha512-K4HMrdFqr9PFquPu178SaSb92CaWe2yErXyPumc8cYWxFmhgJsNY9eSePmO05j0JhBvf2Cdhptd6E6Yv9HVHcg==
   dependencies:
-    "@typescript-eslint/types" "4.28.0"
+    "@typescript-eslint/types" "4.28.1"
     eslint-visitor-keys "^2.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -779,9 +779,9 @@ camelcase@^6.0.0:
   integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
 caniuse-lite@^1.0.30001219:
-  version "1.0.30001239"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz#66e8669985bb2cb84ccb10f68c25ce6dd3e4d2b8"
-  integrity sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ==
+  version "1.0.30001241"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz#cd3fae47eb3d7691692b406568d7a3e5b23c7598"
+  integrity sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==
 
 chai@^4.3.4:
   version "4.3.4"
@@ -942,9 +942,9 @@ convert-source-map@^1.7.0:
     safe-buffer "~5.1.1"
 
 core-js@^3.6.5:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.1.tgz#6c08ab88abdf56545045ccf5fd81f47f407e7f1a"
-  integrity sha512-h8VbZYnc9pDzueiS2610IULDkpFFPunHwIpl8yRwFahAEEdSpHlTy3h3z3rKq5h11CaUdBEeRViu9AYvbxiMeg==
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.15.2.tgz#740660d2ff55ef34ce664d7e2455119c5bdd3d61"
+  integrity sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -1139,9 +1139,9 @@ electron-packager@^15.2.0:
     yargs-parser "^20.0.0"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.756"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.756.tgz#942cee59cd64d19f576d8d5804eef09cb423740c"
-  integrity sha512-WsmJym1TMeHVndjPjczTFbnRR/c4sbzg8fBFtuhlb2Sru3i/S1VGpzDSrv/It8ctMU2bj8G7g7/O3FzYMGw6eA==
+  version "1.3.762"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.762.tgz#3fa4e3bcbda539b50e3aa23041627063a5cffe61"
+  integrity sha512-LehWjRpfPcK8F1Lf/NZoAwWLWnjJVo0SZeQ9j/tvnBWYcT99qDqgo4raAfS2oTKZjPrR/jxruh85DGgDUmywEA==
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -1460,16 +1460,15 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-glob@^3.1.1:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.5.tgz#7939af2a656de79a4f1901903ee8adcaa7cb9661"
-  integrity sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.6.tgz#434dd9529845176ea049acc9343e8282765c6e1a"
+  integrity sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.0"
+    glob-parent "^5.1.2"
     merge2 "^1.3.0"
-    micromatch "^4.0.2"
-    picomatch "^2.2.1"
+    micromatch "^4.0.4"
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1722,7 +1721,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-glob-parent@^5.1.0, glob-parent@^5.1.2, glob-parent@~5.1.0:
+glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -2389,7 +2388,7 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.2:
+micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==


### PR DESCRIPTION
### Intent

The `MainWindow` class was standalone, but needs to be part of the class hierarchy (following design of the C++ version).

### Approach

* MainWindow is now subclassed from GwtWindow. Also switched to passing URL as a string instead of via URL class. Might change mind on that later but it was causing problems.
* Fixed passing of callback sets to include to work with class hierachy.
* Fixed up references that referred to `this.window?.foo`; window is not optional so the `?` wasn't needed.
* Ran `yarn upgrade` to get latest packages

### Automated Tests

No new tests, but added `createSinonStubInstance` helper to enable creating stubs of classes with members annotated by TypeScript as private or protected.

### QA Notes

Work in progress.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


