### PR TITLE
Add check for the LibR.so that rsession believes it's using

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,3 +21,4 @@
 ### Bugfixes
 
 * Fixed errors when uploading files/directory names with invalid characters (Pro #698)
+* Added error when rsession may be running a different version of R than expected (Pro #2477)

--- a/src/cpp/core/include/core/system/LibraryLoader.hpp
+++ b/src/cpp/core/include/core/system/LibraryLoader.hpp
@@ -26,6 +26,7 @@ class Error;
 namespace system {
 
 Error loadLibrary(const std::string& libPath, void** ppLib);
+Error verifyLibrary(const std::string& libPath, void** ppLib);
 Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol);
 Error closeLibrary(void* pLib);
 

--- a/src/cpp/core/include/core/system/LibraryLoader.hpp
+++ b/src/cpp/core/include/core/system/LibraryLoader.hpp
@@ -26,7 +26,7 @@ class Error;
 namespace system {
 
 Error loadLibrary(const std::string& libPath, void** ppLib);
-Error verifyLibrary(const std::string& libPath, void** ppLib);
+Error verifyLibrary(const std::string& libPath);
 Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol);
 Error closeLibrary(void* pLib);
 

--- a/src/cpp/core/system/PosixLibraryLoader.cpp
+++ b/src/cpp/core/system/PosixLibraryLoader.cpp
@@ -53,6 +53,32 @@ Error loadLibrary(const std::string& libPath, void** ppLib)
    }
 }
 
+/**
+ * Verify that we can load a library (without actually loading it)
+ * by passing RTLD_NOLOAD to dlopen
+ */
+Error verifyLibrary(const std::string& libPath, void** ppLib)
+{
+   *ppLib = nullptr;
+   *ppLib = ::dlopen(libPath.c_str(), RTLD_LAZY | RTLD_NOLOAD);
+   if (*ppLib == nullptr)
+   {
+      // dlopen returns a null pointer on error rather than an error number.
+      // using -1 here as a generic non-zero placeholder
+      Error error = Error("LibraryVerifyFailed",
+                          -1,
+                          "Attempt to verify library failed",
+                          ErrorLocation());
+      error.addProperty("lib-path", libPath);
+      addLastDLErrorMessage(&error);
+      return error;
+   }
+   else
+   {
+      return closeLibrary(*ppLib);
+   }
+}
+
 Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol)
 {
    *ppSymbol = nullptr;

--- a/src/cpp/core/system/PosixLibraryLoader.cpp
+++ b/src/cpp/core/system/PosixLibraryLoader.cpp
@@ -57,11 +57,11 @@ Error loadLibrary(const std::string& libPath, void** ppLib)
  * Verify that we can load a library (without actually loading it)
  * by passing RTLD_NOLOAD to dlopen
  */
-Error verifyLibrary(const std::string& libPath, void** ppLib)
+Error verifyLibrary(const std::string& libPath)
 {
-   *ppLib = nullptr;
-   *ppLib = ::dlopen(libPath.c_str(), RTLD_LAZY | RTLD_NOLOAD);
-   if (*ppLib == nullptr)
+   void* pLib = nullptr;
+   pLib = ::dlopen(libPath.c_str(), RTLD_LAZY | RTLD_NOLOAD);
+   if (pLib == nullptr)
    {
       // dlopen returns a null pointer on error rather than an error number.
       // using -1 here as a generic non-zero placeholder
@@ -75,7 +75,7 @@ Error verifyLibrary(const std::string& libPath, void** ppLib)
    }
    else
    {
-      return closeLibrary(*ppLib);
+      return closeLibrary(pLib);
    }
 }
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -213,6 +213,9 @@ void ensureDeserialized();
 // set client metrics 
 void setClientMetrics(const RClientMetrics& metrics);
 
+// report a warning to the user
+void reportWarningToConsole(const std::string& warning);
+
 // report a warning to the user and also log it
 void reportAndLogWarning(const std::string& warning);
 

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -463,6 +463,12 @@ void setClientMetrics(const RClientMetrics& metrics)
    }
 }
 
+void reportWarningToConsole(const std::string& warning)
+{
+   std::string msg = "WARNING: " + warning + "\n";
+   RWriteConsoleEx(msg.c_str(), gsl::narrow_cast<int>(msg.length()), 1);
+}
+
 void reportAndLogWarning(const std::string& warning)
 {
    std::string msg = "WARNING: " + warning + "\n";


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/2477 by adding a check on the `libR.so` that `rsession` believes it is running. If there are issues with loading that shared object, generate an error.

Note that this does not fix the problem. Instead it creates an error that can be used to find and fix the cause of the problem, which is a system environment issue

### Approach

The linked issue describes the problem in detail, but essentially while linux is loading the `rsession` binary, if there's an issue with `libR.so`, it may load a different `libR.so` without `rsession`'s knowledge. To address this, we check for issues manually once `rsession` is fully loaded by calling `dload()` with `RTLD_NOLOAD`. Any issues Linux had with loading the shared object will become apparent with that call, and the error can then be forwarded on to an error.

This is linux-only code; Windows and MacOS won't perform this check.

### Automated Tests

There are no unit tests included. Integration tests will require:

- A linux environment with at least 2 `R` installations
  - One system `R` install
  - One custom `R` install
- Ability to "disable" the custom `R` version's `libR.so` before the test by `chmod`ing out permissions so it can't be opened, and then restoring the permissions after the test is done

The test should include

- Start an `rsession` with the default system `R` install
  - No error should be generated
- Switch `R` version to the broken custom version
  - Error should be generated 

### QA Notes

None, see testing section above for how to reproduce/test

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


