### PR TITLE
properly handle UNC paths with git on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 * Fixed issues causing multiple background jobs to be created when running Shiny applications in the background (#8746, #6904)
 * Fixed issue causing an error when adding files to static content published to RStudio Connect (#9571)
 * Fixed issue where R banner could be displayed twice on startup (#6907)
+* Fixed issue where RStudio was unable to initialize a Git repository in UNC paths on Windows (#4137)
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
 * Fixed issue where adjacent links in the Visual Editor could merge into a single link (#8471)
 * Fixed Issue where items deleted from a local Zotero Collection would still appear in the Visual Editor's Insert Citation dialog.

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -324,7 +324,8 @@ Error gitExec(const ShellArgs& args,
 
    // initialize process options
    core::system::ProcessOptions options = procOptions();
-   options.workingDir = workingDir;
+   if (!workingDir.isEmpty())
+      options.workingDir = workingDir;
 
    // Important to ensure SSH_ASKPASS works
 #ifdef _WIN32
@@ -354,8 +355,14 @@ Error gitExec(const ShellArgs& args,
 #endif
 
    return error;
-      
 }
+
+Error gitExec(const ShellArgs& args,
+              core::system::ProcessResult* pResult)
+{
+   return gitExec(args, FilePath(), pResult);
+}
+
 
 bool commitIsMatch(const std::vector<std::string>& patterns,
                    const CommitInfo& commit)
@@ -3080,9 +3087,7 @@ bool isGitInstalled()
       return false;
 
    core::system::ProcessResult result;
-   Error error = core::system::runCommand(git() << "--version",
-                                          procOptions(),
-                                          &result);
+   Error error = gitExec(gitArgs() << "--version", &result);
    if (error)
       return false;
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/4137.

### Approach

In a few places, RStudio was using `runCommand()` rather than `gitExec()` when attempting to execute some `git` commands. On Windows, RStudio explicitly uses `runProgram()` rather than `runCommand()` as the Windows shell (`cmd.exe`) does not support UNC paths. This PR ensures that those usages go through `gitExec()`.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/4137.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
