### PR TITLE
Improve Logging of MacOS Notarization Failures

### DIFF
--- a/docker/jenkins/notarize-release.sh
+++ b/docker/jenkins/notarize-release.sh
@@ -129,6 +129,7 @@ if [ "$NOTARIZATION_STATUS" == "success" ]; then
     xcrun stapler staple $1
 else
     echo "Notarization failed."
+    cat $XCRUN_RESULT
     exit 1
 fi
 


### PR DESCRIPTION
Add the server response to stdout in the event of a notarization failure
not already covered by other messaging.


### Intent

In a series of notarization failures, no information about the failure was written to stdout, which would require a developer get on the build machine to get the server response. The server response should just be written to the stdout.

### Approach

cat out the server response in the event of a notarization failue.

### Automated Tests

Includes no tests, not a code change.

### QA Notes

build system only change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


