### PR TITLE
misc features for secondary and satellite windows

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -41,7 +41,8 @@ export interface AppState {
   sessionStartDelaySeconds: number;
   sessionEarlyExitCode: number;
   prepareForWindow(pendingWindow: PendingWindow): void;
-  windowCreated(details: Electron.DidCreateWindowDetails, newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void;
+  windowOpening(): { action: 'deny' } | { action: 'allow', overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions | undefined };
+  windowCreated(newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void;
 }
 
 let rstudio: AppState | null = null;

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -153,7 +153,9 @@ export class DesktopBrowserWindow extends EventEmitter {
       this.failLoad = true;
       this.finishLoading(false);
     });
-    this.window.on('close', this.closeEvent.bind(this));
+    this.window.on('close', (event: Electron.Event) => {
+      this.closeEvent(event);
+    });
     this.window.on('closed', () => {
       this.emit(DesktopBrowserWindow.WINDOW_DESTROYED);
     });
@@ -190,10 +192,6 @@ export class DesktopBrowserWindow extends EventEmitter {
         logger().logError(error);
       });
     }
-
-    // forward the close event to the page
-    // TODO
-    // webPage()->event(event);
   }
 
   adjustWindowTitle(title: string, explicitSet: boolean): void {

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -286,7 +286,6 @@ export class DesktopBrowserWindow extends EventEmitter {
       if (input.meta && input.key.toLowerCase() === 'w') {
         // on macOS, intercept Cmd+W and emit the window close signal
         this.emit(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT);
-        event.preventDefault();
       }
     }
   }

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -91,13 +91,13 @@ export class DesktopBrowserWindow extends EventEmitter {
         return { action: 'deny' };
       }
 
-      // proceed with window creation; we'll associate the created BrowserWindow with our 
-      // window wrapper type upon receipt of 'did-create-window' below
-      return { action: 'allow' };
+      // configure window creation; we'll associate the resulting BrowserWindow with our 
+      // window wrapper type via 'did-create-window' below
+      return appState().windowOpening();
     });
 
-    this.window.webContents.on('did-create-window', (newWindow, details) => {
-      appState().windowCreated(details, newWindow, this.window.webContents, this.baseUrl);
+    this.window.webContents.on('did-create-window', (newWindow) => {
+      appState().windowCreated(newWindow, this.window.webContents, this.baseUrl);
     });
 
     this.window.webContents.on('will-navigate', (event, url) => {

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -31,6 +31,7 @@ import { DesktopOptions } from './desktop-options';
 import { RemoteDesktopSessionLauncher } from './remote-desktop-session-launcher-overlay';
 import { CloseServerSessions } from './session-servers-overlay';
 import { waitForUrlWithTimeout } from './utils';
+import { DesktopBrowserWindow } from './desktop-browser-window';
 
 export function closeAllSatellites(mainWindow: BrowserWindow): void {
   const topLevels = BrowserWindow.getAllWindows();
@@ -116,8 +117,7 @@ export class MainWindow extends GwtWindow {
       this.onSessionQuit();
     });
 
-    // connect(webView(), SIGNAL(onCloseWindowShortcut()),
-    //         this, SLOT(onCloseWindowShortcut()));
+    this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
 
     // connect(webView(), &WebView::urlChanged,
     //         this, &MainWindow::onUrlChanged);

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -18,6 +18,7 @@ import { BrowserWindow, WebContents } from 'electron';
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
 import { appState } from './app-state';
+import { DesktopBrowserWindow } from './desktop-browser-window';
 
 export class SatelliteWindow extends GwtWindow {
   constructor(
@@ -29,6 +30,8 @@ export class SatelliteWindow extends GwtWindow {
     super(false, true, name, undefined, undefined, opener,
       mainWindow.isRemoteDesktop, ['desktop'], existingWindow);
     appState().gwtCallback?.registerOwner(this);
+
+    this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
   }
 
   onActivated(): void {

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -14,13 +14,21 @@
  */
 
 import { BrowserWindow, WebContents } from 'electron';
+import { logger } from '../core/logger';
 
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
 import { appState } from './app-state';
 import { DesktopBrowserWindow } from './desktop-browser-window';
 
+const SOURCE_WINDOW_PREFIX = '_rstudio_satellite_source_window_';
+
+type CloseStage = 'CloseStageOpen' | 'CloseStagePending' | 'CloseStageAccepted';
+
 export class SatelliteWindow extends GwtWindow {
+
+  closeStage: CloseStage = 'CloseStageOpen';
+
   constructor(
     mainWindow: MainWindow,
     name: string,
@@ -32,9 +40,55 @@ export class SatelliteWindow extends GwtWindow {
     appState().gwtCallback?.registerOwner(this);
 
     this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
+
+    // TODO
+    // satellites don't have a menu, so connect zoom keyboard shortcuts directly
   }
 
   onActivated(): void {
-    // TODO
+    this.executeJavaScript(
+      'if (window.notifyRStudioSatelliteReactivated) ' +
+      '  window.notifyRStudioSatelliteReactivated(null);')
+      .catch(logger().logError);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  closeSatellite(event: Electron.Event): void {
+    this.executeJavaScript(
+      'if (window.notifyRStudioSatelliteClosing) ' +
+      '  window.notifyRStudioSatelliteClosing();')
+      .catch(logger().logError);
+  }
+
+  closeEvent(event: Electron.Event): void {
+    // the source window has special close semantics; if we're not currently closing, then invoke
+    // custom close handlers. 
+    //
+    // TODO: not sure how to determine "spontaneous" with Electron
+    // we only do this for spontaneous (user-initiated) closures; when the window gets shut down by
+    // its parent or by the OS, we don't prompt since in those cases unsaved document accumulation
+    // and prompting is handled by the parent.
+    if (this.name.startsWith(SOURCE_WINDOW_PREFIX) && this.closeStage === 'CloseStageOpen' /*&& event->spontaneous()*/) {
+      // ignore this event; we need to make sure the window can be closed ourselves
+      event.preventDefault();
+      this.closeStage = 'CloseStagePending';
+
+      this.executeJavaScript('window.rstudioReadyToClose')
+        .then((readyToClose: boolean) => {
+          if (readyToClose) {
+            this.closeStage = 'CloseStageAccepted';
+            this.window.close();
+          } else {
+            // not ready to close, revert close stage and take care of business
+            this.closeStage = 'CloseStageOpen';
+            this.executeJavaScript('window.rstudioCloseSourceWindow()')
+              .catch(logger().logError);
+          }
+        })
+        .catch(logger().logError);
+    } else {
+      // not a  source window, just close it
+      this.closeSatellite(event);
+    }
   }
 }

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -29,5 +29,11 @@ export class SecondaryWindow extends DesktopBrowserWindow {
   ) {
     super(showToolbar, true, name, baseUrl, parent, opener,
       allowExternalNavigate, undefined, existingWindow);
+
+    this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
+  }
+
+  onCloseWindowShortcut(): void {
+    this.window.close();
   }
 }

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -74,11 +74,6 @@ export function configureSecondaryWindow(
   owner: WebContents,
   baseUrl?: string): void {
 
-  // TODO: something is weird about default sizing of secondary windows; need to figure it out,
-  // for now set a reasonable size
-  newWindow.setSize(800, 600);
-  newWindow.setPosition(100, 100);
-
   const window = new SecondaryWindow(
     pendingSecondary.showToolbar,
     pendingSecondary.name,


### PR DESCRIPTION
### Intent

Implement several more TODOs for satellite windows and secondary windows.

### Approach

Ported code that sets size of secondary windows, fixed so Cmd+W on Mac closes documents (main window and satellites) then closes window when no docs are open, and prompts for saving in satellites containing modified/unsaved docs.

### Automated Tests

None

### QA Notes

Try closing satellite windows (editor docs, Git, etc) or Main window with Cmd+W on Mac, should close documents if any are open, and only close the window if all docs are closed or it isn't a document window.

Also check that satellite windows with modified source docs will save prompt to save before the window closes.

Check that secondary windows (e.g. show Help pane in another window) has a reasonable default size and location.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


