### PR TITLE
Add daily/preview tag to mac packages

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -55,8 +55,8 @@ mkdir -p "${INSTALL_DIR}"
 
 # build RStudio version suffix
 RSTUDIO_VERSION_ARRAY=(
-   "${RSTUDIO_VERSION_MAJOR-99}"
-   "${RSTUDIO_VERSION_MINOR-9}"
+   "${RSTUDIO_VERSION_MAJOR-$(date -u '+%Y-%m')}"
+   "${RSTUDIO_VERSION_MINOR-99}"
    "${RSTUDIO_VERSION_PATCH-9}"
 )
 
@@ -67,11 +67,16 @@ if [ -n "${RSTUDIO_VERSION_SUFFIX}" ] && [ "${RSTUDIO_VERSION_SUFFIX}" != "0" ];
    RSTUDIO_VERSION_FULL+="-${RSTUDIO_VERSION_SUFFIX}"
 fi
 
+RSTUDIO_PRO_SUFFIX="-$(cat "${PKG_DIR}/../../BUILDTYPE" | tr -d ' ' | tr '{A-Z}' '{a-z}')"
+if [ "${RSTUDIO_PRO_SUFFIX}" == "-release" ]; then
+   RSTUDIO_PRO_SUFFIX=""
+fi
+
 # build bundle name (handle Pro builds as well)
 if [ -f "${PKG_DIR}/CMakeOverlay.txt" ]; then
-   RSTUDIO_PRO_SUFFIX="-pro"
+   RSTUDIO_PRO_SUFFIX+="-pro"
 else
-   RSTUDIO_PRO_SUFFIX=""
+   RSTUDIO_PRO_SUFFIX+=""
 fi
 
 RSTUDIO_BUNDLE_NAME="RStudio${RSTUDIO_PRO_SUFFIX}-${RSTUDIO_VERSION_FULL}"

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -67,16 +67,16 @@ if [ -n "${RSTUDIO_VERSION_SUFFIX}" ] && [ "${RSTUDIO_VERSION_SUFFIX}" != "0" ];
    RSTUDIO_VERSION_FULL+="-${RSTUDIO_VERSION_SUFFIX}"
 fi
 
-RSTUDIO_PRO_SUFFIX="-$(cat "${PKG_DIR}/../../BUILDTYPE" | tr -d ' ' | tr '{A-Z}' '{a-z}')"
-if [ "${RSTUDIO_PRO_SUFFIX}" == "-release" ]; then
+# build bundle name (handle Pro builds as well)
+if [ -f "${PKG_DIR}/CMakeOverlay.txt" ]; then
+   RSTUDIO_PRO_SUFFIX="-pro"
+else
    RSTUDIO_PRO_SUFFIX=""
 fi
 
-# build bundle name (handle Pro builds as well)
-if [ -f "${PKG_DIR}/CMakeOverlay.txt" ]; then
-   RSTUDIO_PRO_SUFFIX+="-pro"
-else
-   RSTUDIO_PRO_SUFFIX+=""
+RSTUDIO_BUILD_TYPE="$(cat "${PKG_DIR}/../../BUILDTYPE" | tr -d ' ' | tr '{A-Z}' '{a-z}')"
+if [ "${RSTUDIO_BUILD_TYPE}" != "release" ]; then
+   RSTUDIO_PRO_SUFFIX+="-${RSTUDIO_BUILD_TYPE}"
 fi
 
 RSTUDIO_BUNDLE_NAME="RStudio${RSTUDIO_PRO_SUFFIX}-${RSTUDIO_VERSION_FULL}"


### PR DESCRIPTION
### Intent

Addresses #9684.

### Approach

Add `-daily` or `-preview` before the pro suffix in the make-package script.

### Automated Tests

The builds will fail if this causes problems.

### QA Notes

We can visually inspect the new package names on the dailies page after a successful build. The scheme for OSX should match the scheme for the other OSes.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


