### PR TITLE
Correct relative path resolution to Zotero profile on *nix

### DIFF
--- a/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
@@ -723,6 +723,15 @@ FilePath defaultZoteroDataDir()
    return homeDir.completeChildPath("Zotero");
 }
 
+FilePath profileRelativePath(std::string sectionPath, FilePath profilesDir)
+{
+#if defined(_WIN32) || defined(__APPLE__)
+    return profilesDir.getParent().completeChildPath(sectionPath);
+#else
+    return profilesDir.completeChildPath(sectionPath);
+#endif
+}
+
 FilePath defaultProfileDir()
 {
    // read the lines
@@ -769,7 +778,7 @@ FilePath defaultProfileDir()
           if (sectionIsDefault && !sectionPath.empty())
           {
              if (sectionPathIsRelative)
-                return profilesDir.getParent().completeChildPath(sectionPath);
+                return profileRelativePath(sectionPath, profilesDir);
              else
                 return FilePath(sectionPath);
           }


### PR DESCRIPTION
### Intent

We were not correctly finding the default Zotero profile on linux, and consequently we were not detecting whether Better BibTeX was installed (due to different folder structures between platforms). This change will correctly resolve relative paths against the profiles directory on linux.

### Approach

Correct the path we inspect for resolving profiles on linux.

### Automated Tests

n/a

### QA Notes

There should be no change of behavior on Mac or Window, though those are differing code paths.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


