### PR TITLE
Electron: pass through activation click and implement activation callbacks

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -71,7 +71,8 @@ export class DesktopBrowserWindow extends EventEmitter {
           additionalArguments: apiKeys,
           preload: path.join(__dirname, '../renderer/preload.js'),
         },
-        show: false
+        show: false,
+        acceptFirstMouse: true
       });
 
       // Uncomment to have all windows show dev tools by default

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -32,6 +32,7 @@ import { openMinimalWindow } from './minimal-window';
 import { appState } from './app-state';
 import { filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
 import { userHomePath } from '../core/user';
+import { activateWindow } from './window-utils';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -277,11 +278,14 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_activate_minimal_window', (event, name: string) => {
-      GwtCallback.unimpl('desktop_activate_minimal_window');
+      // we can only activate named windows
+      if (name && name !== '_blank') {
+        activateWindow(name);
+      }
     });
 
     ipcMain.on('desktop_activate_satellite_window', (event, name: string) => {
-      console.log(`activate_satellite_window ${name}`);
+      activateWindow(name);
     });
 
     ipcMain.handle('desktop_prepare_for_satellite_window', (event, name: string, x: number,

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -346,6 +346,7 @@ export function raiseAndActivateWindow(window: BrowserWindow): void {
   if (window.isMinimized()) {
     window.restore();
   }
+  window.moveTop();
   window.focus();
 }
 

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -18,7 +18,7 @@ import { appState } from './app-state';
 import { PendingSatelliteWindow, PendingSecondaryWindow } from './pending-window';
 import { SatelliteWindow } from './satellite-window';
 import { SecondaryWindow } from './secondary-window';
-import { getDpiZoomScaling } from './utils';
+import { getDpiZoomScaling, raiseAndActivateWindow } from './utils';
 
 export function configureSatelliteWindow(
   pendingSatellite: PendingSatelliteWindow,
@@ -95,4 +95,14 @@ export function configureSecondaryWindow(
   if (pendingSecondary.name) {
     appState().windowTracker.addWindow(pendingSecondary.name, window);
   }
+}
+
+export function activateWindow(name: string): void {
+  const allWindows = BrowserWindow.getAllWindows();
+  for (const win of allWindows) {
+    if (win.webContents.mainFrame.name === name) {
+      raiseAndActivateWindow(win);
+      return;
+    }
+  } 
 }


### PR DESCRIPTION
### Intent

Porting a couple smaller secondary-window behaviors:

1. On Mac, clicking an RStudio window that is currently inactivate should pass the click through to the underlying page, matching the current Qt behavior.
2. Support activating windows by name (e.g. have Git window open but behind main window, then click on "Diff" in the git pane in main window; Git window should come to front and get focus

### Approach

Implement these.

### Automated Tests

None

### QA Notes

Compare described behaviors to Qt-based desktop.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


