### PR TITLE
basic integration test for main menu (Electron)

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -46,6 +46,10 @@ export function showPlaceholderMenu(): void {
   Menu.setApplicationMenu(mainMenuStub);
 }
 
+function menuIdFromLabel(label: string): string {
+  return label.replace('&', '');
+}
+
 /**
  * Callbacks from renderer to create application menu.
  */
@@ -75,7 +79,7 @@ export class MenuCallback extends EventEmitter {
 
     ipcMain.on('menu_begin', (event, label: string) => {
       const subMenu = new Menu();
-      const opts: MenuItemConstructorOptions = {submenu: subMenu, label: label};
+      const opts: MenuItemConstructorOptions = { submenu: subMenu, label: label, id: menuIdFromLabel(label) };
       if (label === '&File') {
         opts.role = 'fileMenu';
       } else if (label === '&Edit') {

--- a/src/node/desktop/test/int/mocharc.json
+++ b/src/node/desktop/test/int/mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["ts"],
   "spec": "./test/int/**/*.test.ts",
-  "require": "ts-node/register"
+  "require": "ts-node/register",
+  "timeout": 15000
 }

--- a/src/node/desktop/test/int/startup-fail-session.test.ts
+++ b/src/node/desktop/test/int/startup-fail-session.test.ts
@@ -1,0 +1,42 @@
+/*
+ * startup-fail-session.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { ElectronApplication, Page } from 'playwright';
+
+import { launch } from './int-utils';
+
+describe('Startup With Failing RSession', async function () {
+  let electronApp: ElectronApplication;
+  let window: Page;
+
+  beforeEach(async () => {
+    // tell the rsession to immediately terminate with exit code of 1
+    electronApp = await launch(['--session-exit-code=1']);
+    window = await electronApp.firstWindow();
+    window.setDefaultTimeout(5000);
+  });
+
+  afterEach(async () => {
+    await electronApp.close();
+  });
+
+  it('Shows launch failure page if session fails to launch', async function () {
+    // check that page is loaded with H1 containing "Error Starting R"
+    const h1 = await window.innerText('h1');
+    assert.equal(h1, 'Error Starting R');
+  });
+});

--- a/src/node/desktop/test/int/startup.test.ts
+++ b/src/node/desktop/test/int/startup.test.ts
@@ -15,36 +15,65 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import { ElectronApplication, Page } from 'playwright';
 
 import { launch } from './int-utils';
+import { app, MenuItem } from 'electron';
 
 describe('Startup and Exit', async function () {
-  this.timeout(15000);
+  let electronApp: ElectronApplication;
+  let window: Page;
+
+  beforeEach(async () => {
+    electronApp = await launch();
+    window = await electronApp.firstWindow();
+    window.setDefaultTimeout(5000);
+  });
+
+  afterEach(async () => {
+    await electronApp.close();
+  });
 
   it('Shows a window with Console tab', async function () {
-    const electronApp = await launch();
-    
-    // wait for a window
-    const window = await electronApp.firstWindow();
-
     // check that Console tab has role=tab
     const consoleTabRole = await window.getAttribute('#rstudio_workbench_tab_console', 'role');
     assert.equal(consoleTabRole, 'tab');
-
-    // exit app
-    await electronApp.close();
   });
-  it('Shows launch failure page if session fails to launch', async function () {
-    const electronApp = await launch(['--session-exit-code=1']);
-    
-    // wait for a window
-    const window = await electronApp.firstWindow();
+  it('Shows a window with expected main menu', async function () {
+    await window.click('#rstudio_workbench_tab_console');
 
-    // check that page is loaded with H1 containing "Error Starting R"
-    const h1 = await window.innerText('h1');
-    assert.equal(h1, 'Error Starting R');
-
-    // exit app
-    await electronApp.close();
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('File');
+    }), 'Failed to find File menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Edit');
+    }), 'Failed to find Edit menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Code');
+    }), 'Failed to find Code menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('View');
+    }), 'Failed to find View menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Plots');
+    }), 'Failed to find Plots menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Session');
+    }), 'Failed to find Session menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Build');
+    }), 'Failed to find Build menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Debug');
+    }), 'Failed to find Debug menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Profile');
+    }), 'Failed to find Profile menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Tools');
+    }), 'Failed to find Tools menu');
+    assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
+      return !!app.applicationMenu?.getMenuItemById('Help');
+    }), 'Failed to find Help menu');
   });
 });

--- a/src/node/desktop/test/int/startup.test.ts
+++ b/src/node/desktop/test/int/startup.test.ts
@@ -18,7 +18,6 @@ import { assert } from 'chai';
 import { ElectronApplication, Page } from 'playwright';
 
 import { launch } from './int-utils';
-import { app, MenuItem } from 'electron';
 
 describe('Startup and Exit', async function () {
   let electronApp: ElectronApplication;


### PR DESCRIPTION
### Intent

Test that the top-level main menu has expected items on startup for Electron desktop.

### Approach

Used Playwright's `evaluate` mechanism to run code in the main process. Had to assign stable IDs to the main menu, so using the labels minus any ampersand.

Also slightly restructured existing integration tests, working gradually towards a more coherent model. No doubt more refactoring will happen as we learn more. As part of this the Electron app will now shutdown if a test fails, previously you had to go kill it.

### Automated Tests

The new test starts the app, waits for the Console tab to appear (and clicks on it for good measure), then makes sure the top-level menu items exist.

### QA Notes

You can try this by using the `scripts/mac-package` trick (be sure to install a very recent desktop build into Applications before running the script), followed by `yarn testint`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


