### PR TITLE
simple test for showing secondary window (chome gpu diagnostics) in Electron

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -42,13 +42,6 @@ function showRNotFoundError(error?: Error): void {
   dialog.showErrorBox('R not found', message);
 }
 
-function showQueryError(command: string, error: Error): void {
-  const title = 'Error starting R';
-  const message = 
-    `RStudio was unable to invoke R during startup (${command} had error ${error.message})`;
-  dialog.showErrorBox(title, message);
-}
-
 function executeCommand(command: string): Expected<string> {
 
   try {

--- a/src/node/desktop/test/int/int-utils.ts
+++ b/src/node/desktop/test/int/int-utils.ts
@@ -72,3 +72,17 @@ export async function launch(extraArgs?: string[]): Promise<ElectronApplication>
 }
 
 export const setTimeoutPromise = util.promisify(setTimeout);
+
+/**
+ * @returns Array of window titles
+ */
+export async function getWindowTitles(electronApp: ElectronApplication): Promise<string[]> {
+  return electronApp.evaluate(async ({ BrowserWindow } ): Promise<string[]> => {
+    const titles = Array<string>();
+    const windows = BrowserWindow.getAllWindows();
+    for (const window of windows) {
+      titles.push(window.getTitle());
+    }
+    return titles;
+  });
+}

--- a/src/node/desktop/test/int/int-utils.ts
+++ b/src/node/desktop/test/int/int-utils.ts
@@ -15,7 +15,7 @@
 import { ElectronApplication, _electron } from 'playwright';
 import path from 'path';
 import fs from 'fs';
-
+import util from 'util';
 
 interface LaunchArgs {
   args?: string[],
@@ -70,3 +70,5 @@ function getLaunchArgs(extraArgs?: string[]): LaunchArgs {
 export async function launch(extraArgs?: string[]): Promise<ElectronApplication> {
   return _electron.launch(getLaunchArgs(extraArgs));
 }
+
+export const setTimeoutPromise = util.promisify(setTimeout);

--- a/src/node/desktop/test/int/utility-window.test.ts
+++ b/src/node/desktop/test/int/utility-window.test.ts
@@ -1,0 +1,45 @@
+/*
+ * utility-window.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+import { ElectronApplication, Page } from 'playwright';
+
+import { launch, setTimeoutPromise } from './int-utils';
+
+
+describe('Display secondary utility windows', () => {
+  let electronApp: ElectronApplication;
+  let window: Page;
+
+  beforeEach(async () => {
+    electronApp = await launch();
+    window = await electronApp.firstWindow();
+    window.setDefaultTimeout(5000);
+  });
+
+  afterEach(async () => {
+    await electronApp.close();
+  });
+
+  it('Shows GPU utility window', async function () {
+    await window.click('#rstudio_workbench_tab_console');
+    await window.type('#rstudio_console_input', '.rs.api.executeCommand(\'showGpuDiagnostics\')');
+    await window.press('#rstudio_console_input', 'Enter');
+    await setTimeoutPromise(500);
+    const windows = electronApp.windows();
+    assert.equal(windows.length, 2);
+  });
+});

--- a/src/node/desktop/test/int/utility-window.test.ts
+++ b/src/node/desktop/test/int/utility-window.test.ts
@@ -17,7 +17,7 @@ import { describe } from 'mocha';
 import { assert } from 'chai';
 import { ElectronApplication, Page } from 'playwright';
 
-import { launch, setTimeoutPromise } from './int-utils';
+import { getWindowTitles, launch, setTimeoutPromise } from './int-utils';
 
 
 describe('Display secondary utility windows', () => {
@@ -41,5 +41,14 @@ describe('Display secondary utility windows', () => {
     await setTimeoutPromise(500);
     const windows = electronApp.windows();
     assert.equal(windows.length, 2);
+    const titles = await getWindowTitles(electronApp);
+    let found = false;
+    for (const title of titles) {
+      if (title === 'chrome://gpu') {
+        found = true;
+        break;
+      }
+    }
+    assert.isTrue(found);
   });
 });


### PR DESCRIPTION
### Intent

Write a test that displays a secondary window and detects it.

### Approach

Triggers the `showGpuDiagnostics` command via the console, and checks that another window was displayed.

### Automated Tests

Yes it is.

### QA Notes

Another small test to improve my understanding of what we can do (or not do) with Playwright and Electron. Don't like that I had to use a "sleep" to give the window time to appear, will look for a better way to do that but this works in the meantime.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


