### PR TITLE
handle escapes in quoted symbols

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -213,11 +213,10 @@ private:
    Error matchRawStringLiteral(RToken* pToken);
    
    RToken matchWhitespace();
-   RToken matchStringLiteral();
    RToken matchNumber();
    RToken matchIdentifier();
-   RToken matchQuotedIdentifier();
    RToken matchComment();
+   RToken matchDelimited();
    RToken matchUserOperator();
    RToken matchOperator();
    bool eol();

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -310,6 +310,13 @@ test_context("RTokenizer")
       expect_true(rTokens.at(0).isType(RToken::STRING));
    }
    
+   test_that("escapes within symbol names are handled")
+   {
+      RTokens rTokens(L"`a \\` b`");
+      expect_true(rTokens.size() == 1);
+      expect_true(rTokens.at(0).isType(RToken::ID));
+   }
+   
 }
 
 } // namespace r_util

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -42,7 +42,6 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
   {
     var rules = {};
 
-
     rules["start"] = [
       {
         // escaped '@' sign
@@ -317,7 +316,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
     rules["#quoted-identifier"] = [
       {
         token : "identifier",
-        regex : "`.*?`",
+        regex : "[`](?:(?:\\\\.)|(?:[^`\\\\]))*?[`]",
         merge : false,
         next  : "start"
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9573.

### Approach

Since R's quoted symbols are parsed the same as R strings, just with backtick delimiters, consolidate that code into a single block.

### Automated Tests

Unit tests included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9573.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
