### PR TITLE
Create empty FilePaths from null paths

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -402,9 +402,9 @@ FilePath::FilePath(const char* in_absolutePath) :
 }
 
 #ifdef _WIN32
-FilePath::FilePath(const wchar* in_absolutePath)
+FilePath::FilePath(const wchar_t* in_absolutePath)
    : m_impl(in_absolutePath ? 
-         new Impl(absolutePath): 
+         new Impl(in_absolutePath):
          new Impl())
 {
 }

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -394,6 +394,22 @@ FilePath::FilePath(const std::wstring& absolutePath)
 }
 #endif
 
+FilePath::FilePath(const char* in_absolutePath) :
+   m_impl(in_absolutePath ? 
+            new Impl(fromString(in_absolutePath)) :
+            new Impl())
+{
+}
+
+#ifdef _WIN32
+FilePath::FilePath(const wchar* in_absolutePath)
+   : m_impl(in_absolutePath ? 
+         new Impl(absolutePath): 
+         new Impl())
+{
+}
+#endif
+
 bool FilePath::operator==(const FilePath& in_other) const
 {
    return m_impl->Path == in_other.m_impl->Path;

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -399,6 +399,10 @@ FilePath::FilePath(const char* in_absolutePath) :
             new Impl(fromString(in_absolutePath)) :
             new Impl())
 {
+   if (in_absolutePath == nullptr)
+   {
+      log::logDebugMessage("Creating an empty FilePath from a null path", ERROR_LOCATION);
+   }
 }
 
 #ifdef _WIN32
@@ -407,6 +411,10 @@ FilePath::FilePath(const wchar_t* in_absolutePath)
          new Impl(in_absolutePath):
          new Impl())
 {
+   if (in_absolutePath == nullptr)
+   {
+      log::logDebugMessage("Creating an empty FilePath from a null path", ERROR_LOCATION);
+   }
 }
 #endif
 

--- a/src/cpp/shared_core/FilePathTests.cpp
+++ b/src/cpp/shared_core/FilePathTests.cpp
@@ -88,6 +88,17 @@ TEST_CASE("Empty File Path tests")
       CHECK(aPath.getRelativePath(pPath) == "a");
    }
 
+   SECTION("Raw string construction")
+   {
+      const char* path = "/a/path";
+      FilePath f1(path);
+      CHECK(f1.getAbsolutePath() == std::string(path));
+
+      const char* empty = NULL;
+      FilePath f2(empty);
+      CHECK(f2.isEmpty());
+   }
+
    SECTION("Comparison (equal, true)")
    {
       FilePath f1, f2;

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -118,6 +118,17 @@ public:
 #endif
 
    /**
+    * @brief Constructor.
+    *
+    * @param in_absolutePath    The string representation of the path.
+    */
+   explicit FilePath(const char* in_absolutePath);
+
+#ifdef _WIN32
+   explicit FilePath(const wchar* in_absolutePath);
+#endif
+
+   /**
     * @brief Comparison operator. File paths are equal if their absolute representations are equal.
     *
     * @param in_other   The file path to compare with this file path.

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -125,7 +125,7 @@ public:
    explicit FilePath(const char* in_absolutePath);
 
 #ifdef _WIN32
-   explicit FilePath(const wchar* in_absolutePath);
+   explicit FilePath(const wchar_t* in_absolutePath);
 #endif
 
    /**


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6486.

### Approach

This fixes crashes that could result from undefined behavior when constructing an `std::string` from a null pointer during construction of a new `FilePath` object. The new behavior is that the following pattern:

```c
const char* empty = NULL;
FilePath path(empty);
```

will just create an empty FilePath (i.e. `FilePath::isEmpty()` will be true)  instead of possibly crashing. 

### Automated Tests

Unit tests covering the new behavior have been added.

### QA Notes

This change is too low-level to test directly, and we don't have repro steps for any crashes suspected to be caused by it, so manual verification probably isn't warranted here. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


