### PR TITLE
Speed up Mac builds by avoiding double-compile of GWT

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -211,9 +211,14 @@ if [ -n "${build_x86_64}" ]; then
       "${PKG_DIR}/../.."
    info "Done!"
 
-   info "Building for x86_64 with flags '${MAKEFLAGS}' ..."
-   arch -x86_64 "${CMAKE}" --build . --target all -- ${MAKEFLAGS}
-   info "Done!"
+
+   if [ "${build_package}" != "1" ]; then
+      # don't need to build here, it will happen during the packaging step below,
+      # otherwise the lengthy GWT build will happen twice (it isn't incremental)
+      info "Building for x86_64 with flags '${MAKEFLAGS}' ..."
+      arch -x86_64 "${CMAKE}" --build . --target all -- ${MAKEFLAGS}
+      info "Done!"
+   fi
 
    # restore JAVA_HOME
    restore-java-home
@@ -287,7 +292,7 @@ if [ "${build_package}" = "1" ]; then
 
    # perform install
    cd "${BUILD_DIR_X86_64}"
-   "${CMAKE}" --build . --target install
+   "${CMAKE}" --build . --target install -- ${MAKEFLAGS}
 
    if [ "${rstudio_target}" = "Electron" ]; then
       OLDPATH="${PATH}"


### PR DESCRIPTION
### Intent

Our official Mac build (via `make-package`) builds the GWT subproject twice. GWT doesn't do incremental builds, so takes nearly as long the second time as the first.

On my Core i9 MBP, the GWT build alone takes 10 minutes, so given we have a single Mac builder, and an increasing number of branches competing for its services, shaving that amount of time (relatively) off the builds would be nice.

`make-package` for Mac currently does these steps:

1. `cmake generate` for Intel
2. `cmake build all` against that (includes GWT)
3. `cmake generate` and `build` for M1 (doesn't include GWT)
4. `cmake build install` back in the Intel directory (once again builds GWT)
5. bundling up of that produced install image into a DMG 

### Approach

If doing a package build, skip step #2 above. Generate the project tree for Intel but don't build it. Then step #4 will do the full build, including GWT.

I did package builds on my Intel Mac and my ARM Mac and everything appears to be fine. Always possible there's something slightly different on the official builder, but only one way to find that out.

### Automated Tests

No tests. Purely a build-time thing.

### QA Notes

Assuming the builds don't break, confirm the resulting Mac desktop builds "work" on both Intel and ARM. Routine usage, nothing special.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


