### PR TITLE
set logging level with command-line, other misc porting

### DIFF
--- a/src/node/desktop/NEWS-electron.md
+++ b/src/node/desktop/NEWS-electron.md
@@ -1,0 +1,7 @@
+# RStudio "Electron" Release Notes
+
+## Command-line
+
+* `--log-level=LEVEL`: control logging verbosity; from least verbose to 
+most: `OFF`, `ERR`, `WARN`, `INFO`, `DEBUG` (the default is ERR)
+* `--version-json`: output version information on RStudio desktop components, in JSON format, and exit

--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -42,6 +42,25 @@ export interface LogOptions {
   showDiagnostics: boolean;
 }
 
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-empty-function */
+export class NullLogger implements Logger {
+  logError(err: Error): void {
+  }
+  logErrorMessage(message: string): void {
+  }
+  logInfo(message: string): void {
+  }
+  logWarning(warning: string): void {
+  }
+  logDebug(message: string): void {
+  }
+  logDiagnostic(message: string): void {
+  }
+  logDiagnosticEnvVar(name: string): void {
+  }
+}
+
 export function logger(): Logger {
   const logger = coreState().logOptions.logger;
   if (!logger) {
@@ -74,4 +93,29 @@ export function showDiagnosticsOutput(): boolean {
  */
 export function setLoggerLevel(level: LogLevel): void {
   coreState().logOptions.logLevel = level;
+}
+
+/**
+ * Convert a string log level (e.g. 'WARN') to LogLevel enum.
+ * 
+ * @param level String representation of log level
+ * @param defaultLevel Default logging level if unable to parse input
+ * @returns LogLevel enum value 
+ */
+export function parseCommandLineLogLevel(level: string, defaultLevel: LogLevel): LogLevel {
+  level = level.toUpperCase();
+  switch (level) {
+  case 'OFF':
+    return LogLevel.OFF;
+  case 'ERR':
+    return LogLevel.ERR;
+  case 'WARN':
+    return LogLevel.WARN;
+  case 'INFO':
+    return LogLevel.INFO;
+  case 'DEBUG':
+    return LogLevel.DEBUG;
+  default:
+    return defaultLevel;
+  }
 }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -39,6 +39,7 @@ export const kSessionServerUrlOption = '--session-url';
 export const kTempCookiesOption = '--use-temp-cookies';
 export const kVersion = '--version';
 export const kVersionJson = '--version-json';
+export const kLogLevel = 'log-level';
 
 /**
  * The RStudio application

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -79,15 +79,15 @@ export class MainWindow extends GwtWindow {
   }
 
   invokeCommand(cmdId: string): void {
-    this.window.webContents.executeJavaScript(`window.desktopHooks.invokeCommand("${cmdId}")`)
-      .catch(() => {
-        logger().logErrorMessage(`Error: failed to execute desktopHooks.invokeCommand("${cmdId}")`);
+    this.executeJavaScript(`window.desktopHooks.invokeCommand("${cmdId}")`)
+      .catch((error) => {
+        logger().logError(error);
       });
   }
 
   onWorkbenchInitialized(): void {
     this.workbenchInitialized = true;
-    this.window.webContents.executeJavaScript('window.desktopHooks.getActiveProjectDir()')
+    this.executeJavaScript('window.desktopHooks.getActiveProjectDir()')
       .then(projectDir => {
         if (projectDir.length > 0) {
           this.window.setTitle(`${projectDir} - RStudio`);

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -16,9 +16,9 @@
 import { app, dialog } from 'electron';
 
 import { ConsoleLogger } from '../core/console-logger';
-import { LogLevel, setLogger, setLoggerLevel } from '../core/logger';
+import { LogLevel, parseCommandLineLogLevel, setLogger, setLoggerLevel } from '../core/logger';
 
-import { Application } from './application';
+import { Application, kLogLevel } from './application';
 import { setApplication } from './app-state';
 import { parseStatus } from './program-status';
 
@@ -40,9 +40,9 @@ class RStudioMain {
   }
 
   private async startup(): Promise<void> {
-    setLogger(new ConsoleLogger());
-    setLoggerLevel(LogLevel.DEBUG);
     const rstudio = new Application();
+    setLogger(new ConsoleLogger());
+    setLoggerLevel(parseCommandLineLogLevel(app.commandLine.getSwitchValue(kLogLevel), LogLevel.ERR));
     setApplication(rstudio);
 
     if (!parseStatus(await rstudio.beforeAppReady())) {

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -216,6 +216,12 @@ export class SessionLauncher {
   }
 
   onRSessionExited(): void {
+    // if this is a verify-installation session then just quit
+    if (appState().runDiagnostics) {
+      this.mainWindow?.quit();
+      return;
+    }
+
     const pendingQuit = this.mainWindow?.collectPendingQuitRequest();
 
     // if there was no pending quit set then this is a crash

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -15,11 +15,12 @@
 
 import fs from 'fs';
 import path from 'path';
-import { app } from 'electron';
+import { app, WebContents } from 'electron';
 
 import { Xdg } from '../core/xdg';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
+import { logger } from '../core/logger';
 
 import { getRStudioVersion } from './product-info';
 import { MainWindow } from './main-window';
@@ -141,4 +142,10 @@ export function findComponents(): [FilePath, FilePath, FilePath] {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function finalPlatformInitialize(mainWindow: MainWindow): void {
   // TODO - reimplement for each platform
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function executeJavaScript(web: WebContents, cmd: string): Promise<any> {
+  logger().logDebug(`executeJavaScript(${cmd})`);
+  return web.executeJavaScript(cmd);
 }

--- a/src/node/desktop/test/unit/core/logger.test.ts
+++ b/src/node/desktop/test/unit/core/logger.test.ts
@@ -16,37 +16,30 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { Logger, logger, setLogger } from '../../../src/core/logger';
+import { NullLogger, logger, LogLevel, parseCommandLineLogLevel, setLogger } from '../../../src/core/logger';
+import { clearCoreSingleton } from '../../../src/core/core-state';
 
-/* eslint-disable @typescript-eslint/no-unused-vars */
-/* eslint-disable @typescript-eslint/no-empty-function */
-class FakeLogger implements Logger {
-  uniqueId = 123;
-  logError(err: Error): void {
-  }
-  logErrorMessage(message: string): void {
-  }
-  logInfo(message: string): void {
-  }
-  logWarning(warning: string): void {
-  }
-  logDebug(message: string): void {
-  }
-  logDiagnostic(message: string): void {
-  }
-  logDiagnosticEnvVar(name: string): void {
-  }
-}
 
 describe('Logger', () => {
+  beforeEach(() => {
+    clearCoreSingleton();
+  });
+
   it('throws if unset', () => {
     assert.throws(() => { logger(); });
   });
   it('can be set and fetched', () => {
-    const f = new FakeLogger();
+    const f = new NullLogger();
     setLogger(f);
     const fetched = logger();
     assert.exists(logger());
     assert.deepEqual(f, fetched);
+  });
+  it('log level can be parsed from string representation', () => {
+    assert.equal(parseCommandLineLogLevel('OFF', LogLevel.DEBUG), LogLevel.OFF);
+    assert.equal(parseCommandLineLogLevel('ERR', LogLevel.DEBUG), LogLevel.ERR);
+    assert.equal(parseCommandLineLogLevel('WARN', LogLevel.DEBUG), LogLevel.WARN);
+    assert.equal(parseCommandLineLogLevel('INFO', LogLevel.DEBUG), LogLevel.INFO);
+    assert.equal(parseCommandLineLogLevel('DEBUG', LogLevel.OFF), LogLevel.DEBUG);
   });
 });

--- a/src/node/desktop/test/unit/main/window-tracker.test.ts
+++ b/src/node/desktop/test/unit/main/window-tracker.test.ts
@@ -16,11 +16,20 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
+import { NullLogger, setLogger } from '../../../src/core/logger';
+
 import { WindowTracker } from '../../../src/main/window-tracker';
 import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
 import { GwtWindow } from '../../../src/main/gwt-window';
+import { clearCoreSingleton } from '../../../src/core/core-state';
 
 describe('window-tracker', () => {
+  beforeEach(() => {
+    clearCoreSingleton();
+    const f = new NullLogger();
+    setLogger(f);
+  });
+
   it('empty after creation', () => {
     assert.equal(new WindowTracker().length(), 0);
   });


### PR DESCRIPTION
### Intent

The default logging level is ERR, but should have a way to select different logging level.

### Approach

Added command-line switch, `--log-level=LEVEL`. The available levels (case insensitive) are:

- `NONE` (no messages will be logged)
- `ERR` (error messages will be logged)
- `WARN` (warning and error messages will be logged)
- `INFO` (info, warning, and error messages will be logged)
- `DEBUG` (all messages will be logged)

You can use this during development, e.g. `yarn start --log-level=DEBUG`.

Also created a global helper function for `executeJavaScript` (does DEBUG level logging), and a `executeJavaScript` helper in the window base class `RStudioBrowserWindow` which routes through that global helper.

Ported over most of `RStudioBrowserWindow.closeEvent()`.

Created `NEWS-electron.md` to capture news on the Electron port. Will be merged into the global NEWS when we move to public releases of the Electron desktop.

### Automated Tests

Added test for the parsing of command-line logging level to the underlying Enum values, cleaned up some other tests related to logging.

### QA Notes

In the glorious Coming Soon future where you can actually get hold of this mythical Electron RStudio, you too will be able to try this new command-line switch, and marvel.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


