### PR TITLE
Remove lint indicator when associated line is edited in visual mode

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunkRowState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunkRowState.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text.visualmode;
 
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.a11y.A11y;
 import org.rstudio.core.client.dom.DomUtils;
@@ -61,6 +62,7 @@ public class VisualModeChunkRowState extends ChunkRowExecState
       attached_ = false;
       editor_ = editor;
       row_ = -1;
+      registrations_ = new HandlerRegistrations();
       
       // Convert to zero-based row
       row = row - 1;
@@ -75,6 +77,16 @@ public class VisualModeChunkRowState extends ChunkRowExecState
             detach();
          }
       });
+
+      // If the user edits the line containing this indicator, remove the indicator.
+      registrations_.add(editor.addDocumentChangedHandler((evt) ->
+      {
+         if (row_ >= evt.getEvent().start.getRow() &&
+             row_ <= evt.getEvent().end.getRow())
+         {
+            detach();
+         }
+      }));
 
       ele_ = Document.get().createDivElement();
 
@@ -147,6 +159,9 @@ public class VisualModeChunkRowState extends ChunkRowExecState
       {
          anchor_.detach();
       }
+
+      // Remove all event handlers
+      registrations_.removeHandler();
    }
    
    public void attach(Element parent)
@@ -243,4 +258,5 @@ public class VisualModeChunkRowState extends ChunkRowExecState
 
    private final Anchor anchor_;
    private final AceEditor editor_;
+   private final HandlerRegistrations registrations_;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10156. 

### Approach

Watch the document for changes made to the line containing the lint indicator in the gutter. When they occur, remove the indicator. If the user's changes don't address the issue, it'll come back when the chunk is re-linted later.

### Automated Tests

N/A, visual change to gutter indicator only.

### QA Notes

Test via notes in 10156. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


