### PR TITLE
support server development builds on Linux aarch64

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -73,7 +73,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN add-apt-repository -y ppa:openjdk-r/ppa && \
     apt-get update && \
     apt-get install -y openjdk-8-jdk openjdk-11-jdk
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/jre/bin/java
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/linux

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -21,6 +21,11 @@ if(RSTUDIO_CMAKE_GLOBALS_INCLUDED)
 endif()
 set(RSTUDIO_CMAKE_GLOBALS_INCLUDED YES)
 
+# helper for detecting Linux
+if(UNIX AND NOT APPLE)
+   set(LINUX TRUE)
+endif()
+
 # version info
 if ("$ENV{RSTUDIO_VERSION_MAJOR}" STREQUAL "")
   string(TIMESTAMP CPACK_PACKAGE_VERSION_MAJOR "%Y")

--- a/dependencies/common/install-crashpad
+++ b/dependencies/common/install-crashpad
@@ -27,6 +27,11 @@ if [ "$RSTUDIO_DISABLE_CRASHPAD" == "1" ]; then
    exit 0
 fi
 
+if [ "$(arch)" == "aarch64" ]; then
+   echo "Skipping crashpad install (not yet supported on aarch64)"
+   exit 0
+fi
+
 # install dir
 INSTALL_DIR=$(pwd)
 

--- a/dependencies/common/install-npm-dependencies
+++ b/dependencies/common/install-npm-dependencies
@@ -26,7 +26,6 @@ NODE_ROOT="node"
 NODE_SUBDIR="${NODE_ROOT}/${NODE_VERSION}"
 NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}/"
 
-
 # install node if we need it
 if [ ! -d "${NODE_SUBDIR}" ]; then
 
@@ -39,7 +38,13 @@ if [ ! -d "${NODE_SUBDIR}" ]; then
     ;;
 
   "Linux-64")
-    NODE_FILE="node-v${NODE_VERSION}-linux-x64"
+
+    case "$(arch)" in
+    aarch64) ARCH=arm64 ;;
+    *)       ARCH=x64 ;;
+    esac
+
+    NODE_FILE="node-v${NODE_VERSION}-linux-${ARCH}"
     ;;
 
   *)
@@ -76,7 +81,12 @@ DEPS_DIR=`pwd`
 NODE_BIN="${DEPS_DIR}/${NODE_SUBDIR}/bin"
 INSTALL_PATH="${NODE_BIN}:${PATH}"
 
-# install yarn if necessary
+# curl on Ubuntu 20.04 segfaults when using yarn installer
+if [ "$(arch)" = "aarch64" ] && [ "$(platform)" = "ubuntu" ] && [ "$(ubuntu-codename)" = "focal" ]; then
+  echo "Skipping yarn install (curl segfaults on Ubuntu Focal)"
+  exit 0
+fi
+
 if [ ! -x "$(command -v yarn)" ]; then
   YARN_INSTALL_SCRIPT="yarn-install.sh"
   download "https://yarnpkg.com/install.sh" "${YARN_INSTALL_SCRIPT}"

--- a/dependencies/common/install-npm-dependencies
+++ b/dependencies/common/install-npm-dependencies
@@ -84,6 +84,7 @@ INSTALL_PATH="${NODE_BIN}:${PATH}"
 # curl on Ubuntu 20.04 segfaults when using yarn installer
 if [ "$(arch)" = "aarch64" ] && [ "$(platform)" = "ubuntu" ] && [ "$(ubuntu-codename)" = "focal" ]; then
   echo "Skipping yarn install (curl segfaults on Ubuntu Focal)"
+  echo "See https://bugs.launchpad.net/ubuntu/+source/openssl/+bug/1951279 for more details"
   exit 0
 fi
 

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -20,11 +20,6 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing Pandoc"
 
-if [ "$(arch)" = "aarch64" ]; then
-  echo "Pandoc installer not yet available for aarch64"
-  exit 0
-fi
-
 # variables that control download + installation process
 PANDOC_VERSION="2.14.2"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"
@@ -45,20 +40,24 @@ mkdir -p "${PANDOC_SUBDIR}"
 pushd "${PANDOC_SUBDIR}"
 
 # determine sub-directory based on platform
-PLATFORM="$(uname)-$(getconf LONG_BIT)"
+PLATFORM="$(uname -s)-$(uname -m)"
 case "${PLATFORM}" in
 
-"Darwin-64")
-  SUBDIR="macos"
+"Darwin-x86_64" | "Darwin-arm64")
   FILES=(
     "pandoc-${PANDOC_VERSION}-macOS.zip"
   )
   ;;
 
-"Linux-64")
-  SUBDIR="linux"
+"Linux-x86_64")
   FILES=(
     "pandoc-${PANDOC_VERSION}-linux-amd64.tar.gz"
+  )
+  ;;
+
+"Linux-aarch64")
+  FILES=(
+    "pandoc-${PANDOC_VERSION}-linux-arm64.tar.gz"
   )
   ;;
 

--- a/dependencies/common/install-pandoc
+++ b/dependencies/common/install-pandoc
@@ -20,6 +20,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing Pandoc"
 
+if [ "$(arch)" = "aarch64" ]; then
+  echo "Pandoc installer not yet available for aarch64"
+  exit 0
+fi
+
 # variables that control download + installation process
 PANDOC_VERSION="2.14.2"
 PANDOC_SUBDIR="pandoc/${PANDOC_VERSION}"

--- a/dependencies/common/install-qt.sh
+++ b/dependencies/common/install-qt.sh
@@ -39,6 +39,11 @@
 #############################################################################
 set -eu
 
+if [ "$(arch)" = "aarch64" ]; then
+    echo "install-qt not yet available for aarch64"
+    exit 0
+fi
+
 function help() {
     cat <<EOF
 usage: install-qt [options] [components]

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -20,6 +20,11 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing Quarto"
 
+if [ "$(arch)" = "aarch64" ]; then
+  echo "install-quarto not yet available for aarch64"
+  exit 0
+fi
+
 # variables that control download + installation process
 QUARTO_VERSION="0.2.281"
 QUARTO_SUBDIR="quarto"

--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -72,10 +72,11 @@ sudo apt-get -y install \
   zlib1g-dev
 
 # Java 8 (not in official repo for bionic)
+arch=$(dpkg --print-architecture)
 sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get update
 sudo apt-get -y install openjdk-8-jdk
-sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+sudo update-alternatives --set java /usr/lib/jvm/java-8-openjdk-${arch}/jre/bin/java
 
 # R
 if ! [ -x "$(command -v R)" ]; then

--- a/dependencies/linux/install-dependencies-debian
+++ b/dependencies/linux/install-dependencies-debian
@@ -23,7 +23,7 @@ if command -v lsb_release &> /dev/null; then
   platform_script="install-dependencies-$platform_codename"
   if [ -e $platform_script ] ; then
     ./$platform_script "$@"
-    exit 
+    exit
   fi
 fi
 

--- a/dependencies/linux/install-dependencies-focal
+++ b/dependencies/linux/install-dependencies-focal
@@ -73,10 +73,11 @@ sudo apt-get -y install \
   zlib1g-dev
 
 # Java 8 (not in official repo for focal)
+arch=$(dpkg --print-architecture)
 sudo add-apt-repository -y ppa:openjdk-r/ppa
 sudo apt-get update
 sudo apt-get -y install openjdk-11-jdk
-sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-${arch}/bin/java
 
 # R
 if ! [ -x "$(command -v R)" ]; then

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -318,9 +318,18 @@ add_definitions(-DRSTUDIO_BOOST_SIGNALS_VERSION=2)
 # add boost as system include directory
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
-if(NOT DEFINED RSTUDIO_CRASHPAD_ENABLED AND APPLE AND UNAME_M STREQUAL arm64)
-   message(STATUS "Crashpad not yet supported on M1 macOS machines; disabling Crashpad")
-   set(RSTUDIO_CRASHPAD_ENABLED FALSE)
+if(NOT DEFINED RSTUDIO_CRASHPAD_ENABLED)
+   
+   if(APPLE AND UNAME_M STREQUAL arm64)
+      message(STATUS "Crashpad not yet supported on M1 macOS machines; disabling Crashpad")
+      set(RSTUDIO_CRASHPAD_ENABLED FALSE)
+   endif()
+
+   if(LINUX AND UNAME_M STREQUAL aarch64)
+      message(STATUS "Crashpad not yet supported on aarch64 Linux machines; disabling Crashpad")
+      set(RSTUDIO_CRASHPAD_ENABLED FALSE)
+   endif()
+
 endif()
 
 # Crashpad


### PR DESCRIPTION
### Intent

Make it possible to produce development builds of RStudio Server on aarch64 Linux. With this PR, one can generate builds of RStudio Server with something like:

```
cmake ../cpp -DRSTUDIO_DESKTOP=0
```

Note that we don't yet support the use of the visual editor as `curl` segfaults when trying to download the yarn installer.

### Approach

Tweak and disable some dependency installer scripts for aarch64.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
