### PR TITLE
support discovery of addins in user config dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,3 +72,4 @@
 * RStudio no longer treats R objects containing null external pointers specially when building Environment pane (#5546)
 * Make Cmd+Shift+0 the shortcut for restarting session on MacOS (#7695)
 * Update Plumber file template for Plumber 1.0 (#9402)
+* RStudio addins installed within `tools:::R_user_dir(<pkg>, "config")` are now discovered by RStudio. (#9648)

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -38,6 +38,7 @@
 
 #include <r/RExec.hpp>
 #include <r/RErrorCategory.hpp>
+#include <r/RUtil.hpp>
 
 // clean out global definitions of TRUE and FALSE so we can
 // use the Rboolean variations of them
@@ -917,7 +918,7 @@ Error extract(SEXP valueSEXP, std::set<std::string>* pSet, bool asUtf8)
    return Success();
 }
 
-Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pMap, bool asUtf8)
+Error extract(SEXP valueSEXP, std::map<std::string, std::set<std::string>>* pMap, bool asUtf8)
 {
    if (TYPEOF(valueSEXP) != VECSXP)
       return Error(errc::UnexpectedDataTypeError, ERROR_LOCATION);
@@ -940,6 +941,22 @@ Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pM
       pMap->operator [](name) = contents;
    }
    
+   return Success();
+}
+
+Error extract(SEXP valueSEXP, FilePath* pFilePath)
+{
+   // extract result (require UTF-8)
+   std::string path;
+   Error error = extract(valueSEXP, &path, true);
+   if (error)
+      return error;
+   
+   // expand aliased paths
+   path = r::util::expandFileName(path);
+   
+   // return path
+   *pFilePath = FilePath(path);
    return Success();
 }
 

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -74,9 +74,6 @@ bool versionTest(const std::string& comparator, const std::string& version)
 
 std::string expandFileName(const std::string& name)
 {
-   if (name.empty())
-      return name;
-   
    return std::string(R_ExpandFileName(name.c_str()));
 }
 

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -74,6 +74,9 @@ bool versionTest(const std::string& comparator, const std::string& version)
 
 std::string expandFileName(const std::string& name)
 {
+   if (name.empty())
+      return name;
+   
    return std::string(R_ExpandFileName(name.c_str()));
 }
 

--- a/src/cpp/r/RVersionInfo.cpp
+++ b/src/cpp/r/RVersionInfo.cpp
@@ -25,20 +25,25 @@ namespace rstudio {
 namespace r {
 namespace version_info {
 
+namespace {
+
+RVersionNumber readVersion()
+{
+   std::string currentRVersion;
+   Error error = exec::RFunction(".rs.rVersionString").call(&currentRVersion);
+   if (error)
+      LOG_ERROR(error);
+   
+   return RVersionNumber::parse(currentRVersion);
+}
+
+} // end anonymous namespace
+
 // Returns a representation of the current version of R
 RVersionNumber currentRVersion()
 {
-   // Cached R version number; this can't change during the session so it's safe to keep a copy
-   static RVersionNumber current;
-   if (current.empty())
-   {
-      // No cache; ask R for its current version
-      std::string currentRVersion;
-      Error error = exec::RFunction(".rs.rVersionString").call(&currentRVersion);
-      if (!error)
-         current = RVersionNumber::parse(currentRVersion);
-   }
-   return current;
+   static RVersionNumber instance = readVersion();
+   return instance;
 }
 
 } // namespace version_info

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -135,8 +135,9 @@ core::Error extract(SEXP valueSEXP, std::vector<int>* pVector);
 core::Error extract(SEXP valueSEXP, std::string* pString, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::vector<std::string>* pVector, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::set<std::string>* pSet, bool asUtf8 = false);
-core::Error extract(SEXP valueSEXP, std::map< std::string, std::set<std::string> >* pMap, bool asUtf8 = false);
+core::Error extract(SEXP valueSEXP, std::map<std::string, std::set<std::string>>* pMap, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, core::json::Value* pJson);
+core::Error extract(SEXP valueSEXP, core::FilePath* pFilePath);
 
 // create SEXP from c++ type
 SEXP create(SEXP valueSEXP, Protect* pProtect);

--- a/src/cpp/session/modules/SessionRAddins.cpp
+++ b/src/cpp/session/modules/SessionRAddins.cpp
@@ -34,6 +34,7 @@
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
 #include <r/RRoutines.hpp>
+#include <r/RVersionInfo.hpp>
 
 #include <session/projects/SessionProjects.hpp>
 #include <session/SessionModuleContext.hpp>
@@ -340,12 +341,35 @@ class AddinWorker : public ppe::Worker
 {
    void onIndexingStarted()
    {
+      // initialize registry
       pRegistry_ = boost::make_shared<AddinRegistry>();
+      
+      // discover path to user config directory
+      if (r::version_info::currentRVersion().versionMajor() >= 4)
+      {
+         Error error = r::exec::RFunction("tools:::R_user_dir")
+               .addParam("package", "")
+               .addParam("which", "config")
+               .call(&userConfigPath_);
+         if (error)
+            LOG_ERROR(error);
+      }
    }
    
-   void onWork(const std::string& pkgName, const FilePath& addinPath)
+   void onWork(const std::string& pkgName, const FilePath& pkgPath)
    {
-      pRegistry_->add(pkgName, addinPath);
+      // first, check for bundled addins
+      FilePath bundledAddinsPath = pkgPath.completeChildPath("rstudio/addins.dcf");
+      if (bundledAddinsPath.exists())
+         pRegistry_->add(pkgName, bundledAddinsPath);
+      
+      // next, check for addins in R_user_dir() folder
+      if (!userConfigPath_.isEmpty())
+      {
+         FilePath configAddinsPath = userConfigPath_.completeChildPath(pkgName + "/rstudio/addins.dcf");
+         if (configAddinsPath.exists())
+            pRegistry_->add(pkgName, configAddinsPath);
+      }
    }
    
    void onIndexingCompleted(json::Object* pPayload)
@@ -384,7 +408,7 @@ class AddinWorker : public ppe::Worker
 
 public:
    
-   AddinWorker() : ppe::Worker("rstudio/addins.dcf") {}
+   AddinWorker() : ppe::Worker() {}
    
    void addContinuation(json::JsonRpcFunctionContinuation continuation)
    {
@@ -394,6 +418,7 @@ public:
 private:
    boost::shared_ptr<AddinRegistry> pRegistry_;
    std::vector<json::JsonRpcFunctionContinuation> continuations_;
+   FilePath userConfigPath_;
 };
 
 boost::shared_ptr<AddinWorker>& addinWorker()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9648.

### Approach

Allow our addins indexer to accept both package-local paths as well as addins within the corresponding `R_user_dir(which = "config")` location.

### Automated Tests

N/A

### QA Notes

I believe we can allow this to be community tested.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
