### PR TITLE
allow session to copy text to clipboard

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1357,31 +1357,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    
    rendered <- sprintf(template, rstudioVersion, rstudioEdition, osVersion, rVersion, rInfoText)
    
-   # try to copy the text to the clipboard, or print it out and tell the user
-   # to do so
-   if (rstudioInfo$mode == "desktop" && requireNamespace("clipr", quietly = TRUE)) {
-      clipr::write_clip(rendered)
-      writeLines(.rs.heredoc("
-         * The bug report template has been written to the clipboard.
-         * Please paste the clipboard contents into the issue comment section,
-         * and then fill out the rest of the issue details.
-         *
-      "))
-   } else {
-      
-      header <- .rs.heredoc("
-         <!--
-         Please copy the following text to your clipboard,
-         and then click 'Cancel' to close the dialog.
-         -->
-      ")
-      
-      text <- c(header, "", rendered)
-      file <- tempfile("rstudio-bug-report-", fileext = ".html")
-      on.exit(unlink(file), add = TRUE)
-      writeLines(text, con = file)
-      utils::file.edit(file)
-   }
+   # try to copy the text to the clipboard
+   text <- paste(rendered, collapse = "\n")
+   .Call("rs_clipboardCopy", text, PACKAGE = "(embedding)")
    
    # if 'pro' wasn't supplied, then try to guess based on the running edition
    if (is.null(pro))
@@ -1394,8 +1372,15 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
       "https://github.com/rstudio/rstudio/issues/new"
    }
    
-   # let the user know we're about to navigate away
-   fmt <- "* Navigating to '%s' in 3 seconds ..."
+   # notify the user
+   fmt <- .rs.heredoc("
+      * The bug report template has been written to the clipboard.
+      * Please paste the clipboard contents into the issue comment section,
+      * and then fill out the rest of the issue details.
+      *
+      * Navigating to '%s' in 3 seconds ...
+   ")
+   
    msg <- sprintf(fmt, url)
    writeLines(msg)
    Sys.sleep(3)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1380,11 +1380,13 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
          -->
       ")
       
+      # write generated text to file, then open it in an editor
       text <- c(header, "", rendered)
       file <- tempfile("rstudio-bug-report-", fileext = ".html")
       on.exit(unlink(file), add = TRUE)
       writeLines(text, con = file)
       utils::file.edit(file)
+
    }
    
    # if 'pro' wasn't supplied, then try to guess based on the running edition
@@ -1399,14 +1401,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    }
    
    # notify the user
-   fmt <- .rs.heredoc("
-      * The bug report template has been written to the clipboard.
-      * Please paste the clipboard contents into the issue comment section,
-      * and then fill out the rest of the issue details.
-      *
-      * Navigating to '%s' in 3 seconds ...
-   ")
-   
+   fmt <- " * Navigating to '%s' in 3 seconds ... "
    msg <- sprintf(fmt, url)
    writeLines(msg)
    Sys.sleep(3)

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -161,8 +161,8 @@ set(SESSION_SOURCE_FILES
    modules/SessionCodeSearch.cpp
    modules/SessionConfigFile.cpp
    modules/SessionCRANMirrors.cpp
+   modules/SessionClipboard.cpp
    modules/SessionCrashHandler.cpp
-   modules/SessionUserCommands.cpp
    modules/SessionConsole.cpp
    modules/SessionDependencies.cpp
    modules/SessionDependencyList.cpp
@@ -217,6 +217,7 @@ set(SESSION_SOURCE_FILES
    modules/SessionSVN.cpp
    modules/SessionSystemResources.cpp
    modules/SessionUpdates.cpp
+   modules/SessionUserCommands.cpp
    modules/SessionVCS.cpp
    modules/SessionWorkbench.cpp
    modules/SessionUserPrefs.cpp

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -211,6 +211,7 @@ const int kConsoleActivate = 193;
 const int kJobsActivate = 194;
 const int kPresentationPreview = 195;
 const int kSuspendBlocked = 196;
+const int kClipboardAction = 197;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -588,6 +589,8 @@ std::string ClientEvent::typeName() const
          return "presentation_preview";
       case client_events::kSuspendBlocked:
          return "session_suspend_blocked";
+	  case client_events::kClipboardAction:
+		 return "clipboard_action";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -128,6 +128,7 @@
 #include "modules/SessionAuthoring.hpp"
 #include "modules/SessionBreakpoints.hpp"
 #include "modules/SessionHTMLPreview.hpp"
+#include "modules/SessionClipboard.hpp"
 #include "modules/SessionCodeSearch.hpp"
 #include "modules/SessionConfigFile.hpp"
 #include "modules/SessionConsole.hpp"
@@ -551,6 +552,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::crypto::initialize)
 #endif
       (modules::code_search::initialize)
+      (modules::clipboard::initialize)
       (modules::clang::initialize)
       (modules::connections::initialize)
       (modules::files::initialize)

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -212,6 +212,7 @@ extern const int kConsoleActivate;
 extern const int kJobsActivate;
 extern const int kPresentationPreview;
 extern const int kSuspendBlocked;
+extern const int kClipboardAction;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/SessionClipboard.cpp
+++ b/src/cpp/session/modules/SessionClipboard.cpp
@@ -20,6 +20,7 @@
 #include <r/RRoutines.hpp>
 #include <r/RSexp.hpp>
 
+#include <session/SessionOptions.hpp>
 #include <session/SessionClientEvent.hpp>
 #include <session/SessionModuleContext.hpp>
 
@@ -30,26 +31,30 @@ namespace session {
 namespace modules {
 namespace clipboard {
 
-void clipboardCopy(const std::string& text)
+void clipboardSetText(const std::string& text)
 {
+   // not supported on RStudio Server
+   if (options().programMode() == kSessionProgramModeServer)
+      return;
+   
    json::Object payload;
-   payload["type"] = "copy";
+   payload["type"] = "set";
    payload["text"] = text;
    
    ClientEvent event(client_events::kClipboardAction, payload);
    module_context::enqueClientEvent(event);
 }
 
-SEXP rs_clipboardCopy(SEXP textSEXP)
+SEXP rs_clipboardSetText(SEXP textSEXP)
 {
    std::string text = r::sexp::asString(textSEXP);
-   clipboardCopy(text);
+   clipboardSetText(text);
    return R_NilValue;
 }
 
 Error initialize()
 {
-   RS_REGISTER_CALL_METHOD(rs_clipboardCopy);
+   RS_REGISTER_CALL_METHOD(rs_clipboardSetText);
    return Success();
 }
 

--- a/src/cpp/session/modules/SessionClipboard.cpp
+++ b/src/cpp/session/modules/SessionClipboard.cpp
@@ -1,0 +1,59 @@
+/*
+ * SessionClipboard.cpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionClipboard.hpp"
+
+#include <shared_core/json/Json.hpp>
+
+#include <r/RRoutines.hpp>
+#include <r/RSexp.hpp>
+
+#include <session/SessionClientEvent.hpp>
+#include <session/SessionModuleContext.hpp>
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace clipboard {
+
+void clipboardCopy(const std::string& text)
+{
+   json::Object payload;
+   payload["type"] = "copy";
+   payload["text"] = text;
+   
+   ClientEvent event(client_events::kClipboardAction, payload);
+   module_context::enqueClientEvent(event);
+}
+
+SEXP rs_clipboardCopy(SEXP textSEXP)
+{
+   std::string text = r::sexp::asString(textSEXP);
+   clipboardCopy(text);
+   return R_NilValue;
+}
+
+Error initialize()
+{
+   RS_REGISTER_CALL_METHOD(rs_clipboardCopy);
+   return Success();
+}
+
+} // end namespace clipboard
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio

--- a/src/cpp/session/modules/SessionClipboard.hpp
+++ b/src/cpp/session/modules/SessionClipboard.hpp
@@ -30,7 +30,6 @@ namespace session {
 namespace modules {
 namespace clipboard {
 
-void clipboardCopy(const std::string& text);
 core::Error initialize();
 
 } // end namespace clipboard

--- a/src/cpp/session/modules/SessionClipboard.hpp
+++ b/src/cpp/session/modules/SessionClipboard.hpp
@@ -16,8 +16,6 @@
 #ifndef SESSION_CLIPBOARD_HPP
 #define SESSION_CLIPBOARD_HPP
 
-#include <string>
-
 namespace rstudio {
 namespace core {
 class Error;

--- a/src/cpp/session/modules/SessionClipboard.hpp
+++ b/src/cpp/session/modules/SessionClipboard.hpp
@@ -1,0 +1,48 @@
+/*
+ * SessionClipboard.hpp
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_CLIPBOARD_HPP
+#define SESSION_CLIPBOARD_HPP
+
+#include <string>
+
+namespace rstudio {
+namespace core {
+class Error;
+} // end namespace core
+} // end namespace rstudio
+
+
+namespace rstudio {
+namespace session {
+namespace modules {
+namespace clipboard {
+
+void clipboardCopy(const std::string& text);
+core::Error initialize();
+
+} // end namespace clipboard
+} // end namespace modules
+} // end namespace session
+} // end namespace rstudio
+
+#endif /* SESSION_CLIPBOARD_HPP */
+#ifndef SESSION_CLIPBOARD_HPP
+#define SESSION_CLIPBOARD_HPP
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+#endif

--- a/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
+++ b/src/gwt/src/org/rstudio/core/client/command/EditorCommandManager.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.ConfigFileBacked;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -154,7 +155,7 @@ public class EditorCommandManager
             // natively understand "~"
             path = files_.resolveAliasedPath(FileSystemItem.createFile(path));
          }
-         DomUtils.copyToClipboard(path);
+         Clipboard.setText(path);
       });
    }
 

--- a/src/gwt/src/org/rstudio/core/client/dom/Clipboard.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/Clipboard.java
@@ -1,0 +1,57 @@
+/*
+ * Clipboard.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.dom;
+
+public class Clipboard
+{
+   public static final native void setText(String text)
+   /*-{ 
+      
+      // Use newer clipboard APIs if available.
+      var clipboard = ($wnd.navigator || {}).clipboard;
+      if (clipboard != null) {
+         try {
+            clipboard.writeText(text);
+         } catch (e) {
+            console.warn("Copy to clipboard failed: ", e);
+         }
+         return;
+      }
+      
+      // Use 'document.execCommand()' for older browsers.
+      if ($doc.queryCommandSupported && $doc.queryCommandSupported("copy")) {
+      
+         // prepare text area for copy
+         var textarea = $doc.createElement("textarea");
+         textarea.textContent = text;
+         textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in Microsoft Edge.
+         $doc.body.appendChild(textarea);
+         textarea.select();
+         
+         // Security exception may be thrown by some browsers. 
+         try {
+            $doc.execCommand("copy");
+         }
+         catch (ex) {
+            console.warn("Copy to clipboard failed.", ex);
+         }
+         finally {
+            $doc.body.removeChild(textarea);
+         }
+      }
+      
+   }-*/;
+      
+}

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1047,18 +1047,6 @@ public class DomUtils
          el.setSelectionRange(start, end);
    }-*/;
 
-   public static final native void copyCodeToClipboard(String text) /*-{
-      var copyElem = document.createElement('pre');
-      copyElem.contentEditable = true;
-      document.body.appendChild(copyElem);
-      copyElem.innerHTML = text;
-      copyElem.unselectable = "off";
-      copyElem.focus();
-      document.execCommand('SelectAll');
-      document.execCommand("Copy", false, null);
-      document.body.removeChild(copyElem);
-   }-*/;
-
    public static final String extractCssValue(String className,
          String propertyName)
    {
@@ -1343,27 +1331,41 @@ public class DomUtils
    }-*/;
 
    public static final native void copyToClipboard(String text)
-   /*-{
-      if (window.clipboardData && window.clipboardData.setData) {
-         // Internet Explorer-specific code path to prevent textarea being shown while dialog is visible.
-         clipboardData.setData("Text", text);
+   /*-{ 
+      
+      // Use newer clipboard APIs if available.
+      var clipboard = ($wnd.navigator || {}).clipboard;
+      if (clipboard != null) {
+         try {
+            clipboard.writeText(text);
+         } catch (e) {
+            console.warn("Copy to clipboard failed: ", e);
+         }
+         return;
       }
-      else if (document.queryCommandSupported && document.queryCommandSupported("copy")) {
-         var textarea = document.createElement("textarea");
+      
+      // Use 'document.execCommand()' for older browsers.
+      if ($doc.queryCommandSupported && $doc.queryCommandSupported("copy")) {
+      
+         // prepare text area for copy
+         var textarea = $doc.createElement("textarea");
          textarea.textContent = text;
          textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in Microsoft Edge.
-         document.body.appendChild(textarea);
+         $doc.body.appendChild(textarea);
          textarea.select();
+         
+         // Security exception may be thrown by some browsers. 
          try {
-            document.execCommand("copy");  // Security exception may be thrown by some browsers.
+            $doc.execCommand("copy");
          }
          catch (ex) {
             console.warn("Copy to clipboard failed.", ex);
          }
          finally {
-            document.body.removeChild(textarea);
+            $doc.body.removeChild(textarea);
          }
       }
+      
    }-*/;
 
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -1330,43 +1330,6 @@ public class DomUtils
       return el.getBoundingClientRect();
    }-*/;
 
-   public static final native void copyToClipboard(String text)
-   /*-{ 
-      
-      // Use newer clipboard APIs if available.
-      var clipboard = ($wnd.navigator || {}).clipboard;
-      if (clipboard != null) {
-         try {
-            clipboard.writeText(text);
-         } catch (e) {
-            console.warn("Copy to clipboard failed: ", e);
-         }
-         return;
-      }
-      
-      // Use 'document.execCommand()' for older browsers.
-      if ($doc.queryCommandSupported && $doc.queryCommandSupported("copy")) {
-      
-         // prepare text area for copy
-         var textarea = $doc.createElement("textarea");
-         textarea.textContent = text;
-         textarea.style.position = "fixed";  // Prevent scrolling to bottom of page in Microsoft Edge.
-         $doc.body.appendChild(textarea);
-         textarea.select();
-         
-         // Security exception may be thrown by some browsers. 
-         try {
-            $doc.execCommand("copy");
-         }
-         catch (ex) {
-            console.warn("Copy to clipboard failed.", ex);
-         }
-         finally {
-            $doc.body.removeChild(textarea);
-         }
-      }
-      
-   }-*/;
 
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
    private static int SCROLLBAR_WIDTH = -1;

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.application;
 
 import java.util.ArrayList;
 
-import com.gargoylesoftware.htmlunit.javascript.host.event.ClipboardEvent;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.Document;
@@ -47,6 +46,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DocumentEx;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.WindowEx;
@@ -438,13 +438,21 @@ public class Application implements ApplicationEventHandlers
    public void onClipboardAction(ClipboardActionEvent event)
    {
       ClipboardActionEvent.Data data = event.getData();
-      if (StringUtil.equals(data.getType(), "copy"))
+      
+      switch (data.getType())
       {
-         DomUtils.copyToClipboard(data.getText());
+      
+      case SET:
+      {
+         Clipboard.setText(data.getText());
+         return;
       }
-      else
+      
+      default:
       {
          Debug.log("Unimplemented clipboard action '" + data.getText() + "'");
+      }
+      
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.application;
 
 import java.util.ArrayList;
 
+import com.gargoylesoftware.htmlunit.javascript.host.event.ClipboardEvent;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.RunAsyncCallback;
 import com.google.gwt.dom.client.Document;
@@ -158,7 +159,8 @@ public class Application implements ApplicationEventHandlers
       events.addHandler(SessionInitEvent.TYPE, this);
       events.addHandler(FileUploadEvent.TYPE, this);
       events.addHandler(AriaLiveStatusEvent.TYPE, this);
-
+      events.addHandler(ClipboardActionEvent.TYPE, this);
+      
       // register for uncaught exceptions
       uncaughtExHandler.register();
    }
@@ -431,7 +433,21 @@ public class Application implements ApplicationEventHandlers
       if (!ModalDialogTracker.dispatchAriaLiveStatus(event.getMessage(), delayMs, event.getSeverity()))
          view_.reportStatus(event.getMessage(), delayMs, event.getSeverity());
    }
-
+   
+   @Override
+   public void onClipboardAction(ClipboardActionEvent event)
+   {
+      ClipboardActionEvent.Data data = event.getData();
+      if (StringUtil.equals(data.getType(), "copy"))
+      {
+         DomUtils.copyToClipboard(data.getText());
+      }
+      else
+      {
+         Debug.log("Unimplemented clipboard action '" + data.getText() + "'");
+      }
+   }
+   
    @Override
    public void onServerOffline(ServerOfflineEvent event)
    {

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ApplicationEventHandlers.java
@@ -34,6 +34,7 @@ public interface ApplicationEventHandlers extends LogoutRequestedEvent.Handler,
                                                   SessionInitEvent.Handler,
                                                   RestartStatusEvent.Handler,
                                                   FileUploadEvent.Handler,
-                                                  AriaLiveStatusEvent.Handler
+                                                  AriaLiveStatusEvent.Handler,
+                                                  ClipboardActionEvent.Handler
 {
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ClipboardActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ClipboardActionEvent.java
@@ -22,12 +22,23 @@ public class ClipboardActionEvent extends GwtEvent<ClipboardActionEvent.Handler>
 {
    public static class Data extends JavaScriptObject
    {
+      public enum Type
+      {
+         SET
+      }
+      
       protected Data()
       {
       }
+      
+      public final Type getType()
+      {
+         String type = getTypeImpl();
+         return Type.valueOf(type.toUpperCase());
+      }
 
-      public final native String getType() /*-{ return this["type"] || ""; }-*/;
-      public final native String getText() /*-{ return this["text"] || ""; }-*/;
+      public final native String getTypeImpl() /*-{ return this["type"] || ""; }-*/;
+      public final native String getText()     /*-{ return this["text"] || ""; }-*/;
    }
 
    public ClipboardActionEvent(Data data)

--- a/src/gwt/src/org/rstudio/studio/client/application/events/ClipboardActionEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/ClipboardActionEvent.java
@@ -1,0 +1,66 @@
+/*
+ * ClipboardActionEvent.java
+ *
+ * Copyright (C) 2021 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ClipboardActionEvent extends GwtEvent<ClipboardActionEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      public final native String getType() /*-{ return this["type"] || ""; }-*/;
+      public final native String getText() /*-{ return this["text"] || ""; }-*/;
+   }
+
+   public ClipboardActionEvent(Data data)
+   {
+      data_ = data;
+   }
+
+   public Data getData()
+   {
+      return data_;
+   }
+
+   private final Data data_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onClipboardAction(ClipboardActionEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onClipboardAction(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialog.java
@@ -18,6 +18,7 @@ import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ThemedButton;
@@ -42,7 +43,7 @@ public class AboutDialog extends ModalDialogBase
 
       ThemedButton copyVersionButton = new ThemedButton(constants_.copyVersionButtonTitle(), (ClickEvent) ->
       {
-         DomUtils.copyToClipboard("RStudio " + info.version + " " +
+         Clipboard.setText("RStudio " + info.version + " " +
             "\"" + info.release_name + "\" " + info.build_type +
             " (" + info.commit + ", " + info.date + ") " +
             constants_.forText() + info.os + "\n" +

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/AboutDialogContents.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget">
@@ -153,7 +152,7 @@
                         <g:InlineLabel styleName="{style.buildNumber}" ui:field="versionBuildLabel"></g:InlineLabel>
                      </g:HTMLPanel>
                      <g:HTMLPanel styleName="{style.productCopyright}">
-                         <g:InlineLabel text="&copy;"></g:InlineLabel>
+                         <g:InlineLabel text="&#xA9;"></g:InlineLabel>
                          <g:InlineLabel ui:field="copyrightYearLabel"></g:InlineLabel>
                          <g:InlineLabel text="RStudio, PBC"></g:InlineLabel>
                      </g:HTMLPanel>

--- a/src/gwt/src/org/rstudio/studio/client/quarto/ui/NewQuartoDocumentDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/quarto/ui/NewQuartoDocumentDialog.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget"

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -202,6 +202,7 @@ class ClientEvent extends JavaScriptObject
    public static final String JobsActivate = "jobs_activate";
    public static final String PresentationPreview = "presentation_preview";
    public static final String SuspendBlocked = "session_suspend_blocked";
+   public static final String ClipboardAction = "clipboard_action";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1123,6 +1123,11 @@ public class ClientEventDispatcher
             SessionSuspendBlockedEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new SessionSuspendBlockedEvent(data));
          }
+         else if (type == ClientEvent.ClipboardAction)
+         {
+            ClipboardActionEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new ClipboardActionEvent(data));
+         }
          else
          {
             GWT.log("WARNING: Server event not dispatched: " + type, null);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -352,7 +352,7 @@ public class ConnectionsPresenter extends BasePresenter
      
       if (connectVia == ConnectionOptions.CONNECT_COPY_TO_CLIPBOARD)
       {
-         DomUtils.copyCodeToClipboard(connectCode);
+         DomUtils.copyToClipboard(connectCode);
       }
       else if (connectVia == ConnectionOptions.CONNECT_R_CONSOLE)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/connections/ConnectionsPresenter.java
@@ -30,6 +30,7 @@ import org.rstudio.core.client.ListUtil;
 import org.rstudio.core.client.ListUtil.FilterPredicate;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.js.JsObject;
 import org.rstudio.core.client.widget.MessageDialog;
@@ -352,7 +353,7 @@ public class ConnectionsPresenter extends BasePresenter
      
       if (connectVia == ConnectionOptions.CONNECT_COPY_TO_CLIPBOARD)
       {
-         DomUtils.copyToClipboard(connectCode);
+         Clipboard.setText(connectCode);
       }
       else if (connectVia == ConnectionOptions.CONNECT_R_CONSOLE)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -259,7 +259,7 @@ public class DataImport extends Composite
          dataImportResources_.copyImage2x()));
       btn.addClickHandler(clickEvent ->
       {
-         DomUtils.copyCodeToClipboard(codePreview_);
+         DomUtils.copyToClipboard(codePreview_);
       });
       return btn;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.environment.dataimport;
 
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Size;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DomMetrics;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.resources.ImageResource2x;
@@ -259,7 +260,7 @@ public class DataImport extends Composite
          dataImportResources_.copyImage2x()));
       btn.addClickHandler(clickEvent ->
       {
-         DomUtils.copyToClipboard(codePreview_);
+         Clipboard.setText(codePreview_);
       });
       return btn;
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/view/CallFramePanel.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
              xmlns:g="urn:import:com.google.gwt.user.client.ui">
     <ui:style src="EnvironmentObjects.css" type="org.rstudio.studio.client.workbench.views.environment.view.EnvironmentStyle" field="environmentStyle" />

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -31,6 +31,7 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.cellview.ColumnSortInfo;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.Clipboard;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.js.JsObject;
@@ -686,7 +687,7 @@ public class Files
 
    void onCopyFilesPaneCurrentDirectory()
    {
-      DomUtils.copyToClipboard(currentPath_.getPath());
+      Clipboard.setText(currentPath_.getPath());
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -686,7 +686,7 @@ public class Files
 
    void onCopyFilesPaneCurrentDirectory()
    {
-      DomUtils.copyCodeToClipboard(currentPath_.getPath());
+      DomUtils.copyToClipboard(currentPath_.getPath());
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/ChunkContextToolbar.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui">
    <ui:with field="res" type="org.rstudio.studio.client.workbench.views.source.editors.text.rmd.ChunkContextResources" />


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10221.

Previously, we were relying on the `clipr` package being available to write to the clipboard; however, this can be unreliable if the command line tools it relies on aren't available.

This PR makes it possible for the session request the front-end write some text to the clipboard.

### Approach

Fairly straightforward addition of a clipboard module + wiring.

### Automated Tests

N/A

### QA Notes

Test that `.rs.bugReport()` works as expected on RStudio Desktop with Ubuntu 20.04.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
