### PR TITLE
use graphics device backend type when set, to allow for ragg rendering of NB plot

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,10 @@
 
 ### New
 
+#### R
+
+- Added support for using the AGG renderer (as provided by the ragg package) as a graphics backend for inline plot execution; also added support for using the backend graphics device requested by the knitr `dev` chunk option (#9931)
+
 ### Fixed
 
 ### Breaking

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -30,13 +30,6 @@
       res      = 96 * pixelRatio
    )
 
-   gdBackend <- getOption("RStudioGD.backend")
-   if (!identical(gdBackend, "default"))
-   {
-     # pass along graphics device backend if set
-     args$type <- gdBackend
-   }
-
    if (nchar(extraArgs) > 0)
    {
       # trim leading comma from extra args if present
@@ -67,6 +60,15 @@
       )
       
       return(device)
+   }
+
+   gdBackend <- getOption("RStudioGD.backend")
+   if (!identical(gdBackend, "default"))
+   {
+     # pass along graphics device backend if set
+     # we allow this option to be temporarily set by the knitr chunk option while the notebook
+     # chunk is executing; this takes precedence over the device passed via extraArgs
+     args$type <- gdBackend
    }
    
    

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -29,7 +29,14 @@
       units    = units,
       res      = 96 * pixelRatio
    )
-   
+
+   gdBackend <- getOption("RStudioGD.backend")
+   if (gdBackend != "default")
+   {
+     # pass along graphics device backend if set
+     args$type <- gdBackend
+   }
+
    if (nchar(extraArgs) > 0)
    {
       # trim leading comma from extra args if present

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -31,7 +31,7 @@
    )
 
    gdBackend <- getOption("RStudioGD.backend")
-   if (gdBackend != "default")
+   if (!identical(gdBackend, "default"))
    {
      # pass along graphics device backend if set
      args$type <- gdBackend

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -47,6 +47,15 @@
       if (is.list(extraList))
          args <- c(args, extraList)
    }
+
+   gdBackend <- getOption("RStudioGD.backend")
+   if (!identical(gdBackend, "default"))
+   {
+     # pass along graphics device backend if set
+     # we allow this option to be temporarily set by the knitr chunk option while the notebook
+     # chunk is executing; this takes precedence over the device passed via extraArgs
+     args$type <- gdBackend
+   }
    
    # if it looks like we're using AGG, delegate to that
    if (identical(args$type, "ragg"))
@@ -61,16 +70,6 @@
       
       return(device)
    }
-
-   gdBackend <- getOption("RStudioGD.backend")
-   if (!identical(gdBackend, "default"))
-   {
-     # pass along graphics device backend if set
-     # we allow this option to be temporarily set by the knitr chunk option while the notebook
-     # chunk is executing; this takes precedence over the device passed via extraArgs
-     args$type <- gdBackend
-   }
-   
    
    # create the device
    require(grDevices, quietly = TRUE)

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -168,7 +168,9 @@ void ChunkExecContext::connect()
    // extract knitr figure options if present
    double figWidth = options_.getOverlayOption("fig.width", 0.0);
    double figHeight = options_.getOverlayOption("fig.height", 0.0);
-   
+   // the knitr 'dev' option, if set, may override the default graphics device backend
+   std::string chunkGraphicsBackend = options_.getOverlayOption("dev", std::string("png"));
+
    // if 'fig.asp' is set, then use that to override 'fig.height'
    double figAsp = options_.getOverlayOption("fig.asp", 0.0);
    if (figAsp != 0.0)
@@ -193,13 +195,13 @@ void ChunkExecContext::connect()
    {
       // user specified plot size, use it
       error = pPlotCapture->connectPlots(docId_, chunkId_, nbCtxId_, 
-            figHeight, figWidth, PlotSizeManual, outputPath_);
+            figHeight, figWidth, PlotSizeManual, outputPath_, chunkGraphicsBackend);
    }
    else
    {
       // user didn't specify plot size, use the width of the editor surface
       error = pPlotCapture->connectPlots(docId_, chunkId_, nbCtxId_,
-            0, pixelWidth_, PlotSizeAutomatic, outputPath_);
+            0, pixelWidth_, PlotSizeAutomatic, outputPath_, chunkGraphicsBackend);
    }
    if (error)
       LOG_ERROR(error);

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -383,7 +383,7 @@ core::Error PlotCapture::setBackendDeviceOption()
    {
       return r::options::setOption(kGraphicsOptionBackend, "quartz");
    }
-   if (chunkGraphicsBackend_.find("cairo") == 0 || chunkGraphicsBackend_.find("Cairo"))
+   if (chunkGraphicsBackend_.find("cairo") == 0 || chunkGraphicsBackend_.find("Cairo") == 0)
    {
       return r::options::setOption(kGraphicsOptionBackend, "cairo");
    }

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -280,12 +280,15 @@ void PlotCapture::onNewPlot()
 core::Error PlotCapture::connectPlots(const std::string& docId, 
       const std::string& chunkId, const std::string& nbCtxId, 
       double height, double width, PlotSizeBehavior sizeBehavior,
-      const FilePath& plotFolder)
+      const FilePath& plotFolder, const std::string& chunkGraphicsBackend)
 {
    // save identifiers
    docId_ = docId;
    chunkId_ = chunkId;
    nbCtxId_ = nbCtxId;
+
+   // the graphics backend device set by the knitr chunk option 'dev'
+   chunkGraphicsBackend_ = chunkGraphicsBackend;
 
    // clean up any stale plots from the folder
    plotFolder_ = plotFolder;
@@ -380,7 +383,7 @@ core::Error PlotCapture::setGraphicsOption()
    setOption.addParam(r::session::graphics::device::devicePixelRatio());
 
    // other args (OS dependent)
-   setOption.addParam(r::session::graphics::extraBitmapParams());
+   setOption.addParam(r::session::graphics::extraBitmapParams();
 
    return setOption.call();
 }

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -31,6 +31,7 @@
 #include <r/RExec.hpp>
 #include <r/RSexp.hpp>
 #include <r/session/RGraphics.hpp>
+#include <r/session/RGraphicsConstants.h>
 #include <r/ROptions.hpp>
 #include <r/RRoutines.hpp>
 
@@ -289,15 +290,15 @@ core::Error PlotCapture::connectPlots(const std::string& docId,
 
    // the graphics backend device set by the knitr chunk option 'dev'
    chunkGraphicsBackend_ = chunkGraphicsBackend;
-   // the graphics backend device set by the 'RStudioGD.backend' option
-   defaultGraphicsBackend_.set(r::options::getOption("RStudioGD.backend"));
-   
-   // overwrite the original 'RStudioGD.backend' option, if appropriate
+   // the graphics backend device set by the kGraphicsOptionBackend option
+   defaultGraphicsBackend_.set(r::options::getOption(kGraphicsOptionBackend));
+
+   // overwrite the original option, if appropriate
    Error error = setBackendDeviceOption();
    if (error)
    {
       LOG_ERROR(error);
-      r::options::setOption("RStudioGD.backend", defaultGraphicsBackend_.get());
+      r::options::setOption(kGraphicsOptionBackend, defaultGraphicsBackend_.get());
    }
 
 
@@ -361,7 +362,7 @@ void PlotCapture::disconnect()
 
       // restore the graphics device option
       r::options::setOption("device", deviceOption_.get());
-      r::options::setOption("RStudioGD.backend", defaultGraphicsBackend_.get());
+      r::options::setOption(kGraphicsOptionBackend, defaultGraphicsBackend_.get());
 
       onNewPlot_.disconnect();
       onBeforeNewPlot_.disconnect();
@@ -376,15 +377,15 @@ core::Error PlotCapture::setBackendDeviceOption()
    // corresponding backend instead of the global default
    if (chunkGraphicsBackend_.find("ragg") == 0)
    {
-      return r::options::setOption("RStudioGD.backend", "ragg");
+      return r::options::setOption(kGraphicsOptionBackend, "ragg");
    }
    if (chunkGraphicsBackend_.find("quartz") == 0)
    {
-      return r::options::setOption("RStudioGD.backend", "quartz");
+      return r::options::setOption(kGraphicsOptionBackend, "quartz");
    }
    if (chunkGraphicsBackend_.find("cairo") == 0 || chunkGraphicsBackend_.find("Cairo"))
    {
-      return r::options::setOption("RStudioGD.backend", "cairo");
+      return r::options::setOption(kGraphicsOptionBackend, "cairo");
    }
    return Success();
 }

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -289,6 +289,10 @@ core::Error PlotCapture::connectPlots(const std::string& docId,
 
    // the graphics backend device set by the knitr chunk option 'dev'
    chunkGraphicsBackend_ = chunkGraphicsBackend;
+   // the graphics backend device set by the 'RStudioGD.backend' option
+   defaultGraphicsBackend_.set(r::options::getOption("RStudioGD.backend"));
+   // overwrite the original 'RStudioGD.backend' option, if appropriate
+   setBackendDeviceOption();
 
    // clean up any stale plots from the folder
    plotFolder_ = plotFolder;
@@ -358,6 +362,25 @@ void PlotCapture::disconnect()
    NotebookCapture::disconnect();
 }
 
+core::Error PlotCapture::setBackendDeviceOption()
+{
+   // if chunkGraphicsBackend_ starts with 'ragg', 'quartz' or 'Cairo' then we should use the
+   // corresponding backend instead of the global default
+   if (chunkGraphicsBackend_.find("ragg") == 0)
+   {
+      return r::options::setOption("RStudioGD.backend", "ragg");
+   }
+   if (chunkGraphicsBackend_.find("quartz") == 0)
+   {
+      return r::options::setOption("RStudioGD.backend", "quartz");
+   }
+   if (chunkGraphicsBackend_.find("cairo") == 0 || chunkGraphicsBackend_.find("Cairo"))
+   {
+      return r::options::setOption("RStudioGD.backend", "cairo");
+   }
+   return Success();
+}
+
 core::Error PlotCapture::setGraphicsOption()
 {
    Error error;
@@ -383,7 +406,7 @@ core::Error PlotCapture::setGraphicsOption()
    setOption.addParam(r::session::graphics::device::devicePixelRatio());
 
    // other args (OS dependent)
-   setOption.addParam(r::session::graphics::extraBitmapParams();
+   setOption.addParam(r::session::graphics::extraBitmapParams());
 
    return setOption.call();
 }

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.cpp
@@ -291,13 +291,20 @@ core::Error PlotCapture::connectPlots(const std::string& docId,
    chunkGraphicsBackend_ = chunkGraphicsBackend;
    // the graphics backend device set by the 'RStudioGD.backend' option
    defaultGraphicsBackend_.set(r::options::getOption("RStudioGD.backend"));
+   
    // overwrite the original 'RStudioGD.backend' option, if appropriate
-   setBackendDeviceOption();
+   Error error = setBackendDeviceOption();
+   if (error)
+   {
+      LOG_ERROR(error);
+      r::options::setOption("RStudioGD.backend", defaultGraphicsBackend_.get());
+   }
+
 
    // clean up any stale plots from the folder
    plotFolder_ = plotFolder;
    std::vector<FilePath> folderContents;
-   Error error = plotFolder.getChildren(folderContents);
+   error = plotFolder.getChildren(folderContents);
    if (error)
       return error;
 
@@ -354,6 +361,7 @@ void PlotCapture::disconnect()
 
       // restore the graphics device option
       r::options::setOption("device", deviceOption_.get());
+      r::options::setOption("RStudioGD.backend", defaultGraphicsBackend_.get());
 
       onNewPlot_.disconnect();
       onBeforeNewPlot_.disconnect();

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
@@ -55,7 +55,7 @@ public:
    core::Error connectPlots(const std::string& docId, 
       const std::string& chunkId, const std::string& nbCtxId, 
       double height, double width, PlotSizeBehavior sizeBehavior,
-      const core::FilePath& plotFolder);
+      const core::FilePath& plotFolder, const std::string& chunkGraphicsBackend);
    void disconnect();
    void onExprComplete();
 private:
@@ -76,6 +76,8 @@ private:
    std::string docId_;
    std::string chunkId_;
    std::string nbCtxId_;
+
+   std::string chunkGraphicsBackend_;
 
    r::sexp::PreservedSEXP deviceOption_;
    r::sexp::PreservedSEXP lastPlot_;

--- a/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlots.hpp
@@ -60,6 +60,7 @@ public:
    void onExprComplete();
 private:
    core::Error setGraphicsOption();
+   core::Error setBackendDeviceOption();
    void processPlots(bool ignoreEmpty);
    void removeGraphicsDevice();
    void onNewPlot();
@@ -78,6 +79,7 @@ private:
    std::string nbCtxId_;
 
    std::string chunkGraphicsBackend_;
+   r::sexp::PreservedSEXP defaultGraphicsBackend_;
 
    r::sexp::PreservedSEXP deviceOption_;
    r::sexp::PreservedSEXP lastPlot_;


### PR DESCRIPTION
### Intent

Address the issue in #9931. 

```
plot(1, main = "あいう ABC", xlab = "あいう ABC")
```
should be able to render properly with Japanese characters when ragg is the graphics device, whether the plot is being rendered in the console or inline as a notebook chunk.

### Approach

`.rs.createNotebookGraphicsDevice` function should respect and pass along the graphics device type, if it has been set. We can read it in directly from `getOption("RStudioGD.backend")`. 

The user can set the default device by either adding `options(RStudioGD.backend='ragg')` to their .Rprofile, or in the IDE by going to Tools > Global Options > Graphics and selecting AGG under Backend (after installing `ragg`). 

If the device has been set in the knitr chunk options, it will render using that device when knit, but to render properly inline, the user must set the RStudio graphics device backend explicitly.

### Automated Tests

None

### QA Notes

Should test that 

```{r}
plot(1, main = "あいう ABC", xlab = "あいう ABC")
```
renders both inline and in the console when the graphics device is set to `ragg` (see above) and that Japanese characters are missing when the graphics device is left as Default or any other option

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


