### PR TITLE
Fix a bug where the transaction that creates the schema is not committed

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1077,6 +1077,7 @@ Error SchemaUpdater::createSchema()
    if (error)
       return error;
 
+   transaction.commit();
    return Success();
 }
 


### PR DESCRIPTION
### Intent

Fixes a bug where the create schema transaction is not committed.

### Approach

Commit the transaction before returning success.

### Automated Tests

The RStudio server will not run correctly without this fix. All tests should cover it.

### QA Notes

After this PR, the schema should be created in the sqlite/postgresql DB on server start.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


