### PR TITLE
fix mac dependency scripts to create /opt/rstudio-tools via sudo if necessary

### DIFF
--- a/dependencies/osx/install-dependencies-osx
+++ b/dependencies/osx/install-dependencies-osx
@@ -43,7 +43,7 @@ if [ "$(arch)" = "arm64" ]; then
 
    # install x86_64 dependencies
    PATH="$(dirname "${BREW_X86}"):${OLDPATH}"
-   mkdir -p "${OLDROOT}/../x86_64"
+   mkdir-sudo-if-necessary "${OLDROOT}/../x86_64"
    RSTUDIO_TOOLS_ROOT=$(cd "${OLDROOT}/../x86_64"; pwd -P)
 
    section "Installing x86_64 Dependencies"
@@ -51,7 +51,7 @@ if [ "$(arch)" = "arm64" ]; then
 
    # install arm64 dependencies
    PATH="$(dirname "${BREW_ARM}"):${OLDPATH}"
-   mkdir -p "${OLDROOT}/../arm64"
+   mkdir-sudo-if-necessary "${OLDROOT}/../arm64"
    RSTUDIO_TOOLS_ROOT=$(cd "${OLDROOT}/../arm64"; pwd -P)
 
    section "Installing arm64 Dependencies"
@@ -73,7 +73,7 @@ else
    OLDROOT="${RSTUDIO_TOOLS_ROOT}"
 
    PATH="$(dirname "${BREW_X86}"):${OLDPATH}"
-   mkdir -p "${OLDROOT}/../x86_64"
+   mkdir-sudo-if-necessary "${OLDROOT}/../x86_64"
    RSTUDIO_TOOLS_ROOT=$(cd "${OLDROOT}/../x86_64"; pwd -P)
 
    ./install-dependencies-osx-arch

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -82,6 +82,20 @@ sudo-if-necessary-for () {
 
 }
 
+mkdir-sudo-if-necessary () {
+
+	# If the directory does not exist, try to create it without sudo
+	if ! [ -e "$1" ]; then
+		mkdir -p "$1" &> /dev/null || true
+	fi
+
+	# Still not there, create with sudo
+	if ! [ -e "$1" ]; then
+		sudo -E mkdir -p "$1"
+	fi
+
+}
+
 find-file () {
 
 	if [ "$#" -lt 2 ] || [ "$1" = "--help" ]; then


### PR DESCRIPTION
### Intent

Addresses #10094 (currently you have to manually create /opt/rstudio-tools before the dependency scripts will work when setting up an IDE dev machine).

### Approach

Try to create folder without sudo, if that fails, use sudo.

### Automated Tests

None, dev machine scripting

### QA Notes

Purely a dev machine thing

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


