### PR TITLE
prefer user data directory for logs when not root

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -69,14 +69,36 @@ namespace log {
 namespace {
 
 // pick default log path location
-#if defined(__APPLE__)
-const FilePath kDefaultLogPath = core::system::xdg::userDataDir().completePath("log");
-#elif defined(RSTUDIO_SERVER)
-const FilePath kDefaultLogPath("/var/log/rstudio/rstudio-server");
+
+FilePath defaultLogPathImpl()
+{
+#ifdef RSTUDIO_SERVER
+   // server: prefer user data directory if we're not running as root
+   if (core::system::effectiveUserIsRoot())
+   {
+      FilePath defaultPath("/var/log/rstudio/rstudio-server");
+      Error error = defaultPath.ensureDirectory();
+      if (error)
+         LOG_ERROR(error);
+
+      return defaultPath;
+   }
+   else
+   {
+      return core::system::xdg::userDataDir().completePath("log");
+   }
 #else
-// desktop - store logs under user dir
-const FilePath kDefaultLogPath = core::system::xdg::userDataDir().completePath("log");
+   // desktop: always stored in user data directory
+   return core::system::xdg::userDataDir().completePath("log");
 #endif
+}
+
+FilePath& defaultLogPath()
+{
+   static FilePath instance = defaultLogPathImpl();
+   return instance;
+}
+
 
 std::string logLevelToString(LogLevel logLevel)
 {
@@ -166,7 +188,7 @@ struct LoggerOptionsVisitor : boost::static_visitor<>
 
    void setDefaultFileLoggerOptions()
    {
-      FileLogOptions defaultOptions(kDefaultLogPath);
+      FileLogOptions defaultOptions(defaultLogPath());
       profile_.addParams(
          kLogDir, defaultOptions.getDirectory().getAbsolutePath(),
          kLogFileMode, defaultOptions.getFileMode(),
@@ -234,12 +256,12 @@ struct LogDirVisitor : boost::static_visitor<FilePath>
 {
    FilePath operator()(const StdErrLogOptions& options)
    {
-      return FilePath(kDefaultLogPath);
+      return FilePath(defaultLogPath());
    }
 
    FilePath operator()(const SysLogOptions& options)
    {
-      return FilePath(kDefaultLogPath);
+      return FilePath(defaultLogPath());
    }
 
    FilePath operator()(const FileLogOptions& options)
@@ -279,7 +301,7 @@ LogOptions::LogOptions(const std::string& executableName,
 
 FilePath LogOptions::defaultLogDirectory()
 {
-   return kDefaultLogPath;
+   return defaultLogPath();
 }
 
 void LogOptions::initProfile()

--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -73,18 +73,14 @@ namespace {
 FilePath defaultLogPathImpl()
 {
 #ifdef RSTUDIO_SERVER
-   // server: prefer user data directory if we're not running as root
    if (core::system::effectiveUserIsRoot())
    {
-      FilePath defaultPath("/var/log/rstudio/rstudio-server");
-      Error error = defaultPath.ensureDirectory();
-      if (error)
-         LOG_ERROR(error);
-
-      return defaultPath;
+      // server: root uses default documented logging directory
+      return FilePath("/var/log/rstudio/rstudio-server");
    }
    else
    {
+      // server: prefer user data directory if we're not running as root
       return core::system::xdg::userDataDir().completePath("log");
    }
 #else


### PR DESCRIPTION
### Intent

Fixes an issue where the logger would fail to initialize when RStudio Server was run as a non-root user. This also appeared to cascade in a strange way where session restarts would cause RStudio Server to "disconnect" from the session.

Note for review: would this change the existing behavior for existing users of RStudio Server (the open source version)?

### Approach

When we're not root, prefer logging to a user-specific data log directory.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
