### PR TITLE
Fix for GnuPG Code Signing Failure

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse-x86_64
@@ -3,7 +3,7 @@ FROM opensuse/leap:15.3
 ENV OPERATING_SYSTEM=opensuse_leap153
 
 # needed to build RPMs
-RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Leap_42.3/systemsmanagement:wbem:deps.repo
+RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Tumbleweed/systemsmanagement:wbem:deps.repo
 
 # refresh repos and install required packages
 RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
@@ -60,6 +60,9 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# ensure we use the java 8 compiler
+RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
+
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
@@ -72,6 +75,16 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 ENV RSTUDIO_DISABLE_CRASHPAD=1
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse
+
+# install GnuPG 1.4 from source (needed for release signing)
+RUN cd /tmp && \
+    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
+    bzip2 -d gnupg-1.4.23.tar.bz2 && \
+    tar xvf gnupg-1.4.23.tar && \
+    cd gnupg-1.4.23 && \
+    ./configure && \
+    make && \
+    make install
 
 # set github login from build argument if defined
 ARG GITHUB_LOGIN


### PR DESCRIPTION
Code signing being modeled after the working OpenSUSE 15 builds.
Similarly noticed OpenSUSE15 is forcing java 8 so we ported that change
over to prevent future issues.
Updated from 42.3 repo to Tumbleweed


### Intent
The update to OpenSUSE 15 broke code signing for SLES

### Approach

Modeled changes after the existing OpenSUSE 15 builds, primarily set the jvm to jdk8, and install a version of GnuPG that works for us.

### Automated Tests

No code change, no automated testing

### QA Notes

QA has previously tested an earlier version of this in their automated testing.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


