### PR TITLE
Fix detection of R Markdown document types from YAML

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlFrontMatter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/YamlFrontMatter.java
@@ -28,12 +28,17 @@ public class YamlFrontMatter
 {
    // front matter can end with ... rather than ---; see spec:
    // http://www.yaml.org/spec/1.2/spec.html#id2760395
-   private static RegExp frontMatterBegin = RegExp.compile("^---\\s*$", "gm");
-   private static RegExp frontMatterEnd = RegExp.compile("^(---|\\.\\.\\.)\\s*$", "gm");
-   
+   //
+   // note that these can't be statically initialized as fully compiled
+   // regexes due to state reuse
+   private static String frontMatterBeginRegex = "^---\\s*$";
+   private static String frontMatterEndRegex = "^(---|\\.\\.\\.)\\s*$";
+
    public static Range getFrontMatterRange(DocDisplay display)
    {
-     
+      RegExp frontMatterBegin = RegExp.compile(frontMatterBeginRegex, "gm");
+      RegExp frontMatterEnd = RegExp.compile(frontMatterEndRegex, "gm");
+
       Position begin = null;
       Position end = null;
       
@@ -78,6 +83,9 @@ public class YamlFrontMatter
    
    public static String getFrontMatter(String document)
    {
+      RegExp frontMatterBegin = RegExp.compile(frontMatterBeginRegex, "gm");
+      RegExp frontMatterEnd = RegExp.compile(frontMatterEndRegex, "gm");
+
       ArrayList<String> frontMatter = new ArrayList<String>();
       for (String line : StringUtil.getLineIterator(document))
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -3456,15 +3456,17 @@ public class TextEditingTarget implements
          return;
       }
 
-      
       view_.adaptToExtendedFileType(extendedType);
+
+      // save new extended type (updateRmdFormat below reads it)
+      extendedType_ = extendedType;
+
       if (extendedType.startsWith(SourceDocument.XT_RMARKDOWN_PREFIX) ||
           extendedType.equals(SourceDocument.XT_QUARTO_DOCUMENT))
       {
          updateRmdFormat();
       }
-      extendedType_ = extendedType;
-      
+
       quartoHelper_.manageCommands();
    }
 


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/9866.

### Approach

Change https://github.com/rstudio/rstudio/commit/5adc32552110ad8b1db8a02768ddc28b9ec52355 introduced static initializers for the `RegExp` objects that extract front matter. However, these objects maintain state and should not be re-used. The fix is to make these local variables again, while keeping the regular expression patterns themselves static to avoid repeating them. 

### Automated Tests

Covered by automation, which found this issue.

### QA Notes

In addition to the notes in #9866, test that the editor mode preference is respected in the YAML header (which was the new functionality introduced by the change). 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

