### PR TITLE
simplify python detection

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -144,59 +144,6 @@
    if (file.exists(prefsPython))
       return(path.expand(prefsPython))
    
-   # on Windows, help users find a default version of Python if possible
-   if (.rs.platform.isWindows)
-   {
-      pythonPath <- .rs.python.findWindowsPython()
-      if (file.exists(pythonPath))
-         return(pythonPath)
-   }
-   
-   # look for python + python3 on the PATH
-   if (!.rs.platform.isWindows)
-   {
-      python3 <- Sys.which("python3")
-      if (nzchar(python3) && python3 != "/usr/bin/python3")
-         return(python3)
-      
-      python <- Sys.which("python")
-      if (nzchar(python) && python != "/usr/bin/python")
-      {
-         info <- .rs.python.interpreterInfo(python, NULL)
-         version <- numeric_version(info$version, strict = FALSE)
-         if (!is.na(version) && version >= "3.2")
-            return(python)
-      }
-   }
-   
-   # if the user has Anaconda installed, then try auto-activating
-   # the base environment of that Anaconda installation
-   conda <- .rs.python.findCondaBinary()
-   if (file.exists(conda))
-   {
-      pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
-      python <- file.path(dirname(conda), pythonPath)
-      if (file.exists(python))
-         return(python)
-   }
-   
-   # fall back to versions of python in /usr/bin if available
-   if (!.rs.platform.isWindows)
-   {
-      python3 <- Sys.which("python3")
-      if (nzchar(python3) && python3 == "/usr/bin/python3")
-         return(python3)
-      
-      python <- Sys.which("python")
-      if (nzchar(python) && python == "/usr/bin/python")
-      {
-         info <- .rs.python.interpreterInfo(python, NULL)
-         version <- numeric_version(info$version, strict = FALSE)
-         if (!is.na(version) && version >= "3.2")
-            return(python)
-      }
-   }
-   
    # no python found; return empty string placeholder
    ""
    


### PR DESCRIPTION
### Intent

Reduce scenarios where RStudio's auto-selection of a Python environment can stomp over user's configuration (e.g. by over-aggressively setting RETICULATE_PYTHON).

This tackles the short-term approach recommended by @kevinushey in #9999.

There's a longer-term issue to do this additional detection more safely, tracked in #9990.

The original issue for this and closely related problems was #9952.

### Approach

Delete the code it was recommended we remove.

### Automated Tests

Nothing specific to this change

### QA Notes

Retest scenario described in #9952 both with and without the checkbox selected in Python preferences.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


