### PR TITLE
Add early init of env vars (before logging)

### DIFF
--- a/src/cpp/server/ServerEnvVars.cpp
+++ b/src/cpp/server/ServerEnvVars.cpp
@@ -31,29 +31,12 @@ namespace rstudio {
 namespace server {
 namespace env_vars {
 
-// Forwards any HTTP proxy variables from the current process into the given environment.
-void forwardHttpProxyVars(core::system::Options *pEnvironment)
+Error readEnvConfigFile(bool emitInfoLog)
 {
-   for (auto&& proxyVar: {"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"})
-   {
-      std::string val = core::system::getenv(proxyVar);
-      if (!val.empty())
-      {
-         std::string oldVal = core::system::getenv(*pEnvironment, proxyVar);
-         if (!oldVal.empty() && oldVal != val)
-         {
-             LOG_WARNING_MESSAGE("Overriding HTTP proxy setting " + std::string(proxyVar) +
-                                 ": '" + oldVal + "' => '" + val + "'");
-         }
-         core::system::setenv(pEnvironment, proxyVar, val);
-      }
-   }
-}
-
-Error initialize()
-{
-   FilePath envConfPath = core::system::xdg::findSystemConfigFile(
-         "environment variables", "env-vars");
+   // Look up config file location (log search path if enabled)
+   FilePath envConfPath = emitInfoLog ?
+      core::system::xdg::findSystemConfigFile("environment variables", "env-vars") :
+      core::system::xdg::systemConfigFile("env-vars");
 
    // No work to do if we don't have a file specifying server environment variables
    if (!envConfPath.exists())
@@ -87,19 +70,49 @@ Error initialize()
    }
 
    // Indicate where we read the logs from (for diagnostic purposes)
-   LOG_INFO_MESSAGE("Read server environment variables from " + 
-      envConfPath.getAbsolutePath() + " (" +
-      safe_convert::numberToString(env.size()) + " variables found)");
+   if (emitInfoLog)
+   {
+      LOG_INFO_MESSAGE("Read server environment variables from " + 
+         envConfPath.getAbsolutePath() + " (" +
+         safe_convert::numberToString(env.size()) + " variables found)");
+   }
 
    // Set each environment variable
    for (core::system::Option var: env)
    {
-      LOG_INFO_MESSAGE("Setting server environment variable '" +
-            var.first + "' = '" + var.second + "'");
+      if (emitInfoLog)
+      {
+         LOG_INFO_MESSAGE("Setting server environment variable '" +
+               var.first + "' = '" + var.second + "'");
+      }
       core::system::setenv(var.first, var.second);
    }
 
    return Success();
+}
+
+// Forwards any HTTP proxy variables from the current process into the given environment.
+void forwardHttpProxyVars(core::system::Options *pEnvironment)
+{
+   for (auto&& proxyVar: {"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"})
+   {
+      std::string val = core::system::getenv(proxyVar);
+      if (!val.empty())
+      {
+         std::string oldVal = core::system::getenv(*pEnvironment, proxyVar);
+         if (!oldVal.empty() && oldVal != val)
+         {
+             LOG_WARNING_MESSAGE("Overriding HTTP proxy setting " + std::string(proxyVar) +
+                                 ": '" + oldVal + "' => '" + val + "'");
+         }
+         core::system::setenv(pEnvironment, proxyVar, val);
+      }
+   }
+}
+
+Error initialize()
+{
+   return readEnvConfigFile(true /* emit info log */);
 }
 
 } // namespace env_vars

--- a/src/cpp/server/ServerEnvVars.hpp
+++ b/src/cpp/server/ServerEnvVars.hpp
@@ -30,6 +30,8 @@ namespace env_vars {
 
 core::Error initialize();
 
+core::Error readEnvConfigFile(bool emitInfoLog);
+
 void forwardHttpProxyVars(core::system::Options *pEnvironment);
 
 } // namespace env_vars

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -542,6 +542,14 @@ int main(int argc, char * const argv[])
 {
    try
    {
+      // read environment variables from config file; we have to do this before initializing logging
+      // so that logging environment variables like RS_LOG_LEVEL stored in this file will be
+      // respected when logging is initialized (below).
+      //
+      // note that we can't emit any logs or errors while reading this config file since logging
+      // isn't initialized yet, so we suppress logging in this step
+      env_vars::readEnvConfigFile(false /* suppress logs */);
+
       Error error = core::system::initializeLog(kProgramIdentity, core::log::LogLevel::WARN, false);
       if (error)
       {


### PR DESCRIPTION
### Intent

A recent change (https://github.com/rstudio/rstudio-pro/pull/2611) introduced environment variables such as `RS_LOG_LEVEL` to control logging features. Unfortunately, setting those environment variables in `/etc/rstudio/env-vars` doesn't work, because logging is initialized very early, before the `env-vars` file is read.

Addresses https://github.com/rstudio/rstudio-pro/issues/2758. 

### Approach

Read `env-vars` file before initializing logging. There's a bit of a chicken-and-egg problem here: we want to log the info/vars we read out of the file, but we can't do it because we need to read them before initialize the logging system. As a compromise, we now read the variables (w/o any kind of logging) at startup, then re-initialize them with logging later. 

### Automated Tests

None, this alters startup sequencing but is otherwise covered by existing logging tests and env var tests.

### QA Notes

Note that this change makes sure you can set RS_LOG_LEVEL and friends in `env-vars`, but it does not actually touch any logging code (so still need to verify that the logging code respects those values once set). 

If you want to compare behavior, note that you can set environment variables for the rserver process by using systemd instead of env-vars. 

https://serverfault.com/questions/413397/how-to-set-environment-variable-in-systemd-service

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


