### PR TITLE
SLES 12 Downgrade From OpenSSL 1.1 to 1.0.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,7 @@
 * Fixed logging directory permissions to be more restrictive (775 instead of 777) (#3099)
 * Fixed Duplicate --session-collab-server when launching R session (pro #3106)
 * Fixed errors when opening or saving Rmarkdown documents when R is busy (#9868)
+* Fixed issue with SLES 12 builds using OpenSSL 1.1 instead of 1.0.2
 
 ### Breaking
 

--- a/docker/jenkins/Dockerfile.opensuse-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse-x86_64
@@ -5,11 +5,22 @@ ENV OPERATING_SYSTEM=opensuse_leap153
 # needed to build RPMs
 RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Tumbleweed/systemsmanagement:wbem:deps.repo
 
+
 # refresh repos and install required packages
-RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
-    zypper --non-interactive install -y \
+
+RUN zypper --non-interactive --gpg-auto-import-keys refresh
+
+# Remove openssl-1_1, it conflicts with openssl-1_0_0 a dependency of libopenssl-1_0_0-devel
+# and we need libopenssl-1_0_0-devel to link against 1.0.2 ssl for sles 12 artifacts.
+# The package name is openssl-1_0_0 however its version is 1.0.2
+RUN zypper --non-interactive remove -y openssl-1_1
+RUN zypper --non-interactive install -y \
     ant \
     boost-devel \
+    # Uninstalling openssl unfortunately blew away the certificates
+    # Reinstall them here
+    ca-certificates \
+    ca-certificates-mozilla \
     curl \
     expect \
     fakeroot \
@@ -20,6 +31,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libacl-devel \
     libattr-devel \
     libcap-devel \
+    # For openssl 1.0.2 
+    libopenssl-1_0_0-devel \
     libuser-devel \
     libuuid-devel \
     libxml2-devel \
@@ -27,7 +40,8 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libXrandr-devel \
     lsof \
     make \
-    openssl-devel \
+    # For openssl 1.0.2
+    openssl-1_0_0 \
     pam-devel \
     pango-devel \
     postgresql-devel \


### PR DESCRIPTION
### Intent

Our SLES 12 artifacts have been compiling against openssl 1.1 breaking compatibility for SLES 12 users.

### Approach

Our docker build containers use LEAP 15 to build our SLES 12 artifacts, which accidentally introduced the openssl 1.0.2 -> 1.1 upgrade. I rolled back from 1.1, to 1.0.2 manually, and fixed some dependencies that got removed during the transition.

### Automated Tests

This is a build only change, requiring no tests. The build/artifact with test this.

### QA Notes

SLES 12 builds should now run.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


