### PR TITLE
Improved handling of table markdown in visual editor

### DIFF
--- a/src/gwt/panmirror/src/editor/src/nodes/table/table.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/table/table.ts
@@ -67,7 +67,8 @@ const extension = (context: ExtensionContext): Extension | null => {
     !pandocExtensions.grid_tables &&
     !pandocExtensions.pipe_tables &&
     !pandocExtensions.simple_tables &&
-    !pandocExtensions.multiline_tables
+    !pandocExtensions.multiline_tables &&
+    !pandocExtensions.raw_html
   ) {
     return null;
   }


### PR DESCRIPTION
This commit encompasses several changes to the way we handle tables in the visual editor to hopefully provide more stable and predictable output:

-   We now actively prefer pipe tables to grid tables. This is because pipe tables will (mostly) allow HTML or LaTeX rendering engines to auto-size columns (unlike grid tables which fix column sizes based on markdown width, which can be very unreliable especially in the presence of links/images). Note that pipe tables will result in explicit column widths when the total markdown size is greater than `--columns` (which defaults to 80). You can work around this by specifying a very large value for `columns` (e.g. 10000). For quarto, you can do this with:

    ``` yaml
    columns: 10000
    ```

    For rmarkdown, you can do this with:

    ``` yaml
    output:
      html_document:
        pandoc_args: ["--columns", "10000"]
    ```

    Note that you will still always get grid tables if you have cells with multiple blocks (as `grid_tables` are the the only table format that supports multiple blocks). You can also force the use of grid tables by disabling pipe tables. In quarto you do this with:

    ``` yaml
    from: markdown-pipe_tables
    ```

    In rmarkdown you do this with:

    ``` yaml
    output:
      html_document:
        md_extensions: -pipe_tables
    ```

-   To make it easier to migrate to a document that constrains editor table markdown output (e.g. to disable grid tables or force HTML tables) we now always read all table types from input documents (even if they are turned off for writing)

-   Table editing is now always enabled so long as `raw_html` is enabled. If `raw_html` is enabled and no table formats are available then tables will be read/written as HTML. If you want to force the use of html tables in the visual editor (e.g. b/c you want to precisely control relative columns widths) you can do this:

    ``` yaml
    editor_options:
      markdown:
        mode: markdown
        extensions: -grid_tables-pipe_tables-multiline_tables-simple_tables
    ```

    Alternatively for quarto you can do this:

    ``` yaml
    from: markdown-pipe_tables-multiline_tables-simple_tables-grid_tables
    ```

    Or for rmarkdown you can do this:

    ``` yaml
    output:
      html_document:
        md_extensions: -pipe_tables-multiline_tables-simple_tables-grid_tables
    ```

