### PR TITLE
implement isMacOS and isCentOS desktop callbacks (Electron)

### DIFF
--- a/src/node/desktop/src/core/system.ts
+++ b/src/node/desktop/src/core/system.ts
@@ -15,6 +15,9 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import crc from 'crc';
+import fs from 'fs';
+
+import { FilePath } from './file-path';
 
 export function generateUuid(includeDashes = true): string {
   let uuid = uuidv4();
@@ -39,4 +42,19 @@ export function generateRandomPort(): number {
 export function localPeer(port: number): string {
   // local peer used for named-pipe communcation on Windows
   return `\\\\.\\pipe\\${port.toString()}-rsession`;
+}
+
+export function isCentOS(): boolean {
+  if (process.platform === 'linux') {
+    const redhatRelease = new FilePath('/etc/redhat-release');
+    if (redhatRelease.existsSync()) {
+      try {
+        const contents = fs.readFileSync(redhatRelease.getAbsolutePath(), 'utf-8');
+        return contents.includes('CentOS') || contents.includes('Red Hat Enterprise Linux');
+      } catch (error) {
+        return false;
+      }
+    }
+  }
+  return false;
 }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -24,6 +24,7 @@ import EventEmitter from 'events';
 
 import { logger } from '../core/logger';
 import { FilePath } from '../core/file-path';
+import { isCentOS } from '../core/system';
 
 import { PendingWindow } from './pending-window';
 import { MainWindow } from './main-window';
@@ -502,13 +503,11 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_is_macos', () => {
-      // TODO
-      return true;
+      return process.platform === 'darwin';
     });
 
     ipcMain.handle('desktop_is_centos', () => {
-      // TODO
-      return false;
+      return isCentOS();
     });
 
     ipcMain.on('desktop_set_busy', (event, busy) => {

--- a/src/node/desktop/test/unit/core/system.test.ts
+++ b/src/node/desktop/test/unit/core/system.test.ts
@@ -16,7 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { generateRandomPort, generateShortenedUuid, generateUuid } from '../../../src/core/system';
+import { generateRandomPort, generateShortenedUuid, generateUuid, isCentOS } from '../../../src/core/system';
 
 describe('System', () => {
   it('generateUuid returns uuid string with dashes', () => {
@@ -39,5 +39,16 @@ describe('System', () => {
     assert.notEqual(port1, port2);
     assert.isAbove(port1, 0);
     assert.isAbove(port2, 0);
+  });
+  it('isCentOS returns reasonable result on this platform', () => {
+    // Can't fully test this without reimplementing it here; but we can make sure it
+    // is in the ballpark!
+    const centOS = isCentOS();
+    if (centOS) {
+      assert.isTrue(process.platform === 'linux');
+    }
+    if (process.platform !== 'linux') {
+      assert.isFalse(centOS);
+    }
   });
 });


### PR DESCRIPTION
### Intent

Implement more GWT callbacks, in this case the `isMacOS` and `isCentOS` callbacks.

### Approach

Trivial for isMacOS; for isCentOS ported the existing C++ code.

### Automated Tests

Added test for `isCentOS`.

### QA Notes

Internals.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


