### PR TITLE
Assign element ids to job launcher widgets

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -369,6 +369,10 @@ public class ElementIds
    public final static String BUILD_MORE_MENUBUTTON = "build_more_menubutton";
    public final static String BUILD_BOOKDOWN_MENUBUTTON = "build_bookdown_menubutton";
 
+   // JobLauncherPane
+   public final static String JOB_LAUNCHER_JOB_VIEW = "job_launcher_job_view";
+   public final static String JOB_LAUNCHER_OUTPUT_PANEL = "job_launcher_output_panel";
+
    // JobLauncherDialog
    public final static String JOB_LAUNCHER_ENVIRONMENT = "job_launcher_environment";
    public static String getJobLauncherEnvironment() { return getElementId(JOB_LAUNCHER_ENVIRONMENT); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.jobs.view;
 
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.studio.client.common.compile.CompileOutput;
 import org.rstudio.studio.client.common.compile.CompileOutputBufferWithHighlight;
 import org.rstudio.studio.client.common.compile.CompilePanel;
@@ -37,6 +38,7 @@ public class JobOutputPanel extends Composite
    {
       output_ = new CompilePanel(new CompileOutputBufferWithHighlight());
       output_.setHeight("100%");
+      ElementIds.assignElementId(output_.asWidget(), ElementIds.JOB_LAUNCHER_OUTPUT_PANEL);
 
       initWidget(uiBinder.createAndBindUi(this));
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsListViewImpl.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsListViewImpl.java
@@ -15,6 +15,8 @@
 package org.rstudio.studio.client.workbench.views.jobs.view;
 
 import com.google.gwt.user.client.ui.VerticalPanel;
+
+import org.rstudio.core.client.ElementIds;
 import org.rstudio.studio.client.workbench.views.jobs.model.Job;
 
 import java.util.ArrayList;
@@ -35,6 +37,8 @@ public class JobsListViewImpl
       if (hasJob(item.getJob().id))
          return false;
 
+      ElementIds.assignElementId(item.asWidget(),
+         ElementIds.JOB_LAUNCHER_JOB_VIEW + "_" + item.getJob().id);
       jobs_.put(item.getJob().id, item);
       list_.insert(item, 0);
       return true;
@@ -52,6 +56,8 @@ public class JobsListViewImpl
          if (((JobItemView)list_.getWidget(i)).getJob().recorded <= item.getJob().recorded)
             break;
       }
+      ElementIds.assignElementId(item.asWidget(),
+         ElementIds.JOB_LAUNCHER_JOB_VIEW + "_" + item.getJob().id);
       insertJobAt(item, i);
       return true;
    }


### PR DESCRIPTION
### Intent

Add element IDs for launcher UI to allow for automation of #3076
See Jeff's comment here for details:
https://github.com/rstudio/rstudio-pro/issues/3076#issuecomment-996402381

### Approach

Create and assign element IDs to represent each job in the launcher view and to represent the job output pane.

### Automated Tests

N/A - these are to enable writing of automated tests

### QA Notes

N/A - writing the tests will test this

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


