### PR TITLE
Export PDF option fixes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Fixed
 - Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE (#9436)
+- Fixed plot export to PDF options (#9185)
 
 ### Breaking
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -342,12 +342,14 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
                PaperSize paperSize = paperSizeEditor_.selectedPaperSize();
                double width = paperSize.getWidth();
                double height = paperSize.getHeight();
-               if (!isPortraitOrientation())
-               {
-                  width = paperSize.getHeight();
-                  height = paperSize.getWidth();
-               }
-               
+
+               // This is more intuitive for the user to get an aspect ratio based on
+               // portrait/landscape selection regardless of the paper size's aspect ratio
+               width = isPortraitOrientation() ? Math.min(paperSize.getHeight(), paperSize.getWidth())
+                  : Math.max(paperSize.getHeight(), paperSize.getWidth());
+               height = isPortraitOrientation() ? Math.max(paperSize.getHeight(), paperSize.getWidth())
+                  : Math.min(paperSize.getHeight(), paperSize.getWidth());
+
                server_.savePlotAsPdf(targetPath, 
                                      width,
                                      height,
@@ -500,6 +502,7 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
             {
                setCustomPaperSize(width, height);
                sizeIndex = paperSizes_.size() - 1;
+               paperSizeListBox_.setItemText(sizeIndex, constants_.customLabel());
             }
             
             // select 


### PR DESCRIPTION
### Intent
Fixes #9185
Fix orientation to match portrait or landscape selection
Fix setting paper size name to custom when setting a custom size

It's confusing for a user to set a size where the dimensions create a landscape aspect ratio and the landscape option is set. It is assumed that the custom dimensions have a width less than the height (portrait). So setting custom dimensions where width is greater than height (landscape), results in a portrait output when landscape is selected.

This change is more intuitive for the user since it will export the plot according to the set orientation and use the dimensions as the paper size.

Also, the paper size name when setting a custom size has been fixed. It never updated the UI to `(Custom)` despite the model updating the available paper sizes.

### Approach
If portrait is selected, set the width to the smaller value and height to the greater value.
If landscape is selected, set the width to the greater value and the height to the smaller value.

The paper size is respected and it takes the guesswork out of setting the plot's orientation.

When setting a custom paper size, the UI is updated with the `(Custom)` label.

### Automated Tests
None

### QA Notes
Any of the paper sizes custom or not should always orient the plot as is selected with the orientation option. There should be no change in behaviour for the suggested paper sizes. For the `(Device size)`, this is based on the size of the Plots pane and will orient the plot to match the selected option. `(Custom)` will replace `(Device size)` when the dimension values are edited.

Also, equal values for the dimensions (square) should render the same for portrait and landscape options.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


