### PR TITLE
gwtcallback emits event when workbench initialized

### DIFF
--- a/src/node/desktop/src/core/err.ts
+++ b/src/node/desktop/src/core/err.ts
@@ -35,3 +35,11 @@ export type Err = Error | null;
 export function Success(): null {
   return null;
 }
+
+export function isSuccessful(error: Err): boolean {
+  return !error;
+}
+
+export function isFailure(error: Err): boolean {
+  return !!error;
+}

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -769,15 +769,49 @@ export class FilePath {
   /**
    * Removes this file or directory from the filesystem.
    */
-  remove(): Err {
-    throw Error('remove is NYI');
+  async remove(): Promise<Err> {
+    try {
+      await fsPromises.rm(this.path, { recursive: true });
+    } catch (err) {
+      return err;
+    }
+    return Success();
   }
 
   /**
    * Removes this file or directory from the filesystem, if it exists.
    */
-  removeIfExists(): Err {
-    throw Error('removeIfExists is NYI');
+  async removeIfExists(): Promise<Err> {
+    try {
+      await fsPromises.rm(this.path, { force: true, recursive: true });
+    } catch (err) {
+      return err;
+    }
+    return Success();
+  }
+
+  /**
+   * Removes this file or directory from the filesystem.
+   */
+  removeSync(): Err {
+    try {
+      fs.rmSync(this.path, { recursive: true });
+    } catch (err) {
+      return err;
+    }
+    return Success();
+  }
+
+  /**
+   * Removes this file or directory from the filesystem, if it exists.
+   */
+  removeIfExistsSync(): Err {
+    try {
+      fs.rmSync(this.path, { force: true, recursive: true });
+    } catch (err) {
+      return err;
+    }
+    return Success();
   }
 
   /**

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -33,6 +33,8 @@ export interface AppState {
   generateNewPort(): void;
   windowTracker: WindowTracker;
   gwtCallback?: GwtCallback;
+  setScratchTempDir(path: FilePath): void;
+  scratchTempDir(defaultPath: FilePath): FilePath;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -55,7 +55,8 @@ export class Application implements AppState {
 
   appLaunch?: ApplicationLaunch;
   sessionLauncher?: SessionLauncher;
-  activationInst?: DesktopActivation;
+  private activationInst?: DesktopActivation;
+  private scratchPath?: FilePath;
 
   /**
    * Startup code run before app 'ready' event.
@@ -172,5 +173,21 @@ export class Application implements AppState {
 
   generateNewPort(): void {
     this.port = generateRandomPort();
+  }
+
+  setScratchTempDir(path: FilePath): void {
+    this.scratchPath = path;
+  }
+
+  scratchTempDir(defaultPath: FilePath): FilePath {
+    let dir = this.scratchPath;
+    if (!dir?.isEmpty() && dir?.existsSync()) {
+      dir = dir.completeChildPath('tmp');
+      const error = dir.ensureDirectorySync();
+      if (!error) {
+        return dir;
+      }
+    }
+    return defaultPath;
   }
 }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -71,6 +71,47 @@ export class MainWindow extends GwtWindow {
     this.menuCallback.on(MenuCallback.COMMAND_INVOKED, (commandId) => {
       this.invokeCommand(commandId);
     });
+
+    // TODO
+    // connect(&menuCallback_, SIGNAL(zoomActualSize()), this, SLOT(zoomActualSize()));
+    // connect(&menuCallback_, SIGNAL(zoomIn()), this, SLOT(zoomIn()));
+    // connect(&menuCallback_, SIGNAL(zoomOut()), this, SLOT(zoomOut()));
+    // connect(&gwtCallback_, SIGNAL(workbenchInitialized()),
+    //         this, SIGNAL(firstWorkbenchInitialized()));
+
+    appState().gwtCallback?.on(GwtCallback.WORKBENCH_INITIALIZED, () => {
+      this.onWorkbenchInitialized();
+    });
+
+    // connect(&gwtCallback_, SIGNAL(sessionQuit()),
+    //         this, SLOT(onSessionQuit()));
+
+    // connect(webView(), SIGNAL(onCloseWindowShortcut()),
+    //         this, SLOT(onCloseWindowShortcut()));
+
+    // connect(webView(), &WebView::urlChanged,
+    //         this, &MainWindow::onUrlChanged);
+   
+    this.webView.webContents.on('did-finish-load', () => {
+      this.onLoadFinished(true);
+    });
+    this.webView.webContents.on('did-fail-load', () => {
+      this.onLoadFinished(false);
+    });
+
+    // TODO
+    // connect(webPage(), &QWebEnginePage::loadFinished,
+    //         &menuCallback_, &MenuCallback::cleanUpActions);
+
+    // connect(&desktopInfo(), &DesktopInfo::fixedWidthFontListChanged, [this]() {
+    //    QString js = QStringLiteral(
+    //       "if (typeof window.onFontListReady === 'function') window.onFontListReady()");
+    //    this->webPage()->runJavaScript(js);
+    // });
+
+    // connect(qApp, SIGNAL(commitDataRequest(QSessionManager&)),
+    //         this, SLOT(commitDataRequest(QSessionManager&)),
+    //         Qt::DirectConnection);
   }
 
   loadUrl(url: string): void {
@@ -168,5 +209,9 @@ export class MainWindow extends GwtWindow {
 
   onActivated(): void {
     // intentionally left blank
+  }
+
+  onLoadFinished(ok: boolean): void {
+    // TODO
   }
 }

--- a/src/node/desktop/test/unit/core/err.test.ts
+++ b/src/node/desktop/test/unit/core/err.test.ts
@@ -16,7 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { Err, Success } from '../../../src/core/err';
+import { Err, isFailure, isSuccessful, Success } from '../../../src/core/err';
 
 function beSuccessful(): Err {
   return Success();
@@ -27,14 +27,28 @@ function beUnsuccessful(): Err {
 }
 
 describe('Err', () => {
-  describe('Success helper', () => {
-    it('Success return should be falsy', () => {
-      assert.isTrue(beSuccessful() === Success());
-      assert.isNull(beSuccessful());
-    });
-    it('Error return should be truthy', () => {
-      assert.isTrue(beUnsuccessful() !== Success());
-      assert.instanceOf(beUnsuccessful(), Error);
-    });
+  it('Success return should be falsy', () => {
+    assert.isTrue(beSuccessful() === Success());
+    assert.isNull(beSuccessful());
+  });
+  it('Error return should be truthy', () => {
+    assert.isTrue(beUnsuccessful() !== Success());
+    assert.instanceOf(beUnsuccessful(), Error);
+  });
+  it('isSuccessful returns true for success', () => {
+    const result: Err = Success();
+    assert.isTrue(isSuccessful(result));
+  });
+  it('isSuccessful returns false for failure', () => {
+    const result: Err = new Error('oh no');
+    assert.isFalse(isSuccessful(result));
+  });
+  it('isFailure returns true for failure', () => {
+    const result: Err = new Error('whoop');
+    assert.isTrue(isFailure(result));
+  });
+  it('isFailure returns false for success', () => {
+    const result: Err = Success();
+    assert.isFalse(isFailure(result));
   });
 });


### PR DESCRIPTION
### Intent

Reduce coupling (and follow C++ model) by having GwtCallback be an event emitter, starting with the workbench-initialized message.

### Approach

Have GwtCallback emit event instead of directly invoking main-window, and so forth; now sets the scratch path received via that callback as in the C++ code (as another global appState property).

Other changes:

- helpers for testing success/failure of Err result (used in unit tests for readability)
- implement FilePath `remove`, `removeIfExists`, `removeSync`, and `removeIfExistsSync` plus unit tests
- other WIP, mostly some pasted in and commented out (with TODO) C++ code

### Automated Tests

New unit tests for FilePath methods, and for the global scratch path setter/getter.

### QA Notes

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


