### PR TITLE
add API for bug reporting

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1245,3 +1245,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
    invisible(path)
 })
 
+.rs.addApiFunction("bugReport", function()
+{
+   .rs.bugReport(pro = FALSE)
+})

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1316,15 +1316,16 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       if (is.null(rstudioInfo$edition)) "Open Source" else toupper(rstudioInfo$edition)
    )
    
-   rInfo <- local({
-      op <- options(width = 78)
-      on.exit(options(op), add = TRUE)
-      utils::sessionInfo()
-   })
-   
+   rInfo <- utils::sessionInfo()
    rVersion <- rInfo$R.version$version.string
    rVersion <- sub("^R version", "", rVersion, fixed = TRUE)
    osVersion <- rInfo$running
+   
+   rInfoText <- local({
+      op <- options(width = 78)
+      on.exit(options(op), add = TRUE)
+      paste(capture.output(print(rInfo)), collapse = "\n")
+   })
    
    # create issue template and fill in the pieces
    template <- .rs.heredoc("
@@ -1354,7 +1355,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       </details>
    ")
    
-   rInfoText <- paste(capture.output(print(rInfo)), collapse = "\n")
    rendered <- sprintf(template, rstudioVersion, rstudioEdition, osVersion, rVersion, rInfoText)
    
    # try to copy the text to the clipboard, or print it out and tell the user

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1333,8 +1333,8 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
       RStudio Edition : %s
       RStudio Version : %s
-      OS Version      : %s
-      R Version       : %s
+      OS Version : %s
+      R Version : %s
   
       ### Steps to reproduce the problem
       

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1290,6 +1290,113 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    envirs
 })
 
+.rs.addFunction("heredoc", function(text)
+{
+   # remove leading, trailing whitespace
+   trimmed <- gsub("^\\s*\\n|\\n\\s*$", "", text)
+   
+   # split into lines
+   lines <- strsplit(trimmed, "\n", fixed = TRUE)[[1L]]
+   
+   # compute common indent
+   indent <- regexpr("[^[:space:]]", lines)
+   common <- min(setdiff(indent, -1L))
+   paste(substring(lines, common), collapse = "\n")
+})
+
+.rs.addFunction("bugReport", function(pro = NULL)
+{
+   # collect information about the running version of R / RStudio
+   rstudioInfo <- .rs.api.versionInfo()
+   rstudioVersion <- format(rstudioInfo$version)
+   
+   rstudioEdition <- sprintf(
+      "%s [%s]",
+      if (rstudioInfo$mode == "desktop") "Desktop" else "Server",
+      if (is.null(rstudioInfo$edition)) "Open Source" else toupper(rstudioInfo$edition)
+   )
+   
+   rInfo <- local({
+      op <- options(width = 78)
+      on.exit(options(op), add = TRUE)
+      utils::sessionInfo()
+   })
+   
+   rVersion <- rInfo$R.version$version.string
+   rVersion <- sub("^R version", "", rVersion, fixed = TRUE)
+   osVersion <- rInfo$running
+   
+   # create issue template and fill in the pieces
+   template <- .rs.heredoc("
+      ### System details
+
+      RStudio Edition : %s
+      RStudio Version : %s
+      OS Version      : %s
+      R Version       : %s
+  
+      ### Steps to reproduce the problem
+      
+      ### Describe the problem in detail
+      
+      ### Describe the behavior you expected
+      
+      ---
+      
+      <details>
+      
+      <summary>Session Info</summary>
+      
+      ``` r
+      %s
+      ```
+      
+      </details>
+   ")
+   
+   rInfoText <- paste(capture.output(print(rInfo)), collapse = "\n")
+   rendered <- sprintf(template, rstudioVersion, rstudioEdition, osVersion, rVersion, rInfoText)
+   
+   # try to copy the text to the clipboard, or print it out and tell the user
+   # to do so
+   if (rstudioInfo$mode == "desktop" && requireNamespace("clipr", quietly = TRUE)) {
+      clipr::write_clip(rendered)
+      writeLines(.rs.heredoc("
+         * The bug report template has been written to the clipboard.
+         * Please paste the clipboard contents into the issue comment section,
+         * and then fill out the rest of the issue details.
+         *
+      "))
+   } else {
+      header <- "<!-- Please copy and paste this text to the GitHub issue page. -->"
+      text <- c(header, rendered)
+      file <- tempfile("rstudio-bug-report-", fileext = ".html")
+      on.exit(unlink(file), add = TRUE)
+      writeLines(text, con = file)
+      utils::file.edit(file)
+   }
+   
+   # if 'pro' wasn't supplied, then try to guess based on the running edition
+   if (is.null(pro))
+      pro <- !is.null(rstudioInfo$edition)
+   
+   # tell the user we're about to navigate away
+   url <- if (pro) {
+      "https://github.com/rstudio/rstudio-pro/issues/new"
+   } else {
+      "https://github.com/rstudio/rstudio/issues/new"
+   }
+   
+   # let the user know we're about to navigate away
+   fmt <- "* Navigating to '%s' in 3 seconds ..."
+   msg <- sprintf(fmt, url)
+   writeLines(msg)
+   Sys.sleep(3)
+   
+   # perform navigation
+   utils::browseURL(url)
+})
+
 .rs.addFunction("initTools", function()
 {
    ostype <- .Platform$OS.type

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1331,10 +1331,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    template <- .rs.heredoc("
       ### System details
 
-      RStudio Edition : %s
-      RStudio Version : %s
-      OS Version : %s
-      R Version : %s
+      RStudio Edition: %s
+      RStudio Version: %s
+      OS Version: %s
+      R Version: %s
   
       ### Steps to reproduce the problem
       


### PR DESCRIPTION
### Intent

This PR adds two functions, `.rs.bugReport()` and `.rs.api.bugReport()`, intended to be used both internally by us and by users to report bugs in the IDE. The goal is to automate some of the R + RStudio session information discovery, so bug reporters don't need to manually update the issue template for new bugs.

The internal version `.rs.bugReport()` is intended to be used by us, and can be used to report product bugs in both the open source and the Pro products.

Currently, the API function is only used for filing bugs on the open-source repository.

Addresses https://github.com/rstudio/rstudio/issues/10221.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

N/A

### QA Notes

Test that you can create a bug report using `.rs.bugReport()`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
