### PR TITLE
support use of symlinks for file locks

### DIFF
--- a/src/cpp/core/file_lock/FileLock.cpp
+++ b/src/cpp/core/file_lock/FileLock.cpp
@@ -139,7 +139,11 @@ void FileLock::initialize(FileLock::LockType fallbackLockType)
          ? fallbackLockType
          : stringToLockType(lockTypePref, fallbackLockType);
 #endif
-
+   
+   // symlinks
+   bool useSymlinks = settings.getBool("use-symlinks", false);
+   FileLock::s_useSymlinks = useSymlinks;
+   
    // timeout interval
    double timeoutInterval = getFieldPositive(settings, "timeout-interval", kDefaultTimeoutInterval);
    FileLock::s_timeoutInterval = boost::posix_time::seconds(static_cast<long>(timeoutInterval));
@@ -159,6 +163,7 @@ void FileLock::initialize(FileLock::LockType fallbackLockType)
    std::stringstream ss;
    ss << "(PID " << ::getpid() << "): Initialized file locks ("
       << "lock-type=" << lockTypeToString(FileLock::s_defaultType) << ", "
+      << "use-symlinks=" << (useSymlinks ? "true" : "false") << ", "
       << "timeout-interval=" << FileLock::s_timeoutInterval.total_seconds() << "s, "
       << "refresh-rate=" << FileLock::s_refreshRate.total_seconds() << "s, "
       << "log-file=" << logFile << ")"
@@ -229,6 +234,7 @@ boost::posix_time::seconds FileLock::s_timeoutInterval(static_cast<long>(kDefaul
 boost::posix_time::seconds FileLock::s_refreshRate(static_cast<long>(kDefaultRefreshRate));
 bool FileLock::s_loggingEnabled(false);
 bool FileLock::s_isLoadBalanced(false);
+bool FileLock::s_useSymlinks(false);
 FilePath FileLock::s_logFile;
 
 boost::shared_ptr<FileLock> FileLock::create(LockType type)

--- a/src/cpp/core/file_lock/LinkBasedFileLock.cpp
+++ b/src/cpp/core/file_lock/LinkBasedFileLock.cpp
@@ -251,11 +251,10 @@ LockRegistration& lockRegistration()
    return instance;
 }
 
-Error writeLockFile(const FilePath& lockFilePath)
-{
-
 #ifndef _WIN32
 
+Error writeLockFile(const FilePath& lockFilePath)
+{
    // generate proxy lockfile
    FilePath proxyPath = lockFilePath.getParent().completePath(proxyLockFileName());
    
@@ -267,8 +266,8 @@ Error writeLockFile(const FilePath& lockFilePath)
       LOG_ERROR(error);
    
    // ensure the proxy file is created, and remove it when we're done
+   // (only for hard links)
    std::string pid = pidString();
-   RemoveOnExitScope scope(proxyPath, ERROR_LOCATION);
    error = core::writeStringToFile(proxyPath, pid);
    if (error)
    {
@@ -278,40 +277,57 @@ Error writeLockFile(const FilePath& lockFilePath)
       return error;
    }
    
-   // attempt to link to the desired location -- ignore return value
-   // and just stat our original link after, as that's a more reliable
-   // indicator of success on old NFS systems
-   int status = ::link(
-      proxyPath.getAbsolutePathNative().c_str(),
-            lockFilePath.getAbsolutePathNative().c_str());
+   int status = -1;
+   
+   if (FileLock::useSymlinks())
+   {
+      status = ::symlink(
+          proxyPath.getAbsolutePathNative().c_str(),
+          lockFilePath.getAbsolutePathNative().c_str());
+   }
+   else
+   {
+      // attempt to link to the desired location -- ignore return value
+      // and just stat our original link after, as that's a more reliable
+      // indicator of success on old NFS systems
+      status = ::link(
+          proxyPath.getAbsolutePathNative().c_str(),
+          lockFilePath.getAbsolutePathNative().c_str());
+   }
    
    // detect link failure
    if (status == -1)
    {
       // verbose logging
       int errorNumber = errno;
-      LOG("ERROR: ::link() failed (errno " << errorNumber << ")" << std::endl <<
-          "Attempted to link:" << std::endl << " - " <<
-          "'" << proxyPath.getAbsolutePathNative() << "'" <<
-          " => " <<
-          "'" << lockFilePath.getAbsolutePathNative() << "'");
+      
+      std::string msg = string_utils::sprintf(
+         "ERROR: %s() failed (errno %i) [%s => %s]\n",
+          (FileLock::useSymlinks() ? "symlink" : "link"),
+          errorNumber,
+          proxyPath.getAbsolutePathNative().c_str(),
+          lockFilePath.getAbsolutePathNative().c_str());
+      
+      LOG(msg);
       
       // if this failed, we should still make a best-effort attempt to acquire
       // a lock by creating a file using O_CREAT | O_EXCL. note that we prefer
       // ::link() since older NFSes provide more guarantees as to its atomicity,
       // but not all NFS support ::link()
       int fd = ::open(
-         lockFilePath.getAbsolutePathNative().c_str(),
-               O_WRONLY | O_CREAT | O_EXCL,
-               0755);
+          lockFilePath.getAbsolutePathNative().c_str(),
+          O_WRONLY | O_CREAT | O_EXCL,
+          0755);
       
       if (fd == -1)
       {
          // verbose logging
          int errorNumber = errno;
-         LOG("ERROR: ::open() failed (errno " << errorNumber << ")" <<
-                                              std::endl << "Attempted to open:" << std::endl << " - " <<
-                                              "'" << lockFilePath.getAbsolutePathNative() << "'");
+         std::string msg = string_utils::sprintf(
+             "ERROR: open() failed (errno %i) [%s]\n",
+             errorNumber,
+             lockFilePath.getAbsolutePathNative().c_str());
+         LOG(msg);
          
          Error error = systemError(errorNumber, ERROR_LOCATION);
          error.addProperty("lock-file", lockFilePath);
@@ -336,41 +352,91 @@ Error writeLockFile(const FilePath& lockFilePath)
       
       return Success();
    }
-
-   struct stat info;
-   int errc = ::stat(proxyPath.getAbsolutePathNative().c_str(), &info);
-   if (errc)
+   else
    {
-      int errorNumber = errno;
-      
-      // verbose logging
-      LOG("ERROR: ::stat() failed (errno " << errorNumber << ")" << std::endl <<
-                                           "Attempted to stat:" << std::endl << " - " <<
-                                           "'" << proxyPath.getAbsolutePathNative() << "'");
-      
-      // log the error since it isn't expected and could get swallowed
-      // upstream by a caller ignoring lock_not_available errors
-      Error error = systemError(errorNumber, ERROR_LOCATION);
-      LOG_ERROR(error);
-      return error;
-   }
-   
-   // assume that a failure here is the result of someone else
-   // acquiring the lock before we could
-   if (info.st_nlink != 2)
-   {
-      LOG("WARNING: Failed to acquire lock (info.st_nlink == " << info.st_nlink << ")");
-      return fileExistsError(ERROR_LOCATION);
+      // we successfully created our link; do some post-hoc validation
+      if (FileLock::useSymlinks())
+      {
+         // double-check that the created symlink points at our proxy file
+         char resolvedPath[PATH_MAX + 1];
+         char* path = ::realpath(
+             lockFilePath.getAbsolutePathNative().c_str(),
+             resolvedPath);
+         
+         if (path == nullptr)
+         {
+            Error error = systemCallError("realpath", errno, ERROR_LOCATION);
+            error.addProperty("lock-file", lockFilePath);
+            LOG_ERROR(error);
+            return error;
+         }
+         
+         if (proxyPath.getAbsolutePathNative() != resolvedPath)
+         {
+            // verbose logging
+            std::string msg = string_utils::sprintf(
+                "ERROR: ::realpath() returned unexpected path [%s != %s]\n",
+                resolvedPath,
+                proxyPath.getAbsolutePathNative().c_str());
+            LOG(msg);
+            
+            Error error = fileExistsError(ERROR_LOCATION);
+            error.addProperty("lock-file", proxyPath);
+            error.addProperty("symlink", resolvedPath);
+            return error;
+         }
+      }
+      else
+      {
+         // we successfully created a hard link; we can remove that on exit now
+         RemoveOnExitScope scope(proxyPath, ERROR_LOCATION);
+         
+         struct stat info;
+         int errc = ::stat(proxyPath.getAbsolutePathNative().c_str(), &info);
+         if (errc)
+         {
+            // verbose logging
+            int errorNumber = errno;
+            std::string msg = string_utils::sprintf(
+                "ERROR: stat() failed (errno %i) [%s]\n",
+                errorNumber,
+                proxyPath.getAbsolutePathNative().c_str());
+            LOG(msg);
+            
+            // log the error since it isn't expected and could get swallowed
+            // upstream by a caller ignoring lock_not_available errors
+            Error error = systemError(errorNumber, ERROR_LOCATION);
+            LOG_ERROR(error);
+            return error;
+         }
+         
+         // assume that a failure here is the result of someone else
+         // acquiring the lock before we could
+         if (info.st_nlink != 2)
+         {
+            std::string msg = string_utils::sprintf(
+                "WARNING: failed to acquire lock (info.st_nlink == %i)\n",
+                info.st_nlink);
+            LOG(msg);
+            
+            Error error = fileExistsError(ERROR_LOCATION);
+            error.addProperty("st_nlink", info.st_nlink);
+            return error;
+         }
+      }
    }
    
    return Success();
-   
+}
+
 #else
 
+Error writeLockFile(const FilePath& lockFilePath)
+{
    return systemError(boost::system::errc::function_not_supported, ERROR_LOCATION);
+}
 
 #endif
-}
 
 } // end anonymous namespace
 

--- a/src/cpp/core/include/core/FileLock.hpp
+++ b/src/cpp/core/include/core/FileLock.hpp
@@ -92,6 +92,7 @@ public:
    static boost::posix_time::seconds getRefreshRate() { return s_refreshRate; }
    static bool isLoggingEnabled() { return s_loggingEnabled; }
    static bool isLoadBalanced() { return s_isLoadBalanced; }
+   static bool useSymlinks() { return s_useSymlinks; }
    static bool isNoLockAvailable(const Error& error)
    {
       return error == systemError(boost::system::errc::no_lock_available, ErrorLocation());
@@ -99,6 +100,7 @@ public:
    
 protected:
    static LockType s_defaultType;
+   static bool s_useSymlinks;
    static boost::posix_time::seconds s_timeoutInterval;
    static boost::posix_time::seconds s_refreshRate;
    static bool s_loggingEnabled;

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1290,7 +1290,9 @@ bool FilePath::isSymlink() const
 {
    try
    {
-      return exists() && boost::filesystem::is_symlink(m_impl->Path);
+      // NOTE: we omit the exists() check here as that will
+      // return false for existing but broken symlinks
+      return !isEmpty() && boost::filesystem::is_symlink(m_impl->Path);
    }
    catch(const boost::filesystem::filesystem_error& e)
    {


### PR DESCRIPTION
### Intent

Related to https://github.com/rstudio/rstudio-pro/issues/2460.

Some network filesystems (notably, Amazon EFS) do not support hard links, which leads to file locking failures in those environments. This PR provides an alternative that uses symlinks rather than hardlinks, for users who find the advisory file locks are still unreliable in such an environment.

### Approach

Add a new entry to `/etc/rstudio/file-locks`, which allows one to toggle between the use of symlinks vs. hard links when creating file locks. When enabled, we use `::symlink()` instead of `::link()` when creating a lock.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests