### PR TITLE
Feature/source code markers

### DIFF
--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -894,12 +894,10 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
          markerLintType = LintTypeInfo;
       }
 
-      lintItems.add(marker.line - 1,
-                    marker.column,
-                    marker.line,
-                    marker.column,
-                    markerLintType,
-                    marker.message.text());
+      int line = marker.line - 1; // markers begin the index at 1 and lint items begin at 0
+      int col = marker.column;
+      lintItems.add(
+          line, col, line, col, markerLintType, marker.message.text());
    }
 
    pResponse->setResult(lintAsJson(lintItems));

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -873,7 +873,7 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
    LintItems lintItems = results.lint();
 
    using namespace module_context;
-   for (SourceMarker marker : markers)
+   for (const SourceMarker& marker : markers)
    {
       LintType markerLintType;
       switch (marker.type)
@@ -884,12 +884,10 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
       case SourceMarker::Type::Warning:
          markerLintType = LintTypeWarning;
          break;
-      case SourceMarker::Type::Info:
-         markerLintType = LintTypeInfo;
-         break;
       case SourceMarker::Type::Style:
          markerLintType = LintTypeStyle;
          break;
+      case SourceMarker::Type::Info:
       default:
          markerLintType = LintTypeInfo;
       }

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -892,7 +892,10 @@ Error lintRSourceDocument(const json::JsonRpcRequest& request,
          markerLintType = LintTypeInfo;
       }
 
-      int line = marker.line - 1; // markers begin the index at 1 and lint items begin at 0
+      int line =
+          marker.line <= 0
+              ? 1
+              : marker.line - 1; // markers begin the index at 1 and lint items begin at 0
       int col = marker.column;
       lintItems.add(
           line, col, line, col, markerLintType, marker.message.text());

--- a/src/cpp/session/modules/SessionMarkers.cpp
+++ b/src/cpp/session/modules/SessionMarkers.cpp
@@ -233,16 +233,16 @@ public:
       return obj;
    }
 
-   std::vector<module_context::SourceMarker> findMarkers(std::string path) const
+   std::vector<module_context::SourceMarker> findMarkers(const std::string& path) const
    {
       std::vector<module_context::SourceMarker> markers;
       // replace home alias to home path
       core::FilePath resolvedPath = core::FilePath::resolveAliasedPath(
           path, system::User::getUserHomePath());
 
-      for (module_context::SourceMarkerSet markerSet : markerSets_)
+      for (const module_context::SourceMarkerSet& markerSet : markerSets_)
       {
-         for (module_context::SourceMarker marker : markerSet.markers)
+         for (const module_context::SourceMarker& marker : markerSet.markers)
          {
             if (marker.path == resolvedPath)
             {
@@ -492,7 +492,7 @@ json::Object markersStateAsJson()
    return sourceMarkers().stateAsJson();
 }
 
-std::vector<module_context::SourceMarker> markersForFile(std::string path)
+std::vector<module_context::SourceMarker> markersForFile(const std::string& path)
 {
    return sourceMarkers().findMarkers(path);
 }

--- a/src/cpp/session/modules/SessionMarkers.cpp
+++ b/src/cpp/session/modules/SessionMarkers.cpp
@@ -233,6 +233,27 @@ public:
       return obj;
    }
 
+   std::vector<module_context::SourceMarker> findMarkers(std::string path) const
+   {
+      std::vector<module_context::SourceMarker> markers;
+      // replace home alias to home path
+      core::FilePath resolvedPath = core::FilePath::resolveAliasedPath(
+          path, system::User::getUserHomePath());
+
+      for (module_context::SourceMarkerSet markerSet : markerSets_)
+      {
+         for (module_context::SourceMarker marker : markerSet.markers)
+         {
+            if (marker.path == resolvedPath)
+            {
+               markers.push_back(marker);
+            }
+         }
+      }
+
+      return markers;
+   }
+
 private:
    typedef std::vector<module_context::SourceMarkerSet> MarkerSets;
    MarkerSets::const_iterator findSetByName(const std::string& name) const
@@ -469,6 +490,11 @@ void writeSourceMarkers(bool terminatedNormally)
 json::Object markersStateAsJson()
 {
    return sourceMarkers().stateAsJson();
+}
+
+std::vector<module_context::SourceMarker> markersForFile(std::string path)
+{
+   return sourceMarkers().findMarkers(path);
 }
 
 Error initialize()

--- a/src/cpp/session/modules/SessionMarkers.hpp
+++ b/src/cpp/session/modules/SessionMarkers.hpp
@@ -18,6 +18,7 @@
 
 #include <string>
 
+#include <session/SessionModuleContext.hpp>
 #include <shared_core/json/Json.hpp>
 
 namespace rstudio {
@@ -32,6 +33,7 @@ namespace modules {
 namespace markers {
 
 core::json::Object markersStateAsJson();
+std::vector<module_context::SourceMarker> markersForFile(std::string path);
 
 core::Error initialize();
    

--- a/src/cpp/session/modules/SessionMarkers.hpp
+++ b/src/cpp/session/modules/SessionMarkers.hpp
@@ -33,7 +33,7 @@ namespace modules {
 namespace markers {
 
 core::json::Object markersStateAsJson();
-std::vector<module_context::SourceMarker> markersForFile(std::string path);
+std::vector<module_context::SourceMarker> markersForFile(const std::string& path);
 
 core::Error initialize();
    


### PR DESCRIPTION
### Intent
Addresses #10062 to add source code markers to the source code gutter.
![image](https://user-images.githubusercontent.com/9591545/148804506-476ba2ae-5669-4d01-a00b-9e9f75ef674a.png)

### Approach
When the R documented is linted, search the marker sets and collect any for the file. Convert the markers to lint items and add it to the result.

### Automated Tests
None

### QA Notes
Sample code:
```R
markerText <- cli::boxx("I am a source code marker!")
markers <- list(
  list(
    type = "info",
    file = "html.R",
    line = 2,
    column = 1,
    message = markerText)
)
rstudioapi::sourceMarkers("custom markers", markers)
```

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


