### PR TITLE
feat(i18n): i18-nify RSConnect UIBinder files

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/core/client/widget/ProgressDialog.ui.xml
@@ -1,6 +1,9 @@
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
              xmlns:g='urn:import:com.google.gwt.user.client.ui'
-             xmlns:r='urn:import:org.rstudio.core.client.widget'>
+             xmlns:r='urn:import:org.rstudio.core.client.widget'
+             ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+             ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+             ui:generateLocales="default">
 
    <ui:with field="res" type="org.rstudio.core.client.widget.ProgressDialog.Resources"/>
 
@@ -9,7 +12,8 @@
          <tr>
             <td width="100%" class="{res.styles.labelCell}" ui:field="labelCell_"><g:Label ui:field="label_" /></td>
             <td align="right" width="1%" class="{res.styles.progressCell}"><g:Image ui:field="progressAnim_" /></td>
-            <td align="right" width="1%" class="{res.styles.buttonCell}"><r:ThemedButton text="Stop" ui:field="stopButton_" /></td>
+            <td align="right" width="1%" class="{res.styles.buttonCell}"><r:ThemedButton text="Stop" ui:field="stopButton_"><ui:attribute
+                    ui:name="text" key="stopText"/> </r:ThemedButton></td>
          </tr>
          <tr>
             <td colspan="3"><g:Widget ui:field="display_"/></td>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.ui.xml
@@ -15,8 +15,10 @@
    <g:HTMLPanel>
    <g:TextBox ui:field="appTitle_"></g:TextBox>
    <g:HTMLPanel visible="false" ui:field="nameValidatePanel_">
-     <g:Label styleName="{style.validateError}" ui:field="error_">
-               <ui:msg key="validNameText">Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.</ui:msg>
+     <g:Label styleName="{style.validateError}"
+              ui:field="error_"
+              text="Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.">
+        <ui:attribute name="text" key="validNameText"/>
      </g:Label>
    </g:HTMLPanel>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextbox.ui.xml
@@ -1,6 +1,9 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+   ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+   ui:generateLocales="default">
    <ui:style>
    .validateError
    {
@@ -12,9 +15,8 @@
    <g:HTMLPanel>
    <g:TextBox ui:field="appTitle_"></g:TextBox>
    <g:HTMLPanel visible="false" ui:field="nameValidatePanel_">
-     <g:Label styleName="{style.validateError}" 
-              ui:field="error_"
-              text="Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.">
+     <g:Label styleName="{style.validateError}" ui:field="error_">
+               <ui:msg key="validNameText">Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.</ui:msg>
      </g:Label>
    </g:HTMLPanel>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextboxAppNameTextboxUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextboxAppNameTextboxUiBinderImplGenMessages_en.properties
@@ -1,0 +1,4 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.AppNameTextboxAppNameTextboxUiBinderImplGenMessages
+# Source locale en
+
+validNameText=Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextboxAppNameTextboxUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/AppNameTextboxAppNameTextboxUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,4 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.AppNameTextboxAppNameTextboxUiBinderImplGenMessages
+# Source locale fr
+
+validNameText=FR_Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubs.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubs.ui.xml
@@ -1,19 +1,20 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+   ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+   ui:generateLocales="default">
    <ui:style>
    
    </ui:style>
    <g:HTMLPanel>
       <g:HTML>
       <p>
-         RPubs is a free service from RStudio for sharing documents on the web. 
-         Click Publish to get started.
+         <ui:msg key="publishRPubsText">RPubs is a free service from RStudio for sharing documents on the web. Click Publish to get started.</ui:msg>
       </p>
       <p>
-         <strong>IMPORTANT: All documents published to RPubs are publicly 
-         visible.</strong> You should only publish documents you wish to share
-         publicly.
+         <strong><ui:msg key="importantRPubsText">IMPORTANT: All documents published to RPubs are publicly visible.</ui:msg>
+         </strong><ui:msg key="publishDocumentsText">You should only publish documents you wish to share publicly.</ui:msg>
       </p>
       </g:HTML>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPublishRPubsUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPublishRPubsUiBinderImplGenMessages_en.properties
@@ -1,0 +1,8 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.PublishRPubsPublishRPubsUiBinderImplGenMessages
+# Source locale en
+
+importantRPubsText=IMPORTANT\: All documents published to RPubs are publicly visible.
+
+publishDocumentsText=You should only publish documents you wish to share publicly.
+
+publishRPubsText=RPubs is a free service from RStudio for sharing documents on the web. Click Publish to get started.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPublishRPubsUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishRPubsPublishRPubsUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,8 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.PublishRPubsPublishRPubsUiBinderImplGenMessages
+# Source locale fr
+
+importantRPubsText=FR_IMPORTANT\: All documents published to RPubs are publicly visible.
+
+publishDocumentsText=FR_You should only publish documents you wish to share publicly.
+
+publishRPubsText=FR_RPubs is a free service from RStudio for sharing documents on the web. Click Publish to get started.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWait.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWait.ui.xml
@@ -2,7 +2,9 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rs="urn:import:org.rstudio.core.client.widget"
-   >
+   ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+   ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+   ui:generateLocales="default">
    <ui:style>
    .headerLabel
    {
@@ -16,23 +18,23 @@
    </ui:style>
    <g:HTMLPanel>
      <g:HTMLPanel ui:field="waitingPanel_">
-        <g:Label styleName="{style.headerLabel}" text="Waiting for Authentication">
+        <g:Label styleName="{style.headerLabel}">
+            <ui:msg key="waitingAuthenticationText">Waiting for Authentication</ui:msg>
         </g:Label>
          <g:HTML>
             <p>
-               A window will open momentarily to confirm your account. If it doesn't,
-               click here to open it:
+                <ui:msg key="confirmAccountText">A window will open momentarily to confirm your account. If it doesn't, click here to open it:</ui:msg>
             </p>
          </g:HTML>
          <g:Anchor ui:field="claimLink_" target="_blank"></g:Anchor>
       </g:HTMLPanel>
      <g:HTMLPanel ui:field="successPanel_" visible="false">
-        <g:Label styleName="{style.headerLabel}" text="Account Verified">
+        <g:Label styleName="{style.headerLabel}">
+            <ui:msg key="accountVerifiedText">Account Verified</ui:msg>
         </g:Label>
          <g:HTML>
             <p>
-               You've successfully authorized this computer. Click "Connect
-               Account" to add this account to RStudio.
+                <ui:msg key="connectAccountText">You've successfully authorized this computer. Click "Connect Account" to add this account to RStudio.</ui:msg>
             </p>
          </g:HTML>
       </g:HTMLPanel>
@@ -41,8 +43,10 @@
                  ui:field="errorHeader_"></g:Label>
         <g:Label styleName="{style.spaced}" 
                  ui:field="errorMessage_"></g:Label>
+         <!--Cannot use ui:msg for ThemedButton-->
         <rs:ThemedButton ui:field="tryAgainButton_" 
-                         text="Try Again"></rs:ThemedButton>
+                         text="Try Again">
+        </rs:ThemedButton>
       </g:HTMLPanel>
    </g:HTMLPanel>
 </ui:UiBinder> 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWait.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWait.ui.xml
@@ -18,8 +18,9 @@
    </ui:style>
    <g:HTMLPanel>
      <g:HTMLPanel ui:field="waitingPanel_">
-        <g:Label styleName="{style.headerLabel}">
-            <ui:msg key="waitingAuthenticationText">Waiting for Authentication</ui:msg>
+         <g:Label styleName="{style.headerLabel}"
+                  text="Waiting for Authentication">
+             <ui:attribute name="text" key="waitingAuthenticationText"/>
         </g:Label>
          <g:HTML>
             <p>
@@ -29,8 +30,9 @@
          <g:Anchor ui:field="claimLink_" target="_blank"></g:Anchor>
       </g:HTMLPanel>
      <g:HTMLPanel ui:field="successPanel_" visible="false">
-        <g:Label styleName="{style.headerLabel}">
-            <ui:msg key="accountVerifiedText">Account Verified</ui:msg>
+        <g:Label styleName="{style.headerLabel}"
+                 text="Account Verified">
+            <ui:attribute name="text" key="accountVerifiedText" />
         </g:Label>
          <g:HTML>
             <p>
@@ -43,9 +45,9 @@
                  ui:field="errorHeader_"></g:Label>
         <g:Label styleName="{style.spaced}" 
                  ui:field="errorMessage_"></g:Label>
-         <!--Cannot use ui:msg for ThemedButton-->
         <rs:ThemedButton ui:field="tryAgainButton_" 
                          text="Try Again">
+            <ui:attribute ui:name="text" key="tryAgainText"/>
         </rs:ThemedButton>
       </g:HTMLPanel>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_en.properties
@@ -1,0 +1,10 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages
+# Source locale en
+
+accountVerifiedText=Account Verified
+
+confirmAccountText=A window will open momentarily to confirm your account. If it doesn''t, click here to open it\:
+
+connectAccountText=You''ve successfully authorized this computer. Click "Connect Account" to add this account to RStudio.
+
+waitingAuthenticationText=Waiting for Authentication

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_en.properties
@@ -7,4 +7,6 @@ confirmAccountText=A window will open momentarily to confirm your account. If it
 
 connectAccountText=You''ve successfully authorized this computer. Click "Connect Account" to add this account to RStudio.
 
+tryAgainText=Try Again
+
 waitingAuthenticationText=Waiting for Authentication

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_fr.properties
@@ -7,4 +7,6 @@ confirmAccountText=FR_A window will open momentarily to confirm your account. If
 
 connectAccountText=FR_You''ve successfully authorized this computer. Click "Connect Account" to add this account to RStudio.
 
+tryAgainText=FR_Try Again
+
 waitingAuthenticationText=FR_Waiting for Authentication

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,10 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectAuthWaitRSConnectAuthWaitUiBinderImplGenMessages
+# Source locale fr
+
+accountVerifiedText=FR_Account Verified
+
+confirmAccountText=FR_A window will open momentarily to confirm your account. If it doesn''t, click here to open it\:
+
+connectAccountText=FR_You''ve successfully authorized this computer. Click "Connect Account" to add this account to RStudio.
+
+waitingAuthenticationText=FR_Waiting for Authentication

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
@@ -32,7 +32,8 @@
          <p><ui:msg key="showTokenText">Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here:</ui:msg></p>
      </g:HTML>
      <rw:FormTextArea styleName="{style.accountInfo} {style.spaced}"
-                 ui:field="accountInfo" visibleLines="5" ariaLabel="ShinyApps Token and Secret">  <!--This label cannot use <ui:msg>-->
+                 ui:field="accountInfo" visibleLines="5" ariaLabel="ShinyApps Token and Secret">
+         <ui:attribute ui:name="ariaLabel" key="shinyAppsAriaLabelText"/>
      </rw:FormTextArea>
      <g:HTML>
         <small>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccount.ui.xml
@@ -1,7 +1,10 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
-   xmlns:rw="urn:import:org.rstudio.core.client.widget">
+   xmlns:rw="urn:import:org.rstudio.core.client.widget"
+   ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+   ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+   ui:generateLocales="default">
    <ui:style type="org.rstudio.studio.client.rsconnect.ui.RSConnectCloudAccount.ConnectStyle">
     @eval fixedFont org.rstudio.core.client.theme.ThemeFonts.getFixedWidthFont();
    
@@ -24,19 +27,17 @@
    </ui:style>
    <g:HTMLPanel>
      <g:HTML>
-       <p>Go to <a href="http://www.shinyapps.io/" target="_blank">your 
-           account on ShinyApps</a> and log in.</p>
-       <p>Click your name, then choose <b>Tokens</b> from your account menu.</p>
-       <p>Click <b>Show</b> on the token you want to use, then <b>Show
-          Secret</b> and <b>Copy to Clipboard.</b> Paste the result here:</p>
+         <p><ui:msg key="loginShinyAppsText">Go to <a href="http://www.shinyapps.io/" target="_blank">your account on ShinyApps</a> and log in.</ui:msg></p>
+         <p><ui:msg key="chooseTokensText">Click your name, then choose <b>Tokens</b> from your account menu.</ui:msg></p>
+         <p><ui:msg key="showTokenText">Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here:</ui:msg></p>
      </g:HTML>
      <rw:FormTextArea styleName="{style.accountInfo} {style.spaced}"
-                 ui:field="accountInfo" visibleLines="5" ariaLabel="ShinyApps Token and Secret">
+                 ui:field="accountInfo" visibleLines="5" ariaLabel="ShinyApps Token and Secret">  <!--This label cannot use <ui:msg>-->
      </rw:FormTextArea>
      <g:HTML>
         <small>
-        Need a ShinyApps.io account? 
-           <a href="http://www.shinyapps.io" target="_blank">Get started here.</a>
+            <ui:msg key="shinyAppioAccountText">Need a ShinyApps.io account?</ui:msg>
+           <a href="http://www.shinyapps.io" target="_blank"><ui:msg key="getStartedText">Get started here.</ui:msg></a>
         </small>
      </g:HTML>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_en.properties
@@ -1,0 +1,12 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages
+# Source locale en
+
+chooseTokensText=Click your name, then choose <b>Tokens</b> from your account menu.
+
+getStartedText=Get started here.
+
+loginShinyAppsText=Go to <a href\=''http\://www.shinyapps.io/'' target\=''_blank''>your account on ShinyApps</a> and log in.
+
+shinyAppioAccountText=Need a ShinyApps.io account?
+
+showTokenText=Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_en.properties
@@ -9,4 +9,6 @@ loginShinyAppsText=Go to <a href\=''http\://www.shinyapps.io/'' target\=''_blank
 
 shinyAppioAccountText=Need a ShinyApps.io account?
 
+shinyAppsAriaLabelText=ShinyApps Token and Secret
+
 showTokenText=Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,12 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages
+# Source locale en
+
+chooseTokensText=FR_Click your name, then choose <b>Tokens</b> from your account menu.
+
+getStartedText=FR_Get started here.
+
+loginShinyAppsText=FR_Go to <a href\=''http\://www.shinyapps.io/'' target\=''_blank''>your account on ShinyApps</a> and log in.
+
+shinyAppioAccountText=FR_Need a ShinyApps.io account?
+
+showTokenText=FR_Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectCloudAccountRSConnectCloudAccountUiBinderImplGenMessages_fr.properties
@@ -9,4 +9,6 @@ loginShinyAppsText=FR_Go to <a href\=''http\://www.shinyapps.io/'' target\=''_bl
 
 shinyAppioAccountText=FR_Need a ShinyApps.io account?
 
+shinyAppsAriaLabelText=FR_ShinyApps Token and Secret
+
 showTokenText=FR_Click <b>Show</b> on the token you want to use, then <b>Show Secret</b> and <b>Copy to Clipboard.</b> Paste the result here\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -28,23 +28,28 @@
              </g:VerticalPanel>
            </g:ScrollPanel>
            <g:HorizontalPanel>
-               <!--Cannot use ui:msg for ThemedButton-->
                <rw:ThemedButton ui:field="checkUncheckAllButton_"
-                               text="Uncheck All"></rw:ThemedButton>
+                               text="Uncheck All">
+                                <ui:attribute ui:name="text" key="uncheckAllButtonText"/>
+               </rw:ThemedButton>
               <rw:ThemedButton ui:field="addFileButton_" 
                                text="Add More..."
-                               visible="false"></rw:ThemedButton>
+                               visible="false">
+                  <ui:attribute ui:name="text" key="addMoreButtonText"/>
+              </rw:ThemedButton>
            </g:HorizontalPanel>
          </g:VerticalPanel>
          <g:VerticalPanel ui:field="descriptionPanel_"
                           visible="false">
-            <g:Label><ui:msg key="publishText">Publish: </ui:msg></g:Label>
+             <g:Label text="Publish: ">
+                 <ui:attribute name="text" key="publishText"/>
+             </g:Label>
             <g:HTMLPanel styleName="{res.style.fileList} {res.style.descriptionPanel}">
                <rw:DecorativeImage ui:field="descriptionImage_"/>
             </g:HTMLPanel>
-             <!--Cannot use ui:msg for ThemedButton-->
             <rw:ThemedButton ui:field="previewButton_"
                              text="Preview...">
+                <ui:attribute ui:name="text" key="previewText"/>
             </rw:ThemedButton>
          </g:VerticalPanel>
        </g:HTMLPanel>
@@ -53,29 +58,33 @@
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%" ui:field="publishFromPanel_">
             <rw:FormLabel styleName="{res.style.firstControlLabel}"
-                     elementId="{ElementIds.getRscAccountListLabel}"
+                          text="Publish From Account:"
+                          elementId="{ElementIds.getRscAccountListLabel}"
                      ui:field="accountListLabel_">
-                     <ui:msg key="publishFromAccountText">Publish From Account:</ui:msg>
+                <ui:attribute ui:name="text" key="publishFromAccountText"/>
             </rw:FormLabel>
             <rw:HyperlinkLabel styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}"
-                               ui:field="addAccountAnchor_"><ui:msg key="addNewAccountText">Add New Account</ui:msg>
+                               ui:field="addAccountAnchor_" text="Add New Account">
+                <ui:attribute ui:name="text" key="addNewAccountText"/>
             </rw:HyperlinkLabel>
          </g:HorizontalPanel>
          <rsc:RSConnectAccountList styleName="{res.style.accountList}" 
                                    ui:field="accountList_" elementId="{ElementIds.getRscAccountList}">
          </rsc:RSConnectAccountList>
          <g:Label styleName="{res.style.firstControlLabel}"
+                  text="Publish To Account:"
                   ui:field="publishToLabel_">
-                  <ui:msg key="publishToAccountText">Publish To Account:</ui:msg>
+             <ui:attribute name="text" key="publishToAccountText"/>
          </g:Label>
          <g:HTMLPanel styleName="{res.style.accountEntry}" ui:field="accountEntryPanel_">
             <rsc:RSConnectAccountEntry ui:field="accountEntry_">
             </rsc:RSConnectAccountEntry>
          </g:HTMLPanel>
          <g:HTMLPanel ui:field="newAppPanel_">
-            <rw:FormLabel styleName="{res.style.controlLabel}" ui:field="nameLabel_">
-                <ui:msg key="titleText">Title:</ui:msg></rw:FormLabel>
-            <rsc:AppNameTextbox styleName="{res.style.gridControl}" 
+            <rw:FormLabel styleName="{res.style.controlLabel}" ui:field="nameLabel_" text="Title:">
+                <ui:attribute ui:name="text" key="titleText"/>
+            </rw:FormLabel>
+            <rsc:AppNameTextbox styleName="{res.style.gridControl}"
                                 ui:field="appName_">
             </rsc:AppNameTextbox>
          </g:HTMLPanel>
@@ -83,12 +92,12 @@
                       ui:field="appInfoPanel_">
             <g:HorizontalPanel width="100%"
                                styleName="{res.style.controlLabel}">
-               <g:Label>
-                   <ui:msg key="updateText">Update:</ui:msg>
+                <g:Label text="Update:">
+                    <ui:attribute name="text" key="updateText"/>
                </g:Label>
                <rw:HyperlinkLabel stylePrimaryName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
                                   ui:field="createNewAnchor_" text="Create New">
-                   <ui:msg key="createNewText">Create New</ui:msg>
+                  <ui:attribute ui:name="text" key="createNewText"/>
                </rw:HyperlinkLabel>
             </g:HorizontalPanel>
             <g:HTMLPanel ui:field="appDetailsPanel_" 
@@ -101,7 +110,9 @@
             </g:HTMLPanel>
             <g:HTMLPanel styleName="{res.style.progressPanel}" 
                          ui:field="appProgressPanel_" visible="false">
-               <g:InlineLabel><ui:msg key="lookingUpDetailsText">Looking up details for </ui:msg></g:InlineLabel>
+                <g:InlineLabel text="Looking up details for ">
+                    <ui:attribute name="text" key="lookingUpDetailsText"/>
+                </g:InlineLabel>
                <g:InlineLabel styleName="{res.style.statusLabel}" 
                               ui:field="appProgressName_"></g:InlineLabel>
                <g:InlineLabel text="..."></g:InlineLabel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -2,11 +2,15 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:rsc="urn:import:org.rstudio.studio.client.rsconnect.ui"
-    xmlns:rw="urn:import:org.rstudio.core.client.widget">
+    xmlns:rw="urn:import:org.rstudio.core.client.widget"
+    ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+    ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+    ui:generateLocales="default">
     <ui:with field="res" type="org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.DeployResources" />
     <ui:with field="coreRes" type="org.rstudio.core.client.resources.CoreResources" />
     <ui:with field="themeRes" type="org.rstudio.core.client.theme.res.ThemeResources" />
     <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
+
     <g:HTMLPanel ui:field="rootPanel_">
     <rw:DecorativeImage ui:field="deployIllustration_"/>
     <rw:LayoutGrid><rw:row>
@@ -24,7 +28,8 @@
              </g:VerticalPanel>
            </g:ScrollPanel>
            <g:HorizontalPanel>
-              <rw:ThemedButton ui:field="checkUncheckAllButton_" 
+               <!--Cannot use ui:msg for ThemedButton-->
+               <rw:ThemedButton ui:field="checkUncheckAllButton_"
                                text="Uncheck All"></rw:ThemedButton>
               <rw:ThemedButton ui:field="addFileButton_" 
                                text="Add More..."
@@ -33,10 +38,11 @@
          </g:VerticalPanel>
          <g:VerticalPanel ui:field="descriptionPanel_"
                           visible="false">
-            <g:Label text="Publish: "></g:Label>
+            <g:Label><ui:msg key="publishText">Publish: </ui:msg></g:Label>
             <g:HTMLPanel styleName="{res.style.fileList} {res.style.descriptionPanel}">
                <rw:DecorativeImage ui:field="descriptionImage_"/>
             </g:HTMLPanel>
+             <!--Cannot use ui:msg for ThemedButton-->
             <rw:ThemedButton ui:field="previewButton_"
                              text="Preview...">
             </rw:ThemedButton>
@@ -46,26 +52,29 @@
      <rw:customCell styleName="{res.style.rootCell}">
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%" ui:field="publishFromPanel_">
-            <rw:FormLabel styleName="{res.style.firstControlLabel}" 
-                     text="Publish From Account:" elementId="{ElementIds.getRscAccountListLabel}"
-                     ui:field="accountListLabel_"/>
+            <rw:FormLabel styleName="{res.style.firstControlLabel}"
+                     elementId="{ElementIds.getRscAccountListLabel}"
+                     ui:field="accountListLabel_">
+                     <ui:msg key="publishFromAccountText">Publish From Account:</ui:msg>
+            </rw:FormLabel>
             <rw:HyperlinkLabel styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}"
-                       ui:field="addAccountAnchor_" text="Add New Account"/>
+                               ui:field="addAccountAnchor_"><ui:msg key="addNewAccountText">Add New Account</ui:msg>
+            </rw:HyperlinkLabel>
          </g:HorizontalPanel>
          <rsc:RSConnectAccountList styleName="{res.style.accountList}" 
                                    ui:field="accountList_" elementId="{ElementIds.getRscAccountList}">
          </rsc:RSConnectAccountList>
-         <g:Label styleName="{res.style.firstControlLabel}" 
-                  text="Publish To Account:"
+         <g:Label styleName="{res.style.firstControlLabel}"
                   ui:field="publishToLabel_">
+                  <ui:msg key="publishToAccountText">Publish To Account:</ui:msg>
          </g:Label>
          <g:HTMLPanel styleName="{res.style.accountEntry}" ui:field="accountEntryPanel_">
             <rsc:RSConnectAccountEntry ui:field="accountEntry_">
             </rsc:RSConnectAccountEntry>
          </g:HTMLPanel>
          <g:HTMLPanel ui:field="newAppPanel_">
-            <rw:FormLabel styleName="{res.style.controlLabel}" ui:field="nameLabel_" 
-                     text="Title:"></rw:FormLabel>
+            <rw:FormLabel styleName="{res.style.controlLabel}" ui:field="nameLabel_">
+                <ui:msg key="titleText">Title:</ui:msg></rw:FormLabel>
             <rsc:AppNameTextbox styleName="{res.style.gridControl}" 
                                 ui:field="appName_">
             </rsc:AppNameTextbox>
@@ -74,10 +83,13 @@
                       ui:field="appInfoPanel_">
             <g:HorizontalPanel width="100%"
                                styleName="{res.style.controlLabel}">
-               <g:Label text="Update:">
+               <g:Label>
+                   <ui:msg key="updateText">Update:</ui:msg>
                </g:Label>
                <rw:HyperlinkLabel stylePrimaryName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
-                          ui:field="createNewAnchor_" text="Create New"/>
+                                  ui:field="createNewAnchor_" text="Create New">
+                   <ui:msg key="createNewText">Create New</ui:msg>
+               </rw:HyperlinkLabel>
             </g:HorizontalPanel>
             <g:HTMLPanel ui:field="appDetailsPanel_" 
                          styleName="{res.style.appDetailsPanel}" 
@@ -89,7 +101,7 @@
             </g:HTMLPanel>
             <g:HTMLPanel styleName="{res.style.progressPanel}" 
                          ui:field="appProgressPanel_" visible="false">
-               <g:InlineLabel text="Looking up details for "></g:InlineLabel>
+               <g:InlineLabel><ui:msg key="lookingUpDetailsText">Looking up details for </ui:msg></g:InlineLabel>
                <g:InlineLabel styleName="{res.style.statusLabel}" 
                               ui:field="appProgressName_"></g:InlineLabel>
                <g:InlineLabel text="..."></g:InlineLabel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
@@ -1,0 +1,18 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectDeployRSConnectDeployUiBinderImplGenMessages
+# Source locale en
+
+addNewAccountText=Add New Account
+
+createNewText=Create New
+
+lookingUpDetailsText=Looking up details for
+
+publishFromAccountText=Publish From Account\:
+
+publishText=Publish\:
+
+publishToAccountText=Publish To Account\:
+
+titleText=Title\:
+
+updateText=Update\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
@@ -1,11 +1,15 @@
 # Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectDeployRSConnectDeployUiBinderImplGenMessages
 # Source locale en
 
+addMoreButtonText=Add More...
+
 addNewAccountText=Add New Account
 
 createNewText=Create New
 
 lookingUpDetailsText=Looking up details for
+
+previewText=Preview...
 
 publishFromAccountText=Publish From Account\:
 
@@ -14,5 +18,7 @@ publishText=Publish\:
 publishToAccountText=Publish To Account\:
 
 titleText=Title\:
+
+uncheckAllButtonText=Uncheck All
 
 updateText=Update\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_fr.properties
@@ -1,11 +1,15 @@
 # Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectDeployRSConnectDeployUiBinderImplGenMessages
 # Source locale en
 
+addMoreButtonText=FR_Add More...
+
 addNewAccountText=FR_Add New Account
 
 createNewText=FR_Create New
 
 lookingUpDetailsText=FR_Looking up details for
+
+previewText=FR_Preview...
 
 publishFromAccountText=FR_Publish From Account\:
 
@@ -14,5 +18,7 @@ publishText=FR_Publish\:
 publishToAccountText=FR_Publish To Account\:
 
 titleText=FR_Title\:
+
+uncheckAllButtonText=FR_Uncheck All
 
 updateText=FR_Update\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,18 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectDeployRSConnectDeployUiBinderImplGenMessages
+# Source locale en
+
+addNewAccountText=FR_Add New Account
+
+createNewText=FR_Create New
+
+lookingUpDetailsText=FR_Looking up details for
+
+publishFromAccountText=FR_Publish From Account\:
+
+publishText=FR_Publish\:
+
+publishToAccountText=FR_Publish To Account\:
+
+titleText=FR_Title\:
+
+updateText=FR_Update\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
@@ -34,14 +34,18 @@
     </ui:style>
     <g:HTMLPanel>
         <g:VerticalPanel>
-         <rsw:FormLabel for="{ElementIds.getRscServerUrl}"> <ui:msg key="enterPublicURLText">Enter the public URL of the RStudio Connect server:</ui:msg></rsw:FormLabel>
+         <rsw:FormLabel for="{ElementIds.getRscServerUrl}"
+                        text="Enter the public URL of the RStudio Connect server:">
+             <ui:attribute ui:name="text" key="enterPublicURLText"/>
+         </rsw:FormLabel>
          <rsw:TextBoxWithCue styleName="{style.textControl}"
                              cueText="servername.com:3939"
                              width="250px"
                              elementId="{ElementIds.getRscServerUrl}" 
                              ui:field="serverUrl_"/>
-         <g:Label styleName="{style.spaced} {style.explanatoryText}">
-             <ui:msg key="contactAdminText">Contact your RStudio Connect server administrator if you need its URL.</ui:msg>
+         <g:Label styleName="{style.spaced} {style.explanatoryText}"
+             text="Contact your RStudio Connect server administrator if you need its URL.">
+             <ui:attribute name="text" key="contactAdminText"/>
          </g:Label>
          <rsc:HelpLink caption="About RStudio Connect" 
                        link="rstudio_connect"

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccount.ui.xml
@@ -2,7 +2,10 @@
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
     xmlns:g="urn:import:com.google.gwt.user.client.ui"
     xmlns:rsw="urn:import:org.rstudio.core.client.widget"
-    xmlns:rsc="urn:import:org.rstudio.studio.client.common">
+    xmlns:rsc="urn:import:org.rstudio.studio.client.common"
+    ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+    ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+    ui:generateLocales="default">
     <ui:with field="ElementIds" type="org.rstudio.core.client.ElementIds"/>
     <ui:style>
     .explanatoryText
@@ -30,16 +33,15 @@
     }
     </ui:style>
     <g:HTMLPanel>
-      <g:VerticalPanel>
-         <rsw:FormLabel for="{ElementIds.getRscServerUrl}"
-                        text="Enter the public URL of the RStudio Connect server:"/>
+        <g:VerticalPanel>
+         <rsw:FormLabel for="{ElementIds.getRscServerUrl}"> <ui:msg key="enterPublicURLText">Enter the public URL of the RStudio Connect server:</ui:msg></rsw:FormLabel>
          <rsw:TextBoxWithCue styleName="{style.textControl}"
                              cueText="servername.com:3939"
                              width="250px"
                              elementId="{ElementIds.getRscServerUrl}" 
                              ui:field="serverUrl_"/>
-         <g:Label styleName="{style.spaced} {style.explanatoryText}"
-                  text="Contact your RStudio Connect server administrator if you need its URL.">
+         <g:Label styleName="{style.spaced} {style.explanatoryText}">
+             <ui:msg key="contactAdminText">Contact your RStudio Connect server administrator if you need its URL.</ui:msg>
          </g:Label>
          <rsc:HelpLink caption="About RStudio Connect" 
                        link="rstudio_connect"

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages_en.properties
@@ -1,0 +1,7 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages
+# Source locale en
+
+
+contactAdminText=Contact your RStudio Connect server administrator if you need its URL.
+
+enterPublicURLText=Enter the public URL of the RStudio Connect server\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,7 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectLocalAccountRSConnectLocalAccountUiBinderImplGenMessages
+# Source locale fr
+
+
+contactAdminText=FR_Contact your RStudio Connect server administrator if you need its URL.
+
+enterPublicURLText=FR_Enter the public URL of the RStudio Connect server\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccount.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccount.ui.xml
@@ -1,18 +1,19 @@
 <!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
-   xmlns:g="urn:import:com.google.gwt.user.client.ui">
+   xmlns:g="urn:import:com.google.gwt.user.client.ui"
+   ui:generateFormat='com.google.gwt.i18n.server.PropertyCatalogFactory'
+   ui:generateKeys="com.google.gwt.i18n.server.keygen.MD5KeyGenerator"
+   ui:generateLocales="default">
    <ui:style>
    
    </ui:style>
    <g:HTMLPanel>
    <g:HTML>
    <p>
-      To publish content, you first need to connect RStudio to an account on 
-      the service you want to publish to.
+      <ui:msg key="publishContentText">To publish content, you first need to connect RStudio to an account on the service you want to publish to.</ui:msg>
    </p>
    <p>
-      Once you've authorized this computer to publish content to an account, 
-      you can publish any time without re-entering your credentials.
+      <ui:msg key="authorizeNewAccountText">Once you've authorized this computer to publish content to an account, you can publish any time without re-entering your credentials.</ui:msg>
    </p>
    </g:HTML>
    </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages_en.properties
@@ -1,0 +1,6 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages
+# Source locale en
+
+authorizeNewAccountText=Once you''ve authorized this computer to publish content to an account, you can publish any time without re-entering your credentials.
+
+publishContentText=To publish content, you first need to connect RStudio to an account on the service you want to publish to.

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages_fr.properties
@@ -1,0 +1,6 @@
+# Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectNewAccountRSConnectNewAccountUiBinderImplGenMessages
+# Source locale fr
+
+authorizeNewAccountText=FR_Once you''ve authorized this computer to publish content to an account, you can publish any time without re-entering your credentials.
+
+publishContentText=FR_To publish content, you first need to connect RStudio to an account on the service you want to publish to.


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

This PR tackles ui.xml files in studio.client.rsconnect.
Issue: https://github.com/StatCan/daaas/issues/755

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

@gtritchie I started i18n-ifying the ui.xml files under the rsconnect folder. I followed the [gwt i18n documentation on UiBinder](http://www.gwtproject.org/doc/latest/DevGuideUiBinderI18n.html) I was able to verify a few html pages in the Connect Account page. But for the other ui.xmls I was not sure where they existed in RStudio/how to access them. 

I used the ui:msg tags to replace all text in the xml  for e.g. `<ui:msg key="validNameText">Valid names contain 4 to 64 alphanumeric characters, dashes, and underscores </ui:msg>`

I had an issue with the `<rw:ThemedButton` tags. Those tags don't allow child elements (unable to add <ui:msg tag inside).  I did see there is a java class called ThemedButton.java. I am not too sure if that can be modified to accept an element inside the tag.

As you may know GWT auto generates the properties files at compile time. The name of the file is preset and cannot be changed e.g. AppNameTextboxAppNameTextboxUiBinderImplGenMessages_en.properties. This file is generated in the extras folder and then must be copied to where the ui.xml file exists. I've created the _fr.properties files  and appended FR_ to each literal for now. French props files will be updated very soon.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

Modify an entry in one of the new _en.properties files, and refresh RStudio with ant in devmode.
Run create_dev_locale.sh to clone all _en properties files, which will add a prefix of "@" to each constant and message. Then open RStudio using http://localhost:8787/?locale=dev and browse to the Options->* menus. You can also view in desktop mode by swapping the locale element value attribute from value="en" to value="dev" in RStudio.gwt.xml.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

cc @gtritchie 

