### PR TITLE
Use native M1 Java if available when building on M1 Mac

### DIFF
--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -185,6 +185,10 @@ is-verbose () {
 	[ -n "${VERBOSE}" ] && [ "${VERBOSE}" != "0" ]
 }
 
+is-m1-mac () {
+	[ "$(arch)" = "arm64" ]
+}
+
 # Download a single file
 download () {
 

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -27,6 +27,32 @@ set-java-home () {
       _OLD_JAVA_HOME="${JAVA_HOME}"
       JAVA_HOME="$1"
       export JAVA_HOME
+      info "Found Java: ${JAVA_HOME}"
+   fi
+}
+
+# Find and set the best JAVA_HOME for the build; on an M1 Mac, prefer a native M1
+# JDK even for Intel builds. The GWT build outputs JavaScript, not anything
+# processor-native, so can use the fastest tool for the job.
+find-java-home () {
+   if is-m1-mac; then
+      if [ -e "/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home" ]; then
+         # native M1 JDK11; see https://www.azul.com/downloads
+         set-java-home "/Library/Java/JavaVirtualMachines/zulu-11.jdk/Contents/Home"
+      elif [ -e "${HOME}/homebrew/arm64/opt/openjdk@11" ]; then
+         # see install-dependencies-osx-jenkins
+         set-java-home "${HOME}/homebrew/arm64/opt/openjdk@11"
+      elif [ -e "/opt/homebrew/opt/openjdk@11" ]; then
+         # default location for M1 homebrew
+         set-java-home "/opt/homebrew/opt/openjdk@11"
+      fi
+   else # Intel Mac
+      if [ -e "${HOME}/homebrew/x86_64/opt/openjdk@11" ]; then
+         # see install-dependencies-osx-jenkins
+         set-java-home "${HOME}/homebrew/x86_64/opt/openjdk@11"
+      elif [ -e "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home" ]; then
+         set-java-home "/Library/Java/JavaVirtualMachines/adoptopenjdk-11.jdk/Contents/Home"
+      fi
    fi
 }
 
@@ -92,7 +118,7 @@ find-program YARN yarn \
    "${HOME}/.yarn/bin"
 
 # determine architectures to build for
-if [ "$(arch)" = "arm64" ]; then
+if is-m1-mac; then
    arch=x86_64,arm64
 else
    arch=x86_64
@@ -109,7 +135,7 @@ use_creds=0
 rstudio_target=Desktop
 
 # by default, use RStudio credentials for builds on Jenkins
-if [ -n "${JENKINS_URL}" ]; then
+if is-jenkins; then
    use_creds=1
 fi
 
@@ -170,6 +196,9 @@ fi
 # set up MAKEFLAGS
 MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
 
+# set up JAVA_HOME if necessary
+find-java-home
+
 # perform an x86_64 build
 if [ -n "${build_x86_64}" ]; then
 
@@ -181,9 +210,6 @@ if [ -n "${build_x86_64}" ]; then
    # prefer using x86_64 build of cmake
    CMAKE="${CMAKE_X86_64:-/usr/local/bin/cmake}"
    info "Using CMake '${CMAKE}' for x86_64 build"
-
-   # set up JAVA_HOME if necessary
-   set-java-home "${HOME}/homebrew/x86_64/opt/openjdk@11"
 
    # prepare for build
    mkdir -p "${BUILD_DIR_X86_64}"
@@ -220,9 +246,6 @@ if [ -n "${build_x86_64}" ]; then
       info "Done!"
    fi
 
-   # restore JAVA_HOME
-   restore-java-home
-
 fi
 
 # perform an arm64 build
@@ -236,9 +259,6 @@ if [ -n "${build_arm64}" ]; then
    # prefer using arm64 build of cmake
    CMAKE="${CMAKE_ARM64:-/opt/homebrew/bin/cmake}"
    info "Using CMake '${CMAKE}' for arm64 build"
-
-   # set up JAVA_HOME if necessary
-   set-java-home "${HOME}/homebrew/arm64/opt/openjdk@11"
 
    # prepare for build
    mkdir -p "${BUILD_DIR_ARM64}"
@@ -266,9 +286,6 @@ if [ -n "${build_arm64}" ]; then
    arch -arm64 "${CMAKE}" --build . --target all -- ${MAKEFLAGS}
    info "Done!"
 
-   # restore JAVA_HOME
-   restore-java-home
-
 fi
 
 if [ "${build_package}" = "1" ]; then
@@ -284,11 +301,6 @@ if [ "${build_package}" = "1" ]; then
    # remove an existing install directory
    rm -rf "${INSTALL_DIR}"
    mkdir -p "${INSTALL_DIR}"
-
-   # set up JAVA_HOME (strictly speaking, shouldn't be necessary
-   # at this step but we set it just in case we need to invoke
-   # ant or gwtc)
-   set-java-home "${HOME}/homebrew/arm64/opt/openjdk@11"
 
    # perform install
    cd "${BUILD_DIR_X86_64}"
@@ -335,11 +347,11 @@ if [ "${build_package}" = "1" ]; then
 
    fi
 
-   # clean up JAVA_HOME
-   restore-java-home
-
    info "Done!"
 fi
+
+# clean up JAVA_HOME
+restore-java-home
 
 cd "${PKG_DIR}"
 

--- a/src/gwt/ant
+++ b/src/gwt/ant
@@ -23,6 +23,7 @@ if [ -z "${JAVA_HOME}" ]; then
 	for home in ${homes}; do
 		if [ -d "${home}" ]; then
 			export JAVA_HOME="${home}"
+			echo "Building with Java at ${JAVA_HOME}"
 			break
 		fi
 	done


### PR DESCRIPTION
### Intent

We use Intel Java even when building on M1. Noticed while working on Electron build and documenting [how to setup a dev machine on M1 Mac](https://github.com/rstudio/rstudio/wiki/M1-Mac-Dev-Machine-Setup).

This works, but is slower than a native M1 Java when building GWT. On my M1 Mini, took 11 minutes for a full GWT build with Intel, down to 7 minutes with the M1 Java. Only tried once so not particularly scientific.

Homebrew doesn't install an M1 JDK, nor is it available (for JDK8 or 11, at least), directly via https://adoptium.net/ (formerly https://adoptopenjdk.net/). See also: https://github.com/AdoptOpenJDK/homebrew-openjdk/issues/530

### Approach

Update make-package to prefer the `zulu-11` JDK if installed, otherwise use what it's currently using. Note that M1 Mac can use the M1 Java even when building for Intel (GWT build output is JavaScript, not native code).

Not bothering to install this M1 JDK on the actual build machines for now. Saving a few more minutes would be nice but don't want to mess with it right now. Just speeding up dev workflow.

### Automated Tests

None, dev / build tweak.

### QA Notes

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


