### PR TITLE
Fix spacing around small buttons in find/replace

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/SmallButton.css
@@ -13,6 +13,10 @@
    font-size: 9px;
    color: black;
    white-space: nowrap;
+   margin-top: 3px;
+   margin-left: 6px;
+   margin-right: 6px;
+   margin-bottom: 3px;
 }
 
 button.smallButton {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.css
@@ -19,6 +19,14 @@
    white-space: nowrap;
 }
 
+.findTextBox, .replaceTextBox {
+   margin-top: 1px;
+}
+
+.findTextBox {
+   margin-left: 3px;
+}
+
 .replaceTextBox {
    margin-left: 10px;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/findreplace/FindReplaceBar.java
@@ -54,6 +54,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
    interface Styles extends CssResource
    {
       String findReplaceBar();
+      String findTextBox();
       String replaceTextBox();
       String findPanel();
       String optionsPanel();
@@ -85,6 +86,7 @@ public class FindReplaceBar extends Composite implements Display, RequiresResize
       HorizontalPanel findReplacePanel = new HorizontalPanel();
       findReplacePanel.addStyleName(RES.styles().findPanel());
       findReplacePanel.add(txtFind_ = new FindTextBox(constants_.findCapitalized()));
+      txtFind_.addStyleName(RES.styles().findTextBox());
       txtFind_.setIconVisible(true);
 
       Commands cmds = RStudioGinjector.INSTANCE.getCommands();


### PR DESCRIPTION
### Intent

This fixes a visual regression caused by the removal of the classic theme in https://github.com/rstudio/rstudio/pull/10081. 

I noticed that the elements in the affected area had some alignment issues so I nudged some margins to improve those while I was in the code.

Before (Ghost Orchid):

![image](https://user-images.githubusercontent.com/470418/148589566-37d3b916-8c58-4b38-8eb8-c277cdfb8e47.png)

After: 

![image](https://user-images.githubusercontent.com/470418/148589770-bb85eabf-fc1d-4b00-95b0-6671d6b6adbf.png)

Addresses https://github.com/rstudio/rstudio/issues/10316.

### Approach

Just CSS tweaks.

### Automated Tests

NA, visual impact only.

### QA Notes

NA, visual impact only.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


