### PR TITLE
Implement "restart r session" for Electron

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -46,7 +46,7 @@
     "watch": "tsc -w",
     "package": "yarn run build && electron-packager ./ --prune --package-manager=yarn --out=./package --overwrite --ignore tsconfig.tsbuildinfo",
     "lint": "eslint ./src ./test",
-    "start": "yarn run build && electron --trace-warnings --log-level=debug ./dist/src/main/main.js",
+    "start": "yarn run build && electron --trace-warnings ./dist/src/main/main.js",
     "start-diag": "yarn run build && electron --trace-warnings ./dist/src/main/main.js --run-diagnostics",
     "show-version": "yarn run build && electron ./dist/src/main/main.js --version-json",
     "test": "electron-mocha -c --config ./test/unit/mocharc.json",

--- a/src/node/desktop/src/core/r-user-data.ts
+++ b/src/node/desktop/src/core/r-user-data.ts
@@ -1,0 +1,39 @@
+/*
+ * r-user-data.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { Err } from './err';
+
+export const kRStudioInitialWorkingDir = 'RS_INITIAL_WD';
+export const kRStudioInitialEnvironment = 'RS_INITIAL_ENV';
+export const kRStudioInitialProject = 'RS_INITIAL_PROJECT';
+
+export enum SessionType
+{
+   SessionTypeDesktop = 0,
+   SessionTypeServer = 1
+}
+
+/**
+ * This routine migrates user state data from its home in RStudio 1.3 and prior
+ * (usually ~/.rstudio) to its XDG-compliant home in RStudio 1.4 and later
+ * (~/.local/share/rstudio or $XDG_DATA_HOME).
+ *
+ * This is a one-time migration that cleans up the old folder. 
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function migrateUserStateIfNecessary(sessionType: SessionType): Err {
+  // TODO Implement migrateUserStateIfNecessary()
+  return new Error('migrateUserStateIfNecessary NYI');
+}

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -105,14 +105,14 @@ function prepareEnvironmentImpl(): Err {
 function detectREnvironment(): Expected<REnvironment> {
 
   // scan for R
-  let [R, scanError] = scanForR();
+  const [RLocation, scanError] = scanForR();
   if (scanError) {
     showRNotFoundError();
     return err(scanError);
   }
 
   // normalize separators
-  R = path.normalize(R);
+  const R = path.normalize(RLocation);
 
   // generate small script for querying information about R
   const rQueryScript = String.raw`writeLines(c(
@@ -256,13 +256,13 @@ function scanForRWin32(): Expected<string> {
   // look for a 32-bit version of R
   const i386InstallPath = findDefaultInstallPathWin32('R');
   if (i386InstallPath && existsSync(i386InstallPath)) {
-      const rPath = `${i386InstallPath}/bin/i386/R.exe`;
-      logger().logDebug(`Using R ${rPath} (found via registry)`);
-      return ok(rPath);
+    const rPath = `${i386InstallPath}/bin/i386/R.exe`;
+    logger().logDebug(`Using R ${rPath} (found via registry)`);
+    return ok(rPath);
   }
 
   // nothing found; return empty filepath
-  logger().logDebug("Failed to discover R");
+  logger().logDebug('Failed to discover R');
   return err();
 
 }

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -383,7 +383,6 @@ export class SessionLauncher {
     }
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   launchNextSession(reload: boolean): Err {
 
     // unset the initial project environment variable it this doesn't

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -211,7 +211,7 @@ export function findComponents(): [FilePath, FilePath, FilePath] {
   // some primitive scanning for common developer workflows
   let buildRoot = getenv('RSTUDIO_CPP_BUILD_OUTPUT');
   if (buildRoot && !existsSync(buildRoot)) {
-    console.log(`RSTUDIO_CPP_BUILD_OUTPUT is set (${buildRoot}) but does not exist`);
+    logger().logDebug(`RSTUDIO_CPP_BUILD_OUTPUT is set (${buildRoot}) but does not exist`);
     buildRoot = '';
   }
 

--- a/src/node/desktop/test/int/console.ts
+++ b/src/node/desktop/test/int/console.ts
@@ -1,0 +1,48 @@
+/*
+ * console.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { Page } from 'playwright';
+
+export const CONSOLE_TAB_SEL = '#rstudio_workbench_tab_console';
+export const CONSOLE_INPUT_SEL = '#rstudio_console_input';
+export const CONSOLE_OUTPUT_SEL = '#rstudio_workbench_panel_console';
+
+export async function waitForConsoleReady(page: Page): Promise<void> {
+  await page.waitForSelector(CONSOLE_TAB_SEL);
+  await page.waitForSelector(CONSOLE_INPUT_SEL);
+}
+
+export async function clickConsoleTab(page: Page): Promise<void> {
+  await page.click(CONSOLE_TAB_SEL);
+}
+
+export async function typeConsoleCommand(page: Page, command: string): Promise<void> {
+  await clickConsoleTab(page);
+  await clearConsoleInputLine(page);
+  await page.type(CONSOLE_INPUT_SEL, command);
+  await page.press(CONSOLE_INPUT_SEL, 'Enter');
+}
+
+export async function clearConsoleInputLine(page: Page): Promise<void> {
+  await waitForConsoleReady(page);
+  await page.press(CONSOLE_INPUT_SEL, 'Control+A'); // cursor to start
+  await page.press(CONSOLE_INPUT_SEL, 'Control+K'); // clear to end of line
+}
+
+export async function clearConsole(page: Page): Promise<void> {
+  await waitForConsoleReady(page);
+  await page.press(CONSOLE_INPUT_SEL, 'Control+L'); // clean console
+  await clearConsoleInputLine(page);
+}

--- a/src/node/desktop/test/int/session-restart.test.ts
+++ b/src/node/desktop/test/int/session-restart.test.ts
@@ -1,5 +1,5 @@
 /*
- * utility-window.test.ts
+ * session-restart.test.ts
  *
  * Copyright (C) 2021 by RStudio, PBC
  *
@@ -14,14 +14,13 @@
  */
 
 import { describe } from 'mocha';
-import { assert } from 'chai';
 import { ElectronApplication, Page } from 'playwright';
 
-import { getWindowTitles, launch, setTimeoutPromise } from './int-utils';
-import { typeConsoleCommand } from './console';
+import { launch } from './int-utils';
+import { clearConsole, typeConsoleCommand } from './console';
 
 
-describe('Display secondary utility windows', () => {
+describe('Session restart scenarios', () => {
   let electronApp: ElectronApplication;
   let window: Page;
 
@@ -35,19 +34,11 @@ describe('Display secondary utility windows', () => {
     await electronApp.close();
   });
 
-  it('Shows GPU utility window', async function () {
-    await typeConsoleCommand(window, '.rs.api.executeCommand(\'showGpuDiagnostics\')');
-    await setTimeoutPromise(500); // TODO: yuck, find a better way to do this
-    const windows = electronApp.windows();
-    assert.equal(windows.length, 2);
-    const titles = await getWindowTitles(electronApp);
-    let found = false;
-    for (const title of titles) {
-      if (title === 'chrome://gpu') {
-        found = true;
-        break;
-      }
-    }
-    assert.isTrue(found);
+  it('Restart current session', async function () {
+    await clearConsole(window);
+    await typeConsoleCommand(window, '.rs.api.executeCommand(\'restartR\')');
+
+    // TODO: figure out how to assert that 'Restarting R session...' is present in 
+    // the console output
   });
 });

--- a/src/node/desktop/test/int/startup.test.ts
+++ b/src/node/desktop/test/int/startup.test.ts
@@ -18,6 +18,7 @@ import { assert } from 'chai';
 import { ElectronApplication, Page } from 'playwright';
 
 import { launch } from './int-utils';
+import { waitForConsoleReady } from './console';
 
 describe('Startup and Exit', () => {
   let electronApp: ElectronApplication;
@@ -33,13 +34,8 @@ describe('Startup and Exit', () => {
     await electronApp.close();
   });
 
-  it('Shows a window with Console tab', async function () {
-    // check that Console tab has role=tab
-    const consoleTabRole = await window.getAttribute('#rstudio_workbench_tab_console', 'role');
-    assert.equal(consoleTabRole, 'tab');
-  });
   it('Shows a window with expected main menu', async function () {
-    await window.click('#rstudio_workbench_tab_console');
+    await waitForConsoleReady(window);
 
     assert.isTrue(await electronApp.evaluate(async ({ app }): Promise<boolean> => {
       return !!app.applicationMenu?.getMenuItemById('File');

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -20,6 +20,8 @@ import { app } from 'electron';
 
 import { FilePath } from '../../../src/core/file-path';
 import { getenv, setenv, unsetenv } from '../../../src/core/environment';
+import { clearCoreSingleton } from '../../../src/core/core-state';
+import { NullLogger, setLogger } from '../../../src/core/logger';
 
 import * as Utils from '../../../src/main/utils';
 import { userHomePath } from '../../../src/core/user';
@@ -31,6 +33,9 @@ describe('Utils', () => {
 
   beforeEach(() => {
     saveAndClear(envVars);
+    clearCoreSingleton();
+    const f = new NullLogger();
+    setLogger(f);
   });
 
   afterEach(() => {


### PR DESCRIPTION
### Intent

The ability to `launchNextSession` was NYI, so the "Restart R Session" command didn't do anything.

### Approach

Implement enough of `launchNextSession` for that command to work.

### Automated Tests

Wrote "most" of an integration test for this, including factoring out some console-helpers to a separate file. Still need to figure out how to detect that the console output contains a string so I can assert on that.

### QA Notes

The Session / Restart R command should now work.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


