### PR TITLE
remove duplicate command for serveQuartoSite

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -2437,11 +2437,6 @@ well as menu structures (for main menu and popup menus).
         menuLabel="_Quarto Doc..."
         desc="Create a blank Quarto document in current directory"
         rebindable="false"/>
-        
-   <cmd id="serveQuartoSite"
-        menuLabel="_Serve Site"
-        desc="Run development server for Quarto site in current directory"
-        rebindable="false"/>      
 
    <cmd id="touchRHTMLDoc"
         menuLabel="R _HTML"


### PR DESCRIPTION
### Intent

`Commands.cmd.xml` has two almost identical entries for `serveQuartoSite`. This hasn't been a problem (apparently) but some incoming work for adding localizability to commands and menus breaks if there are duplicates, so want this in before that.

The original is here:

https://github.com/rstudio/rstudio/blob/7dcb20a2cc2ca8ba2a83387e38e23f222d7d4db0/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml#L1122-L1125

The newer one here (only difference is addition of the "... in current directory" to the description):

https://github.com/rstudio/rstudio/blob/7dcb20a2cc2ca8ba2a83387e38e23f222d7d4db0/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml#L2441-L2444

### Approach

Kept the original, got rid of the newer one.

### Automated Tests

None, this should be a no-op from an end-user and automation standpoint.

### QA Notes

The command in question is shown on the Build menu when a Quarto project is currently open, and the name is dynamically set at runtime (e.g. to "Serve Website" for a Quarto website project).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


