### PR TITLE
Fix packaged Windows layout (Electron)

### DIFF
--- a/src/node/desktop/scripts/package-helper.ts
+++ b/src/node/desktop/scripts/package-helper.ts
@@ -61,15 +61,17 @@ async function packageWin32(): Promise<number> {
   }
   console.log(info(`Using RStudio binaries found at: ${rstudioInstallDir}`));
 
-  const resourceDest = path.join(packageDir, 'resources/app');
+  const appDest = path.join(packageDir, 'resources/app');
 
   console.log(info('Copying binary files'));
   await copy(
-    path.join(rstudioInstallDir, 'bin'), path.join(resourceDest, 'bin'), {
+    path.join(rstudioInstallDir, 'bin'), path.join(appDest, 'bin'), {
     filter: [
       '**/*',
       '!Qt5*',
+      '!QtWebEngineProcess.exe',
       '!resources/*',
+      '!translations/*',
       '!rstudio.exe',
       '!d3dcompiler_47.dll',
       '!libEGL.dll',
@@ -78,11 +80,13 @@ async function packageWin32(): Promise<number> {
   });
 
   console.log(info('Copying R resources'));
-  await copy(path.join(rstudioInstallDir, 'R'), path.join(resourceDest, 'R'));
-  console.log(info('Copying misc resources'));
-  await copy(path.join(rstudioInstallDir, 'resources'), resourceDest, { filter: ['**/*', '!html/*'] });
+  await copy(path.join(rstudioInstallDir, 'R'), path.join(appDest, 'R'));
   console.log(info('Copying www files'));
-  await copy(path.join(rstudioInstallDir, 'www'), path.join(resourceDest, 'www'));
+  await copy(path.join(rstudioInstallDir, 'www'), path.join(appDest, 'www'));
+  console.log(info('Copying www-symbolmaps files'));
+  await copy(path.join(rstudioInstallDir, 'www-symbolmaps'), path.join(appDest, 'www-symbolmaps'));
+  console.log(info('Copying misc resources'));
+  await copy(path.join(rstudioInstallDir, 'resources'), path.join(appDest, 'resources'), { filter: ['**/*', '!html/*'] });
 
   return 0;
 }


### PR DESCRIPTION
### Intent

Make it possible to create a runnable package build of RStudio for Windows (Electron), using the binaries from the RStudio build installed in Program Files. This is an intermediate step towards real builds, enabling:

* determining file layout for a Windows package build
* enable creation and running of Electron build on Windows without needing a full dev environment (akin to what I created for Mac a while back)

### Approach

Tweaks to the script I created before my week off. It wasn't quite right; now it produces a package build that runs.

### Automated Tests

None, this is an internal script.

### QA Notes

To try this, follow steps here: https://github.com/rstudio/rstudio/wiki/Electron-Desktop/_edit#windows

(repeated)

* clone the rstudio repo (for this example, assuming to `~/rstudio`)
* install a recent daily build of `RStudio.exe` to default location in `Program Files`
* in the `~/rstudio/src/node/desktop` folder, run `./scripts/update-yarn`
* then `yarn win-package`

This will build and package RStudio for Windows, pulling in the non-Electron bits from the installed daily build. The result is in:

`~rstudio\src\node\desktop\package\RStudio-win32-x64\RStudio.exe`



### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


