### PR TITLE
Encode RSTUDIO_VERSION when checking for updates

### DIFF
--- a/src/cpp/session/modules/SessionUpdates.cpp
+++ b/src/cpp/session/modules/SessionUpdates.cpp
@@ -96,7 +96,7 @@ void beginUpdateCheck(bool manual,
    cmd.append("source('");
    cmd.append(string_utils::jsLiteralEscape(scriptPath));
    cmd.append("'); downloadUpdateInfo('");
-   cmd.append(RSTUDIO_VERSION);
+   cmd.append(http::util::urlEncode(RSTUDIO_VERSION));
    cmd.append("', '");
 #if defined(_WIN32)
    cmd.append("windows");


### PR DESCRIPTION
### Intent

Addresses #9911 
Replace `+` with `%2B` in RSTUDIO_VERSION when checking for a new version of RStudio.

### Approach

Use `http::util::urlEncode`. I also logged the command we are trying to run for ease of testing.

### Automated Tests

N/A - not sure how this would work since we run our tests against the most recent builds.
rstudio/rstudio-web already includes significant testing for version comparisons: https://github.com/rstudio/rstudio-web/blob/master/web/rstudio.org/site/links/check_for_update.php


### QA Notes

It will not be possible to test through the "Check for Updates" functionality until we update the active version stored on rstudio.org to something later than 2021.09.0. However, we now log the R command we attempt to run to check for the updates so this can be tested by configuring debug logging and verifying that the version in the logged command uses %2B instead of +. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


