### PR TITLE
Implement scroll workaround to RMD files using iframes to show content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 * Fixed a bug where Slurm Launcher jobs with standard error would never be written to the output file (#203)
 * Fixed a bug where Slurm Launcher jobs that exited due to a signal would not show the exit code as 128+signal (#203)
 * Fixed a bug where Launcher log files could be stuck being owned by the root user (#9728)
+* Fixed scrolling past long sub-content (like kables) in RMD files. User must interact with sub-content in order to scroll through it (#2202)
 
 ### Misc
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
@@ -36,6 +36,9 @@ public class ChunkOutputFrame extends DynamicIFrame
             loadUrl(url_, onCompleted_);
          }
       };
+
+      getElement().getStyle().setProperty("pointerEvents", "none");
+      getElement().getStyle().setProperty("opacity", "0.7");
    }
 
    void loadUrl(String url, Command onCompleted)
@@ -115,7 +118,7 @@ public class ChunkOutputFrame extends DynamicIFrame
       
       onRenderedTimer.schedule(100);
    }
-   
+
    private final Timer timer_;
    private String url_;
    private Command onCompleted_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -683,18 +683,43 @@ public class ChunkOutputStream extends FlowPanel
     * @param el the Element to target for event setup, which should always be {@code this}
     */
    private native void setUpEvents(Element el) /*-{
+                                             
+      // debounce user inputs to make scrolling behavior more forgiving: the user does not have to keep their
+      // mouse exactly in place to continue scrolling. The user most pause over the sub-content after
+      // scrolling before we allow them to enable it with a mousemove.
+      var debounceId = -1
+      var debounceHandler = function(dispatch) {
+         return function() {
+            el.removeEventListener("mouseover", overEventHandler);
+            el.removeEventListener("mousemove", moveEventHandler);
+            el.addEventListener("mouseout", outEventHandler, { once: true });
+            clearTimeout(debounceId);
+            debounceId = setTimeout(function() {
+
+               if (dispatch)
+                  moveEventHandler();
+               else
+                  el.addEventListener("mousemove", moveEventHandler, { once: true });
+            }, 333);
+         };
+      };
+
+      var overEventHandler = debounceHandler(true);
+
       // create two event handlers: 
       // - one to handle when the mouse leaves the iframe,
       // - another to handle when the mouse moves inside the current widget
       //
       // mousemove events signal user intent to do something with the current iframe, which will
       // "unlock" the frame for interaction. When the mouse leaves, the frame is disabled, which prevents the
-      // frame from eating mouse events (like scroll). This makes it possible to scroll accross iframes
+      // frame from eating mouse events (like scroll). This makes it possible to scroll across iframes
       // without interruptions, assuming the user keeps their mouse perfectly still.
       //
       // Each event sets up the other in such a way that they can only ever trigger once at a time.
-
       var moveEventHandler = function() {
+         // need to remove the mouseout event on the parent el, stop it from firing when the
+         // iframe starts intercepting events -- it actually counts as a mouseout on the parent.
+         el.removeEventListener("mouseout", outEventHandler);
          var frames = el.querySelectorAll("iframe");
          if (!frames.length)
             return;
@@ -707,7 +732,9 @@ public class ChunkOutputStream extends FlowPanel
       };
 
       var outEventHandler = function() {
+         clearTimeout(debounceId);
          var frames = el.querySelectorAll("iframe");
+
          if (!frames.length)
             return;
 
@@ -716,10 +743,17 @@ public class ChunkOutputStream extends FlowPanel
             frame.style.opacity = 0.7;
          });
 
-         el.addEventListener("mousemove", moveEventHandler, { once: true });
+         el.addEventListener("mouseover", overEventHandler, { once: true });
       }
 
-      el.addEventListener("mousemove", moveEventHandler, { once: true });
+      el.addEventListener("click", function() { 
+         clearTimeout(debounceId);
+         el.removeEventListener("mouseover", overEventHandler);
+         el.removeEventListener("mousemove", moveEventHandler);
+         moveEventHandler(); 
+      });
+      el.addEventListener("wheel", debounceHandler());
+      el.addEventListener("mouseover", overEventHandler, { once: true });
    }-*/;
    
    private String classOfOutput(int type)


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio/issues/2202

### Intent

Solve an annoying UX issue in which users scrolling through RMarkdown files with sub-content (like kables), will be be stopped once their mouse enters the content area.

The "real" solution would be to not use `<iframe/>` anymore, as `<iframe/>` can cause unpredictable behavior.

### Approach

The solution is a hack using a native function - by default the rendered output `<iframe/>` elements are "disabled" from user interaction until the user moves their mouse inside the sub-content. This will "enable" the `<iframe/>`, and it will begin accepting pointer events. Moving the mouse out of the content "re-disables" user interaction so that scroll behavior becomes predictable again.

This makes it possible to scroll vertically through a document, uninterrupted, assuming you do not move your mouse at all, without being interrupted by sub-content. 

### Automated Tests

I am not sure if this is possible to test with automation, as it is so specific to mouse movement and scroll inputs.

### QA Notes

Use [kable_scolling.rmd](https://github.com/rstudio/rstudio/files/1727946/kable_scolling.txt) as an example
- Run all code blocks to generate sub-content that both scrolls and does not scroll
- Verify that you can scroll from the top of the document to the bottom without encountering a pause, provided you keep the mouse pointer perfectly still.
- Verify that moving the mouse over sub-content allows you to scroll its content
- Verify that removing the mouse from the sub-content area disables the sub-content again, and scroll behavior on the main document is restored.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


