### PR TITLE
Support userIdentifier to local userName mapping via uid

### DIFF
--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -130,7 +130,8 @@ void doSignIn(const http::Request& request,
                                                             &plainText);
       if (error)
       {
-         LOG_ERROR_MESSAGE("Failed sign-in - unable to decrypt password - error: " + error.asString());
+         error.addProperty("description", "Failed sign-in - unable to decrypt password - error");
+         LOG_ERROR(error);
          redirectToLoginPage(request, pResponse, appUri, kErrorServer);
          return;
       }
@@ -225,7 +226,7 @@ bool pamLogin(const std::string& username, const std::string& password)
       &result);
    if (error)
    {
-      LOG_ERROR_MESSAGE("Error running pamHelper: " + pamHelperPath.getAbsolutePath() + ": " + error.asString());
+      LOG_ERROR(error);
       return false;
    }
 

--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -53,6 +53,8 @@ bool mainPageFilter(const core::http::Request& request,
    std::string userIdentifier = auth::handler::getUserIdentifier(request, true);
    if (userIdentifier.empty())
    {
+      LOG_DEBUG_MESSAGE("Request for main page with no user-identifier - redirecting to login page: " + request.uri());
+
       // otherwise redirect to sign-in
       clearSignInCookies(request, pResponse);
       redirectToLoginPage(request, pResponse, request.uri());
@@ -100,6 +102,8 @@ void signIn(const core::http::Request& request,
       {
          appUri = "./" + appUri;
       }
+      LOG_DEBUG_MESSAGE("Signed in user: " + username + " redirecting to: " + appUri);
+
       pResponse->setMovedTemporarily(request, appUri);
       return;
    }
@@ -125,6 +129,7 @@ bool validateSignIn(const core::http::Request& request,
    // a csrf token should always be present on the sign in form
    if (!core::http::validateCSRFForm(request, pResponse))
    {
+      LOG_ERROR_MESSAGE("Failed to validate sign-in with invalid CSRF form");
       return false;
    }
    return true;
@@ -135,6 +140,7 @@ ErrorType checkUser(const std::string& username, bool authenticated)
    // ensure user is valid
    if (!server::auth::validateUser(username))
    {
+      LOG_DEBUG_MESSAGE("Validate user failed for: " + username + (authenticated ? " authenticated" : " not authenticated"));
       // notify monitor of failed login
       using namespace monitor;
       client().logEvent(Event(kAuthScope,
@@ -148,6 +154,7 @@ ErrorType checkUser(const std::string& username, bool authenticated)
    // ensure user is not throttled from logging in
    if (auth::handler::isUserSignInThrottled(username))
    {
+      LOG_DEBUG_MESSAGE("User throttled: " + username + (authenticated ? " authenticated" : " not authenticated"));
       using namespace monitor;
       client().logEvent(Event(kAuthScope,
                               kAuthLoginThrottledEvent,
@@ -174,6 +181,7 @@ ErrorType checkUser(const std::string& username, bool authenticated)
 
    if (!isLicensed)
    {
+      LOG_DEBUG_MESSAGE("User not licensed: " + username + (authenticated ? " authenticated" : " not authenticated"));
       using namespace monitor;
       client().logEvent(Event(kAuthScope,
                               kAuthLoginUnlicensedEvent,
@@ -225,6 +233,9 @@ bool doSignIn(const core::http::Request& request,
       appUri = "/" + appUri;
    }
    setSignInCookies(request, username, persist, pResponse);
+
+   LOG_DEBUG_MESSAGE("Sign in for user: " + username + " redirecting to: " + appUri);
+
    pResponse->setMovedTemporarily(request, appUri);
    return true;
 }
@@ -237,6 +248,7 @@ std::string signOut(const core::http::Request& request,
    // validate sign-out request
    if (!core::http::validateCSRFForm(request, pResponse))
    {
+      LOG_ERROR_MESSAGE("Failed to validate sign-out with invalid CSRF form");
       return "";
    }
    // register logout with monitor if we have the username
@@ -262,6 +274,9 @@ std::string signOut(const core::http::Request& request,
    {
       signOutUrl = core::http::URL::uncomplete(request.baseUri(), signOutUrl);
    }
+
+   LOG_DEBUG_MESSAGE("Sign out for user: " + username + " redirecting to: " + signOutUrl);
+
    pResponse->setMovedTemporarily(request, signOutUrl);
    return username;
 }
@@ -422,6 +437,58 @@ void prepareHandler(handler::Handler& handler,
       handler.signOut = boost::bind(signOut, _1, _2, getUserIdentifierArg, signOutUrl);
    }
    handler.refreshAuthCookies = boost::bind(setSignInCookies, _1, _2, _3, _4);
+}
+
+std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
+{
+   static core::thread::ThreadsafeMap<std::string, std::string> cache;
+   std::string username = userIdentifier;
+
+   if (cache.contains(userIdentifier))
+   {
+      username = cache.get(userIdentifier);
+   }
+   else
+   {
+      // The username returned from this function is eventually used to create
+      // a local stream path, so it's important that it agree with the system
+      // view of the username (as that's what the session uses to form the
+      // stream path), which is why we do a username => username transform
+      // here. See case 5413 for details.
+      core::system::User user;
+      // This call getpwnam - that will return the passwd line that matches this user identifier
+      Error error = core::system::User::getUserFromIdentifier(userIdentifier, user);
+      if (error)
+      {
+         // log the error and return the original user identifier as a fallback
+         LOG_ERROR_MESSAGE("Error converting userIdentifier to username: " + error.asString());
+      }
+      else
+      {
+         // This gets the passwd entry for the user-id - this is what the session will do so
+         // when a uid is aliased, we need to go back to the uid for the real username
+         error = core::system::User::getUserFromIdentifier(user.getUserId(), user);
+         if (error)
+         {
+            // log the error and return the original user identifier as a fallback
+            LOG_ERROR_MESSAGE("Error converting uid to username: " + error.asString());
+         }
+         else
+         {
+            username = user.getUsername();
+
+            if (username != userIdentifier)
+               LOG_DEBUG_MESSAGE("Auth handler mapped incoming user identifier: " + userIdentifier + " to system username: " + username);
+         }
+      }
+
+      // cache the username -- we do this even if the lookup fails since
+      // otherwise we're likely to keep hitting (and logging) the error on
+      // every request
+      cache.set(userIdentifier, username);
+   }
+
+   return username;
 }
 
 } // namespace common

--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -461,7 +461,8 @@ std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
       if (error)
       {
          // log the error and return the original user identifier as a fallback
-         LOG_ERROR_MESSAGE("Error converting userIdentifier to username: " + error.asString());
+         error.addProperty("description", "Error converting userIdentifier to username");
+         LOG_ERROR(error);
       }
       else
       {
@@ -471,7 +472,8 @@ std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
          if (error)
          {
             // log the error and return the original user identifier as a fallback
-            LOG_ERROR_MESSAGE("Error converting uid to username: " + error.asString());
+            error.addProperty("description", "Error converting uid to username");
+            LOG_ERROR(error);
          }
          else
          {

--- a/src/cpp/server/include/server/auth/ServerAuthCommon.hpp
+++ b/src/cpp/server/include/server/auth/ServerAuthCommon.hpp
@@ -83,6 +83,8 @@ void prepareHandler(handler::Handler& handler,
                     UserIdentifierToLocalUsernameGetter userIdentifierToLocalUsername,
                     UserIdentifierGetter getUserIdentifier = NULL);
 
+std::string userIdentifierToLocalUsername(const std::string& userIdentifier);
+
 } // namespace common
 } // namespace auth
 } // namespace server


### PR DESCRIPTION

### Intent

In the pro version, it seems increasingly common that the assertion the auth-system provides is either an email address, upper-case user-name, or other alias for the system username. Although they can login using these aliases, RSW passes the uid to the session launch that then gets the canonical username. This creates problems for the file-name of the unix socket  and is a blocker for two customers.

Addresses: https://github.com/rstudio/rstudio-pro/issues/2736

### Approach

This PR takes the existing userIdentifierToLocalUsername function in ServerSAMLAuth.cpp and moves it into ServerAuthCommon.cpp so it can be used by all auth-handlers. Further it changes that method so it uses uid to fetch the username (since getpwnam can return the username it was passed, not the canonical one for that uid) 

A companion PR for pro will call this method for openId, SAML, and proxy auth handlers.

In this PR, this is always-on but I could add a new server option if anyone thinks that's valuable. 

### Automated Tests

The existing automated tests will verify that login works correctly with this change. If needed, I could add a user-name alias to one of our existing test configurations, and verify that we can start a session using this alias. 

### QA Notes

It's possible to do an adduser aliasName and then edit /etc/passwd to change the uid of aliasName to match an existing user. On ubuntu, you can create an email-address as a username by adding the --force-bad-names option to adduser. 

When you login using one of these aliases, the UI will show you logged in using the canonical name. 

### Checklist

- [TBD ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests



