### PR TITLE
implement GwtWindow zooming (electron)

### DIFF
--- a/src/node/desktop/src/core/array-utils.ts
+++ b/src/node/desktop/src/core/array-utils.ts
@@ -1,0 +1,46 @@
+/*
+ * array-utils.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+/**
+ * Return next-highest value from an array of choices
+ * @param val Current value
+ * @param choices Array of allowed values
+ * @returns Next highest value, or the highest choice if no higher values
+ */
+export function nextHighest(val: number, choices: number[]): number {
+  if (choices.length === 0) {
+    return val;
+  }
+  let nextVal = choices.find(x => x > val);
+  if (!nextVal) {
+    nextVal = choices.slice(-1)[0];
+  }
+  return nextVal;
+}
+
+/**
+ * Return next-lowest value from an array of choices
+ * @param val Current value
+ * @param choices Array of allowed values
+ * @returns Next lowest value, or the lowest choice if no lower values
+ */
+export function nextLowest(val: number, choices: number[]): number {
+  if (choices.length === 0) {
+    return val;
+  }
+  let index = choices.findIndex(x => x >= val);
+  index = (index <= 0) ? 0 : --index;
+  return choices[index];
+}

--- a/src/node/desktop/src/main/activation-overlay.ts
+++ b/src/node/desktop/src/main/activation-overlay.ts
@@ -16,13 +16,10 @@
 import { BrowserWindow } from 'electron';
 import { EventEmitter } from 'events';
 
-export enum ActivationEvents {
-  LAUNCH_FIRST_SESSION = 'launchFirstSession',
-  LAUNCH_ERROR = 'launchError'
-}
-
 /* eslint-disable @typescript-eslint/no-empty-function */
 export class DesktopActivation extends EventEmitter {
+  static LAUNCH_FIRST_SESSION = 'desktop-activation-launch_first_session';
+  static LAUNCH_ERROR = 'desktop-activation-launch_error';
 
   getInitialLicense(): void {
     this.emitLaunchFirstSession();
@@ -80,7 +77,7 @@ export class DesktopActivation extends EventEmitter {
    * start a session after validating initial license
    */
   emitLaunchFirstSession(): void {
-    this.emit(ActivationEvents.LAUNCH_FIRST_SESSION);
+    this.emit(DesktopActivation.LAUNCH_FIRST_SESSION);
   }
 
   /**
@@ -88,7 +85,7 @@ export class DesktopActivation extends EventEmitter {
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   emitLaunchError(message: string): void {
-    this.emit(ActivationEvents.LAUNCH_ERROR, message);
+    this.emit(DesktopActivation.LAUNCH_ERROR, message);
   }
 
   /**

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -24,7 +24,7 @@ import { getenv, setenv } from '../core/environment';
 
 import { ApplicationLaunch } from './application-launch';
 import { appState } from './app-state';
-import { ActivationEvents } from './activation-overlay';
+import { DesktopActivation } from './activation-overlay';
 import { EXIT_FAILURE } from './program-status';
 import { MainWindow } from './main-window';
 import { PendingQuit } from './gwt-callback';
@@ -51,8 +51,8 @@ export class SessionLauncher {
   ) { }
 
   launchFirstSession(): void {
-    appState().activation().on(ActivationEvents.LAUNCH_FIRST_SESSION, this.onLaunchFirstSession.bind(this));
-    appState().activation().on(ActivationEvents.LAUNCH_ERROR, this.onLaunchError.bind(this));
+    appState().activation().on(DesktopActivation.LAUNCH_FIRST_SESSION, this.onLaunchFirstSession.bind(this));
+    appState().activation().on(DesktopActivation.LAUNCH_ERROR, this.onLaunchError.bind(this));
 
     // This will ultimately trigger one of the above events to continue with startup (or failure).
     appState().activation().getInitialLicense();

--- a/src/node/desktop/src/main/web-view.ts
+++ b/src/node/desktop/src/main/web-view.ts
@@ -1,0 +1,42 @@
+/*
+ * web-view.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { WebContents } from 'electron';
+import { EventEmitter } from 'stream';
+
+export class WebView extends EventEmitter {
+  static CLOSE_WINDOW_SHORTCUT = 'webview-close_window_shortcut';
+
+  constructor(
+    public webContents: WebContents,
+    public baseUrl?: string,
+    public allowExternalNavigate: boolean = false
+  ) {
+    super();
+    this.webContents.on('before-input-event', (event, input) => {
+      this.keyPressEvent(event, input);
+    });
+  }
+
+  keyPressEvent(event: Electron.Event, input: Electron.Input): void {
+    if (process.platform === 'darwin') {
+      if (input.meta && input.key.toLowerCase() === 'w') {
+        // on macOS, intercept Cmd+W and emit the window close signal
+        this.emit(WebView.CLOSE_WINDOW_SHORTCUT);
+        event.preventDefault();
+      }
+    }
+  }
+}

--- a/src/node/desktop/test/unit/core/array-utils.test.ts
+++ b/src/node/desktop/test/unit/core/array-utils.test.ts
@@ -1,0 +1,65 @@
+/*
+ * array-utils.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { nextLowest, nextHighest } from '../../../src/core/array-utils';
+
+describe('array-util', () => {
+
+  const choices = [1, 3, 9, 11, 17];
+
+  describe('nextLowest', () => {
+    it('returns next lowest choice', () => {
+      const current = 9;
+      assert.equal(nextLowest(current, choices), 3);
+    });
+    it('returns lowest choice when already at bottom', () => {
+      const current = 1;
+      assert.equal(nextLowest(current, choices), 1);
+    });
+    it('returns next lowest choice when between choices', () => {
+      const current = 5;
+      assert.equal(nextLowest(current, choices), 3);
+    });
+    it('returns current value if no choices', () => {
+      const noChoices: number[] = [];
+      const current = 5;
+      assert.equal(nextLowest(current, noChoices), 5);
+    });
+  });
+
+  describe('nextHighest', () => {
+    it('returns next highest choice', () => {
+      const current = 9;
+      assert.equal(nextHighest(current, choices), 11);
+    });
+    it('returns highest choice when already at top', () => {
+      const current = 17;
+      assert.equal(nextHighest(current, choices), 17);
+    });
+    it('returns next highest choice when between choices', () => {
+      const current = 10;
+      assert.equal(nextHighest(current, choices), 11);
+    });
+    it('returns current value if no choices', () => {
+      const noChoices: number[] = [];
+      const current = 5;
+      assert.equal(nextHighest(current, noChoices), 5);
+    });
+  });
+});
+ 

--- a/src/node/desktop/test/unit/main/web-view.test.ts
+++ b/src/node/desktop/test/unit/main/web-view.test.ts
@@ -1,0 +1,28 @@
+/*
+ * web-view.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { WebView } from '../../../src/main/web-view';
+import { BrowserWindow } from 'electron';
+
+describe('WebView', () => {
+  it('can be created', () => {
+    const window = new BrowserWindow({ show: false });
+    const webView = new WebView(window.webContents);
+    assert.isObject(webView);
+  });
+});


### PR DESCRIPTION
### Intent

The `GwtWindow` base class mainly deals with zooming in and out, plus handling Cmd+W on Mac (for source windows and the main window, this shortcut should close source docs and only close the window itself if there are no docs to close).

### Approach

Ported GwtWindow from the C++ code. Assorted other cleanup around events, and making the code align better with some C++-isms to make it easier to track what has or hasn't been ported yet.

### Automated Tests

Added unit tests to some areas.

### QA Notes

Move along, nothing to see here yet.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


