### PR TITLE
use Err instead of Expected for prepareEnvironment

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -136,7 +136,7 @@ export class Application implements AppState {
       }
     }
 
-    const [, error] = prepareEnvironment();
+    const error = prepareEnvironment();
     if (error) {
       return exitFailure();
     }

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -21,6 +21,7 @@ import { existsSync } from 'fs';
 import { Environment, getenv, setVars } from '../core/environment';
 import { Expected, ok, err } from '../core/expected';
 import { logger } from '../core/logger';
+import { Err, Success } from '../core/err';
 
 
 interface REnvironment {
@@ -59,24 +60,24 @@ function executeCommand(command: string): Expected<string> {
  * // (for example, R_HOME) and other platform-specific work required
  * for R to launch.
  */
-export function prepareEnvironment(): Expected<REnvironment> {
+export function prepareEnvironment(): Err {
 
   try {
     return prepareEnvironmentImpl();
   } catch (error) {
     logger().logError(error);
-    return err(error);
+    return error;
   }
 
 }
 
-function prepareEnvironmentImpl(): Expected<REnvironment> {
+function prepareEnvironmentImpl(): Err {
 
   // attempt to detect R environment
   const [rEnvironment, error] = detectREnvironment();
   if (error) {
     showRNotFoundError(error);
-    return err(error);
+    return error;
   }
 
   // set environment variables from R
@@ -90,7 +91,7 @@ function prepareEnvironmentImpl(): Expected<REnvironment> {
     process.env.PATH = `${binDir};${process.env.PATH}`;
   }
 
-  return ok(rEnvironment);
+  return Success();
 
 }
 

--- a/src/node/desktop/test/unit/core/expected.test.ts
+++ b/src/node/desktop/test/unit/core/expected.test.ts
@@ -1,0 +1,41 @@
+/*
+ * expected.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { err, Expected, ok } from '../../../src/core/expected';
+
+function returnResult(shouldSucceed: boolean): Expected<string> {
+  if (shouldSucceed) {
+    return ok('victory');
+  } else {
+    return err(new Error('Try again'));
+  }
+}
+
+describe('Expected', () => {
+  it('Success return should contain result', () => {
+    const [result, error] = returnResult(true);
+    assert.isNull(error);
+    assert.isNotNull(result);
+    assert.deepEqual(result, 'victory');
+  });
+  it('Error return should have an error', () => {
+    const [result, error] = returnResult(false);
+    assert.isNull(result);
+    assert.isNotNull(error);
+    assert.deepEqual(error?.message, 'Try again');
+  });
+});


### PR DESCRIPTION
### Intent

`prepareEnvironment` doesn't need to return a value other than success/failure.

### Approach

Switch it to return `Err` instead of `Expected`.

### Automated Tests

Added tests for `Expected<>` pattern.

### QA Notes

Code internals.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


