### PR TITLE
Adds the ability to passthrough log messages and add structured data to log messages

### DIFF
--- a/src/cpp/core/Log.cpp
+++ b/src/cpp/core/Log.cpp
@@ -15,68 +15,11 @@
 
 #include <core/Log.hpp>
 
-#include <iostream>
-#include <sstream>
-#include <algorithm>
-
-#include <core/system/System.hpp>
-
 #include <shared_core/Error.hpp>
-#include <shared_core/SafeConvert.hpp>
 
 namespace rstudio {
 namespace core {
 namespace log {
-
-namespace {
-
-void logAction(LogLevel logLevel,
-               const boost::function<std::string()>& action,
-               const ErrorLocation& loggedFromLocation = ErrorLocation(),
-               const std::string& logSection = std::string())
-{
-   switch (logLevel)
-   {
-      case LogLevel::ERR:
-         return logErrorMessage(action(), logSection, loggedFromLocation);
-      case LogLevel::WARN:
-         return logWarningMessage(action(), logSection, loggedFromLocation);
-      case LogLevel::DEBUG:
-         return logDebugMessage(action(), logSection, loggedFromLocation);
-      case LogLevel::INFO:
-         return logInfoMessage(action(), logSection, loggedFromLocation);
-      case LogLevel::OFF:
-         return;
-      default:
-      {
-         assert(false);
-         logErrorMessage(
-            "Failed to log action. Invalid log level specified: " +
-            safe_convert::numberToString(static_cast<int>(logLevel)));
-         return;
-      }
-   }
-}
-
-} // anonymous namespace
-
-void logDebugAction(const boost::function<std::string()>& action,
-                    const ErrorLocation& loggedFromLocation)
-{
-   logAction(LogLevel::DEBUG,
-             action,
-             loggedFromLocation);
-}
-
-void logDebugAction(const std::string& logSection,
-                    const boost::function<std::string ()>& action,
-                    const ErrorLocation& loggedFromLocation)
-{
-   logAction(LogLevel::DEBUG,
-             action,
-             loggedFromLocation,
-             logSection);
-}
    
 std::string errorAsLogEntry(const Error& error)
 {

--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -622,6 +622,261 @@ test_context("Logging")
             REQUIRE(boost::ends_with(logContents, logStr));
          }
       }
+
+      test_that("Can passthrough log")
+      {
+         FilePath tmpConfPath;
+         REQUIRE_FALSE(FilePath::tempFilePath(".conf", tmpConfPath));
+
+         std::string confFileContents =
+               "[*]\n"
+               "logger-type=file\n"
+               "log-level=INFO\n"
+               "log-dir=" + tmpConfPath.getParent().getAbsolutePath();
+
+         REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
+
+         clearLogEnvVars();
+         core::system::setenv("RS_LOG_CONF_FILE", tmpConfPath.getAbsolutePath());
+
+         std::string id = core::system::generateShortenedUuid();
+         REQUIRE_FALSE(core::system::initializeStderrLog("logging-tests-" + id, log::LogLevel::WARN, true));
+         REQUIRE_FALSE(core::system::reinitLog());
+
+         LOG_INFO_MESSAGE("This is a message");
+
+         FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
+         REQUIRE(logFile.exists());
+
+         std::string logFileContents;
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+
+         boost::replace_all(logFileContents, "INFO", "DEBUG");
+         LOG_PASSTHROUGH_MESSAGE("mysource", logFileContents);
+
+         logFileContents.empty();
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+         REQUIRE(logFileContents.find("DEBUG") == std::string::npos);
+
+         boost::replace_all(logFileContents, "INFO", "WARNING");
+         boost::replace_all(logFileContents, "This is a message", "This is a passthrough message");
+         boost::replace_all(logFileContents, "[logging-tests-" + id + "]", "[subproc]");
+         LOG_PASSTHROUGH_MESSAGE("mysource", logFileContents);
+
+         logFileContents.empty();
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+
+         REQUIRE(logFileContents.find("WARNING") != std::string::npos);
+         REQUIRE(logFileContents.find("[subproc, log-source: mysource]") != std::string::npos);
+         REQUIRE(logFileContents.find("This is a passthrough message") != std::string::npos);
+      }
+
+      test_that("Can json log error")
+      {
+         FilePath tmpConfPath;
+         REQUIRE_FALSE(FilePath::tempFilePath(".conf", tmpConfPath));
+
+         std::string confFileContents =
+               "[*]\n"
+               "logger-type=file\n"
+               "log-message-format=json\n"
+               "log-level=debug\n"
+               "log-dir=" + tmpConfPath.getParent().getAbsolutePath();
+
+         REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
+
+         clearLogEnvVars();
+         core::system::setenv("RS_LOG_CONF_FILE", tmpConfPath.getAbsolutePath());
+
+         std::string id = core::system::generateShortenedUuid();
+         REQUIRE_FALSE(core::system::initializeStderrLog("logging-tests-" + id, log::LogLevel::WARN, true));
+         REQUIRE_FALSE(core::system::reinitLog());
+
+         LOG_ERROR(systemError(boost::system::errc::no_such_file_or_directory, "Couldn't read the file", ERROR_LOCATION));
+
+         FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
+         REQUIRE(logFile.exists());
+
+         std::string logFileContents;
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+
+         json::Object logObj;
+         REQUIRE_FALSE(logObj.parse(logFileContents));
+
+         json::Object errorObj;
+         REQUIRE_FALSE(json::readObject(logObj,
+                                        "error", errorObj));
+
+         int code = 0;
+         std::string message, type;
+         json::Object errorProperties;
+         REQUIRE_FALSE(json::readObject(errorObj,
+                                        "code", code,
+                                        "message", message,
+                                        "type", type,
+                                        "properties", errorProperties));
+
+         REQUIRE(code == boost::system::errc::no_such_file_or_directory);
+         REQUIRE(message == "No such file or directory");
+         REQUIRE(type == "system");
+
+         std::string description;
+         REQUIRE_FALSE(json::readObject(errorProperties,
+                                        "description", description));
+
+         REQUIRE(description == "Couldn't read the file");
+      }
+
+      test_that("Can log LogMessageProperties")
+      {
+         FilePath tmpConfPath;
+         REQUIRE_FALSE(FilePath::tempFilePath(".conf", tmpConfPath));
+
+         std::string confFileContents =
+               "[*]\n"
+               "logger-type=file\n"
+               "log-message-format=pretty\n"
+               "log-level=debug\n"
+               "log-dir=" + tmpConfPath.getParent().getAbsolutePath();
+
+         REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
+
+         clearLogEnvVars();
+         core::system::setenv("RS_LOG_CONF_FILE", tmpConfPath.getAbsolutePath());
+
+         std::string id = core::system::generateShortenedUuid();
+         REQUIRE_FALSE(core::system::initializeStderrLog("logging-tests-" + id, log::LogLevel::WARN, true));
+         REQUIRE_FALSE(core::system::reinitLog());
+
+         json::Object obj;
+         obj["first"] = 1;
+         obj["second"] = 2;
+         obj["third"] = 3;
+         json::Array arr;
+         arr.push_back(1);
+         arr.push_back(2);
+         arr.push_back(3);
+
+         Error err = systemError(boost::system::errc::no_such_file_or_directory,
+                                 "Couldn't find file",
+                                 ERROR_LOCATION);
+
+         uint_least64_t val = 1;
+         core::log::LogMessageProperties props = {{"prop1", val}, {"prop2", "2"}, {"prop3", 3.14}, {"prop4", obj}, {"prop5", arr}, {"prop6", err}};
+         LOG_DEBUG_MESSAGE_WITH_PROPS("Message 1", props);
+
+         FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
+         REQUIRE(logFile.exists());
+
+         std::string logFileContents;
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+
+         REQUIRE(logFileContents.find("Message 1") != std::string::npos);
+         REQUIRE(logFileContents.find("prop1: 1") != std::string::npos);
+         REQUIRE(logFileContents.find("prop2: 2") != std::string::npos);
+         REQUIRE(logFileContents.find("prop3: 3.14") != std::string::npos);
+         REQUIRE(logFileContents.find(", prop4: " + obj.write()) != std::string::npos);
+         REQUIRE(logFileContents.find(", prop5: " + arr.write()) != std::string::npos);
+         REQUIRE(logFileContents.find("Couldn't find file") != std::string::npos);
+         REQUIRE(logFileContents.find("No such file or directory") != std::string::npos);
+         REQUIRE(logFileContents.find("LoggingTests.cpp") != std::string::npos);
+
+         boost::replace_all(confFileContents, "pretty", "json");
+         REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
+
+         // reload logging configuration by sending SIGHUP to ourselves
+         // we also have to wait awhile because this is an asynchronous process handled by another thread
+         core::system::sendSignalToSelf(core::system::SigHup);
+         bool success = false;
+         for (int i = 0; i < 5; ++i)
+         {
+            boost::this_thread::sleep(boost::posix_time::milliseconds(250));
+
+            LOG_DEBUG_MESSAGE_WITH_PROPS("Message 1", props);
+
+            std::vector<std::string> logLines;
+            REQUIRE_FALSE(core::readStringVectorFromFile(logFile, &logLines));
+
+            const std::string& lastLine = logLines.at(logLines.size() - 1);
+            json::Object logObj;
+            Error err = logObj.parse(lastLine);
+            if (err)
+               continue;
+
+            std::string message;
+            json::Object properties;
+            err = json::readObject(logObj,
+                                   "message", message,
+                                   "properties", properties);
+            if (err)
+               continue;
+
+            int prop1 = 0;
+            std::string prop2;
+            double prop3;
+            json::Object prop4;
+            json::Array prop5;
+            json::Object prop6;
+
+            err = json::readObject(properties,
+                                   "prop1", prop1,
+                                   "prop2", prop2,
+                                   "prop3", prop3,
+                                   "prop4", prop4,
+                                   "prop5", prop5,
+                                   "prop6", prop6);
+            if (err)
+               continue;
+
+            success = prop1 == 1 &&
+                      prop2 == "2" &&
+                      prop3 == 3.14 &&
+                      prop4 == obj &&
+                      prop5 == arr;
+
+            if (success)
+               break;
+         }
+
+         REQUIRE(success);
+      }
+
+      test_that("Can debug action log")
+      {
+         FilePath tmpConfPath;
+         REQUIRE_FALSE(FilePath::tempFilePath(".conf", tmpConfPath));
+
+         std::string confFileContents =
+               "[*]\n"
+               "logger-type=file\n"
+               "log-message-format=pretty\n"
+               "log-level=debug\n"
+               "log-dir=" + tmpConfPath.getParent().getAbsolutePath();
+
+         REQUIRE_FALSE(core::writeStringToFile(tmpConfPath, confFileContents));
+
+         clearLogEnvVars();
+         core::system::setenv("RS_LOG_CONF_FILE", tmpConfPath.getAbsolutePath());
+
+         std::string id = core::system::generateShortenedUuid();
+         REQUIRE_FALSE(core::system::initializeStderrLog("logging-tests-" + id, log::LogLevel::WARN, true));
+         REQUIRE_FALSE(core::system::reinitLog());
+
+         log::logDebugAction([&](boost::optional<log::LogMessageProperties>* pProps) {
+            log::LogMessageProperties props = {{"1", 1}, {"2", "Two"}};
+            *pProps = props;
+            return "This was an action log";
+         });
+
+         FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
+         REQUIRE(logFile.exists());
+
+         std::string logFileContents;
+         REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
+
+         REQUIRE(logFileContents.find("This was an action log") != std::string::npos);
+         REQUIRE(logFileContents.find("[1: 1, 2: Two]") != std::string::npos);
+      }
    }
 }
 

--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -34,13 +34,6 @@ enum class LoggerType
    kFile = 2
 };
 
-void logDebugAction(const boost::function<std::string()>& action,
-                    const ErrorLocation& loggedFromLocation = ErrorLocation());
-
-void logDebugAction(const std::string& logSection,
-                    const boost::function<std::string()>& action,
-                    const ErrorLocation& loggedFromLocation = ErrorLocation());
-
 std::string errorAsLogEntry(const Error& error);
 
 // Macros for automatic inclusion of ERROR_LOCATION and easy ability to 
@@ -56,31 +49,53 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_ERROR_MESSAGE(message) rstudio::core::log::logErrorMessage(message, \
                                                                        ERROR_LOCATION)
 
+#define LOG_ERROR_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logErrorMessage(message, \
+                                                                                         std::string(), \
+                                                                                         props, \
+                                                                                         ERROR_LOCATION)
+
 #define LOG_ERROR_MESSAGE_NAMED(logSection, message) rstudio::core::log::logErrorMessage(message, \
                                                                                          logSection, \
+                                                                                         boost::none, \
                                                                                          ERROR_LOCATION)
 
 #define LOG_WARNING_MESSAGE(message) rstudio::core::log::logWarningMessage(message, \
                                                                            ERROR_LOCATION)
 
+#define LOG_WARNING_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logWarningMessage(message, \
+                                                                                             std::string(), \
+                                                                                             props, \
+                                                                                             ERROR_LOCATION)
+
 #define LOG_WARNING_MESSAGE_NAMED(logSection, message) rstudio::core::log::logWarningMessage(message, \
                                                                                              logSection, \
+                                                                                             boost::none, \
                                                                                              ERROR_LOCATION)
 
 #define LOG_INFO_MESSAGE(message) rstudio::core::log::logInfoMessage(message)
+
+#define LOG_INFO_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logInfoMessage(message, \
+                                                                                       std::string(), \
+                                                                                       props, \
+                                                                                       ErrorLocation())
 
 #define LOG_INFO_MESSAGE_NAMED(logSection, message) rstudio::core::log::logInfoMessage(message, \
                                                                                        logSection)
 
 #define LOG_DEBUG_MESSAGE(message) rstudio::core::log::logDebugMessage(message)
 
-#define LOG_DEBUG_ACTION(action) rstudio::core::log::logDebugAction(action)
+#define LOG_DEBUG_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logDebugMessage(message, \
+                                                                                         std::string(), \
+                                                                                         props, \
+                                                                                         ErrorLocation())
 
 #define LOG_DEBUG_MESSAGE_NAMED(logSection, message) rstudio::core::log::logDebugMessage(message, \
                                                                                          logSection)
 
 #define LOG_DEBUG_ACTION_NAMED(logSection, action) rstudio::core::log::logDebugAction(logSection, \
                                                                                       action)
+
+#define LOG_PASSTHROUGH_MESSAGE(source, message) rstudio::core::log::logPassthroughMessage(source, message)
 
 // define named logging sections
 #define kFileLockingLogSection "file-locking"

--- a/src/cpp/server_core/SecureKeyFile.cpp
+++ b/src/cpp/server_core/SecureKeyFile.cpp
@@ -36,7 +36,7 @@ core::Error readSecureKeyFile(const FilePath& secureKeyPath,
    if (secureKeyPath.exists())
    {
       *pKeyPathUsed = secureKeyPath.getAbsolutePath();
-      LOG_DEBUG_MESSAGE("Using secure key file: \"" + *pKeyPathUsed + "\"");
+      LOG_DEBUG_MESSAGE("Using secure key file: " + *pKeyPathUsed);
 
       // read the key
       std::string secureKey;

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -28,7 +28,10 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <vector>
 
+#include <boost/any.hpp>
+#include <boost/function.hpp>
 #include <boost/optional.hpp>
 
 #include <shared_core/system/User.hpp>
@@ -92,6 +95,14 @@ enum class LogLevel
 };
 
 /**
+ * @brief Convenience type for log message properties.
+ * Using a boost::any instead of a boost::variant allows access to json
+ * as it is currently impossible to include json types here because that
+ * would cause a circular dependency.
+ */
+typedef std::vector<std::pair<std::string, boost::any>> LogMessageProperties;
+
+/**
  * @enum LogMessageFormatType
  * @brief Enum which represents the format type for log messages.
  */
@@ -100,6 +111,22 @@ enum class LogMessageFormatType
    PRETTY = 0,   // A human-readable single line log message format
    JSON   = 1    // A JSON format, one JSON object per line
 };
+
+/**
+ * @brief Helper function which cleans the log delimiter character from a string.
+ *
+ * @param in_str    The string to be cleaned
+ *
+ * @return The cleaned string.
+ */
+std::string cleanDelimiters(const std::string& in_str);
+
+/**
+ * @brief Sets the program ID for the logger.
+ *
+ * @param in_programId       The ID of the program.
+ */
+void setProgramId(const std::string& in_programId);
 
 /**
  * @brief Adds an un-sectioned log destination to the logger.
@@ -124,15 +151,6 @@ void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination);
 void addLogDestination(const std::shared_ptr<ILogDestination>& in_destination, const std::string& in_section);
 
 /**
- * @brief Helper function which cleans the log delimiter character from a string.
- *
- * @param in_str    The string to be cleaned
- *
- * @return The cleaned string.
- */
-std::string cleanDelimiters(const std::string& in_str);
-
-/**
  * @brief Returns whether or not a file log destination is configured.
  *
  * @return Whether or not a file log destination is configured.
@@ -146,12 +164,21 @@ bool hasFileLogDestination();
  */
 bool hasStderrLogDestination();
 
-/** 
+/**
  * @brief Use to write code conditioned on whether logging is configured or not
- * 
+ *
  * @return true if log messages at this level will be displayed.
  */
 bool isLogLevel(log::LogLevel level);
+
+/**
+ * @brief Replaces logging delimiters with ' ' in the specified string.
+ *
+ * @param in_toClean    The string from which to clean logging delimiters.
+ *
+ * @return The cleaned string.
+ */
+std::string cleanDelims(const std::string& in_toClean);
 
 /**
  * @brief Logs an error to all registered destinations.
@@ -235,9 +262,13 @@ void logErrorMessage(const std::string& in_message, const ErrorLocation& in_logg
  *
  * @param in_message        The message to log as an error.
  * @param in_section        The section of the log that the message belongs in.
- * @param in_location       The location from which the error message was logged.
+ * @param in_properties     The log message properties to log.
+ * @param in_location       The location from which the message was logged.
  */
-void logErrorMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom);
+void logErrorMessage(const std::string& in_message,
+                     const std::string& in_section,
+                     const boost::optional<LogMessageProperties>& in_properties,
+                     const ErrorLocation& in_loggedFrom);
 
 /**
  * @brief Logs a warning message to all registered destinations.
@@ -269,9 +300,13 @@ void logWarningMessage(const std::string& in_message, const ErrorLocation& in_lo
  *
  * @param in_message      The message to log as a warning.
  * @param in_section      The section of the log that the message belongs in.
- * @param in_location     The location from which the error message was logged.
+ * @param in_properties   The log message properties to log.
+ * @param in_location     The location from which the message was logged.
  */
-void logWarningMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom);
+void logWarningMessage(const std::string& in_message,
+                       const std::string& in_section,
+                       const boost::optional<LogMessageProperties>& in_properties,
+                       const ErrorLocation& in_loggedFrom);
 
 /**
  * @brief Logs a debug message to all registered destinations.
@@ -303,9 +338,25 @@ void logDebugMessage(const std::string& in_message, const ErrorLocation& in_logg
  *
  * @param in_message      The message to log as a debug message.
  * @param in_section      The section of the log that the message belongs in.
- * @param in_location     The location from which the error message was logged.
+ * @param in_properties   The log message properties to log.
+ * @param in_location     The location from which the message was logged.
  */
-void logDebugMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom);
+void logDebugMessage(const std::string& in_message,
+                     const std::string& in_section,
+                     const boost::optional<LogMessageProperties>& in_properties,
+                     const ErrorLocation& in_loggedFrom);
+
+/**
+ * @brief Logs a debug message to all registered destinations by invoking an action.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::DEBUG, no log will be written.
+ *
+ * @param in_action       The action that will construct the log message if a logger is configured with debug level.
+ * @param in_section      The section of the log that the message belongs in.
+ */
+void logDebugAction(const boost::function<std::string(boost::optional<LogMessageProperties>*)>& in_action,
+                    const std::string& in_section = std::string());
 
 /**
  * @brief Logs an info message to all registered destinations.
@@ -337,9 +388,23 @@ void logInfoMessage(const std::string& in_message, const ErrorLocation& in_logge
  *
  * @param in_message      The message to log as an info message.
  * @param in_section      The section of the log that the message belongs in.
+ * @param in_properties   The log message properties to log.
  * @param in_location     The location from which the error message was logged.
  */
-void logInfoMessage(const std::string& in_message, const std::string& in_section, const ErrorLocation& in_loggedFrom);
+void logInfoMessage(const std::string& in_message,
+                    const std::string& in_section,
+                    const boost::optional<LogMessageProperties>& in_properties,
+                    const ErrorLocation& in_loggedFrom);
+
+/**
+ * @brief Logs an entire log message as is with an annotation indicating it came from source.
+ *
+ * If no destinations are registered, no log will be written.
+ *
+ * @param in_source       The source of the log message.
+ * @param in_message      The log entire log message (as would be logged by the logging engine).
+ */
+void logPassthroughMessage(const std::string& in_source, const std::string& in_message);
 
 /**
  * @brief Refreshes all log destinations. May be used after fork to prevent stale file handles.
@@ -365,13 +430,6 @@ void removeLogDestination(const std::string& in_destinationId, const std::string
  *        and re-registered with the logger to update the desired changes to the logging system.
  */
 void removeReloadableLogDestinations();
-
-/**
- * @brief Sets the program ID for the logger.
- *
- * @param in_programId       The ID of the program.
- */
-void setProgramId(const std::string& in_programId);
 
 /**
  * @brief Writes an error to the specified output stream.


### PR DESCRIPTION


### Intent

JSON logging is currently supported but not very helpful, as one has to parse JSON-within-JSON or escaped strings to get any useful information from a log message. Adding structured log properties to log messages allows JSON logging tools (such as Kibana) to easily categorize and search the data, so these properties should be included as raw JSON somehow.

Another issue is that subprocess log streams are currently relogged like so:

> 2021-10-14T17:08:46.576749Z [rstudio-launcher] INFO Received stderr from plugin Kubernetes: 2021-10-14T17:08:46.576479Z [rstudio-kubernetes-launcher] DEBUG Received get collection response...

This makes parsing of this difficult as well. Ideally, the subprocess logs would be neatly folded into the log stream as-is (and filtered out as appropriate based on the log level).

See https://github.com/rstudio/launcher/issues/226 for motivation and examples of what the properties/passthrough logging looks like in the Launcher with these changes.

### Approach

Adds structured logging via `LogMessageProperties` and passthrough logging of subprocesses via `logPassthroughMessage`.

This PR does NOT change any RSW logging (aside from the secure cookie key as that was updated on the Launcher side). This can be done by the RSW team when/as appropriate. 

Addresses https://github.com/rstudio/launcher/issues/226.

### Automated Tests

Added tests of new functionality to `LoggingTests.cpp`.

### QA Notes

No additional QA necessary. No existing logging functionality has been altered.



