### PR TITLE
Generate quarto headers for docs

### DIFF
--- a/src/cpp/generate-options.R
+++ b/src/cpp/generate-options.R
@@ -115,8 +115,15 @@ generateRmd <- function (optionsJson, overlayOptionsJson) {
       stop(sprintf("No outputDocFile specified for %s config", configFile))
    }
    
-   rmd <- sprintf("## %s\n", configFile)
-   
+   # header for Quarto file
+   rmd <- paste("---",
+                paste0("title: \"", configFile, "\""),
+                "aliases:",
+                paste0("\t- /rstudio-configuration-1.html#", configFile),
+                "---",
+                "",
+                sep = "\n")
+
    docDescription <- metadata$docDescription
    if (is.null(docDescription)) {
       docDescription <- 


### PR DESCRIPTION
### Intent

With our docs now generated from Quarto, the tooling that generates our docs from our options needs to be updated to write docs in the new format.

### Approach

Write Quarto header instead of R Markdown header. For an example of output, see:

https://github.com/rstudio/rstudio-pro/blob/main/docs/server/rstudio_server_configuration/rsession_conf.qmd

### Automated Tests

None, doc change only

### QA Notes

None, dev tool only

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


