### PR TITLE
Omit "Presentation" from labels

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -149,7 +149,7 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
          ArrayList<String> value = new ArrayList<>();
          for (CheckBox checkBox : checkBoxes_)
          {
-            if (checkBox.getValue() && checkBox.getText() != "Presentation")
+            if (checkBox.getValue() && !StringUtil.equals(checkBox.getText(), "Presentation"))
                value.add(checkBox.getText());
          }
          return value;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PaneLayoutPreferencesPane.java
@@ -149,7 +149,7 @@ public class PaneLayoutPreferencesPane extends PreferencesPane
          ArrayList<String> value = new ArrayList<>();
          for (CheckBox checkBox : checkBoxes_)
          {
-            if (checkBox.getValue())
+            if (checkBox.getValue() && checkBox.getText() != "Presentation")
                value.add(checkBox.getText());
          }
          return value;


### PR DESCRIPTION
### Intent

addresses #10213

### Approach

I've tried to be minimal, as the "Presentation" item seems te be special somehow. The associated checkbox seems to be always hidden, in the `ModuleList` constructor: 

```java
ModuleList(String width)
      {
         checkBoxes_ = new ArrayList<>();
         FlowPanel flowPanel = new FlowPanel();
         for (String module : PaneConfig.getAllTabs())
         {
            CheckBox checkBox = new CheckBox(module, false);
            checkBox.addValueChangeHandler(this);
            checkBoxes_.add(checkBox);
            flowPanel.add(checkBox);
            if (module == "Presentation")
              checkBox.setVisible(false);
         }

         ScrollPanel scrollPanel = new ScrollPanelWithClick();
         scrollPanel.setStyleName(res_.styles().paneLayoutTable());
         scrollPanel.setWidth(width);
         scrollPanel.add(flowPanel);
         initWidget(scrollPanel);
      }
```

But still there however, this pr just skips it from `getValue()` so that it does not appear in e.g. 

```java
String itemText1 = tabSet1ModuleList_.getValue().isEmpty() ?
         "TabSet" : StringUtil.join(tabSet1ModuleList_.getValue(), ", "); 
```

![image](https://user-images.githubusercontent.com/2625526/146194030-724d78d1-6b74-4039-a71a-99c28c088eba.png)
![image](https://user-images.githubusercontent.com/2625526/146194079-9deae280-6da7-4001-8a28-269e14443515.png)


### Automated Tests

Supposedly we could add a unit test checking that `ModuleList.getValue()` does not include "Presentation" but I have yet to learn how to do that ... 

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


