### PR TITLE
Prevent session resume messages from appearing too often and persisting in console history

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -76,6 +76,9 @@ private:
    const std::string kRVersionHome = "r_version_home";
    const std::string kRVersionLabel = "r_version_label";
    const std::string kWorkingDir = "working_directory";
+   const std::string kLastResumed = "last_resumed";
+   const std::string kSuspendTimestamp = "suspend_timestamp";
+   const std::string kBlockingSuspend = "blocking_suspend";
 
  public:
 
@@ -158,43 +161,28 @@ private:
    {
       if (!empty())
       {
-         writeProperty("blocking-suspend", blocking.writeFormatted());
+         writeProperty(kBlockingSuspend, blocking.writeFormatted());
       }
    }
 
-   void setSuspensionTime()
+   boost::posix_time::ptime suspensionTime() const
    {
-      if (!empty())
-      {
-         std::string suspendTime = boost::posix_time::to_iso_extended_string(
-                                    boost::posix_time::second_clock::universal_time());
-         writeProperty("suspend-timestamp", suspendTime);
-      }
+      return ptimeTimestampProperty(kSuspendTimestamp);
    }
 
-   boost::posix_time::ptime suspensionTime()
+   void setSuspensionTime(const boost::posix_time::ptime value = boost::posix_time::second_clock::universal_time())
    {
-      if (!empty())
-      {
-         try
-         {
-            std::string value = readProperty("suspend-timestamp");
-            if (value.empty())
-               return boost::posix_time::not_a_date_time;
+      setPtimeTimestampProperty(kSuspendTimestamp, value);
+   }
 
-            boost::posix_time::ptime retVal = boost::posix_time::from_iso_extended_string(value);
+   boost::posix_time::ptime lastResumed() const
+   {
+      return ptimeTimestampProperty(kLastResumed);
+   }
 
-            if (retVal.is_not_a_date_time())
-               return boost::posix_time::not_a_date_time;
-
-            return retVal;
-         }
-         catch (std::exception const& e)
-         {
-            LOG_ERROR_MESSAGE("Failed to read session suspend timestamp: " + std::string(e.what()));
-         }
-      }
-      return boost::posix_time::not_a_date_time;
+   void setLastResumed(const boost::posix_time::ptime value = boost::posix_time::second_clock::universal_time())
+   {
+      setPtimeTimestampProperty(kLastResumed, value);
    }
 
    double lastUsed() const
@@ -395,7 +383,6 @@ private:
       sortConditions_.running_ = running();
       sortConditions_.lastUsed_ = lastUsed();
    }
- 
 
    void setTimestampProperty(const std::string& property)
    {
@@ -414,6 +401,39 @@ private:
          return 0;
    }
 
+   void setPtimeTimestampProperty(const std::string& property, const boost::posix_time::ptime& time)
+   {
+      if (!empty())
+      {
+         std::string suspendTime = boost::posix_time::to_iso_extended_string(time);
+         writeProperty(property, suspendTime);
+      }
+   }
+
+   boost::posix_time::ptime ptimeTimestampProperty(const std::string& property) const
+   {
+      if (!empty())
+      {
+         try
+         {
+            std::string value = readProperty(property);
+            if (value.empty())
+               return boost::posix_time::not_a_date_time;
+
+            boost::posix_time::ptime retVal = boost::posix_time::from_iso_extended_string(value);
+
+            if (retVal.is_not_a_date_time())
+               return boost::posix_time::not_a_date_time;
+
+            return retVal;
+         }
+         catch (std::exception const& e)
+         {
+            LOG_ERROR_MESSAGE("Failed to read property " + property + ": " + std::string(e.what()));
+         }
+      }
+      return boost::posix_time::not_a_date_time;
+   }
 
    void setRunning(bool running)
    {

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -65,6 +65,7 @@ Error ActiveSessions::create(const std::string& project,
    activeSession.setInitial(initial);
    activeSession.setLastUsed();
    activeSession.setRunning(false);
+   activeSession.setLastResumed();
 
    // return the id if requested
    if (pId != nullptr)

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -294,15 +294,20 @@ void handleClientInit(const boost::function<void()>& initFunction,
       // console actions
       json::Object actionsObject;
       consoleActions.asJson(&actionsObject);
-      sessionInfo["console_actions"] = actionsObject;
-
-      suspend::initFromResume();
 
       std::string resumeMsg = suspend::getResumedMessage();
       if (!resumeMsg.empty())
       {
-         module_context::consoleWriteOutput(resumeMsg);
+         // Manually adding message to the console here instead of using consoleWriteOutput()
+         // to avoid it ending up in the history and printing out every time this session
+         // resumes/reloads and potentially resulting in an unecessarily long list of
+         // previous resumed messages
+         actionsObject["data"].getArray().push_back(resumeMsg);
+         actionsObject["type"].getArray().push_back(kConsoleActionOutput);
       }
+      sessionInfo["console_actions"] = actionsObject;
+
+      suspend::initFromResume();
    }
 
    sessionInfo["rnw_weave_types"] = modules::authoring::supportedRnwWeaveTypes();


### PR DESCRIPTION
Improve session resumed message so only the most recent message appears on resume
Add timestamps when a client last connected to a session
Improve detecting of connecting to a running session vs. a suspended session
Remove parenthetical plural from mostSignificantTimeAgo()


### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3158. Also fixes https://github.com/rstudio/rstudio-pro/issues/3158

### Approach

Added timestamps that record when a client connects to a session. This "resumed" timestamp, when used in conjunction with the "suspended" timestamp is used to determine if a client is connecting to a session that was awake (has a valid resumed timestamp, but an invalid suspended timestamp) or that was suspended (has a valid suspended timestamp).

Unfortunately, I couldn't come up with a way to determine the difference between connecting to a session that's been active for hours vs a simple browser refresh. To accommodate this, no session resume message is printed if the last timestamp was less than 2 minutes prior. Unfortunately this still means if a user uses the session for 2 or more minutes and then refreshes the browser, this will generate a session resume message.

To prevent the session resumed messages from being added to the console history and stacking up indefinitely, the message is manually added into the client_init message when a client connects to a session, circumnavigating the console history entirely. This results in only the most recent resumed message ever showing.

### Automated Tests

There are already multiple automated tests around this functionality. These changes are likely covered in existing changes and should not break the current tests

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


