### PR TITLE
Change regex flags and add unit tests for word boundaries

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,7 +12,7 @@
 - Fixed plot export to PDF options (#9185)
 - `.rs.formatDataColumnDispatch()` iterates through classes of `x` (#10073)
 - Fixed Find in Files whole-word replace option, so that when "Whole word" is checked, only file matches containing the whole word are replaced, as displayed in the preview (#9813)
-- Adds support for POSIX extended regular expressions with backreferences in Find in Files find and replace modes, so that quantifiers such as `+` and `?` do not need to be escaped, and other ERE escape sequences such as `\b`, `\w`, and `\d` are now supported (#9344)
+- Adds support for POSIX extended regular expressions with backreferences in Find in Files find and replace modes, so that special regex characters such as `+` and `?`, `|`, `(`, etc do not need to be escaped, and other ERE escape sequences such as `\b`, `\w`, and `\d` are now supported (#9344)
 
 ### Breaking
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@
 - Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE (#9436)
 - Fixed plot export to PDF options (#9185)
 - `.rs.formatDataColumnDispatch()` iterates through classes of `x` (#10073)
+- Fixed Find in Files whole-word replace option, so that when "Whole word" is checked, only file matches containing the whole word are replaced, as displayed in the preview (#9813)
+- Adds support for POSIX extended regular expressions with backreferences in Find in Files find and replace modes, so that quantifiers such as `+` and `?` do not need to be escaped, and other ERE escape sequences such as `\b`, `\w`, and `\d` are now supported (#9344)
 
 ### Breaking
 

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1753,7 +1753,8 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::grep | boost::regex::icase);
+      // emacs flavor regex includes POSIX BRE
+      boost::regex find(findRegex, boost::regex::emacs | boost::regex::icase);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;
@@ -1778,7 +1779,7 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::grep);
+      boost::regex find(findRegex, boost::regex::emacs);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1404,7 +1404,8 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-c" << "grep.fullName=false";
       cmd << "-C";
       cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
-      cmd <<  "grep";
+      cmd << "grep";
+      cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...
       cmd << "--exclude-standard"; // but exclude gitignore
@@ -1753,8 +1754,9 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      // emacs flavor regex includes POSIX BRE
-      boost::regex find(findRegex, boost::regex::emacs | boost::regex::icase);
+
+      // egrep (grep -E) flavor regex includes POSIX ERE
+      boost::regex find(findRegex, boost::regex::egrep | boost::regex::icase);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;
@@ -1779,7 +1781,7 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::emacs);
+      boost::regex find(findRegex, boost::regex::egrep);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1757,7 +1757,9 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
    {
 
       // egrep (grep -E) flavor regex includes POSIX ERE
-      boost::regex find(findRegex, boost::regex::egrep | boost::regex::icase);
+      boost::regex_constants::syntax_option_type flags = boost::regex::egrep & boost::regex::bk_vbar;
+      flags = flags | boost::regex::icase;
+      boost::regex find(findRegex, flags);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;
@@ -1782,7 +1784,8 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::egrep);
+      boost::regex_constants::syntax_option_type flags = boost::regex::egrep & boost::regex::bk_vbar;
+      boost::regex find(findRegex, flags);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1432,6 +1432,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    }
    else
    {
+      cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       cmd << "--binary-files=without-match";
       cmd << "-rHn";
       cmd << "--color=always";

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1405,7 +1405,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-C";
       cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
       cmd << "grep";
-      cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...
       cmd << "--exclude-standard"; // but exclude gitignore
@@ -1417,7 +1416,9 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       // escaping double quotes, etc.
       cmd << "-f";
       cmd << tempFile;
-      if (!grepOptions.asRegex())
+      if (grepOptions.asRegex())
+         cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
+      else
          cmd << "-F";
       addDirectoriesToCommand(
          grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPath, &cmd);
@@ -1432,7 +1433,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    }
    else
    {
-      cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       cmd << "--binary-files=without-match";
       cmd << "-rHn";
       cmd << "--color=always";
@@ -1445,7 +1445,9 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       // escaping double quotes, etc.
       cmd << "-f";
       cmd << tempFile;
-      if (!grepOptions.asRegex())
+      if (grepOptions.asRegex())
+         cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
+      else
          cmd << "-F";
       for (std::string arg : grepOptions.includeArgs())
          cmd << arg;

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -47,6 +47,11 @@ const std::string kReplaceRegex("\\1\\2\\1\\2");
 
 const std::string kGrepPattern("aba \033[01m\033[KOOOkkk\033[m\033[K okab AAOO awesome aa abab");
 const std::string kGitGrepPattern("aba \033[1;31mOOOkkk\033[m okab AAOO awesome aa abab");
+
+const std::string kWordBoundaryRegex("\\bgreat\\b");
+const size_t wMatchOn = 15;
+const size_t wMatchOff = 20;
+const std::string kLineNoMatch("RStudio is the greatest");
 } // anonymous namespace
 
 TEST_CASE("SessionFind")
@@ -104,6 +109,30 @@ TEST_CASE("SessionFind")
          &replaceMatchOff);
       CHECK(line.compare("aba OOOkkk okab AAOO abab aa abab") == 0);
       CHECK(replaceMatchOff == 25);
+   }
+
+   SECTION("Replace regex word boundaries")
+   {
+      std::string line(kLine);
+      size_t replaceMatchOff;
+
+      Replacer replacer(true);
+      replacer.replaceRegex(matchOn, matchOff, kWordBoundaryRegex, kReplaceString,
+                            &line, &replaceMatchOff);
+      CHECK(line.compare("RStudio is awesome") == 0);
+      CHECK(replaceMatchOff == 18);
+   }
+
+   SECTION("Replace regex word boundaries - no match")
+   {
+      std::string line(kLineNoMatch);
+      size_t replaceMatchOff;
+
+      Replacer replacer(true);
+      replacer.replaceRegex(wMatchOn, wMatchOff, kWordBoundaryRegex, kReplaceString,
+                            &line, &replaceMatchOff);
+      CHECK(line.compare("RStudio is the greatest") == 0);
+      CHECK(replaceMatchOff == wMatchOff);
    }
 
    SECTION("Replace ASCII encoding")

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -42,7 +42,7 @@ const size_t rMatchOff = 10;
 const size_t caseMatchOn = 21;
 const size_t caseMatchOff = 27;
 
-const std::string kFindRegex("\\([a-z]\\)\\1\\{2\\}\\([a-z]\\)\\2\\{2\\}");
+const std::string kFindRegex("([a-z])\\1{2}([a-z])\\2{2}");
 const std::string kReplaceRegex("\\1\\2\\1\\2");
 
 const std::string kGrepPattern("aba \033[01m\033[KOOOkkk\033[m\033[K okab AAOO awesome aa abab");

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -278,7 +278,7 @@ TEST_CASE("SessionFind")
    SECTION("Replace regex with quantifiers")
    {
       std::string line("helllooo");
-      const std::string regex("l+o+");
+      const std::string regex("l+o+X?");
       const std::string replacement("LO!");
       Replacer replacer(false);
       const size_t matchOn = 2;
@@ -303,6 +303,36 @@ TEST_CASE("SessionFind")
       replacer.replaceRegex(matchOn, matchOff, regex, replacement, &line, &replaceMatchOff);
       CHECK(line.compare("good and more!") == 0);
       CHECK(replaceMatchOff == 3);
+   }
+
+   SECTION("Replace regex with bounded repeat and alternation")
+   {
+      std::string line("11 cats");
+      const std::string regex("\\d{2} (cat|dog)");
+      const std::string replacement("x");
+      Replacer replacer(false);
+      const size_t matchOn = 0;
+      const size_t matchOff = 5;
+      size_t replaceMatchOff;
+
+      replacer.replaceRegex(matchOn, matchOff, regex, replacement, &line, &replaceMatchOff);
+      CHECK(line.compare("xs") == 0);
+      CHECK(replaceMatchOff == 0);
+   }
+
+   SECTION("Replace regex with square brackets and literal special characters")
+   {
+      std::string line("How are you? Mr. (x)");
+      const std::string regex("\\? [A-Z][a-z]{0,2}\\. \\(\\w\\)");
+      const std::string replacement("\\?!");
+      Replacer replacer(false);
+      const size_t matchOn = 11;
+      const size_t matchOff = 19;
+      size_t replaceMatchOff;
+
+      replacer.replaceRegex(matchOn, matchOff, regex, replacement, &line, &replaceMatchOff);
+      CHECK(line.compare("How are you?!") == 0);
+      CHECK(replaceMatchOff == 12);
    }
 
 }

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -275,6 +275,36 @@ TEST_CASE("SessionFind")
       CHECK(match[2].str().compare("1") == 0);
    }
 
+   SECTION("Replace regex with quantifiers")
+   {
+      std::string line("helllooo");
+      const std::string regex("l+o+");
+      const std::string replacement("LO!");
+      Replacer replacer(false);
+      const size_t matchOn = 2;
+      const size_t matchOff = 7;
+      size_t replaceMatchOff;
+
+      replacer.replaceRegex(matchOn, matchOff, regex, replacement, &line, &replaceMatchOff);
+      CHECK(line.compare("heLO!") == 0);
+      CHECK(replaceMatchOff == 4);
+   }
+
+   SECTION("Replace regex with quantifiers")
+   {
+      std::string line("good, !@$ good and more!");
+      const std::string regex("^(\\w+)(\\W+)\\1");
+      const std::string replacement("\\1");
+      Replacer replacer(false);
+      const size_t matchOn = 0;
+      const size_t matchOff = 13;
+      size_t replaceMatchOff;
+
+      replacer.replaceRegex(matchOn, matchOff, regex, replacement, &line, &replaceMatchOff);
+      CHECK(line.compare("good and more!") == 0);
+      CHECK(replaceMatchOff == 3);
+   }
+
 }
 
 } // end namespace tests

--- a/src/cpp/session/modules/SessionFindTests.cpp
+++ b/src/cpp/session/modules/SessionFindTests.cpp
@@ -290,7 +290,7 @@ TEST_CASE("SessionFind")
       CHECK(replaceMatchOff == 4);
    }
 
-   SECTION("Replace regex with quantifiers")
+   SECTION("Replace regex with quantifiers, word character, and backreferences")
    {
       std::string line("good, !@$ good and more!");
       const std::string regex("^(\\w+)(\\W+)\\1");

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -302,8 +302,12 @@ public class FindOutputPresenter extends BasePresenter
                         for (String pattern : dialogState_.getExcludeFilePatterns())
                            excludeFilePatterns.push(pattern);
 
-                        server_.completeReplace(dialogState_.getQuery(),
-                                                dialogState_.isRegex(),
+                        String serverQuery = dialogState_.getQuery();
+                        if (dialogState_.isWholeWord())
+                           serverQuery = "\\b" + serverQuery + "\\b";
+
+                        server_.completeReplace(serverQuery,
+                                                dialogState_.isRegex() || dialogState_.isWholeWord(),
                                                 !dialogState_.isCaseSensitive(),
                                                 searchPath,
                                                 includeFilePatterns,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -222,6 +222,8 @@ public class FindOutputPresenter extends BasePresenter
             for (String pattern : dialogState_.getExcludeFilePatterns())
                excludeFilePatterns.push(pattern);
 
+            // this event is only ever triggered when dialogState_.isRegex() is true
+            // so we don't need to check for and handle dialogState_.isWholeWord() here
             server_.previewReplace(dialogState_.getQuery(),
                                    dialogState_.isRegex(),
                                    !dialogState_.isCaseSensitive(),


### PR DESCRIPTION
### Intent

Addresses both #9344 and #9813. 

### Approach

Apparently, `grep` flavor regexes within the `boost::regex_replace` function don't process `\b` as word boundaries, even though grep on the command line, which we use to find the matches in the first place, works just fine. [This page](https://www.boost.org/doc/libs/1_76_0/libs/regex/doc/html/boost_regex/syntax/basic_syntax.html) indicates that the `egrep` flavor which supports POSIX ERE, and is equivalent to `grep -E` in the command line, resolves the original issue.

By adding support for ERE, we have now changed which characters do and do not need to be escaped. In general, only escape sequences such as `\b` need to be escaped.  Characters with special regex meaning

```
.[{}()\*+?|^$
```
will now be treated as literals if escaped with a backslash, and will retain their special regex meaning if unescaped.

- Quantifiers (such as `?` and `+`) were previously supported but were treated as literals if unescaped, and needed to be escaped with `\` to be treated as quantifiers. They will now be treated as quantifiers if unescaped, and will need to be escaped to be treated as literals.
- Parentheses and curly braces `()` and `{}` were previously supported but were treated as literals if unescaped, and needed to be escaped with to be treated as their special regex meaning (e.g. marked sub-expressions, bounded repeats). They will now be parsed with their regex meaning if unescaped, and will need to be escaped to be treated as literals.
- The same is true for other characters such as `|`, `^`, and `$` which previously needed to be escaped and were treated as literals if unescaped. They now do not need to be escaped and will be treated as literals only if escaped.
- Extended regex escape sequences, such as `\w`, `\W`, `\b`, `\B`, `\d`, `\D` that are part of the POSIX ERE standard, are now supported, during find, preview, and replace. See [this page](https://www.boost.org/doc/libs/1_71_0/libs/regex/doc/html/boost_regex/syntax/basic_extended.html#boost_regex.syntax.basic_extended.single_character_character_class) for more examples

See also [this](https://en.wikibooks.org/wiki/Regular_Expressions/POSIX-Extended_Regular_Expressions#Table_of_metacharacters) for a table of the differences in escaping between BRE and ERE.

### Automated Tests

Existing CPP unit tests in [SessionFindTests.cpp](https://github.com/rstudio/rstudio/blob/12bc87d051519f11c096024023cc8996616b138f/src/cpp/session/modules/SessionFindTests.cpp) all pass. I've also added two new test cases to specifically test the word boundary handling

### QA Notes

Should be QA'd on at least Windows and either Mac or Linux, since the find part of Find in Files is handled slightly differently on Windows. 

Should test that when "Whole Word" is checked under Find in Files, the find matches, preview replacements, and final replacements match whole word matches only and do not replace partial word matches (e.g. `map` replaces the `map` in `map this!` and `map(1:5)` but not `mapping`)

Should test that when Regular expression is checked, and special characters such as `.[{}()\*+?|^$` are escaped with a single backslash, they are matched literally.

Should test that when Regular expression is checked and and special characters such as `.[{}()\*+?|^$` are not escaped with a single backslash, they are treated as special regex characters (e.g. `+` means match the preceding item 1 or more times, `{n}` means match the preceding item exactly n times, etc, using the POSIX extended regular expression standard.

Should test that escape sequences such as `\b` (word boundary), `\w` (word-like character) `\d` (digit), `\s` (whitespace characters) and their inverses (e.g. `\B` `\W` `\D`) match expected characters.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


