### PR TITLE
Add Date: field with default to `r Sys.Date()`

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -239,6 +239,8 @@ public class ElementIds
    public static String getNewRmdTemplateLabel() { return getElementId(NEW_RMD_TEMPLATE_LABEL); }
    public final static String NEW_RMD_TEMPLATE = "new_rmd_template";
    public static String getNewRmdTemplate() { return getElementId(NEW_RMD_TEMPLATE); }
+   public final static String NEW_RMD_AUTO_DATE = "new_rmd_auto_date";
+   public static String getNewRmdAutoDate() { return getElementId(NEW_RMD_AUTO_DATE); }
 
    // RmdTemplateChooser
    public final static String RMD_TEMPLATE_CHOOSER_NAME = "rmd_template_chooser_name";

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RmdFrontMatter.java
@@ -41,9 +41,8 @@ public class RmdFrontMatter extends JavaScriptObject
       this.runtime = runtime;
    }-*/;
 
-   public final native void addDate() /*-{
-      // using iso format: yyyy-mm-dd
-      this.date = new Date().toISOString().replace(/T.*$/, "");
+   public final native void setDate(String date) /*-{
+      this.date = date;
    }-*/;
    
    public final native void addResourceFile(String file) /*-{
@@ -133,14 +132,13 @@ public class RmdFrontMatter extends JavaScriptObject
      }
    }-*/;
    
-   public final void applyCreateOptions(String author, String title, 
+   public final void applyCreateOptions(String author, String title, String date, 
                                         String format, boolean isShiny)
    {
       setTitle(title);
       if (author.length() > 0)
       {
          setAuthor(author);
-         addDate();
       }
       if (isShiny)
       {
@@ -149,6 +147,9 @@ public class RmdFrontMatter extends JavaScriptObject
       if (format != null)
       {
          setOutputOption(format, RmdFrontMatterOutputOptions.create());
+      }
+      if (date.length() > 0) {
+         setDate(date);
       }
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1682,6 +1682,19 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to use current date when rendering document
+    */
+   public PrefValue<Boolean> rmdAutoDate()
+   {
+      return bool(
+         "rmd_auto_date", 
+         _constants.rmdAutoDateTitle(),
+         _constants.rmdAutoDateDescription(), 
+         false
+      );
+   }
+
+   /**
     * The path to the preferred R Markdown template.
     */
    public PrefValue<String> rmdPreferredTemplatePath()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -999,6 +999,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String rmdViewerTypeDescription();
 
    /**
+    * Whether to use current date when rendering document.
+    */
+   @DefaultStringValue("Use current date when rendering document")
+   String rmdAutoDateTitle();
+   @DefaultStringValue("Use current date when rendering document.")
+   String rmdAutoDateDescription();
+
+   /**
     * Whether to show verbose diagnostic information when publishing content.
     */
    @DefaultStringValue("Show diagnostic info when publishing")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetRMarkdownHelper.java
@@ -1172,7 +1172,7 @@ public class TextEditingTargetRMarkdownHelper
                server_,
                context,
                workbenchContext_,
-               prefs_.documentAuthor().getGlobalValue(),
+               prefs_,
                onComplete).showModal();
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -190,7 +190,8 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       checkboxAutoDate_.setText(prefs.rmdAutoDate().getDescription());
       
       boolean auto = prefs.rmdAutoDate().getGlobalValue();
-      setTextDate(auto);
+      txtDate_.setText(getISODate());
+      txtDate_.setEnabled(!auto);
 
       checkboxAutoDate_.setValue(auto);
       checkboxAutoDate_.addValueChangeHandler(new ValueChangeHandler<Boolean>() {
@@ -199,7 +200,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
          public void onValueChange(ValueChangeEvent<Boolean> event) {
             Boolean auto = event.getValue();
             prefs.rmdAutoDate().setGlobalValue(auto);
-            setTextDate(auto);
+            txtDate_.setEnabled(!auto);
          }
       });
       
@@ -323,7 +324,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
             new RmdNewDocument(getSelectedTemplate(), 
                                txtAuthor_.getText().trim(), 
                                txtTitle_.getText().trim(), 
-                               txtDate_.getText().trim(),
+                               checkboxAutoDate_.getValue() ? "`r Sys.Date()`" : txtDate_.getText().trim(),
                                formatName,
                                isShiny),
             templateChooser_.getChosenTemplate(),
@@ -430,11 +431,6 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       }
    }
    
-   private void setTextDate(boolean auto) {
-      txtDate_.setEnabled(!auto);
-      txtDate_.setText(auto ? "`r Sys.Date()`" : getISODate());
-   }
-
    private native String getISODate() /*-{
       return new Date().toISOString().substring(0, 10);
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.java
@@ -65,15 +65,16 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
    private static final ViewsSourceConstants constants_ = GWT.create(ViewsSourceConstants.class);
    public static class RmdNewDocument
    {  
-      public RmdNewDocument(String template, String author, String title, 
+      public RmdNewDocument(String template, String author, String title, String date, 
                             String format, boolean isShiny)
       {
          template_ = template;
          title_ = title;
          author_ = author;
+         date_ = date;
          isShiny_ = isShiny;
          format_ = format;
-         result_ = toJSO(author, title, format, isShiny);
+         result_ = toJSO(author, title, date, format, isShiny);
       }
       
       public String getTemplate()
@@ -89,6 +90,11 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       public String getTitle()
       {
          return title_;
+      }
+
+      public String getDate()
+      {
+         return date_;
       }
       
       public boolean isShiny()
@@ -108,17 +114,19 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       
       private final JavaScriptObject toJSO(String author, 
                                            String title, 
+                                           String date,
                                            String format, 
                                            boolean isShiny)
       {
          RmdFrontMatter result = RmdFrontMatter.create();
-         result.applyCreateOptions(author, title, format, isShiny);
+         result.applyCreateOptions(author, title, date, format, isShiny);
          return result;
       }
 
       private final String template_;
       private final String author_;
       private final String title_;
+      private final String date_;
       private final boolean isShiny_;
       private final String format_;
       private final JavaScriptObject result_;
@@ -176,6 +184,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
       resources.styles().ensureInjected();
       txtAuthor_.setText(author);
       txtTitle_.setText(constants_.untitledCapitalized());
+      txtDate_.setText("`r Sys.Date()`");
       Roles.getListboxRole().setAriaLabelProperty(listTemplates_.getElement(), constants_.templatesCapitalized());
       listTemplates_.addChangeHandler(new ChangeHandler()
       {
@@ -296,6 +305,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
             new RmdNewDocument(getSelectedTemplate(), 
                                txtAuthor_.getText().trim(), 
                                txtTitle_.getText().trim(), 
+                               txtDate_.getText().trim(),
                                formatName,
                                isShiny),
             templateChooser_.getChosenTemplate(),
@@ -434,6 +444,7 @@ public class NewRMarkdownDialog extends ModalDialog<NewRMarkdownDialog.Result>
    
    @UiField TextBox txtAuthor_;
    @UiField TextBox txtTitle_;
+   @UiField TextBox txtDate_;
    @UiField WidgetListBox<TemplateMenuItem> listTemplates_;
    @UiField NewDocumentResources resources;
    @UiField HTMLPanel templateFormatPanel_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -44,10 +44,11 @@
                 </rw:customCell>
                 <rw:customCell>
                    <rw:FormTextBox elementId="{ElementIds.getNewRmdAuthor}" styleName="{resources.styles.textBox}" 
-                                   ui:field="txtDate_"/>
+                                   ui:field="txtDate_"/>   
                 </rw:customCell>
               </rw:row>
            </rw:LayoutGrid>
+           <rw:FormCheckBox elementId="{ElementIds.getNewRmdAutoDate}" ui:field="checkboxAutoDate_" />
            <rw:FieldSetPanel legend="Default Output Format:" styleName="{resources.styles.defaultOutputLabel}">
               <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>
                <ui:attribute name="legend" key="defaultOutputFormat"/>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ui/NewRMarkdownDialog.ui.xml
@@ -38,6 +38,15 @@
                                    ui:field="txtAuthor_"/>
                 </rw:customCell>
               </rw:row>
+              <rw:row>
+                <rw:customCell>
+                   <rw:FormLabel for="{ElementIds.getNewRmdAuthor}" styleName="{resources.styles.topLabel}">Date:</rw:FormLabel>
+                </rw:customCell>
+                <rw:customCell>
+                   <rw:FormTextBox elementId="{ElementIds.getNewRmdAuthor}" styleName="{resources.styles.textBox}" 
+                                   ui:field="txtDate_"/>
+                </rw:customCell>
+              </rw:row>
            </rw:LayoutGrid>
            <rw:FieldSetPanel legend="Default Output Format:" styleName="{resources.styles.defaultOutputLabel}">
               <g:HTMLPanel ui:field="templateFormatPanel_"></g:HTMLPanel>


### PR DESCRIPTION
### Intent

addresses #10328 and follow up #10152

### Approach

Adding a Date field, with default to `` "`r  Sys.Date()`" ``

![image](https://user-images.githubusercontent.com/2625526/149337082-f5b4c1dc-06bc-457c-bab4-7fe0f6f5a355.png)


### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

- `File > New File > R Markdown` 
- Leave default
- ok 

The front matter will look like this

```
---
title: "Untitled"
author: "me"
date: "`r Sys.Date()`"
output: html_document
---
```

- save to file
- knit

the rendered file should have today's date.  

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


