### PR TITLE
Fix wrapping for RStudio Workbench in About

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.java
@@ -65,7 +65,8 @@ public class AboutDialogContents extends Composite
       initWidget(uiBinder.createAndBindUi(this));
       versionMajorLabel.setText(info.version_major + "." + info.version_minor);
       versionBuildLabel.setText("Build " + info.version_patch +
-         (StringUtil.isNullOrEmpty(info.version_suffix) ? "" : "-" + info.version_suffix));
+         ((StringUtil.isNullOrEmpty(info.version_suffix) || StringUtil.equals(info.version_suffix, "0")) ?
+            "" : "-" + info.version_suffix));
 
       // a11y
       productInfo.getElement().setId("productinfo");

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -12,7 +12,7 @@
          margin-bottom: 3px;
       }
       
-      .productVersion, .productCopyright {
+      .productVersion {
          margin-bottom: 3px;
       }
 
@@ -30,7 +30,8 @@
       }
 
       .productCopyright {
-         margin-top: 10px;
+         margin-bottom: 10px;
+         margin-top: 5px;
          font-size: 10pt;
       }
 
@@ -82,15 +83,19 @@
       .productInfo {
          text-align: left;
          overflow: hidden;
-         margin-left: auto;
-         margin-right: auto;
-         width: 55%;
          user-select: text;
       }
       
       .outerProductInfo {
-         text-align: center;
          width: 580px;
+         display: flex;
+         flex-direction: column;
+         align-items: center;
+      }
+
+      .innerProductInfo {
+         display: flex;
+         flex-direction: column;
       }
 
       .licenseLabel {
@@ -141,15 +146,17 @@
                            width="48"
                            height="48"
                            altText="RStudio Logo"/>
-                  <g:Label ui:field="productName" text="RStudio" styleName="{style.productName}"></g:Label>
-                  <g:HTMLPanel styleName="{style.productVersion}">
-                     <g:InlineLabel styleName="{style.majorVersion}" ui:field="versionMajorLabel"></g:InlineLabel>
-                     <g:InlineLabel styleName="{style.buildNumber}" ui:field="versionBuildLabel"></g:InlineLabel>
-                  </g:HTMLPanel>
-                  <g:HTMLPanel styleName="{style.productCopyright}">
-                          <g:InlineLabel text="&copy;"></g:InlineLabel>
-                          <g:InlineLabel ui:field="copyrightYearLabel"></g:InlineLabel>
-                          <g:InlineLabel text="RStudio, PBC"></g:InlineLabel>
+                  <g:HTMLPanel styleName="{style.innerProductInfo}">
+                     <g:Label ui:field="productName" text="RStudio" styleName="{style.productName}"></g:Label>
+                     <g:HTMLPanel styleName="{style.productVersion}">
+                        <g:InlineLabel styleName="{style.majorVersion}" ui:field="versionMajorLabel"></g:InlineLabel>
+                        <g:InlineLabel styleName="{style.buildNumber}" ui:field="versionBuildLabel"></g:InlineLabel>
+                     </g:HTMLPanel>
+                     <g:HTMLPanel styleName="{style.productCopyright}">
+                         <g:InlineLabel text="&copy;"></g:InlineLabel>
+                         <g:InlineLabel ui:field="copyrightYearLabel"></g:InlineLabel>
+                         <g:InlineLabel text="RStudio, PBC"></g:InlineLabel>
+                     </g:HTMLPanel>
                   </g:HTMLPanel>
                </g:HTMLPanel>
             </g:HTMLPanel>


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2860.

### Approach

The reason this happens is that the CSS box that contains the product name has a fixed size; the position of the RStudio logo is also fixed. This makes it somewhat difficult to accommodate all the different product names and keep the name/logo centered. So I've make a somewhat larger change that uses Flexbox to lay these all out. Now the logo can move to help center the larger Workbench product name.

Server:
![image](https://user-images.githubusercontent.com/470418/128768472-a077f080-a364-4bdd-a580-fc05569997f0.png)

Workbench:
![image](https://user-images.githubusercontent.com/470418/128768585-d78add64-3cd1-4077-975c-54cb4715f3ab.png)

### Automated Tests

N/A, style change only

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2860.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


