### PR TITLE
support for R graphics engine 15 (#10058)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,10 @@
 * Remove 'Classic' IDE theme (#9738)
 * Added support for Amazon Linux 2 (Pro #2474)
 
+#### R
+
+* Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
+
 ### Fixed
 
 * Fixed an issue that could cause calls to `grid` functions to fail after restart (#2919)

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -64,7 +64,7 @@ struct ROptions
 {
    ROptions() :
          useInternet2(true),
-         rCompatibleGraphicsEngineVersion(14),
+         rCompatibleGraphicsEngineVersion(15),
          serverMode(false),
          autoReloadSource(false),
          restoreWorkspace(true),

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -1380,7 +1380,7 @@ SEXP capabilities(SEXP cap)
     SEXP (*callback)(SEXP cap) = nullptr;
 
     if (callback != nullptr)
-    return callback(cap);
+        return callback(cap);
 
     return R_NilValue;
 }

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -228,11 +228,47 @@ pDevDesc allocate(const RSDevDesc& devDesc)
 
       return (pDevDesc) pDD;
    }
+
+   case 15:
+   {
+       DevDescVersion15* pDD =
+               allocAndInitCommonMembers<DevDescVersion15>(devDesc);
+
+       pDD->path = devDesc.path;
+       pDD->raster = devDesc.raster;
+       pDD->cap = devDesc.cap;
+       pDD->eventEnv = devDesc.eventEnv;
+       pDD->eventHelper = devDesc.eventHelper;
+
+       pDD->holdflush = devDesc.holdflush;
+       pDD->haveTransparency = devDesc.haveTransparency;
+       pDD->haveTransparentBg = devDesc.haveTransparentBg;
+       pDD->haveRaster = devDesc.haveRaster;
+       pDD->haveCapture = devDesc.haveCapture;
+       pDD->haveLocator = devDesc.haveLocator;
+
+       pDD->setPattern = devDesc.setPattern;
+       pDD->releasePattern = devDesc.releasePattern;
+       pDD->setClipPath = devDesc.setClipPath;
+       pDD->releaseClipPath = devDesc.releaseClipPath;
+       pDD->setMask = devDesc.setMask;
+       pDD->releaseMask = devDesc.releaseMask;
+
+       pDD->defineGroup = devDesc.defineGroup;
+       pDD->useGroup = devDesc.useGroup;
+       pDD->releaseGroup = devDesc.releaseGroup;
+       pDD->stroke = devDesc.stroke;
+       pDD->fill = devDesc.fill;
+       pDD->fillStroke = devDesc.fillStroke;
+       pDD->capabilities = devDesc.capabilities;
+
+       return (pDevDesc) pDD;
+   }
       
    default:
    {
-      DevDescVersion14* pDD =
-            (DevDescVersion14*) std::calloc(1, sizeof(DevDescVersion14));
+      DevDescVersion15* pDD =
+            (DevDescVersion15*) std::calloc(1, sizeof(DevDescVersion15));
       *pDD = devDesc;
       return (pDevDesc) pDD;
    }
@@ -326,12 +362,14 @@ void setDeviceAttributes(pDevDesc pDev, pDevDesc pShadow)
    }
       
    case 14:
+   case 15:
+
    default:
    {
-      setCommonDeviceAttributes((DevDescVersion14*) pDev, (DevDescVersion14*) pShadow);
+      setCommonDeviceAttributes((DevDescVersion15*) pDev, (DevDescVersion15*) pShadow);
       
-      auto* pLhs = (DevDescVersion14*) pDev;
-      auto* pRhs = (DevDescVersion14*) pShadow;
+      auto* pLhs = (DevDescVersion15*) pDev;
+      auto* pRhs = (DevDescVersion15*) pShadow;
       
       pLhs->canGenIdle      = pRhs->canGenIdle;
       
@@ -371,8 +409,9 @@ void activate(const pDevDesc dd)
       pActivateFn = ((DevDescVersion12*)dd)->activate;
       break;
    case 14:
+   case 15:
    default:
-      pActivateFn = ((DevDescVersion14*)dd)->activate;
+      pActivateFn = ((DevDescVersion15*)dd)->activate;
       break;
    }
 
@@ -410,8 +449,9 @@ void circle(double x, double y, double r, const pGEcontext gc, pDevDesc dd)
       pCircleFn = ((DevDescVersion12*)dd)->circle;
       break;
    case 14:
+   case 15:
    default:
-      pCircleFn = ((DevDescVersion14*)dd)->circle;
+      pCircleFn = ((DevDescVersion15*)dd)->circle;
       break;
    }
 
@@ -449,8 +489,9 @@ void clip(double x0, double x1, double y0, double y1, pDevDesc dd)
       pClipFn = ((DevDescVersion12*)dd)->clip;
       break;
    case 14:
+   case 15:
    default:
-      pClipFn = ((DevDescVersion14*)dd)->clip;
+      pClipFn = ((DevDescVersion15*)dd)->clip;
       break;
    }
 
@@ -488,8 +529,9 @@ void close(pDevDesc dd)
       pCloseFn = ((DevDescVersion12*)dd)->close;
       break;
    case 14:
+   case 15:
    default:
-      pCloseFn = ((DevDescVersion14*)dd)->close;
+      pCloseFn = ((DevDescVersion15*)dd)->close;
       break;
       
    }
@@ -528,8 +570,9 @@ void deactivate(pDevDesc dd)
       pDeactivateFn = ((DevDescVersion12*)dd)->deactivate;
       break;
    case 14:
+   case 15:
    default:
-      pDeactivateFn = ((DevDescVersion14*)dd)->deactivate;
+      pDeactivateFn = ((DevDescVersion15*)dd)->deactivate;
       break;
    }
 
@@ -567,8 +610,9 @@ Rboolean locator(double *x, double *y, pDevDesc dd)
       pLocatorFn = ((DevDescVersion12*)dd)->locator;
       break;
    case 14:
+   case 15:
    default:
-      pLocatorFn = ((DevDescVersion14*)dd)->locator;
+      pLocatorFn = ((DevDescVersion15*)dd)->locator;
       break;
    }
 
@@ -606,8 +650,9 @@ void line(double x1, double y1, double x2, double y2, const pGEcontext gc, pDevD
       pLineFn = ((DevDescVersion12*)dd)->line;
       break;
    case 14:
+   case 15:
    default:
-      pLineFn = ((DevDescVersion14*)dd)->line;
+      pLineFn = ((DevDescVersion15*)dd)->line;
       break;
    }
 
@@ -645,8 +690,9 @@ void metricInfo(int c, const pGEcontext gc, double *ascent, double *descent, dou
       pMetricInfoFn = ((DevDescVersion12*)dd)->metricInfo;
       break;
    case 14:
+   case 15:
    default:
-      pMetricInfoFn = ((DevDescVersion14*)dd)->metricInfo;
+      pMetricInfoFn = ((DevDescVersion15*)dd)->metricInfo;
       break;
    }
 
@@ -684,8 +730,9 @@ void mode(int mode, pDevDesc dd)
       pModeFn = ((DevDescVersion12*)dd)->mode;
       break;
    case 14:
+   case 15:
    default:
-      pModeFn = ((DevDescVersion14*)dd)->mode;
+      pModeFn = ((DevDescVersion15*)dd)->mode;
       break;
    }
 
@@ -724,8 +771,9 @@ void newPage(const pGEcontext gc, pDevDesc dd)
       pNewPageFn = ((DevDescVersion12*)dd)->newPage;
       break;
    case 14:
+   case 15:
    default:
-      pNewPageFn = ((DevDescVersion14*)dd)->newPage;
+      pNewPageFn = ((DevDescVersion15*)dd)->newPage;
       break;
    }
 
@@ -802,8 +850,9 @@ void polyline(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd)
       pPolylineFn = ((DevDescVersion12*)dd)->polyline;
       break;
    case 14:
+   case 15:
    default:
-      pPolylineFn = ((DevDescVersion14*)dd)->polyline;
+      pPolylineFn = ((DevDescVersion15*)dd)->polyline;
       break;
    }
 
@@ -841,8 +890,9 @@ void rect(double x0, double y0, double x1, double y1, const pGEcontext gc, pDevD
       pRectFn = ((DevDescVersion12*)dd)->rect;
       break;
    case 14:
+   case 15:
    default:
-      pRectFn = ((DevDescVersion14*)dd)->rect;
+      pRectFn = ((DevDescVersion15*)dd)->rect;
       break;
    }
 
@@ -878,8 +928,9 @@ void path(double *x,
       pPathFn = ((DevDescVersion12*)dd)->path;
       break;
    case 14:
+   case 15:
    default:
-      pPathFn = ((DevDescVersion14*)dd)->path;
+      pPathFn = ((DevDescVersion15*)dd)->path;
       break;
    }
 
@@ -924,8 +975,9 @@ void raster(unsigned int *raster,
       pRasterFn = ((DevDescVersion12*)dd)->raster;
       break;
    case 14:
+   case 15:
    default:
-      pRasterFn = ((DevDescVersion14*)dd)->raster;
+      pRasterFn = ((DevDescVersion15*)dd)->raster;
       break;
    }
 
@@ -959,8 +1011,9 @@ SEXP cap(pDevDesc dd)
       pCapFn = ((DevDescVersion12*)dd)->cap;
       break;
    case 14:
+   case 15:
    default:
-      pCapFn = ((DevDescVersion14*)dd)->cap;
+      pCapFn = ((DevDescVersion15*)dd)->cap;
       break;
    }
 
@@ -997,8 +1050,9 @@ void size(double *left, double *right, double *bottom, double *top, pDevDesc dd)
       pSizeFn = ((DevDescVersion12*)dd)->size;
       break;
    case 14:
+   case 15:
    default:
-      pSizeFn = ((DevDescVersion14*)dd)->size;
+      pSizeFn = ((DevDescVersion15*)dd)->size;
       break;
    }
 
@@ -1035,8 +1089,9 @@ double strWidth(const char *str, const pGEcontext gc, pDevDesc dev)
       pStrWidthFn = ((DevDescVersion12*)dev)->strWidth;
       break;
    case 14:
+   case 15:
    default:
-      pStrWidthFn = ((DevDescVersion14*)dev)->strWidth;
+      pStrWidthFn = ((DevDescVersion15*)dev)->strWidth;
       break;
    }
 
@@ -1080,8 +1135,9 @@ void text(double x,
       pTextFn = ((DevDescVersion12*)dev)->text;
       break;
    case 14:
+   case 15:
    default:
-      pTextFn = ((DevDescVersion14*)dev)->text;
+      pTextFn = ((DevDescVersion15*)dev)->text;
       break;
    }
 
@@ -1098,8 +1154,9 @@ SEXP setPattern(SEXP pattern, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->setPattern;
+      callback = ((DevDescVersion15*)dd)->setPattern;
       break;
    }
    
@@ -1118,8 +1175,9 @@ void releasePattern(SEXP ref, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->releasePattern;
+      callback = ((DevDescVersion15*)dd)->releasePattern;
       break;
    }
    
@@ -1136,8 +1194,9 @@ SEXP setClipPath(SEXP path, SEXP ref, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->setClipPath;
+      callback = ((DevDescVersion15*)dd)->setClipPath;
       break;
    }
    
@@ -1156,8 +1215,9 @@ void releaseClipPath(SEXP ref, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->releaseClipPath;
+      callback = ((DevDescVersion15*)dd)->releaseClipPath;
       break;
    }
    
@@ -1174,8 +1234,9 @@ SEXP setMask(SEXP path, SEXP ref, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->setMask;
+      callback = ((DevDescVersion15*)dd)->setMask;
       break;
    }
    
@@ -1194,13 +1255,144 @@ void releaseMask(SEXP ref, pDevDesc dd)
    switch (engineVersion)
    {
    case 14:
+   case 15:
    default:
-      callback = ((DevDescVersion14*)dd)->releaseMask;
+      callback = ((DevDescVersion15*)dd)->releaseMask;
       break;
    }
    
    if (callback != nullptr)
        callback(ref, dd);
+}
+
+SEXP defineGroup(SEXP source, int op, SEXP destination, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    SEXP (*callback)(SEXP source, int op, SEXP destination, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->defineGroup;
+            break;
+    }
+
+    if (callback != nullptr)
+        return callback(source, op, destination, dd);
+
+    return R_NilValue;
+}
+
+void useGroup(SEXP ref, SEXP trans, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    void (*callback)(SEXP ref, SEXP trans, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->useGroup;
+            break;
+    }
+
+    if (callback != nullptr)
+        callback(ref, trans, dd);
+}
+
+void releaseGroup(SEXP ref, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    void (*callback)(SEXP ref, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->releaseGroup;
+            break;
+    }
+
+    if (callback != nullptr)
+        callback(ref, dd);
+}
+
+void stroke(SEXP path, const pGEcontext gc, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    void (*callback)(SEXP path, const pGEcontext gc, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->stroke;
+            break;
+    }
+
+    if (callback != nullptr)
+        callback(path, gc, dd);
+}
+
+void fill(SEXP path, int rule, const pGEcontext gc, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    void (*callback)(SEXP path, int rule, const pGEcontext gc, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->fill;
+            break;
+    }
+
+    if (callback != nullptr)
+        callback(path, rule, gc, dd);
+}
+
+void fillStroke(SEXP path, int rule, const pGEcontext gc, pDevDesc dd)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    void (*callback)(SEXP path, int rule, const pGEcontext gc, pDevDesc dd) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->fillStroke;
+            break;
+    }
+
+    if (callback != nullptr)
+        callback(path, rule, gc, dd);
+}
+
+SEXP capabilities(SEXP cap)
+{
+    int engineVersion = ::R_GE_getVersion();
+
+    SEXP (*callback)(SEXP cap) = nullptr;
+
+    switch (engineVersion)
+    {
+        case 15:
+        default:
+            callback = ((DevDescVersion15*)dd)->capabilities;
+        break;
+    }
+
+    if (callback != nullptr)
+    return callback(cap);
+
+    return R_NilValue;
 }
 
 
@@ -1233,8 +1425,9 @@ void setSize(pDevDesc pDD)
       pSizeFn = ((DevDescVersion12*)pDD)->size;
       break;
    case 14:
+   case 15:
    default:
-      pSizeFn = ((DevDescVersion14*)pDD)->size;
+      pSizeFn = ((DevDescVersion15*)pDD)->size;
       break;
    }
 

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -367,7 +367,7 @@ void setDeviceAttributes(pDevDesc pDev, pDevDesc pShadow)
    default:
    {
       setCommonDeviceAttributes((DevDescVersion15*) pDev, (DevDescVersion15*) pShadow);
-      
+
       auto* pLhs = (DevDescVersion15*) pDev;
       auto* pRhs = (DevDescVersion15*) pShadow;
       
@@ -1380,14 +1380,6 @@ SEXP capabilities(SEXP cap)
     int engineVersion = ::R_GE_getVersion();
 
     SEXP (*callback)(SEXP cap) = nullptr;
-
-    switch (engineVersion)
-    {
-        case 15:
-        default:
-            callback = ((DevDescVersion15*)dd)->capabilities;
-        break;
-    }
 
     if (callback != nullptr)
     return callback(cap);

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -1377,8 +1377,6 @@ void fillStroke(SEXP path, int rule, const pGEcontext gc, pDevDesc dd)
 
 SEXP capabilities(SEXP cap)
 {
-    int engineVersion = ::R_GE_getVersion();
-
     SEXP (*callback)(SEXP cap) = nullptr;
 
     if (callback != nullptr)

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.hpp
@@ -26,7 +26,7 @@
 
 #include "RGraphicsDevDescVersions.hpp"
 
-typedef DevDescVersion14 RSDevDesc;
+typedef DevDescVersion15 RSDevDesc;
 
 namespace rstudio {
 namespace r {
@@ -83,7 +83,15 @@ void releaseClipPath(SEXP ref, pDevDesc dd);
 SEXP setMask(SEXP path, SEXP ref, pDevDesc dd);
 void releaseMask(SEXP ref, pDevDesc dd);
 
+SEXP defineGroup(SEXP source, int op, SEXP destination, pDevDesc dd);
+void useGroup(SEXP ref, SEXP trans, pDevDesc dd);
+void releaseGroup(SEXP ref, pDevDesc dd);
 
+void stroke(SEXP path, const pGEcontext gc, pDevDesc dd);
+void fill(SEXP path, int rule, const pGEcontext gc, pDevDesc dd);
+void fillStroke(SEXP path, int rule, const pGEcontext gc, pDevDesc dd);
+
+SEXP capabilities(SEXP cap);
 
 } // namespace dev_desc
 } // namespace handler

--- a/src/cpp/r/session/graphics/RGraphicsDevDescVersions.hpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDescVersions.hpp
@@ -655,6 +655,128 @@ struct DevDescVersion14
    char reserved[64];
 };
 
+struct DevDescVersion15
+{
+    double left;
+    double right;
+    double bottom;
+    double top;
+    double clipLeft;
+    double clipRight;
+    double clipBottom;
+    double clipTop;
+    double xCharOffset;
+    double yCharOffset;
+    double yLineBias;
+    double ipr[2];
+    double cra[2];
+    double gamma;
+    Rboolean canClip;
+    Rboolean canChangeGamma;
+    int canHAdj;
+    double startps;
+    int startcol;
+    int startfill;
+    int startlty;
+    int startfont;
+    double startgamma;
+    void *deviceSpecific;
+    Rboolean displayListOn;
+    Rboolean canGenMouseDown;
+    Rboolean canGenMouseMove;
+    Rboolean canGenMouseUp;
+    Rboolean canGenKeybd;
+    Rboolean canGenIdle; // version 12
+    Rboolean gettingEvent;
+
+    void (*activate)(const pDevDesc );
+    void (*circle)(double x, double y, double r, const pGEcontext gc, pDevDesc dd);
+    void (*clip)(double x0, double x1, double y0, double y1, pDevDesc dd);
+    void (*close)(pDevDesc dd);
+    void (*deactivate)(pDevDesc );
+    Rboolean (*locator)(double *x, double *y, pDevDesc dd);
+    void (*line)(double x1, double y1, double x2, double y2,
+                 const pGEcontext gc, pDevDesc dd);
+    void (*metricInfo)(int c, const pGEcontext gc,
+                       double* ascent, double* descent, double* width,
+                       pDevDesc dd);
+    void (*mode)(int mode, pDevDesc dd);
+    void (*newPage)(const pGEcontext gc, pDevDesc dd);
+    void (*polygon)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+    void (*polyline)(int n, double *x, double *y, const pGEcontext gc, pDevDesc dd);
+    void (*rect)(double x0, double y0, double x1, double y1,
+                 const pGEcontext gc, pDevDesc dd);
+
+
+    // dev_Path added in version 8
+    void (*path)(double *x, double *y,
+                 int npoly, int *nper,
+                 Rboolean winding,
+                 const pGEcontext gc, pDevDesc dd);
+
+    // dev_Raster and dev_Cap added in version 6
+    void (*raster)(unsigned int *raster, int w, int h,
+                   double x, double y,
+                   double width, double height,
+                   double rot,
+                   Rboolean interpolate,
+                   const pGEcontext gc, pDevDesc dd);
+    SEXP (*cap)(pDevDesc dd);
+
+    void (*size)(double *left, double *right, double *bottom, double *top,
+                 pDevDesc dd);
+    double (*strWidth)(const char *str, const pGEcontext gc, pDevDesc dd);
+    void (*text)(double x, double y, const char *str, double rot,
+                 double hadj, const pGEcontext gc, pDevDesc dd);
+    void (*onExit)(pDevDesc dd);
+    SEXP (*getEvent)(SEXP, const char *);
+    Rboolean (*newFrameConfirm)(pDevDesc dd);
+
+    Rboolean hasTextUTF8; /* and strWidthUTF8 */
+    void (*textUTF8)(double x, double y, const char *str, double rot,
+                     double hadj, const pGEcontext gc, pDevDesc dd);
+    double (*strWidthUTF8)(const char *str, const pGEcontext gc, pDevDesc dd);
+    Rboolean wantSymbolUTF8;
+    Rboolean useRotatedTextInContour;
+
+    // eventEnv and eventHelper added in version 7
+    SEXP eventEnv;
+    void (*eventHelper)(pDevDesc dd, int code);
+
+    // holdFlush and have* added in version 9 (R 2.14)
+    int (*holdflush)(pDevDesc dd, int level);
+    int haveTransparency;
+    int haveTransparentBg;
+    int haveRaster;
+    int haveCapture, haveLocator;
+
+    // below added in version 14 (R 4.1.0)
+    SEXP (*setPattern)(SEXP pattern, pDevDesc dd);
+    void (*releasePattern)(SEXP ref, pDevDesc dd);
+
+    SEXP (*setClipPath)(SEXP path, SEXP ref, pDevDesc dd);
+    void (*releaseClipPath)(SEXP ref, pDevDesc dd);
+
+    SEXP (*setMask)(SEXP path, SEXP ref, pDevDesc dd);
+    void (*releaseMask)(SEXP ref, pDevDesc dd);
+
+    int deviceVersion;
+    Rboolean deviceClip;
+
+    // below added in version 15 (R 4.2.0)
+    SEXP (*defineGroup)(SEXP source, int op, SEXP destination, pDevDesc dd);
+    void (*useGroup)(SEXP ref, SEXP trans, pDevDesc dd);
+    void (*releaseGroup)(SEXP ref, pDevDesc dd);
+
+    void (*stroke)(SEXP path, const pGEcontext gc, pDevDesc dd);
+    void (*fill)(SEXP path, int rule, const pGEcontext gc, pDevDesc dd);
+    void (*fillStroke)(SEXP path, int rule, const pGEcontext gc, pDevDesc dd);
+
+    SEXP (*capabilities)(SEXP cap);
+
+    char reserved[64];
+};
+
 } // extern "C"
 
 #endif // R_SESSION_GRAPHICS_DEV_DESC_VERSIONS_HPP

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -298,7 +298,7 @@ protected:
       value<bool>(&autoReloadSource_)->default_value(false),
       "Indicates whether or not to automatically reload R source if it changes during the session.")
       ("r-compatible-graphics-engine-version",
-      value<int>(&rCompatibleGraphicsEngineVersion_)->default_value(14),
+      value<int>(&rCompatibleGraphicsEngineVersion_)->default_value(15),
       "Specifies the maximum graphics engine version that this version of RStudio is compatible with.")
       ("r-resources-path",
       value<std::string>(&rResourcesPath_)->default_value("resources"),

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -553,7 +553,7 @@
             "name": "r-compatible-graphics-engine-version",
             "type": "int",
             "memberName": "rCompatibleGraphicsEngineVersion_",
-            "defaultValue": 14,
+            "defaultValue": 15,
             "description": "Specifies the maximum graphics engine version that this version of RStudio is compatible with."
          },
          {


### PR DESCRIPTION
### Intent

IDE support for R graphics engine 15 used in R version 4.2 (not yet released -- latest devel build)
Addresses issue #10058.
This should be roughly similar to the [PR for graphics engine 14](https://github.com/rstudio/rstudio/pull/9283)

### Approach

Followed approach outlined in [wiki](https://github.com/rstudio/rstudio-pro/wiki/RStudio-Graphics-Device)

### Automated Tests

None

### QA Notes

TBD

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests



