### PR TITLE
ensure graphics device initialized when replaying plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 
 ### Bugfixes
 
+* Fixed an issue that could cause calls to `grid` functions to fail after restart (#2919)
 * Fixed errors when uploading files/directory names with invalid characters (Pro #698)
 * Added error when rsession may be running a different version of R than expected (Pro #2477)
 * Fixed "No such file or directory" errors when auto-saving R Notebook chunks while running them (#9284)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -389,14 +389,14 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 # record an object to a file
-.rs.addFunction( "saveGraphics", function(filename)
+.rs.addFunction("saveGraphics", function(filename)
 {
-   plot = grDevices::recordPlot()
-   save(plot, file=filename)
+   plot <- grDevices::recordPlot()
+   save(plot, file = filename)
 })
 
 # restore an object from a file
-.rs.addFunction( "restoreGraphics", function(filename)
+.rs.addFunction("restoreGraphics", function(filename)
 {
    # load the 'plot' object
    envir <- new.env(parent = emptyenv())
@@ -454,7 +454,18 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    if (is.null(plotPid) || (plotPid != Sys.getpid()))
       attr(plot, "pid") <- Sys.getpid()
    
-   # we suppressWarnings so that R doesnt print a warning if we restore
+   # if this plot depends on the grid package, and we don't have a graphics
+   # device open, then we'll have to create a new one
+   # https://github.com/rstudio/rstudio/issues/2919
+   for (item in plot) {
+      name <- attr(item, "pkgName", exact = TRUE)
+      if (is.character(name) && name[[1L]] %in% c("grid", "ggplot2")) {
+         grid::grid.newpage()
+         break
+      }
+   }
+   
+   # we suppressWarnings so that R doesn't print a warning if we restore
    # a plot saved from a previous version of R (which will occur if we 
    # do a resume after upgrading the version of R on the server)
    suppressWarnings(grDevices::replayPlot(plot))

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -460,7 +460,8 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    for (item in plot) {
       name <- attr(item, "pkgName", exact = TRUE)
       if (is.character(name) && name[[1L]] %in% c("grid", "ggplot2")) {
-         grid::grid.newpage()
+         if (requireNamespace("grid", quietly = TRUE))
+            grid::grid.newpage()
          break
       }
    }

--- a/src/cpp/session/modules/SessionPlots.R
+++ b/src/cpp/session/modules/SessionPlots.R
@@ -17,14 +17,14 @@
 setHook(
   hookName = "before.plot.new", 
   value = function() { 
-    .Call("rs_emitBeforeNewPlot")
+    .Call("rs_emitBeforeNewPlot", PACKAGE = "(embedding)")
   },
   action = "append")
 
 setHook(
   hookName = "before.grid.newpage", 
   value = function() { 
-    .Call("rs_emitBeforeNewGridPage")
+    .Call("rs_emitBeforeNewGridPage", PACKAGE = "(embedding)")
   },
   action = "append")
 
@@ -32,7 +32,7 @@ setHook(
 setHook(
   hookName = "plot.new", 
   value = function() { 
-    .Call("rs_emitNewPlot")
+    .Call("rs_emitNewPlot", PACKAGE = "(embedding)")
   },
   action = "append")
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/2919.

### Approach

When using `grDevices::replayPlot()`, one needs to ensure that an appropriate graphics device is already available for use. `replayPlot()` seems to make a best-effort to initialize the graphics device, but it seems to fail if the plot depends on (for example) the `grid` package.

This PR forces us to check and see whether the plot depends on `grid`, and explicitly creates a new page for the graphics device to draw in before calling `replayPlot()`.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/2919#issue-329523236.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
