### PR TITLE
close minimal windows with keyboard and when parent closes

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -159,4 +159,9 @@ export class DesktopBrowserWindow {
   executeJavaScript(cmd: string): Promise<any> {
     return executeJavaScript(this.window.webContents, cmd);
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setViewerUrl(url: string): void {
+    // TODO: in the Qt version this is implemented in webPage()
+  }
 }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -193,7 +193,12 @@ export class GwtCallback {
     ipcMain.on('desktop_open_minimal_window', (event: IpcMainEvent, name: string, url: string,
       width: number, height: number
     ) => {
-      const minimalWindow = openMinimalWindow(name, url, width, height);
+      const sender = this.getSender(event.processId, event.frameId);
+      if (!sender) {
+        logger().logWarning('received open_minimal_window from unknown window');
+        return;
+      }
+      const minimalWindow = openMinimalWindow(sender, name, url, width, height);
       minimalWindow.window.once('ready-to-show', () => {
         minimalWindow.window.show();
       });
@@ -349,9 +354,9 @@ export class GwtCallback {
     });
 
     ipcMain.on('desktop_zoom_actual_size', (event) => {
-      const owner = this.getOwner(event.processId, event.frameId);
-      if (owner) {
-        owner.window.webContents.zoomFactor = 1.0;
+      const sender = this.getSender(event.processId, event.frameId);
+      if (sender) {
+        sender.window.webContents.zoomFactor = 1.0;
       } else {
         logger().logWarning('received zoom_actual_size from unknown window');
       }
@@ -465,9 +470,9 @@ export class GwtCallback {
     });
   
     ipcMain.on('desktop_set_viewer_url', (event, url) => {
-      const owner = this.getOwner(event.processId, event.frameId);
-      if (owner) {
-        owner.setViewerUrl(url);
+      const sender = this.getSender(event.processId, event.frameId);
+      if (sender) {
+        sender.setViewerUrl(url);
       }
     });
 
@@ -652,7 +657,7 @@ export class GwtCallback {
    * @param event
    * @returns Registered GwtWindow that sent the event (or undefined if not found)
    */
-  getOwner(processId: number, frameId: number): GwtWindow | undefined {
+  getSender(processId: number, frameId: number): GwtWindow | undefined {
     // TODO: probably(?) need to use both processId and frameId to make this determination
     for (const win of this.owners) {
       if (win.window.webContents.getProcessId() === processId) {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -193,7 +193,7 @@ export class GwtCallback {
     ipcMain.on('desktop_open_minimal_window', (event: IpcMainEvent, name: string, url: string,
       width: number, height: number
     ) => {
-      const minimalWindow = openMinimalWindow(name, url, width, height, this.mainWindow);
+      const minimalWindow = openMinimalWindow(name, url, width, height);
       minimalWindow.window.once('ready-to-show', () => {
         minimalWindow.window.show();
       });
@@ -465,7 +465,10 @@ export class GwtCallback {
     });
   
     ipcMain.on('desktop_set_viewer_url', (event, url) => {
-      GwtCallback.unimpl('desktop_set_viewer_url');
+      const owner = this.getOwner(event.processId, event.frameId);
+      if (owner) {
+        owner.setViewerUrl(url);
+      }
     });
 
     ipcMain.on('desktop_reload_viewer_zoom_window', (event, url) => {
@@ -650,6 +653,7 @@ export class GwtCallback {
    * @returns Registered GwtWindow that sent the event (or undefined if not found)
    */
   getOwner(processId: number, frameId: number): GwtWindow | undefined {
+    // TODO: probably(?) need to use both processId and frameId to make this determination
     for (const win of this.owners) {
       if (win.window.webContents.getProcessId() === processId) {
         return win;

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -15,15 +15,12 @@
 
 import { appState } from './app-state';
 import { DesktopBrowserWindow } from './desktop-browser-window';
-import { MainWindow } from './main-window';
 
 export function openMinimalWindow(
   name: string,
   url: string,
   width: number,
-  height: number,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  mainWindow: MainWindow
+  height: number
 ): DesktopBrowserWindow {
 
   const named = !!name && name !== '_blank';

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -15,8 +15,10 @@
 
 import { appState } from './app-state';
 import { DesktopBrowserWindow } from './desktop-browser-window';
+import { GwtWindow } from './gwt-window';
 
 export function openMinimalWindow(
+  sender: GwtWindow,
   name: string,
   url: string,
   width: number,
@@ -31,26 +33,32 @@ export function openMinimalWindow(
   }
 
   if (!browser) {
-    const isViewerZoomWindow = name === '_rstudio_viewer_zoom';
+    const isViewerZoomWindow = (name === '_rstudio_viewer_zoom');
 
-    // TODO
     // create the new browser window; pass along our own base URL so that the new window's
     // WebProfile knows how to apply the appropriate headers
-    browser = new DesktopBrowserWindow(false, !isViewerZoomWindow, name,
-      // TODO
-      // pMainWindow_->webView()->baseUrl(), nullptr, pMainWindow_->webPage());
-      undefined);
-      
-    // TODO  https://www.electronjs.org/docs/tutorial/keyboard-shortcuts#shortcuts-within-a-browserwindow
-    //     // ensure minimal windows can be closed with Ctrl+W (Cmd+W on macOS)
-    //     QAction* closeWindow = new QAction(browser);
-    //     closeWindow->setShortcut(Qt::CTRL + Qt::Key_W);
-    //     connect(closeWindow, &QAction::triggered,
-    //             browser, &BrowserWindow::close);
-    //     browser->addAction(closeWindow);
-      
-    //     connect(this, &GwtCallback::destroyed, browser, &BrowserWindow::close);
-      
+    browser = new DesktopBrowserWindow(
+      false,
+      !isViewerZoomWindow,
+      name,
+      '', // TODO pMainWindow_->webView()->baseUrl()
+      sender,
+      undefined /* opener */);
+
+    // ensure minimal windows can be closed with Ctrl+W (Cmd+W on macOS)
+    browser.window.webContents.on('before-input-event', (event, input) => {
+      const ctrlOrMeta = (process.platform === 'darwin') ? input.meta : input.control;
+      if (ctrlOrMeta && input.key.toLowerCase() === 'w') {
+        event.preventDefault();
+        browser?.window.close();
+      }
+    });
+
+    // ensure minimal window closes when creating window closes
+    sender.window.on('closed', () => {
+      browser?.window.close();
+    });
+
     if (named) {
       appState().windowTracker.addWindow(name, browser);
     }

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -15,10 +15,7 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
-import sinon from 'sinon';
-import { createSinonStubInstance } from '../unit-utils';
 
-import { MainWindow } from '../../../src/main/main-window';
 import { openMinimalWindow } from '../../../src/main/minimal-window';
 import { clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
 import { Application } from '../../../src/main/application';
@@ -29,12 +26,10 @@ describe('minimal-window', () => {
   });
   afterEach(() => {
     clearApplicationSingleton();
-    sinon.restore();
   });
 
   it('can be constructed', () => {
-    const mainWindowStub = createSinonStubInstance(MainWindow);
-    const minWin = openMinimalWindow('test-win', 'about:blank', 640, 480, mainWindowStub);
+    const minWin = openMinimalWindow('test-win', 'about:blank', 640, 480);
     assert.isObject(minWin);
   });
 });

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -19,6 +19,7 @@ import { assert } from 'chai';
 import { openMinimalWindow } from '../../../src/main/minimal-window';
 import { clearApplicationSingleton, setApplication } from '../../../src/main/app-state';
 import { Application } from '../../../src/main/application';
+import { GwtWindow } from '../../../src/main/gwt-window';
 
 describe('minimal-window', () => {
   beforeEach(() => {
@@ -29,7 +30,8 @@ describe('minimal-window', () => {
   });
 
   it('can be constructed', () => {
-    const minWin = openMinimalWindow('test-win', 'about:blank', 640, 480);
+    const gwtWindow = new GwtWindow(false, false, '');
+    const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
     assert.isObject(minWin);
   });
 });


### PR DESCRIPTION
### Intent

Minimal windows should close with Ctrl+W (Cmd+W on Mac), and automatically close when the window that opened them closes.

### Approach

Add keyboard support for closing, and an event handler to ensure closing when parent closes.

### Automated Tests

Updated existing unit tests.

### QA Notes

Work in progress, getting close to full implementation of minimal windows, still some work to do on ensuring they are locked down in terms of what they are allowed to load.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


