### PR TITLE
rename FilePath.exists to FilePath.existsAsync (Electron)

### DIFF
--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -112,8 +112,22 @@ export class FilePath {
 
   /**
    * Checks whether the specified path exists.
+   * 
+   * Returns Promise<boolean>; do not use without 'await' or * .then().
+   * 
+   * For example, this can give the WRONG result:
+   * 
+   * if (FilePath.existsAync(file)) { WRONG USAGE always true, a Promise is truthy }
+   *
+   * Use either:
+   * 
+   * if (await FilePath.existsAsync(file)) { ...}
+   * 
+   * or
+   * 
+   * if (FilePath.existsAsync(file).then((result) => { if (result) { ... } }
    */
-  static async exists(filePath: string): Promise<boolean> {
+  static async existsAsync(filePath: string): Promise<boolean> {
     if (!filePath) {
       return false;
     }
@@ -214,7 +228,7 @@ export class FilePath {
     // revert to the specified path if it exists, otherwise
     // take the user home path from the system
     let safePath = revertToPath;
-    if (! await FilePath.exists(safePath.path)) {
+    if (! await FilePath.existsAsync(safePath.path)) {
       safePath = userHomePath();
     }
 
@@ -391,7 +405,7 @@ export class FilePath {
    * Creates this directory, if it does not exist.
    */
   async ensureDirectory(): Promise<Err> {
-    if (!await this.exists()) {
+    if (!await this.existsAsync()) {
       return await this.createDirectory();
     } else {
       return Success();
@@ -419,8 +433,22 @@ export class FilePath {
 
   /**
    * Checks whether this file path exists in the file system.
+   * 
+   * Returns Promise<boolean>; do not use without 'await' or * .then().
+   * 
+   * For example, this can give the WRONG result:
+   * 
+   * if (file.existsAync()) { WRONG USAGE always true, a Promise is truthy }
+   *
+   * Use either:
+   * 
+   * if (await file.existsAsync()) { ...}
+   * 
+   * or
+   * 
+   * if (file.existsAsync().then((result) => { if (result) { ... } }
    */
-  async exists(): Promise<boolean> {
+  async existsAsync(): Promise<boolean> {
     try {
       if (this.isEmpty()) {
         return false;

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -151,7 +151,7 @@ describe('FilePath', () => {
     });
     it('getCanonicalPath should return empty results for empty path', async () => {
       const f = new FilePath();
-      assert.isFalse(await f.exists());
+      assert.isFalse(await f.existsAsync());
       assert.isFalse(!!f.getAbsolutePath());
       assert.isTrue(f.isEmpty());
       assert.isTrue(f.isWithin(f));
@@ -160,12 +160,12 @@ describe('FilePath', () => {
     });
     it('getCanonicalPath should return a non-empty path for a path that exists', async () => {
       const f = new FilePath(os.tmpdir());
-      assert.isTrue(await f.exists());
+      assert.isTrue(await f.existsAsync());
       assert.isNotEmpty(await f.getCanonicalPath());
     });
     it('getCanonicalPath should return an empty path for a path that doesn\'t exist', async () => {
       const f = new FilePath('/some/really/bogus/path');
-      assert.isFalse(await f.exists());
+      assert.isFalse(await f.existsAsync());
       const result = await f.getCanonicalPath();
       assert.isEmpty(result);
     });
@@ -337,22 +337,22 @@ describe('FilePath', () => {
       assert.isFalse(new FilePath().existsSync());
     });
     it('exists should return false for empty path', async () => {
-      assert.isFalse(await new FilePath().exists());
+      assert.isFalse(await new FilePath().existsAsync());
     });
     it('exists should detect when object\'s path exists', async () => {
-      assert.isTrue(await new FilePath(os.tmpdir()).exists());
+      assert.isTrue(await new FilePath(os.tmpdir()).existsAsync());
     });
     it('exists should detect when object\'s path doesn\'t exist', async () => {
-      assert.isFalse(await new FilePath(bogusPath).exists());
+      assert.isFalse(await new FilePath(bogusPath).existsAsync());
     });
     it('exists should detect when a supplied path exists', async () => {
-      assert.isTrue(await FilePath.exists(os.tmpdir()));
+      assert.isTrue(await FilePath.existsAsync(os.tmpdir()));
     });
     it('exists should detect when a supplied path doesn\'t exist', async () => {
-      assert.isFalse(await FilePath.exists(bogusPath));
+      assert.isFalse(await FilePath.existsAsync(bogusPath));
     });
     it('exists should return false for existence of a null path', async () => {
-      assert.isFalse(await new FilePath().exists());
+      assert.isFalse(await new FilePath().existsAsync());
     });
   });
 
@@ -433,17 +433,17 @@ describe('FilePath', () => {
     });
     it('ensureDirectory should return success when asked to ensure existing directory exists', async () => {
       const existingFolder = new FilePath(os.homedir());
-      assert.isTrue(await existingFolder.exists());
+      assert.isTrue(await existingFolder.existsAsync());
       const result = await existingFolder.ensureDirectory();
       assert(isSuccessful(result));
     });
     it('ensureDirectory should create directory when asked to ensure it exists', async () => {
       const newFolder = path.join(os.tmpdir(), randomString());
       const newFilePath = new FilePath(newFolder);
-      assert.isFalse(await FilePath.exists(newFolder));
+      assert.isFalse(await FilePath.existsAsync(newFolder));
       const result = await newFilePath.ensureDirectory();
       assert(isSuccessful(result));
-      assert.isTrue(await FilePath.exists(newFolder));
+      assert.isTrue(await FilePath.existsAsync(newFolder));
       await fsPromises.rmdir(newFolder);
     });
   });
@@ -454,17 +454,17 @@ describe('FilePath', () => {
       const fp = new FilePath(target);
       const result = await fp.createDirectory();
       assert(isSuccessful(result));
-      assert.isTrue(await fp.exists());
+      assert.isTrue(await fp.existsAsync());
       await fsPromises.rmdir(target);
     });
     it('createDirectory should succeed if directory in FilePath already exists', async () => {
       const target = path.join(os.tmpdir(), randomString());
       const fp = new FilePath(target);
       let result = await fp.createDirectory();
-      assert.isTrue(await fp.exists());
+      assert.isTrue(await fp.existsAsync());
       result = await fp.createDirectory();
       assert(isSuccessful(result));
-      assert.isTrue(await fp.exists());
+      assert.isTrue(await fp.existsAsync());
       await fsPromises.rmdir(target);
     });
     it('createDirectory should create directory relative to path in FilePath', async () => {
@@ -472,7 +472,7 @@ describe('FilePath', () => {
       const fp = new FilePath(os.tmpdir());
       assert(isSuccessful(await fp.createDirectory(target)));
       const newPath = path.join(os.tmpdir(), target);
-      assert.isTrue(await FilePath.exists(newPath));
+      assert.isTrue(await FilePath.existsAsync(newPath));
       await fsPromises.rmdir(newPath);
     });
     it('createDirectory should recursively create directories', async () => {
@@ -480,7 +480,7 @@ describe('FilePath', () => {
       const fp = new FilePath(target);
       const result = await fp.createDirectory();
       assert(isSuccessful(result));
-      assert.isTrue(await fp.exists());
+      assert.isTrue(await fp.existsAsync());
       await fsPromises.rmdir(target);
     });
     it('createDirectory should recursively create directories relative to path in FilePath', async () => {
@@ -491,7 +491,7 @@ describe('FilePath', () => {
       const result = await fp.createDirectory(extraFolder);
       assert(isSuccessful(result));
       const newPath = path.join(target, extraFolder);
-      assert.isTrue(await FilePath.exists(newPath));
+      assert.isTrue(await FilePath.existsAsync(newPath));
       await fsPromises.rmdir(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
     it('createDirectory should fail when it cannot create the directory', async () => {
@@ -506,7 +506,7 @@ describe('FilePath', () => {
       const target = path.join(os.tmpdir(), randomString());
       const result = await fp.createDirectory(target);
       assert(isSuccessful(result));
-      assert.isTrue(await FilePath.exists(target));
+      assert.isTrue(await FilePath.existsAsync(target));
       await fsPromises.rmdir(target);
     });
   });
@@ -638,13 +638,13 @@ describe('FilePath', () => {
     it('remove deletes an existing folder', async () => {
       const testDir = getTestDir();
       await testDir.createDirectory();
-      assert.isTrue(await testDir.exists());
+      assert.isTrue(await testDir.existsAsync());
       assert(isSuccessful(await testDir.remove()));
-      assert.isFalse(await testDir.exists());
+      assert.isFalse(await testDir.existsAsync());
     });
     it('remove fails if asked to delete a non-existing folder', async () => {
       const testDir = getTestDir();
-      assert.isFalse(await testDir.exists());
+      assert.isFalse(await testDir.existsAsync());
       assert(isFailure(await testDir.remove()));
     });
 
@@ -664,13 +664,13 @@ describe('FilePath', () => {
     it('removeIfExists deletes an existing folder', async () => {
       const testDir = getTestDir();
       await testDir.createDirectory();
-      assert.isTrue(await testDir.exists());
+      assert.isTrue(await testDir.existsAsync());
       assert(isSuccessful(await testDir.removeIfExists()));
-      assert.isFalse(await testDir.exists());
+      assert.isFalse(await testDir.existsAsync());
     });
     it('removeIfExists returns success if asked to delete a non-existing folder', async () => {
       const testDir = getTestDir();
-      assert.isFalse(await testDir.exists());
+      assert.isFalse(await testDir.existsAsync());
       assert(isSuccessful(await testDir.removeIfExists()));
     });
 

--- a/src/node/desktop/test/unit/main/application.test.ts
+++ b/src/node/desktop/test/unit/main/application.test.ts
@@ -72,11 +72,11 @@ describe('Application', () => {
       const tmpDir = testDir();
 
       app.setScratchTempDir(tmpDir);
-      assert.isFalse(await tmpDir.exists());
+      assert.isFalse(await tmpDir.existsAsync());
       assert.isFalse(!! await tmpDir.ensureDirectory());
 
       const expectedDir = tmpDir.completeChildPath('tmp');
-      assert.isFalse(await expectedDir.exists());
+      assert.isFalse(await expectedDir.existsAsync());
 
       // note, every testDir call returns different random path 
       const scratch = app.scratchTempDir(testDir());

--- a/src/node/desktop/tsconfig.json
+++ b/src/node/desktop/tsconfig.json
@@ -11,7 +11,8 @@
     }
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "test/**/*"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
### Intent

In the C++ code, `FilePath.exists()` is synchronous and returns a boolean. In our ported `FilePath` class, `exists()` is async and returns `Promise<boolean>`, and `existsSync()` returns a boolean. This makes it easy to accidentally create ported code with the pattern:

```ts
if (file.exists()) { doSomething(); }
```

That is incorrect, since it will always be `true`. It should be invoked either as:

```ts
if (await file.exists()) { doSomething(); }
```

or directly with Promises as:

```ts
if (file.exists().then((result) => { if (result) { doSomething(); }});
```

### Approach

Rename to `existsAsync()`. Then code pasted in from the C++ requires a conscious decision about whether using async or sync.

Also put the test sources in scope for the top-level tsconfig; otherwise refactoring don't update that code.

### Automated Tests

Updated existing tests.

### QA Notes

Code internals.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


