### PR TITLE
using guess_max instead of n_max

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -427,7 +427,7 @@
          options[["na"]] <- dataImportOptions$na
          options[["comment"]] <- dataImportOptions$comments
          options[["skip"]] <- dataImportOptions$skip
-         options[["n_max"]] <- dataImportOptions$maxRows
+         options[["guess_max"]] <- dataImportOptions$maxRows
          options[["col_types"]] <- dataImportOptions$columnDefinitions
 
          # set special parameter types
@@ -794,7 +794,7 @@
       data <- suppressWarnings(
          eval(parse(text=importInfo$previewCode))
       )
-
+      
       parsingErrors <- parsingErrorsFromMode(dataImportOptions$mode, data)
 
       preparedData <- .rs.prepareViewerData(


### PR DESCRIPTION
### Intent

Adresses (part of) #8945

### Approach

Using `read_csv(guess_max = 50)` instead of `read_csv(n_max = 50)` for the preview gives better guess when the data is not too big. 

When it is too big, we end up with the bad guess we previously were getting, but then we could (not done here) have access to the `problems()` and then show it in the ui somehow. 
 
### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Generate some data: 

```r
library(readr)

temp_data <- function(file, n = 1e5) {
  df = data.frame(col1=rep(NA, n), col2=rep(NA, n))
  df$col1[1e2] = 1
  df$col1[1e5] = 5000
  write.csv(df, file, row.names=FALSE, na="")
  invisible(NULL)
} 

tf5 <- temp_data("1e5.csv", 1e5)
tf7 <- temp_data("1e7.csv", 1e7)
```

Trying to import `1e5.csv` gives: 

<img width="434" alt="image" src="https://user-images.githubusercontent.com/2625526/147245051-ff6c3a93-eda5-4343-8121-de8fa4c3f5a9.png">

Same with bigger file: 

Bad guess, but the footer says there is a parsing error, perhaps we can promote the error to the ui somehow: 

<img width="325" alt="image" src="https://user-images.githubusercontent.com/2625526/147245252-0b3bfb8f-5454-4bce-984c-ee13d7c81cb7.png">


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


