### PR TITLE
get testthat version only if TestFile/TestPackage

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -678,18 +678,15 @@ private:
       type_ = type;
 
       // add testthat and shinytest result parsers
-      core::Version testthatVersion;
-      module_context::packageVersion("testthat", &testthatVersion);
-      
       if (type == kTestFile)
       {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.getParent(), testthatVersion));
+         parsers.add(testthatErrorParser(packagePath.getParent()));
       }
       else if (type == kTestPackage)
       {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat"), testthatVersion));
+         parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat")));
       }
 
       initErrorParser(packagePath, parsers);

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -681,12 +681,17 @@ private:
       if (type == kTestFile)
       {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.getParent()));
+         if (module_context::isPackageInstalled("testthat")) {
+            parsers.add(testthatErrorParser(packagePath.getParent()));
+         }
+         
       }
       else if (type == kTestPackage)
       {
          openErrorList_ = false;
-         parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat")));
+         if (module_context::isPackageInstalled("testthat")) {
+            parsers.add(testthatErrorParser(packagePath.completePath("tests/testthat")));
+         }
       }
 
       initErrorParser(packagePath, parsers);

--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -433,9 +433,11 @@ CompileErrorParser rErrorParser(const FilePath& basePath)
    return boost::bind(parseRErrors, basePath, _1);
 }
 
-CompileErrorParser testthatErrorParser(const FilePath& basePath,
-                                       const core::Version& testthatVersion)
+CompileErrorParser testthatErrorParser(const FilePath& basePath)
 {
+   core::Version testthatVersion;
+   module_context::packageVersion("testthat", &testthatVersion);
+
    return boost::bind(parseTestThatErrors, basePath, _1, testthatVersion);
 }
 

--- a/src/cpp/session/modules/build/SessionBuildErrors.hpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.hpp
@@ -70,8 +70,7 @@ CompileErrorParser gccErrorParser(const core::FilePath& basePath);
 
 CompileErrorParser rErrorParser(const core::FilePath& basePath);
 
-CompileErrorParser testthatErrorParser(const core::FilePath& basePath,
-                                       const rstudio::core::Version& testthatVersion);
+CompileErrorParser testthatErrorParser(const core::FilePath& basePath);
 
 CompileErrorParser shinytestErrorParser(const core::FilePath& basePath, const core::FilePath& rdsPath);
 


### PR DESCRIPTION
### Intent

closes #10252

### Approach

Delaying retrieving the version of testthat until we know we need it, i.e. when this is a build of type "TestFile" or "TestPackage". Getting the version directly in `testthatErrorParser()` rather than pass it in `testthatErrorParser`

```cpp
CompileErrorParser testthatErrorParser(const FilePath& basePath)
{
   core::Version testthatVersion;
   module_context::packageVersion("testthat", &testthatVersion);

   return boost::bind(parseTestThatErrors, basePath, _1, testthatVersion);
}
```

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


