### PR TITLE
complete implementation of get_open_file_name callback

### DIFF
--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -25,6 +25,7 @@ import { NullLogger, setLogger } from '../../../src/core/logger';
 
 import * as Utils from '../../../src/main/utils';
 import { userHomePath } from '../../../src/core/user';
+import { FileFilter } from 'electron/main';
 
 describe('Utils', () => {
   const envVars: Record<string, string> = {
@@ -111,5 +112,26 @@ describe('Utils', () => {
     assert.isAtLeast(resultStr.length, start.length);
     assert.notEqual(resultStr.charAt(0), '~');
     assert.isAbove(resultStr.lastIndexOf('/foo/bar'), -1);
+  });
+  it('filterFromQFileDialogFilter converts file filter with one extension', () => {
+    const input = 'R Projects (*.Rproj)';
+    const expected: FileFilter[] = [{ name: 'R Projects', extensions: ['Rproj'] }];
+    const result = Utils.filterFromQFileDialogFilter(input);
+    assert.deepEqual(expected, result);
+  });
+  it('filterFromQFileDialogFilter converts file filter with multiple extensions', () => {
+    const input = 'Theme Files (*.tmTheme *.rstheme)';
+    const expected: FileFilter[] = [{ name: 'Theme Files', extensions: ['tmTheme', 'rstheme'] }];
+    const result = Utils.filterFromQFileDialogFilter(input);
+    assert.deepEqual(expected, result);
+  });
+  it('filterFromQFileDialogFilter converts file filter with file types', () => {
+    const input = 'Images (*.png *.xpm *.jpg);;Text files (*.txt);;XML files (*.xml)';
+    const expected: FileFilter[] = [
+      { name: 'Images', extensions: ['png', 'xpm', 'jpg'] },
+      { name: 'Text files', extensions: ['txt'] },
+      { name: 'XML files', extensions: ['xml']} ];
+    const result = Utils.filterFromQFileDialogFilter(input);
+    assert.deepEqual(expected, result);
   });
 });


### PR DESCRIPTION
### Intent

The callback for File Open dialogs wasn't completed implemented, it didn't support file-type filters or the focusOwner argument.

### Approach

Implement, converting the QFileDialog format for specifying filters to the one expected by Electron.

### Automated Tests

Added unit tests for the filter conversion function.

### QA Notes

Verify that opening a project (File / Open Project) filters down to .Rproj files, another good test is importing theme files (which has multiple extensions).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


