### PR TITLE
Feature/electron window position restore

### DIFF
--- a/src/node/desktop/src/main/desktop-options.ts
+++ b/src/node/desktop/src/main/desktop-options.ts
@@ -16,7 +16,6 @@
 
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
-import { MainWindow } from './main-window';
  
 const kProportionalFont = 'Font.ProportionalFont';
 const kFixWidthFont = 'Font.FixWidthFont';

--- a/src/node/desktop/src/main/desktop-options.ts
+++ b/src/node/desktop/src/main/desktop-options.ts
@@ -14,7 +14,7 @@
  * 
  */
 
-import { Rectangle, screen } from 'electron';
+import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
 import { MainWindow } from './main-window';
  
@@ -162,7 +162,7 @@ export class DesktopOptionsImpl {
   }
 
   // Note: screen can only be used after the 'ready' event has been emitted
-  public restoreMainWindowBounds(mainWindow: MainWindow): void {
+  public restoreMainWindowBounds(mainWindow: BrowserWindow): void {
     const savedBounds = this.windowBounds(); 
 
     // Check if saved bounds is still in one of the available displays
@@ -172,24 +172,24 @@ export class DesktopOptionsImpl {
 
     // Restore it to previous location if possible, or center of primary display otherwise
     if (goodDisplays) {
-      mainWindow.window.setBounds(savedBounds);
+      mainWindow.setBounds(savedBounds);
     } else {
       const primaryBounds = screen.getPrimaryDisplay().bounds;
       const newSize = {width: Math.min(kDesktopOptionDefaults.View.WindowBounds.width, primaryBounds.width), 
         height: Math.min(kDesktopOptionDefaults.View.WindowBounds.height, primaryBounds.height)};
 
-      mainWindow.window.setSize(newSize.width, newSize.height);
+      mainWindow.setSize(newSize.width, newSize.height);
       
       // window.center() doesn't consistently pick the primary display, 
       // so manually calculating the center of the primary display
-      mainWindow.window.setPosition(
+      mainWindow.setPosition(
         primaryBounds.x + ((primaryBounds.width - newSize.width) / 2), 
         primaryBounds.y + ((primaryBounds.height - newSize.height) / 2));
     }
 
     // ensure a minimum size for the window on restore
-    const currSize = mainWindow.window.getSize();
-    mainWindow.window.setSize(
+    const currSize = mainWindow.getSize();
+    mainWindow.setSize(
       Math.max(300, currSize[0]),
       Math.max(200, currSize[1])
     );

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -309,8 +309,8 @@ export class MainWindow extends GwtWindow {
     //                      false);
 
     if (!this.geometrySaved) {
-      const size = this.window.getSize();
-      DesktopOptions().saveWindowBounds({width: size[0], height: size[1]});
+      const bounds = this.window.getBounds();
+      DesktopOptions().saveWindowBounds(bounds);
       this.geometrySaved = true;
     }
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -152,7 +152,7 @@ export class SessionLauncher {
     this.mainWindow.appLauncher = this.appLaunch;
     this.appLaunch.setActivationWindow(this.mainWindow);
 
-    DesktopOptions().restoreMainWindowBounds(this.mainWindow);
+    DesktopOptions().restoreMainWindowBounds(this.mainWindow.window);
 
     logger().logDiagnostic('\nConnected to R session, attempting to initialize...\n');
 

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -12,13 +12,16 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  */
 
+import { BrowserWindow, Rectangle, screen } from 'electron';
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import sinon from 'sinon';
 
-import { DesktopOptions, DesktopOptionsImpl, kDesktopOptionDefaults, clearOptionsSingleton } from '../../../src/main/desktop-options';
+import { DesktopOptions, DesktopOptionsImpl, kDesktopOptionDefaults, clearOptionsSingleton, firstIsInsideSecond } from '../../../src/main/desktop-options';
 import { FilePath } from '../../../src/core/file-path';
 import { Err, isSuccessful } from '../../../src/core/err';
 import { tempDirectory } from '../unit-utils';
+import { Display } from 'electron/main';
 
 const kTestingConfigDirectory = tempDirectory('DesktopOptionsTesting').toString();
 
@@ -29,7 +32,11 @@ function testingDesktopOptions(): DesktopOptionsImpl {
 function deleteTestingDesktopOptions(): Err {
   clearOptionsSingleton();
   const filepath = new FilePath(kTestingConfigDirectory);
-  return filepath.removeSync();
+  return filepath.removeIfExistsSync();
+}
+
+function rec(height = 10, width = 10, x = 0, y = 0): Rectangle {
+  return {height: height, width: width, x: x, y: y};
 }
 
 describe('DesktopOptions', () => {
@@ -69,7 +76,7 @@ describe('DesktopOptions', () => {
     const newFixWidthFont = 'testFixWidthFont';
     const newUseFontConfigDb = !kDesktopOptionDefaults.Font.UseFontConfigDb;
     const newZoom = 123;
-    const newWindowBounds = {width: 123, height: 321};
+    const newWindowBounds = {width: 123, height: 321, x: 0, y: 0};
     const newAccessibility = !kDesktopOptionDefaults.View.Accessibility;
     const newLastRemoteSessionUrl = 'testLastRemoteSessionUrl';
     const newAuthCookies = ['test', 'Autht', 'Cookies'];
@@ -126,5 +133,124 @@ describe('DesktopOptions', () => {
     clearOptionsSingleton();
     const options2 = testingDesktopOptions();
     assert.equal(options2.zoomLevel(), newZoom);
+  });
+  it('restores window bounds to correct display', () => {
+    const displays = [{workArea: {width: 2000, height: 2000, x: 0, y: 0}}, {workArea: {width: 2000, height: 2000, x: 2000, y: 0}}];
+    const savedWinBounds = {width: 500, height: 500, x: 2100, y: 100};
+
+    // Save bounds onto a secondary display on the right
+    DesktopOptions().saveWindowBounds(savedWinBounds);
+
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(screen, 'getAllDisplays').returns(displays as Display[]);
+    const testMainWindow = sandbox.createStubInstance(BrowserWindow);
+    testMainWindow.setBounds.withArgs(savedWinBounds);
+    testMainWindow.getSize.returns([savedWinBounds.width, savedWinBounds.height]);
+    
+    DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
+
+    sandbox.assert.calledOnceWithExactly(testMainWindow.setBounds, savedWinBounds);
+    sandbox.assert.calledOnce(testMainWindow.setSize);
+    sandbox.assert.alwaysCalledWith(testMainWindow.setSize, savedWinBounds.width, savedWinBounds.height);
+    sandbox.assert.callCount(testMainWindow.setPosition, 0);
+    sandbox.restore();
+  });
+  it('restores window bounds to default when saved display no longer present', () => {
+    const defaultDisplay = {bounds: {width: 2000, height: 2000, x: 0, y: 0}};
+    const savedWinBounds = {width: 500, height: 500, x: 0, y: 0};
+    const defaultWinWidth = kDesktopOptionDefaults.View.WindowBounds.width;
+    const defaultWinHeight = kDesktopOptionDefaults.View.WindowBounds.height;
+
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(screen, 'getAllDisplays').returns([]);
+    sandbox.stub(screen, 'getPrimaryDisplay').returns(defaultDisplay as Display);
+    const testMainWindow = sandbox.createStubInstance(BrowserWindow);
+    testMainWindow.setSize
+      .withArgs(defaultWinWidth, defaultWinHeight);
+    testMainWindow.getSize.returns([defaultWinWidth, defaultWinHeight]);
+
+    // Make sure some bounds are already saved
+    DesktopOptions().saveWindowBounds(savedWinBounds);
+    
+    DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
+
+    sandbox.assert.calledTwice(testMainWindow.setSize);
+    sandbox.assert.alwaysCalledWith(testMainWindow.setSize, defaultWinWidth, defaultWinHeight);
+    sandbox.restore();
+  });
+});
+
+/**
+ * A note on Electron's rectangle/display coordinate system:
+ * (x, y) coord is top left corner of a Rectangle or Display object
+ * (x + width, y + height) is bottom right corner
+ * 
+ * x increases to the right, decreases to the left
+ * y increases downwards, decreases upwards
+ * 
+ * primary display's (x, y) coord is always (0, 0)
+ * negative values are legal
+ * external display to the right of primary display could be (primary.width, 0) ex. (1920, 0)
+ * external display to the left of primary display could be (-secondary.width, 0) ex. (-1200, 0)
+ */
+describe('FirstIsInsideSecond', () => {
+  const INNER_WIDTH = 10;
+  const INNER_HEIGHT = 10;
+  const INNER_X = 0;
+  const INNER_Y = 0;
+
+  const OUTER_WIDTH = 20;
+  const OUTER_HEIGHT = 20;
+  const OUTER_X = 0;
+  const OUTER_Y = 0;
+
+  const X_FAR_OUT_WEST = -100;
+  const X_FAR_BACK_EAST = 100;
+  const Y_FAR_UP_NORTH = -100;
+  const Y_FAR_DOWN_SOUTH = 100;
+
+  it('basic case', () => {
+    assert.isTrue(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, INNER_X + 1, INNER_Y + 1), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y))); // entirely inside
+    assert.isTrue(firstIsInsideSecond(
+      rec(), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y))); // top and left boarders shared
+    assert.isTrue(firstIsInsideSecond(
+      rec(), 
+      rec())); // same size rectangles is valid
+  });
+  it('backwards case', () => {
+    assert.isFalse(firstIsInsideSecond(
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y), 
+      rec()));
+  });
+  it ('partially outside', () => {
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, INNER_X + 11, INNER_Y), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, INNER_X, INNER_Y + 11), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, INNER_X - 1, INNER_Y), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, INNER_X, INNER_Y - 1), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+  });
+  it ('entirely outside', () => {
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, X_FAR_BACK_EAST, Y_FAR_DOWN_SOUTH), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, X_FAR_OUT_WEST, Y_FAR_DOWN_SOUTH), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, X_FAR_BACK_EAST, Y_FAR_UP_NORTH), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+    assert.isFalse(firstIsInsideSecond(
+      rec(INNER_WIDTH, INNER_HEIGHT, X_FAR_OUT_WEST, Y_FAR_UP_NORTH), 
+      rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
   });
 });

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -147,6 +147,7 @@ describe('DesktopOptions', () => {
     testMainWindow.setBounds.withArgs(savedWinBounds);
     testMainWindow.getSize.returns([savedWinBounds.width, savedWinBounds.height]);
     
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
 
     sandbox.assert.calledOnceWithExactly(testMainWindow.setBounds, savedWinBounds);
@@ -172,6 +173,7 @@ describe('DesktopOptions', () => {
     // Make sure some bounds are already saved
     DesktopOptions().saveWindowBounds(savedWinBounds);
     
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
 
     sandbox.assert.calledTwice(testMainWindow.setSize);


### PR DESCRIPTION
Add main window position restore (in addition to the already-present window size restore). Loosely mirrors the C++ desktop code. Accounts for display arrangement changing between window save/restore