### PR TITLE
Escape paths in custom HTTP handler

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1773,6 +1773,14 @@ SEXP rs_base64decode(SEXP dataSEXP, SEXP binarySEXP)
       return r::sexp::create(output, &protect);
 }
 
+SEXP rs_htmlEscape(SEXP textSEXP, SEXP attributeSEXP)
+{
+   std::string escaped = string_utils::htmlEscape(r::sexp::safeAsString(textSEXP), 
+         r::sexp::asLogical(attributeSEXP));
+   r::sexp::Protect protect;
+   return r::sexp::create(escaped, &protect);
+}
+
 SEXP rs_resolveAliasedPath(SEXP pathSEXP)
 {
    std::string path = r::sexp::asUtf8String(pathSEXP);
@@ -2987,6 +2995,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_base64decode);
    RS_REGISTER_CALL_METHOD(rs_base64encode);
    RS_REGISTER_CALL_METHOD(rs_base64encodeFile);
+   RS_REGISTER_CALL_METHOD(rs_htmlEscape);
    RS_REGISTER_CALL_METHOD(rs_enqueClientEvent);
    RS_REGISTER_CALL_METHOD(rs_ensureFileHidden);
    RS_REGISTER_CALL_METHOD(rs_generateShortUuid);

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -840,6 +840,13 @@
    gsub("([\\-\\[\\]\\{\\}\\(\\)\\*\\+\\?\\.\\,\\\\\\^\\$\\|\\#\\s])", "\\\\\\1", regex, perl = TRUE)
 })
 
+# Escapes HTML entities in a character vector (text); "attribute" is a boolean indicating whether
+# additional characters specific to HTML attributes should be escaped (newlines).
+.rs.addFunction("htmlEscape", function(text, attribute = FALSE)
+{
+   .Call("rs_htmlEscape", text, attribute, PACKAGE = "(embedding)")
+})
+
 .rs.addFunction("objectsOnSearchPath", function(token = "",
                                                 caseInsensitive = FALSE,
                                                 excludeGlobalEnv = FALSE)

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -90,7 +90,7 @@ options(help_type = "html")
    payload = paste(
       "<h3>R Custom HTTP Handler Not Found</h3>",
       "<p>Unable to locate custom HTTP handler for",
-      "<i>", path, "</i>",
+      "<i>", .rs.htmlEscape(path), "</i>",
       "<p>Is the package which implements this HTTP handler loaded?</p>")
    
    list(payload, "text/html", character(), 404)

--- a/src/cpp/tests/testthat/test-codetools.R
+++ b/src/cpp/tests/testthat/test-codetools.R
@@ -79,3 +79,12 @@ test_that(".rs.CRANDownloadOptionsString() fills missing CRAN repo", {
    expect_equal(unlist(actual[["repos"]]["CRAN"]), c(CRAN = cran))
 })
 
+
+test_that("HTML escaping escapes HTML entities", {
+   fake_header <- "<h1>Not a real header.</h1>"
+
+   escaped <- .rs.htmlEscape(fake_header)
+   expect_false(grepl(escaped, "<"))
+   expect_false(grepl(escaped, ">"))
+})
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2943. 

### Approach

Escape HTML entities in the custom HTTP handler.

### Automated Tests

Included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/2943.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


