### PR TITLE
Add check for "not-a-date-time" values in session property timestamps

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -414,10 +414,15 @@ private:
    {
       if (!empty())
       {
+         std::string value = "Value Not Read";
          try
          {
-            std::string value = readProperty(property);
+            value = readProperty(property);
             if (value.empty())
+               return boost::posix_time::not_a_date_time;
+
+            // posix_time::from_iso_extended_string can't parse not_a_date_time correctly, so handling it here
+            if (value == boost::posix_time::to_iso_extended_string(boost::posix_time::not_a_date_time))
                return boost::posix_time::not_a_date_time;
 
             boost::posix_time::ptime retVal = boost::posix_time::from_iso_extended_string(value);
@@ -429,7 +434,7 @@ private:
          }
          catch (std::exception const& e)
          {
-            LOG_ERROR_MESSAGE("Failed to read property " + property + ": " + std::string(e.what()));
+            LOG_INFO_MESSAGE("Failure reading property " + property + ": " + std::string(e.what()) + ". Property contents: " + value);
          }
       }
       return boost::posix_time::not_a_date_time;


### PR DESCRIPTION
Improve error message, and reduce severity, when session property timestamps can't be read


### Intent

When reading timestamps from a string/file, a valid value is `not-a-date-time`, which can be generated by `boost::posix_time::to_iso_extended_string`. However, the companion function `boost::posix_time::from_iso_extended_string` does not handle the `not-a-date-time` case and will throw an error:

```
 2022-01-11T20:00:23.749984Z [rsession-rstudio] ERROR Failed to read property suspend_timestamp with value: 'not-a-date-time' error: bad lexical cast: source type value could not be interpreted as target; LOGGED FROM: rstudio_boost::posix_time::ptime rstudio::core::r_util::ActiveSession::ptimeTimestampProperty(const string&) const src/cpp/session/SessionSuspend.cpp:433
```

### Approach

Added a check to handle the `not-a-date-time` case manually
Improved the error message to also print out the value that was read, if any
Lowered the severity of the error, since the code can largely recover without impacting stability, even when the value cannot be read or cast into a `ptime` object

### Automated Tests

None, this is more a convenience change to improve the logs

### QA Notes

None 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


