### PR TITLE
Update dependency graphs for Shiny, LearnR, R Markdown

### DIFF
--- a/NEWS-2021.09-ghost-orchid.md
+++ b/NEWS-2021.09-ghost-orchid.md
@@ -62,6 +62,7 @@
 * **BREAKING:** The `session-env-var-save-blacklist` option has been renamed to `session-ephemeral-env-vars`.
 * **BREAKING:** The `directory-view-whitelist` option has been renamed to `directory-view-allow-list`.
 * Update bundled Pandoc to version 2.14.1 
+* Depend on new versions of `rmarkdown` (2.10) and `shiny` (1.6)
 * Fixed an issue where scroll position in PDFs was not preserved on re-render (#9603)
 * Support highlight of 'css' and 'asis' chunks in R Markdown documents (#4821)
 * Improved ordering of completion results within `library()` calls (#9293)

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -30,13 +30,33 @@
             "location": "cran",
             "source": false
         },
+        "bslib": {
+            "version": "0.2.2",
+            "location": "cran",
+            "source": false
+        },
         "base64enc": {
             "version": "0.1-3",
             "location": "cran",
             "source": false
         },
+        "checkmate": {
+            "version": "1.0",
+            "location": "cran",
+            "source": false
+        },
         "crayon": {
             "version": "1.3.4",
+            "location": "cran",
+            "source": false
+        },
+        "cachem": {
+            "version": "1.0.0",
+            "location": "cran",
+            "source": false
+        },
+        "commonmark": {
+            "version": "1.7",
             "location": "cran",
             "source": false
         },
@@ -51,7 +71,7 @@
             "source": false
         },
         "digest": {
-            "version": "0.6",
+            "version": "0.6.25",
             "location": "cran",
             "source": false
         },
@@ -60,8 +80,18 @@
             "location": "cran",
             "source": false
         },
+        "ellipsis": {
+            "version": "0.1.0",
+            "location": "cran",
+            "source": false
+        },
+        "fastmap": {
+            "version": "1.1.0",
+            "location": "cran",
+            "source": false
+        },
         "glue": {
-            "version": "1.3.0",
+            "version": "1.3.2",
             "location": "cran",
             "source": false
         },
@@ -76,7 +106,7 @@
             "source": false
         },
         "htmltools": {
-            "version": "0.3.6",
+            "version": "0.5.1",
             "location": "cran",
             "source": false
         },
@@ -86,7 +116,7 @@
             "source": true
         },
         "httpuv": {
-            "version": "1.3.3",
+            "version": "1.5.2",
             "location": "cran",
             "source": false
         },
@@ -106,12 +136,17 @@
             "source": false
         },
         "later": {
-            "version": "0.7.2",
+            "version": "1.0.0",
             "location": "cran",
             "source": false
         },
         "learnr": {
             "version": "0.10.1",
+            "location": "cran",
+            "source": false
+        },
+        "lifecycle": {
+            "version": "0.2.0",
             "location": "cran",
             "source": false
         },
@@ -171,7 +206,7 @@
             "source": false
         },
         "promises": {
-            "version": "1.0.1",
+            "version": "1.1.0",
             "location": "cran",
             "source": false
         },
@@ -182,6 +217,11 @@
         },
         "ragg": {
             "version": "0.1.5",
+            "location": "cran",
+            "source": false
+        },
+        "rappdirs": {
+            "version": "0.3.0",
             "location": "cran",
             "source": false
         },
@@ -211,7 +251,7 @@
             "source": false
         },
         "rlang": {
-            "version": "0.2.2",
+            "version": "0.4.9",
             "location": "cran",
             "source": false
         },
@@ -222,6 +262,11 @@
         },
         "roxygen2": {
             "version": "6.0.1",
+            "location": "cran",
+            "source": false
+        },
+        "rprojroot": {
+            "version": "1.0",
             "location": "cran",
             "source": false
         },
@@ -241,7 +286,7 @@
             "source": false
         },
         "shiny": {
-            "version": "1.2.0",
+            "version": "1.6.0",
             "location": "cran",
             "source": true
         },
@@ -272,6 +317,11 @@
         },
         "tinytex": {
             "version": "0.16",
+            "location": "cran",
+            "source": false
+        },
+        "withr": {
+            "version": "1.0.0",
             "location": "cran",
             "source": false
         },
@@ -385,20 +435,27 @@
         "shiny": {
             "description": "Shiny",
             "packages": [
-                "Rcpp",
-                "httpuv",
-                "mime",
-                "jsonlite",
-                "xtable",
-                "digest",
                 "R6",
-                "sourcetools",
-                "htmltools",
-                "promises",
+                "bslib",
+                "cachem",
+                "commonmark",
                 "crayon",
-                "rlang",
+                "digest",
+                "ellipsis", 
+                "fastmap",
+                "glue",
+                "htmltools",
+                "httpuv",
+                "jsonlite",
                 "later",
-                "shiny"
+                "lifecycle",
+                "mime",
+                "promises",
+                "rlang",
+                "shiny",
+                "sourcetools",
+                "withr",
+                "xtable"
             ]
         },
         "reticulate": {
@@ -533,8 +590,22 @@
         "tutorial": {
             "description": "RStudio Tutorials",
             "packages": [
+                "checkmate",
+                "ellipsis",
+                "evaluate",
+                "fastmap",
+                "htmltools",
+                "htmlwidgets",
+                "jsonlite",
+                "knitr",
                 "learnr",
-                "rstudioapi"
+                "markdown",
+                "rappdirs",
+                "renv",
+                "rprojroot",
+                "rstudioapi",
+                "shiny",
+                "withr"
             ]
         }
     }

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -125,6 +125,11 @@
             "location": "cran",
             "source": false
         },
+        "jquerylib": {
+            "version": "0.1.1",
+            "location": "cran",
+            "source": false
+        },
         "keyring": {
             "version": "1.1.0",
             "location": "cran",
@@ -326,7 +331,7 @@
             "source": false
         },
         "xfun": {
-            "version": "0.15",
+            "version": "0.21",
             "location": "cran",
             "source": false
         },
@@ -412,6 +417,7 @@
                 "glue",
                 "highr",
                 "htmltools",
+                "jquerylib",
                 "jsonlite",
                 "knitr",
                 "magrittr",


### PR DESCRIPTION
### Intent

Brings the internal dependency lists up to date with the R packages required by Shiny, LearnR, and R Markdown. The largest change here is a major bump in the required Shiny version (1.2 => 1.6). This is necessitated by a string of events that goes as follows:

- We must depend on a very new version of R Markdown to support changes made to the visual editor.
- Very new versions of R Markdown call `shiny::getCurrentTheme()` when running Shiny R Markdown documents. This function exists only in Shiny 1.6. https://github.com/rstudio/rmarkdown/commit/9dc5d971f686d4a64ee7579117f78e648ec17a1f
- Shiny 1.6 introduces a number of new R package dependencies that were not required by Shiny 1.2. 

Addresses https://github.com/rstudio/rstudio/issues/8703. 

### Approach

Bump package versions and add new packages to our database. This affects the auto-installer as well as our documentation.

### Automated Tests

N/A, no imperative code change.

### QA Notes

Ensure that auto-install for R Markdown, Shiny R Markdown, Shiny, and Tutorials installs the correct set of packages.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


