### PR TITLE
Resolve aliased directory on file save

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -32,6 +32,7 @@ import { GwtWindow } from './gwt-window';
 import { openMinimalWindow } from './minimal-window';
 import { appState } from './app-state';
 import { filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
+import { userHomePath } from '../core/user';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -95,9 +96,12 @@ export class GwtCallback extends EventEmitter {
       dir: string, defaultExtension: string, forceDefaultExtension: boolean,
       focusOwner: boolean
     ) => {
+
+      const resolvedDir = FilePath.resolveAliasedPathSync(dir, userHomePath()).toString();
+
       const saveDialogOptions: SaveDialogOptions = {
         title: caption,
-        defaultPath: dir,
+        defaultPath: resolvedDir,
         buttonLabel: label
       };
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -78,16 +78,19 @@ export function getDesktopBridge() {
           if (result.canceled as boolean) {
             callback('');
           } else {
+            if (defaultExtension.length !== 0) {
 
-            // Add default extension, if it's missing
-            const fp = new FilePath(result.filePath);
-            if ((fp.getExtension().length == 0) ||
-               (forceDefaultExtension &&
-               (fp.getExtension() !== defaultExtension))) {
-              callback(fp.getStem() + defaultExtension);
-            } else {
-              callback(result.filePath);
+              // Add default extension, if it's missing
+              const fp = new FilePath(result.filePath);
+              if ((fp.getExtension().length == 0) ||
+                (forceDefaultExtension &&
+                (fp.getExtension() !== defaultExtension))) {
+                callback(fp.getStem() + defaultExtension);
+                return;
+              } 
             }
+
+            callback(result.filePath);
           }
         })
         .catch(error => reportIpcError('getSaveFileName', error));


### PR DESCRIPTION
Skip extension checks if defaultExtension is empty

Addresses #9720.

### Intent

When saving a new, untitled document, the default save value should be `Untitled.R`, instead of the current `~.R` when on MacOS. On Windows and Linux the default save value is currently empty


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


