### PR TITLE
File pane toolbar button titles react to pane width to remain accessible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,6 @@
 * Added support for setting the `subPath` on Kubernetes sessions using `KubernetesPersistentVolumeClaim` mounts in `/etc/rstudio/launcher-mounts` (Pro #2976).
 * Fixed custom shortcuts not appearing correctly in menus (#9915)
 * Fixed custom shortcuts not appearing correctly in "Keyboard Shortcuts Help" and Electron menus. (#9953)
-* File pane controls adjust based on the width of the pane so they are always visible (#9870)
 * Updated Files Pane buttons to resize and remain visible at smaller widths (#9870)
 
 ### Misc

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * Fixed custom shortcuts not appearing correctly in menus (#9915)
 * Fixed custom shortcuts not appearing correctly in "Keyboard Shortcuts Help" and Electron menus. (#9953)
 * File pane controls adjust based on the width of the pane so they are always visible (#9870)
+* Updated Files Pane buttons to resize and remain visible at smaller widths (#9870)
 
 ### Misc
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Added support for setting the `subPath` on Kubernetes sessions using `KubernetesPersistentVolumeClaim` mounts in `/etc/rstudio/launcher-mounts` (Pro #2976).
 * Fixed custom shortcuts not appearing correctly in menus (#9915)
 * Fixed custom shortcuts not appearing correctly in "Keyboard Shortcuts Help" and Electron menus. (#9953)
+* File pane controls adjust based on the width of the pane so they are always visible (#9870)
 
 ### Misc
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -16,6 +16,8 @@ package org.rstudio.studio.client.workbench.views.files.ui;
 
 import com.google.inject.Inject;
 
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeStyles;
@@ -36,7 +38,8 @@ public class FileCommandToolbar extends Toolbar
       super("File Commands");
       StandardIcons icons = StandardIcons.INSTANCE;
 
-      addLeftWidget(commands.newFolder().createToolbarButton());
+      newFolderButton_ = commands.newFolder().createToolbarButton();
+      addLeftWidget(newFolderButton_);
       addLeftSeparator();
       
       // New Blank File Menu
@@ -60,19 +63,25 @@ public class FileCommandToolbar extends Toolbar
       newFileMenu.addItem(commands.touchSweaveDoc().createMenuItem(false));
       newFileMenu.addItem(commands.touchRHTMLDoc().createMenuItem(false));
 
-      ToolbarMenuButton newFileButton = new ToolbarMenuButton(
+      newFileButton_ = new ToolbarMenuButton(
             "New Blank File",
             "Create a new blank file in current directory",
             new ImageResource2x(icons.stock_new2x()),
             newFileMenu);
-      ElementIds.assignElementId(newFileButton, ElementIds.MB_FILES_TOUCH_FILE);
-      addLeftWidget(newFileButton);
+      ElementIds.assignElementId(newFileButton_, ElementIds.MB_FILES_TOUCH_FILE);
+      addLeftWidget(newFileButton_);
       addLeftSeparator();
       
-      addLeftWidget(commands.uploadFile().createToolbarButton());
+      uploadButton_ = commands.uploadFile().createToolbarButton();
+      addLeftWidget(uploadButton_);
+
       addLeftSeparator();
-      addLeftWidget(commands.deleteFiles().createToolbarButton());
+
+      deleteButton_ = commands.deleteFiles().createToolbarButton();
+      addLeftWidget(deleteButton_);
+
       addLeftWidget(commands.renameFile().createToolbarButton());
+
       addLeftSeparator();
 
       // More
@@ -98,17 +107,60 @@ public class FileCommandToolbar extends Toolbar
       moreMenu.addSeparator();
       moreMenu.addItem(new UserPrefMenuItem<>(prefs.showHiddenFiles(), true, "Show Hidden Files", prefs));
 
-      ToolbarMenuButton moreButton = new ToolbarMenuButton(
+      moreButton_ = new ToolbarMenuButton(
             "More",
             "More file commands",
             new ImageResource2x(icons.more_actions2x()),
             moreMenu);
-      ElementIds.assignElementId(moreButton, ElementIds.MB_FILES_MORE);
-      addLeftWidget(moreButton);
+      ElementIds.assignElementId(moreButton_, ElementIds.MB_FILES_MORE);
+      addLeftWidget(moreButton_);
 
       // Refresh
       ToolbarButton refreshButton = commands.refreshFiles().createToolbarButton();
       refreshButton.addStyleName(ThemeStyles.INSTANCE.refreshToolbarButton());
       addRightWidget(refreshButton);
+
+      this.addHandler(new ResizeHandler()
+      {
+         @Override
+         public void onResize(ResizeEvent event)
+         {
+            manageToolbarSizes(event.getWidth());
+         }
+      }, ResizeEvent.getType());
    }
+
+   private void manageToolbarSizes(int width) 
+   {
+      if (width < 450) 
+      {
+         newFolderButton_.setText("");
+         newFileButton_.setText("");
+         uploadButton_.setText("");
+         deleteButton_.setText("");
+         moreButton_.setText("");
+      }
+      else if (width < 540)
+      {
+         newFolderButton_.setText("Folder");
+         newFileButton_.setText("Blank File");
+         uploadButton_.setText("Upload");
+         deleteButton_.setText("Delete");
+         moreButton_.setText("");
+      }
+      else
+      {
+         newFolderButton_.setText("New Folder");
+         newFileButton_.setText("New Blank File");
+         uploadButton_.setText("Upload");
+         deleteButton_.setText("Delete");
+         moreButton_.setText("More");
+      }
+   }
+
+   private ToolbarButton newFolderButton_;
+   private ToolbarMenuButton newFileButton_;
+   private ToolbarButton uploadButton_;
+   private ToolbarButton deleteButton_;
+   private ToolbarMenuButton moreButton_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -80,7 +80,8 @@ public class FileCommandToolbar extends Toolbar
       deleteButton_ = commands.deleteFiles().createToolbarButton();
       addLeftWidget(deleteButton_);
 
-      addLeftWidget(commands.renameFile().createToolbarButton());
+      renameButton_ = commands.renameFile().createToolbarButton();
+      addLeftWidget(renameButton_);
 
       addLeftSeparator();
 
@@ -138,6 +139,7 @@ public class FileCommandToolbar extends Toolbar
          newFileButton_.setText("");
          uploadButton_.setText("");
          deleteButton_.setText("");
+         renameButton_.setText("");
          moreButton_.setText("");
       }
       else if (width < 540)
@@ -146,6 +148,7 @@ public class FileCommandToolbar extends Toolbar
          newFileButton_.setText("Blank File");
          uploadButton_.setText("Upload");
          deleteButton_.setText("Delete");
+         renameButton_.setText("Rename");
          moreButton_.setText("");
       }
       else
@@ -154,6 +157,7 @@ public class FileCommandToolbar extends Toolbar
          newFileButton_.setText("New Blank File");
          uploadButton_.setText("Upload");
          deleteButton_.setText("Delete");
+         renameButton_.setText("Rename");
          moreButton_.setText("More");
       }
    }
@@ -162,5 +166,6 @@ public class FileCommandToolbar extends Toolbar
    private ToolbarMenuButton newFileButton_;
    private ToolbarButton uploadButton_;
    private ToolbarButton deleteButton_;
+   private ToolbarButton renameButton_;
    private ToolbarMenuButton moreButton_;
 }


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio/issues/9870

### Intent

When the file pane is resized to narrower than 540 px, the controls begin to become cutoff due to a lack of horizontal space. The purpose of this bugfix is to alter the titles of the buttons dynamically according to the width, so that every control remains visible*

\*At prohibitively-narrow widths of less than ~280px, controls will start to be cutoff again.

Full width:
![image](https://user-images.githubusercontent.com/5544965/137766551-48b9b158-3b06-4639-abdb-9a6cafa00d2c.png)

Slightly narrower:
![image](https://user-images.githubusercontent.com/5544965/137766686-ce7f9b42-7f6a-4a0e-9121-00f009060ce4.png)

Fully narrow:
![image](https://user-images.githubusercontent.com/5544965/137766958-7a99280e-e2ce-4ec5-b519-cc6d1a00376f.png)

### Approach

I copied the approach used for several other toolbars that resize their own content based on their width. 

~At very narrow widths, most of the controls have their names removed __except__ for "Rename," and this was because I felt that the iconography for the other controls was self-explanatory-enough that they can stand without names, whereas "Rename" always needs it. This may be up for further discussion.~

2021-10-18 edit: "Rename" also has its name cleared out at narrow widths. Since it has a tooltip, I think it is acceptable that the name is cleared out.

### Automated Tests

There are no automated tests at this time.

### QA Notes

This one is straightforward to verify: just check that the titles change as you make the file pane narrower. All controls should remain on screen at widths greater than ~280px.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


