### PR TITLE
Fix issue preventing adding files to static content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 * Fixed issue where busy sessions can't be interrupted and block basic file operations (#2038)
 * Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
 * Fixed issues causing multiple background jobs to be created when running Shiny applications in the background (#8746, #6904)
+* Fixed issue causing an error when adding files to static content published to RStudio Connect (#9571)
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
 
 

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -241,8 +241,9 @@
    current <- fileExists && 
       file.info(outputPath)$mtime >= file.info(target)$mtime
    
+   # return named list and alias paths (this data goes to the client)
    list(
-      output_file = .rs.scalar(outputPath),
+      output_file = .rs.scalar(.rs.createAliasedPath(outputPath)),
       is_current  = .rs.scalar(current),
       output_file_exists = .rs.scalar(fileExists)
    )

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -996,7 +996,7 @@ public class RSConnectDeploy extends Composite
                         display_.showMessage(GlobalDisplay.MSG_INFO, 
                               "Cannot Add File", 
                               "Only files in the same folder as the " +
-                              "document (" + sourceDir + ") or one of its " +
+                              "document (" + sourceDir.getPath() + ") or one of its " +
                               "sub-folders may be added.");
                         return;
                      }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9571. 

### Approach

There were two small bugs here:

- A path intended for the client was not aliased, with the result that files selected by the user never looked like they were inside the path.
- The error message didn't extract the path correctly.

### Automated Tests

Test automation doesn't currently support publishing; see https://github.com/rstudio/rstudio-ide-automation/issues/131. 

### QA Notes

Note that the self_published step of the repro is important (you can't choose additional files otherwise). 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

