### PR TITLE
use web dialogs for input prompts w/Electron

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -41,6 +41,11 @@
       return window.navigator.userAgent.indexOf("RStudio Remote Desktop") > 0 ? "true" : "false";
    ]]></property-provider>
 
+   <define-property name="rstudio.electron" values="true,false"/>
+   <property-provider name="rstudio.electron"><![CDATA[
+      return window.navigator.userAgent.indexOf("Electron") > 0;
+   ]]></property-provider>
+
    <set-property name="user.agent" value="safari">
       <when-property-is name="rstudio.desktop" value="true"/>
    </set-property>
@@ -125,7 +130,7 @@
    </replace-with>
    <replace-with class="org.rstudio.studio.client.common.impl.DesktopTextInput">
       <when-type-is class="org.rstudio.studio.client.common.TextInput"/>
-      <when-property-is name="rstudio.desktop" value="true"/>
+      <when-property-is name="rstudio.electron" value="false"/>
    </replace-with>
 
    <!-- define permutations for emulated and native stack modes -->

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -26,10 +26,7 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.user.client.Command;
 
 /**
- * This is an interface straight through to a C++ object that lives
- * in the Qt desktop frame.
- * 
- * String arguments must not be null.
+ * This is an interface to callbacks registered by the desktop frame.
  */
 @BaseExpression("$wnd.desktop")
 public interface DesktopFrame extends JavaScriptPassthrough

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -525,15 +525,11 @@ public class Files
       ArrayList<FileSystemItem> selectedFiles = view_.getSelectedFiles();
 
       // validation: some selection exists
-      if  (selectedFiles.size() == 0)
-         return;
-
-      // validation: no more than one file selected
-      if  (selectedFiles.size() > 1)
+      if (selectedFiles.size() != 1)
       {
          globalDisplay_.showErrorMessage(
-                           "Invalid Selection",
-                           "Please select only one file to rename");
+               "Invalid Selection",
+               "Please select a single file to rename.");
          return;
       }
 
@@ -786,6 +782,7 @@ public class Files
       // guard for reentrancy
       if (renaming_)
          return;
+      
       renaming_ = true;
 
       // prompt for new file name then execute the rename

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -354,13 +354,6 @@ export class GwtCallback extends EventEmitter {
       }
     });
 
-    ipcMain.handle('desktop_prompt_for_text', (event, title, caption, defaultValue, type, 
-      rememberPasswordPrompt, rememberByDefault,
-      selectionStart, selectionLength, okButtonCaption) => {
-      GwtCallback.unimpl('desktop_prompt_for_text');
-      return ''; 
-    });
-
     ipcMain.on('desktop_bring_main_frame_to_front', () => {
     });
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -312,24 +312,6 @@ export function getDesktopBridge() {
         .catch(error => reportIpcError('showMessageBox', error));
     },
 
-    promptForText: (title: string,
-      caption: string,
-      defaultValue: string,
-      type: number,
-      rememberPasswordPrompt: boolean,
-      rememberByDefault: boolean,
-      selectionStart: number,
-      selectionLength: number,
-      okButtonCaption: string,
-      callback: VoidCallback<string>) => {
-      ipcRenderer
-        .invoke('desktop_prompt_for_text', title, caption, defaultValue, type,
-          rememberPasswordPrompt, rememberByDefault,
-          selectionStart, selectionLength, okButtonCaption)
-        .then(text => callback(text))
-        .catch(error => reportIpcError('promptForText', error));
-    },
-
     bringMainFrameToFront: () => {
       ipcRenderer.send('desktop_bring_main_frame_to_front');
     },


### PR DESCRIPTION
### Intent

Use the existing GWT `promptForText()` functions when prompting for text in Electron.

### Approach

Detect whether we're running within Electron, and if we are, use the web dialogs rather than desktop dialogs.

### Automated Tests

Should be covered by any existing automation that tests input prompts for RStudio Server.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
