### PR TITLE
move forge config into separate JS file (Electron)

### DIFF
--- a/src/node/desktop/.eslintignore
+++ b/src/node/desktop/.eslintignore
@@ -1,4 +1,5 @@
 .eslintrc.js
+forge.config.js
 scripts/
 webpack.main.config.js
 webpack.plugins.js

--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -1,0 +1,70 @@
+module.exports = {
+  packagerConfig: {
+    icon: "./resources/icons/RStudio"
+  },
+  makers: [
+    {
+      name: "@electron-forge/maker-squirrel",
+      config: {
+        name: "rstudio"
+      }
+    },
+    {
+      name: "@electron-forge/maker-zip",
+      platforms: [
+        "darwin"
+      ]
+    },
+    {
+      name: "@electron-forge/maker-deb",
+      config: {}
+    },
+    {
+      name: "@electron-forge/maker-rpm",
+      config: {}
+    }
+  ],
+  plugins: [
+    [
+      "@electron-forge/plugin-webpack",
+      {
+        mainConfig: "./webpack.main.config.js",
+        renderer: {
+          config: "./webpack.renderer.config.js",
+          entryPoints: [
+            {
+              js: "./src/renderer/renderer.ts",
+              name: "main_window",
+              preload: {
+                js: "./src/renderer/preload.ts"
+              }
+            },
+            {
+              html: "./src/ui/loading/loading.html",
+              js: "./src/ui/loading/loading.ts",
+              name: "loading_window"
+            },
+            {
+              html: "./src/ui/error/error.html",
+              js: "./src/ui/error/error.ts",
+              name: "error_window"
+            },
+            {
+              html: "./src/ui/connect/connect.html",
+              js: "./src/ui/connect/connect.ts",
+              name: "connect_window"
+            },
+            {
+              html: "./src/ui/widgets/choose-r/ui.html",
+              js: "./src/ui/widgets/choose-r/load.ts",
+              preload: {
+                js: "./src/ui/widgets/choose-r/preload.ts"
+              },
+              name: "choose_r"
+            }
+          ]
+        }
+      }
+    ]
+  ]
+}

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -21,77 +21,8 @@
     "make": "electron-forge make"
   },
   "config": {
-    "forge": {
-      "packagerConfig": {
-        "icon": "./resources/icons/RStudio"
-      },
-      "makers": [
-        {
-          "name": "@electron-forge/maker-squirrel",
-          "config": {
-            "name": "rstudio"
-          }
-        },
-        {
-          "name": "@electron-forge/maker-zip",
-          "platforms": [
-            "darwin"
-          ]
-        },
-        {
-          "name": "@electron-forge/maker-deb",
-          "config": {}
-        },
-        {
-          "name": "@electron-forge/maker-rpm",
-          "config": {}
-        }
-      ],
-      "plugins": [
-        [
-          "@electron-forge/plugin-webpack",
-          {
-            "mainConfig": "./webpack.main.config.js",
-            "renderer": {
-              "config": "./webpack.renderer.config.js",
-              "entryPoints": [
-                {
-                  "js": "./src/renderer/renderer.ts",
-                  "name": "main_window",
-                  "preload": {
-                    "js": "./src/renderer/preload.ts"
-                  }
-                },
-                {
-                  "html": "./src/ui/loading/loading.html",
-                  "js": "./src/ui/loading/loading.ts",
-                  "name": "loading_window"
-                },
-                {
-                  "html": "./src/ui/error/error.html",
-                  "js": "./src/ui/error/error.ts",
-                  "name": "error_window"
-                },
-                {
-                  "html": "./src/ui/connect/connect.html",
-                  "js": "./src/ui/connect/connect.ts",
-                  "name": "connect_window"
-                },
-                {
-                  "html": "./src/ui/widgets/choose-r/ui.html",
-                  "js": "./src/ui/widgets/choose-r/load.ts",
-                  "preload": {
-                    "js": "./src/ui/widgets/choose-r/preload.ts"
-                  },
-                  "name": "choose_r"
-                }
-              ]
-            }
-          }
-        ]
-      ]
-    }
-  },
+    "forge": "./forge.config.js"
+   },
   "devDependencies": {
     "@electron-forge/cli": "^6.0.0-beta.60",
     "@electron-forge/maker-deb": "^6.0.0-beta.60",


### PR DESCRIPTION
### Intent

Electron forge config currently in package.json, but will need in JavaScript format so I can use Forge's custom hooks during package builds.

### Approach

Move into separate JS file and reference it. Also makes package.json less huge.

### Automated Tests

None. This is a build tooling thing.

### QA Notes

NA

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


