### PR TITLE
Added correct cursor icon for Vertical and Horizontal Separators

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -87,6 +87,22 @@ export class DesktopBrowserWindow extends EventEmitter {
         acceptFirstMouse: true,
       });
 
+      const customStyles =
+        // eslint-disable-next-line max-len
+        '.gwt-SplitLayoutPanel-HDragger{cursor:ew-resize !important;} .gwt-SplitLayoutPanel-VDragger{cursor:ns-resize !important;}';
+
+      this.window.webContents
+        .insertCSS(customStyles, {
+          cssOrigin: 'author',
+        })
+        .then((result) => {
+          console.log('Custom Styles Added Successfully');
+        })
+        .catch((error) => {
+          console.log('Error when adding custom styles');
+          console.log(error);
+        });
+
       // Uncomment to have all windows show dev tools by default
       // this.window.webContents.openDevTools();
     }


### PR DESCRIPTION
### Intent

Fix an issue that would make the cursor icon for when it was hovering separators, to appear differently than the ones used in the regular RStudio app.

### Approach

Added a custom CSS styling for when the cursor was hovering the separator classes. This should also fix this issue in other platforms as well.

### Automated Tests

None

### QA Notes

Run the electron app by running `yarn start` under `src/node/desktop` folder. Then check the cursor over the vertical and horizontal separators. It should match the ones on the regular RStudio app.

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #9673
