### PR TITLE
Ensure that onWarning onMessage handlers actually get respected during chunk execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Added support for using the AGG renderer (as provided by the ragg package) as a graphics backend for inline plot execution; also added support for using the backend graphics device requested by the knitr `dev` chunk option (#9931)
 
 ### Fixed
+- Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE.
 
 ### Breaking
 

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -42,13 +42,8 @@
 
 .rs.addFunction("notebookConditions.connectImpl", function()
 {
-   # NOTE: because the body of this function will be evaluated in the
-   # global environment, we need to avoid defining variables here.
-   #
-   # https://github.com/rstudio/rstudio/issues/8834
-   base::assign(
-      x = ".rs.notebookConditions.handlerStack",
-      value = .Internal(.addCondHands(
+  .rs.notebookConditions.handlerStack <-
+   .Internal(.addCondHands(
          c("warning", "message"),
          list(
             warning = .rs.notebookConditions.onWarning,
@@ -57,9 +52,7 @@
          base::globalenv(),
          NULL,
          TRUE
-      )),
-      envir = base::as.environment("tools:rstudio")
-   )
+      ))
 })
 
 .rs.addFunction("notebookConditions.disconnectCall", function()
@@ -69,19 +62,8 @@
 
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
-   # NOTE: because the body of this function will be evaluated in the
-   # global environment, we need to avoid defining variables here.
-   #
-   # https://github.com/rstudio/rstudio/issues/8834
    .Internal(.resetCondHands(
-      base::get(
-         x = ".rs.notebookConditions.handlerStack",
-         envir = base::as.environment("tools:rstudio")
-      )
+     .rs.notebookConditions.handlerStack
    ))
-   
-   base::rm(
-      list = ".rs.notebookConditions.handlerStack",
-      envir = base::as.environment("tools:rstudio")
-   )
+  rm(.rs.notebookConditions.handlerStack)
 })

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -42,6 +42,11 @@
 
 .rs.addFunction("notebookConditions.connectImpl", function()
 {
+  
+  # NOTE: because the body of this function will be evaluated in the
+  # global environment, we need to avoid defining variables here.
+  #
+  # https://github.com/rstudio/rstudio/issues/8834
   .rs.notebookConditions.handlerStack <-
    .Internal(.addCondHands(
          c("warning", "message"),
@@ -66,6 +71,10 @@
 
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
+  # NOTE: because the body of this function will be evaluated in the
+  # global environment, we need to avoid defining variables here.
+  #
+  # https://github.com/rstudio/rstudio/issues/8834
    .Internal(.resetCondHands(
      base::get(
        x = ".rs.notebookConditions.handlerStack",

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -53,6 +53,10 @@
          NULL,
          TRUE
       ))
+  base::assign(".rs.notebookConditions.handlerStack", 
+               .rs.notebookConditions.handlerStack,
+               .rs.toolsEnv())
+  rm(.rs.notebookConditions.handlerStack)
 })
 
 .rs.addFunction("notebookConditions.disconnectCall", function()
@@ -63,7 +67,11 @@
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
    .Internal(.resetCondHands(
-     .rs.notebookConditions.handlerStack
+     base::get(
+       x = ".rs.notebookConditions.handlerStack",
+       envir = .rs.toolsEnv()
+     )
+     
    ))
-  rm(.rs.notebookConditions.handlerStack)
+  base::rm(.rs.notebookConditions.handlerStack, envir = .rs.toolsEnv())
 })

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -43,10 +43,10 @@
 .rs.addFunction("notebookConditions.connectImpl", function()
 {
   
-  # NOTE: because the body of this function will be evaluated in the
-  # global environment, we need to avoid defining variables here.
-  #
-  # https://github.com/rstudio/rstudio/issues/8834
+   # NOTE: because the body of this function will be evaluated in the
+   # global environment, we need to avoid defining variables here.
+   #
+   # https://github.com/rstudio/rstudio/issues/8834
   .rs.notebookConditions.handlerStack <-
    .Internal(.addCondHands(
          c("warning", "message"),
@@ -58,9 +58,9 @@
          NULL,
          TRUE
       ))
-  base::assign(".rs.notebookConditions.handlerStack", 
-               .rs.notebookConditions.handlerStack,
-               .rs.toolsEnv())
+  base::assign(x = ".rs.notebookConditions.handlerStack", 
+               value = .rs.notebookConditions.handlerStack,
+               envir = .rs.toolsEnv())
   base::rm(.rs.notebookConditions.handlerStack)
 })
 
@@ -71,10 +71,10 @@
 
 .rs.addFunction("notebookConditions.disconnectImpl", function()
 {
-  # NOTE: because the body of this function will be evaluated in the
-  # global environment, we need to avoid defining variables here.
-  #
-  # https://github.com/rstudio/rstudio/issues/8834
+   # NOTE: because the body of this function will be evaluated in the
+   # global environment, we need to avoid defining variables here.
+   #
+   # https://github.com/rstudio/rstudio/issues/8834
    .Internal(.resetCondHands(
      base::get(
        x = ".rs.notebookConditions.handlerStack",

--- a/src/cpp/session/modules/NotebookConditions.R
+++ b/src/cpp/session/modules/NotebookConditions.R
@@ -56,7 +56,7 @@
   base::assign(".rs.notebookConditions.handlerStack", 
                .rs.notebookConditions.handlerStack,
                .rs.toolsEnv())
-  rm(.rs.notebookConditions.handlerStack)
+  base::rm(.rs.notebookConditions.handlerStack)
 })
 
 .rs.addFunction("notebookConditions.disconnectCall", function()


### PR DESCRIPTION
### Intent

Addresses #9436. 

### Approach

Handle message and warning chunk options with rs.notebookConditions.onWarning and rs.notebookConditions.onMessage handlers. These functions handle whether or not warnings and messages should be output to the console, but they weren't actually being called. Assigning the handler to a temporary variable in the global environment, rather than the rstudio::tools environment fixes the issue.

### Automated Tests

NA

### QA Notes

Run the following notebook chunks inline and ensure warnings and messages are shown/not shown as expected.
~~~
---
title: "message"
output: html_document
---

```{r, message=FALSE}
message("You will NOT see the message.")
```

```{r}
message("You WILL see the message.")
```

```{r, message=TRUE}
message("You WILL see the message.")
```


```{r, warning=FALSE}
warning("You will NOT see the warning")
```

```{r}
warning("You WILL see the warning")
```
~~~

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


