### PR TITLE
set events pending flag to false by default for async completions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 * Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
 * Fixed issues causing multiple background jobs to be created when running Shiny applications in the background (#8746, #6904)
 * Fixed issue causing an error when adding files to static content published to RStudio Connect (#9571)
+* Fixed issue where R banner could be displayed twice on startup (#6907)
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
 
 

--- a/src/cpp/core/include/core/json/JsonRpc.hpp
+++ b/src/cpp/core/include/core/json/JsonRpc.hpp
@@ -402,7 +402,12 @@ public:
    void setField(const std::string& name, const Value& value)
    { 
       response_[name] = value;
-   }             
+   }
+   
+   bool hasField(const std::string& name)
+   {
+      return response_.hasMember(name);
+   }
                 
    template <typename T>
    void setField(const std::string& name, const T& value) 
@@ -411,8 +416,7 @@ public:
    }
 
    template <typename T>
-   Error getField(const std::string& name,
-                 T* pValue)
+   Error getField(const std::string& name, T* pValue)
    {
       return readObject(response_, name, *pValue);
    }

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -2353,6 +2353,7 @@ FilePath sourceDiagnostics()
 }
    
 namespace {
+
 void beginRpcHandler(json::JsonRpcFunction function,
                      json::JsonRpcRequest request,
                      std::string asyncHandle)
@@ -2363,9 +2364,11 @@ void beginRpcHandler(json::JsonRpcFunction function,
       Error error = function(request, &response);
       BOOST_ASSERT(!response.hasAfterResponse());
       if (error)
-      {
          response.setError(error);
-      }
+      
+      if (!response.hasField(kEventsPending))
+         response.setField(kEventsPending, "false");
+      
       json::Object value;
       value["handle"] = asyncHandle;
       value["response"] = response.getRawResponse();
@@ -2375,6 +2378,7 @@ void beginRpcHandler(json::JsonRpcFunction function,
    CATCH_UNEXPECTED_EXCEPTION
 
 }
+
 } // anonymous namespace
 
 core::Error executeAsync(const json::JsonRpcFunction& function,

--- a/src/cpp/session/SessionRpc.cpp
+++ b/src/cpp/session/SessionRpc.cpp
@@ -259,9 +259,11 @@ void endHandleRpcRequestIndirect(
            pJsonRpcResponse ? *pJsonRpcResponse : temp;
 
    if (executeError)
-   {
       jsonRpcResponse.setError(executeError);
-   }
+   
+   if (!jsonRpcResponse.hasField(kEventsPending))
+      jsonRpcResponse.setField(kEventsPending, "false");
+   
    json::Object value;
    value["handle"] = asyncHandle;
    value["response"] = jsonRpcResponse.getRawResponse();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/6907.

### Approach

See https://github.com/rstudio/rstudio/issues/6907#issuecomment-881088465 for rationale.

### Automated Tests

N/A

### QA Notes

Unfortunately, I don't have a clear way to reliably reproduce this issue.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
