### PR TITLE
Persist modified python_project_environment_automatic_activate setting

### DIFF
--- a/NEWS-2021.09.1-ghost-orchid.md
+++ b/NEWS-2021.09.1-ghost-orchid.md
@@ -3,6 +3,7 @@
 
 ### Bugfixes
 
-Fixed issue causing verify-installation to hang in load balanced launcher environments (Pro #3036)
+* Fixed issue causing verify-installation to hang in load balanced launcher environments (Pro #3036)
 * Fixed bug that prevented publishing to Connect from a preview window (#9901)
 * Fixed bug that prevented RStudio from correctly reporting new versions when running 'Check for Updates' (Pro #9911)
+* Fixed bug that prevented disabling the "Automatically activate project-local Python environments" setting (#9952)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PythonPreferencesPaneBase.java
@@ -173,8 +173,8 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          cbAutoUseProjectInterpreter_ =
                new CheckBox("Automatically activate project-local Python environments");
          
-         cbAutoUseProjectInterpreter_.setValue(
-               prefs_.pythonProjectEnvironmentAutomaticActivate().getGlobalValue());
+         initialAutoUseProjectInterpreter_ = prefs_.pythonProjectEnvironmentAutomaticActivate().getGlobalValue();
+         cbAutoUseProjectInterpreter_.setValue(initialAutoUseProjectInterpreter_);
          
          cbAutoUseProjectInterpreter_.getElement().setTitle(
                "When enabled, RStudio will automatically find and activate a " +
@@ -384,6 +384,15 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
          if (projDir.exists() && newValue.startsWith(projDir.getPath()))
             newValue = newValue.substring(projDir.getLength() + 1);
       }
+      else
+      {
+         boolean newAutoActivateValue = cbAutoUseProjectInterpreter_.getValue();
+         if (newAutoActivateValue != initialAutoUseProjectInterpreter_)
+         {
+            prefs_.pythonProjectEnvironmentAutomaticActivate().setGlobalValue(newAutoActivateValue);
+            requirement.setSessionRestartRequired(true);
+         }
+      }
       
       // check if the interpreter appears to have been set by the user
       boolean isValidInterpreterSet =
@@ -438,6 +447,7 @@ public abstract class PythonPreferencesPaneBase<T> extends PreferencesDialogPane
    protected final SimplePanel interpreterDescription_ = new SimplePanel();
    
    protected CheckBox cbAutoUseProjectInterpreter_;
+   protected boolean initialAutoUseProjectInterpreter_;
    
    protected String initialPythonPath_;
    protected PythonInterpreter interpreter_;


### PR DESCRIPTION
NOTE: this is targeting the Ghost Orchid patch.

Adding assorted code reviewers since I'm one owner of this area, and Kevin is the other and is mostly OOO.

### Intent

The setting in Python preferences entitled "Automatically activate project-local Python environments" was not being persisted when the options dialog was closed. This made it impossible to disable the new functionality that this setting was added for.

See related issue: #9952

### Approach

When closing/applying preference changes, persist the setting if modified, and prompt for session restart. That is necessary for the setting to take effect.

### Automated Tests

None

### QA Notes

Verify that this setting can be enabled/disabled, and the setting persists. Also verify that the scenario described in the related issue is now working (i.e. if you turn off this checkbox, the RETICULATE_PYTHON environment variable will not be set automatically).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


