### PR TITLE
backport gwt build speedups: 9885, 9889, 9986

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -140,12 +140,7 @@ if [ "${clean}" = "1" ]; then
 fi
 
 # set up MAKEFLAGS
-# don't use all CPUs on build machine (appears to cause hangs)
-if [ -n "${JENKINS_URL}" ]; then
-   MAKEFLAGS="${MAKEFLAGS} -j2"
-else
-   MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
-fi
+MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
 
 # perform an x86_64 build
 if [ -n "${build_x86_64}" ]; then
@@ -188,9 +183,13 @@ if [ -n "${build_x86_64}" ]; then
       "${PKG_DIR}/../.."
    info "Done!"
 
-   info "Building for x86_64 with flags '${MAKEFLAGS}' ..."
-   arch -x86_64 "${CMAKE}" --build . --target all -- ${MAKEFLAGS}
-   info "Done!"
+   if [ "${build_package}" != "1" ]; then
+      # don't need to build here, it will happen during the packaging step below,
+      # otherwise the lengthy GWT build will happen twice (it isn't incremental)
+      info "Building for x86_64 with flags '${MAKEFLAGS}' ..."
+      arch -x86_64 "${CMAKE}" --build . --target all -- ${MAKEFLAGS}
+      info "Done!"
+   fi
 
    # restore JAVA_HOME
    restore-java-home
@@ -265,7 +264,7 @@ if [ "${build_package}" = "1" ]; then
 
    # perform install
    cd "${BUILD_DIR_X86_64}"
-   "${CMAKE}" --build . --target install
+   "${CMAKE}" --build . --target install -- ${MAKEFLAGS}
 
    if [ "${build_dmg}" = "1" ]; then
 

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -61,6 +61,19 @@ if(GWT_BUILD)
 
    # invoke ant to build
    add_custom_target(gwt_build ALL)
+
+   # wait for major C++ work to complete before running the GWT build;
+   # the Java compiler often runs out of resources when a parallel C++
+   # is happening: https://github.com/rstudio/rstudio/issues/7660
+   if (TARGET rserver)
+      add_dependencies(gwt_build rsession rserver)
+   elseif(TARGET desktop)
+      add_dependencies(gwt_build rsession desktop)
+   else()
+      add_dependencies(gwt_build rsession)
+   endif()
+
+
    add_custom_command(
       TARGET gwt_build
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
### Intent

Backport macOS build-time reductions from main:

- run GWT (Java) build step after C++ builds complete #9885
- use all cores on Mac builder #9889
- Speed up Mac builds by avoiding double-compile of GWT #9986
