### PR TITLE
Automate dependencies for i18n regeneration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,6 +48,7 @@ RUN apt-get update && \
     patchelf \
     pkg-config \
     python \
+    python3 \
     r-base \
     rrdtool \
     software-properties-common \

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -62,6 +62,7 @@ sudo apt-get -y install \
   patchelf \
   pkg-config \
   python \
+  python3 \
   rrdtool \
   software-properties-common \
   unzip \

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -96,3 +96,10 @@ cd ../common
 ./install-common bionic
 cd ../linux
 
+# Python packages for i18n
+if [ -x "$(command -v python3)" ]; then
+  pushd ../../src/gwt/tools/i18n-helpers
+  python3 -m venv VENV
+  ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
+  popd
+fi 

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -63,6 +63,7 @@ sudo apt-get -y install \
   patchelf \
   pkg-config \
   python \
+  python3 \
   rrdtool \
   software-properties-common \
   unzip \

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -100,3 +100,10 @@ sudo ./install-crashpad bionic
 ./install-common focal
 cd ../linux
 
+# Python packages for i18n
+if [ -x "$(command -v python3)" ]; then
+  pushd ../../src/gwt/tools/i18n-helpers
+  python3 -m venv VENV
+  ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
+  popd
+fi 

--- a/dependencies/linux/install-dependencies-stretch
+++ b/dependencies/linux/install-dependencies-stretch
@@ -63,6 +63,7 @@ sudo apt-get -y install \
   p7zip-full \
   patchelf \
   python \
+  python3 \
   r-base \
   rrdtool \
   uuid-dev \

--- a/dependencies/linux/install-dependencies-stretch
+++ b/dependencies/linux/install-dependencies-stretch
@@ -84,3 +84,10 @@ cd ../common
 ./install-common debian9
 cd ../linux
 
+# Python packages for i18n
+if [ -x "$(command -v python3)" ]; then
+  pushd ../../src/gwt/tools/i18n-helpers
+  python3 -m venv VENV
+  ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
+  popd
+fi 

--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -105,3 +105,13 @@ if ! is-jenkins; then
    fi
 fi
 
+# ensure python requirements are installed
+if ! is-jenkins; then
+   if has-program python3; then
+     section "Installing python packages for i18n"
+     pushd ../../src/gwt/tools/i18n-helpers
+     python3 -m venv VENV
+     ./VENV/bin/pip install --disable-pip-version-check -r commands.cmd.xml/requirements.txt
+     popd
+   fi
+fi

--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -50,6 +50,13 @@ FORMULAS=(
    r
 )
 
+# Python only needed for developer builds
+if ! is-jenkins; then
+  if [ ! has-program python3; then
+    FORMULAS+=(python3)
+  fi
+fi
+
 HOMEBREW_PREFIX=$(brew --prefix)
 for FORMULA in "${FORMULAS[@]}"; do
    if [ -d "${HOMEBREW_PREFIX}/opt/${FORMULA}" ]; then
@@ -66,4 +73,3 @@ grep -qxF 'set startup-with-shell off' ~/.gdbinit || echo "set startup-with-shel
 cd ../common
 ./install-common
 cd ../osx
-

--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -52,7 +52,7 @@ FORMULAS=(
 
 # Python only needed for developer builds
 if ! is-jenkins; then
-  if [ ! has-program python3; then
+  if ! has-program python3; then
     FORMULAS+=(python3)
   fi
 fi

--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -75,6 +75,7 @@ choco install -y visualstudio2017buildtools --version 15.8.2.0
 choco install -y visualstudio2017-workload-vctools --version 1.3.0
 choco install -y nsis
 choco install -y activeperl
+choco install -y python
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -192,6 +192,12 @@ pushd ..\..\src\gwt\panmirror\src\editor
 call yarn install
 popd
 
+if exist C:\Windows\py.exe (
+  pushd ..\..\src\gwt\tools\i18n-helpers\
+  py -3 -m venv VENV
+  VENV\Scripts\pip install --disable-pip-version-check -r commands.cmd.xml\requirements.txt
+  popd
+)
 
 call install-packages.cmd
 

--- a/dependencies/windows/tools/.gitignore
+++ b/dependencies/windows/tools/.gitignore
@@ -1,0 +1,1 @@
+.wget-hsts

--- a/src/gwt/ant
+++ b/src/gwt/ant
@@ -13,6 +13,8 @@ fi
 if [ -z "${JAVA_HOME}" ]; then
 	
 	read -r -d '' homes <<- EOF
+	/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home
+	/usr/lib/jvm/java-11-openjdk-amd64/jre
 	/Library/Java/JavaVirtualMachines/adoptopenjdk-8.jdk/Contents/Home
 	/usr/lib/jvm/java-8-openjdk-amd64/jre
 	EOF

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -240,14 +240,15 @@
    </target>
 
    <!-- configure props for i18n tasks -->
-   <condition property="python.bin" value="${tools.dir}/i18n-helpers/VENV/Scripts/python.exe">
+   <condition property="python.bin.detect" value="${tools.dir}/i18n-helpers/VENV/Scripts/python.exe">
      <os family="windows" />
    </condition>
-   <condition property="python.bin" value="${tools.dir}/i18n-helpers/VENV/bin/python">
+   <condition property="python.bin.detect" value="${tools.dir}/i18n-helpers/VENV/bin/python">
      <not>
         <os family="windows" />
      </not>
    </condition>
+   <property name="python.bin" location="${python.bin.detect}"/> <!-- location of i18n script -->
    <property name="commands.dir" value="${src.dir}/org/rstudio/studio/client/workbench/commands"/> <!-- location of Commands.cmd.xml directory -->
    <property name="python-executable-full-path" location="${tools.dir}/i18n-helpers/commands.cmd.xml/commands_xml_to_i18n.py"/> <!-- location of i18n script -->
    <property name="commands-xml-full-path" location="${commands.dir}/Commands.cmd.xml"/> <!-- location of Commands & Menus definition file -->

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -240,9 +240,16 @@
    </target>
 
    <!-- configure props for i18n tasks -->
+   <condition property="python.bin" value="${tools.dir}/i18n-helpers/VENV/Scripts/python.exe">
+     <os family="windows" />
+   </condition>
+   <condition property="python.bin" value="${tools.dir}/i18n-helpers/VENV/bin/python">
+     <not>
+        <os family="windows" />
+     </not>
+   </condition>
    <property name="commands.dir" value="${src.dir}/org/rstudio/studio/client/workbench/commands"/> <!-- location of Commands.cmd.xml directory -->
    <property name="python-executable-full-path" location="${tools.dir}/i18n-helpers/commands.cmd.xml/commands_xml_to_i18n.py"/> <!-- location of i18n script -->
-   <property name="python-check-version-full-path" location="${tools.dir}/i18n-helpers/python-check-version.py"/> <!-- location of script for python version check -->
    <property name="commands-xml-full-path" location="${commands.dir}/Commands.cmd.xml"/> <!-- location of Commands & Menus definition file -->
    <property name="command-constants-full-path" location="${commands.dir}/CmdConstants.java"/> <!-- location of CmdConstants.java -->
    <property name="command-prop-full-path" location="${commands.dir}/CmdConstants_en.properties"/> <!-- location of CmdConstants en properties file -->
@@ -275,54 +282,46 @@
 
    <!-- execute i18n tasks -->
    <target name="i18n-windows" depends="i18n-windows-check" if="generate-i18n-windows">
-      <!-- verify Python version -->
+      <!-- generate Commands interface -->
       <exec executable="cmd" failifexecutionfails="true" failonerror="true">
          <arg value="/c"/>
-         <arg line="python ${python-check-version-full-path}"/>
-      </exec>
-       <!-- generate Commands interface -->
-      <exec executable="cmd" failifexecutionfails="true" failonerror="true">
-         <arg value="/c"/>
-         <arg line="python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd constant &quot;${command-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;"/>
+         <arg line="${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd constant &quot;${command-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;"/>
       </exec>
       <!-- generate Commands english property file -->
       <exec executable="cmd" failifexecutionfails="true" failonerror="true">
          <arg value="/c"/>
-         <arg line="python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd properties &quot;${command-prop-full-path}&quot;"/>
+         <arg line="${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd properties &quot;${command-prop-full-path}&quot;"/>
       </exec>
       <!-- generate Menu interface -->
       <exec executable="cmd" failifexecutionfails="true" failonerror="true">
          <arg value="/c"/>
-         <arg line="python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu constant &quot;${menu-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;"/>
+         <arg line="${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu constant &quot;${menu-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;"/>
       </exec>
       <!-- generate Menu english prop file -->
       <exec executable="cmd" failifexecutionfails="true" failonerror="true">
          <arg value="/c"/>
-         <arg line="python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu properties &quot;${menu-prop-full-path}&quot;"/>
+         <arg line="${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu properties &quot;${menu-prop-full-path}&quot;"/>
       </exec>
       <!-- regenerate checksum -->
       <checksum file="${commands-xml-full-path}" forceOverwrite="yes"/>
    </target>
    <target name="i18n-unix" depends="i18n-unix-check" if="generate-i18n-unix">
-      <!-- verify Python version -->
+
+      <!-- generate Commands interface -->
       <exec executable="/bin/sh" failifexecutionfails="true" failonerror="true">
-         <arg line="-c 'python ${python-check-version-full-path}'"/>
-      </exec>
-       <!-- generate Commands interface -->
-      <exec executable="/bin/sh" failifexecutionfails="true" failonerror="true">
-         <arg line="-c 'python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd constant &quot;${command-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;'"/>
+         <arg line="-c '${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd constant &quot;${command-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;'"/>
       </exec>
       <!-- generate Commands english property file -->
       <exec executable="/bin/sh" failifexecutionfails="true" failonerror="true">
-         <arg line="-c 'python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd properties &quot;${command-prop-full-path}&quot;'"/>
+         <arg line="-c '${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; cmd properties &quot;${command-prop-full-path}&quot;'"/>
       </exec>
       <!-- generate Menu interface -->
       <exec executable="/bin/sh" failifexecutionfails="true" failonerror="true">
-         <arg line="-c 'python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu constant &quot;${menu-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;'"/>
+         <arg line="-c '${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu constant &quot;${menu-constants-full-path}&quot; --package &quot;package org.rstudio.studio.client.workbench.commands;&quot;'"/>
       </exec>
       <!-- generate Menu english prop file -->
       <exec executable="/bin/sh" failifexecutionfails="true" failonerror="true">
-         <arg line="-c 'python ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu properties &quot;${menu-prop-full-path}&quot;'"/>
+         <arg line="-c '${python.bin} ${python-executable-full-path} &quot;${commands-xml-full-path}&quot; menu properties &quot;${menu-prop-full-path}&quot;'"/>
       </exec>
       <!-- regenerate checksum -->
       <checksum file="${commands-xml-full-path}" forceOverwrite="yes"/>

--- a/src/gwt/tools/i18n-helpers/.gitignore
+++ b/src/gwt/tools/i18n-helpers/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+VENV/

--- a/src/gwt/tools/i18n-helpers/commands.cmd.xml/.gitignore
+++ b/src/gwt/tools/i18n-helpers/commands.cmd.xml/.gitignore
@@ -1,7 +1,0 @@
-__pycache__/
-venv/
-venv2/
-venv3/
-ENV/
-VENV/
-.venv/

--- a/src/gwt/tools/i18n-helpers/python-check-version.py
+++ b/src/gwt/tools/i18n-helpers/python-check-version.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-import sys
-
-if __name__ == "__main__":
-    if sys.version_info[0] < 3:
-        raise Exception("Must use Python 3 for i18n generation")


### PR DESCRIPTION
### Intent

Addresses: #10068 (which was caused by #9987)

Developers shouldn't have to do anything special to build GWT after modifying Commands.cmd.xml. Currently you have to ensure python3 is installed and create a virtual-environment and pip install and so forth.

Note the build machines don't have this requirement for python/venv, etc, only dev machines when making changes that impact localization.

### Approach

For Mac and Linux, the standard dev-machine dependency scripts now ensure python3 is installed and the required packages are pip-installed into a virtual environment under `src/gwt/tools/i18n-helpers/VENV`.

On Windows, the PowerShell bootstrapper installs python, and install-dependencies.cmd will install the python packages into the VENV (if python is detected).

The GWT build (ant/build.xml) now references python directly from the VENV when regenerating i18n.

### Automated Tests

None, dev machine tooling.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


