### PR TITLE
Implement session reload in current window (Electron)

### DIFF
--- a/src/node/desktop/src/core/wait-utils.ts
+++ b/src/node/desktop/src/core/wait-utils.ts
@@ -1,0 +1,71 @@
+/*
+ * wait-utils.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { Err, success } from './err';
+import util from 'util';
+
+export const setTimeoutPromise = util.promisify(setTimeout);
+
+export type WaitResultType = 'WaitSuccess' | 'WaitContinue' | 'WaitError';
+
+export class WaitResult {
+  type: WaitResultType;
+  error: Err;
+
+  constructor(type: WaitResultType, error: Err) {
+    this.type = type;
+    this.error = error;
+  }
+}
+
+export type WaitTimeoutFn = () => Promise<WaitResult>;
+
+export async function waitWithTimeout(
+  waitFunction: WaitTimeoutFn,
+  initialWaitMs: number,
+  incrementWaitMs: number,
+  maxWaitSec: number
+) : Promise<Err> {
+
+  // wait for the session to be available
+
+  // wait 30ms (this value is somewhat arbitrary -- ideally it would
+  // be as close as possible to the expected total launch time of
+  // rsession (observed to be ~35ms on a 3ghz MacPro w/ SSD disk)
+  await setTimeoutPromise(initialWaitMs);
+
+  // try the connection again and if we don't get it try to reconnect
+  // every 10ms until a timeout occurs -- we use a low granularity
+  // here because expect our initial guess of 30ms to be pretty close
+  // to the total launch time
+  const timeoutTime = Date.now() + maxWaitSec * 1000;
+  while(Date.now() < timeoutTime) {
+    const result = await waitFunction();
+    if (result.type === 'WaitSuccess') {
+      return success();
+    }
+
+    if (result.type === 'WaitContinue') {
+      // try again after waiting a short while
+      await setTimeoutPromise(incrementWaitMs);
+      continue;
+    } else {
+      // unrecoverable error (return connectError below)
+      return result.error;
+    }
+  }
+
+  return Error('Exceeded timeout');
+}

--- a/src/node/desktop/src/core/wait-utils.ts
+++ b/src/node/desktop/src/core/wait-utils.ts
@@ -24,7 +24,7 @@ export class WaitResult {
   type: WaitResultType;
   error: Err;
 
-  constructor(type: WaitResultType, error: Err) {
+  constructor(type: WaitResultType, error: Err = null) {
     this.type = type;
     this.error = error;
   }
@@ -32,6 +32,14 @@ export class WaitResult {
 
 export type WaitTimeoutFn = () => Promise<WaitResult>;
 
+/**
+ * Helper routine 
+ * @param waitFunction Function invoked on each retry
+ * @param initialWaitMs Delay first first try
+ * @param incrementWaitMs Delay between subsequent tries
+ * @param maxWaitSec Maximum time to keep trying
+ * @returns 
+ */
 export async function waitWithTimeout(
   waitFunction: WaitTimeoutFn,
   initialWaitMs: number,

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -18,12 +18,15 @@ import os from 'os';
 import path from 'path';
 import { sep } from 'path';
 import { app, FileFilter, WebContents } from 'electron';
+import http from 'http';
 
 import { Xdg } from '../core/xdg';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 import { logger } from '../core/logger';
 import { userHomePath } from '../core/user';
+import { WaitResult, WaitTimeoutFn, waitWithTimeout } from '../core/wait-utils';
+import { Err } from '../core/err';
 
 import { productInfo } from './product-info';
 import { MainWindow } from './main-window';
@@ -313,3 +316,29 @@ export function filterFromQFileDialogFilter(qtFilters: string): FileFilter[] {
   }
   return result;
 }
+
+/**
+ * Wait for a URL to respond, with retries and timeout
+ */
+export async function waitForUrlWithTimeout(
+  url: string,
+  initialWaitMs: number,
+  incrementWaitMs: number,
+  maxWaitSec: number
+): Promise<Err> {
+
+  const checkReady: WaitTimeoutFn = async () => {
+    return new Promise((resolve) => {
+      http.get(url, (res) => {
+        res.resume(); // consume response data to free up memory
+        resolve(new WaitResult('WaitSuccess'));
+      }).on('error', (e) => {
+        logger().logDebug(`Connection to ${url} failed: ${e.message}`);
+        resolve(new WaitResult('WaitContinue'));
+      });
+    });
+  };
+
+  return waitWithTimeout(checkReady, initialWaitMs, incrementWaitMs, maxWaitSec);
+}
+

--- a/src/node/desktop/test/unit/core/wait-utils.test.ts
+++ b/src/node/desktop/test/unit/core/wait-utils.test.ts
@@ -1,0 +1,22 @@
+/*
+ * wait-utils.test.ts
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+describe('wait-utils', () => {
+  // TODO
+  assert.isTrue(true);
+});

--- a/src/node/desktop/test/unit/core/wait-utils.test.ts
+++ b/src/node/desktop/test/unit/core/wait-utils.test.ts
@@ -15,8 +15,41 @@
 
 import { describe } from 'mocha';
 import { assert } from 'chai';
+import { WaitResult, WaitTimeoutFn, waitWithTimeout } from '../../../src/core/wait-utils';
+import { isFailure, isSuccessful } from '../../../src/core/err';
 
 describe('wait-utils', () => {
-  // TODO
-  assert.isTrue(true);
+  it('waitWithTimeout returns error after max wait reached', async () => {
+    let numCalls = 0;
+    const neverSucceeds: WaitTimeoutFn = async () => {
+      numCalls++;
+      return Promise.resolve(new WaitResult('WaitContinue'));
+    };
+    
+    const error = await waitWithTimeout(neverSucceeds, 1, 2, 1);
+    assert.isTrue(isFailure(error));
+    assert.isAbove(numCalls, 0);
+  });
+  it('waitWithTimeout returns success on first try', async () => {
+    let numCalls = 0;
+    const immediatelySucceeds: WaitTimeoutFn = async () => {
+      numCalls++;
+      return Promise.resolve(new WaitResult('WaitSuccess'));
+    };
+    
+    const error = await waitWithTimeout(immediatelySucceeds, 1, 2, 1);
+    assert.isTrue(isSuccessful(error));
+    assert.equal(numCalls, 1);
+  });
+  it('waitWithTimeout returns success on retry', async () => {
+    let numCalls = 0;
+    const eventuallySucceeds: WaitTimeoutFn = async () => {
+      numCalls++;
+      return Promise.resolve(new WaitResult(numCalls == 2 ? 'WaitSuccess' : 'WaitContinue'));
+    };
+    
+    const error = await waitWithTimeout(eventuallySucceeds, 1, 2, 1);
+    assert.isTrue(isSuccessful(error));
+    assert.equal(numCalls, 2);
+  });
 });


### PR DESCRIPTION
### Intent

Reloading a session in current window was not fully implemented; needed to open/close projects.

### Approach

Port the relevant code.

### Automated Tests

Unit test added for the ported method for waiting for the session to respond.

### QA Notes

Can now open/close projects in the current window. This does not implement opening projects/sessions in a separate window.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


