### PR TITLE
use libcurl with windows and R 4.2+

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 * RStudio now supports the experimental UTF-8 UCRT builds of R (#9824)
 * Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
-* Default file download method in Windows for R 4.2 and above changed from `wininet` to `libcurl` (#10301)
+* Default file download method in Windows for R 4.2 and above changed from `wininet` to `libcurl` (#10163)
 
 #### Misc
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 
 #### R
 
+* RStudio now supports the experimental UTF-8 UCRT builds of R (#9824)
 * Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
 * Default file download method in Windows for R 4.2 and above changed from `wininet` to `libcurl` (#10301)
 
@@ -52,11 +53,6 @@
 * Added support for Amazon Linux 2 (Pro #2474)
 * Treat Alt and Caption fields differently depending on file type (#9713)
 * Fixed shortcut conflict on German keyboard (#9276)
-
-#### R
-
-* RStudio now supports the experimental UTF-8 UCRT builds of R (#9824)
-* Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,11 @@
 * Disable session SSL for Code Server 3.9.3 and support auth changes in Code Server 3.11.0 (Pro #3111)
 * Show user's full name, or proxied auth display name, in Project Sharing presence indicator (Pro #3121)
 
+#### R
+
+* Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
+* Default file download method in Windows for R 4.2 and above changed from `wininet` to `libcurl` (#10301)
+
 #### Misc
 
 * Add commands to open selected files in columns or active editor (#7920)

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -1304,8 +1304,9 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       getRversion() >= "3.3" && .rs.haveRequiredRSvnRev(69197)
    }
 
-   # Check whether we are running R 3.2 and whether we have libcurl
+   # Check whether we are running R 3.2+, R 4.2+, and whether we have libcurl
    isR32 <- getRversion() >= "3.2"
+   isR42 <- getRversion() >= "4.2"
    haveLibcurl <- isR32 && capabilities("libcurl") && libcurlHandles404()
    
    # Utility function to bind to libcurl or a fallback utility (e.g. wget)
@@ -1321,12 +1322,14 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
    # Determine the right secure download method per-system
    sysName <- Sys.info()[['sysname']]
    
-   # For windows we prefer binding directly to wininet if we can (since
-   # that doesn't rely on the value of setInternet2). If it's R <= 3.1
-   # then we can use "internal" for https so long as internet2 is enabled 
-   # (we don't use libcurl on Windows because it doesn't check certs).
+   # For windows, with R versions >= 3.2 to <= 4.1, we prefer binding directly to wininet
+   # if we can (since that doesn't rely on the value of setInternet2).
+   # In R 4.2+ wininet is deprecated, so we use libcurl instead when available.
+   # If it's R <= 3.1 then we can use "internal" for https so long as internet2 is enabled
    if (identical(sysName, "Windows")) {
-      if (isR32)
+      if (isR42 && haveLibcurl)
+         "libcurl"
+      else if (isR32)
          "wininet"
       else if (isTRUE(.rs.setInternet2(NA)))
          "internal"


### PR DESCRIPTION
### Intent

wininet for secure download is soft-deprecated in R 4.2. It was previously the default download method on Windows. Users would see a deprecation warning message whenever installing packages on Windows using R-devel (R 4.2+)

We are replacing wininet with libcurl as the default method for secure download for Windows where R is version 4.2+ and libcurl is available.

It deals with how Windows handles downloading any file from the internet (http or https), which most importantly is part of every call to install.packages

You will see that currently in the daily builds if you use R-devel (4.2) on Windows, and run `install.packages(pkg)` you will get a warning message
```
Warning in install.packages :
  the 'wininet' method is deprecated for http:// and https:// URLs
```
And if you run `getOption("download.file.method")` you will get `"wininet"`

This branch should 1) remove the warning you get every time you call `install.packages` and 2) change `getOption("download.file.method")`  to `"libcurl"` for R-devel. 
3) On R 4.1 or below, there should be no warning, and download.file.method will still be "wininet"

### Approach

Use wininet on Windows with R versions 3.2 to 4.1. Use libcurl with R versions 4.2+
No change to linux or Mac

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Using R-devel (4.2), ran on Windows 11 VM. Ran `install.packages("remotes")` and verified that package installed successfully, and warning message that was previously there is no longer there.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


