### PR TITLE
Add retry and timeout logic for sentry upload

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,12 @@ def s3_upload(type, flavor, os, arch) {
 
 def sentry_upload(type, flavor) {
   withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]){
-    sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ../../../../../docker/jenkins/sentry-upload.sh ${SENTRY_API_KEY}"
+    retry(2) {
+      // timeout sentry in 15 minutes
+      timeout(activity: true, time: 15) {
+	sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ../../../../../docker/jenkins/sentry-upload.sh ${SENTRY_API_KEY}"
+      }
+    }
   }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,7 +136,7 @@ def s3_upload(type, flavor, os, arch) {
 
 def sentry_upload(type, flavor) {
   withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]){
-    retry(2) {
+    retry(5) {
       // timeout sentry in 15 minutes
       timeout(activity: true, time: 15) {
 	sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ../../../../../docker/jenkins/sentry-upload.sh ${SENTRY_API_KEY}"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -125,7 +125,7 @@ pipeline {
             def RSTUDIO_RELEASE = "${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
 
 
-            retry(2) {
+            retry(5) {
                // timeout sentry in 15 minutes
                timeout(activity: true, time: 15) {
 

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -123,21 +123,28 @@ pipeline {
           withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]){
             // construct release version
             def RSTUDIO_RELEASE = "${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
- 
-            // create new release on Sentry
-            sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend new ${RSTUDIO_RELEASE}"
 
-            // upload Javascript source maps
-            sh "cd package/osx/build/gwt && sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend files ${RSTUDIO_RELEASE} upload-sourcemaps --ext js --ext symbolMap --rewrite ."
 
-            // associate commits
-            sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend set-commits --auto ${RSTUDIO_RELEASE}"
+            retry(2) {
+               // timeout sentry in 15 minutes
+               timeout(activity: true, time: 15) {
 
-            // finalize release
-            sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend finalize ${RSTUDIO_RELEASE}"
+                // create new release on Sentry
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend new ${RSTUDIO_RELEASE}"
 
-            // upload C++ debug information
-            sh "cd package/osx/build/src/cpp && sentry-cli --auth-token ${SENTRY_API_KEY} upload-dif --org rstudio --project ide-backend -t dsym ."
+                // upload Javascript source maps
+                sh "cd package/osx/build/gwt && sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend files ${RSTUDIO_RELEASE} upload-sourcemaps --ext js --ext symbolMap --rewrite ."
+
+                // associate commits
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend set-commits --auto ${RSTUDIO_RELEASE}"
+
+                // finalize release
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend finalize ${RSTUDIO_RELEASE}"
+
+                // upload C++ debug information
+                sh "cd package/osx/build/src/cpp && sentry-cli --auth-token ${SENTRY_API_KEY} upload-dif --org rstudio --project ide-backend -t dsym ."
+              }
+            }
           }
 
           // publish build to dailies page

--- a/docker/jenkins/sentry-upload.sh
+++ b/docker/jenkins/sentry-upload.sh
@@ -41,8 +41,8 @@ while true; do
         break
     fi
 
-    # Don't try more than 5 times
-    if [ $RETRIES -gt 5 ]; then
+    # Retry and timeout are now done in Jenkinsfile
+    if [ $RETRIES -gt 0 ]; then
         echo "Giving up upload after $RETRIES attempts"
         exit 1
     fi


### PR DESCRIPTION
(disabled the old retry logic in sentry-upload.sh)

this is primarily to get around the a problem when sentry can hang up the build indefinitely.  Note that previously we were retrying 5 times with 30 seconds of sleep in between. I just disabled that logic in favor of 2 retries with a timeout.  

