### PR TITLE
Fix BetterBibTeX detection on Linux

### DIFF
--- a/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsLocal.cpp
@@ -723,12 +723,12 @@ FilePath defaultZoteroDataDir()
    return homeDir.completeChildPath("Zotero");
 }
 
-FilePath profileRelativePath(std::string sectionPath, FilePath profilesDir)
+FilePath platformProfileDir(FilePath profilePath)
 {
 #if defined(_WIN32) || defined(__APPLE__)
-    return profilesDir.getParent().completeChildPath(sectionPath);
+    return profilePath.getParent();
 #else
-    return profilesDir.completeChildPath(sectionPath);
+    return profilePath;
 #endif
 }
 
@@ -736,7 +736,7 @@ FilePath defaultProfileDir()
 {
    // read the lines
    FilePath profilesDir = zoteroProfilesDir();
-   FilePath profileIni = profilesDir.getParent().completeChildPath("profiles.ini");
+   FilePath profileIni = platformProfileDir(profilesDir).completeChildPath("profiles.ini");
    if (profileIni.exists())
    {
 
@@ -778,7 +778,7 @@ FilePath defaultProfileDir()
           if (sectionIsDefault && !sectionPath.empty())
           {
              if (sectionPathIsRelative)
-                return profileRelativePath(sectionPath, profilesDir);
+                return platformProfileDir(profilesDir).completeChildPath(sectionPath);
              else
                 return FilePath(sectionPath);
           }


### PR DESCRIPTION
### Intent

Our Better BibTeX detection wasn't properly finding the default profile on Linux. Fix the path that paths are resolved to fix this.

### Approach

Don't use the parent path on Linux.

### Automated Tests

N/A

### QA Notes

Note that code paths for Win, MacOs, and Linux are each different in this case.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


