### PR TITLE
Fix race condition in notebook autosave

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,3 +21,4 @@
 ### Bugfixes
 
 * Fixed errors when uploading files/directory names with invalid characters (Pro #698)
+* Fixed "No such file or directory" errors when auto-saving R Notebook chunks while running them (#9284)

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -27,6 +27,7 @@
 
 #include <core/Algorithm.hpp>
 #include <core/Exec.hpp>
+#include <core/FileLock.hpp>
 #include <core/FileSerializer.hpp>
 
 #include <r/RExec.hpp>
@@ -398,11 +399,40 @@ void onDocAdded(const std::string& id)
    }
 }
 
+// Creates a migration file; used to mark a folder to be migrated to another location
+// when it's possible to do so.
+Error createMigrationFile(const FilePath& source, const FilePath& target)
+{
+   Error error;
+   FilePath migrationFile = source.completePath(kMigrationTarget);
+
+   // Ensure migration file doesn't already exist. This shouldn't happen unless a crash occurred
+   // during a previous chunk execution.
+   if (migrationFile.exists())
+   {
+      LOG_WARNING_MESSAGE("Notebook output migration file " kMigrationTarget " already exists in " + 
+            source.getAbsolutePath());
+      error = migrationFile.remove();
+      if (error)
+      {
+         error.addProperty("description", "Unable to remove notebook output migration file");
+         return error;
+      }
+   }
+
+   error = writeStringToFile(migrationFile, target.getAbsolutePath()); 
+   if (error)
+   {
+      error.addProperty("description", "Unable to write notebook output migration file");
+   }
+   return error;
+}
+
 void onDocSaved(FilePath path)
 {
    Error error;
-   // ignore non-R Markdown saves
-   if (!path.hasExtensionLowerCase(".rmd"))
+   // only R Markdown or Quarto docs can have notebooks
+   if (!(path.hasExtensionLowerCase(".rmd") || path.hasExtensionLowerCase(".qmd")))
       return;
 
    // find cache folder (bail out if it doesn't exist)
@@ -453,6 +483,30 @@ void onDocSaved(FilePath path)
       }
       else if (source.isDirectory())
       {
+         // Check to see if this folder represents a notebook chunk that is 
+         // currently executing; this can happen in cases where the notebook
+         // is saved while code is running.
+         FilePath executionLock = source.completePath(kExecutionLock);
+         if (executionLock.exists())
+         {
+            auto lock = FileLock::createDefault();
+            if (lock->isLocked(executionLock))
+            {
+               // There's code running; save a migration file and move on. The
+               // chunk execution context is responsible for picking up this file
+               // and migrating the folder once execution is complete (see
+               // ChunkExecContext).
+               error = createMigrationFile(source, target);
+               if (error)
+               {
+                  LOG_ERROR(error);
+               }
+
+               // Move on
+               continue;
+            }
+         }
+
          // library folders should be merged and then removed, so we don't
          // lose library contents 
          if (source.getFilename() == kChunkLibDir)

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -505,6 +505,20 @@ void onDocSaved(FilePath path)
                // Move on
                continue;
             }
+            else
+            {
+               // The execution lock exists, but isn't actually locked. This suggests
+               // that a crash occurred while the chunk was executing, since the
+               // execution context should have cleaned up the lock after execution
+               // was complete. Just clean up the lock ourselves so it doesn't clutter
+               // the saved cache folder.
+               error = executionLock.remove();
+               if (error)
+               {
+                  error.addProperty("description", "Unable to clean up execution lock");
+                  LOG_ERROR(error);
+               }
+            }
          }
 
          // library folders should be merged and then removed, so we don't

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.hpp
@@ -36,7 +36,9 @@
 //   the document
 // - there are two types of cache folders -- one for content which has been
 //   committed ("s") and one for content which has not been committed ("u");
-//   there may be many uncomitted folders, but only one committed folder.
+//   there may be many uncommitted folders, but only one committed folder.
+//   - if an uncommitted folder corresponds to the currently running chunk, 
+//     it also contains an "execution.lock" file lock
 // - the folder contains a sequence of files which represent the content inside
 //   the chunk -- textual output, plots, and HTML; this content's output order
 //   is implied in the filenames 
@@ -50,6 +52,9 @@
 #define SESSION_NOTEBOOK_CACHE_HPP
 
 #define kSavedCtx "s"
+#define kStagingSuffix "_t"
+#define kExecutionLock "execution.lock"
+#define kMigrationTarget "migration.target"
 
 #include <string>
 

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -19,6 +19,7 @@
 #include <session/SessionModuleContext.hpp>
 
 #include <core/BoostSignals.hpp>
+#include <core/FileLock.hpp>
 #include <shared_core/json/Json.hpp>
 
 #include <r/RSexp.hpp>
@@ -26,8 +27,6 @@
 #include "NotebookCapture.hpp"
 #include "NotebookOutput.hpp"
 #include "NotebookChunkOptions.hpp"
-
-#define kStagingSuffix "_t"
 
 namespace rstudio {
 namespace core {
@@ -113,6 +112,7 @@ private:
    bool hasErrors_;
 
    std::vector<boost::shared_ptr<NotebookCapture> > captures_;
+   std::vector<boost::shared_ptr<core::ScopedFileLock> > locks_;
    std::vector<RSTUDIO_BOOST_CONNECTION> connections_;
 };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.DebouncedCommand;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.patch.SubstringDiff;
 import org.rstudio.core.client.widget.Operation;
@@ -136,10 +137,12 @@ public class DocUpdateSentinel
 
       prefs_.autoSaveOnIdle().bind((String behavior) ->
       {
-         if (behavior == UserPrefs.AUTO_SAVE_ON_IDLE_BACKUP)
+         if (StringUtil.isNullOrEmpty(sourceDoc_.getPath()) ||
+             StringUtil.equals(behavior, UserPrefs.AUTO_SAVE_ON_IDLE_BACKUP))
          {
             // Set up the debounced auto-save method when the preference is
-            // enabled
+            // enabled. This is always enabled when we don't have a path because
+            // it isn't possible to do other kinds of saving in this case.
             createAutosaver();
          }
          else if (autosaver_ != null)
@@ -369,6 +372,15 @@ public class DocUpdateSentinel
    {
       if (autosaver_ != null)
          autosaver_.suspend();
+
+      // If the user pref indicates we should do a full save on idle, turn off the autosaver,
+      // which may have been on if the file han't been previously saved.
+      if (autosaver_ != null &&
+          !StringUtil.isNullOrEmpty(path) &&
+          StringUtil.equals(prefs_.autoSaveOnIdle().getValue(), UserPrefs.AUTO_SAVE_ON_IDLE_COMMIT))
+      {
+         autosaver_ = null;
+      }
 
       doSave(path, fileType, encoding, retryWrite, new ProgressIndicator()
       {


### PR DESCRIPTION
### Intent

This fixes an intermittent error, arising from a race condition, that can occur when autosave is used with R Notebooks. 

The problem occurs when the notebook save trigger and chunk execution trigger are executed with exactly the wrong timing. This used to be rare, but is becoming common on rstudio.cloud due to a combination of longer save times (caused by the visual editor) combined with save on blur (which causes execution to trigger a save, so they run almost in parallel). Because saving a notebook moves the notebook's cache to a new location, code that is executing during save may no longer be able to write to the cache's old location. 

The change also fixes a second problem mentioned in the same issue, in which untitled documents don't get autosaved if autosave is set to *Commit*. 

Addresses https://github.com/rstudio/rstudio/issues/9284.

### Approach

The general idea is that we need to delay moving the cache folder until execution is complete. This is accomplished as follows:

- While a notebook is executing, a file lock named `execution.lock` is created in the cache folders that correspond to currently executing chunks.
- When a notebook is saved, any folders that have an active `execution.lock` are not moved. Instead, a file named `migration.target` is created in the folder.
- When a notebook chunk is finished executing, it checks to see if `migration.target` exists. If it does, the folder is moved. 

To address the autosave issue, we always use backup (not commit) autosave for documents which have never been saved, since there's no path to commit changes to. 

### Automated Tests

N/A, this is a race condition that can't be reliably reproduced in tests. 

### QA Notes

Because this is a race condition it doesn't happen all the time; ensure you can reproduce somewhat reliably in your environment before verifying a fixed build. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


