### PR TITLE
use UTF-8 code page with UCRT builds of R

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 
 ### Misc
 
+* RStudio now supports the experimental UTF-8 UCRT builds of R (#9824)
 * Add commands to open selected files in columns or active editor (#7920)
 * Add *New Blank File* command to Files pane to create empty files of selected type in the directory (#1564)
 * Rename CSRF token header `X-CSRF-Token` and cookie `csrf-token` to `X-RS-CSRF-Token` and `rs-csrf-token`, respectively, to avoid clashing with similarly named headers and cookies in other services (#7319)

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -22,6 +22,7 @@
 #define R_INTERNAL_FUNCTIONS
 #include <Rversion.h>
 #include <r/RInternal.hpp>
+#include <r/RUtil.hpp>
 #include <r/RVersionInfo.hpp>
 
 #define Win32
@@ -36,6 +37,7 @@
 #include <shared_core/FilePath.hpp>
 #include <core/Exec.hpp>
 #include <core/StringUtils.hpp>
+#include <core/Version.hpp>
 #include <core/system/LibraryLoader.hpp>
 
 #include <r/RInterface.hpp>
@@ -171,6 +173,12 @@ bool initializeMaxMemoryViaCmdLineOptions()
 
 void initializeMaxMemory(const core::FilePath& rHome)
 {
+   // no action required with newer versions of R
+   const char* dllVersion = getDLLVersion();
+   core::Version rVersion(dllVersion);
+   if (rVersion >= core::Version("4.2.0"))
+      return;
+
    initializeMaxMemoryDangerously() ||
          initializeMaxMemoryViaCmdLineOptions();
 }

--- a/src/cpp/session/rsession.exe.manifest
+++ b/src/cpp/session/rsession.exe.manifest
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-   <assemblyIdentity version="1.0.0.0"
-      name="rsession"
-      type="win32"/>
+
+   <assemblyIdentity version="1.0.0.0" name="rsession" type="win32"/>
+
+   <!-- Support UTF-8 code page with R 4.2.0 and newer. -->
+   <application>
+     <windowsSettings>
+       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
+     </windowsSettings>
+   </application>
+
    <description>rsession</description>
+
    <!-- Identify the application security requirements. -->
    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
       <security>
@@ -12,6 +20,8 @@
          </requestedPrivileges>
       </security>
    </trustInfo>
+
+   <!-- Declare compatibility with different versions of Windows. -->
    <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
       <application>
          <!-- Windows 10 -->
@@ -26,4 +36,5 @@
          <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       </application>
    </compatibility>
+
 </assembly>


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9824.
Addresses https://github.com/rstudio/rstudio/issues/9792.

<img width="587" alt="Screen Shot 2021-11-15 at 4 59 33 PM" src="https://user-images.githubusercontent.com/1976582/141876563-c1904638-c54a-4907-a89d-744799dc910b.png">

<img width="108" alt="Screen Shot 2021-11-15 at 5 01 37 PM" src="https://user-images.githubusercontent.com/1976582/141876746-9744b279-ab6c-4fd9-9063-f933fa47a572.png">

### Approach

- Don't set memory limits for new versions of R, as these are not supported. (https://github.com/wch/r-source/commit/a984cc29b9b8d8821f8eb2a1081d9e0d1d4df56e)
- Define an application manifest, indicating that we want a UTF-8 code page.

### Automated Tests

N/A

### QA Notes

This would require a general QA run-through on Windows. I've at least confirmed that these builds of RStudio work with both UCRT R (where a UTF-8 code page is used) and older builds of R (where we fall back to the default ANSI code page)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
