### PR TITLE
Show class in collapsed chunk summary

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/ui.ts
+++ b/src/gwt/panmirror/src/editor/src/api/ui.ts
@@ -43,7 +43,7 @@ export interface EditorUIChunkCallbacks {
 
 export interface EditorUIChunks {
   // create a code chunk editor
-  createChunkEditor: (type: string, element: Element, index: number, callbacks: EditorUIChunkCallbacks) => ChunkEditor;
+  createChunkEditor: (type: string, element: Element, index: number, classes: string[], callbacks: EditorUIChunkCallbacks) => ChunkEditor;
 
   // expand or collapse all chunk editors
   setChunksExpanded: (expanded: boolean) => void;

--- a/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
+++ b/src/gwt/panmirror/src/editor/src/optional/ace/ace.ts
@@ -517,7 +517,7 @@ export class AceNodeView implements NodeView {
     }
 
     // call host factory to instantiate editor
-    this.chunk = this.ui.chunks.createChunkEditor('ace', this.dom, this.node.attrs.md_index, {
+    this.chunk = this.ui.chunks.createChunkEditor('ace', this.dom, this.node.attrs.md_index, this.node.attrs.classes, {
       getPos: () => this.getPos(),
       scrollIntoView: ele => this.scrollIntoView(ele),
       scrollCursorIntoView: () => this.scrollCursorIntoView(),

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIChunks.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.panmirror.ui;
 
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
 import jsinterop.annotations.JsFunction;
 import jsinterop.annotations.JsType;
@@ -27,7 +28,8 @@ public class PanmirrorUIChunks
    @JsFunction
    public interface CreateChunkEditor
    {
-      PanmirrorUIChunkEditor create(String type, Element element, int position, PanmirrorUIChunkCallbacks callbacks);
+      PanmirrorUIChunkEditor create(String type, Element element, int position, JsArrayString classes,
+                                    PanmirrorUIChunkCallbacks callbacks);
    }
 
    @JsFunction

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/assist/RChunkHeaderParser.java
@@ -29,11 +29,11 @@ public class RChunkHeaderParser
    public static Map<String, String> parse(String line)
    {
       Map<String, String> options = new HashMap<>();
-      parse(line, options);
+      parse(line, "r", options);
       return options;
    }
    
-   public static final void parse(String line, Map<String, String> options)
+   public static final void parse(String line, String defaultEngine, Map<String, String> options)
    {
       // set up state
       Mutable<String> key = new Mutable<>();
@@ -71,9 +71,9 @@ public class RChunkHeaderParser
       
       TextCursor cursor = new TextCursor(line);
       
-      // force default R engine
-      options.put("engine", ensureQuoted("r"));
-      
+      // force default engine
+      options.put("engine", ensureQuoted(defaultEngine));
+
       // for R Markdown documents, we need to also parse
       // an engine and an optional label, which adds a bit
       // of extra work for the parser

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -23,6 +23,7 @@ import com.google.gwt.aria.client.ExpandedValue;
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.dom.client.SpanElement;
@@ -108,6 +109,7 @@ public class VisualModeChunk
    public VisualModeChunk(Element element,
                           int index,
                           boolean isExpanded,
+                          JsArrayString classes,
                           PanmirrorUIChunkCallbacks chunkCallbacks,
                           DocUpdateSentinel sentinel,
                           TextEditingTarget target,
@@ -124,6 +126,7 @@ public class VisualModeChunk
       releaseOnDismiss_ = new ArrayList<>();
       destroyHandlers_ = new ArrayList<>();
       lint_ = JsArray.createArray().cast();
+      classes_ = classes;
 
       // Instantiate CSS style
       ChunkStyle style = GWT.create(ChunkStyle.class);
@@ -1069,9 +1072,19 @@ public class VisualModeChunk
             }
             else
             {
+               // By convention, the first class in a non-executable chunk is its language.
+               // Use that as the "engine" unless another is explicitly specified.
+               Map<String, String> options = new HashMap<>();
+               if (classes_ != null &&
+                   classes_.length() > 0 &&
+                   !StringUtil.isNullOrEmpty(classes_.get(0)))
+               {
+                  engine = classes_.get(0);
+               }
+
                // This is the first line in the chunk (its header). Parse it, reintroducing
                // the backticks since they aren't present in the embedded editor.
-               Map<String, String> options = RChunkHeaderParser.parse("```" + line);
+               RChunkHeaderParser.parse("```" + line, engine, options);
 
                // Check for the "engine" (language) option; extract it if specified
                String optionEngine = options.get("engine");
@@ -1154,6 +1167,7 @@ public class VisualModeChunk
    private Scope scope_;
    private ChunkContextPanmirrorUi toolbar_;
    private boolean active_;
+   private JsArrayString classes_;
    private PanmirrorUIChunkCallbacks chunkCallbacks_;
    private Styles style_;
    private JsArray<LintItem> lint_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -70,7 +70,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
    public PanmirrorUIChunks uiChunks()
    {
       PanmirrorUIChunks chunks = new PanmirrorUIChunks();
-      chunks.createChunkEditor = (type, ele, index, callbacks) ->
+      chunks.createChunkEditor = (type, ele, index, classes, callbacks) ->
       {
          // only know how to create ace instances right now
          if (!type.equals("ace"))
@@ -88,7 +88,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          }
 
          VisualModeChunk chunk = new VisualModeChunk(
-               ele, index, expanded, callbacks, sentinel_, target_, sync_);
+               ele, index, expanded, classes, callbacks, sentinel_, target_, sync_);
 
          // Add the chunk to our index, and remove it when the underlying chunk
          // is removed in Prosemirror


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9929.

### Approach

The classes are already being parsed on the panmirror side, so this change does the following:

1. Forwards the set of classes on the chunk/node from Panmirror to GWT
2. Uses the chunk's class as its execution "engine" displayed in the summary if no knitr engine is specified

### Automated Tests

The visual editor does not currently have automated testing. See https://github.com/rstudio/rstudio-ide-automation/issues/106.

### QA Notes

In addition to the scenario outlined in the bug, there are a number of ways of specifying classes for non-executable code; they all should work. See this doc for a list:

https://quarto.org/docs/getting-started/running-code.html#non-executable-blocks

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


