### PR TITLE
forward CONDA_PREFIX to terminal sessions

### DIFF
--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -819,12 +819,19 @@ bool augmentTerminalProcessPython(ConsoleProcessPtr cp)
    if (!prefs::userPrefs().terminalPythonIntegration())
       return false;
    
-   // find currently-configured version of Python
+   // forward RETICULATE_PYTHON if set
    std::string reticulatePython = modules::reticulate::reticulatePython();
    if (!reticulatePython.empty())
-   {
       cp->setenv("RETICULATE_PYTHON", reticulatePython);
-   }
+   
+   // forward CONDA_PREFIX if set
+   // use custom environment variable name since the user profile
+   // might override this to use the 'base' environment by default;
+   // our terminal hooks ensure we 'clean up' after whatever the
+   // user profile might've done
+   std::string condaPrefix = core::system::getenv("CONDA_PREFIX");
+   if (!condaPrefix.empty())
+      cp->setenv("_RS_CONDA_PREFIX", condaPrefix);
 
    // return true if we have a configured version of python
    // (indicating that we want terminal hooks to be installed)

--- a/src/cpp/session/resources/terminal/hooks
+++ b/src/cpp/session/resources/terminal/hooks
@@ -1,5 +1,24 @@
 #!/usr/bin/env sh
 
+# if we have a conda prefix, ensure it's still used
+if [ -n "${_RS_CONDA_PREFIX}" ]; then
+
+	# activate the environment
+	conda activate "${_RS_CONDA_PREFIX}"
+
+	# unset CONDA_PROMPT_MODIFIER for project-local envs
+	# (look for slash in environment variable value)
+	case "${PS1}" in
+	"${CONDA_PROMPT_MODIFIER}"*)
+		PS1="${PS1:${#CONDA_PROMPT_MODIFIER}}"
+		unset CONDA_PROMPT_MODIFIER
+	;;
+	esac
+
+	unset _RS_CONDA_PREFIX
+
+fi
+
 if [ -f "${RETICULATE_PYTHON}" ]; then
 
 	_RS_PYTHON_BIN=$(dirname "${RETICULATE_PYTHON}")
@@ -25,7 +44,7 @@ if [ -f "${RETICULATE_PYTHON}" ]; then
 	if [ "$(echo "${PATH}" | cut -d":" -f"1")" != "${_RS_PYTHON_BIN}" ]; then
 		PATH="${_RS_PYTHON_BIN}:${PATH}"
 	fi
-	
+
 	unset _RS_PYTHON_BIN
 
 fi


### PR DESCRIPTION
### Intent

Addresses #10271.

### Approach

If `CONDA_PREFIX` is set in the R session (normally done for project-local Conda environments), then forward that to Terminal sessions.

Also munge `PS1` to avoid an extra-long prefix for project-local environments.

### Automated Tests

N/A

### QA Notes

Create an RStudio project, and then create a project-local Anaconda Python environment. You can do this with:

```
conda create -p /path/to/project/env
```

Then, within the R session, create a terminal instance and try installing a conda package, e.g.

```
conda install numpy
```

Verify that the package is installed into the project-local conda environment.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
