### PR TITLE
port the session-launcher launchProcess method

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -14,7 +14,9 @@
  */
 
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
+import { sep } from 'path';
 import { app, WebContents } from 'electron';
 
 import { Xdg } from '../core/xdg';
@@ -148,4 +150,27 @@ export function finalPlatformInitialize(mainWindow: MainWindow): void {
 export function executeJavaScript(web: WebContents, cmd: string): Promise<any> {
   logger().logDebug(`executeJavaScript(${cmd})`);
   return web.executeJavaScript(cmd);
+}
+
+/**
+ * Return a "probably unique" folder name in the system tempdir, with a user-provided
+ * prefix string followed by a randomly generated component.
+ * 
+ * The folder is not created by this call so possible someone else could create it, thus the
+ * "probably unique" nature of this call.
+ * 
+ * @param folderPrefix Custom prefix string to include at the beginning of the folder name.
+ * @returns A fully qualified path in the temporary folder (not actually created).
+ */
+export function getCurrentlyUniqueFolderName(folderPrefix: string): FilePath {
+  const prefix = `${os.tmpdir()}${sep}${folderPrefix}`;
+
+  // should be highly unlikely to ever get stuck in the loop, but just in case...
+  for (let tries = 0; tries < 10; tries++) {
+    const fallbackPath = new FilePath(`${prefix}${randomString()}`);
+    if (!fallbackPath.existsSync()) {
+      return fallbackPath;
+    }
+  }
+  return new FilePath();
 }

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -72,13 +72,11 @@ describe('Application', () => {
       const tmpDir = testDir();
 
       app.setScratchTempDir(tmpDir);
-      console.log(`setting ${tmpDir.getAbsolutePath()}`);
       assert.isFalse(await tmpDir.exists());
       assert.isFalse(!! await tmpDir.ensureDirectory());
 
       const expectedDir = tmpDir.completeChildPath('tmp');
       assert.isFalse(await expectedDir.exists());
-      console.log(`expected is ${expectedDir.getAbsolutePath()}`);
 
       // note, every testDir call returns different random path 
       const scratch = app.scratchTempDir(testDir());

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -34,58 +34,66 @@ describe('Utils', () => {
     restore(envVars);
   });
 
-  describe('Helper functions', () => {
-    it('userLogPath returns a non-empty string', () => {
-      assert.isNotEmpty(Utils.userLogPath().getAbsolutePath());
-    });
-    it('usereWebCachePath returns a non-empty string', () => {
-      assert.isNotEmpty(Utils.userWebCachePath().getAbsolutePath());
-    });
-    it('devicePixelRatio returns 1.0', () => {
-      assert.strictEqual(Utils.devicePixelRatio(), 1.0);
-    });
-    it('randomString genereates a random string', () => {
-      const str1 = Utils.randomString();
-      const str2 = Utils.randomString();
-      const str3 = Utils.randomString();
-      assert.notEqual(str1, str2);
-      assert.notEqual(str1, str3);
-      assert.notEqual(str2, str3);
-    });
-    it('getComponentVersions returns expected JSON', () => {
-      const result = Utils.getComponentVersions();
-      const json: Utils.VersionInfo = JSON.parse(result);
-      assert.isNotEmpty(json.electron);
-      assert.isNotEmpty(json.rstudio);
-      assert.isNotEmpty(json.node);
-      assert.isNotEmpty(json.v8);
-    });
-    it('augmentCommandLineArguments adds contents of env var', () => {
-      assert.isFalse(app.commandLine.hasSwitch('disable-gpu'));
-      assert.isEmpty(getenv('RSTUDIO_CHROMIUM_ARGUMENTS'));
-      setenv('RSTUDIO_CHROMIUM_ARGUMENTS', '--disable-gpu');
-      Utils.augmentCommandLineArguments();
-      assert.isTrue(app.commandLine.hasSwitch('disable-gpu'));
-      unsetenv('RSTUDIO_CHROMIUM_ARGUMENTS');
-    });
-    it('initializeSharedSecret generates a random string in RS_SHARED_SECRET envvar_', () => {
-      const envvar = 'RS_SHARED_SECRET';
-      assert.equal(getenv(envvar).length, 0);
-      Utils.initializeSharedSecret();
-      assert.isAtLeast(getenv(envvar).length, 0);
-    });
-    it('rsessionExeName returns non-empty string', () => {
-      assert.isNotEmpty(Utils.rsessionExeName());
-    });
-    it('removeStaleOptionsLockfile is callable', () => {
-      Utils.removeStaleOptionsLockfile();
-      assert(true);
-    });
-    it('findComponents returns session and scripts paths', () => {
-      process.env.RSTUDIO_CPP_BUILD_OUTPUT = '/somewhere/interesting/';
-      const [, session, scripts] = Utils.findComponents();
-      assert.isNotEmpty(session.getAbsolutePath());
-      assert.isNotEmpty(scripts.getAbsolutePath());
-    });
+  it('userLogPath returns a non-empty string', () => {
+    assert.isNotEmpty(Utils.userLogPath().getAbsolutePath());
+  });
+  it('usereWebCachePath returns a non-empty string', () => {
+    assert.isNotEmpty(Utils.userWebCachePath().getAbsolutePath());
+  });
+  it('devicePixelRatio returns 1.0', () => {
+    assert.strictEqual(Utils.devicePixelRatio(), 1.0);
+  });
+  it('randomString genereates a random string', () => {
+    const str1 = Utils.randomString();
+    const str2 = Utils.randomString();
+    const str3 = Utils.randomString();
+    assert.notEqual(str1, str2);
+    assert.notEqual(str1, str3);
+    assert.notEqual(str2, str3);
+  });
+  it('getComponentVersions returns expected JSON', () => {
+    const result = Utils.getComponentVersions();
+    const json: Utils.VersionInfo = JSON.parse(result);
+    assert.isNotEmpty(json.electron);
+    assert.isNotEmpty(json.rstudio);
+    assert.isNotEmpty(json.node);
+    assert.isNotEmpty(json.v8);
+  });
+  it('augmentCommandLineArguments adds contents of env var', () => {
+    assert.isFalse(app.commandLine.hasSwitch('disable-gpu'));
+    assert.isEmpty(getenv('RSTUDIO_CHROMIUM_ARGUMENTS'));
+    setenv('RSTUDIO_CHROMIUM_ARGUMENTS', '--disable-gpu');
+    Utils.augmentCommandLineArguments();
+    assert.isTrue(app.commandLine.hasSwitch('disable-gpu'));
+    unsetenv('RSTUDIO_CHROMIUM_ARGUMENTS');
+  });
+  it('initializeSharedSecret generates a random string in RS_SHARED_SECRET envvar_', () => {
+    const envvar = 'RS_SHARED_SECRET';
+    assert.equal(getenv(envvar).length, 0);
+    Utils.initializeSharedSecret();
+    assert.isAtLeast(getenv(envvar).length, 0);
+  });
+  it('rsessionExeName returns non-empty string', () => {
+    assert.isNotEmpty(Utils.rsessionExeName());
+  });
+  it('removeStaleOptionsLockfile is callable', () => {
+    Utils.removeStaleOptionsLockfile();
+    assert(true);
+  });
+  it('findComponents returns session and scripts paths', () => {
+    process.env.RSTUDIO_CPP_BUILD_OUTPUT = '/somewhere/interesting/';
+    const [, session, scripts] = Utils.findComponents();
+    assert.isNotEmpty(session.getAbsolutePath());
+    assert.isNotEmpty(scripts.getAbsolutePath());
+  });
+  it('getCurrentlyUniqueFolderName returns a unique foldername with prefix', () => {
+    const folder1 = Utils.getCurrentlyUniqueFolderName('my-prefix-');
+    assert.isFalse(folder1.existsSync()); // shouldn't create folder
+    assert.isTrue(folder1.getAbsolutePath().indexOf('my-prefix-') >= 0); // contains prefix
+  });
+  it('getCurrentlyUniqueFolderName returns a unique foldername for each call', () => {
+    const folder1 = Utils.getCurrentlyUniqueFolderName('my-prefix-');
+    const folder2 = Utils.getCurrentlyUniqueFolderName('my-prefix-');
+    assert.notEqual(folder1, folder2);
   });
 });


### PR DESCRIPTION
### Intent

Currently the SessionLauncher class has two of the C++ methods (launchSession and launchProcess) smooshed into a single method. This came from the prototype. For easier porting and keeping in sync, should split back into two so more closely matches original.

### Approach

Split back into two methods, implementing the Mac-only `fallbackLibraryPath` logic in the process.

### Automated Tests

Added unit tests for the fallback path generation routine.

### QA Notes

Probably a B-flat, but that's because I play trumpet.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


