### PR TITLE
Generate Mac OS packages with a `-` instead of a `+`

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -69,7 +69,7 @@ else
    RSTUDIO_PRO_SUFFIX=""
 fi
 
-RSTUDIO_BUNDLE_NAME="RStudio${RSTUDIO_PRO_SUFFIX}-${RSTUDIO_VERSION_FULL}"
+RSTUDIO_BUNDLE_NAME=$(echo "RStudio${RSTUDIO_PRO_SUFFIX}-${RSTUDIO_VERSION_FULL}" | sed 's/+/-/g')
 
 # use Ninja if available
 if has-program ninja; then


### PR DESCRIPTION
### Intent

Addresses #10063 

### Approach

I was expecting cpack to set the package name, but it happens in the make-package script. Now update the bundle name to be correct.

I will have to merge this to Pro and main/main-Pro

### Automated Tests

N/A - package file name

### QA Notes

Mac OS dailies should have a `-` instead a `+`

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


