### PR TITLE
Richer prompt for file deletion

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -618,7 +618,7 @@ public class Files
       final ArrayList<FileSystemItem> selectedFiles = view_.getSelectedFiles();
 
       // validation: some selection exists
-      String message = "Are you sure you want to delete ";
+      String message = "Are you sure you want to permanently delete ";
       if (selectedFiles.size() == 0)
       {
          return;
@@ -631,7 +631,7 @@ public class Files
       {
          message += "the " + selectedFiles.size() + " selected files";
       }
-      message += "?";
+      message += "?\n\nThis cannot be undone.";
 
 
       // validation -- not prohibited move of public folder

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -618,8 +618,21 @@ public class Files
       final ArrayList<FileSystemItem> selectedFiles = view_.getSelectedFiles();
 
       // validation: some selection exists
-      if  (selectedFiles.size() == 0)
+      String message = "Are you sure you want to delete ";
+      if (selectedFiles.size() == 0)
+      {
          return;
+      }
+      else if (selectedFiles.size() == 1)
+      {
+         message += selectedFiles.get(0).getName();
+      }
+      else
+      {
+         message += "the " + selectedFiles.size() + " selected files";
+      }
+      message += "?";
+
 
       // validation -- not prohibited move of public folder
       if (!validateNotRestrictedFolder(selectedFiles, "deleted"))
@@ -629,7 +642,7 @@ public class Files
       globalDisplay_.showYesNoMessage(
                         GlobalDisplay.MSG_QUESTION,
                         "Confirm Delete",
-                        "Are you sure you want to delete the selected files?",
+                        message,
                         new ProgressOperation() {
                            public void execute(final ProgressIndicator progress)
                            {


### PR DESCRIPTION
### Intent

Make it harder to accidentally delete files by:

- Naming the file to be deleted, if only one is selected
- Providing a count of files to be deleted, if multiple files are selected

### Approach

Change the message.

### Automated Tests

N/A, UI string change

### QA Notes

Test deleting no files, 1 file, and more than 1 file.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


