### PR TITLE
Remove temp file created as part of pandocSelfContainedHtml

### DIFF
--- a/src/cpp/session/modules/ModuleTools.R
+++ b/src/cpp/session/modules/ModuleTools.R
@@ -379,6 +379,7 @@
 
    # create a temporary copy of the file for conversion
    inputFile <- tempfile(tmpdir = dirname(input), fileext = ".html")
+   on.exit(unlink(inputFile), add=TRUE)
    inputLines <- readLines(con = input, warn = FALSE)
 
    # write all the lines from the input except the DOCTYPE declaration, which pandoc will not treat


### PR DESCRIPTION
@mine-cetinkaya-rundel reported seeing a temp file left over after publishing a Quarto presentation to RPubs. I initially thought it was something Quarto specific but it looks to me as if whenever we call `.rs.pandocSelfContainedHtml` we don't remove the temp file. Here's the commit where creation of the temp file was introduced:

https://github.com/rstudio/rstudio/commit/364819687bf1498a27554056b25a170ce93de1c7

This fix just adds an `on.exit` handler that removes the temp file. @jmcphers asking for your review as a sanity check.