### PR TITLE
Avoid offline requests before the session is initialized

### DIFF
--- a/src/cpp/session/SessionOfflineService.cpp
+++ b/src/cpp/session/SessionOfflineService.cpp
@@ -36,6 +36,7 @@
 #include "SessionAsyncRpcConnection.hpp"
 #include "modules/SessionSystemResources.hpp"
 #include "session/prefs/UserPrefs.hpp"
+#include "SessionInit.hpp"
 
 using namespace rstudio::core;
 
@@ -230,7 +231,8 @@ void OfflineService::run()
 
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
 
-            if (handleOfflineMillis > 0)
+	    // Make sure session is initialized before doing any processing in the offline thread to avoid the call to lazily init it
+            if (handleOfflineMillis > 0 && init::isSessionInitialized())
             {
                boost::shared_ptr<HttpConnection> ptrConnection;
                do

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -51,6 +51,7 @@
 #include "../SessionUriHandlers.hpp"
 #include "../SessionHttpMethods.hpp"
 #include "../SessionRpc.hpp"
+#include "../SessionInit.hpp"
 
 
 namespace rstudio {
@@ -349,7 +350,7 @@ private:
             eventsActive_ = false;
          }
          if (options().handleOfflineEnabled() && options().handleOfflineTimeoutMs() == 0 &&
-             rpc::isOfflineableRequest(ptrHttpConnection))
+             rpc::isOfflineableRequest(ptrHttpConnection) && init::isSessionInitialized())
          {
             // TODO: handleOffline - should these be put into a separate queue and run in a dedicated thread?
             if (http_methods::protocolDebugEnabled())


### PR DESCRIPTION
This fixes a problem that showed up when running the test suite
with session-handle-offline-timeout-ms=0 - basically, running all
offlineable requests on the offline thread. Every once and a while it
would try to run an offline request before the session was initialized.
That would initialize the session on the wrong thread, getting a ton of
errors and eventually a crash.

I don't think it's likely without that setting but just to
be safe I also added the session init test to the offline thread as well.


### Intent

Part of the fix for: https://github.com/rstudio/rstudio/issues/9868

### Approach

Check if session has been initialized before all "offlineable" request handling. 

### Automated Tests

Covered by existing automation.

### QA Notes

Tested as part of #9868 

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests


