### PR TITLE
Lower log priority of unrecognized files in db folder

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -945,7 +945,7 @@ bool SchemaUpdater::parseVersionOfFile(const FilePath& file, SchemaVersion* pVer
    boost::split(split, fileStem, boost::is_any_of("_"));
    if (split.size() != 3)
    {
-      LOG_WARNING_MESSAGE("Unrecognized file in the db folder, it will be skipped: " + file.getAbsolutePath());
+      LOG_DEBUG_MESSAGE("Unrecognized file in /usr/lib/rstudio-server/db, it will be skipped: " + file.getAbsolutePath());
       return false;
    }
 

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -945,7 +945,10 @@ bool SchemaUpdater::parseVersionOfFile(const FilePath& file, SchemaVersion* pVer
    boost::split(split, fileStem, boost::is_any_of("_"));
    if (split.size() != 3)
    {
-      LOG_DEBUG_MESSAGE("Unrecognized file in /usr/lib/rstudio-server/db, it will be skipped: " + file.getAbsolutePath());
+     if (split.size() == 2)
+         LOG_DEBUG_MESSAGE("Not applying sql schema file from previous release: " + file.getAbsolutePath());
+     else
+         LOG_DEBUG_MESSAGE("Not applying unrecognized sql schema file: " + file.getAbsolutePath());
       return false;
    }
 


### PR DESCRIPTION
### Intent

Addresses [Pro #2790](https://github.com/rstudio/rstudio-pro/issues/2790)

### Approach

Lower the log level from WARNING to DEBUG. This will ensure that these probably innocuous logs will not cause undue concern. The probably better long term solution here would be to have the installer remove the db/ files as a pre-install step, since all the needed files will be installed during the regular install step anyway.

### Automated Tests

N/A, logging change only.

### QA Notes

The logs should not appear unless the admin has enabled debug logging. Here is what it looks like when that is enabled:
![image](https://user-images.githubusercontent.com/37987486/128074721-c2bb134a-70b6-40ec-ba94-0a2e2927239e.png)


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


