### PR TITLE
Fix for Desktop Creating Metadata Files

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -40,6 +40,12 @@ private:
 
    friend class ActiveSessions;
 
+   explicit ActiveSession(const std::string& id) 
+      : id_(id)
+   {
+
+   }
+
    ActiveSession(
       const std::string& id,
       const FilePath& scratchPath) : 

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -40,13 +40,11 @@ private:
 
    friend class ActiveSessions;
 
-   explicit ActiveSession(const std::string& id) 
-      : id_(id)
+   explicit ActiveSession(const std::string& id) : id_(id) 
    {
-
    }
 
-   ActiveSession(
+   explicit ActiveSession(
       const std::string& id,
       const FilePath& scratchPath) : 
          id_(id),

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -156,8 +156,7 @@ boost::shared_ptr<ActiveSession> ActiveSessions::get(const std::string& id) cons
 
 boost::shared_ptr<ActiveSession> ActiveSessions::emptySession(const std::string& id) const
 {
-   FilePath scratchPath = storagePath_.completeChildPath(kSessionDirPrefix + id);
-   return boost::shared_ptr<ActiveSession>(new ActiveSession(id, scratchPath));
+   return boost::shared_ptr<ActiveSession>(new ActiveSession(id));
 }
 
 std::vector<boost::shared_ptr<GlobalActiveSession> >


### PR DESCRIPTION
Empty Sessions should not have a storage backing, and this was causing
desktop to produce metadata files


### Intent

Desktop uses an empty session, which should not be connected to s storage backend.

### Approach

Drop the call to the scratchpath constructor for empty sessions.

### Automated Tests

None added.

### QA Notes

Run a desktop session, then investigate your user directory, rstudion/sessions/active should contain no metadata files now.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


