### PR TITLE
Add sql hash comment highlighting

### DIFF
--- a/src/gwt/acesupport/acemode/sql_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/sql_highlight_rules.js
@@ -61,6 +61,9 @@ define("mode/sql_highlight_rules", ["require", "exports", "module"], function(re
             start : "/\\*",
             end : "\\*/"
         }, {
+            token: "comment",
+            regex: "#.*$"
+        }, {
           token : "comment.doc.tag",
           regex : "\\?[a-zA-Z_][a-zA-Z0-9_$]*"
         }, {

--- a/src/gwt/test/highlight_test_sql.html
+++ b/src/gwt/test/highlight_test_sql.html
@@ -1,0 +1,96 @@
+<html>
+<head>
+  <script type="text/javascript" src="../src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/ace-uncompressed.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/utils.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/rainbow_paren_highlight_rules.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/auto_brace_insert.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/doc_comment_highlight_rules.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/tex_highlight_rules.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/token_cursor.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/token_utils.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/r_highlight_rules.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/r_matching_brace_outdent.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/r_scope_tree.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/r_code_model.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/sql_highlight_rules.js"></script>
+  <script type="text/javascript" src="../acesupport/acemode/sql.js"></script>
+  <style type="text/css">
+  pre {
+    margin-bottom: 30px;
+    padding: 3px;
+    border: 1px solid #999;
+  }
+  .error {
+    position: absolute;
+    background-color: #D77;
+  }
+  .pass {
+    position: absolute;
+    background-color: #3A3;
+  }
+
+
+  </style>
+</head>
+<body>
+
+  <h2>SQL Highlight Tester</h2>
+  <div id="editor" style="position: aboluste; width: 600px; height: 600px; border: 1px solid #999"></div>
+
+  <script type="text/javascript">
+
+  var SqlMode = require("mode/sql").Mode;
+  var Range = require("ace/range").Range;
+
+  var tokenMap = new Map();
+  tokenMap.set("--", "comment");
+  tokenMap.set("/*", "comment.start");
+  tokenMap.set("*/", "comment.end");
+  tokenMap.set("#", "comment");
+  tokenMap.set("select", "keyword");
+  console.log(tokenMap);
+
+  var text = Array.from(tokenMap.keys()).join("\n");
+
+  var editor = ace.edit("editor");
+  var session = editor.getSession();
+  session.setMode(new SqlMode(false, session));
+
+  editor.insert(text);
+
+  var markers = [];
+  var n = session.getLength();
+  var count = n;
+  for (var i = 0; i < n; i++) {
+    var tokens = session.getTokens(i);
+    console.log(tokens);
+    if (tokens.length > 0) {
+      tokens.forEach((token) => {
+        console.log(tokenMap.get(token.value));
+        if (tokenMap.get(token.value) !== token.type) {
+          count--;
+          session.addMarker(
+              new Range(i, 0, i, session.getLine(i).length),
+              "error",
+              "fullLine"
+              );
+        } else {
+          session.addMarker(
+            new Range(i, 0, i, session.getLine(i).length),
+              "pass",
+              "fullLine"
+          )
+        }
+      })
+    }
+  }
+
+  var div = document.createElement("div");
+  div.innerHTML = "Passed " + count + " of " + n + " tests.";
+  document.body.appendChild(div);
+
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
### Intent
adds `#` highlighting to sql files #9578 

### Approach
Added another regex rule to find `#` and include text to end of line in the highlight.

### Automated Tests
There appear to be some ace tests that are html files to execute the highlighting code. It doesn't appear to be part of any kind of test harness and is a manual test. I did create another one to show the token is detected as a comment.

### QA Notes
Low risk. Adds highlighting using a similar rule to the `--` comment token.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


