### PR TITLE
wrapping up IDE python integration items

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -78,11 +78,50 @@
   
 })
 
+.rs.addFunction("python.findWindowsPython", function()
+{
+   # NOTE: ideally, we would just parse the output of 'py --list-paths',
+   # but for whatever reason the '*' indicating the default version of
+   # Python is omitted when run from RStudio, so we try to explicitly
+   # run Python here and then ask where the executable lives.
+   #
+   # We pass '-E' here just to avoid things like PYTHONPATH potentially
+   # influencing how the python session is launched
+   pythonPath <- .rs.tryCatch(
+      system2(
+         command = "py",
+         args    = c("-E"),
+         input   = "import sys; print(sys.executable)",
+         stdout  = TRUE,
+         stderr  = TRUE
+      )
+   )
+   
+   if (inherits(pythonPath, "error"))
+      return("")
+   
+   pythonPath
+})
+
 .rs.addFunction("python.configuredInterpreterPath", function(projectDir)
 {
+   # on Windows, check if PY_PYTHON is defined; if it is, we should use 'py'
+   # to determine the version of python to be used
+   if (.rs.platform.isWindows && nzchar(Sys.which("py")))
+   {
+      pyPython <- Sys.getenv("PY_PYTHON", unset = NA)
+      if (!is.na(pyPython))
+      {
+         python <- .rs.python.findWindowsPython()
+         if (file.exists(python))
+            return(python)
+      }
+   }
+   
    # check some pre-defined environment variables
    vars <- c("RENV_PYTHON", "RETICULATE_PYTHON")
-   for (var in vars) {
+   for (var in vars)
+   {
       value <- Sys.getenv(var, unset = NA)
       if (!is.na(value))
          return(value)
@@ -101,59 +140,69 @@
    if (file.exists(prefsPython))
       return(path.expand(prefsPython))
    
-   # check for Python on the PATH -- if we have an appropriate version of
-   # python3 or python on the PATH, then use it. we ignore python installations
-   # in /usr/bin because we primarily want to target python installations that
-   # appear to have been "intentionally" installed by the user. in addition,
-   # many Linux package managers install "minimized" versions of Python onto
-   # the system path that will fail to work without extra supporting packages
-   # installed, and managing and communicating all that state to the user is
-   # challenging
-   python3 <- Sys.which("python3")
-   if (nzchar(python3) && python3 != "/usr/bin/python3")
-      return(python3)
-   
-   # use a plain 'python' executable if it's not python 2
-   python <- Sys.which("python")
-   if (nzchar(python) && python != "/usr/bin/python") {
-      info <- .rs.python.interpreterInfo(python, NULL)
-      version <- numeric_version(info$version, strict = FALSE)
-      if (!is.na(version) && version >= "3.2")
-         return(python)
-   }
-   
    # on Windows, help users find a default version of Python if possible
    if (.rs.platform.isWindows && nzchar(Sys.which("py")))
    {
-      # NOTE: ideally, we would just parse the output of 'py --list-paths',
-      # but for whatever reason the '*' indicating the default version of
-      # Python is omitted when run from RStudio, so we try to explicitly
-      # run Python here and then ask where the executable lives.
-      #
-      # We pass '-E' here just to avoid things like PYTHONPATH potentially
-      # influencing how the python session is launched
-      pythonPath <- .rs.tryCatch(
-         system2(
-            command = "py",
-            args    = c("-E"),
-            input   = "import sys; print(sys.executable)",
-            stdout  = TRUE,
-            stderr  = TRUE
-         )
-      )
-      
-      if (!inherits(pythonPath, "error") && file.exists(pythonPath))
+      pythonPath <- .rs.python.findWindowsPython()
+      if (file.exists(pythonPath))
          return(pythonPath)
+   }
+   
+   # look for python + python3 on the PATH
+   if (!.rs.platform.isWindows)
+   {
+      python3 <- Sys.which("python3")
+      if (nzchar(python3) &&
+          python3 != "/usr/bin/python3" &&
+          .rs.python.isModuleAvailable(python3, "pip"))
+      {
+         return(python3)
+      }
+      
+      python <- Sys.which("python")
+      if (nzchar(python) &&
+          python != "/usr/bin/python" &&
+          .rs.python.isModuleAvailable(python, "pip"))
+      {
+         info <- .rs.python.interpreterInfo(python, NULL)
+         version <- numeric_version(info$version, strict = FALSE)
+         if (!is.na(version) && version >= "3.2")
+            return(python)
+      }
    }
    
    # if the user has Anaconda installed, then try auto-activating
    # the base environment of that Anaconda installation
    conda <- .rs.python.findCondaBinary()
-   if (file.exists(conda)) {
+   if (file.exists(conda))
+   {
       pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
       python <- file.path(dirname(conda), pythonPath)
       if (file.exists(python))
          return(python)
+   }
+   
+   # fall back to versions of python in /usr/bin if available
+   if (!.rs.platform.isWindows)
+   {
+      python3 <- Sys.which("python3")
+      if (nzchar(python3) &&
+          python3 == "/usr/bin/python3" &&
+          .rs.python.isModuleAvailable(python3, "pip"))
+      {
+         return(python3)
+      }
+      
+      python <- Sys.which("python")
+      if (nzchar(python) &&
+          python == "/usr/bin/python" &&
+          .rs.python.isModuleAvailable(python, "pip"))
+      {
+         info <- .rs.python.interpreterInfo(python, NULL)
+         version <- numeric_version(info$version, strict = FALSE)
+         if (!is.na(version) && version >= "3.2")
+            return(python)
+      }
    }
    
    # no python found; return empty string placeholder
@@ -720,4 +769,18 @@
 {
    info <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    .rs.scalarListFromList(info)
+})
+
+.rs.addFunction("python.isModuleAvailable", function(pythonPath, module)
+{
+   fmt <- "from importlib.util import find_spec; exit(find_spec(\"%s\") is None)"
+   code <- sprintf(fmt, module)
+   status <- system2(
+      command = pythonPath,
+      args = c("-E", "-c", shQuote(code)),
+      stdout = FALSE,
+      stderr = FALSE
+   )
+   
+   status == 0L
 })

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -156,17 +156,11 @@
    if (!.rs.platform.isWindows)
    {
       python3 <- Sys.which("python3")
-      if (nzchar(python3) &&
-          python3 != "/usr/bin/python3" &&
-          .rs.python.isModuleAvailable(python3, "pip"))
-      {
+      if (nzchar(python3) && python3 != "/usr/bin/python3")
          return(python3)
-      }
       
       python <- Sys.which("python")
-      if (nzchar(python) &&
-          python != "/usr/bin/python" &&
-          .rs.python.isModuleAvailable(python, "pip"))
+      if (nzchar(python) && python != "/usr/bin/python")
       {
          info <- .rs.python.interpreterInfo(python, NULL)
          version <- numeric_version(info$version, strict = FALSE)
@@ -190,17 +184,11 @@
    if (!.rs.platform.isWindows)
    {
       python3 <- Sys.which("python3")
-      if (nzchar(python3) &&
-          python3 == "/usr/bin/python3" &&
-          .rs.python.isModuleAvailable(python3, "pip"))
-      {
+      if (nzchar(python3) && python3 == "/usr/bin/python3")
          return(python3)
-      }
       
       python <- Sys.which("python")
-      if (nzchar(python) &&
-          python == "/usr/bin/python" &&
-          .rs.python.isModuleAvailable(python, "pip"))
+      if (nzchar(python) && python == "/usr/bin/python")
       {
          info <- .rs.python.interpreterInfo(python, NULL)
          version <- numeric_version(info$version, strict = FALSE)
@@ -773,18 +761,4 @@
 {
    info <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    .rs.scalarListFromList(info)
-})
-
-.rs.addFunction("python.isModuleAvailable", function(pythonPath, module)
-{
-   fmt <- "from importlib.util import find_spec; exit(find_spec(\"%s\") is None)"
-   code <- sprintf(fmt, module)
-   status <- system2(
-      command = pythonPath,
-      args = c("-E", "-c", shQuote(code)),
-      stdout = FALSE,
-      stderr = FALSE
-   )
-   
-   status == 0L
 })

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -80,6 +80,10 @@
 
 .rs.addFunction("python.findWindowsPython", function()
 {
+   # if 'py' is not available, nothing we can do
+   if (!nzchar(Sys.which("py")))
+      return("")
+   
    # NOTE: ideally, we would just parse the output of 'py --list-paths',
    # but for whatever reason the '*' indicating the default version of
    # Python is omitted when run from RStudio, so we try to explicitly
@@ -107,7 +111,7 @@
 {
    # on Windows, check if PY_PYTHON is defined; if it is, we should use 'py'
    # to determine the version of python to be used
-   if (.rs.platform.isWindows && nzchar(Sys.which("py")))
+   if (.rs.platform.isWindows)
    {
       pyPython <- Sys.getenv("PY_PYTHON", unset = NA)
       if (!is.na(pyPython))
@@ -141,7 +145,7 @@
       return(path.expand(prefsPython))
    
    # on Windows, help users find a default version of Python if possible
-   if (.rs.platform.isWindows && nzchar(Sys.which("py")))
+   if (.rs.platform.isWindows)
    {
       pythonPath <- .rs.python.findWindowsPython()
       if (file.exists(pythonPath))

--- a/src/cpp/session/resources/terminal/hooks
+++ b/src/cpp/session/resources/terminal/hooks
@@ -13,9 +13,16 @@ if [ -f "${RETICULATE_PYTHON}" ]; then
 	# check for an activate script in the same directory
 	# as the configured version of Python; if it exists,
 	# use that to activate Python (mainly for venv)
+	#
+	# note that this might also discover a conda activate
+	# script; unfortunately, running that isn't sufficient
+	# to update the PATH so we make that check below as well
 	if [ -f "${_RS_PYTHON_BIN}/activate" ]; then
 		. "${_RS_PYTHON_BIN}/activate"
-	else
+	fi
+
+	# ensure that our python was placed on the PATH
+	if [ "$(echo "${PATH}" | cut -d":" -f"1")" != "${_RS_PYTHON_BIN}" ]; then
 		PATH="${_RS_PYTHON_BIN}:${PATH}"
 	fi
 	

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -97,23 +97,20 @@ define("mode/r", ["require", "exports", "module"], function(require, exports, mo
       };
 
       this.transformAction = function(state, action, editor, session, text) {
+
          if (action === 'insertion' && text === "\n") {
 
-            // If newline in a doxygen comment, continue the comment
+            // Continue certain special comments by default
             var pos = editor.getSelectionRange().start;
             var docLine = session.doc.getLine(pos.row);
-            var match = /^((\s*#+')\s*)/.exec(docLine);
-            if (match && editor.getSelectionRange().start.column >= match[2].length) {
-               return {text: "\n" + match[1]};
-            }
-
-            // If newline in a plumber comment, continue the comment
-            match = /^((\s*#+\*)\s*)/.exec(docLine);
+            var match = /^((\s*#+['>*|])\s*)/.exec(docLine);
             if (match && editor.getSelectionRange().start.column >= match[2].length) {
                return {text: "\n" + match[1]};
             }
          }
+
          return false;
+
       };
 
       this.$id = "mode/r";

--- a/src/gwt/acesupport/acemode/r.js
+++ b/src/gwt/acesupport/acemode/r.js
@@ -96,23 +96,6 @@ define("mode/r", ["require", "exports", "module"], function(require, exports, mo
          return "";
       };
 
-      this.transformAction = function(state, action, editor, session, text) {
-
-         if (action === 'insertion' && text === "\n") {
-
-            // Continue certain special comments by default
-            var pos = editor.getSelectionRange().start;
-            var docLine = session.doc.getLine(pos.row);
-            var match = /^((\s*#+['>*|])\s*)/.exec(docLine);
-            if (match && editor.getSelectionRange().start.column >= match[2].length) {
-               return {text: "\n" + match[1]};
-            }
-         }
-
-         return false;
-
-      };
-
       this.$id = "mode/r";
    }).call(Mode.prototype);
    exports.Mode = Mode;

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -230,7 +230,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       {
         // R Markdown chunk metadata comments
         token : "comment.doc.tag",
-        regex : "#+[|].*$",
+        regex : "#[|].*$",
         next  : "start"
       },
       {

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -228,6 +228,12 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         next  : "start"
       },
       {
+        // R Markdown chunk metadata comments
+        token : "comment.doc.tag",
+        regex : "#+[|].*$",
+        next  : "start"
+      },
+      {
         // Begin Roxygen with todo
         token : ["comment", "comment.keyword.operator"],
         regex : "(#+'\\s*)(TODO|FIXME)\\b",

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -236,13 +236,13 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       {
         // Begin Roxygen with todo
         token : ["comment", "comment.keyword.operator"],
-        regex : "(#+'\\s*)(TODO|FIXME)\\b",
+        regex : "(#+['*]\\s*)(TODO|FIXME)\\b",
         next  : "rd-start"
       },
       {
         // Roxygen
         token : "comment",
-        regex : "#+'",
+        regex : "#+['*]",
         next  : "rd-start"
       },
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9618

### Approach

- Support auto-activate for copies of Python on the PATH
- Support auto-activate for Anaconda installations
- Fix an issue that prevents `python` from being placed on the PATH when activating a base Conda installation
- Add in comment highlight rule + continue comment behaviors for `#|` chunk metadata comments.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
