### PR TITLE
ensure scroll position preserved when re-rendering PDFs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 ### Misc
 
 * **BREAKING:** RStudio Desktop Pro only supports activation with license files (Pro #2300)
+* Fixed an issue where scroll position in PDFs was not preserved on re-render (#9603)
 * Improved ordering of completion results within `library()` calls (#9293)
 * Syntax support for embedded knitr chunks (#9579)
 * Added support for publishing Quarto documents and websites (#9556)

--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/PDFViewer.java
@@ -127,8 +127,11 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
       }
          
       lastSuccessfulPdfPath_ = result.getPdfPath();
-      openPdfUrl(result.getViewPdfUrl(), result.isSynctexAvailable(), 
-                 pdfLocation == null);
+      openPdfUrl(
+            result.getViewPdfUrl(),
+            result.getPdfPath(),
+            result.isSynctexAvailable(), 
+            pdfLocation == null);
    }
 
    @Override
@@ -189,7 +192,15 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
       }
    }
    
-   public void viewPdfUrl(final String url, final Integer initialPage)
+   public void viewPdfUrl(final String url,
+                          final Integer initialPage)
+   {
+      viewPdfUrl(url, null, initialPage);
+   }
+   
+   public void viewPdfUrl(final String url,
+                          final String path,
+                          final Integer initialPage)
    {
       if (initialPage != null)
       {
@@ -202,13 +213,15 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
             }
          };
       }
-      lastSuccessfulPdfPath_ = null;
-      openPdfUrl(url, false, initialPage == null);
+      lastSuccessfulPdfPath_ = path;
+      openPdfUrl(url, path, false, initialPage == null);
    }
   
    // Private methods ---------------------------------------------------------
    
-   private void openPdfUrl(final String url, final boolean synctex, 
+   private void openPdfUrl(final String url,
+                           final String path,
+                           final boolean synctex, 
                            boolean restorePosition)
    {
       int width = 1070;
@@ -216,7 +229,9 @@ public class PDFViewer implements CompilePdfCompletedEvent.Handler,
       Point pos = null;
       
       // if there's a window open, restore the position when we're done
-      if (restorePosition && url == lastSuccessfulPdfUrl_)
+      if (restorePosition && (
+            url == lastSuccessfulPdfUrl_ ||
+            path == lastSuccessfulPdfPath_))
       {
          // if we don't have an active window, we'll use the hash stored when
          // the window closed

--- a/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/pdfviewer/model/PdfJsWindow.java
@@ -237,8 +237,21 @@ public class PdfJsWindow extends WindowEx
    }-*/;
    
    public final native void applyLocationHash(String hash) /*-{
-      if (hash !== null)
-         this.PDFView.setHash(hash);
+      
+      // ignore empty hashes
+      if (hash == null || hash.length === 0) {
+         return;
+      }
+      
+      // add an event listener that waits until the page has been rendered
+      var self = this;
+      var callback = function(event) {
+         self.PDFView.pdfLinkService.setHash(hash);
+         self.removeEventListener(callback);
+      };
+      
+      self.addEventListener("documentload", callback);
+            
    }-*/;
    
    public final native float getCurrentScale() /*-{


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/9603 (at least, for PDF documents).

We had some existing code to handle saving + loading the position with `pdf.js`. Unfortunately, when `pdf.js` was updated ~6 years ago (!) the API changed and we didn't make the changes required to adapt.

### Approach

When the document has been loaded. `pdf.js` fires a `documentload` event. Use that to determine when we can try to restore the scroll position.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9603.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
