### PR TITLE
add bivariate to whitelist spelling

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
@@ -31,6 +31,7 @@ bioc
 bioconductor
 bioinformatics
 bitbucket
+bivariate
 blogdown
 bom
 bookdown


### PR DESCRIPTION
### Intent

Hi! I noticed the real time spell checker (which I LOVE, thank you!) flags `bivariate`.

![image](https://user-images.githubusercontent.com/17747575/131367316-2e2576c2-076d-495e-aef4-c6df151331df.png)

so just a suggestion to add to the whitelist if you think appropriate.

Thanks!


### QA Notes

A quick google of the word `bivariate` points to many resources including the [Bivariate analysis wikipedia entry](https://en.wikipedia.org/wiki/Bivariate_analysis), indicating that it is a mainstream term.

### Checklist


<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

I emailed the signed individual_contributor_agreement.pdf to JJ as indicated.

