### PR TITLE
Fix a bug on RHEL 7 caused by sqlite pragma query

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -923,9 +923,9 @@ Error SchemaUpdater::getSchemaTableColumnCount(int* pColumnCount)
    Error error;
    if (connection_->driverName() == SQLITE_DRIVER)
    {
-      Query query = connection_->query("SELECT * FROM PRAGMA_TABLE_INFO('") + SCHEMA_TABLE + "')");
+      Query query = connection_->query(std::string("SELECT * FROM ") + SCHEMA_TABLE);
       Rowset rows;
-      error = connection->execute(query, rows);
+      error = connection_->execute(query, rows);
       columnCount = rows.columnCount();
    }
    else

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -921,7 +921,7 @@ Error SchemaUpdater::getSchemaTableColumnCount(int* pColumnCount)
    }
    else
    {
-      queryStr = std::string("SELECT COUNT(*) FROM information_schema.columns WHERE table_name='") + SCHEMA_TABLE +
+      queryStr = std::string("SELECT COUNT(1) FROM information_schema.columns WHERE table_name='") + SCHEMA_TABLE +
                  "' AND table_schema = current_schema";
    }
 

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -478,6 +478,11 @@ RowsetIterator Rowset::end()
    return RowsetIterator();
 }
 
+size_t Rowset::columnCount() const
+{
+   return row_.size();
+}
+
 Connection::Connection(const soci::backend_factory& factory,
                        const std::string& connectionStr) :
    session_(factory, connectionStr)
@@ -914,22 +919,28 @@ Error SchemaUpdater::isSchemaVersionPresent(bool* pIsPresent)
 
 Error SchemaUpdater::getSchemaTableColumnCount(int* pColumnCount)
 {
-   std::string queryStr;
+   int columnCount = 0;
+   Error error;
    if (connection_->driverName() == SQLITE_DRIVER)
    {
-      queryStr = std::string("SELECT COUNT(*) FROM PRAGMA_TABLE_INFO('") + SCHEMA_TABLE + "')";
+      Query query = connection_->query("SELECT * FROM PRAGMA_TABLE_INFO('") + SCHEMA_TABLE + "')");
+      Rowset rows;
+      error = connection->execute(query, rows);
+      columnCount = rows.columnCount();
    }
    else
    {
-      queryStr = std::string("SELECT COUNT(1) FROM information_schema.columns WHERE table_name='") + SCHEMA_TABLE +
-                 "' AND table_schema = current_schema";
+      Query query = connection_->query(std::string("SELECT COUNT(1) FROM information_schema.columns WHERE table_name='") + SCHEMA_TABLE +
+                 "' AND table_schema = current_schema")
+                 .withOutput(columnCount);
+      error = connection_->execute(query);
    }
 
-   int columnCount = 0;
-   Query query = connection_->query(queryStr).withOutput(columnCount);
-   Error error = connection_->execute(query);
    if (error)
-      return error;
+   {
+      error.addProperty("query", connection_->session().get_last_query());
+      return error;   
+   }
 
    *pColumnCount = columnCount;
    return Success();
@@ -1086,8 +1097,6 @@ Error SchemaUpdater::createSchema()
 
 Error SchemaUpdater::updateToVersion(const SchemaVersion& maxVersion)
 {
-
-
    // create a transaction to perform the following steps:
    // 1. Check the current database schema version
    // 2. Check if we need to update

--- a/src/cpp/core/include/core/Database.hpp
+++ b/src/cpp/core/include/core/Database.hpp
@@ -123,6 +123,8 @@ class Rowset
 public:
    RowsetIterator begin();
    RowsetIterator end();
+   
+   size_t columnCount() const;
 
 private:
    friend class Connection;


### PR DESCRIPTION
### Intent

Addresses #9706

### Approach

Backport @melissa-barca's fix for the same issue on Pro to OS (see this pull: https://github.com/rstudio/rstudio-pro/pull/2827)

### Automated Tests

Do we have automated integration tests that validate restarts? If not, can we?

### QA Notes

* This issue affects OS on Centos/RHEL 7 only.
* Starting RStudio the first time works correctly.
* Restarting afterwards leads to DB errors and a failure to start.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


