### PR TITLE
Fix horizontal scroll behavior of data viewer tables in non-active frames

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 
 * Added support for setting the `subPath` on Kubernetes sessions using `KubernetesPersistentVolumeClaim` mounts in `/etc/rstudio/launcher-mounts` (Pro #2976).
 * Fixed custom shortcuts not appearing correctly in menus (#9915)
+* Fixed header scrolling in data viewer tables not following table contents in unfocused windows (#8208)
 
 ### Misc
 

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -320,9 +320,11 @@
     var scrollBody = $(".dataTables_scrollBody");
     if (scrollBody) {
       // reattach handlers
+      /*
       for (var i = 0; i < detachedHandlers.length; i++) {
         scrollBody.on("scroll", detachedHandlers[i]);
       }
+      */
 
       // restore position
       if (lastScrollPos) scrollBody.scrollTop(lastScrollPos);
@@ -1573,6 +1575,7 @@
     lastScrollPos = scrollBody.scrollTop();
 
     // save all the of the scroll event handlers
+    /*
     detachedHandlers = [];
     var scrollEvents = $._data(scrollBody[0], "events");
     jQuery.each(scrollEvents.scroll, function (k, v) {
@@ -1581,6 +1584,7 @@
 
     // detach all scroll event handlers
     scrollBody.off("scroll");
+    */
   };
 
   window.setData = function (data) {


### PR DESCRIPTION
See https://github.com/rstudio/rstudio/issues/8208

### Intent

Solve the issue described in https://github.com/rstudio/rstudio/issues/8208 in which focusing a source panel in a different column causes a strange scrolling behavior in the data viewer.

Investigation revealed that this was a previously-implemented Firefox compatibility bugfix, in which all of the scroll event listeners are purged when focus is lost in a source window. The intent of that was to fix a vertical scrolling issue, but I haven't been able to replicate this in current versions of Firefox. 

The problem with the previous fix is that removing all scroll listeners also breaks horizontal scrolling, because both vertical and horizontal scrolling listens to the same `scroll` event. JQuery scrolls the table headers programmatically using a `scroll` event listener, so scroll events cannot be removed because we cannot assume we know which scroll listeners is which.

### Approach

I have commented out the code that removes the scroll listeners, and the code that adds them back. I have left in the code that stores and reloads the vertical scroll positions, however, as it is harmless.

### Automated Tests

There are no automated tests that I can think of that would be able to test this.

### QA Notes

* Ensure that **Firefox** is used to test, as the original code was added to solve a Firefox-specific bug
* Open a regular source pane and a new source column, so there are two focusable windows present on screen (like shown in https://github.com/rstudio/rstudio/issues/8208)
* Make sure there are files loaded in each source pane.
* Run a `View(mtcars)` to load in a dataset that is both long-enough and wide-enough to create scroll bars on both the vertical and horizontal axes
* Click between the source panels and verify that the column headers continue to scroll with the table data in either state
* Verify that no vertical scrolling artifacts appear as a result of these changes

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


