### PR TITLE
Automatically select result when there is only a single result

### DIFF
--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/insert_citation.tsx
@@ -499,12 +499,15 @@ export const InsertCitationPanel: React.FC<InsertCitationPanelProps> = props => 
           .search(searchTerm, insertCitationPanelState.selectedNode, existingCitationIds)
           .then(searchResult => {
             if (!searchCanceled.current) {
+              // If only a single result is returned, select that by default
+              const selectedIndex = searchResult?.citations.length === 1 ? 0 : -1;
+
               updateState({
                 searchTerm,
                 citations: searchResult?.citations,
                 status: searchResult?.status,
                 statusMessage: searchResult?.statusMessage,
-                selectedIndex: -1,
+                selectedIndex,
               });
             }
           });

--- a/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-doi.tsx
+++ b/src/gwt/panmirror/src/editor/src/behaviors/insert_citation/source_panels/insert_citation-source-panel-doi.tsx
@@ -99,13 +99,6 @@ export function doiSourcePanel(
 
 export const DOISourcePanel = React.forwardRef<HTMLDivElement, CitationSourcePanelProps>(
   (props: CitationSourcePanelProps, ref) => {
-    // When rendered, be sure that the item is selected
-    React.useEffect(() => {
-      if (props.citations.length > 0 && props.selectedIndex !== 0) {
-        props.onSelectedIndexChanged(0);
-      }
-    });
-
     // Track whether we are mounted to allow a latent search that returns after the
     // component unmounts to nmot mutate state further
     return (


### PR DESCRIPTION
### Intent

Improve the behavior of the Insert Citation panel, specifically the DOI panel, which currently doesn't allow the result to be unselected, once populated. 

(Addresses leftover in issue #9124)

### Approach

The DOI panel used to force the result to always be selected. Instead, the global panel will default select a single result whenever any search returns a single result, then allow that single result to have normal selection behavior.

### Automated Tests

n/a

### QA Notes

n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


