### PR TITLE
React 1.7 Changes Focus Behavior

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_symbol/insert_symbol-plugin.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_symbol/insert_symbol-plugin.tsx
@@ -65,7 +65,7 @@ export class InsertSymbolPlugin extends Plugin<boolean> {
         destroy: () => {
           this.closePopup();
           this.scrollUnsubscribe();
-          window.document.removeEventListener('focusin', this.focusChanged);
+          window.document.removeEventListener('onfocus', this.focusChanged);
         },
       }),
     });
@@ -76,7 +76,7 @@ export class InsertSymbolPlugin extends Plugin<boolean> {
     this.scrollUnsubscribe = events.subscribe(ScrollEvent, this.closePopup);
 
     this.focusChanged = this.focusChanged.bind(this);
-    window.document.addEventListener('focusin', this.focusChanged);
+    window.document.addEventListener('onfocus', this.focusChanged);
   }
 
   public showPopup(view: EditorView) {


### PR DESCRIPTION
Switch to onFocus events which have different event bubbling behavior in React 1.7.

- fixes #10176


### Intent

Fixes issue with insert emoji and symbol dialog when launched from the insert menu.

### Approach

Switch to different focus events due to behavior change in React 1.7.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


