### PR TITLE
Set LANG/LC_CTYPE for Mac desktop (Electron)

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -21,7 +21,7 @@ import { generateRandomPort } from '../core/system';
 import { logger, enableDiagnosticsOutput } from '../core/logger';
 
 import { productInfo } from './product-info';
-import { findComponents, initializeSharedSecret, raiseAndActivateWindow } from './utils';
+import { findComponents, initializeLang, initializeSharedSecret, raiseAndActivateWindow } from './utils';
 import { augmentCommandLineArguments, getComponentVersions, removeStaleOptionsLockfile } from './utils';
 import { exitFailure, exitSuccess, run, ProgramStatus } from './program-status';
 import { ApplicationLaunch } from './application-launch';
@@ -122,6 +122,8 @@ export class Application implements AppState {
         return exitFailure();
       }
     }
+
+    initializeLang();
 
     // switch for setting a session start delay in seconds (used for testing, troubleshooting)
     if (app.commandLine.hasSwitch(kDelaySessionSeconds)) {

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -374,3 +374,19 @@ export function isSafeHost(host: string): boolean {
   }
   return false;
 }
+
+export function initializeLang(): void {
+  if (process.platform === 'darwin') {
+    // TODO: port full language detection, see initializeLang() in DesktopUtilsMac.mm
+
+    let lang = getenv('LANG');
+
+    // None of the above worked. Just hard code it.
+    if (!lang) {
+      lang = 'en_US.UTF-8';
+    }
+
+    setenv('LANG', lang);
+    setenv('LC_CTYPE', lang);
+  }
+}


### PR DESCRIPTION
### Intent

When starting packaged Electron IDE on Mac, getting warning in R console:

```
Warning message:
Character set is not UTF-8; please change your locale 
```

### Approach
For the August milestone, add a stub for `initializeLang()` that hardcodes to en_US.UTF-8, with a TODO comment for implementing the full Mac detection logic.

### Automated Tests

None

### QA Notes

Try running a package build by double-clicking on the icon. Then hit <enter> in the R console and confirm that the above warning message is no longer present.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


