### PR TITLE
make GwtCallback a singleton (Electron)

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -13,19 +13,17 @@
  *
  */
 
-import { BrowserWindow } from 'electron';
-
 import { FilePath } from '../core/file-path';
 
 import { DesktopActivation } from './activation-overlay';
 import { Application } from './application';
+import { GwtCallback } from './gwt-callback';
 import { WindowTracker } from './window-tracker';
 
 /**
  * Global application state
  */
 export interface AppState {
-  mainWindow?: BrowserWindow;
   runDiagnostics: boolean;
   sessionPath?: FilePath;
   scriptsPath?: FilePath;
@@ -34,6 +32,7 @@ export interface AppState {
   port: number;
   generateNewPort(): void;
   windowTracker: WindowTracker;
+  gwtCallback?: GwtCallback;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, dialog, BrowserWindow } from 'electron';
+import { app, dialog } from 'electron';
 
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
@@ -30,6 +30,7 @@ import { prepareEnvironment } from './detect_r';
 import { SessionLauncher } from './session-launcher';
 import { DesktopActivation } from './activation-overlay';
 import { WindowTracker } from './window-tracker';
+import { GwtCallback } from './gwt-callback';
 
 // RStudio command-line switches
 export const kRunDiagnosticsOption = '--run-diagnostics';
@@ -43,13 +44,13 @@ export const kVersionJson = '--version-json';
  * The RStudio application
  */
 export class Application implements AppState {
-  mainWindow?: BrowserWindow;
   runDiagnostics = false;
   scriptsPath?: FilePath;
   sessionPath?: FilePath;
   supportPath?: FilePath;
   port = generateRandomPort();
   windowTracker = new WindowTracker();
+  gwtCallback?: GwtCallback;
 
   appLaunch?: ApplicationLaunch;
   sessionLauncher?: SessionLauncher;

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -19,19 +19,19 @@ import { ChildProcess } from 'child_process';
 
 import { logger } from '../core/logger';
 
-import { GwtCallback } from './gwt-callback';
+import { GwtCallback, PendingQuit } from './gwt-callback';
 import { MenuCallback } from './menu-callback';
 import { PendingWindow } from './pending-window';
 import { RCommandEvaluator } from './r-command-evaluator';
 import { SessionLauncher } from './session-launcher';
 import { ApplicationLaunch } from './application-launch';
 import { GwtWindow } from './gwt-window';
+import { appState } from './app-state';
 
 export class MainWindow extends GwtWindow {
   sessionLauncher?: SessionLauncher;
   sessionProcess?: ChildProcess;
   appLauncher?: ApplicationLaunch;
-  desktopCallback: GwtCallback;
   menuCallback: MenuCallback;
   quitConfirmed = false;
   workbenchInitialized = false;
@@ -39,7 +39,7 @@ export class MainWindow extends GwtWindow {
 
   constructor(url: string, public isRemoteDesktop: boolean) {
     super(false, '', url, undefined, undefined, isRemoteDesktop, ['desktop', 'desktopMenuCallback']);
-    this.desktopCallback = new GwtCallback(this, isRemoteDesktop);
+    appState().gwtCallback = new GwtCallback(this, isRemoteDesktop);
     this.menuCallback = new MenuCallback(this);
 
     RCommandEvaluator.setMainWindow(this);
@@ -101,7 +101,7 @@ export class MainWindow extends GwtWindow {
   }
 
   collectPendingQuitRequest(): number {
-    return this.desktopCallback.collectPendingQuitRequest();
+    return appState().gwtCallback?.collectPendingQuitRequest() ?? PendingQuit.PendingQuitNone;
   }
 
   createWindow(width: number, height: number): BrowserWindow {

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -17,6 +17,7 @@ import { WebContents } from 'electron';
 
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
+import { appState } from './app-state';
 
 export class SatelliteWindow extends GwtWindow {
   constructor(
@@ -25,5 +26,6 @@ export class SatelliteWindow extends GwtWindow {
     opener: WebContents
   ) {
     super(true, name, undefined, undefined, opener, mainWindow.isRemoteDesktop, ['desktop']);
+    appState().gwtCallback?.registerOwner(this);
   }
 }

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -198,8 +198,8 @@ export class SessionLauncher {
     if (message) {
       dialog.showErrorBox(appState().activation().editionName(), message);
     }
-    if (appState().mainWindow) {
-      appState().mainWindow?.close();
+    if (this.mainWindow) {
+      this.mainWindow.window.close();
     } else {
       app.exit(EXIT_FAILURE);
     }

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -51,6 +51,9 @@ export function getDesktopBridge() {
           } else {
             callback(result.filePaths[0]);
           }
+        })
+        .catch(error => {
+          console.log(`getOpenFileName bridge: ${error}`); // TODO real logging here?
         });
     },
 

--- a/src/node/desktop/test/unit/main/app-state.test.ts
+++ b/src/node/desktop/test/unit/main/app-state.test.ts
@@ -23,6 +23,9 @@ describe('Appstate', () => {
   beforeEach(() => {
     clearApplicationSingleton();
   });
+  afterEach(() => {
+    clearApplicationSingleton();
+  });
 
   it('fetching appstate before created throws', () => {
     assert.throws(() => appState());

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -25,15 +25,14 @@ import { Application } from '../../../src/main/application';
 
 describe('minimal-window', () => {
   beforeEach(() => {
-    clearApplicationSingleton();
+    setApplication(new Application());
   });
   afterEach(() => {
+    clearApplicationSingleton();
     sinon.restore();
   });
 
-
   it('can be constructed', () => {
-    setApplication(new Application());
     const mainWindowStub = createSinonStubInstance(MainWindow);
     const minWin = openMinimalWindow('test-win', 'about:blank', 640, 480, mainWindowStub);
     assert.isObject(minWin);

--- a/src/node/desktop/test/unit/main/satellite-window.test.ts
+++ b/src/node/desktop/test/unit/main/satellite-window.test.ts
@@ -22,9 +22,16 @@ import { BrowserWindow } from 'electron';
 
 import { SatelliteWindow } from '../../../src/main/satellite-window';
 import { MainWindow } from '../../../src/main/main-window';
+import { clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
+import { Application } from '../../../src/main/application';
 
 describe('SatelliteWindow', () => {
+  beforeEach(() => {
+    setApplication(new Application());
+  });
+
   afterEach(() => {
+    clearApplicationSingleton();
     sinon.restore();
   });
 
@@ -32,8 +39,8 @@ describe('SatelliteWindow', () => {
     const mainWindowStub = createSinonStubInstance(MainWindow);
     const browserWin = new BrowserWindow({show: false});
     const win = new SatelliteWindow(mainWindowStub, 'satellite window', browserWin.webContents);
-    assert.isObject(win);
-    assert.isObject(win.window);
-    assert.isFalse(win.window.isVisible());
+    assert.isObject(win, 'failed isObject test');
+    assert.isObject(win.window, 'failed has window test');
+    assert.isFalse(win.window.isVisible(), 'failed window not visible test');
   });
 });

--- a/src/node/desktop/test/unit/main/session-launcher.test.ts
+++ b/src/node/desktop/test/unit/main/session-launcher.test.ts
@@ -35,7 +35,6 @@ describe('session-launcher', () => {
   };
 
   beforeEach(() => {
-    clearApplicationSingleton();
     setApplication(new Application());
     saveAndClear(saveVars);
   });


### PR DESCRIPTION
### Intent

The GwtCallback in the main process has to be a singleton, and be able to map an event to the window that sent it (for some callbacks, at least, many don't actually care).

### Approach

Hang GwtCallback off the global app state, initialized when the main window is created. Satellite Windows also register for GwtCallbacks when they are created (by notifying the GwtCallback instead of creating a new one per-window which is how I found the problem).

### Automated Tests

Various unit tests updated.

### QA Notes

Internals

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


