### PR TITLE
Ignore path not found when looking for quarto

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -453,7 +453,11 @@ bool isInstalled(bool refresh)
       }
       else
       {
-         LOG_ERROR(error);
+         // path not found errors are okay here (just means quarto isn't installed)
+         if (!isNotFoundError(error))
+         {
+            LOG_ERROR(error);
+         }
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9563. 

### Approach

Avoid logging path not found errors, which occur during the regular course of operations when testing for quarto installations. 

### Automated Tests

None, logging change only.

### QA Notes

Test via notes in #9563.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


