### PR TITLE
Adds needsDebugLog() method for conditionally formatting LOG_DEBUG

### DIFF
--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -580,6 +580,11 @@ bool hasStderrLogDestination()
    return hasLogDestination<StderrLogDestination>();
 }
 
+bool needsDebugLog()
+{
+   return logger().MaxLogLevel >= LogLevel::DEBUG;
+}
+
 } // namespace log
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -412,6 +412,11 @@ void logInfoMessage(const std::string& in_message, const std::string& in_section
    logger().writeMessageToDestinations(LogLevel::INFO, in_message, in_section, in_loggedFrom);
 }
 
+bool isLogLevel(LogLevel in_logLevel)
+{
+   return logger().MaxLogLevel >= in_logLevel;
+}
+
 void refreshAllLogDestinations(const log::RefreshParams& in_refreshParams)
 {
    Logger& log = logger();
@@ -578,11 +583,6 @@ bool hasFileLogDestination()
 bool hasStderrLogDestination()
 {
    return hasLogDestination<StderrLogDestination>();
-}
-
-bool needsDebugLog()
-{
-   return logger().MaxLogLevel >= LogLevel::DEBUG;
 }
 
 } // namespace log

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -374,6 +374,8 @@ void removeLogDestination(const std::string& in_destinationId, const std::string
  */
 void removeReloadableLogDestinations();
 
+bool needsDebugLog();
+
 /**
  * @brief Writes an error to the specified output stream.
  *

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -102,22 +102,6 @@ enum class LogMessageFormatType
 };
 
 /**
- * @brief Helper function which cleans the log delimiter character from a string.
- *
- * @param in_str    The string to be cleaned
- *
- * @return The cleaned string.
- */
-std::string cleanDelimiters(const std::string& in_str);
-
-/**
- * @brief Sets the program ID for the logger.
- *
- * @param in_programId       The ID of the program.
- */
-void setProgramId(const std::string& in_programId);
-
-/**
  * @brief Adds an un-sectioned log destination to the logger.
  *
  * If a duplicate destination is added, the duplicate will be ignored.
@@ -140,6 +124,15 @@ void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination);
 void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const std::string& in_section);
 
 /**
+ * @brief Helper function which cleans the log delimiter character from a string.
+ *
+ * @param in_str    The string to be cleaned
+ *
+ * @return The cleaned string.
+ */
+std::string cleanDelimiters(const std::string& in_str);
+
+/**
  * @brief Returns whether or not a file log destination is configured.
  *
  * @return Whether or not a file log destination is configured.
@@ -153,14 +146,13 @@ bool hasFileLogDestination();
  */
 bool hasStderrLogDestination();
 
-/**
- * @brief Replaces logging delimiters with ' ' in the specified string.
- *
- * @param in_toClean    The string from which to clean logging delimiters.
- *
- * @return The cleaned string.
+/** 
+ * @brief Use to write code conditioned on whether logging is configured or not
+ * 
+ * @return true if log messages at this level will be displayed.
  */
-std::string cleanDelims(const std::string& in_toClean);
+bool isLogLevel(log::LogLevel level);
+
 /**
  * @brief Logs an error to all registered destinations.
  *
@@ -374,7 +366,12 @@ void removeLogDestination(const std::string& in_destinationId, const std::string
  */
 void removeReloadableLogDestinations();
 
-bool needsDebugLog();
+/**
+ * @brief Sets the program ID for the logger.
+ *
+ * @param in_programId       The ID of the program.
+ */
+void setProgramId(const std::string& in_programId);
 
 /**
  * @brief Writes an error to the specified output stream.


### PR DESCRIPTION
For some of my debug logging changes, I'd like a way to avoid running some code when debug logging is not enabled.

I decided against adding a new trace level or the trace-feature-flags, at least for now, as I don't think the messages we need at this stage are noisy enough. 

Let me know if there's a better way to do this or if you can think of a better name. Thanks!