### PR TITLE
don't update R variables in Environment pane when Python active

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -233,7 +233,7 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void onEnvironmentObjectAssigned(EnvironmentObjectAssignedEvent event)
          {
-            // ignore changes in R environment when Python is running
+            // ignore changes in R environment when Python is active in Environment pane
             if (StringUtil.equalsIgnoreCase(view_.getActiveLanguage(), "R"))
             {
                view_.addObject(event.getObjectInfo());
@@ -247,7 +247,7 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void onEnvironmentObjectRemoved(EnvironmentObjectRemovedEvent event)
          {
-            // ignore changes in R environment when Python is running
+            // ignore changes in R environment when Python is active in Environment pane
             if (StringUtil.equalsIgnoreCase(view_.getActiveLanguage(), "R"))
             {
                view_.removeObject(event.getObjectName());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java
@@ -233,7 +233,11 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void onEnvironmentObjectAssigned(EnvironmentObjectAssignedEvent event)
          {
-            view_.addObject(event.getObjectInfo());
+            // ignore changes in R environment when Python is running
+            if (StringUtil.equalsIgnoreCase(view_.getActiveLanguage(), "R"))
+            {
+               view_.addObject(event.getObjectInfo());
+            }
          }
       });
 
@@ -243,7 +247,11 @@ public class EnvironmentPresenter extends BasePresenter
          @Override
          public void onEnvironmentObjectRemoved(EnvironmentObjectRemovedEvent event)
          {
-            view_.removeObject(event.getObjectName());
+            // ignore changes in R environment when Python is running
+            if (StringUtil.equalsIgnoreCase(view_.getActiveLanguage(), "R"))
+            {
+               view_.removeObject(event.getObjectName());
+            }
          }
       });
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9400.

### Approach

Right now, R and Python use slightly different code paths towards updating the Environment pane. In particular, `reticulate` uses a centralized "environment changed" event:

https://github.com/rstudio/rstudio/blob/b80b77cf161c01e3a24cda3104f0d743fe3f689a/src/cpp/session/modules/SessionReticulate.R#L1859-L1863

https://github.com/rstudio/rstudio/blob/b80b77cf161c01e3a24cda3104f0d743fe3f689a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/EnvironmentPresenter.java#L258-L271

whereas R uses separate "object added" and "object removed" events. If we see that an R-related update path is being used while Python is active in the Environment pane, then we can drop the change request.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9400.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
