### PR TITLE
install panmirror node deps even if yarn already installed

### DIFF
--- a/dependencies/common/install-yarn
+++ b/dependencies/common/install-yarn
@@ -28,22 +28,22 @@ INSTALL_PATH="${NODE_BIN}:${PATH}"
 # check for yarn installation
 # TODO: do we want to allow yarn installs from other PATH locations?
 if command -v yarn 2> /dev/null; then
-	echo "yarn ${YARN_VERSION} already installed at '${NODE_BIN}/yarn'"
-	exit 0
+  YARN_VERSION=$(PATH="${INSTALL_PATH}" yarn --version)
+  echo "yarn ${YARN_VERSION} already installed at '${NODE_BIN}/yarn'"
+else
+  # download the yarn installer
+  YARN_INSTALL_URL="https://yarnpkg.com/install.sh"
+  YARN_INSTALL_SCRIPT="yarn-install.sh"
+  download "${YARN_INSTALL_URL}" "${YARN_INSTALL_SCRIPT}"
+
+  # run the installer script
+  chmod +x "${YARN_INSTALL_SCRIPT}"
+  PATH=${INSTALL_PATH} ./"${YARN_INSTALL_SCRIPT}"
+  rm "${YARN_INSTALL_SCRIPT}"
+
+  # update INSTALL_PATH
+  INSTALL_PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${INSTALL_PATH}"
 fi
-
-# download the yarn installer
-YARN_INSTALL_URL="https://yarnpkg.com/install.sh"
-YARN_INSTALL_SCRIPT="yarn-install.sh"
-download "${YARN_INSTALL_URL}" "${YARN_INSTALL_SCRIPT}"
-
-# run the installer script
-chmod +x "${YARN_INSTALL_SCRIPT}"
-PATH=${INSTALL_PATH} ./"${YARN_INSTALL_SCRIPT}"
-rm "${YARN_INSTALL_SCRIPT}"
-
-# update INSTALL_PATH
-INSTALL_PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${INSTALL_PATH}"
 
 # install panmirror dependencies
 if [ -d "/opt/rstudio-tools/panmirror" ]; then
@@ -58,5 +58,3 @@ PATH=${INSTALL_PATH} yarn config set ignore-engines true
 PATH=${INSTALL_PATH} yarn install
 
 popd
-
-


### PR DESCRIPTION
### Intent

This prior PR (#10159) changed dependency script behavior such that if yarn is already installed it no longer ran the "yarn install" step for the panmirror dependencies. Installing yarn vs. "yarn install" in `src/gwt/panmirror/src/editor` are separate things.

Without this it's easy to get into a situation (e.g. juggling multiple repos) where trying to build GWT will give:

```
panmirror:
     [exec] internal/modules/cjs/loader.js:892
     [exec]   throw err;
     [exec]   ^
     [exec]
     [exec] Error: Cannot find module 'fuse-box/sparky'
     [exec] Require stack:
     [exec] - /Users/gary/alt/loc/rstudio/src/gwt/panmirror/src/editor/fuse.js
     [exec]     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:889:15)
     [exec]     at Function.Module._load (internal/modules/cjs/loader.js:745:27)
     [exec]     at Module.require (internal/modules/cjs/loader.js:961:19)
     [exec]     at require (internal/modules/cjs/helpers.js:92:18)
     [exec]     at Object.<anonymous> (/Users/gary/alt/loc/rstudio/src/gwt/panmirror/src/editor/fuse.js:16:27)
     [exec]     at Module._compile (internal/modules/cjs/loader.js:1072:14)
     [exec]     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1101:10)
     [exec]     at Module.load (internal/modules/cjs/loader.js:937:32)
     [exec]     at Function.Module._load (internal/modules/cjs/loader.js:778:12)
     [exec]     at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12) {
     [exec]   code: 'MODULE_NOT_FOUND',
     [exec]   requireStack: [
     [exec]     '/Users/gary/alt/loc/rstudio/src/gwt/panmirror/src/editor/fuse.js'
     [exec]   ]
     [exec] }
     [exec] Result: 1
     [java] Compiling module org.rstudio.studio.RStudio
```

### Approach

Always run the yarn install, even if yarn is already installed. This restores old behaviour. Also fixed small glitch where the script wasn't reporting the version of existing yarn install.

### Automated Tests

None, purely dev / build tooling.

### QA Notes

Move along, nothing to see here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


