### PR TITLE
Make RSTUDIO_VERSION parsable

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -271,6 +271,21 @@ enum RenderTerminateType
 std::vector<std::string> s_renderOutputs(kMaxRenderOutputs);
 int s_currentRenderOutput = 0;
 
+std::string parsableRStudioVersion()
+{
+   std::string version(RSTUDIO_VERSION_MAJOR);
+   version.append(".")
+      .append(RSTUDIO_VERSION_MINOR)
+      .append(".")
+      .append(RSTUDIO_VERSION_PATCH)
+      .append(".")
+      .append(boost::regex_replace(
+         std::string(RSTUDIO_VERSION_SUFFIX),
+         boost::regex("[a-zA-Z\\-+]"),
+         ""));
+   return version;
+}
+
 FilePath outputCachePath()
 {
    return module_context::sessionScratchPath().completeChildPath("rmd-outputs");
@@ -604,7 +619,8 @@ private:
          LOG_ERROR(error);
 
       // pass along the RSTUDIO_VERSION
-      environment.push_back(std::make_pair("RSTUDIO_VERSION", RSTUDIO_VERSION));
+      environment.push_back(std::make_pair("RSTUDIO_VERSION", parsableRStudioVersion()));
+      environment.push_back(std::make_pair("RSTUDIO_LONG_VERSION", RSTUDIO_VERSION));
 
       // set the not cran env var
       environment.push_back(std::make_pair("NOT_CRAN", "true"));


### PR DESCRIPTION
### Intent

Addresses #9795

Here is a screenshot of part of a knitted RMD that includes the environment variables as output in a chunk:

![image](https://user-images.githubusercontent.com/37987486/131578472-da85ad11-b556-4588-88f5-961982417d9f.png)


### Approach

* Make `RSTUDIO_VERSION` match the output of `RStudio.Version()$version`
* Add `RSTUDIO_LONG_VERSION`

### Automated Tests

N/A

### QA Notes

* `package_version(Sys.getenv("RSTUDIO_VERSION"))` should succeed
* `package_version(Sys.getenv("RSTUDIO_LONG_VERSION"))` will not succeed
* These variables are only set in the context of a knitted R Markdown document - they do not appear in the terminal or the R console

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


