### PR TITLE
New highlighted IDE Keywords such as TODO

### DIFF
--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -236,7 +236,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       {
         // Begin Roxygen with todo
         token : ["comment", "comment.keyword.operator"],
-        regex : "(#+['*]\\s*)(TODO|FIXME)\\b",
+        regex : "(#+['*]\\s*)(TODO|FIXME|CHECKME|DOCME|TESTME|DISCUSS|REVIEW)\\b",
         next  : "rd-start"
       },
       {
@@ -248,7 +248,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       {
         // todo in plain comment
         token : ["comment", "comment.keyword.operator", "comment"],
-        regex : "(#+\\s*)(TODO|FIXME)\\b(.*)$",
+        regex : "(#+\\s*)(TODO|FIXME|CHECKME|DOCME|TESTME|DISCUSS|REVIEW)\\b(.*)$",
         next  : "start"
       },
       {


### PR DESCRIPTION
### Intent

Based on the discussions here:
https://community.rstudio.com/t/keyword-colors-in-source-editor/30259/2
and here:
https://stackoverflow.com/questions/9586478/ide-comment-keywords

I added the keywords CHECKME, DOCME, TESTME, DISCUSS, and REVIEW for R language comment highlighting, similar to the previous TODO.

### Approach

I edited the src/gwt/acesupport/acemode/r_highlight_rules.js as suggested from the forum thread. I have no previous knowledge of the technology used to achieve the result, but I copied the behaviour for the previous keywords and added more, hoping that this will also enable these.

### Automated Tests

No

### QA Notes

I have not built or tested anything. The change is based on a suggestion from a Kevin - a Rstudio Employee - see the first link above.

Will greatly appreciate any support to fulfil all requirements for including this new feature.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


