### PR TITLE
Change SQL comment highlight to line start

### DIFF
--- a/src/gwt/acesupport/acemode/sql_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/sql_highlight_rules.js
@@ -62,7 +62,7 @@ define("mode/sql_highlight_rules", ["require", "exports", "module"], function(re
             end : "\\*/"
         }, {
             token: "comment",
-            regex: "#.*$"
+            regex: "^#.*$"
         }, {
           token : "comment.doc.tag",
           regex : "\\?[a-zA-Z_][a-zA-Z0-9_$]*"


### PR DESCRIPTION
### Intent
Compromise for MySQL comments and SQL Server temp table syntax. Without building vendor specific highlighting rules, this allows for comment highlighting when `#` is at the beginning of the line.

#9578

### Approach
Change regex to match at the beginning of the line

### Automated Tests
None

### QA Notes
SQL Server temp table creation syntax won't be highlighted. The comment highlighting only works when `#` is at the beginning of the line.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


