### PR TITLE
Update SessionDataViewer.R

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -132,7 +132,13 @@
       if (is.character(label))
          col_label <- label
       else if (idx <= length(colLabels))
+      {
+      # check if colLabels is a named vector, if yes, use the named value, if not use the idx'th element
+      if (!is.null(names(colLabels)))
+         col_label <- colLabels[[col_name]]
+      else
          col_label <- colLabels[[idx]]
+      }
       else 
          col_label <- ""
       


### PR DESCRIPTION
Fixes issue https://github.com/rstudio/rstudio/issues/9771
Checks if the colLabels is named vector and uses the named value. Otherwise uses idx'th element of the vector colLabels.


### Intent

The sessionDataViewer currently shows wrong labels of variables. It assumes the variable label of n-th variable is also n-th value of variable.labels attribute, but this is not guaranteed. This change will take the variable label from the named vector of variable.labels, matching the variable label with the name of the variable.

### Approach

There is first a test if the colLabels is named vector. If it is, it finds the matching value from named vector. If colLabels is not a named vector it returns to old behaviour and sets the n-th value in colLabels to be the name of n-th variable.

Note that it does not currently check if the matching value exists. Would there be any circumstance that variable.labels would be a named vector but the names would be something else than variable names?  The check can be added.

### Automated Tests

No test but a visual one described in the issue and in the QA Note.

### QA Notes

```r
df <- data.frame(a=1, b=2, c=3)
attr(df, "variable.labels") <- c(a = "a", b = "b", c = "c")
View(df) #variable labels showed correctly
library(dplyr)
View(select(df, -b)) #wrong variable labels showed, should show the correct ones
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
I have sent a signed contributor agreement.

