### PR TITLE
Don't refresh log file destinations between fork and exec

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2472,10 +2472,6 @@ Error permanentlyDropPriv(const std::string& newUsername)
    if (error)
       return error;
 
-   // before changing the process user, ensure it becomes the new
-   // owner of any file logs so we can ensure that we can keep writing to them
-   core::log::refreshAllLogDestinations(core::log::RefreshParams{ user });
-
    // clear error state
    errno = 0;
 

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2472,6 +2472,11 @@ Error permanentlyDropPriv(const std::string& newUsername)
    if (error)
       return error;
 
+   // Refresh the destinations without providing a user since we are have the parent processes's file destinations 
+   // and don't want to change the ownership of the log files to newUsername. We do still want to make sure we are set up to log in case
+   // there are errors before we call ::execve - in particular, for syslog
+   core::log::refreshAllLogDestinations();
+
    // clear error state
    errno = 0;
 

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -574,6 +574,12 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
       if (!m_impl->openLogFile())
       {
          m_impl->closeLogFile();
+
+#ifndef _WIN32
+         // Still write to syslog even if main file is no good
+         if (in_logLevel <= LogLevel::WARN && m_impl->SyslogDest)
+            m_impl->SyslogDest->writeLog(in_logLevel, in_message);
+#endif
          return;
       }
 

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -562,6 +562,12 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
    {
       boost::lock_guard<boost::mutex> lock(m_impl->Mutex);
 
+#ifndef _WIN32
+         // First write to syslog if configured
+         if (in_logLevel <= LogLevel::WARN && m_impl->SyslogDest)
+            m_impl->SyslogDest->writeLog(in_logLevel, in_message);
+#endif
+
       // Check to make sure path to file is valid. If not, log nothing.
       if (!m_impl->verifyLogFilePath())
          return;
@@ -574,12 +580,6 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
       if (!m_impl->openLogFile())
       {
          m_impl->closeLogFile();
-
-#ifndef _WIN32
-         // Still write to syslog even if main file is no good
-         if (in_logLevel <= LogLevel::WARN && m_impl->SyslogDest)
-            m_impl->SyslogDest->writeLog(in_logLevel, in_message);
-#endif
          return;
       }
 
@@ -601,12 +601,6 @@ void FileLogDestination::writeLog(LogLevel in_logLevel, const std::string& in_me
       }
 
       m_impl->closeLogFile();
-
-#ifndef _WIN32
-      // Finally, send warn and error to syslog if configured
-      if (in_logLevel <= LogLevel::WARN && m_impl->SyslogDest)
-         m_impl->SyslogDest->writeLog(in_logLevel, in_message);
-#endif
    }
    catch (...)
    {


### PR DESCRIPTION
As far as I can tell, this function is only called between fork and exec. In that case, we still have the parent's file destinations and yet end up changing the perms to the child's runAsUser.  So rserver.log ends up with the session user's ownership perms after a session launch in open source.  Looks like maybe this is needed for temporarilyDropPrivs, but not permanentlyDropPrivs?

Addresses [this issue](https://github.com/rstudio/rstudio/issues/9715)