### PR TITLE
Ensure source ref change triggers context update

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -190,8 +190,11 @@ bool RCntxt::operator==(const RCntxt& other) const
    if (other.pCntxt_ == pCntxt_)
       return true;
 
-   // Also equivalent if they refer to the same call, at the same depth, on the stack
-   if (other.call() == call() && other.evaldepth() == evaldepth())
+   // Also equivalent if they refer to the same call at the same stack position and have the same
+   // source references
+   if (other.call() == call() && 
+       other.evaldepth() == evaldepth() &&
+       other.srcref() == srcref())
       return true;
 
    return false;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10045, a regression introduced by https://github.com/rstudio/rstudio/pull/9922. 

### Approach

The original equality check in #9922 didn't check source references, so stepping linewise through a function (which changes the source references as you step) didn't register as an update. The fix is to add these to the equality check.

### Automated Tests

https://github.com/rstudio/rstudio-ide-automation/issues/497

### QA Notes

There's a good repo case in https://github.com/rstudio/rstudio/issues/10045. The original issue that #9922 was intended to fix was https://github.com/rstudio/rstudio/issues/9918, so make sure that this change keeps that fix intact, too. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


