### PR TITLE
Rename X-CSRF-Token 

### DIFF
--- a/src/cpp/core/include/core/http/CSRFToken.hpp
+++ b/src/cpp/core/include/core/http/CSRFToken.hpp
@@ -22,7 +22,7 @@
 
 #include <core/http/Cookie.hpp>
 
-#define kCSRFTokenHeader "X-CSRF-Token"
+#define kCSRFTokenHeader "X-RS-CSRF-Token"
 #define kCSRFTokenCookie "csrf-token"
 
 namespace rstudio {

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -97,7 +97,7 @@ public class RpcRequest
       // in server mode, append a CSRF token for request validation
       if (!Desktop.isDesktop())
       {
-         builder.setHeader("X-CSRF-Token", ApplicationCsrfToken.getCsrfToken());
+         builder.setHeader("X-RS-CSRF-Token", ApplicationCsrfToken.getCsrfToken());
       }
 
       // inform the server if we should not refresh auth creds


### PR DESCRIPTION
### Intent

We discovered the root cause for https://github.com/rstudio/rstudio/issues/7319 on Databricks due to conflicting `X-CSRF-Token` request header name between Databricks and RStudio. This header name is very commonly used by many web services. It is preferable to not have common header or cookie names and scope it to the respective services instead.

### Approach

As part of the fix to the problem, we created a patch that renames `X-CSRF-Token` to be `X-RS-CSRF-Token` on RStudio, based on the fact that we have an existing RID header name scoped to RStudio under `X-RS-RID`. Hopefully, this new change improves RStudio to be more robust when used in conjunction with multiple services.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
