### PR TITLE
Add option to show line numbers in visual mode chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 ## RStudio 2021-11 "Prairie Trillium" Release Notes
 
+### Visual Mode
+
+* Added option to show line numbers in visual mode code chunks (#9387)
+
 ### RStudio Workbench
 
 * Added support for setting the `subPath` on Kubernetes sessions using `KubernetesPersistentVolumeClaim` mounts in `/etc/rstudio/launcher-mounts`.

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -348,6 +348,7 @@ namespace prefs {
 #define kVisualMarkdownEditingMaxContentWidth "visual_markdown_editing_max_content_width"
 #define kVisualMarkdownEditingShowDocOutline "visual_markdown_editing_show_doc_outline"
 #define kVisualMarkdownEditingShowMargin "visual_markdown_editing_show_margin"
+#define kVisualMarkdownCodeEditorLineNumbers "visual_markdown_code_editor_line_numbers"
 #define kVisualMarkdownEditingFontSizePoints "visual_markdown_editing_font_size_points"
 #define kVisualMarkdownCodeEditor "visual_markdown_code_editor"
 #define kVisualMarkdownCodeEditorAce "ace"
@@ -1600,6 +1601,12 @@ public:
     */
    bool visualMarkdownEditingShowMargin();
    core::Error setVisualMarkdownEditingShowMargin(bool val);
+
+   /**
+    * Whether to show line numbers in the code editors used in visual mode
+    */
+   bool visualMarkdownCodeEditorLineNumbers();
+   core::Error setVisualMarkdownCodeEditorLineNumbers(bool val);
 
    /**
     * The default visual editing mode font size, in points

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2637,6 +2637,19 @@ core::Error UserPrefValues::setVisualMarkdownEditingShowMargin(bool val)
 }
 
 /**
+ * Whether to show line numbers in the code editors used in visual mode
+ */
+bool UserPrefValues::visualMarkdownCodeEditorLineNumbers()
+{
+   return readPref<bool>("visual_markdown_code_editor_line_numbers");
+}
+
+core::Error UserPrefValues::setVisualMarkdownCodeEditorLineNumbers(bool val)
+{
+   return writePref("visual_markdown_code_editor_line_numbers", val);
+}
+
+/**
  * The default visual editing mode font size, in points
  */
 int UserPrefValues::visualMarkdownEditingFontSizePoints()
@@ -3139,6 +3152,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kVisualMarkdownEditingMaxContentWidth,
       kVisualMarkdownEditingShowDocOutline,
       kVisualMarkdownEditingShowMargin,
+      kVisualMarkdownCodeEditorLineNumbers,
       kVisualMarkdownEditingFontSizePoints,
       kVisualMarkdownCodeEditor,
       kZoteroLibraries,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1350,6 +1350,12 @@
             "title": "Show margin in visual mode code blocks",
             "description": "Whether to show the margin guide in the visual mode code blocks."
         },
+        "visual_markdown_code_editor_line_numbers": {
+            "type": "boolean",
+            "default": true,
+            "title": "Show line numbers in visual mode code blocks",
+            "description": "Whether to show line numbers in the code editors used in visual mode"
+        },
         "visual_markdown_editing_font_size_points": {
             "type": "integer",
             "default": 0,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2846,6 +2846,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to show line numbers in the code editors used in visual mode
+    */
+   public PrefValue<Boolean> visualMarkdownCodeEditorLineNumbers()
+   {
+      return bool(
+         "visual_markdown_code_editor_line_numbers",
+         "Show line numbers in visual mode code blocks", 
+         "Whether to show line numbers in the code editors used in visual mode", 
+         true);
+   }
+
+   /**
     * The default visual editing mode font size, in points
     */
    public PrefValue<Integer> visualMarkdownEditingFontSizePoints()
@@ -3575,6 +3587,8 @@ public class UserPrefsAccessor extends Prefs
          visualMarkdownEditingShowDocOutline().setValue(layer, source.getBool("visual_markdown_editing_show_doc_outline"));
       if (source.hasKey("visual_markdown_editing_show_margin"))
          visualMarkdownEditingShowMargin().setValue(layer, source.getBool("visual_markdown_editing_show_margin"));
+      if (source.hasKey("visual_markdown_code_editor_line_numbers"))
+         visualMarkdownCodeEditorLineNumbers().setValue(layer, source.getBool("visual_markdown_code_editor_line_numbers"));
       if (source.hasKey("visual_markdown_editing_font_size_points"))
          visualMarkdownEditingFontSizePoints().setValue(layer, source.getInteger("visual_markdown_editing_font_size_points"));
       if (source.hasKey("visual_markdown_code_editor"))
@@ -3826,6 +3840,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(visualMarkdownEditingMaxContentWidth());
       prefs.add(visualMarkdownEditingShowDocOutline());
       prefs.add(visualMarkdownEditingShowMargin());
+      prefs.add(visualMarkdownCodeEditorLineNumbers());
       prefs.add(visualMarkdownEditingFontSizePoints());
       prefs.add(visualMarkdownCodeEditor());
       prefs.add(zoteroLibraries());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/RMarkdownPreferencesPane.java
@@ -226,7 +226,14 @@ public class RMarkdownPreferencesPane extends PreferencesPane
             false);
       lessSpaced(visualEditorShowMargin);
       visualModeOptions.add(visualEditorShowMargin);
-      
+
+      // line numbers
+      CheckBox visualEditorShowLineNumbers = checkboxPref(
+         "Show line numbers in code blocks",
+         prefs_.visualMarkdownCodeEditorLineNumbers(),
+         false);
+      lessSpaced(visualEditorShowLineNumbers);
+      visualModeOptions.add(visualEditorShowLineNumbers);
 
       // content width
       visualModeContentWidth_ = numericPref(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
@@ -224,6 +224,11 @@ public class TextEditingTargetPrefsHelper
                {
                   docDisplay.setShowPrintMargin(arg);
                }));
+         releaseOnDismiss.add(prefs.visualMarkdownCodeEditorLineNumbers().bind(
+            (arg) ->
+            {
+               docDisplay.setShowLineNumbers(arg);
+            }));
       }
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -252,9 +252,6 @@ public class VisualModeChunk
       chunkEditor.setMaxLines(1000);
       chunkEditor.setMinLines(1);
 
-      // Turn off line numbers as they're not helpful in chunks
-      chunkEditor.getRenderer().setShowGutter(false);
-      
       chunk_ = chunk;
    }
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9387.

![image](https://user-images.githubusercontent.com/470418/133162954-4cfa1ae2-87ca-468f-9fc8-6a3de3f4b90b.png)


### Approach

Add a new option that toggles whether or not line numbers are shown for visual mode chunks; respect it. This option is separate from the option that toggles line numbers for the code editor in general. 

### Automated Tests

N/A

### QA Notes

The option can be also be toggled in real time on the Command Palette. Note that line numbers start at 1 in each chunk.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


