### PR TITLE
Reintroduce Level 1 Heading menu item

### DIFF
--- a/src/gwt/panmirror/src/editor/src/nodes/heading.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/heading.ts
@@ -129,6 +129,7 @@ const extension = (context: ExtensionContext): Extension => {
 
     commands: (schema: Schema) => {
       return [
+        new HeadingCommand(schema, EditorCommandId.Heading1, 1, heading1OmniInsert(ui)),
         new HeadingCommand(schema, EditorCommandId.Heading2, 2, heading2OmniInsert(ui)),
         new HeadingCommand(schema, EditorCommandId.Heading3, 3, heading3OmniInsert(ui)),
         new HeadingCommand(schema, EditorCommandId.Heading4, 4, heading4OmniInsert(ui)),
@@ -204,6 +205,12 @@ class HeadingCommand extends ProsemirrorCommand {
 }
 
 
+function heading1OmniInsert(ui: EditorUI) {
+  return headingOmniInsert(ui, 1, ui.context.translateText('Top level heading'), [
+    ui.images.omni_insert?.heading1!,
+    ui.images.omni_insert?.heading1_dark!,
+  ]);
+}
 function heading2OmniInsert(ui: EditorUI) {
   return headingOmniInsert(ui, 2, ui.context.translateText('Section heading'), [
     ui.images.omni_insert?.heading2!,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10228.

### Approach

Reintroduces Level 1 headings removed in https://github.com/rstudio/rstudio/commit/898299b58ff04e033b1cb33c7f3c46a6504cbb01#diff-e6b80021dffd9dc8f868e302235bc49936473385d419014fae99cc09c6234504.

### Automated Tests

Already present; found by automation.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10228.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


