### PR TITLE
use all cores on Mac builder

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -140,12 +140,7 @@ if [ "${clean}" = "1" ]; then
 fi
 
 # set up MAKEFLAGS
-# don't use all CPUs on build machine (appears to cause hangs)
-if [ -n "${JENKINS_URL}" ]; then
-   MAKEFLAGS="${MAKEFLAGS} -j2"
-else
-   MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
-fi
+MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
 
 # perform an x86_64 build
 if [ -n "${build_x86_64}" ]; then


### PR DESCRIPTION
### Intent

With work done in #9885 to let C++ build finish before starting the GWT build, should now be able to use all cores on the Mac builder machine.

### Approach

Remove the hardcoded `-j2` we were setting on a Jenkins-driven build.

### Automated Tests

None, this is purely a build-time thing.

### QA Notes

Nothing to test here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


