### PR TITLE
Enable satellite windows in Electron desktop

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { WebContents } from 'electron';
+import { BrowserWindow, WebContents } from 'electron';
 import { FilePath } from '../core/file-path';
 
 import { DesktopActivation } from './activation-overlay';
@@ -41,7 +41,7 @@ export interface AppState {
   sessionStartDelaySeconds: number;
   sessionEarlyExitCode: number;
   prepareForWindow(pendingWindow: PendingWindow): void;
-  createWindow(details: Electron.HandlerDetails, webContents: WebContents, baseUrl?: string): void;
+  windowCreated(details: Electron.DidCreateWindowDetails, newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -251,15 +251,15 @@ export class Application implements AppState {
       }
 
       if (pendingWindow.type === 'satellite') {
-        configureSatelliteWindow(pendingWindow, newWindow, owner, details);
+        configureSatelliteWindow(pendingWindow, newWindow, owner);
       } else {
-        configureSecondaryWindow(pendingWindow, newWindow, details, owner, baseUrl);
+        configureSecondaryWindow(pendingWindow, newWindow, owner, baseUrl);
       }
     } else {
       // No pending window, make it a generic secondary window
       configureSecondaryWindow(
         { type: 'secondary', name: '', allowExternalNavigate: false, showToolbar: true },
-        newWindow, details, owner, baseUrl);
+        newWindow, owner, baseUrl);
     }
   }
 }

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -90,7 +90,7 @@ export class DesktopBrowserWindow extends EventEmitter {
     });
 
     this.window.webContents.on('did-create-window', (newWindow, details) => {
-      appState().windowCreated(details, newWindow, this.window.webContents);
+      appState().windowCreated(details, newWindow, this.window.webContents, this.baseUrl);
     });
 
     this.window.webContents.on('will-navigate', (event, url) => {

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { WebContents } from 'electron';
+import { BrowserWindow, WebContents } from 'electron';
 import { logger } from '../core/logger';
 
 import { nextHighest, nextLowest } from '../core/array-utils';
@@ -38,9 +38,11 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
     parent?: DesktopBrowserWindow,
     opener?: WebContents,
     isRemoteDesktop = false,
-    addedCallbacks: string[] = []
+    addedCallbacks: string[] = [],
+    existingWindow?: BrowserWindow
   ) {
-    super(showToolbar, adjustTitle, name, baseUrl, parent, opener, isRemoteDesktop, addedCallbacks);
+    super(showToolbar, adjustTitle, name, baseUrl, parent,
+      opener, isRemoteDesktop, addedCallbacks, existingWindow);
 
     this.window.on('focus', this.onActivated.bind(this));
   }

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { WebContents } from 'electron';
+import { BrowserWindow, WebContents } from 'electron';
 
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
@@ -23,9 +23,11 @@ export class SatelliteWindow extends GwtWindow {
   constructor(
     mainWindow: MainWindow,
     name: string,
-    opener: WebContents
+    opener: WebContents,
+    existingWindow?: BrowserWindow
   ) {
-    super(false, true, name, undefined, undefined, opener, mainWindow.isRemoteDesktop, ['desktop']);
+    super(false, true, name, undefined, undefined, opener,
+      mainWindow.isRemoteDesktop, ['desktop'], existingWindow);
     appState().gwtCallback?.registerOwner(this);
   }
 

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -14,7 +14,7 @@
  *
  */
 
-import { WebContents } from 'electron';
+import { BrowserWindow, WebContents } from 'electron';
 import { DesktopBrowserWindow } from './desktop-browser-window';
 
 export class SecondaryWindow extends DesktopBrowserWindow {
@@ -24,8 +24,10 @@ export class SecondaryWindow extends DesktopBrowserWindow {
     baseUrl?: string,
     parent?: DesktopBrowserWindow,
     opener?: WebContents,
-    allowExternalNavigate = false
+    allowExternalNavigate = false,
+    existingWindow?: BrowserWindow
   ) {
-    super(showToolbar, true, name, baseUrl, parent, opener, allowExternalNavigate);
+    super(showToolbar, true, name, baseUrl, parent, opener,
+      allowExternalNavigate, undefined, existingWindow);
   }
 }

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -355,3 +355,22 @@ export function getDpiZoomScaling(): number {
   // apply a custom scale -- but more testing is warranted
   return 1.0;
 }
+
+/**
+ * Determine if given host is considered safe to load in an IDE window.
+ */
+export function isSafeHost(host: string): boolean {
+  const safeHosts = [
+    '.youtube.com',
+    '.vimeo.com',
+    '.c9.ms',
+    '.google.com'
+  ];
+
+  for (const safeHost of safeHosts) {
+    if (host.endsWith(safeHost)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -91,7 +91,8 @@ export function configureSecondaryWindow(
     baseUrl,
     undefined,
     owner,
-    pendingSecondary.allowExternalNavigate);
+    pendingSecondary.allowExternalNavigate,
+    newWindow);
 
   // TODO
   // allow for Ctrl + W to close window (NOTE: Ctrl means Meta on macOS)

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -14,7 +14,6 @@
  */
 
 import { BrowserWindow, WebContents } from 'electron';
-import { logger } from '../core/logger';
 import { appState } from './app-state';
 import { PendingSatelliteWindow, PendingSecondaryWindow } from './pending-window';
 import { SatelliteWindow } from './satellite-window';
@@ -24,8 +23,7 @@ import { getDpiZoomScaling } from './utils';
 export function configureSatelliteWindow(
   pendingSatellite: PendingSatelliteWindow,
   newWindow: BrowserWindow,
-  owner: WebContents,
-  details: Electron.DidCreateWindowDetails): void {
+  owner: WebContents): void {
 
   // get width and height, and adjust for high DPI
   const dpiZoomScaling = getDpiZoomScaling();
@@ -68,22 +66,18 @@ export function configureSatelliteWindow(
   if (pendingSatellite.name) {
     appState().windowTracker.addWindow(pendingSatellite.name, window);
   }
-
-  window.window.loadURL(details.url)
-    .then(() => {
-      window.window.show();
-    })
-    .catch((reason) => {
-      logger().logErrorMessage(reason);
-    });
 }
 
 export function configureSecondaryWindow(
   pendingSecondary: PendingSecondaryWindow,
   newWindow: BrowserWindow,
-  details: Electron.DidCreateWindowDetails,
   owner: WebContents,
   baseUrl?: string): void {
+
+  // TODO: something is weird about default sizing of secondary windows; need to figure it out,
+  // for now set a reasonable size
+  newWindow.setSize(800, 600);
+  newWindow.setPosition(100, 100);
 
   const window = new SecondaryWindow(
     pendingSecondary.showToolbar,
@@ -106,12 +100,4 @@ export function configureSecondaryWindow(
   if (pendingSecondary.name) {
     appState().windowTracker.addWindow(pendingSecondary.name, window);
   }
-
-  window.window.loadURL(details.url)
-    .then(() => {
-      window.window.show();
-    })
-    .catch((reason) => {
-      logger().logErrorMessage(reason);
-    });
 }

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { WebContents } from 'electron';
+import { BrowserWindow, WebContents } from 'electron';
 import { logger } from '../core/logger';
 import { appState } from './app-state';
 import { PendingSatelliteWindow, PendingSecondaryWindow } from './pending-window';
@@ -21,10 +21,11 @@ import { SatelliteWindow } from './satellite-window';
 import { SecondaryWindow } from './secondary-window';
 import { getDpiZoomScaling } from './utils';
 
-export function createSatelliteWindow(
-  webContents: WebContents,
+export function configureSatelliteWindow(
   pendingSatellite: PendingSatelliteWindow,
-  details: Electron.HandlerDetails): void {
+  newWindow: BrowserWindow,
+  owner: WebContents,
+  details: Electron.DidCreateWindowDetails): void {
 
   // get width and height, and adjust for high DPI
   const dpiZoomScaling = getDpiZoomScaling();
@@ -33,8 +34,7 @@ export function createSatelliteWindow(
   const x = pendingSatellite.screenX;
   const y = pendingSatellite.screenY;
 
-  // create and size
-  const window = new SatelliteWindow(pendingSatellite.mainWindow, pendingSatellite.name, webContents);
+  const window = new SatelliteWindow(pendingSatellite.mainWindow, pendingSatellite.name, owner, newWindow);
   window.window.setSize(width, height);
 
   if (x >= 0 && y >= 0) {
@@ -78,10 +78,11 @@ export function createSatelliteWindow(
     });
 }
 
-export function createSecondaryWindow(
-  webContents: WebContents,
+export function configureSecondaryWindow(
   pendingSecondary: PendingSecondaryWindow,
-  details: Electron.HandlerDetails,
+  newWindow: BrowserWindow,
+  details: Electron.DidCreateWindowDetails,
+  owner: WebContents,
   baseUrl?: string): void {
 
   const window = new SecondaryWindow(
@@ -89,7 +90,7 @@ export function createSecondaryWindow(
     pendingSecondary.name,
     baseUrl,
     undefined,
-    webContents,
+    owner,
     pendingSecondary.allowExternalNavigate);
 
   // TODO

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -134,4 +134,12 @@ describe('Utils', () => {
     const result = Utils.filterFromQFileDialogFilter(input);
     assert.deepEqual(expected, result);
   });
+  it('isSafeHost detects safe host', () => {
+    const host = 'somewhere.c9.ms';
+    assert.isTrue(Utils.isSafeHost(host));
+  });
+  it('isSafeHost detects unsafe host', () => {
+    const host = 'bad.place.foo';
+    assert.isFalse(Utils.isSafeHost(host));
+  });
 });


### PR DESCRIPTION
### Intent

RStudio creates additional windows for various operations, such as opening editor tabs in another window, the version control windows, and showing help content in another window (this isn't the full list).

### Approach

Now implemented in the Electron app. Some rough edges to sand off, mainly unimplemented logic in `secondary-window.ts` and `satellite-window.ts` (for example, can't yet close the windows with Cmd+W on Mac), but overall they are fully functional.

The key "ah-hah" here was to use `nativeWindowOpen: true`; this causes windows opened by the main window (via `window.open`) to be created in the same renderer process. This is necessary because we rely on doing things with the pattern `window.opener.doSomething()` and that can't work if each window is in its own renderer process.

This has the nice additional benefit of removing the worry we had about each new window having to fire up another Chromium instance. Now we have the same process model we did with QtWebEngine!

Note to self: `nativeWindowOpen` is experimental in Electron 13. If it causes us trouble the stable approach is to use `sandbox: true`, instead. This has the side effect, however, of severely limiting what the preload script can do (for example, it all has to be in a single .js file; can't use import or require). That's not terrible as I will be hooking up webpack, so we could manage if we had to. More on this here: https://www.electronjs.org/docs/tutorial/sandbox#preload-scripts  

### Automated Tests

None added yet; will look at adding proof-of-concept integration tests for this.

### QA Notes

Try scenarios that bring up new windows. Pop out editor tabs, the version control window, and so forth.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


