### PR TITLE
Fix for Verify Installation

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -53,7 +53,7 @@ namespace r_util {
       const std::string propertiesDirName_ = "properites";
 
       FilePath getPropertyDir() const;
-      FilePath getPropertyFile(const std::string& id, const std::string& name) const;
+      FilePath getPropertyFile(const std::string& name) const;
       
       static const std::map<std::string, std::string> fileNames;
       

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -49,9 +49,8 @@ namespace r_util {
       Error writeProperties(const std::string& id, const std::map<std::string, std::string>& properties) override;
 
    private:
-      FilePath activeSessionsDir_;
+      FilePath scratchPath_;
       const std::string propertiesDirName_ = "properites";
-      const std::string fileSessionDirPrefix_ = "session-";
 
       FilePath getPropertyDir(const std::string& id) const;
       FilePath getPropertyFile(const std::string& id, const std::string& name) const;
@@ -84,8 +83,7 @@ namespace r_util {
    class ActiveSessionStorageFactory
    {
    public:
-      static std::shared_ptr<IActiveSessionStorage> getActiveSessionStorage();
-      static std::shared_ptr<IActiveSessionStorage> getFileActiveSessionStorage();
+      static std::shared_ptr<IActiveSessionStorage> getFileActiveSessionStorage(const FilePath& scratchPath);
    };
 
 } // namespace r_util

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -52,7 +52,7 @@ namespace r_util {
       FilePath scratchPath_;
       const std::string propertiesDirName_ = "properites";
 
-      FilePath getPropertyDir(const std::string& id) const;
+      FilePath getPropertyDir() const;
       FilePath getPropertyFile(const std::string& id, const std::string& name) const;
       
       static const std::map<std::string, std::string> fileNames;

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -39,17 +39,6 @@ class ActiveSession : boost::noncopyable
 private:
 
    friend class ActiveSessions;
-   explicit ActiveSession() 
-   {
-      storage_ = ActiveSessionStorageFactory::getActiveSessionStorage();
-   }
-
-   ActiveSession(
-      const std::string& id) :
-         id_(id) 
-   {
-      storage_ = ActiveSessionStorageFactory::getActiveSessionStorage();
-   }
 
    ActiveSession(
       const std::string& id,
@@ -57,7 +46,6 @@ private:
          id_(id),
          scratchPath_(scratchPath)
    {
-      storage_ = ActiveSessionStorageFactory::getActiveSessionStorage();
       core::Error error = scratchPath_.ensureDirectory();
       if (error)
          LOG_ERROR(error);
@@ -66,6 +54,8 @@ private:
       error = propertiesPath_.ensureDirectory();
       if (error)
          LOG_ERROR(error);
+
+      storage_ = ActiveSessionStorageFactory::getFileActiveSessionStorage(scratchPath_);
    }
 
    const std::string kExecuting = "executing";
@@ -395,7 +385,6 @@ public:
    explicit ActiveSessions(const FilePath& rootStoragePath)
    {
       storagePath_ = storagePath(rootStoragePath);
-      storage_ = ActiveSessionStorageFactory::getActiveSessionStorage();
       Error error = storagePath_.ensureDirectory();
       if (error)
          LOG_ERROR(error);
@@ -434,7 +423,6 @@ public:
 
 private:
    core::FilePath storagePath_;
-   std::shared_ptr<IActiveSessionStorage> storage_;
 };
 
 // active session as tracked by rserver processes

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -107,7 +107,7 @@ namespace
 
     Error FileActiveSessionStorage::readProperties(const std::string& id, std::map<std::string, std::string>* pValues)
     {
-        FilePath propertyDir = getPropertyDir(id);
+        FilePath propertyDir = getPropertyDir();
         std::vector<FilePath> files{};
         std::vector<FilePath> failedFiles{};
         pValues->empty();
@@ -156,7 +156,7 @@ namespace
                 failedFiles, ERROR_LOCATION);
     }
 
-    FilePath FileActiveSessionStorage::getPropertyDir(const std::string& id) const
+    FilePath FileActiveSessionStorage::getPropertyDir() const
     {
         FilePath propertiesDir = scratchPath_.completeChildPath(propertiesDirName_);
         propertiesDir.ensureDirectory();
@@ -165,7 +165,7 @@ namespace
 
     FilePath FileActiveSessionStorage::getPropertyFile(const std::string& id, const std::string& name) const
     {
-        FilePath propertiesDir = getPropertyDir(id);
+        FilePath propertiesDir = getPropertyDir();
         const std::string& fileName = getPropertyFileName(name);
         return propertiesDir.completeChildPath(fileName);
     }

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -43,10 +43,10 @@ namespace
     }
 } // anonymous namespace
 
-    FileActiveSessionStorage::FileActiveSessionStorage(const FilePath& activeSessionsDir) :
-        activeSessionsDir_ (activeSessionsDir)
+    FileActiveSessionStorage::FileActiveSessionStorage(const FilePath& scratchPath) :
+        scratchPath_ (scratchPath)
     {
-        Error error = activeSessionsDir_.ensureDirectory();
+        Error error = scratchPath_.ensureDirectory();
         if(error)
             LOG_ERROR(error);
     }
@@ -158,7 +158,7 @@ namespace
 
     FilePath FileActiveSessionStorage::getPropertyDir(const std::string& id) const
     {
-        FilePath propertiesDir = activeSessionsDir_.completeChildPath(fileSessionDirPrefix_ + id + "/" + propertiesDirName_);
+        FilePath propertiesDir = scratchPath_.completeChildPath(propertiesDirName_);
         propertiesDir.ensureDirectory();
         return propertiesDir;
     }
@@ -170,15 +170,9 @@ namespace
         return propertiesDir.completeChildPath(fileName);
     }
 
-    std::shared_ptr<IActiveSessionStorage> ActiveSessionStorageFactory::getActiveSessionStorage()
+    std::shared_ptr<IActiveSessionStorage> ActiveSessionStorageFactory::getFileActiveSessionStorage(const FilePath& scratchPath)
     {
-        return getFileActiveSessionStorage();
-    }
-
-    std::shared_ptr<IActiveSessionStorage> ActiveSessionStorageFactory::getFileActiveSessionStorage()
-    {
-        FilePath dataDir = ActiveSessions::storagePath(core::system::xdg::userDataDir());
-        return std::make_shared<FileActiveSessionStorage>(FileActiveSessionStorage(dataDir));
+        return std::make_shared<FileActiveSessionStorage>(FileActiveSessionStorage(scratchPath));
     }
 } // namespace r_util
 } // namepsace core

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -85,7 +85,7 @@ namespace
         pValues->empty();
         for (const std::string &name : names)
         {
-            FilePath readPath = getPropertyFile(id, name);
+            FilePath readPath = getPropertyFile(name);
             std::string value = "";
 
             if (readPath.exists())
@@ -143,7 +143,7 @@ namespace
         for (const std::pair<std::string, std::string> &prop : properties)
         {
 
-            FilePath writePath = getPropertyFile(id, prop.first);
+            FilePath writePath = getPropertyFile(prop.first);
             Error error = core::writeStringToFile(writePath, prop.second);
             if (error)
                 failedFiles.push_back(writePath);
@@ -163,7 +163,7 @@ namespace
         return propertiesDir;
     }
 
-    FilePath FileActiveSessionStorage::getPropertyFile(const std::string& id, const std::string& name) const
+    FilePath FileActiveSessionStorage::getPropertyFile(const std::string& name) const
     {
         FilePath propertiesDir = getPropertyDir();
         const std::string& fileName = getPropertyFileName(name);

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -156,7 +156,8 @@ boost::shared_ptr<ActiveSession> ActiveSessions::get(const std::string& id) cons
 
 boost::shared_ptr<ActiveSession> ActiveSessions::emptySession(const std::string& id) const
 {
-   return boost::shared_ptr<ActiveSession>(new ActiveSession(id));
+   FilePath scratchPath = storagePath_.completeChildPath(kSessionDirPrefix + id);
+   return boost::shared_ptr<ActiveSession>(new ActiveSession(id, scratchPath));
 }
 
 std::vector<boost::shared_ptr<GlobalActiveSession> >


### PR DESCRIPTION
RActiveSessionStorage was making assumptions about the context when a
ActiveSessionStorage was created, using our XDG to discover the storage
directory.

Launcher creates some sessions to do verification but the XDG is not
populated, so it was searching in the / of the filesystem.

Removing unused or easily substitutable constructors for ActiveSession
to increase clarity.

Switched to the FileActiveSessionStorage always taking a directory,
which will be the scratch path (session-<id>) path. Gets
FileActiveStorage out of the storage discovery game.

Removed unused factory methods, we can reintroduce them later, but they were leading us astray here.
The id will still be necessary for DB calls to read and write properties


### Intent

Address issue [3084](https://github.com/rstudio/rstudio-pro/issues/3084) When using verify-installation, and certain other activities, rserver or rlauncher throws out
```
ERROR system error 13 (Permission denied) [path: /root/.local/share/rstudio/sessions/active, target-dir: ]; OCCURRED AT rstudio::core::Error rstudio::core::FilePath::createDirectory(const string&) const src/cpp/shared_core/FilePath.cpp:838; LOGGED FROM: rstudio::core::r_util::FileActiveSessionStorage::FileActiveSessionStorage(const rstudio::core::FilePath&) src/cpp/core/r_util/RActiveSessionStorage.cpp:51
```
This is caused by the no argument use of the getActiveSessionStorage() which then attempts to discover the storage directory. In some contexts the appropriate user dir isn't populated, or is populated with root's info.

### Approach

Stop using no arg getActiveSessionStorage(). We now use the getFileActiveStorage(scratchPath) to construct a FileActiveStorage for a specific scratchpath, instead of attempting discovery.
Refactor FileActiveStorage to hold the scratch path, not the storage path, so that changes the paths to the property files.

Removed unused factory methods.

Removed unused ActiveSession constructors which just muddied the waters.

### Automated Tests

Without running as an integration test this will only either perform trivial tests, or be untestable.

### QA Notes

The above error message should no longer appear when running verify-installation in launcher configuration.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


