### PR TITLE
only interrupt R on suspend if it's busy

### DIFF
--- a/src/cpp/r/CMakeLists.txt
+++ b/src/cpp/r/CMakeLists.txt
@@ -33,6 +33,7 @@ set (R_SOURCE_FILES
    RSourceManager.cpp
    RUtil.cpp
    RVersionInfo.cpp
+   session/RBusy.cpp
    session/RClientMetrics.cpp
    session/RClientState.cpp
    session/RConsoleActions.cpp

--- a/src/cpp/r/include/r/session/RBusy.hpp
+++ b/src/cpp/r/include/r/session/RBusy.hpp
@@ -1,0 +1,33 @@
+/*
+ * RBusy.hpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_SESSION_BUSY_HPP
+#define R_SESSION_BUSY_HPP
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+// is the R session busy?
+// here, busy implies that the R session is executing some R code,
+// even if that wasn't explicitly executed by the user
+// (e.g. this captured code executed in the background by RStudio)
+bool isBusy();
+
+} // namespace session
+} // namespace r
+} // namespace rstudio
+
+#endif // R_SESSION_BUSY_HPP

--- a/src/cpp/r/session/RBusy.cpp
+++ b/src/cpp/r/session/RBusy.cpp
@@ -1,0 +1,45 @@
+/*
+ * RBusy.cpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <r/RInterface.hpp>
+
+extern "C" {
+
+typedef struct RCNTXT {
+   struct RCNTXT *nextcontext;
+} RCNTXT, *context;
+
+int Rf_framedepth(RCNTXT* pContext);
+
+} // extern "C"
+
+namespace rstudio {
+namespace r {
+namespace session {
+
+bool isBusy()
+{
+   // sanity check
+   if (R_GlobalContext == NULL)
+      return false;
+
+   // are there any R frames in the global context?
+   // if so, conclude this is because R is busy
+   return Rf_framedepth((RCNTXT*) R_GlobalContext);
+}
+
+} // namespace session
+} // namespace r
+} // namespace rstudio

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -136,23 +136,18 @@ void handleUSR1(int unused)
 // and the 'force' flag is set
 void handleUSR2(int unused)
 {
-   // note whether R was interrupted
+   // if R is busy executing code, we'll need to interrupt and force suspend
+   //
+   // for launcher sessions, we only want to interrupt user code to fix
+   // an excess logging issue caused by interrupting RStudio code that
+   // takes longer to execute in docker containers
    if (console_input::executing())
-      s_forceSuspendInterruptedR = 1;
-
-   bool isLauncherSession = options().getBoolOverlayOption(kLauncherSessionOption);
-
-   if (!isLauncherSession || console_input::executing())
    {
-      // interrupt R
-      // for launcher sessions, we only want to interrupt user code to fix
-      // an excess logging issue caused by interrupting RStudio code that
-      // takes longer to execute in docker containers
-      // when not in launcher session mode, always interrupt
+      s_forceSuspendInterruptedR = 1;
       rstudio::r::exec::setInterruptsPending(true);
    }
 
-   // note that a suspend is being forced. 
+   // note that a suspend is being forced
    s_forceSuspend = 1;
 }
 

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -23,8 +23,9 @@
 #include <session/SessionOptions.hpp>
 #include <session/SessionConstants.hpp>
 
-#include <r/session/RSession.hpp>
 #include <r/RExec.hpp>
+#include <r/session/RBusy.hpp>
+#include <r/session/RSession.hpp>
 
 namespace rstudio {
 namespace session {
@@ -141,7 +142,7 @@ void handleUSR2(int unused)
    // for launcher sessions, we only want to interrupt user code to fix
    // an excess logging issue caused by interrupting RStudio code that
    // takes longer to execute in docker containers
-   if (console_input::executing())
+   if (console_input::executing() || r::session::isBusy())
    {
       s_forceSuspendInterruptedR = 1;
       rstudio::r::exec::setInterruptsPending(true);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10110.

### Approach

Previously, we _always_ sent R an interrupt. This had the unfortunate side-effect of interrupting any potential future calls to `R_ProcessEvents()`, whose errors we also log. With this change, we only interrupt R if it appears to be busy (that is, has something on the stack that can be interrupted).

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
