### PR TITLE
support running integration test against packaged build

### DIFF
--- a/src/node/desktop/scripts/update-yarn
+++ b/src/node/desktop/scripts/update-yarn
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+#
+# update-yarn
+#
+# Copyright (C) 2021 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+cd $(dirname "${BASH_SOURCE[0]}")/..
+source "../../../dependencies/tools/rstudio-tools.sh"
+
+section Installing/updating components...
+PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 yarn

--- a/src/node/desktop/test/int/int-utils.ts
+++ b/src/node/desktop/test/int/int-utils.ts
@@ -1,0 +1,69 @@
+/*
+ * int-utils.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+import { ElectronApplication, _electron } from 'playwright';
+import path from 'path';
+import fs from 'fs';
+
+
+interface LaunchArgs {
+  args?: string[],
+  cwd?: string,
+  executablePath?: string,
+}
+
+// Find path to RStudio entrypoint
+function getLaunchArgs(): LaunchArgs {
+  // use the package build if it exists
+  let isPackaged = true;
+  const result: LaunchArgs = {};
+  let entryPoint = '';
+  let executable = '';
+  let cwd = '';
+
+  if (process.platform === 'darwin') {
+    entryPoint = path.join(__dirname, '../../package/RStudio-darwin-x64/RStudio.app/Contents/Resources/app/dist/main/main.js');
+    cwd = path.join(__dirname, '../../package/RStudio-darwin-x64/');
+  } else {
+    // TODO -- other platforms!
+  }
+
+  if (!fs.existsSync(entryPoint)) {
+    // otherwise try the dev build
+    isPackaged = false;
+    entryPoint =  path.join(__dirname, '../../dist/main/main.js');
+  }
+
+  result.args = [entryPoint];
+  result.cwd = cwd;
+
+  if (isPackaged) {
+    if (process.platform === 'darwin') {
+      executable = path.join(__dirname, '../../package/RStudio-darwin-x64/RStudio.app/Contents/MacOS/RStudio');
+    } else {
+      // TODO -- other platforms!
+    }
+  }
+
+  if (executable) {
+    result.executablePath = executable;
+  }
+
+  console.log(result);
+  return result;
+}
+
+export async function launch(): Promise<ElectronApplication> {
+  return await _electron.launch(getLaunchArgs());
+}

--- a/src/node/desktop/test/int/startup.test.ts
+++ b/src/node/desktop/test/int/startup.test.ts
@@ -16,18 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { ElectronApplication, _electron } from 'playwright';
-
-import path from 'path';
-
-// Find path to RStudio entrypoint
-function getMain(): string {
-  return path.join(__dirname, '../../dist/main/main.js');
-}
-
-async function launch(): Promise<ElectronApplication> {
-  return await _electron.launch({ args: [getMain()] });
-}
+import { launch } from './int-utils';
 
 describe('Startup and Exit', async function () {
   this.timeout(15000);


### PR DESCRIPTION
### Intent

We should enable running the integration tests (Playwright) against package builds, not just developer builds.

### Approach

If a package build is found, run tests against it, otherwise run against the dev build. Presumably do something fancier later (e.g. to run in CI, etc).

Currently macOS only.

### Automated Tests

If you've done a package build using the `scripts/mac-package` script, running `yarn testint` will now run the massive test suite (one test) against it instead of the dev build.

This means if you've done a package build but want to run against dev, you'll need to delete the package build.

Also created a script, `scripts/update-yarn` to use instead of just `yarn` if you don't want the playwright install to suck in a whole bunch of browser components we don't need. They are harmless, but take time to download.

### QA Notes

Sync the repo to latest, then run `scripts/update-yarn`, then `scripts/mac-package`, then `yarn testint`.

The startup timing issue is not yet fixed, so if you hit that the test will fail, and you'll need to Ctrl+C and try again.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


