### PR TITLE
generate rdesktop-dev.conf on M1 mac for dev builds

### DIFF
--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -653,7 +653,7 @@ else()
       endif()
 
       # configure desktop files
-      if(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON)
+      if(RSTUDIO_DESKTOP)
          if(NOT WIN32)
             if(NOT APPLE)
                configure_file(rstudio-dev.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-dev)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -647,9 +647,13 @@ else()
       # processing which we do in desktop
       add_subdirectory(session)
 
+      # desktop conf file used for dev-mode for both Qt desktop and Electron desktop
+      if(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON OR RSTUDIO_DEVELOPMENT)
+         configure_file(conf/rdesktop-dev.conf ${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf)
+      endif()
+
       # configure desktop files
       if(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON)
-         configure_file(conf/rdesktop-dev.conf ${CMAKE_CURRENT_BINARY_DIR}/conf/rdesktop-dev.conf)
          if(NOT WIN32)
             if(NOT APPLE)
                configure_file(rstudio-dev.in ${CMAKE_CURRENT_BINARY_DIR}/rstudio-dev)


### PR DESCRIPTION
### Intent

When working on RStudio Electron on an M1 Mac, the app will fail to launch if you generate the native code build using no explicit RSTUDIO_TARGET, e.g.:

`cmake ../cpp`

This fails because the config here becomes RSTUDIO_DEVELOPMENT but doesn't include RSTUDIO_DESKTOP (by design on an M1 Mac only), and the required `rdesktop-dev.conf` file is thus not generated.

It does work if you generate with `-DRSTUDIO_TARGET=Electron` but shouldn't really need to do that, just like you don't when working on Qt desktop.

Eventually, on Mac, we'll automatically set RSTUDIO_ELECTRON as the target when none is specified, but not ready for that just yet.

### Implementation

Generate this file even if only RSTUDIO_DEVELOPMENT target was enabled.

### Automated Tests

None, purely a dev machine thing.

### QA Notes

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


