### PR TITLE
Read class as engine for zero line chunks

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -1057,6 +1057,15 @@ public class VisualModeChunk
       String engine = "R";
       String label = "";
 
+      // By convention, the first class in a non-executable chunk is its language.
+      // Use that as the "engine" unless another is explicitly specified.
+      if (classes_ != null &&
+         classes_.length() > 0 &&
+         !StringUtil.isNullOrEmpty(classes_.get(0)))
+      {
+         engine = StringUtil.capitalize(classes_.get(0));
+      }
+
       // Quarto chunks use this syntax, which must be parsed separately
       String quartoLabel = "#| label:";
 
@@ -1073,18 +1082,9 @@ public class VisualModeChunk
             }
             else
             {
-               // By convention, the first class in a non-executable chunk is its language.
-               // Use that as the "engine" unless another is explicitly specified.
-               Map<String, String> options = new HashMap<>();
-               if (classes_ != null &&
-                   classes_.length() > 0 &&
-                   !StringUtil.isNullOrEmpty(classes_.get(0)))
-               {
-                  engine = classes_.get(0);
-               }
-
                // This is the first line in the chunk (its header). Parse it, reintroducing
                // the backticks since they aren't present in the embedded editor.
+               Map<String, String> options = new HashMap<>();
                RChunkHeaderParser.parse("```" + line, engine, options);
 
                // Check for the "engine" (language) option; extract it if specified


### PR DESCRIPTION
### Intent

Addresses an unfinished part of https://github.com/rstudio/rstudio/issues/9929, in which zero-line chunks didn't have the right summary shown when collapsed. 

### Approach

Read the class outside the loop that parses lines, since that loop doesn't run at all if there are no lines. 

### Automated Tests

No automation available for visual editor. 

### QA Notes

See https://github.com/rstudio/rstudio/issues/9929.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

