### PR TITLE
Use a different DB for OS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,8 +17,8 @@
 * Log files will now rotate by time in addition to the existing rotation by file size. This can be controlled by the `rotate-days` parameter in `logging.conf`.
 * For more information, see section 2 of the Admin Guide.
 
-### Internal Databse
-* Add a separate schema for OS Server instances (`rstudio-os`) and Workbench instances (`rstudio`) to avoid conflicts (Pro #2725)
+### Internal Database
+* Use separate database schema for open source RStudio Server instances (`rstudio-os`) and RStudio Workbench instances (`rstudio`) to avoid conflicts (Pro #2725)
 
 ### Bugfixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,8 @@
 * Log files will now rotate by time in addition to the existing rotation by file size. This can be controlled by the `rotate-days` parameter in `logging.conf`.
 * For more information, see section 2 of the Admin Guide.
 
+### Internal Databse
+* Add a separate schema for OS Server instances (`rstudio-os`) and Workbench instances (`rstudio`) to avoid conflicts (Pro #2725)
 
 ### Bugfixes
 

--- a/src/cpp/server_core/CMakeLists.txt
+++ b/src/cpp/server_core/CMakeLists.txt
@@ -24,6 +24,7 @@ set (SERVER_CORE_SOURCE_FILES
    RVersionsScanner.cpp
    SecureKeyFile.cpp
    ServerDatabase.cpp
+   ServerLicense.cpp
    sessions/SessionSignature.cpp
    system/Pam.cpp
    UrlPorts.cpp

--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -48,7 +48,7 @@ constexpr const char* kDefaultSqliteDatabaseDirectory = "/var/lib/rstudio-server
 constexpr const char* kDatabaseHost = "host";
 constexpr const char* kDefaultDatabaseHost = "localhost";
 constexpr const char* kDatabaseName = "database";
-constexpr const char* kDefaultDatabaseName = "rstudio";
+constexpr const char* kDefaultDatabaseName = "rstudio-os";
 constexpr const char* kDatabasePort = "port";
 constexpr const char* kDefaultPostgresqlDatabasePort = "5432";
 constexpr const char* kDatabaseUsername = "username";
@@ -122,7 +122,7 @@ Error readOptions(const std::string& databaseConfigFile,
 
       // get the database directory - if not specified, we fallback to a hardcoded default path
       FilePath databaseDirectory = FilePath(settings.get(kSqliteDatabaseDirectory, kDefaultSqliteDatabaseDirectory));
-      FilePath databaseFile = databaseDirectory.completeChildPath("rstudio.sqlite");
+      FilePath databaseFile = databaseDirectory.completeChildPath(std::string(kDefaultDatabaseName) + ".sqlite");
       options.file = databaseFile.getAbsolutePath();
       options.poolSize = settings.getInt(kConnectionPoolSize, 0);
 

--- a/src/cpp/server_core/ServerLicense.cpp
+++ b/src/cpp/server_core/ServerLicense.cpp
@@ -1,0 +1,30 @@
+/*
+ * ServerLicense.cpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ */
+
+#include <server_core/ServerLicense.hpp>
+
+#include <shared_core/Error.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace server_core {
+namespace license {
+
+bool isProfessionalEdition()
+{
+   return false;
+}
+
+Error initialize()
+{
+   return Success();
+}
+
+} // namespace license
+} // namespace server
+} // namespace rstudio

--- a/src/cpp/server_core/include/server_core/ServerLicense.hpp
+++ b/src/cpp/server_core/include/server_core/ServerLicense.hpp
@@ -1,0 +1,30 @@
+/*
+ * ServerLicense.hpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ */
+
+#ifndef SERVER_LICENSE_HPP
+#define SERVER_LICENSE_HPP
+
+namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+
+namespace rstudio {
+namespace server_core {
+namespace license {
+
+bool isProfessionalEdition();
+
+core::Error initialize();
+
+} // namespace license
+} // namespace server
+} // namespace rstudio
+
+#endif // SERVER_LICENSE_HPP
+


### PR DESCRIPTION
### Intent

Addresses [Pro #2725](https://github.com/rstudio/rstudio-pro/issues/2725).

### Approach

To avoid any possible conflicts and reduce the testing matrix, we will store OS and Pro/Workbench in different schemas. I chose to keep Pro/Workbench in the existing `rstudio` schema, since it currently stores more information.

I will need to merge this PR  and a companion Workbench PR in sync to ensure Workbench keeps the `rstudio` schema.

Note: Should we implement something that moves existing revoked cookies from the `rstudio` schema into the `rstudio-os` schema?

### Automated Tests

There are already DB tests, and any OS Server automated tests around revoked cookies should cover this change.

### QA Notes

We discovered the bug listed above during development, so don't have an active repro for it. The best way to verify that this works correctly is to install OS, see that it's writing to `rstudio-os.sqlite`, and then install Workbench over it and see that it's writing to `rstudio.sqlite` and the `rstudio-os.sqlite` schema is now untouched. Schema name in postgres should also be `rstudio` for Workbench and `rstudio-os` for OS.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


