### PR TITLE
Add Element ID's to the Filter field and Reset button for automation

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -369,6 +369,8 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
          }
          
       });
+
+      filterWidget_.getElement().setId(FILTER_WIDGET_ID);
       
       filterWidget_.addValueChangeHandler(new ValueChangeHandler<String>()
       {
@@ -381,7 +383,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       
       filterWidget_.setPlaceholderText("Filter...");
       
-      addLeftWidget(new ThemedButton("Reset...", new ClickHandler()
+      resetButton_ = new ThemedButton("Reset...", new ClickHandler()
       {
          @Override
          public void onClick(ClickEvent event)
@@ -425,7 +427,9 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
                   },
                   false);
          }
-      }));
+      });
+      resetButton_.getElement().setId(RESET_BUTTON_ID);
+      addLeftWidget(resetButton_);
    }
    
    private void applyChanges()
@@ -1452,6 +1456,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
    private final DataGrid<KeyboardShortcutEntry> table_;
    private final ListDataProvider<KeyboardShortcutEntry> dataProvider_;
    private final Map<KeyboardShortcutEntry, KeyboardShortcutEntry> changes_;
+   private static final String FILTER_WIDGET_ID = "rstudio_kybrd_shrtcts_fltr";
    private final SearchWidget filterWidget_;
    private final String initialFilterText_;
    
@@ -1465,6 +1470,8 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
    private Pair<Integer, Integer> lastSelectedIndices_;
    private boolean swallowNextKeyUpEvent_;
 
+   private static final String RESET_BUTTON_ID = "rstudio_kybrd_shrtcts_rst";
+   private ThemedButton resetButton_;
    private ThemedButton applyButton_;
    
    // Columns ----


### PR DESCRIPTION
### Intent

Add Element ID's to the filter and reset buttons in the Keyboard Shortcuts Editor so that automation testing can find these elements and make use of them.

### Approach

Add a reference to the reset button so that GWT can attach an ID to it. Declare two new `private static final String` constants that fix the ID values.

### Automated Tests

The purpose of this branch is to enable automated testing on the other Keyboard shortcut-related issues.

### QA Notes

Verify that you get elements when you run the following queries on the document:
* Filter element: `document.getElementById('rstudio_kybrd_shrtcts_fltr')` 
  Keep in mind that this does not point directly to the `<input/>`, but to the parent `<div/>` of the filter Widget. If you want the `<input/>` then you have to add a `querySelectorAll('input')` to find it in the widget hierarchy.
* Reset button: `document.getElementById('rstudio_kybrd_shrtcts_rst')` this returns the `<button/>` element directly.

### Checklist

- [x] ~If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
- [x] ~If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


