### PR TITLE
Correctly show custom shortcuts in Electron app menus and "Keyboard Shortcuts Help"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 
 * Added support for setting the `subPath` on Kubernetes sessions using `KubernetesPersistentVolumeClaim` mounts in `/etc/rstudio/launcher-mounts` (Pro #2976).
 * Fixed custom shortcuts not appearing correctly in menus (#9915)
+* Fixed custom shortcuts not appearing correctly in "Keyboard Shortcuts Help" and Electron menus. (#9953)
 
 ### Misc
 

--- a/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
+++ b/src/gwt/src/org/rstudio/core/client/command/AppCommand.java
@@ -707,6 +707,11 @@ public class AppCommand implements Command, ClickHandler, ImageResourceProvider
       return customShortcut_ != null ? customShortcut_ : shortcut_;
    }
 
+   public KeyboardShortcut getShortcut(boolean custom)
+   {
+      return custom ? customShortcut_ : shortcut_;
+   }
+
    public KeySequence getKeySequence()
    {
       if (getShortcut() == null)

--- a/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ApplicationCommandManager.java
@@ -19,10 +19,12 @@ import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.Pair;
 import org.rstudio.core.client.command.EditorCommandManager.EditorKeyBindings;
 import org.rstudio.core.client.command.KeyMap.KeyMapType;
+import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.files.ConfigFileBacked;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.RStudioKeybindingsChangedEvent;
 import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.rstudioapi.model.RStudioAPIServerOperations;
 import org.rstudio.studio.client.common.satellite.Satellite;
@@ -213,6 +215,10 @@ public class ApplicationCommandManager
 
       // TODO: Set the bindings in the AppCommand keymap, removing any
       // previously registered bindings.
+
+      if (Desktop.hasDesktopFrame())
+         DesktopMenuCallback.commitCommandShortcuts();
+
       if (afterLoad != null)
          afterLoad.execute(bindings);
    }

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
@@ -53,8 +53,23 @@ public class ShortcutInfo
       List<String> shortcuts = new ArrayList<>();
       for (KeyboardShortcut shortcut: shortcuts_)
       {
-         shortcuts.add(shortcut.toString(true));
+         // if there is a command, then the shorcut must NOT match BOTH the
+         // custom shortcut AND the default shortcut for that command,
+         // Add to the list otherwise.
+         if (getCommand() == null) 
+            shortcuts.add(shortcut.toString(true));
+         else if ( 
+               !shortcut.equals(getCommand().getShortcut(false)) &&
+               !shortcut.equals(getCommand().getShortcut(true))
+               )
+            shortcuts.add(shortcut.toString(true));
       }
+
+      // if there is a command, add the shorcut here. This will choose the
+      // correct shorcut: the custom one if it exists, otherwise the default one
+      if (getCommand() != null) 
+         shortcuts.add(getCommand().getShortcut().toString(true));
+
       return shortcuts;
    }
 

--- a/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
@@ -102,6 +102,18 @@ public class DesktopMenuCallback implements MenuCallback
       callbacks.setCommandShortcut(commandId, shortcut);
    }-*/;
 
+   public static final void commitCommandShortcuts()
+   {
+      commitCommandShortcutsImpl(MENU_CALLBACKS);
+   }
+
+   private native static final void commitCommandShortcutsImpl(JavaScriptObject callbacks)
+   /*-{
+      // MAY NOT BE DEFINED
+      if (callbacks.commitCommandShortcuts)
+         callbacks.commitCommandShortcuts();
+   }-*/;
+
    public native static final void setMainMenuEnabled(boolean enabled)
    /*-{
        if ($wnd.desktopMenuCallback)

--- a/src/node/desktop/src/renderer/menu-bridge.ts
+++ b/src/node/desktop/src/renderer/menu-bridge.ts
@@ -65,5 +65,9 @@ export function getMenuBridge() {
     setCommandShortcut: (commandId: string, shortcut: string) => {
       ipcRenderer.send('menu_set_command_shortcut', commandId, shortcut);
     },
+
+    commitCommandShortcuts: () => {
+      ipcRenderer.send('menu_commit_command_shortcuts');
+    },
   };
 }

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -53,7 +53,7 @@ ipcRenderer.on('initialize', (event, data) => {
   rInstalls.forEach(rInstall => {
 
     // normalize separators, etc
-    rInstall = path.normalize(rInstall).replaceAll(/[/\\]+$/g, '');
+    rInstall = path.normalize(rInstall).replace(/[/\\]+$/g, '');
 
     // skip if we've already seen this
     if (visitedInstallations[rInstall]) {

--- a/src/node/desktop/tsconfig.json
+++ b/src/node/desktop/tsconfig.json
@@ -11,8 +11,8 @@
       "*": ["node_modules/*"]
     },
     "lib": [
-      "DOM",
-    ],
+      "DOM"
+    ]
   },
   "include": [
     "src/**/*",


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio/issues/9953

### Intent

Keyboard shortcuts update properly in Server menus and Desktop QT menus, so this commit adds support for make those changes in Electron menus. However, updating shortcuts in Electron menus is no small task. Shortcuts are the only property that cannot be updated with a simple write, so an entire menu rebuild must be performed in order to make that change. 

I also went ahead and addressed the custom shortcuts not appearing in "Keyboard Shortcuts Help" (https://github.com/rstudio/rstudio/issues/9953) because it is related. The only remaining issue to fix for https://github.com/rstudio/rstudio/issues/5256 is tooltips.

### Approach

What we had to do was what I would call a hack, but we have to work around the constraints that Electron applies.

The update approach for shortcuts (called "Accelerators" in Electron) is to queue up changes from GWT and then have GWT commit them once all updates have been submitted. Upon commit, the entire app menu is copied to a new menu, including submenus, with the changes from the queue applied. In order to do this properly, the templates for each menu item are stored for re-use, so that they can be used to re-build the new menu without manually copying keys between `MenuItems` and their constructors.

### Automated Tests

There are no automated tests yet.

### QA Notes

Verification is the same as in https://github.com/rstudio/rstudio/pull/9907, only Electron is the Desktop environment to use rather than QT.

Additionally, verify the following:
* Verify that the Command is visible in Keyboard Shortcuts Help.
* Set a custom keyboard shortcut for one of the commands (can be blank).
* Verify that shortcut listed in Keyboard Shortcuts Help reflects all changes made.
* Reset all changes in the Modify Keyboard Shortcuts dialog
* Verify that the reset has worked, and that Keyboard Shortcuts Help reflects this

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


