### PR TITLE
Loosen equality check for context comparison

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,3 +24,4 @@
 * Fixed errors when uploading files/directory names with invalid characters (Pro #698)
 * Added error when rsession may be running a different version of R than expected (Pro #2477)
 * Fixed "No such file or directory" errors when auto-saving R Notebook chunks while running them (#9284)
+* Fixed issue causing unnecessary document switching when evaluating statements in debugger (#9918)

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -186,12 +186,20 @@ Error RCntxt::invokeFunctionOnCall(const char* rFunction,
 
 bool RCntxt::operator==(const RCntxt& other) const
 {
-   return other.pCntxt_ == pCntxt_;
+   // Equivalent if they refer to the same underlying object
+   if (other.pCntxt_ == pCntxt_)
+      return true;
+
+   // Also equivalent if they refer to the same call, at the same depth, on the stack
+   if (other.call() == call() && other.evaldepth() == evaldepth())
+      return true;
+
+   return false;
 }
 
 bool RCntxt::operator!=(const RCntxt& other) const
 {
-   return other.pCntxt_ != pCntxt_;
+   return !(*this == other);
 }
 
 RCntxt::iterator RCntxt::begin()


### PR DESCRIPTION
### Intent

Fixes an issue in which the debugger constantly thinks the context stack has changed every time the console prompt appears, causing it to reset the IDE's active file unnecessarily. 

Addresses https://github.com/rstudio/rstudio/issues/9918. 

### Approach

The equality test for context objects was too strict; it compares underlying pointers to R's context stack, but it turns out that it is possible (perhaps due to a change in R?) to get two different pointers on the context stack that actually refer to the same entry. 

The fix is to consider two context stack entries to be identical if they refer to exactly the same call object (S-expression) at the same evaluation depth. 

### Automated Tests

N/A

### QA Notes

This is a pretty low-level change that affects building the debugger's stack. Ensure that the IDE returns focus to the instruction pointer when it moves (such as when stepping into or through code). 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


