### PR TITLE
get RStudio running on Linux with Electron

### DIFF
--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -38,6 +38,17 @@ class RStudioMain {
   }
 
   private async startup(): Promise<void> {
+
+    // NOTE: On Linux it looks like Electron prefers using ANGLE for GPU rendering;
+    // however, we've seen in at least one case (Ubuntu 20.04 in Parallels VM) fails
+    // to render in that case (we just get a white screen). Prefer 'desktop' by default,
+    // but we'll need to respect the user-defined property as well.
+    if (process.platform === 'linux') {
+      if (!app.commandLine.hasSwitch('use-gl')) {
+        app.commandLine.appendSwitch('use-gl', 'desktop');
+      }
+    }
+
     const rstudio = new Application();
     setLogger(new ConsoleLogger());
     setLoggerLevel(parseCommandLineLogLevel(app.commandLine.getSwitchValue(kLogLevel), LogLevel.ERR));


### PR DESCRIPTION
### Intent

This PR gets RStudio running with Electron on Linux.

### Approach

Ensure we read and use the correct R environment variables, here by explicitly asking R where they are located. (R installations on Linux typically set `R_DOC_DIR` and friends to customize their locations; e.g. in `/etc` somewhere.)

This PR also brings in our very first GPU-related workaround (oh joy!). On my Linux VM, RStudio was rendering with a blank white screen when running with the default GPU renderer (ANGLE); fixed by defaulting to the 'desktop' renderer (but we'll want to ensure we respect the user choice via desktop options).

### Automated Tests

N/A; would be tested by "regular" integration tests on Linux.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
