### PR TITLE
Reduce duplicate file from error to warning for ninja

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -66,6 +66,7 @@ set +x
 if has-program ninja
 then 
    CMAKE_GENERATOR="Ninja"
+   MAKEFLAGS="-w dupbuild=warn ${MAKEFLAGS}"
 else
    CMAKE_GENERATOR="Unix Makefiles"
 fi
@@ -99,7 +100,7 @@ cmake -G"${CMAKE_GENERATOR}"                           \
       -DGWT_BUILD="$GWT_BUILD"                         \
       $PKG_DIR/../..
 
-cmake --build . --target all
+cmake --build . --target all -- ${MAKEFLAGS}
 
 if [ "$2" != "DEB" ]
 then


### PR DESCRIPTION
### Intent

Desktop builds on linux are failing due to the `NOTICE` file being included twice. Rather than change the what's already working, this PR lowers the severity of the dupbuild flag from error to warning.

### Approach

See intent.

### Automated Tests

N/A - builds only

### QA Notes

N/A - builds only

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


