### PR TITLE
highlight color for yaml in python node

### DIFF
--- a/src/gwt/acesupport/acemode/python_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/python_highlight_rules.js
@@ -108,7 +108,12 @@ var PythonHighlightRules = function() {
     var stringEscape =  "\\\\(x[0-9A-Fa-f]{2}|[0-7]{3}|[\\\\abfnrtv'\"]|U[0-9A-Fa-f]{8}|u[0-9A-Fa-f]{4})";
 
     this.$rules = {
-        "start" : [ {
+        "start" : [  {
+            // chunk metadata comments
+            token : "comment.doc.tag",
+            regex : "#[|].*$",
+            next  : "start"
+        }, {
             token : "comment",
             regex : "#.*$"
         }, {


### PR DESCRIPTION
### Intent

Match special highlighting for YAML chunk options in R mode within Python mode.

### Approach

Added a highlighting rule that runs before the default default highlighting rule for Python comments.

