### PR TITLE
rework `.rs.flattenFrame()` so that matrix columns are shown

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -367,10 +367,11 @@
       if (is.matrix(cols)) {
         colnames <- colnames(cols)
         if (is.null(colnames)) {
-          colnames(cols) <- paste0(prefix, '[, ', 1:ncol(cols), ']')
+          colnames(cols) <- paste0(prefix, '[,\u00a0', 1:ncol(cols), ']')
         } else {
-          colnames(cols) <- paste0(prefix, '[, "', colnames, '"]')
+          colnames(cols) <- paste0(prefix, '[,\u00a0"', colnames, '"]')
         }
+
       } else if (is.data.frame(cols)) {
         names(cols) <- paste(prefix, names(cols), sep = "$")
       }

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -363,8 +363,7 @@
       }
       
       # apply column names
-      
-      prefix <- c(names(multicol)[[1]], rep("", ncol(cols) - 1L))
+      prefix <- names(multicol)[[1]]
       if (is.matrix(cols)) {
         colnames <- colnames(cols)
         if (is.null(colnames)) {

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -367,9 +367,9 @@
       if (is.matrix(cols)) {
         colnames <- colnames(cols)
         if (is.null(colnames)) {
-          colnames(cols) <- paste0(prefix, '[,\u00a0', 1:ncol(cols), ']')
+          colnames(cols) <- paste0(prefix, '[,', 1:ncol(cols), ']')
         } else {
-          colnames(cols) <- paste0(prefix, '[,\u00a0"', colnames, '"]')
+          colnames(cols) <- paste0(prefix, '[,"', colnames, '"]')
         }
 
       } else if (is.data.frame(cols)) {

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -1,0 +1,39 @@
+#
+# test-dataviewer.R
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+context("data viewer")
+
+test_that(".rs.flattenFrame() handles matrices and data frames", {
+   tbl1 <- data.frame(x = 1:2)
+   df_col <- data.frame(y = 1:2, z = 1:2)
+   tbl1$df_col <- df_col
+   tbl1$mat_col <- matrix(1:4, ncol = 2)
+   flat1 <- .rs.flattenFrame(tbl1)
+
+   # same but matrix has colnames
+   tbl2 <- tbl1
+   tbl2$mat_col <- matrix(1:4, ncol = 2, dimnames = list(1:2, c("a", "b")))
+   flat2 <- .rs.flattenFrame(tbl2)
+   
+   # further df nesting 
+   tbl3 <- tbl2
+   df_col$df <- df_col
+   tbl3$df_col <- df_col
+   flat3 <- .rs.flattenFrame(tbl3)
+
+   expect_equal(names(flat1), c("x", "df_col$y", "df_col$z", "mat_col[,1]", "mat_col[,2]"))
+   expect_equal(names(flat2), c("x", "df_col$y", "df_col$z", 'mat_col[,"a"]', 'mat_col[,"b"]'))
+   expect_equal(names(flat3), c("x", "df_col$y", "df_col$z", "df_col$df$y", "df_col$df$z", 'mat_col[,"a"]', 'mat_col[,"b"]'))
+})


### PR DESCRIPTION
### Intent

deal with #10332

### Approach

Improve `.rs.flattenFrame()` so that matrices are also flattened. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

```r
library(tibble)
set.seed(123)

my_matrix <- matrix(c(1:20, 1:20), ncol = 2)
df_col <- data.frame(x = 1:20, y = 1:20)

# unnamed matrix
tbl <- tibble(x = letters[1:20], y = 1:20, mat_col = my_matrix, df_col = df_col)
View(tbl)
```

should display: 

<img width="566" alt="image" src="https://user-images.githubusercontent.com/2625526/149949117-8f48f5aa-b8b8-4dfc-ad5b-593219fa2eaf.png">

filter and sort should work just fine. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


