### PR TITLE
set defaults for java Xmx and Xss in build.xml

### DIFF
--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -23,6 +23,8 @@
    <property name="lib.dir" value="./lib"/>        <!-- libraries (GWT, GIN, etc. -->
    <property name="tools.dir" value="./tools"/>    <!-- other tools -->
    <property name="extras.dir" value="./extras"/>  <!-- extras: symbol maps, etc. -->
+   <property name="gwt.xmx" value="-Xmx1536M"/>    <!-- set maximum Java heap size -->
+   <property name="gwt.xss" value="-Xss16M"/>      <!-- set java thread stack size -->
 
    <taskdef name="jscomp"
             classname="com.google.javascript.jscomp.ant.CompileTask"


### PR DESCRIPTION
### Intent

Regression from #9336

Building GWT code directly via `ant` or `ant draft` (without using cmake to drive the operation) fails:

```
[exec] [10:02:00] Resolved 'ide-dist' after 15s 484ms
[java] Error: Could not find or load main class ${gwt.xmx}
[java] Caused by: java.lang.ClassNotFoundException: ${gwt.xmx}
```

On a dev environment it is common to build GWT directly with ant. Note that `ant devmode` and `ant desktop` do work.

### Approach

Defaults for ant properties `gwt.xmx` and `gwt.xss` were being passed on command-line from the CMakeLists.txt but this doesn't help when using ant directly, so set defaults in build.xml. Note that properties specified on command-line will override those set via `property` in build.xml.

### Automated Tests

None, purely a dev environment thing.

### QA Notes

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


