### PR TITLE
support auto-discovery of R on Windows

### DIFF
--- a/src/node/desktop/src/core/expected.ts
+++ b/src/node/desktop/src/core/expected.ts
@@ -13,12 +13,16 @@
  *
  */
 
-export type Expected<T> = [ T | null, Error | null ];
+export type Expected<T> = [ T, Error | null ];
 
 export function ok<T>(value: T): Expected<T> {
   return [value, null];
 }
 
-export function unexpected<T>(error: Error): Expected<T> {
-  return [null, error];
+// NOTE: we intentionally lie to the type checker here; the intention is that
+// users of Expected should only use the resulting value T if error is null or
+// unset. Effectively, this implies that "correct" usages of Expected will never
+// give the user a non-T value.
+export function err<T>(error?: Error): Expected<T> {
+  return [null as unknown as T, error ?? new Error()];
 }

--- a/src/node/desktop/src/core/expected.ts
+++ b/src/node/desktop/src/core/expected.ts
@@ -1,0 +1,24 @@
+/*
+ * expected.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+export type Expected<T> = [ T | null, Error | null ];
+
+export function ok<T>(value: T): Expected<T> {
+  return [value, null];
+}
+
+export function unexpected<T>(error: Error): Expected<T> {
+  return [null, error];
+}

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -26,7 +26,7 @@ import { augmentCommandLineArguments, getComponentVersions, removeStaleOptionsLo
 import { exitFailure, exitSuccess, run, ProgramStatus } from './program-status';
 import { ApplicationLaunch } from './application-launch';
 import { AppState } from './app-state';
-import { prepareEnvironment } from './detect_r';
+import { prepareEnvironment } from './detect-r';
 import { SessionLauncher } from './session-launcher';
 import { DesktopActivation } from './activation-overlay';
 import { WindowTracker } from './window-tracker';

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -136,7 +136,8 @@ export class Application implements AppState {
       }
     }
 
-    if (!await prepareEnvironment()) {
+    const [, error] = prepareEnvironment();
+    if (error) {
       return exitFailure();
     }
 

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -1,5 +1,5 @@
 /*
- * detect_r.ts
+ * detect-r.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -14,14 +14,14 @@
  */
 
 import { dialog } from 'electron';
+import { dirname } from 'path';
 import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 
-import { logger } from '../core/logger';
 import { Environment, getenv, setVars } from '../core/environment';
-
-import { dirname } from 'path';
 import { Expected, ok, err } from '../core/expected';
+import { logger } from '../core/logger';
+
 
 interface REnvironment {
   rScriptPath: string,
@@ -53,9 +53,11 @@ function executeCommand(command: string): Expected<string> {
 }
 
 /**
- * Detect R and prepare environment for launching rsession.
+ * Detect R and prepare environment for launching the rsession process.
  * 
- * @returns true if startup should continue, false on fatal error
+ * This entails setting environment variables relevant to R on startup
+ * // (for example, R_HOME) and other platform-specific work required
+ * for R to launch.
  */
 export function prepareEnvironment(): Expected<REnvironment> {
 

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -87,7 +87,7 @@ async function detectREnvironment(): Promise<REnvironment> {
   }
 
   // get R_HOME + other related R environment variables
-  const stdout = execSync(`${R} RHOME`, { encoding: 'utf-8'});
+  const stdout = execSync(`${R} RHOME`, { encoding: 'utf-8' });
   const home = stdout.trim();
   const envvars = {
     R_HOME:        `${home}`,

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -15,20 +15,27 @@
 
 import { app, dialog } from 'electron';
 import { exec, execSync } from 'child_process';
-import { promisify } from 'util';
 import { existsSync } from 'fs';
-import { assert } from 'console';
 
 import { logger } from '../core/logger';
-import { Environment, getenv, setVars } from '../core/environment';
+import { Environment, getenv, setenv, setVars } from '../core/environment';
 import { FilePath } from '../core/file-path';
 
 import { appState } from './app-state';
+import path, { dirname } from 'path';
 
-const asyncExec = promisify(exec);
+interface REnvironment {
+  rScriptPath: string,
+  version: string,
+  envVars: Environment,
+}
+
+function rNotFoundErrorMessage(): string {
+  return "Could not locate an R installation on the system.";
+}
 
 function showRNotFoundError(msg: string): void {
-  dialog.showErrorBox('R Not Found', msg);
+  dialog.showErrorBox('R not found', msg);
 }
 
 /**
@@ -37,123 +44,98 @@ function showRNotFoundError(msg: string): void {
  * @returns true if startup should continue, false on fatal error
  */
 export async function prepareEnvironment(): Promise<boolean> {
-  if (process.platform === 'win32') {
-    return await prepareEnvironmentWin32();
-  } else {
-    return await prepareEnvironmentPosix();
+
+  try {
+    return prepareEnvironmentImpl();
+  } catch (error) {
+    logger().logError(error);
+    return false;
   }
+
 }
 
-async function prepareEnvironmentPosix(): Promise<boolean> {
-
-  assert((process.platform !== 'win32'));
-
-  // check for which R override
-  let rWhichRPath = new FilePath();
-  const whichROverride = getenv('RSTUDIO_WHICH_R');
-  if (whichROverride) {
-    rWhichRPath = new FilePath(whichROverride);
-  }
-
-  // determine rLdPaths script location
-  let rLdScriptPath = new FilePath();
-  if (process.platform === 'darwin') {
-    if (app.isPackaged) {
-      rLdScriptPath = appState().scriptsPath?.completePath('session/r-ldpath') ?? new FilePath();
-      if (!rLdScriptPath.existsSync()) {
-        rLdScriptPath = new FilePath(app.getAppPath()).completePath('r-ldpath');
-      }
-    } else {
-      rLdScriptPath = appState().sessionPath?.completePath('../r-ldpath') ?? new FilePath();
-    }
-  } else {
-    rLdScriptPath = appState().supportingFilePath().completePath('bin/r-ldpath');
-    if (!rLdScriptPath.existsSync()) {
-      rLdScriptPath = appState().supportingFilePath().completePath('session/r-ldpath');
-    }
-  }
+async function prepareEnvironmentImpl(): Promise<boolean> {
 
   // attempt to detect R environment
-  const detectResult = await detectREnvironment(rWhichRPath, rLdScriptPath, '');
-  if (!detectResult.success) {
-    showRNotFoundError(detectResult.errMsg ?? 'Unknown error');
+  var detectResult : REnvironment;
+  try {
+    detectResult = await detectREnvironment();
+  } catch (error) {
+    showRNotFoundError(error ?? 'An unknown error occurred.');
     return false;
   }
 
-  logger().logDiagnostic(`Using R script: ${detectResult.rScriptPath}`);
+  // set environment variables from R
+  setVars(detectResult.envVars);
 
-  setREnvironmentVars(detectResult.envVars ?? {});
-
-  if (process.platform === 'darwin') {
-    // TODO: deal with selection of x86_64 or arm64 build of R
-  }
-
-  return true;
-}
-
-async function prepareEnvironmentWin32(): Promise<boolean> {
-  assert((process.platform === 'win32'));
-
-  // TODO: this is just a hacked-together placeholder for dev purposes
-
-  // check for which R override
-  let rWhichRPath = new FilePath();
-  const whichROverride = getenv('RSTUDIO_WHICH_R');
-  if (!whichROverride) {
-    dialog.showErrorBox(
-      'RSTUDIO_WHICH_R Not Set',
-      'Temporary: RSTUDIO_WHICH_R environment variable must point to R installation folder. Cannot continue.');
-    return false;
-  }
-
-  rWhichRPath = new FilePath(whichROverride);
-  if (!rWhichRPath.existsSync()) {
-    dialog.showErrorBox(
-      'RSTUDIO_WHICH_R Incorrect',
-      `RSTUDIO_WHICH_R environment variable set incorrectly; ${rWhichRPath.getAbsolutePathNative()} not found. Cannot continue.`);
-    return false;
-  }
-
-
-  process.env.R_HOME = rWhichRPath.getAbsolutePathNative();
-  const rPath = rWhichRPath.completeChildPath('bin\\x64');
-  process.env.PATH = `${rPath};${process.env.PATH}`;
-
-  return true;
-}
-
-async function scanForR(rsessionWhichR: FilePath): Promise<FilePath> {
+  // on Windows, ensure R is on the PATH so that companion DLLs
+  // in the same directory can be resolved
+  const scriptPath = detectResult.rScriptPath || '';
   if (process.platform === 'win32') {
-    return await scanForRWin32(rsessionWhichR);
-  } else {
-    return await scanForRPosix(rsessionWhichR);
+    const binDir = dirname(scriptPath);
+    process.env.PATH = `${binDir};${process.env.PATH}`;
   }
+
+  return true;
+
 }
 
-async function scanForRPosix(rsessionWhichR: FilePath): Promise<FilePath> {
-  assert((process.platform !== 'win32'));
+async function detectREnvironment(): Promise<REnvironment> {
 
-  // if an override has been supplied (typically from rsession-which-r)
-  // then prefer that
-  if (!rsessionWhichR.isEmpty()) {
-    return rsessionWhichR;
+  // scan for R
+  const R = await scanForR();
+  if (!R) {
+    throw rNotFoundErrorMessage();
   }
+
+  // get R_HOME + other related R environment variables
+  const stdout = execSync(`${R} RHOME`, { encoding: 'utf-8'});
+  const home = stdout.trim();
+  const envvars = {
+    R_HOME:        `${home}`,
+    R_SHARE_DIR:   `${home}/share`,
+    R_INCLUDE_DIR: `${home}/include`,
+    R_DOC_DIR:     `${home}/doc`
+  };
+
+  // get R version string
+  const rVersion = execSync(
+    `${R} --vanilla -s -e "cat(format(getRversion()))"`,
+    { encoding: 'utf-8' }
+  );
+
+  return {
+    rScriptPath: R,
+    version:     rVersion,
+    envVars:     envvars
+  };
+
+}
+
+async function scanForR(): Promise<string> {
 
   // if the RSTUDIO_WHICH_R environment variable is set, use that
   const rstudioWhichR = getenv('RSTUDIO_WHICH_R');
   if (rstudioWhichR) {
-    return new FilePath(rstudioWhichR);
+    logger().logDiagnostic(`Using RSTUDIO_WHICH_R: ${rstudioWhichR}`)
+    return rstudioWhichR;
   }
 
-  // first look for R on the PATH
-  try {
-    const { stdout } = await asyncExec('/usr/bin/which R', { encoding: 'utf-8' });
-    const R = stdout.trim();
-    if (R) {
-      return new FilePath(R);
-    }
-  } catch (error) {
-    logger().logError(error);
+  // otherwise, use platform-specific lookup strategies
+  if (process.platform === 'win32') {
+    return await scanForRWin32();
+  } else {
+    return await scanForRPosix();
+  }
+}
+
+async function scanForRPosix(): Promise<string> {
+
+  // first, look for R on the PATH
+  const stdout = execSync('/usr/bin/which R', { encoding: 'utf-8' });
+  const R = stdout.trim();
+  if (R) {
+    return R;
   }
 
   // otherwise, look in some hard-coded locations
@@ -170,83 +152,55 @@ async function scanForRPosix(rsessionWhichR: FilePath): Promise<FilePath> {
 
   for (const location of defaultLocations) {
     if (existsSync(location)) {
-      return new FilePath(location);
+      return location;
     }
   }
 
   // nothing found
-  return new FilePath();
+  return '';
+
 }
 
-export async function scanForRWin32(rsessionWhichR: FilePath): Promise<FilePath> {
+function findDefaultInstallPathWin32(version: string): string {
 
-  assert((process.platform === 'win32'));
+  const keyName = `HKEY_LOCAL_MACHINE\\SOFTWARE\\R-Core\\${version}`;
+  const regOutput = execSync(`reg query ${keyName} /v InstallPath`, { encoding: 'utf-8'});
 
-  // if an override has been supplied (typically from rsession-which-r)
-  // then prefer that
-  if (!rsessionWhichR.isEmpty()) {
-    return rsessionWhichR;
+  const lines = regOutput.split('\r\n');
+  for (const line of lines) {
+    const match = /^\s*InstallPath\s*REG_SZ\s*(.*)$/.exec(line);
+    if (match != null) {
+      return match[1];
+    }
   }
+
+  return '';
+
+}
+
+export async function scanForRWin32(): Promise<string> {
 
   // if the RSTUDIO_WHICH_R environment variable is set, use that
   const rstudioWhichR = getenv('RSTUDIO_WHICH_R');
   if (rstudioWhichR) {
-    return new FilePath(rstudioWhichR);
+    return rstudioWhichR;
   }
 
-  // read default version information from registry
-  const keyName = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\R-Core\\R64';
-  const regOutput = execSync(`reg query ${keyName} /v InstallPath`, { encoding: 'utf-8'});
-
-  const lines = regOutput.split('\n');
-  for (const line of lines) {
-    const match = /^\s*InstallPath\s*REG_SZ\s*(.*)$/.exec(line);
-    if (match != null) {
-      const installPath = match[1];
-      return new FilePath(installPath);
+  // look for a 64-bit version of R
+  if (process.arch !== 'x32') {
+    const x64InstallPath = findDefaultInstallPathWin32("R64");
+    if (x64InstallPath) {
+      return `${x64InstallPath}/bin/x64/R.exe`;
     }
   }
 
-  // For now must set env var to run on Windows
-  return new FilePath();
-}
-
-interface REnvironment {
-  success: boolean,
-  rScriptPath?: string,
-  version?: string,
-  envVars?: Environment,
-  errMsg?: string,
-}
-
-async function detectREnvironment(
-  whichRScript: FilePath,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ldPathsScript: FilePath,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ldLibraryPath: string
-): Promise<REnvironment> {
-
-  const scanResult = await scanForR(whichRScript);
-  if (scanResult.isEmpty()) {
-    return { success: false, errMsg: 'Did not find R' };
+  // look for a 32-bit version of R
+  const i386InstallPath = findDefaultInstallPathWin32("R");
+  if (i386InstallPath) {
+    return `${i386InstallPath}/bin/i386/R.exe`;
   }
-  const R = scanResult.getAbsolutePath();
 
-  // read some important environment variables
-  const { stdout } = await asyncExec(`${R} --no-save --no-restore RHOME`);
-  const rHome = stdout.trim();
-  const rEnv = {
-    R_HOME: `${rHome}`,
-    R_SHARE_DIR: `${rHome}/share`,
-    R_DOC_DIR: `${rHome}/doc`
-  };
+  // nothing found; return empty filepath
+  return '';
 
-  // TODO: detect and return R version 
-
-  return { success: true, rScriptPath: scanResult.getAbsolutePath(), envVars: rEnv };
-}
-
-function setREnvironmentVars(vars: Environment) {
-  setVars(vars);
 }

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -13,16 +13,14 @@
  *
  */
 
-import { app, dialog } from 'electron';
-import { exec, execSync } from 'child_process';
+import { dialog } from 'electron';
+import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 
 import { logger } from '../core/logger';
-import { Environment, getenv, setenv, setVars } from '../core/environment';
-import { FilePath } from '../core/file-path';
+import { Environment, getenv, setVars } from '../core/environment';
 
-import { appState } from './app-state';
-import path, { dirname } from 'path';
+import { dirname } from 'path';
 
 interface REnvironment {
   rScriptPath: string,
@@ -31,7 +29,7 @@ interface REnvironment {
 }
 
 function rNotFoundErrorMessage(): string {
-  return "Could not locate an R installation on the system.";
+  return 'Could not locate an R installation on the system.';
 }
 
 function showRNotFoundError(msg: string): void {
@@ -57,7 +55,7 @@ export async function prepareEnvironment(): Promise<boolean> {
 async function prepareEnvironmentImpl(): Promise<boolean> {
 
   // attempt to detect R environment
-  var rEnvironment : REnvironment;
+  let rEnvironment : REnvironment;
   try {
     rEnvironment = await detectREnvironment();
   } catch (error) {
@@ -188,14 +186,14 @@ export async function scanForRWin32(): Promise<string> {
 
   // look for a 64-bit version of R
   if (process.arch !== 'x32') {
-    const x64InstallPath = findDefaultInstallPathWin32("R64");
+    const x64InstallPath = findDefaultInstallPathWin32('R64');
     if (x64InstallPath) {
       return `${x64InstallPath}/bin/x64/R.exe`;
     }
   }
 
   // look for a 32-bit version of R
-  const i386InstallPath = findDefaultInstallPathWin32("R");
+  const i386InstallPath = findDefaultInstallPathWin32('R');
   if (i386InstallPath) {
     return `${i386InstallPath}/bin/i386/R.exe`;
   }

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -57,20 +57,20 @@ export async function prepareEnvironment(): Promise<boolean> {
 async function prepareEnvironmentImpl(): Promise<boolean> {
 
   // attempt to detect R environment
-  var detectResult : REnvironment;
+  var rEnvironment : REnvironment;
   try {
-    detectResult = await detectREnvironment();
+    rEnvironment = await detectREnvironment();
   } catch (error) {
     showRNotFoundError(error ?? 'An unknown error occurred.');
     return false;
   }
 
   // set environment variables from R
-  setVars(detectResult.envVars);
+  setVars(rEnvironment.envVars);
 
   // on Windows, ensure R is on the PATH so that companion DLLs
   // in the same directory can be resolved
-  const scriptPath = detectResult.rScriptPath || '';
+  const scriptPath = rEnvironment.rScriptPath;
   if (process.platform === 'win32') {
     const binDir = dirname(scriptPath);
     process.env.PATH = `${binDir};${process.env.PATH}`;

--- a/src/node/desktop/src/main/detect_r.ts
+++ b/src/node/desktop/src/main/detect_r.ts
@@ -139,7 +139,7 @@ function scanForR(): Expected<string> {
   // if the RSTUDIO_WHICH_R environment variable is set, use that
   const rstudioWhichR = getenv('RSTUDIO_WHICH_R');
   if (rstudioWhichR) {
-    logger().logDiagnostic(`Using RSTUDIO_WHICH_R: ${rstudioWhichR}`);
+    logger().logDiagnostic(`Using ${rstudioWhichR} (found by RSTUDIO_WHICH_R environment variable)`);
     return ok(rstudioWhichR);
   }
 

--- a/src/node/desktop/test/unit/main/detect-r.test.ts
+++ b/src/node/desktop/test/unit/main/detect-r.test.ts
@@ -1,5 +1,5 @@
 /*
- * detect_r.test.ts
+ * detect-r.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -17,7 +17,7 @@ import { describe } from 'mocha';
 
 import { saveAndClear, restore } from '../unit-utils';
 
-describe('detect_r', () => {
+describe('detect-r', () => {
   const vars: Record<string, string> = {
     RSTUDIO_WHICH_R: ''
   };


### PR DESCRIPTION
### Intent

- Support auto-discovery of R on Windows, using the most recently recorded version from the Windows registry.
- Also support auto-discovery of C++ build sources, for those of us too lazy to set `RSTUDIO_CPP_OUTPUT_FOLDER`.

### Approach

- Use `reg query <...>` to find what version of R is recorded in the Windows registry. This approach was taken specifically because I was having trouble installing + building https://www.npmjs.com/package/windows-registry on Windows.
- Some other heuristics for locating C++ build artefacts in non-package builds.

### Automated Tests

Not yet implemented.

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
