### PR TITLE
Fix display of selected items in Files pane

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilesListDataGridStyle.css
@@ -34,3 +34,11 @@
   border-color: transparent;
 }
 
+.dataGridEvenRow,
+.dataGridOddRow,
+.dataGridHoveredRow,
+.dataGridSelectedRow,
+.dataGridKeyboardSelectedRow {
+  background: inherit;
+}
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10219.

### Approach

Restore some style rules that were over-aggressively removed when excising the Classic theme.

### Automated Tests

N/A, this is a pure CSS/visual change. 

### QA Notes

This change only affects the Files pane.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


