### PR TITLE
implement callbacks for cursor hit detection (Electron)

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-empty-function */
 
-import { ipcMain, dialog, BrowserWindow, webFrameMain, shell } from 'electron';
+import { ipcMain, dialog, BrowserWindow, webFrameMain, shell, screen } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 
 import EventEmitter from 'events';
@@ -197,11 +197,22 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_get_cursor_position', () => {
-      GwtCallback.unimpl('desktop_get_cursor_position');
-      return {x: 20, y: 20};
+      const cursorPos = screen.getCursorScreenPoint();
+      return {x: cursorPos.x, y: cursorPos.y};
     });
 
     ipcMain.handle('desktop_does_window_exist_at_cursor_position', () => {
+      const cursorPos = screen.getCursorScreenPoint();
+      const windows = BrowserWindow.getAllWindows();
+      for (const window of windows) {
+        if (window.isVisible()) {
+          const windowPos = window.getBounds();
+          if ((cursorPos.x >= windowPos.x && cursorPos.x <= (windowPos.x + windowPos.width)) &&
+            (cursorPos.y >= windowPos.y && cursorPos.y <= (windowPos.y + windowPos.height))) {
+            return true;
+          }
+        }
+      }
       return false;
     });
 


### PR DESCRIPTION
### Intent

When dragging and dropping editor tabs, callbacks are used to decide what to do upon release. These were NYI.

### Approach

Implement `desktop_get_cursor_position` and `desktop_does_window_exist_at_cursor_position` callbacks.

### Automated Tests

None.

### QA Notes

Scenarios with dragging editor tabs out of main window onto non-rstudio screen area, or onto existing editor satellite should now work, ditto for dragging tabs from satellite windows onto non-rstudio screen area or another editor satellite.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


