### PR TITLE
Feature/db session metadata

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -102,6 +102,7 @@ set(CORE_SOURCE_FILES
    markdown/sundown/markdown.c
    markdown/sundown/stack.c
    r_util/RActiveSessions.cpp
+   r_util/RActiveSessionStorage.cpp
    r_util/RPackageInfo.cpp
    r_util/RProjectFile.cpp
    r_util/RSessionContext.cpp

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -826,6 +826,7 @@ const std::map<std::string, int>& SchemaVersion::versionMap()
          {
             versions[""] = 0;
             versions["Ghost Orchid"] = 1;
+            versions["Prairie Trillium"] = 2;
          }
       }
       END_LOCK_MUTEX
@@ -868,7 +869,6 @@ Error SchemaUpdater::migrationFiles(std::vector<std::pair<SchemaVersion, FilePat
                         const std::pair<SchemaVersion, FilePath>& b)
    { return a.first > b.first; };
    std::sort(pMigrationFiles->begin(), pMigrationFiles->end(), comparator);
-
    return Success();
 }
 
@@ -1020,6 +1020,7 @@ Error SchemaUpdater::isUpToDate(bool* pUpToDate)
       return error;
 
    *pUpToDate = version >= migrationVersion;
+
    return Success();
 }
 
@@ -1039,6 +1040,10 @@ Error SchemaUpdater::update()
 
       SchemaVersion currentVersion;
       error = databaseSchemaVersion(&currentVersion);
+
+      LOG_DEBUG_MESSAGE("Database Schema Version:\t\t" + currentVersion.Date + " : " + currentVersion.Flower);
+      LOG_DEBUG_MESSAGE("Highest Migration Schema Version:\t" + migrationVersion.Date + " : " + migrationVersion.Flower);
+
       if (currentVersion < migrationVersion)
       {
          LOG_INFO_MESSAGE(
@@ -1135,6 +1140,13 @@ Error SchemaUpdater::updateToVersion(const SchemaVersion& maxVersion)
    for (const std::pair<SchemaVersion, FilePath>& migrationFile : files)
    {
 
+      // Is the migration file from a update that predates the current version?
+      // If so, skip it
+      if(migrationFile.first <= currentVersion)
+      {
+         continue;
+      }
+
       bool applyMigration = false;
 
       if (migrationFile.second.getExtensionLowerCase() == SQL_EXTENSION)
@@ -1168,6 +1180,7 @@ Error SchemaUpdater::updateToVersion(const SchemaVersion& maxVersion)
       error = connection_->executeStr(fileContents);
       if (error)
          return error;
+
    }
 
    transaction.commit();

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -1156,6 +1156,8 @@ Error SchemaUpdater::updateToVersion(const SchemaVersion& maxVersion)
       if (!applyMigration)
          continue;
 
+      LOG_DEBUG_MESSAGE("Applying database schema alter file " + migrationFile.second.getAbsolutePath());
+
       // we are clear to apply the migration
       // load the file and execute its SQL contents
       std::string fileContents;

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -1,0 +1,65 @@
+#ifndef CORE_R_UTIL_R_ACTIVE_SESSION_STORAGE
+#define CORE_R_UTIL_R_ACTIVE_SESSION_STORAGE
+
+#include <shared_core/FilePath.hpp>
+
+namespace rstudio {
+namespace core {
+namespace r_util {
+
+   class IActiveSessionStorage 
+   {
+   public:
+      Error virtual readProperty(const std::string& id, const std::string& name, std::string* pValue) = 0;
+      Error virtual writeProperty(const std::string& id, const std::string& name, const std::string& value) = 0;
+
+   protected:
+      virtual ~IActiveSessionStorage() = default;
+      IActiveSessionStorage() = default;
+   };
+
+   class LegacySessionStorage : public IActiveSessionStorage
+   {
+   public:
+      explicit LegacySessionStorage(const FilePath& location);
+
+      Error readProperty(const std::string& id, const std::string& name, std::string* pValue) override;   
+      Error writeProperty(const std::string& id, const std::string& name, const std::string& value) override;
+
+   private:
+      FilePath activeSessionsDir_;
+      const std::string propertiesDirName_ = "properites";
+      const std::string legacySessionDirPrefix_ = "session-";
+
+      FilePath buildPropertyPath(const std::string& id, const std::string& name);
+
+      static const std::string& getLegacyName(const std::string& name)
+      {
+         static const std::map<std::string, std::string> legacyNames = 
+         {
+            { "last_used" , "last-used" },
+            { "r_version" , "r-version" },
+            { "r_version_label" , "r-version-label" },
+            { "r_version_home" , "r-version-home" },
+            { "working_directory" , "working-dir" },
+            { "launch_parameters" , "launch-parameters" }
+         };
+
+         if (legacyNames.find(name) != legacyNames.end())
+            return legacyNames.at(name);
+
+         return name;
+      }
+   };
+
+   class ActiveSessionStorageFactory
+   {
+   public:
+      static std::shared_ptr<IActiveSessionStorage> getActiveSessionStorage();
+      static std::shared_ptr<IActiveSessionStorage> getLegacyActiveSessionStorage();
+   };
+} // namespace r_util
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_R_UTIL_ACTIVE_SESSIONS_STORAGE_HPP

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -1,0 +1,65 @@
+#include <core/r_util/RActiveSessionStorage.hpp>
+#include <core/r_util/RActiveSessions.hpp>
+#include <core/FileSerializer.hpp>
+#include <core/Log.hpp>
+#include <core/system/Xdg.hpp>
+
+
+
+namespace rstudio {
+namespace core {
+namespace r_util {
+
+    LegacySessionStorage::LegacySessionStorage(const FilePath& activeSessionsDir) :
+        activeSessionsDir_ (activeSessionsDir)
+    {
+        Error error = activeSessionsDir_.ensureDirectory();
+        if(error)
+            LOG_ERROR(error);
+    }
+
+    Error LegacySessionStorage::readProperty(const std::string& id, const std::string& name, std::string* pValue)
+    {
+        const std::string& legacyName = getLegacyName(name);
+
+        using namespace rstudio::core;
+        *pValue = "";
+
+        FilePath readPath = buildPropertyPath(id, legacyName);
+        if (readPath.exists())
+        {
+            Error error = core::readStringFromFile(readPath, pValue);
+            if (error)
+                return error;
+
+            boost::algorithm::trim(*pValue);
+        }
+        return Success();
+    }
+
+    Error LegacySessionStorage::writeProperty(const std::string& id, const std::string& name, const std::string& value)
+    {
+        FilePath writePath = buildPropertyPath(id, name);
+        return core::writeStringToFile(writePath, value);
+    }
+
+    FilePath LegacySessionStorage::buildPropertyPath(const std::string& id, const std::string& name)
+    {
+        FilePath propertiesDir = activeSessionsDir_.completeChildPath(legacySessionDirPrefix_ + id + "/" + propertiesDirName_);
+        propertiesDir.ensureDirectory();
+        return propertiesDir.completeChildPath(name);
+    }
+
+    std::shared_ptr<IActiveSessionStorage> ActiveSessionStorageFactory::getActiveSessionStorage()
+    {
+        return getLegacyActiveSessionStorage();
+    }
+
+    std::shared_ptr<IActiveSessionStorage> ActiveSessionStorageFactory::getLegacyActiveSessionStorage()
+    {
+        FilePath dataDir = ActiveSessions::storagePath(core::system::xdg::userDataDir());
+        return std::make_shared<LegacySessionStorage>(LegacySessionStorage(dataDir));
+    }
+} // namespace r_util
+} // namepsace core
+} // namespace rstudio

--- a/src/cpp/server/db/20210916132211194382021_Prairie-Trillium_AlterTables.postgresql
+++ b/src/cpp/server/db/20210916132211194382021_Prairie-Trillium_AlterTables.postgresql
@@ -1,31 +1,3 @@
-/* Stores the version of the schema. */
-CREATE TABLE schema_version(
-   /* The date at which this schema version was created. */
-   current_version text NOT NULL,
-
-   /* The name of the release to which this version of the schema belongs. */
-   release_name text NOT NULL
-);
-
-LOCK schema_version IN ACCESS EXCLUSIVE MODE;
-
-/* Stores revoked auth cookies - cookies that are not yet expired, but
-   have been invalidated due to a user signing out. These cookies will
-   not be allowed to be used again for sign-in purposes.
-*/
-CREATE TABLE revoked_cookie(
-   /* The expiration date string at which this cookie expires. Derivative of the CookieData,
-      used for sorting purposes
-   */
-   expiration text NOT NULL,
-   
-   /* The actual cookie data */
-   cookie_data text NOT NULL,
-
-   /* Primary key is the actual cookie data itself (no duplicate cookies can be issued) */
-   PRIMARY KEY (cookie_data)
-);
-
 /* Stores users of RStudio Server */
 CREATE TABLE licensed_users(
 
@@ -109,7 +81,8 @@ CREATE TABLE active_session_metadata(
          ON DELETE CASCADE
 );
 
-/* Index to be used for sorting revoked cookies by expiration */
-CREATE INDEX revoked_cookie_expiration_index ON revoked_cookie(expiration);
+/* Remove previous schema version data */
+TRUNCATE schema_version;
 
+/* Update the version to the latest after all alter statements are applied. */
 INSERT INTO schema_version (current_version, release_name) VALUES ('20210916132211194382021', 'Prairie Trillium');

--- a/src/cpp/server/db/20210916132211194382021_Prairie-Trillium_AlterTables.sqlite
+++ b/src/cpp/server/db/20210916132211194382021_Prairie-Trillium_AlterTables.sqlite
@@ -1,31 +1,3 @@
-/* Stores the version of the schema. */
-CREATE TABLE schema_version(
-   /* The date at which this schema version was created. */
-   current_version text NOT NULL,
-
-   /* The name of the release to which this version of the schema belongs. */
-   release_name text NOT NULL
-);
-
-LOCK schema_version IN ACCESS EXCLUSIVE MODE;
-
-/* Stores revoked auth cookies - cookies that are not yet expired, but
-   have been invalidated due to a user signing out. These cookies will
-   not be allowed to be used again for sign-in purposes.
-*/
-CREATE TABLE revoked_cookie(
-   /* The expiration date string at which this cookie expires. Derivative of the CookieData,
-      used for sorting purposes
-   */
-   expiration text NOT NULL,
-   
-   /* The actual cookie data */
-   cookie_data text NOT NULL,
-
-   /* Primary key is the actual cookie data itself (no duplicate cookies can be issued) */
-   PRIMARY KEY (cookie_data)
-);
-
 /* Stores users of RStudio Server */
 CREATE TABLE licensed_users(
 
@@ -45,11 +17,7 @@ CREATE TABLE licensed_users(
    user_id integer NOT NULL DEFAULT -1,
 
    /* Auto incrementing ID for each user for internal FK relationships. */
-   id integer NOT NULL,
-
-   /* Add Primary Key */
-   PRIMARY KEY(id)
-
+   id integer PRIMARY KEY
 );
 
 /* Stores metadata about actvie sessions */ 
@@ -103,13 +71,11 @@ CREATE TABLE active_session_metadata(
    PRIMARY KEY (session_id),
    
    /* User entries should not be deleted, but if they are, remove all of that user's sessions */
-   CONSTRAINT fk_user
-      FOREIGN KEY (user_id) 
-         REFERENCES licensed_users(id) 
-         ON DELETE CASCADE
+   FOREIGN KEY (user_id) REFERENCES licensed_users(id) ON DELETE CASCADE
 );
 
-/* Index to be used for sorting revoked cookies by expiration */
-CREATE INDEX revoked_cookie_expiration_index ON revoked_cookie(expiration);
+/* Remove old schema version */
+DELETE FROM schema_version;
 
+/* Update the version to the latest after all alter statements are applied. */
 INSERT INTO schema_version (current_version, release_name) VALUES ('20210916132211194382021', 'Prairie Trillium');

--- a/src/cpp/server/db/CreateTables.sqlite
+++ b/src/cpp/server/db/CreateTables.sqlite
@@ -24,7 +24,83 @@ CREATE TABLE revoked_cookie(
    PRIMARY KEY (cookie_data)
 );
 
+/* Stores users of RStudio Server */
+CREATE TABLE licensed_users(
+
+   /* The username associated with the user */
+   user_name text NOT NULL,
+
+   /* Always false column, to keep the order the same as in Workbench */
+   locked text NOT NULL DEFAULT 'not_locked',
+
+   /* The date time when the user last signed in */
+   last_sign_in text NOT NULL,
+
+   /* Always false column, to keep the order the same as in Workbench */
+   is_admin text NOT NULL DEFAULT 'not_admin',
+
+   /* The Posix/Operating-System-Level ID of the user */
+   user_id integer NOT NULL DEFAULT -1,
+
+   /* Auto incrementing ID for each user for internal FK relationships. */
+   id integer PRIMARY KEY
+);
+
+/* Stores metadata about actvie sessions */ 
+CREATE TABLE active_session_metadata(
+
+   /* The ID of the session which this row describes */
+   session_id text NOT NULL,
+
+   /* The ID of the row in licensed_users which corresponds to the user that owns this session */
+   user_id integer NOT NULL,
+
+   /* The type of workbench for this session */
+   workbench text NOT NULL,
+
+   /* The time at which this session was first created */
+   created text NOT NULL,
+
+   /* The time at which this session was last used */
+   last_used text NOT NULL,
+
+   /* The version of R in use, if this session's workbench type is R */
+   r_version text,
+
+   /* The label of the version of R in use, if this session's workbench type is R */
+   r_version_label text,
+
+   /* The R home of the version of R in use, if this session's workbench type is R */
+   r_version_home text,
+
+   /* The open project, if any */
+   project text,
+
+   /* The working directory of the session */
+   working_directory text,
+
+   /* The state of the session (running, executing, suspended) */
+   activity_state text NOT NULL,
+
+   /* The display label for this session */
+   label text NOT NULL,
+
+   /* The parameters with which this session was launched */
+   launch_parameters text NOT NULL,
+
+   /* The parameters with which this session was launched */
+   save_prompt_required text NOT NULL DEFAULT 'not_required',
+
+   /* The size of the session on disk, if it is curruently suspended */
+   suspended_size_kb integer,
+
+   PRIMARY KEY (session_id),
+   
+   /* User entries should not be deleted, but if they are, remove all of that user's sessions */
+   FOREIGN KEY (user_id) REFERENCES licensed_users(id) ON DELETE CASCADE
+);
+
 /* Index to be used for sorting revoked cookies by expiration */
 CREATE INDEX revoked_cookie_expiration_index ON revoked_cookie(expiration);
 
-INSERT INTO schema_version  (current_version, release_name) VALUES ('20210712182145921760944', 'Ghost Orchid');
+INSERT INTO schema_version (current_version, release_name) VALUES ('20210916132211194382021', 'Prairie Trillium');


### PR DESCRIPTION
### Intent

Lay the groundwork for storing session information in a database. This has the potential to resolve a number of bugs and pain points around session management.

### Approach

I've encapsulated the on disk session metadata storage to limit the knowledge that calling classes have about how the session metadata is stored. An interface and factory have been created so that in the future switching to other storage options will be opaque to the callers.

### Automated Tests

This does not include additional automated testing.

### QA Notes

There are two things to be checked by QA:

- The new licensed_users and active_session_metadata tables will exist in a fresh install, and migration from previous databases will create them. This should be true of both sqlite and postgresql
- That there are no regressions surrounding session metadata. Examples to test: where it's written to disk, make sure the files are being updated as expected.

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests


