### PR TITLE
update based on new vesrion format

### DIFF
--- a/docker/jenkins/publish-daily-binary.sh
+++ b/docker/jenkins/publish-daily-binary.sh
@@ -45,8 +45,8 @@ if [ "$OS" == "macos" ];  then
 fi
 
 # figure out the "latest" package name by replacing the version number with "latest"; for example
-# for "rstudio-server-pro-1.3.413-4.deb", we want "rstudio-server-pro-latest.deb"
-LATEST=$(echo "$FILENAME" | sed -e 's/[[:digit:]]\.[[:digit:]][[:digit:]]*\.[[:digit:]][[:digit:]]*\(-[[:digit:]][[:digit:]]*\)*/latest/')
+# for "rstudio-workbench-2021.09.0-daily+123.pro1.deb", we want "rstudio-workbench-latest.deb"
+LATEST=$(echo "$FILENAME" | sed -e 's/[[:digit:]][[:digit:]][[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]\.[[:digit:]][[:digit:]]*-daily+[[:digit:]][[:digit:]]*\(\.pro[[:digit:]][[:digit:]]*\)*/latest/')
 echo "Publishing $FILENAME as daily $FLAVOR build for $OS ($PLATFORM): $LATEST..."
 
 # download the current .htaccess file to a temporary location


### PR DESCRIPTION
### Intent

Adjust the latest download URL for the new version format.

### Approach

Change the regex in the sed command for the new version scheme.

Tested this on the command line.

### Automated Tests

None.

### QA Notes

It should be possible to download RStudio-latest.dmg et. al. and get the latest GO or PT daily.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


