### PR TITLE
Save main window geometry in same location as in the C++ code

### DIFF
--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -299,6 +299,74 @@ export class MainWindow extends GwtWindow {
     }
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  closeEvent(event: Electron.Event): void {
+    if (process.platform === 'win32') {
+      // TODO
+      // if (eventHook_) {
+      // :: UnhookWinEvent(eventHook_);
+      // }
+    }
+
+    // desktopInfo().onClose();
+    // saveRemoteAuthCookies(boost::bind(&Options::authCookies, &options()),
+    //                      boost::bind(&Options::setAuthCookies, &options(), _1),
+    //                      false);
+
+    if (!this.geometrySaved) {
+      const size = this.window.getSize();
+      DesktopOptions().saveWindowBounds({width: size[0], height: size[1]});
+      this.geometrySaved = true;
+    }
+
+    // CloseServerSessions close = sessionServerSettings().closeServerSessionsOnExit();
+
+    // if (this.quitConfirmed || (!this.isRemoteDesktop && !this.sessionProcess) ||
+    //   (!this.isRemoteDesktop && this.sessionProcess -> state() != QProcess:: Running)) {
+
+    //   closeAllSatellites(this.window);
+    //   pEvent->accept();
+    //   return;
+    // }
+
+    // auto quit = [this]() {
+    //   closeAllSatellites(this);
+    //   this->quit();
+    // };
+
+    // pEvent->ignore();
+    // webPage()->runJavaScript(
+    //         QStringLiteral("!!window.desktopHooks"),
+    //         [=](QVariant hasQuitR) {
+
+    //   if (!hasQuitR.toBool()) {
+    //      LOG_ERROR_MESSAGE("Main window closed unexpectedly");
+
+    //      // exit to avoid user having to kill/force-close the application
+    //      quit();
+    //   } else {
+    //      if (!isRemoteDesktop_ ||
+    //          close == CloseServerSessions::Always) {
+    //         webPage()->runJavaScript(
+    //                  QStringLiteral("window.desktopHooks.quitR()"),
+    //                  [=](QVariant ignored) {
+    //            quitConfirmed_ = true;
+    //         });
+    //      }
+    //      else if (close == CloseServerSessions::Never) {
+    //         quit();
+    //      }
+    //      else {
+    //         webPage()->runJavaScript(
+    //                  QStringLiteral("window.desktopHooks.promptToQuitR()"),
+    //                  [=](QVariant ignored) {
+    //            quitConfirmed_ = true;
+    //         });
+    //      }
+    //   }
+    // });
+  }
+ 
   collectPendingQuitRequest(): PendingQuit {
     return appState().gwtCallback?.collectPendingQuitRequest() ?? PendingQuit.PendingQuitNone;
   }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -152,11 +152,6 @@ export class MainWindow extends GwtWindow {
     //             QString());
     //   ::_exit(EXIT_FAILURE);
     // }
-    
-    this.window.on('close', () => {
-      const size = this.window.getSize();
-      DesktopOptions().saveWindowBounds({width: size[0], height: size[1]});
-    });
   }
 
   launchSession(reload: boolean): void {


### PR DESCRIPTION
### Intent

Save window geometry in closeEvent handler, mimicking the C++ code.

### Approach

Added closeEvent override, put in code similar to the C++ (including some commented out code needing further investigation.).

Background: `closeEvent` is a QtWebEngine event, which gets invoked automatically if a class implements it. In Electron, I have this hooked up to 'close' in the desktop-browser-window base class, so if a class implements it, it will be called.

### Automated Tests

None yet.

### QA Notes

Work in progress.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


