### PR TITLE
support older versions of getS3method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 * Fixed issue where busy sessions can't be interrupted and block basic file operations (#2038)
 * Fixed issue where R Markdown error output was not properly formatted when displayed (#9390)
 * Fixed issue where R Markdown template skeletons with a '.rmd' extension were not discovered (Pro #1607)
+* Fixed issue where autocompletion system could emit errors with R (< 3.3.0). (Pro #2680)
 * Fixed issues causing multiple background jobs to be created when running Shiny applications in the background (#8746, #6904)
 * Fixed issue causing an error when adding files to static content published to RStudio Connect (#9571)
 * Fixed issue where R banner could be displayed twice on startup (#6907)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -946,6 +946,7 @@
    
    # interleave super classes after the corresponding original classes
    classes <- unlist(lapply(class(object), classAndSuper), recursive = TRUE)
+   
    # either remove or add an explicit (=non-mode) list/environment class
    classes <- if (excludeBaseClasses)
       setdiff(classes, c("list", "environment"))
@@ -954,12 +955,24 @@
    
    for (class in classes)
    {
-      method <- utils::getS3method(
-         f = ".DollarNames",
-         class = class,
-         envir = envir,
-         optional = TRUE
-      )
+      # support older getS3method() definitions (without envir)
+      method <- if ("envir" %in% names(formals(utils::getS3method)))
+      {
+         utils::getS3method(
+            f = ".DollarNames",
+            class = class,
+            optional = TRUE,
+            envir = envir
+         )
+      }
+      else
+      {
+         utils::getS3method(
+            f = ".DollarNames",
+            class = class,
+            optional = TRUE
+         )
+      }
       
       if (!is.null(method))
          return(method)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2680.

While we might not intend to support R 3.2.x going forward, I think this change is small / narrow enough to take.

### Approach

Detect whether `envir` is accepted by the definition of `utils::getS3method()`, and pass it along only if it is.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2680.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
