### PR TITLE
run GWT (Java) build step after C++ builds complete

### DIFF
--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -61,6 +61,19 @@ if(GWT_BUILD)
 
    # invoke ant to build
    add_custom_target(gwt_build ALL)
+
+   # wait for major C++ work to complete before running the GWT build;
+   # the Java compiler often runs out of resources when a parallel C++
+   # is happening: https://github.com/rstudio/rstudio/issues/7660
+   if (TARGET rserver)
+      add_dependencies(gwt_build rsession rserver)
+   elseif(TARGET desktop)
+      add_dependencies(gwt_build rsession desktop)
+   else()
+      add_dependencies(gwt_build rsession)
+   endif()
+
+
    add_custom_command(
       TARGET gwt_build
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
### Intent

Addresses: #7660

When doing a full build (e.g. package build), the GWT portion builds in parallel with the C++ code, and this can cause thrashing and resource exhaustion that leads to a GWT build failure. Our answer has been to constrain number of cores allowed for building (`-j#`), e.g. for Mac `make-package` we set `-j2` because of this.

### Approach

Make the GWT code dependent (cmake-wise) on the major C++ components; rsession, rstudio (desktop), and/or rserver so it waits for them to complete, then can give Java all available resources.

Once this gets through a round of builds or two, I'll go back and bump up the `-j` value for Mac a bit (after finding out how many cores the builder actually has...).

### Automated Tests

None, purely a build-time thing.

I tested by doing a local Mac desktop build via make-package, and a Bionic Server build via docker.

### QA Notes

Nothing to test here; problems would manifest as build failures.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


