### PR TITLE
fix integration test in dev build

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -190,7 +190,7 @@ export class Application implements AppState {
     if (app.isPackaged) {
       return new FilePath(app.getAppPath());
     } else {
-      return new FilePath(app.getAppPath()).completePath('../..');
+      return new FilePath(app.getAppPath()).completePath('../../..');
     }
   }
 

--- a/src/node/desktop/tsconfig.json
+++ b/src/node/desktop/tsconfig.json
@@ -15,8 +15,7 @@
     "test/**/*"
   ],
   "exclude": [
-    "node_modules",
-    "src/build/**"
+    "node_modules"
   ],
   "ts-node": {
     "transpileOnly": true


### PR DESCRIPTION
### Intent

When I added the tests to the tsconfig.json (so vscode's refactoring tools would also "see" the tests sources), I broke the Electron integration tests (when run against a dev build; it did still work against a package build).

https://github.com/rstudio/rstudio/blob/fe920b839f632715eb9504255fbf7abfa373020d/src/node/desktop/tsconfig.json#L15

### Approach

This was causing the ResourcePath to be returned incorrectly on a dev build, causing failure to load the pages used to show loading progress, load failure, etc. Fixed by adjusting the path for non-packaged case.

Unrelated, but also removed a line in tsconfig I had added while implementing the "clean" command, ended up not needing this line.

### Automated Tests

This fixes ability of dev build to load these resource pages again.

Note that the integration tests (`yarn testint`) will use the package build if found, otherwise they run against the dev build. You can use `yarn clean` to get rid of both and start fresh.

### QA Notes

Fixes a dev-machine-only scenario.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


