### PR TITLE
Fix permissions for /var/lib/rstudio-server directory for sqlite 

### DIFF
--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -151,7 +151,23 @@ Error readOptions(const std::string& databaseConfigFile,
          // always ensure the database file user is correct, if specified
          error = databaseFile.changeOwnership(databaseFileUser.get());
          if (error)
+         {
+            error.addProperty("description", "Unable to change ownership of database file");
             return error;
+         }
+
+#ifndef _WIN32
+         error = databaseDirectory.changeOwnership(databaseFileUser.get());
+         if (error)
+         {
+            bool writable = false;
+            Error writableError = databaseDirectory.isWriteable(writable);
+            if (writableError || !writable)
+            {
+                LOG_ERROR_MESSAGE("Sqllite database directory: " + databaseDirectory.getAbsolutePath() + " must be writable by: " + databaseFileUser.get().getUsername());
+            }
+         }
+#endif
       }
 
       LOG_INFO_MESSAGE("Connecting to sqlite3 database at " + options.file);

--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -152,6 +152,7 @@ Error readOptions(const std::string& databaseConfigFile,
          error = databaseFile.changeOwnership(databaseFileUser.get());
          if (error)
          {
+            error.addProperty("server-user", databaseFileUser.get().getUsername());
             error.addProperty("description", "Unable to change ownership of database file");
             return error;
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9715

### Approach

The sqlite database requires that write perms be available for the directory. Other parts of the code do this for Workbench but OS is missing some code to try and do the chown of the directory so I added it. 

### Automated Tests

Not necessary

### QA Notes

A clean install on a linux machine of the OS version should show /var/lib/rstudio-server owned and writable by rstudio-server

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


