### PR TITLE
Ensure HTML entities in filenames/paths are handled on upload

### DIFF
--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -455,6 +455,20 @@ std::string jsonLiteralEscape(const std::string& str)
 
    return escape(escapes, subs, str);
 }
+
+// Escapes possible HTML inside JSON strings. Generally not necessary unless there is a chance
+// the JSON could be misconstrued by the browser as HTML.
+std::string jsonHtmlEscape(const std::string& str)
+{
+   std::string escapes = "<>";
+   std::map<char, std::string> subs;
+
+   subs['<'] = "\\u003c"; // JSON unicode character encoding
+   subs['>'] = "\\u003e"; // JSON unicode character encoding
+
+   return escape(escapes, subs, str);
+}
+
 // The str that is passed in should INCLUDE the " " around the value!
 // (Sorry this is inconsistent with jsonLiteralEscape, but it's more efficient
 // than adding double-quotes in this function)

--- a/src/cpp/core/StringUtilsTests.cpp
+++ b/src/cpp/core/StringUtilsTests.cpp
@@ -153,6 +153,12 @@ test_context("Comment extraction")
       expect_true(jsLiteralEscape("'goodbye'") == "\\'goodbye\\'");
       expect_true(jsLiteralEscape("</script>") == "\\074/script>");
    }
+
+   test_that("HTML tags in JSON are escaped")
+   {
+      expect_true(jsonHtmlEscape("<h1>") == "\\u003ch1\\u003e");
+      expect_true(jsonHtmlEscape("<script>alert!") == "\\u003cscript\\u003ealert!");
+   }
 }
 
 test_context("String formatting")

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -94,6 +94,7 @@ std::string htmlEscape(const std::string& str, bool isAttributeValue = false);
 std::string jsLiteralEscape(const std::string& str);
 std::string jsonLiteralEscape(const std::string& str);
 std::string jsonLiteralUnescape(const std::string& str);
+std::string jsonHtmlEscape(const std::string& str);
 std::string singleQuotedStrEscape(const std::string& str);
 
 void convertLineEndings(std::string* str, LineEnding type);

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1138,7 +1138,19 @@ bool handleFileUploadRequestAsync(const http::Request& request,
    json::Object uploadJson;
    uploadJson["token"] = uploadTokenJson;
    uploadJson["overwrites"] = overwritesJson;
-   json::setJsonRpcResult(uploadJson, &response);
+
+   // write the JSON result, escaping HTML since the client requires text/html
+   // (see below)
+   json::JsonRpcResponse uploadResponse;
+   uploadResponse.setResult(uploadJson);
+   std::stringstream uploadResult;
+   uploadResponse.write(uploadResult);
+   Error error = response.setBody(string_utils::jsonHtmlEscape(uploadResult.str()));
+   if (error)
+   {
+      writeError(error);
+      return false;
+   }
 
    // response content type must always be text/html to be handled
    // properly by the browser/gwt on the client side

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcRequest.java
@@ -144,7 +144,7 @@ public class RpcRequest
                         Debug.log("Response: " + responseText);
                      requestLogEntry_.logResponse(ResponseType.Normal,
                                                  responseText);
-                     rpcResponse = RpcResponse.parse(responseText);
+                     rpcResponse = RpcResponse.parseUnsafe(responseText);
                      
                      // response received and validated, process it!
                      requestCallback.onResponseReceived(enclosingRequest, 

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
@@ -69,10 +69,9 @@ public class RpcResponse extends JavaScriptObject
          {
             try
             {
-               // there are some cases where json emitted by our
-               // server isn't parsable by parseStrict (for example,
-               // see bug #3025). for these situations we call
-               // parseLenient (which in turn calls eval)
+               // there are some cases where json emitted by our server isn't parsable by 
+               // parseStrict. for these situations we call parseLenient
+               // (which in turn calls eval)
                @SuppressWarnings("deprecation")
                JSONValue val = JSONParser.parseLenient(json);
                return val.isObject().getJavaScriptObject().cast();

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcResponse.java
@@ -25,8 +25,31 @@ public class RpcResponse extends JavaScriptObject
    {
       
    }
-   
-   public final static RpcResponse parse(String json) 
+
+   /**
+    * Parses an RPC response from a JSON string; uses eval() if necessary. Not for use on strings that
+    * may contain untrusted input.
+    *
+    * @param json The string to parse
+    * @return An RpcResponse parsed from the string
+    */
+   public final static RpcResponse parseUnsafe(String json)
+   {
+      return parse(json, false);
+   }
+
+   /**
+    * Parses an RPC response from a JSON string; will not use eval().
+    *
+    * @param json The string to parse
+    * @return An RpcResponse parsed from the string
+    */
+   public final static RpcResponse parseStrict(String json)
+   {
+      return parse(json, true);
+   }
+
+   private final static RpcResponse parse(String json, boolean strict)
    {      
       try
       {
@@ -37,19 +60,27 @@ public class RpcResponse extends JavaScriptObject
       }
       catch(Exception e)
       {
-         try
+         if (strict)
          {
-            // there are some cases where json emitted by our 
-            // server isn't parsable by parseStrict (for example,
-            // see bug #3025). for these situations we call 
-            // parseLenient (which in turn calls eval)
-            @SuppressWarnings("deprecation")
-            JSONValue val = JSONParser.parseLenient(json);
-            return val.isObject().getJavaScriptObject().cast();
-         }
-         catch(Exception e2)
-         {
+            // in strict mode, don't try eval
             return null;
+         }
+         else
+         {
+            try
+            {
+               // there are some cases where json emitted by our
+               // server isn't parsable by parseStrict (for example,
+               // see bug #3025). for these situations we call
+               // parseLenient (which in turn calls eval)
+               @SuppressWarnings("deprecation")
+               JSONValue val = JSONParser.parseLenient(json);
+               return val.isObject().getJavaScriptObject().cast();
+            }
+            catch (Exception e2)
+            {
+               return null;
+            }
          }
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerAuth.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerAuth.java
@@ -176,7 +176,7 @@ class RemoteServerAuth
          {
             // parse the results
             String results = event.getResults();
-            RpcResponse response = RpcResponse.parse(event.getResults());
+            RpcResponse response = RpcResponse.parseUnsafe(event.getResults());
             if (response != null)
             {
                logEntry.logResponse(ResponseType.Normal, results);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileUploadDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileUploadDialog.java
@@ -85,6 +85,8 @@ public class FileUploadDialog extends HtmlFormModalDialog<PendingFileUpload>
    @Override
    protected void setFormPanelEncodingAndMethod(FormPanel formPanel)
    {
+      // NOTE: FormPanel is technically the wrong GWT abstraction to use here because it presumes a response
+      // type of text/html, whereas our file upload endpoint actually returns JSON (coerced to HTML).
       formPanel.setEncoding(FormPanel.ENCODING_MULTIPART);
       formPanel.setMethod(FormPanel.METHOD_POST);
    }
@@ -92,7 +94,8 @@ public class FileUploadDialog extends HtmlFormModalDialog<PendingFileUpload>
    @Override
    protected PendingFileUpload parseResults(String results) throws Exception
    {
-      RpcResponse response = RpcResponse.parse(results);
+      // Use strict parsing mode here since the results object contains untrusted file/path names
+      RpcResponse response = RpcResponse.parseStrict(results);
       if (response == null)
          throw new Exception("Unexpected response from server");
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/698.

### Approach

This one's sort of a mess and has to do with the way GWT's `FormPanel` works (see original issue for discussion). It'd be nice to refactor this whole thing in such a way that the body doesn't get treated as `text/html`, but the issue doesn't warrant it. Instead:

- Ensure the special characters `<` and `>` are encoded with Unicode escape sequences in the response body. 
- As a further failsafe, don't fall back on `eval()` for JSON responses that might contain untrusted data. 

### Automated Tests

Adds a unit test.

### QA Notes

Test with both file and path names containing HTML tags (see original issue).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

