### PR TITLE
use RSTUDIO_WHICH_R to find R on windows (dev mode hack)

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -12,7 +12,7 @@
     "@types/chai": "^4.2.18",
     "@types/crc": "^3.4.0",
     "@types/mocha": "^8.2.2",
-    "@types/node": "^15.6.1",
+    "@types/node": "^15.14.0",
     "@types/sinon": "^10.0.2",
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^4.25.0",

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -94,8 +94,32 @@ async function prepareEnvironmentPosix(): Promise<boolean> {
 async function prepareEnvironmentWin32(): Promise<boolean> {
   assert((process.platform === 'win32'));
 
-  dialog.showErrorBox('NYI', 'R detection and environment setup NYI on Windows, cannot continue');
-  return false;
+  // TODO: this is just a hacked-together placeholder for dev purposes
+
+  // check for which R override
+  let rWhichRPath = new FilePath();
+  const whichROverride = getenv('RSTUDIO_WHICH_R');
+  if (!whichROverride) {
+    dialog.showErrorBox(
+      'RSTUDIO_WHICH_R Not Set',
+      'Temporary: RSTUDIO_WHICH_R environment variable must point to R installation folder. Cannot continue.');
+    return false;
+  }
+
+  rWhichRPath = new FilePath(whichROverride);
+  if (!rWhichRPath.existsSync()) {
+    dialog.showErrorBox(
+      'RSTUDIO_WHICH_R Incorrect',
+      `RSTUDIO_WHICH_R environment variable set incorrectly; ${rWhichRPath.getAbsolutePathNative()} not found. Cannot continue.`);
+    return false;
+  }
+
+
+  process.env.R_HOME = rWhichRPath.getAbsolutePathNative();
+  const rPath = rWhichRPath.completeChildPath('bin\\x64');
+  process.env.PATH = `${rPath};${process.env.PATH}`;
+
+  return true;
 }
 
 async function scanForR(rstudioWhichR: FilePath): Promise<FilePath> {

--- a/src/node/desktop/test/unit/main/session-launcher.test.ts
+++ b/src/node/desktop/test/unit/main/session-launcher.test.ts
@@ -55,7 +55,7 @@ describe('session-launcher', () => {
     const localPeer = getenv('RS_LOCAL_PEER');
     if (process.platform === 'win32') {
       assert.isNotEmpty(localPeer);
-      assert.isAbove(-1, localPeer.indexOf(appState().port.toString()));
+      assert.isAbove(localPeer.indexOf(appState().port.toString()), -1);
     } else {
       assert.isEmpty(localPeer);
     }

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -376,10 +376,10 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.2.tgz#91daa226eb8c2ff261e6a8cbf8c7304641e095e0"
   integrity sha512-Lwh0lzzqT5Pqh6z61P3c3P5nm6fzQK/MMHl9UKeneAeInVflBSz1O2EkX6gM6xfJd7FBXBY5purtLx7fUiZ7Hw==
 
-"@types/node@*", "@types/node@^15.6.1":
-  version "15.12.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.12.5.tgz#9a78318a45d75c9523d2396131bd3cca54b2d185"
-  integrity sha512-se3yX7UHv5Bscf8f1ERKvQOD6sTyycH3hdaoozvaLxgUiY5lIGEeH37AD0G0Qi9kPqihPn0HOfd2yaIEN9VwEg==
+"@types/node@*", "@types/node@^15.14.0":
+  version "15.14.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.14.0.tgz#74dbf254fb375551a9d2a71faf6b9dbc2178dc53"
+  integrity sha512-um/+/ip3QZmwLfIkWZSNtQIJNVAqrJ92OkLMeuZrjZMTAJniI7fh8N8OICyDhAJ2mzgk/fmYFo72jRr5HyZ1EQ==
 
 "@types/node@^14.6.2":
   version "14.17.4"
@@ -1139,9 +1139,9 @@ electron-packager@^15.2.0:
     yargs-parser "^20.0.0"
 
 electron-to-chromium@^1.3.723:
-  version "1.3.762"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.762.tgz#3fa4e3bcbda539b50e3aa23041627063a5cffe61"
-  integrity sha512-LehWjRpfPcK8F1Lf/NZoAwWLWnjJVo0SZeQ9j/tvnBWYcT99qDqgo4raAfS2oTKZjPrR/jxruh85DGgDUmywEA==
+  version "1.3.764"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.764.tgz#24c61a7a3c92630f1723078c59e1dbb42648d581"
+  integrity sha512-nI8fb0ePu2LjzGQMoJ2j4wCnpbSMtuXmOZz/dFAduroICL/B9rU6Iwck/oTvXdzZCfN3ZdU5mpY4XCizU2saow==
 
 electron-window@^0.8.0:
   version "0.8.1"
@@ -1151,9 +1151,9 @@ electron-window@^0.8.0:
     is-electron-renderer "^2.0.0"
 
 electron@^13.0.1:
-  version "13.1.4"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.4.tgz#6d20d932a0651c3cba9f09a3d08cbaf5b69aa84b"
-  integrity sha512-4qhRZbRvGqHmMWsCG/kRVF4X8VIq9Nujgm+gXZLBSpiR6uUtMHy7ViBTQZl1PGf6O9Ppxhpr9Yz+k6Um9WoP3Q==
+  version "13.1.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-13.1.5.tgz#faa6127ac3428ec12c14779a6fe0a89b150ce614"
+  integrity sha512-ZoMCcPQNs/zO/Zdb5hq5H+rwRaKrdI3/sfXEwBVMx7f5jwa9jPQB3dZ2+7t59uD9VcFAWsH/pozr8nPPlv0tyw==
   dependencies:
     "@electron/get" "^1.0.1"
     "@types/node" "^14.6.2"
@@ -1568,9 +1568,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.1.0:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.1.tgz#c4b489e80096d9df1dfc97c79871aea7c617c469"
-  integrity sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.0.tgz#da07fb8808050aba6fdeac2294542e5043583f05"
+  integrity sha512-XprP7lDrVT+kE2c2YlfiV+IfS9zxukiIOvNamPNsImNhXadSsQEbosItdL9bUQlCZXR13SvPk20BjWSWLA7m4A==
 
 flora-colossus@^1.0.0:
   version "1.0.1"
@@ -3413,9 +3413,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.3.2:
-  version "4.3.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.4.tgz#3f85b986945bcf31071decdd96cf8bfa65f9dcbc"
-  integrity sha512-uauPG7XZn9F/mo+7MrsRjyvbxFpzemRjKEZXS4AK83oP2KKOJPvb+9cO/gmnv8arWZvhnjVOXz7B49m1l0e9Ew==
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Intent

Make the IDE runnable on Windows (for dev purposes). Currently can't because finding R is NYI on Win32.

### Approach

Use RSTUDIO_WHICH_R env var. This is a temporary hack until we implement the real thing. Fixed a broken win32 unit test in the process.

### Automated Tests

Nothing new, but fixes on that was broken on Windows.

### QA Notes

Development only.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


