### PR TITLE
Remove Unnecessary rm

### DIFF
--- a/package/linux/debian-control/postrm.in
+++ b/package/linux/debian-control/postrm.in
@@ -10,9 +10,6 @@ rm -f /usr/sbin/rstudio-server
 rm -rf /tmp/rstudio-rsession
 rm -rf /tmp/rstudio-rserver
 
-# remove database files
-rm -rf /usr/lib/rstudio-server/db/*
-
 # determine which init system is in use
 # a variation on:
 # https://wiki.ubuntu.com/SystemdForUpstartUsers#How_to_identify_which_init_system_you_are_currently_booting_with

--- a/package/linux/rpm-script/postrm.sh.in
+++ b/package/linux/rpm-script/postrm.sh.in
@@ -27,9 +27,6 @@ then
    rm -rf /tmp/rstudio-rsession
    rm -rf /tmp/rstudio-rserver
 
-   # remove database files
-   rm -rf /usr/lib/rstudio-server/db/*
-
    # stop and remove service under systemd
    if test "$INIT_SYSTEM" = "systemd"
    then


### PR DESCRIPTION
### Intent

Addresses [Pro #2806](https://github.com/rstudio/rstudio-pro/issues/2806)

### Approach

We introduced a postrm step to clean up old database files to address [Pro #2790](https://github.com/rstudio/rstudio-pro/issues/2790), which caused the above bug. We also reduced the severity of the logs in the 2790, which sufficiently addresses the concern about confusing log entries. As a result to fix 2806, I'm simply removing the aforementioned postrm step.

### Automated Tests

N/A.

### QA Notes

* This bug only affects upgrade.
* You may see debug level logs about the old files - we've deemed that acceptable (you may not depending on the installer's order of operations).
* After upgrade, whether or not there are log entries, the old database files should not be present.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


