### PR TITLE
Build packages with Ninja on Linux

### DIFF
--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -49,6 +49,7 @@ RUN apt-get update && \
     libxml2-dev \
     libxslt1-dev \
     lsof \
+    ninja-build \
     openjdk-8-jdk \
     p7zip-full \
     pkg-config \

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -33,6 +33,7 @@ RUN yum install -y \
     lsof \
     make \
     mariadb-libs \
+    ninja-build \
     openssl-devel \
     p7zip \
     p7zip-plugins \

--- a/docker/jenkins/Dockerfile.centos8-x86_64
+++ b/docker/jenkins/Dockerfile.centos8-x86_64
@@ -35,6 +35,7 @@ RUN yum install -y \
     llvm-devel \
     lsof \
     make \
+    ninja-build \
     mesa-libGL-devel \
     openssl-devel \
     p7zip \

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -34,6 +34,7 @@ RUN apt-get update -y && apt-get install -y \
     libpq-dev \
     libsqlite3-dev \
     libxml2-dev \
+    ninja-build \
     procps \
     uuid-dev \
     make \

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -30,6 +30,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libXrandr-devel \
     lsof \
     make \
+    ninja \
     openssl-devel \
     p7zip \
     pam-devel \

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -58,8 +58,14 @@ else
   INSTALL_DIR=rstudio-server
 fi
 
+if [ -z $CMAKE_GENERATOR ] && [ has-program ninja ]
+then 
+   CMAKE_GENERATOR="Ninja"
+else
+   CMAKE_GENERATOR="Unix Makefiles"
+fi
+
 : ${CMAKE_INSTALL_PREFIX="/usr/lib/${INSTALL_DIR}"}
-: ${CMAKE_GENERATOR="Unix Makefiles"}
 
 PKG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $PKG_DIR

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -2,6 +2,9 @@
 
 set -e
 
+PKG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${PKG_DIR}/../../dependencies/tools/rstudio-tools.sh"
+
 # remember cwd for later restoration
 PREV_WD=$(pwd)
 
@@ -58,7 +61,9 @@ else
   INSTALL_DIR=rstudio-server
 fi
 
-if [ -z $CMAKE_GENERATOR ] && [ has-program ninja ]
+set +x
+
+if has-program ninja
 then 
    CMAKE_GENERATOR="Ninja"
 else
@@ -66,6 +71,8 @@ else
 fi
 
 : ${CMAKE_INSTALL_PREFIX="/usr/lib/${INSTALL_DIR}"}
+
+echo "Building and packing with CMake Generator: $CMAKE_GENERATOR"
 
 PKG_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 echo $PKG_DIR


### PR DESCRIPTION
### Intent

Build packages with Ninja on Linux to avoid hang potentially caused by cpack-ing with Unix Makefiles.

### Approach

If ninja is present, use ninja. Otherwise, continue to use Unix Makefiles.

Install ninja in all linux docker images except SLES12, because it doesn't have the package available.

### Automated Tests

N/A - build system change only.

### QA Notes

N/A - build system change only.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


