### PR TITLE
visual mode: check explicitly for http urls in dnd image resolver

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -21,7 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.XRef;
@@ -232,24 +231,19 @@ public class VisualModePanmirrorContext
             for (int i=0; i<imageUris.length(); i++)
             {
                String uri = imageUris.get(i);
-               Debug.logToRConsole(uri);
-               if (isValidURL(uri))
+               if (isHttpURL(uri))
                {
-                  Debug.logToRConsole("resolved: " + uri);
                   resolvedUris.push(uri);
                }
                else
                {
-                  Debug.logToRConsole("mapping: " + uri);
                   String path = uiContext.mapPathToResource.map(uri);
                   if (path != null)
                   {
-                     Debug.logToRConsole("mapped: " + path);
                      resolvedUris.push(path);
                   }
                   else
                   {
-                     Debug.logToRConsole("unmapped: " + path);
                      unresolvedUris.push(uri);
                   }
                }
@@ -258,7 +252,6 @@ public class VisualModePanmirrorContext
             // import unresolved uris
             if (unresolvedUris.length() > 0)
             {
-               Debug.logToRConsole("importing unresolved uris");
                FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
                String imagesDir = resourceDir.completePath("images");
                server_.rmdImportImages(unresolvedUris, imagesDir, new SimpleRequestCallback<JsArrayString>() {
@@ -291,9 +284,10 @@ public class VisualModePanmirrorContext
       return uiContext;
    }
 
-   private native boolean isValidURL(String url)  /*-{
+   private native boolean isHttpURL(String url)  /*-{
       try {
-         new URL(url);
+         url = new URL(url);
+         return url.protocol === "http:" || url.protocol === "https:";
       } catch (_) {
          return false;
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.XRef;
@@ -132,7 +133,10 @@ public class VisualModePanmirrorContext
       uiContext.mapPathToResource = path -> {
          FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
          FileSystemItem file = FileSystemItem.createFile(path);
+         Debug.logToConsole(resourceDir.getPath());
+         Debug.logToConsole(file.getPath());
          String resourcePath = file.getPathRelativeTo(resourceDir);
+         Debug.logToConsole(resourcePath);
          if (resourcePath != null)
          {
             return resourcePath;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -133,10 +133,7 @@ public class VisualModePanmirrorContext
       uiContext.mapPathToResource = path -> {
          FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
          FileSystemItem file = FileSystemItem.createFile(path);
-         Debug.logToConsole(resourceDir.getPath());
-         Debug.logToConsole(file.getPath());
          String resourcePath = file.getPathRelativeTo(resourceDir);
-         Debug.logToConsole(resourcePath);
          if (resourcePath != null)
          {
             return resourcePath;
@@ -235,23 +232,33 @@ public class VisualModePanmirrorContext
             for (int i=0; i<imageUris.length(); i++)
             {
                String uri = imageUris.get(i);
+               Debug.logToRConsole(uri);
                if (isValidURL(uri))
                {
+                  Debug.logToRConsole("resolved: " + uri);
                   resolvedUris.push(uri);
                }
                else
                {
+                  Debug.logToRConsole("mapping: " + uri);
                   String path = uiContext.mapPathToResource.map(uri);
                   if (path != null)
+                  {
+                     Debug.logToRConsole("mapped: " + path);
                      resolvedUris.push(path);
+                  }
                   else
+                  {
+                     Debug.logToRConsole("unmapped: " + path);
                      unresolvedUris.push(uri);
+                  }
                }
             }
 
             // import unresolved uris
             if (unresolvedUris.length() > 0)
             {
+               Debug.logToRConsole("importing unresolved uris");
                FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
                String imagesDir = resourceDir.completePath("images");
                server_.rmdImportImages(unresolvedUris, imagesDir, new SimpleRequestCallback<JsArrayString>() {


### PR DESCRIPTION
Enables us to accurately detect https URLs on windows (formerly windows paths were getting recognized as URLs)