### PR TITLE
support highlighting + syntax for knitr embedded chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
 * Improved ordering of completion results within `library()` calls (#9293)
+* Syntax support for embedded knitr chunks (#9579)
 * Added support for publishing Quarto documents and websites (#9556)
 * Add option to synchronize the Files pane with the current working directory in R (#4615)
 * Add new *Set Working Directory* command to context menu for source files (#6781)

--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -218,6 +218,7 @@ private:
    RToken matchComment();
    RToken matchDelimited();
    RToken matchUserOperator();
+   RToken matchKnitrEmbeddedChunk();
    RToken matchOperator();
    bool eol();
    wchar_t peek();

--- a/src/cpp/core/r_util/RTokenizerTests.cpp
+++ b/src/cpp/core/r_util/RTokenizerTests.cpp
@@ -317,6 +317,12 @@ test_context("RTokenizer")
       expect_true(rTokens.at(0).isType(RToken::ID));
    }
    
+   test_that("knitr chunk embeds are handled")
+   {
+      RTokens rTokens(L"<<chunk>>");
+      expect_true(rTokens.size() == 1);
+   }
+   
 }
 
 } // namespace r_util

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -439,6 +439,14 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       }
     ];
 
+    rules["#knitr-embed"] = [
+      {
+        token: "constant.language",
+        regex: "^[<][<][^>]+[>][>]$",
+        merge: false
+      }
+    ];
+
     rules["#text"] = [
       {
         token : "text",
@@ -451,7 +459,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       "#comment", "#string", "#number",
       "#package-access", "#quoted-identifier",
       "#function-call-or-keyword", "#keyword-or-identifier",
-      "#operator", "#text"
+      "#knitr-embed", "#operator", "#text"
     ]);
 
     rules["afterDollar"] = include([


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9579.

### Approach

Mostly straightforward addition of highlight rules for `<<label>>`.

<img width="173" alt="Screen Shot 2021-07-08 at 12 16 46 PM" src="https://user-images.githubusercontent.com/1976582/124978317-7696d280-dfe6-11eb-815f-c76459b61fa1.png">


### Automated Tests

Unit test included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9579. Confirm that R code diagnostics function even in the presence of knitr embedded chunks, e.g. `<<chunk>>`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
