### PR TITLE
Feature/gwt callbacks craig

### DIFF
--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -582,6 +582,14 @@ export class FilePath {
   }
 
   /**
+   * Gets only the name of the file, not encluding the extension
+   */
+  getFileStem(): string {
+    const components = path.parse(this.path);
+    return components.name;
+  }
+
+  /**
    * Get the last time this file path was written.
    */
   getLastWriteTimeSync(): number {

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -582,14 +582,6 @@ export class FilePath {
   }
 
   /**
-   * Gets only the name of the file, not encluding the extension
-   */
-  getFileStem(): string {
-    const components = path.parse(this.path);
-    return components.name;
-  }
-
-  /**
    * Get the last time this file path was written.
    */
   getLastWriteTimeSync(): number {
@@ -651,7 +643,13 @@ export class FilePath {
    * Gets only the name of the file, excluding the extension.
    */
   getStem(): string {
-    throw Error('getStem is NYI');
+    // If this is just a path to a directory, then there is no filename or stem.
+    if (this.path.endsWith('/') || this.path.endsWith('\\')) {
+      return '';
+    }
+    
+    const components = path.parse(this.path);
+    return components.name;
   }
 
   /**

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -18,7 +18,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 
 import { ipcMain, dialog, BrowserWindow, webFrameMain } from 'electron';
-import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions } from 'electron/main';
+import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 
 import EventEmitter from 'events';
 
@@ -91,12 +91,22 @@ export class GwtCallback extends EventEmitter {
       }
     });
 
-    ipcMain.handle('desktop_get_save_file_name', (event, caption: string, label: string,
+    ipcMain.handle('desktop_get_save_file_name', async (event, caption: string, label: string,
       dir: string, defaultExtension: string, forceDefaultExtension: boolean,
       focusOwner: boolean
     ) => {
-      GwtCallback.unimpl('desktop_get_save_file_name');
-      return '';
+      const saveDialogOptions: SaveDialogOptions = {
+        title: caption,
+        defaultPath: dir,
+        buttonLabel: label
+      };
+
+      const focusedWindow = BrowserWindow.getFocusedWindow();
+      if (focusedWindow) {
+        return dialog.showSaveDialog(focusedWindow, saveDialogOptions);
+      } else {
+        return dialog.showSaveDialog(saveDialogOptions);
+      }
     });
 
     ipcMain.handle('desktop_get_existing_directory', (event, caption: string, label: string,

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -101,6 +101,12 @@ export class GwtCallback extends EventEmitter {
         buttonLabel: label
       };
 
+      if (defaultExtension) {
+        saveDialogOptions['filters'] = [
+          {name: '', extensions: [defaultExtension.replace('.', '')]}
+        ];
+      }
+
       let focusedWindow = BrowserWindow.getFocusedWindow();
       if (focusOwner) {
         focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;
@@ -200,10 +206,9 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_show_folder', (event, path: string) => {
-      void shell.openPath(path)
-        .then((value) => {
-          if (value)
-            logger().logErrorMessage(value);
+      shell.openPath(path)
+        .catch((value) => {
+          logger().logErrorMessage(value);
         });
     });
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -14,6 +14,7 @@
  */
 
 import { ipcRenderer } from 'electron';
+import { FilePath } from '../core/file-path';
 
 interface VoidCallback<Type> {
   (result: Type): void;
@@ -77,7 +78,16 @@ export function getDesktopBridge() {
           if (result.canceled as boolean) {
             callback('');
           } else {
-            callback(result.filePath);
+
+            // Add default extension, if it's missing
+            const fp = new FilePath(result.filePath);
+            if ((fp.getExtension().length == 0) ||
+               (forceDefaultExtension &&
+               (fp.getExtension() !== defaultExtension))) {
+              callback(fp.getFileStem() + defaultExtension);
+            } else {
+              callback(result.filePath);
+            }
           }
         })
         .catch(error => reportIpcError('getSaveFileName', error));

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -93,7 +93,13 @@ export function getDesktopBridge() {
           label,
           dir,
           focusOwner)
-        .then(directory => callback(directory))
+        .then(result => {
+          if (result.canceled as boolean) {
+            callback('');
+          } else {
+            callback(result.filePaths[0]);
+          }
+        })
         .catch(error => reportIpcError('getExistingDirectory', error));
     },
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -84,7 +84,7 @@ export function getDesktopBridge() {
             if ((fp.getExtension().length == 0) ||
                (forceDefaultExtension &&
                (fp.getExtension() !== defaultExtension))) {
-              callback(fp.getFileStem() + defaultExtension);
+              callback(fp.getStem() + defaultExtension);
             } else {
               callback(result.filePath);
             }

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -73,7 +73,13 @@ export function getDesktopBridge() {
           defaultExtension,
           forceDefaultExtension,
           focusOwner)
-        .then(filename => callback(filename))
+        .then(result => {
+          if (result.canceled as boolean) {
+            callback('');
+          } else {
+            callback(result.filePath);
+          }
+        })
         .catch(error => reportIpcError('getSaveFileName', error));
     },
 

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -205,6 +205,20 @@ describe('FilePath', () => {
       const f = new FilePath('/some/file/that/will/not/exist');
       assert.strictEqual(f.getLastWriteTimeSync(), 0);
     });
+    it('getStem returns the file stem', () => {
+      assert.equal(new FilePath('/path/to/file.txt').getStem(), 'file');
+      assert.equal(new FilePath('file.txt').getStem(), 'file');
+      assert.equal(new FilePath('noExtension').getStem(), 'noExtension');
+      assert.equal(new FilePath('.hiddenFile.txt').getStem(), '.hiddenFile');
+      assert.equal(new FilePath('.hiddenFileNoExtension').getStem(), '.hiddenFileNoExtension');
+      
+      // You could debate that this should only return 'file'. Including test here to show current behavior
+      assert.equal(new FilePath('/path/to/file.extra.txt').getStem(), 'file.extra');
+
+      // A full path to a file with no extension is ambiguous. Including test here to show current behavior
+      assert.equal(new FilePath('/path/to/noExtensionOrDirectory').getStem(), 'noExtensionOrDirectory');
+      assert.equal(new FilePath('/path/to/directory/').getStem(), '');
+    });
   });
 
   describe('Get a safe current path', () => {
@@ -749,20 +763,6 @@ describe('FilePath', () => {
       assert.equal(subDir.getAbsolutePath(), children[0].getAbsolutePath());
       subDir.removeIfExistsSync();
       testDir.removeIfExistsSync();
-    });
-    it('WIPgetStem returns the file stem', () => {
-      assert.equal(new FilePath('/path/to/file.txt').getStem(), 'file');
-      assert.equal(new FilePath('file.txt').getStem(), 'file');
-      assert.equal(new FilePath('noExtension').getStem(), 'noExtension');
-      assert.equal(new FilePath('.hiddenFile.txt').getStem(), '.hiddenFile');
-      assert.equal(new FilePath('.hiddenFileNoExtension').getStem(), '.hiddenFileNoExtension');
-      
-      // You could debate that this should only return 'file'. Including test here to show current behavior
-      assert.equal(new FilePath('/path/to/file.extra.txt').getStem(), 'file.extra');
-
-      // A full path to a file with no extension is ambiguous. Including test here to show current behavior
-      assert.equal(new FilePath('/path/to/noExtensionOrDirectory').getStem(), 'noExtensionOrDirectory');
-      assert.equal(new FilePath('/path/to/directory/').getStem(), '');
     });
   });
 

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -750,6 +750,20 @@ describe('FilePath', () => {
       subDir.removeIfExistsSync();
       testDir.removeIfExistsSync();
     });
+    it('WIPgetStem returns the file stem', () => {
+      assert.equal(new FilePath('/path/to/file.txt').getStem(), 'file');
+      assert.equal(new FilePath('file.txt').getStem(), 'file');
+      assert.equal(new FilePath('noExtension').getStem(), 'noExtension');
+      assert.equal(new FilePath('.hiddenFile.txt').getStem(), '.hiddenFile');
+      assert.equal(new FilePath('.hiddenFileNoExtension').getStem(), '.hiddenFileNoExtension');
+      
+      // You could debate that this should only return 'file'. Including test here to show current behavior
+      assert.equal(new FilePath('/path/to/file.extra.txt').getStem(), 'file.extra');
+
+      // A full path to a file with no extension is ambiguous. Including test here to show current behavior
+      assert.equal(new FilePath('/path/to/noExtensionOrDirectory').getStem(), 'noExtensionOrDirectory');
+      assert.equal(new FilePath('/path/to/directory/').getStem(), '');
+    });
   });
 
   describe('NYI placeholders', () => {
@@ -776,7 +790,6 @@ describe('FilePath', () => {
       assert.throws(() => fp1.getRelativePath(fp2));
       assert.throws(() => fp1.getSize());
       assert.throws(() => fp1.getSizeRecursive());
-      assert.throws(() => fp1.getStem());
       assert.throws(() => fp1.hasExtension('.txt'));
       assert.throws(() => fp1.hasExtensionLowerCase('.txt'));
       assert.throws(() => fp1.hasTextMimeType());


### PR DESCRIPTION
### Intent

Connect electron's save file/open directory dialogs to GWT's requests for them. Also added open/show file/folder in the OS' file explorer cause (I thought) I needed them for debugging.

### Approach

Mirrored the existing open file functionality very closely.

### Automated Tests

I didn't add any tests, because this seems like something that's more tested as part of integrated testing for full system testing. If I'm mistaken I'd be happy to add some

### QA Notes

None
### Checklist

- [ x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ x ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


