### PR TITLE
Add hover text to Project button

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/PathBreadcrumbWidget.java
@@ -116,6 +116,7 @@ public class PathBreadcrumbWidget
 
          projIcon.addClickHandler(event -> SelectionCommitEvent.fire(PathBreadcrumbWidget.this, projDir));
          projIcon.getImage().addStyleName(RES.styles().project());
+         projIcon.setTitle(constants_.projectIconDesc());
 
          eastFrame_.insert(projIcon, 0);
 


### PR DESCRIPTION
### Intent
Addresses #10092
Adds a hover title for the go to project directory button
![image](https://user-images.githubusercontent.com/9591545/147135301-297b1afb-b0ca-42e2-a9b1-aebcc9faf34b.png)

### Approach
There was an existing description set on the button but it needed to be set for the title.

### Automated Tests
none

### QA Notes
Just a hover title added on the button

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


