### PR TITLE
Bugfix/publish static documents from preview

### DIFF
--- a/NEWS-2021.09.1-ghost-orchid.md
+++ b/NEWS-2021.09.1-ghost-orchid.md
@@ -3,4 +3,4 @@
 
 ### Bugfixes
 
-* Fixed bug that preventing publishing to Connect from a preview window (#9901)
+* Fixed bug that prevented publishing to Connect from a preview window (#9901)

--- a/NEWS-2021.09.1-ghost-orchid.md
+++ b/NEWS-2021.09.1-ghost-orchid.md
@@ -1,3 +1,6 @@
 
 ## RStudio 2021.09.1 "Ghost Orchid" Release Notes
 
+### Bugfixes
+
+* Fixed bug that preventing publishing to Connect from a preview window (#9901)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -1147,7 +1147,7 @@ public class RSConnect implements SessionInitEvent.Handler,
    private final native void exportNativeCallbacks() /*-{
       var thiz = this;
       $wnd.deployToRSConnect = $entry(
-         function(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, isSelfContained, isShiny, asMultiple, asStatic, launch, record) {
+         function(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record) {
             thiz.@org.rstudio.studio.client.rsconnect.RSConnect::deployToRSConnect(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;Lcom/google/gwt/core/client/JsArrayString;ZZZZZZLcom/google/gwt/core/client/JavaScriptObject;)(sourceFile, deployDir, deployFile, websiteDir, description, deployFiles, additionalFiles, ignoredFiles, isSelfContained, isShiny, asMultiple, asStatic, isQuarto, launch, record);
          }
       );


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio/issues/9901

### Approach

Added missing `isQuarto` flag to `deployToRSConnect()` function call

### Automated Tests

None

### QA Notes

Repro details in ticket. Publishing to Connect from a preview window should succeed

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


