### PR TITLE
Update how quarto is bundled in macOS package

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -615,9 +615,20 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
 
    # install quarto (or pandoc if quarto disabled)
    if(QUARTO_ENABLED)
-      install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
-              DESTINATION "${RSTUDIO_INSTALL_BIN}"
-              USE_SOURCE_PERMISSIONS)
+   # install some quarto folders into Resources, as needed
+      if(APPLE)
+         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
+               DESTINATION "${RSTUDIO_INSTALL_BIN}"
+               USE_SOURCE_PERMISSIONS
+               PATTERN "*/share" EXCLUDE)
+         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
+               DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/quarto"
+               USE_SOURCE_PERMISSIONS)
+      else()
+         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
+               DESTINATION "${RSTUDIO_INSTALL_BIN}"
+               USE_SOURCE_PERMISSIONS)
+      endif()
    else()
       install(DIRECTORY "${RSTUDIO_DEPENDENCIES_PANDOC_DIR}/"
               DESTINATION "${RSTUDIO_INSTALL_BIN}/pandoc"


### PR DESCRIPTION



### Intent

Places the `quarto/share` folder under `Rstudio.app/Contents/Resources/quarto/` to prevent signing errors caused by a folder inside of `share` called `deno.land`. The period in the folder name throws off the macOS signing code.

### Approach

And Apple-specific switch case was added to copy the quarto directory as normal _except_ for the `share/` directory. The `share/` directory is then copied into `Rstudio.app/Contents/Resources/quarto/`

### Automated Tests

None. This should fix the broken builds by allowing the package to be signed correctly

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


