### PR TITLE
Improve logging of the libR location

### DIFF
--- a/cmake/modules/FindLibR.cmake
+++ b/cmake/modules/FindLibR.cmake
@@ -111,6 +111,11 @@ else()
             message(STATUS "Unable to locate R home (not written to registry)")
          endif()
 
+         # make sure path exists
+         if (NOT EXISTS "${LIBR_HOME}")
+            message(STATUS "Path to R found in registry '${LIBR_HOME}' doesn't exist")
+         endif()
+
       endif()
 
       # set other R paths based on home path

--- a/src/cpp/tools/dll2lib.R
+++ b/src/cpp/tools/dll2lib.R
@@ -6,6 +6,8 @@ Sys.setenv(PATH = paste(dirname(args[1]), Sys.getenv("PATH"), sep = ";"))
 # Find R DLLs.
 dlls <- list.files(R.home("bin"), pattern = "dll$", full.names = TRUE)
 
+message("Generating .lib files for DLLs in ", R.home("bin"))
+
 # Generate corresponding 'lib' file for each DLL.
 for (dll in dlls) {
    
@@ -16,6 +18,7 @@ for (dll in dlls) {
    
    # Call it on R.dll to generate exports.
    command <- sprintf("dumpbin.exe /EXPORTS /NOLOGO %s", dll)
+   message("> ", command)
    output <- system(paste(command), intern = TRUE)
    
    # Remove synonyms.


### PR DESCRIPTION
### Intent

I just lost a couple hours trying to fix my Windows R installation, which was failing in cmake with this error:

```
CMake Error at cmake/modules/FindLibR.cmake:152 (message):
  Failed to generate .lib files for R DLLs!
Call Stack (most recent call first):
  src/cpp/CMakeLists.txt:590 (find_package)
```

Finally figured out the problem, which was that due to a registry issue (no theories about how it arose), it was getting the string `/registry` as the path to R. 

### Approach

Add logging to CMake so it's clear when this happens. 

### Automated Tests

None, not a product change.

### QA Notes

No QA required.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


