### PR TITLE
exported functions shouldn't throw (Electron)

### DIFF
--- a/src/node/desktop/src/core/file-serializer.ts
+++ b/src/node/desktop/src/core/file-serializer.ts
@@ -14,6 +14,7 @@
  */
 
 import lineReader from 'line-reader';
+import { err, Expected, ok } from './expected';
 
 import { FilePath } from './file-path';
 
@@ -40,18 +41,20 @@ const eachLine = async function(filename: string, iteratee: (line: string) => vo
 export async function readStringArrayFromFile(
   filePath: FilePath,
   trimAndIgnoreBlankLines = true
-): Promise<Array<string>> {
+): Promise<Expected<Array<string>>> {
 
   const result: string[] = [];
-  await eachLine(filePath.getAbsolutePath(), (line: string) => {
-    if (trimAndIgnoreBlankLines) {
-      line = line.trim();
-    }
-    if (line.length > 0) {
-      result.push(line);
-    }
-  }).catch((error) => {
-    throw error;
-  });
-  return result;
+  try {
+    await eachLine(filePath.getAbsolutePath(), (line: string) => {
+      if (trimAndIgnoreBlankLines) {
+        line = line.trim();
+      }
+      if (line.length > 0) {
+        result.push(line);
+      }
+    });
+  } catch (error) {
+    return err(error);
+  }
+  return ok(result);
 }

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -202,8 +202,6 @@ export class SessionLauncher {
       this.mainWindow.loadUrl(launchContext.url);
     }
 
-    // TODO
-    // qApp->setQuitOnLastWindowClosed(true);
     return Success();
   }
 
@@ -241,7 +239,10 @@ export class SessionLauncher {
         logFile = log.getAbsolutePath();
 
         // Read all the lines from a file into a string vector
-        const lines = await readStringArrayFromFile(log);
+        const [lines, error] = await readStringArrayFromFile(log);
+        if (error) {
+          throw error;
+        }
 
         // Combine the three most recent lines
         let logContents = '';

--- a/src/node/desktop/test/int/mocharc.json
+++ b/src/node/desktop/test/int/mocharc.json
@@ -2,5 +2,6 @@
   "extension": ["ts"],
   "spec": "./test/int/**/*.test.ts",
   "require": "ts-node/register",
-  "timeout": 15000
+  "timeout": 15000,
+  "slow": 6000
 }

--- a/src/node/desktop/test/unit/core/file-serializer.test.ts
+++ b/src/node/desktop/test/unit/core/file-serializer.test.ts
@@ -43,19 +43,22 @@ function writeTestFile(lineCount: number, includeBlanks: boolean): FilePath {
 describe('file-serializer', () => {
   it('readStringArrayFromFile reads a simple file including blank lines', async () => {
     const tmpFile = writeTestFile(100, true);
-    const result = await readStringArrayFromFile(tmpFile, false);
+    const [result, error] = await readStringArrayFromFile(tmpFile, false);
+    assert.isNull(error);
     assert.equal(100, result.length);
     tmpFile.removeSync();
   });
   it('readStringArrayFromFile reads a simple file without any blank lines', async () => {
     const tmpFile = writeTestFile(100, false);
-    const result = await readStringArrayFromFile(tmpFile, false);
+    const [result, error] = await readStringArrayFromFile(tmpFile, false);
+    assert.isNull(error);
     assert.equal(100, result.length);
     tmpFile.removeSync();
   });
   it('readStringArrayFromFile skips blank lines when requested', async () => {
     const tmpFile = writeTestFile(100, true);
-    const result = await readStringArrayFromFile(tmpFile, true);
+    const [result, error] = await readStringArrayFromFile(tmpFile, true);
+    assert.isNull(error);
     assert.equal(66, result.length);
     for (const line in result) {
       assert.isFalse(line.length === 0);
@@ -64,7 +67,8 @@ describe('file-serializer', () => {
   });
   it('readStringArrayFromFile with skip set works when no blank lines', async () => {
     const tmpFile = writeTestFile(100, false);
-    const result = await readStringArrayFromFile(tmpFile, true);
+    const [result, error] = await readStringArrayFromFile(tmpFile, true);
+    assert.isNull(error);
     assert.equal(100, result.length);
     tmpFile.removeSync();
   });

--- a/src/node/desktop/test/unit/mocharc.json
+++ b/src/node/desktop/test/unit/mocharc.json
@@ -1,5 +1,6 @@
 {
   "extension": ["ts"],
   "spec": "./test/unit/**/*.test.ts",
-  "require": "ts-node/register"
+  "require": "ts-node/register",
+  "slow": "750"
 }


### PR DESCRIPTION
### Intent

We decided to take the approach where exported functions shouldn't throw (except, ideally, in truly exceptional cases such as programming errors). I had written `readStringArrayFromFile` using `throw` to indicate errors.

### Approach

Switch to the `Expected<result, error>` pattern. Note there are some internal helpers in this scenario that do still throw, which we also agreed was OK (though that might bite us later if we export currently private things, so we should probably minimize that, too).

### Automated Tests

Updated tests. Also, bumped up the threshold for "slow" tests in both unit tests and integration tests to reduce scary-looking red text in test results.

### QA Notes

Internal code change only, but test runs should now be much happier looking.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


