### PR TITLE
Improved Zotero Caching

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
 * Fixed code execution via selection in indented visual mode code chunks (#9108)
 * Fixed detection of HTTP(S) URLs on Windows in the image resolver (#9837)
 * Improved behavior of citekey removal in Insert Citation dialog (#9124)
+* Fix issue with unicode characters in citation data (#9745)
+* Fix issue with unicode characters in citekeys (#9754)
+* Fix issue with delay showing newly added Zotero references when inserting citations (#9800)
 
 ### RStudio Workbench
 

--- a/src/cpp/session/modules/zotero/SessionZotero.cpp
+++ b/src/cpp/session/modules/zotero/SessionZotero.cpp
@@ -363,7 +363,7 @@ void zoteroGetCollections(const json::JsonRpcRequest& request,
       auto jsonSpec = json.getObject();
       ZoteroCollectionSpec cacheSpec;
       cacheSpec.name = jsonSpec[kName].getString();
-      cacheSpec.version = jsonSpec[kVersion].getInt();
+      cacheSpec.version = jsonSpec[kVersion].getDouble();
       cacheSpec.key = jsonSpec[kKey].getString();
       cacheSpec.parentKey = jsonSpec[kParentKey].getString();
       return cacheSpec;

--- a/src/cpp/session/modules/zotero/ZoteroCollections.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollections.cpp
@@ -67,7 +67,7 @@ FilePath collectionsCacheDir(const std::string& type, const std::string& context
 struct IndexedCollection
 {
    bool empty() const { return file.empty(); }
-   int version;
+   double version;
    std::string file;
    std::string key;
    std::string parentKey;
@@ -92,7 +92,7 @@ std::map<std::string,IndexedCollection> collectionsCacheIndex(const FilePath& ca
 
                json::Object entryJson = member.getValue().getObject();
                IndexedCollection coll;
-               coll.version = entryJson[kVersion].getInt();
+               coll.version = entryJson[kVersion].getDouble();
                coll.file = entryJson[kFile].getString();
                coll.key = entryJson[kKey].getString();
                coll.parentKey = entryJson[kParentKey].getString();
@@ -142,7 +142,7 @@ Error readCollection(const FilePath& filePath, ZoteroCollection* pCollection)
       return error;
 
    pCollection->name = collectionJson[kName].getString();
-   pCollection->version = collectionJson[kVersion].getInt();
+   pCollection->version = collectionJson[kVersion].getDouble();
    pCollection->key = collectionJson[kKey].getString();
    pCollection->parentKey = collectionJson[kParentKey].getString();
    pCollection->items = collectionJson[kItems].getArray();
@@ -326,7 +326,7 @@ const char * const kKey = "key";
 const char * const kParentKey = "parentKey";
 const char * const kItems = "items";
 
-const int kNoVersion = -1;
+const double kNoVersion = -1;
 
 ZoteroCollectionSpec findParentSpec(const ZoteroCollectionSpec& spec, const ZoteroCollectionSpecs& specs)
 {

--- a/src/cpp/session/modules/zotero/ZoteroCollections.hpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollections.hpp
@@ -41,7 +41,7 @@ extern const char * const kKey;
 extern const char * const kParentKey;
 extern const char * const kItems;
 
-extern const int kNoVersion;
+extern const double kNoVersion;
 
 // collection spec
 struct ZoteroCollectionSpec
@@ -49,11 +49,11 @@ struct ZoteroCollectionSpec
    explicit ZoteroCollectionSpec(const std::string& name = "",
                                  const std::string& key = "",
                                  const std::string& parentKey = "",
-                                 int version = kNoVersion)
+                                 double version = kNoVersion)
       : name(name), key(key), parentKey(parentKey), version(version)
    {
    }
-   explicit ZoteroCollectionSpec(const std::string& colName, const std::string& key, int version)
+   explicit ZoteroCollectionSpec(const std::string& colName, const std::string& key, double version)
        : ZoteroCollectionSpec(colName, key, "", version)
    {
    }
@@ -62,7 +62,7 @@ struct ZoteroCollectionSpec
    std::string name;
    std::string key;
    std::string parentKey;
-   int version;
+   double version;
 };
 typedef std::vector<ZoteroCollectionSpec> ZoteroCollectionSpecs;
 typedef boost::function<void(core::Error,ZoteroCollectionSpecs)> ZoteroCollectionSpecsHandler;

--- a/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
@@ -106,7 +106,7 @@ std::string creatorsSQL(const ZoteroCollectionSpec& spec)
    boost::format fmt(R"(
       SELECT
         items.key as key,
-        items.version,
+        strftime('%%s', items.clientDateModified) AS version,
         creators.firstName as firstName,
         creators.LastName as lastName,
         itemCreators.orderIndex,
@@ -140,7 +140,6 @@ std::string collectionSQL(const ZoteroCollectionSpec& spec)
    boost::format fmt(R"(
       SELECT
          items.key as key,
-         items.version,
          fields.fieldName as name,
          itemDataValues.value as value,
          itemTypeFields.orderIndex as fieldOrder
@@ -163,7 +162,6 @@ std::string collectionSQL(const ZoteroCollectionSpec& spec)
    UNION
       SELECT
          items.key as key,
-         items.version,
          'type' as name,
          itemTypes.typeName as  value,
          0 as fieldOrder
@@ -181,7 +179,6 @@ std::string collectionSQL(const ZoteroCollectionSpec& spec)
    UNION
       SELECT
          items.key as key,
-         items.version,
          'libraryID' as name,
          CAST(items.libraryID as text) as value,
          500 as fieldOrder
@@ -199,7 +196,6 @@ std::string collectionSQL(const ZoteroCollectionSpec& spec)
    UNION
       SELECT
          items.key as key,
-         items.version,
          'collectionKeys' as name,
          libraries.libraryID || ',' || IFNULL(group_concat(collections.key), '') as value,
          10000 as fieldOrder
@@ -232,7 +228,58 @@ std::string collectionSQL(const ZoteroCollectionSpec& spec)
          ("AND collections.key = '" + spec.key + "'")
       );
    }
+}
 
+double getCollectionVersion(boost::shared_ptr<database::IConnection> pConnection, const ZoteroCollectionSpec& spec) {
+    // This is a library
+    std::string query;
+    if (spec.parentKey.empty()) {
+        query = R"(
+                   SELECT
+                       IFNULL(strftime('%%s', MAX(MAX(items.clientDateModified), MAX(collections.clientDateModified))), '0') AS version
+                   FROM
+                       libraries
+                       left join items on libraries.libraryID = items.libraryID
+                       left join collections on libraries.libraryID = collections.libraryID
+                       join itemTypes on items.itemTypeID = itemTypes.itemTypeID
+                       left join deletedItems on items.itemId = deletedItems.itemID
+                   WHERE
+                       libraries.libraryID = %1%
+                   AND
+                       itemTypes.typeName <> 'attachment'
+                   AND
+                       itemTypes.typeName <> 'note'
+                   AND
+                       deletedItems.dateDeleted IS NULL
+                )";
+    } else {
+        query = R"(
+                SELECT
+                    IFNULL(strftime('%%s', MAX(MAX(items.clientDateModified), MAX(collections.clientDateModified))), '0') AS version
+                FROM
+                    collections
+                    left join collectionItems on collections.collectionID = collectionItems.collectionID
+                    left join items on collectionItems.itemID = items.itemID
+                    left join itemTypes on items.itemTypeID = itemTypes.itemTypeID
+                    left join collections as parentCollections on collections.parentCollectionID = parentCollections.collectionID
+                WHERE
+                    collections.collectionID = %1%
+                   )";
+
+    }
+
+    double version = 0;
+    Error error = execQuery(pConnection, boost::str(boost::format(query) % spec.key),
+                      [&version](const database::Row& row) {
+        try
+        {
+           std::string versionStr = readString(row, "version", "0");
+           version = safe_convert::stringTo<double>(versionStr, 0);
+        }
+        CATCH_UNEXPECTED_EXCEPTION
+
+    });
+    return version;
 }
 
 ZoteroCollection getCollection(boost::shared_ptr<database::IConnection> pConnection, const ZoteroCollectionSpec& spec)
@@ -271,12 +318,10 @@ ZoteroCollection getCollection(boost::shared_ptr<database::IConnection> pConnect
       return collection;
    }
 
-   int version = 0;
    std::map<std::string,std::string> currentItem;
    json::Array itemsJson;
    error = execQuery(pConnection, collectionSQL(spec),
-                     [&creators, &version, &currentItem, &itemsJson](const database::Row& row) {
-
+                     [&creators, &currentItem, &itemsJson](const database::Row& row) {
 
       std::string key = row.get<std::string>("key");
       std::string currentKey = currentItem.count("key") ? currentItem["key"] : "";
@@ -294,16 +339,6 @@ ZoteroCollection getCollection(boost::shared_ptr<database::IConnection> pConnect
          currentItem.clear();
          currentItem["key"] = key;
       }
-
-      // update version
-      // further fix for https://github.com/rstudio/rstudio/issues/8861
-      try
-      {
-         int rowVersion = row.get<int>("version");
-         if (rowVersion > version)
-            version = rowVersion;
-      }
-      CATCH_UNEXPECTED_EXCEPTION
 
       // read the csl name value pairs
       soci::indicator nameIndicator = row.get_indicator("name");
@@ -328,6 +363,9 @@ ZoteroCollection getCollection(boost::shared_ptr<database::IConnection> pConnect
       return collection;
    }
 
+   // Read the collection version
+   double version = getCollectionVersion(pConnection, spec);
+
    // success!
    collection.version = version;
    collection.items = itemsJson;
@@ -338,7 +376,7 @@ struct LibraryInfo
 {
    LibraryInfo() : version(0) {}
    std::string name;
-   int version;
+   double version;
 };
 
 
@@ -349,13 +387,22 @@ ZoteroCollectionSpecs getCollections(boost::shared_ptr<database::IConnection> pC
                                   CAST(libraries.libraryID as text) as collectionKey,
                                   IFNULL(groups.name, 'My Library') as collectionName,
                                   NULL as parentCollectionKey,
-                                  IFNULL(MAX(items.version), 0) AS version
+                                  IFNULL(strftime('%s', MAX(MAX(items.clientDateModified), MAX(collections.clientDateModified))), '0') AS version
                               FROM
                                   libraries
                                   left join items on libraries.libraryID = items.libraryID
+                                  left join collections on libraries.libraryID = collections.libraryID
+                                  join itemTypes on items.itemTypeID = itemTypes.itemTypeID
+                                  left join deletedItems on items.itemId = deletedItems.itemID
                                   left join groups as groups on libraries.libraryID = groups.libraryID
                               WHERE
                                   libraries.type in ('user', 'group')
+                              AND
+                                  itemTypes.typeName <> 'attachment'
+                              AND
+                                  itemTypes.typeName <> 'note'
+                              AND
+                                  deletedItems.dateDeleted IS NULL
                               GROUP
                                   BY libraries.libraryID
                           )";
@@ -365,7 +412,7 @@ ZoteroCollectionSpecs getCollections(boost::shared_ptr<database::IConnection> pC
                                     collections.key as collectionKey,
                                     collections.collectionName as collectionName,
                                     IFNULL(parentCollections.key, libraries.libraryId) as parentCollectionKey,
-                                    IFNULL(MAX(items.version), 0) AS version
+                                    IFNULL(strftime('%s', MAX(MAX(items.clientDateModified), MAX(collections.clientDateModified))), '0') AS version
                                 FROM
                                     collections
                                     join libraries on libraries.libraryID = collections.libraryID
@@ -398,7 +445,7 @@ ZoteroCollectionSpecs getCollections(boost::shared_ptr<database::IConnection> pC
          spec.key = readString(row, "collectionKey", "-1");
 
          std::string versionStr = readString(row, "version", "0");
-         spec.version = safe_convert::stringTo<int>(versionStr, 0);
+         spec.version = safe_convert::stringTo<double>(versionStr, 0);
 
          const soci::indicator indicator = row.get_indicator("parentCollectionKey");
          if (indicator == soci::i_ok)
@@ -440,17 +487,44 @@ Error connect(std::string dataDir, boost::shared_ptr<database::IConnection>* ppC
 {
    // get path to actual sqlite db
    FilePath dbFile(dataDir + "/zotero.sqlite");
+   FilePath dbJournal(dbFile.getAbsolutePath() + "-journal");
 
    // get path to copy of file we will use for queries
    FilePath dbCopyFile = zoteroSqliteCopyPath(dataDir);
+   FilePath dbCopyJournal(dbCopyFile.getAbsolutePath() + "-journal");
+
+   bool databaseIsStale = dbCopyFile.getLastWriteTime() < dbFile.getLastWriteTime();
+   bool journalIsStale = dbCopyJournal.getLastWriteTime() < dbJournal.getLastWriteTime();
+
 
    // if the copy file doesn't exist or is older than the dbFile then make another copy
-   if (!dbCopyFile.exists() || (dbCopyFile.getLastWriteTime() < dbFile.getLastWriteTime()))
+   if (databaseIsStale || journalIsStale)
    {
       TRACE("Copying " + dbFile.getAbsolutePath());
+      std::time_t writeTime = dbFile.getLastWriteTime();
       Error error = dbFile.copy(dbCopyFile, true);
       if (error)
          return error;
+      dbCopyFile.setLastWriteTime(writeTime);
+
+      // Manage journal files that may be open as well
+      if (dbJournal.exists()) {
+          TRACE("Copying Journal");
+          // If there a journal, we should copy that as well
+          std::time_t writeTime = dbJournal.getLastWriteTime();
+          Error error = dbJournal.copy(dbCopyJournal, true);
+          if (error)
+              return error;
+          dbCopyJournal.setLastWriteTime(writeTime);
+      } else {
+          TRACE("Removing Journal");
+          // If there is no journal file, we should ensure that any existing journal is removed
+          if (dbCopyJournal.exists()) {
+              Error error = dbCopyJournal.remove();
+              if (error)
+                  return error;
+          }
+      }
    }
 
    // create connection
@@ -561,7 +635,7 @@ void getLocalCollections(std::string key,
    for (auto userCollection : userCollections)
    {  
       std::string name = userCollection.name;
-      int version = userCollection.version;
+      double version = userCollection.version;
       std::string key = userCollection.key;
       std::string parentKey = userCollection.parentKey;
 

--- a/src/cpp/session/modules/zotero/ZoteroCollectionsWeb.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsWeb.cpp
@@ -355,7 +355,7 @@ private:
          for (auto collectionSpecJson : collectionSpecsJson)
          {
             json::Object collectionJson = collectionSpecJson.getObject()["data"].getObject();
-            int version = collectionJson[kVersion].getInt();
+            double version = collectionJson[kVersion].getDouble();
             std::string name = collectionJson[kName].getString();
             std::string collectionID = collectionJson[kKey].getString();
 
@@ -475,10 +475,10 @@ private:
       else
       {
          // calculate library version from max of items downloaed
-         int version = 0;
+         double version = 0;
          json::Array itemsJson = jsonValue.getArray();
          std::for_each(itemsJson.begin(), itemsJson.end(), [&version](const json::Value& item) {
-            int itemVersion = item.getObject()[kVersion].getInt();
+            double itemVersion = item.getObject()[kVersion].getDouble();
             if (itemVersion > version)
                version = itemVersion;
          });


### PR DESCRIPTION
### Intent
The visual editor's Zotero integration caches data from the user's Zotero database (if configured). We were being very aggressive about the caching and often it would take 10-30 seconds for the cache to be invalidated when the zotero database was updated. In some cased, the cache would fail to be invalidated. This PR improves the cache behavior for Zotero data.

### Approach

We use the 'version' of the Zotero Collection Spec to manage the caching behavior of items throughout the system. We had been using exclusively the `version` column of items to provide this value, but this had a couple of issues:

1) the version column is set by syncing to the server, which means that it will not be set if there is no sync, but even if there is sync, the version isn't set until the server has been updating (often many seconds after it has been written).

2) the version column of items doesn't capture all the ways that the cache should be broken, especially changes to collections or collection ownership of items.

This change does two major things:

1) Switch to using the clientDateModified field to provide the version. To support this, we need to switch the version of the client spec (and all intermediaries) to doubles.

2) Check both the collection clientDateModified and the item clientDateModified dates to determine the version.

### Automated Tests

This doesn't include automated tests.

### QA Notes

I was able to verify the correctness of the Zotero citation data post change, including when configured to use the web version of zotero.

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


