### PR TITLE
Fix logging bug where chowning the logfile before writing to it does not work

### DIFF
--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -218,6 +218,11 @@ struct FileLogDestination::Impl
 #else
       LogOptions.getDirectory().ensureDirectory();
 #endif
+
+      // initialize LogFile path here - this ensures that it is set properly
+      // in case we attempt to chown the file (due to permissions changing) before
+      // attempting to write to the log file for the first time during this process run
+      verifyLogFilePath();
    }
 
    ~Impl()


### PR DESCRIPTION


### Intent

The following sequence of events will prevent the log file from being chowned:

1. Log file was previously created as root and was never chowned to service user.
2. Process starts up again at a later time and goes to drop privilege thus attempting to chown the log BEFORE attempting to write to the log file.
3. Log cannot be chowned because the LogFile variable is not properly initialized.

This is because initialization currently only occurs when the log file is attempted to be written to.

### Approach

This change also makes sure that the initialization happens in the constructor as well as during calls to write, to ensure that the path of the log file is always properly initializated and up-to-date.

### Automated Tests

None

### QA Notes

None - very specific failure sequence that is reproducible and verified on the Launcher


