### PR TITLE
enable external links in secondary windows

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -13,11 +13,13 @@
  *
  */
 
+import { WebContents } from 'electron';
 import { FilePath } from '../core/file-path';
 
 import { DesktopActivation } from './activation-overlay';
 import { Application } from './application';
 import { GwtCallback } from './gwt-callback';
+import { PendingWindow } from './pending-window';
 import { WindowTracker } from './window-tracker';
 
 /**
@@ -38,6 +40,8 @@ export interface AppState {
   scratchTempDir(defaultPath: FilePath): FilePath;
   sessionStartDelaySeconds: number;
   sessionEarlyExitCode: number;
+  prepareForWindow(pendingWindow: PendingWindow): void;
+  createWindow(details: Electron.HandlerDetails, webContents: WebContents, baseUrl?: string): void;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -272,7 +272,7 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle('desktop_prepare_for_satellite_window', (event, name: string, x: number,
       y: number, width: number, height: number
     ) => {
-      this.mainWindow.prepareForWindow({
+      appState().prepareForWindow({
         type: 'satellite',
         name: name,
         mainWindow: this.mainWindow,
@@ -284,7 +284,7 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle('desktop_prepare_for_named_window', (event, name: string,
       allowExternalNavigate: boolean, showToolbar: boolean
     ) => {
-      this.mainWindow.prepareForWindow({
+      appState().prepareForWindow({
         type: 'secondary',
         name: name,
         allowExternalNavigate: allowExternalNavigate,


### PR DESCRIPTION
### Intent

Secondary windows (e.g. if you popup help into a separate window) should be able to launch system browser when user clicks on a link.

### Approach

Moved handling of window-creation to root window class instead of main window class, more closely matching behavior of the Qt app. Make the "application" class be in charge of implementing most of this behavior.

### Automated Tests

None.

### QA Notes

Bring up a secondary window, for example, show a help topic in the Help pane then display it in a window. Now click on links. Confirm that behavior matches that of current Qt desktop.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


