### PR TITLE
eliminate "as any" and "eslint-disables" in restore window position unit tests

### DIFF
--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -16,6 +16,7 @@ import { BrowserWindow, Rectangle, screen } from 'electron';
 import { describe } from 'mocha';
 import { assert } from 'chai';
 import sinon from 'sinon';
+import { createSinonStubInstanceForSandbox } from '../unit-utils';
 
 import { DesktopOptions, DesktopOptionsImpl, kDesktopOptionDefaults, clearOptionsSingleton, firstIsInsideSecond } from '../../../src/main/desktop-options';
 import { FilePath } from '../../../src/core/file-path';
@@ -143,12 +144,11 @@ describe('DesktopOptions', () => {
 
     const sandbox = sinon.createSandbox();
     sandbox.stub(screen, 'getAllDisplays').returns(displays as Display[]);
-    const testMainWindow = sandbox.createStubInstance(BrowserWindow);
+    const testMainWindow = createSinonStubInstanceForSandbox(sandbox, BrowserWindow);
     testMainWindow.setBounds.withArgs(savedWinBounds);
     testMainWindow.getSize.returns([savedWinBounds.width, savedWinBounds.height]);
     
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
+    DesktopOptions().restoreMainWindowBounds(testMainWindow);
 
     sandbox.assert.calledOnceWithExactly(testMainWindow.setBounds, savedWinBounds);
     sandbox.assert.calledOnce(testMainWindow.setSize);
@@ -165,7 +165,7 @@ describe('DesktopOptions', () => {
     const sandbox = sinon.createSandbox();
     sandbox.stub(screen, 'getAllDisplays').returns([]);
     sandbox.stub(screen, 'getPrimaryDisplay').returns(defaultDisplay as Display);
-    const testMainWindow = sandbox.createStubInstance(BrowserWindow);
+    const testMainWindow = createSinonStubInstanceForSandbox(sandbox, BrowserWindow);
     testMainWindow.setSize
       .withArgs(defaultWinWidth, defaultWinHeight);
     testMainWindow.getSize.returns([defaultWinWidth, defaultWinHeight]);
@@ -173,8 +173,7 @@ describe('DesktopOptions', () => {
     // Make sure some bounds are already saved
     DesktopOptions().saveWindowBounds(savedWinBounds);
     
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    DesktopOptions().restoreMainWindowBounds(testMainWindow as any);
+    DesktopOptions().restoreMainWindowBounds(testMainWindow);
 
     sandbox.assert.calledTwice(testMainWindow.setSize);
     sandbox.assert.alwaysCalledWith(testMainWindow.setSize, defaultWinWidth, defaultWinHeight);

--- a/src/node/desktop/test/unit/unit-utils.ts
+++ b/src/node/desktop/test/unit/unit-utils.ts
@@ -16,7 +16,7 @@
 import path from 'path';
 import os from 'os';
 
-import { createStubInstance, StubbableType, SinonStubbedInstance, SinonStubbedMember } from 'sinon';
+import { createStubInstance, StubbableType, SinonStubbedInstance, SinonStubbedMember, SinonSandbox } from 'sinon';
 import { FilePath } from '../../src/core/file-path';
 
 export function randomString(): string {
@@ -58,6 +58,16 @@ export function createSinonStubInstance<T>(
   const stub = createStubInstance<T>(constructor, overrides);
   return stub as unknown as StubbedClass<T>;
 }
+
+export function createSinonStubInstanceForSandbox<T>(
+  sandbox: SinonSandbox,
+  constructor: StubbableType<T>,
+  overrides?: { [K in keyof T]?: SinonStubbedMember<T[K]> },
+): StubbedClass<T> {
+  const stub = sandbox.createStubInstance<T>(constructor, overrides);
+  return stub as unknown as StubbedClass<T>;
+}
+
 
 /**
  * Creates a random directory name located inside the temp directory


### PR DESCRIPTION
### Intent

Unit tests for #9645 had a couple instances of "as any" assertions and corresponding es-lint disables. We should try to avoid needing these. 

### Approach

Add a variation of `createSinonStubInstance` helper named `createSinonStubInstanceForSandbox` that works with non-default sandbox. This helper uses some TypeScript magic to work around this problem (the line ` return stub as unknown as StubbedClass<T>;`).

Note, occasionally VSCode's TypeScript support loses its mind on this construct and will flag it as an error. If you close and restart VSCode it resolves. In any case TypeScript itself (and ESLint) are both happy with it.

### Automated Tests

This is some source code cleanup on unit tests, no change to product code.

### QA Notes

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


