### PR TITLE
catch exception thrown during startup from Finder

### DIFF
--- a/src/node/desktop/scripts/mac-package
+++ b/src/node/desktop/scripts/mac-package
@@ -132,4 +132,5 @@ if ${START}; then
   start 
 else
   package
+  open ./package/RStudio-darwin-x64/
 fi

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -139,10 +139,14 @@ async function scanForRPosix(rstudioWhichR: FilePath): Promise<FilePath> {
   }
 
   // first look for R on the PATH
-  const { stdout } = await asyncExec('/usr/bin/which R', { encoding: 'utf-8' });
-  const R = stdout.trim();
-  if (R) {
-    return new FilePath(R);
+  try {
+    const { stdout } = await asyncExec('/usr/bin/which R', { encoding: 'utf-8' });
+    const R = stdout.trim();
+    if (R) {
+      return new FilePath(R);
+    }
+  } catch (error) {
+    logger().logError(error);
   }
 
   // otherwise, look in some hard-coded locations

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -31,9 +31,7 @@ class RStudioMain {
     try {
       await this.startup();
     } catch (error) {
-      if (!app.isPackaged) {
-        dialog.showErrorBox('Unhandled exception', error.message);
-      }
+      dialog.showErrorBox('Unhandled Exception', error.message);
       console.error(error.message); // logging possibly not available this early in startup
       app.exit(1);
     }


### PR DESCRIPTION
### Intent

Locally packaged RStudio.app (Electron) failing silently when launched from Finder (double-click the app), but working when run from terminal.

There was an uncaught exception trying to run `which R` but only from Finder; presumably a Mac entitlement issue. Also, I had the global "report uncaught exceptions" dialog suppressed in Package builds, making it harder to see what was happening.

### Approach

Show the unhandled exceptions dialog even for package builds. Wrap the attempt to invoke `which R` in try/catch and carry on trying the other approaches if that happens.

Also tweaked the `mac-package` script to open the resulting folder in Finder for easier double-clicking.

### Automated Tests

No new tests.

### QA Notes

Try using the `mac-package` script again, and see if you can launch RStudio.app from finder.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


