### PR TITLE
support highlight of css / asis chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 ### Misc
 
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
+* Support highlight of 'css' and 'asis' chunks in R Markdown documents (#4821)
 * Improved ordering of completion results within `library()` calls (#9293)
 * Syntax support for embedded knitr chunks (#9579)
 * Added support for publishing Quarto documents and websites (#9556)

--- a/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js
@@ -31,7 +31,10 @@ var YamlHighlightRules = require("mode/yaml_highlight_rules").YamlHighlightRules
 var ShHighlightRules = require("mode/sh_highlight_rules").ShHighlightRules;
 var StanHighlightRules = require("mode/stan_highlight_rules").StanHighlightRules;
 var SqlHighlightRules = require("mode/sql_highlight_rules").SqlHighlightRules;
+var HtmlHighlightRules = require("ace/mode/html_highlight_rules").HtmlHighlightRules;
 var JavaScriptHighlightRules = require("ace/mode/javascript_highlight_rules").JavaScriptHighlightRules;
+var CssHighlightRules = require("ace/mode/css_highlight_rules").CssHighlightRules;
+var TextHighlightRules = require("ace/mode/text_highlight_rules").TextHighlightRules;
 var Utils = require("mode/utils");
 
 function makeDateRegex()
@@ -52,7 +55,7 @@ var RMarkdownHighlightRules = function() {
 
    // use 'firstLine' rule so that YAML rules can apply only there
    this.$rules["firstLine"] = this.$rules["allowBlock"].slice();
-   
+
    // Embed R highlight rules
    Utils.embedRules(
       this,
@@ -128,45 +131,78 @@ var RMarkdownHighlightRules = function() {
 
    // Embed shell scripting highlight rules (sh, bash)
    Utils.embedRules(
-       this,
-       ShHighlightRules,
-       "sh",
-       this.$reShChunkStartString,
-       this.$reChunkEndString,
-       ["start", "listblock", "allowBlock"]
+      this,
+      ShHighlightRules,
+      "sh",
+      this.$reShChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
    );
 
    // Embed stan highlighting rules
    Utils.embedRules(
-       this,
-       StanHighlightRules,
-       "stan",
-       this.$reStanChunkStartString,
-       this.$reChunkEndString,
-       ["start", "listblock", "allowBlock"]
+      this,
+      StanHighlightRules,
+      "stan",
+      this.$reStanChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
    );
 
    // Embed sql highlighting rules
    Utils.embedRules(
-       this,
-       SqlHighlightRules,
-       "sql",
-       this.$reSqlChunkStartString,
-       this.$reChunkEndString,
-       ["start", "listblock", "allowBlock"]
+      this,
+      SqlHighlightRules,
+      "sql",
+      this.$reSqlChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+   // Embed Html highlighting rules
+   Utils.embedRules(
+      this,
+      HtmlHighlightRules,
+      "html",
+      this.$reHtmlChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
    );
 
    // Embed JavaScript highlighting rules
    Utils.embedRules(
-       this,
-       JavaScriptHighlightRules,
-       "js",
-       this.$reJavaScriptChunkStartString,
-       this.$reChunkEndString,
-       ["start", "listblock", "allowBlock"]
+      this,
+      JavaScriptHighlightRules,
+      "js",
+      this.$reJavaScriptChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
    );
 
+   // Embed JavaScript highlighting rules
+   Utils.embedRules(
+      this,
+      CssHighlightRules,
+      "css",
+      this.$reCssChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+   // Embed text highlight rules
+   Utils.embedRules(
+      this,
+      TextHighlightRules,
+      "text",
+      this.$reTextChunkStartString,
+      this.$reChunkEndString,
+      ["start", "listblock", "allowBlock"]
+   );
+
+
+
    // Embed YAML highlighting rules
+   // (Handled specially: should only ever activate on first line of document)
    Utils.embedRules(
       this,
       YamlHighlightRules,
@@ -210,7 +246,10 @@ oop.inherits(RMarkdownHighlightRules, TextHighlightRules);
    this.$reShChunkStartString         = engineRegex("(?:bash|sh)");
    this.$reStanChunkStartString       = engineRegex("stan");
    this.$reSqlChunkStartString        = engineRegex("sql");
+   this.$reHtmlChunkStartString       = engineRegex("html");
    this.$reJavaScriptChunkStartString = engineRegex("(?:d3|js|ojs|observable)");
+   this.$reCssChunkStartString        = engineRegex("css");
+   this.$reTextChunkStartString       = engineRegex("(?:asis|text)");
    
 }).call(RMarkdownHighlightRules.prototype);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/4821.

### Approach

Straight-forward embed of existing Ace highlight rules for CSS + text in R Markdown documents.

<img width="359" alt="Screen Shot 2021-07-14 at 12 51 48 PM" src="https://user-images.githubusercontent.com/1976582/125684203-65724901-078f-4cbe-b069-1ea7b25c133a.png">

### Automated Tests

N/A

### QA Notes

Verify that highlighting is applied in CSS + asis chunks.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
