### PR TITLE
ensure we use a pre element when computing console width

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@
 * Removed the breaking change introduced in Juliet Rose that changed the behavior of the X-Forwarded-Proto header when RSW is behind a proxy server (Pro #2657)
 * Fixed issue where adjacent links in the Visual Editor could merge into a single link (#8471)
 * Fixed Issue where items deleted from a local Zotero Collection would still appear in the Visual Editor's Insert Citation dialog.
+* Fixed issue where Console width was computed incorrectly with some custom fonts (#8696)
 
 ### Misc
 

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -20,6 +20,8 @@ import com.google.gwt.core.client.JsArrayMixed;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.*;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.HasAllKeyHandlers;
 import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.event.dom.client.KeyDownEvent;
@@ -30,8 +32,6 @@ import com.google.gwt.event.dom.client.KeyUpEvent;
 import com.google.gwt.event.dom.client.KeyUpHandler;
 import com.google.gwt.resources.client.TextResource;
 import com.google.gwt.user.client.*;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.TextBox;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
@@ -1111,23 +1111,27 @@ public class DomUtils
       return result;
    }-*/;
 
-   public static int getCharacterWidth(int clientWidth, int offsetWidth,
-         String style)
+   public static int getCharacterWidth(int clientWidth,
+                                       int offsetWidth,
+                                       String style)
    {
-      // create width checker label and add it to the root panel
-      Label widthChecker = new Label();
-      widthChecker.setStylePrimaryName(style);
+      // create width checker element and add it to the document
+      PreElement widthChecker = Document.get().createPreElement();
+      widthChecker.getStyle().setPosition(Position.ABSOLUTE);
+      widthChecker.getStyle().setLeft(-1000, Unit.PX);
+      widthChecker.getStyle().setTop(-1000, Unit.PX);
+      widthChecker.addClassName(style);
       FontSizer.applyNormalFontSize(widthChecker);
-      RootPanel.get().add(widthChecker, -1000, -1000);
+      Document.get().getBody().appendChild(widthChecker);
 
       // put the text into the label, measure it, and remove it
       String text = new String("abcdefghijklmnopqrstuvwzyz0123456789");
-      widthChecker.setText(text);
+      widthChecker.setInnerText(text);
       int labelWidth = widthChecker.getOffsetWidth();
-      RootPanel.get().remove(widthChecker);
+      widthChecker.removeFromParent();
 
       // compute the points per character
-      float pointsPerCharacter = (float)labelWidth / (float)text.length();
+      double pointsPerCharacter = (double) labelWidth / (double) text.length();
 
       // compute client width
       if (clientWidth == offsetWidth)
@@ -1141,12 +1145,12 @@ public class DomUtils
 
       // compute character width (add pad so characters aren't flush to right)
       final int RIGHT_CHARACTER_PAD = 2;
-      int width = Math.round((float)clientWidth / pointsPerCharacter) -
-            RIGHT_CHARACTER_PAD;
-
+      int computedWidth = (int) Math.floor(clientWidth / pointsPerCharacter);
+      int adjustedWidth = computedWidth - RIGHT_CHARACTER_PAD;
+      
       // enforce a minimum width
       final int MINIMUM_WIDTH = 30;
-      return Math.max(width, MINIMUM_WIDTH);
+      return Math.max(adjustedWidth, MINIMUM_WIDTH);
    }
 
    public static int getCharacterWidth(Element ele, String style)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8696.

### Approach

We normally only apply our fonts to `<pre>` elements, as per https://github.com/rstudio/rstudio/blob/bugfix/font-size-computation-custom-fonts/src/cpp/session/resources/themes/css/fonts.css. However, when computing the Console width, we were doing so with a `<div>` element, which wouldn't have the custom font applied.

Because we were computing the width using a different font from the actual Console font, it's possible for text to overflow if the user has configured RStudio to use a font that is wider than the default font. This is most common on Windows, where the default font (Calibri) is somewhat more narrow.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8696.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
