### PR TITLE
mechanical rename of Success() to success()

### DIFF
--- a/src/node/desktop/src/core/err.ts
+++ b/src/node/desktop/src/core/err.ts
@@ -32,7 +32,7 @@ export type Err = Error | null;
  * Convenience function for returning "no error" state from a function that
  * can return an Error.
  */
-export function Success(): null {
+export function success(): null {
   return null;
 }
 

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -18,7 +18,7 @@ import fsPromises from 'fs/promises';
 
 import { logger } from './logger';
 import path from 'path';
-import { Err, Success } from './err';
+import { Err, success } from './err';
 import { userHomePath } from './user';
 import { err, Expected, ok } from './expected';
 
@@ -268,7 +268,7 @@ export class FilePath {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   changeFileMode(fileModeStr: string, setStickyBit = false): Err {
     if (process.platform === 'win32')
-      return Success(); // no-op on Windows
+      return success(); // no-op on Windows
 
     throw Error('changeFileMode is NYI');
   }
@@ -374,7 +374,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -393,7 +393,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -403,7 +403,7 @@ export class FilePath {
     if (!this.existsSync()) {
       return this.createDirectorySync();
     } else {
-      return Success();
+      return success();
     }
   }
 
@@ -414,7 +414,7 @@ export class FilePath {
     if (!await this.existsAsync()) {
       return this.createDirectory();
     } else {
-      return Success();
+      return success();
     }
   }
 
@@ -540,7 +540,7 @@ export class FilePath {
         dir.closeSync();
       }
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -781,7 +781,7 @@ export class FilePath {
 
     try {
       process.chdir(this.path);
-      return Success();
+      return success();
     } catch (err) {
       return err;
     }
@@ -826,7 +826,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -838,7 +838,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -850,7 +850,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**
@@ -862,7 +862,7 @@ export class FilePath {
     } catch (err) {
       return err;
     }
-    return Success();
+    return success();
   }
 
   /**

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -21,7 +21,7 @@ import { existsSync } from 'fs';
 import { Environment, getenv, setVars } from '../core/environment';
 import { Expected, ok, err } from '../core/expected';
 import { logger } from '../core/logger';
-import { Err, Success } from '../core/err';
+import { Err, success } from '../core/err';
 
 let kLdLibraryPathVariable : string;
 if (process.platform === 'darwin') {
@@ -96,7 +96,7 @@ function prepareEnvironmentImpl(): Err {
     process.env.PATH = `${binDir};${process.env.PATH}`;
   }
 
-  return Success();
+  return success();
 
 }
 

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -20,7 +20,7 @@ import fs from 'fs';
 import { logger } from '../core/logger';
 import { FilePath } from '../core/file-path';
 import { generateShortenedUuid, localPeer } from '../core/system';
-import { Err, Success } from '../core/err';
+import { Err, success } from '../core/err';
 import { getenv, setenv } from '../core/environment';
 import { renderTemplateFile } from '../core/template-filter';
 import { readStringArrayFromFile } from '../core/file-serializer';
@@ -202,7 +202,7 @@ export class SessionLauncher {
       this.mainWindow.loadUrl(launchContext.url);
     }
 
-    return Success();
+    return success();
   }
 
   closeAllSatellites(): void {

--- a/src/node/desktop/test/unit/core/err.test.ts
+++ b/src/node/desktop/test/unit/core/err.test.ts
@@ -16,10 +16,10 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { Err, isFailure, isSuccessful, Success } from '../../../src/core/err';
+import { Err, isFailure, isSuccessful, success } from '../../../src/core/err';
 
 function beSuccessful(): Err {
-  return Success();
+  return success();
 }
 
 function beUnsuccessful(): Err {
@@ -28,15 +28,15 @@ function beUnsuccessful(): Err {
 
 describe('Err', () => {
   it('Success return should be falsy', () => {
-    assert.isTrue(beSuccessful() === Success());
+    assert.isTrue(beSuccessful() === success());
     assert.isNull(beSuccessful());
   });
   it('Error return should be truthy', () => {
-    assert.isTrue(beUnsuccessful() !== Success());
+    assert.isTrue(beUnsuccessful() !== success());
     assert.instanceOf(beUnsuccessful(), Error);
   });
   it('isSuccessful returns true for success', () => {
-    const result: Err = Success();
+    const result: Err = success();
     assert.isTrue(isSuccessful(result));
   });
   it('isSuccessful returns false for failure', () => {
@@ -48,7 +48,7 @@ describe('Err', () => {
     assert.isTrue(isFailure(result));
   });
   it('isFailure returns false for success', () => {
-    const result: Err = Success();
+    const result: Err = success();
     assert.isFalse(isFailure(result));
   });
 });


### PR DESCRIPTION
### Intent

The `Success()` function doesn't follow standard naming (shouldn't be capitalized).

### Approach

Rename and update usages.

### Automated Tests

Updated

### QA Notes

Code internals

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


