### PR TITLE
Explain TTY Logging on Startup

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -262,6 +262,23 @@ void LogOptions::initProfile()
 
 Error LogOptions::read()
 {
+   FilePath optionsFile = getLogConfigFile();
+
+   // if the options file does not exist, that's fine - we'll just use default values
+   if (!optionsFile.exists())
+      return Success();
+
+   Error error = profile_.load(optionsFile);
+   if (error)
+      return error;
+
+   setLowestLogLevel();
+
+   return Success();
+}
+
+FilePath LogOptions::getLogConfigFile() {
+
    // look for config file in a specific environment variable
    FilePath optionsFile(core::system::getenv(kLogConfEnvVar));
    if (!optionsFile.exists())
@@ -274,19 +291,9 @@ Error LogOptions::read()
       if (!optionsFile.exists())
             optionsFile = core::system::xdg::systemConfigFile(kLogConfFile);
    #endif
-
-      // if the options file does not exist, that's fine - we'll just use default values
-      if (!optionsFile.exists())
-         return Success();
    }
 
-   Error error = profile_.load(optionsFile);
-   if (error)
-      return error;
-
-   setLowestLogLevel();
-
-   return Success();
+   return optionsFile;
 }
 
 void LogOptions::setLowestLogLevel()

--- a/src/cpp/core/include/core/LogOptions.hpp
+++ b/src/cpp/core/include/core/LogOptions.hpp
@@ -80,6 +80,8 @@ public:
 
    static FilePath defaultLogDirectory();
 
+   FilePath getLogConfigFile();
+   
 private:
    void initProfile();
 

--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -178,6 +178,8 @@ void initializeLogConfigReload();
 Error initLog();
 Error reinitLog();
 
+void ttyCheck(const std::string& destination);
+
 void initFileLogDestination(const log::LogLevel level, const FilePath defaultLogDir);
 
 // exit

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -244,10 +244,10 @@ void ttyCheck(const std::string& destination)
    // When running in a TTY, log some information about why we're logging to the TTY
    // in addition to file/syslog.
    if (stderrIsTerminal())
-      std::cerr << "Logging configuration loaded from '"
-                << s_logOptions->getLogConfigFile().getAbsolutePath()
-                << "'. Logging to '" << destination << "'. "
-                << "Displaying this message since a TTY was detected.\n";
+      std::cerr << "TTY detected. Printing informational message about logging configuration. "
+                << "Logging configuration loaded from '"
+                << s_logOptions->getLogConfigFile().getAbsolutePath() << "'. "
+                << "Logging to '" << destination << "'.\n";
 }
 
 log::LoggerType loggerType(const std::string& in_sectionName)

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -131,14 +131,16 @@ void initializeLogWriter()
    {
       case LoggerType::kFile:
       {
-         addLogDestination(
-            std::shared_ptr<ILogDestination>(new FileLogDestination(
+         FileLogDestination* dst = new FileLogDestination(
                generateShortenedUuid(),
                logLevel,
                formatType,
                s_programIdentity,
                boost::get<FileLogOptions>(options),
-               true)));
+               true);
+         addLogDestination(
+            std::shared_ptr<ILogDestination>(dst));
+         ttyCheck(dst->path());
          break;
       }
       case LoggerType::kStdErr:
@@ -162,6 +164,7 @@ void initializeLogWriter()
                formatType,
                s_programIdentity,
                true)));
+         ttyCheck("syslog");
 #endif
       }
    }
@@ -235,6 +238,17 @@ void initializeLogWriters()
 }
 
 } // anonymous namespace
+
+void ttyCheck(const std::string& destination)
+{
+   // When running in a TTY, log some information about why we're logging to the TTY
+   // in addition to file/syslog.
+   if (stderrIsTerminal())
+      std::cerr << "Logging configuration loaded from '"
+                << s_logOptions->getLogConfigFile().getAbsolutePath()
+                << "'. Logging to '" << destination << "'. "
+                << "Displaying this message since a TTY was detected.\n";
+}
 
 log::LoggerType loggerType(const std::string& in_sectionName)
 {

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -538,6 +538,11 @@ FileLogDestination::~FileLogDestination()
       m_impl->LogOutputStream->flush();
 }
 
+std::string FileLogDestination::path()
+{
+   return m_impl->LogFile.getAbsolutePath();
+}
+
 void FileLogDestination::refresh(const RefreshParams& in_refreshParams)
 {
    // Close the log file to ensure that if we just forked old FDs are cleared out

--- a/src/cpp/shared_core/include/shared_core/FileLogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/FileLogDestination.hpp
@@ -288,6 +288,11 @@ public:
    ~FileLogDestination() override;
 
    /**
+    * @brief Returns the log destination.
+    */
+   std::string path();
+
+   /**
     * @brief Refreshes the log destintation. Ensures that the log does not have any stale file handles.
     *
     * @param in_refreshParams   Refresh params to use when refreshing the log destinations (if applicable).


### PR DESCRIPTION
Connected rstudio/launcher#73.

### Intent

When configured to log to `file` or `syslog` but running in a TTY, adds a log like the following:
> Logging configuration loaded from '[path to logging.conf]'. Logging to '[path to log file | "syslog"]'. Displaying this since a TTY was detected.

This was requested in rstudio/launcher#73 to clarify why you sometimes see STDERR logs even when configured to log to a file or syslog.

### Approach

When initializing the main log writer, we check to see if we're running in a TTY and output a message to STDERR if (a) running in a TTY and (b) not configured to log to STDERR.

### Automated Tests

Unit tests didn't seem practical due to the complexity of mocking or simulating running in (or not in) a TTY. There are a couple of options, but none seem ideal, so I skipped unit tests:
* Update `stderrIsTerminal()` to look for a test env var that overrides the result. This clutters production code with test conditionals.
* Create a mockable interface that includes a new `stderrIsTerminal()` method. Inject an instance of this class, but use a mock implementation for unit tests. This is a bit complicated since we'd need to reference it from a number of methods.
* Use `Pseudoterminal` to launch a process during a unit teset. This also seems like overkill.

### QA Notes

* Configure `logging.conf` at various supported locations. The new STDERR message should include the correct path to `logging.conf` in any case.
* Configure `logging.conf` with an `[@rserver]` (or other binary) section. When running the process in a TTY, the new STDERR message should appear *unless* configured explicitly to log to STDERR. The message should indicate that you are configured to log to either `file` or `syslog` correctly.
* Configure `logging.confg` with an `[*]` section. When running the process in a TTY, the new STDERR message should appear *unless* configured explicitly to log to STDERR.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` (n/a)
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility) (n/a)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
