### PR TITLE
Fix Electron desktop on Windows (blank window)

### DIFF
--- a/src/node/desktop/src/core/array-utils.ts
+++ b/src/node/desktop/src/core/array-utils.ts
@@ -44,3 +44,18 @@ export function nextLowest(val: number, choices: number[]): number {
   index = index <= 0 ? 0 : --index;
   return choices[index];
 }
+
+/**
+ * @param strArray Array to search
+ * @param prefix String prefix to match 
+ * @returns Value of first array member starting with `prefix` (with `prefix` removed) or
+ * empty string if no matches.
+ */
+export function firstStartingWith(strArray: string[], prefix: string): string {
+  for (const item of strArray) {
+    if (item.startsWith(prefix)) {
+      return item.slice(prefix.length);
+    }
+  }
+  return '';
+}

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -60,7 +60,7 @@ export class DesktopBrowserWindow extends EventEmitter {
     existingWindow?: BrowserWindow, // attach to this window instead of creating a new one
   ) {
     super();
-    const apiKeys = [['desktopInfo', ...addApiKeys].join('|')];
+    const apiKeys = [['--apiKeys=desktopInfo', ...addApiKeys].join('|')];
     if (existingWindow) {
       this.window = existingWindow;
     } else {

--- a/src/node/desktop/src/renderer/preload.ts
+++ b/src/node/desktop/src/renderer/preload.ts
@@ -19,6 +19,7 @@ import { removeDups } from '../core/string-utils';
 import { getDesktopInfoBridge } from './desktop-info-bridge';
 import { getMenuBridge } from './menu-bridge';
 import { getDesktopBridge } from './desktop-bridge';
+import { firstStartingWith } from '../core/array-utils';
 
 /**
  * The preload script is run in the renderer before our GWT code and enables
@@ -34,8 +35,8 @@ import { getDesktopBridge } from './desktop-bridge';
  * Actual implementation happens in the main process, reached via ipcRenderer.
  */
 
-// Last argument contains list of apiKeys to expose, separated by '|'.
-const apiKeys = removeDups(process.argv.slice(-1)[0].split('|'));
+// --apiKeys= argument contains list of apiKeys to expose, separated by '|'.
+const apiKeys = removeDups(firstStartingWith(process.argv, '--apiKeys=').split('|'));
 for (const apiKey of apiKeys) {
   switch (apiKey) {
     case 'desktop':

--- a/src/node/desktop/test/unit/core/array-utils.test.ts
+++ b/src/node/desktop/test/unit/core/array-utils.test.ts
@@ -16,7 +16,7 @@
 import { describe } from 'mocha';
 import { assert } from 'chai';
 
-import { nextLowest, nextHighest } from '../../../src/core/array-utils';
+import { nextLowest, nextHighest, firstStartingWith } from '../../../src/core/array-utils';
 
 describe('array-util', () => {
   const choices = [1, 3, 9, 11, 17];
@@ -58,6 +58,24 @@ describe('array-util', () => {
       const noChoices: number[] = [];
       const current = 5;
       assert.equal(nextHighest(current, noChoices), 5);
+    });
+  });
+
+  describe('firstStartingWith', () => {
+    it('returns empty string for empty input array', () => {
+      const input: string[] = [];
+      const result = firstStartingWith(input, 'hello');
+      assert.equal(result, '');
+    });
+    it('returns empty string for no match', () => {
+      const input = ['one', 'two'];
+      const result = firstStartingWith(input, 'three');
+      assert.equal(result, '');
+    });
+    it('returns match minus prefix', () => {
+      const input = ['one', '--two=stuff', 'three'];
+      const result = firstStartingWith(input, '--two=');
+      assert.equal(result, 'stuff');
     });
   });
 });


### PR DESCRIPTION
### Intent

Launching dev build of Electron on MS-Windows was giving a blank screen, with exceptions being thrown by GWT indicating the desktop hooks are undefined.

### Approach

Preload code assumed that argument added via `additionalArguments` mechanism when creating `BrowserWindow` was guaranteed to be last item in `process.argv`; it was not on Windows. Webpack was appending `/prefetch:1`, and the code then tried to use this as the list of apiKeys to attach, thus attaching none of them.

Fixed by using a prefix `--apiKeys=` to identify this argument, and looking for that instead of assuming the position.

### Automated Tests

Added unit test for new routine `firstStartingWith`.

### QA Notes

Can now launch Electron IDE on Windows and see... the IDE.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


