### PR TITLE
Render ANSI codes in gutter text

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -14,9 +14,20 @@
  */
 package org.rstudio.studio.client.workbench.views.output.lint;
 
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.RetinaStyleInjector;
@@ -39,15 +50,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppComp
 import org.rstudio.studio.client.workbench.views.source.editors.text.cpp.CppCompletionRequest;
 import org.rstudio.studio.client.workbench.views.source.editors.text.yaml.YamlDocumentLinter;
 import org.rstudio.studio.client.workbench.views.source.model.CppDiagnostic;
-
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Timer;
-import com.google.inject.Inject;
 
 import java.util.List;
 
@@ -365,6 +367,17 @@ public class LintManager
       }
       else
          finalLint = lint;
+
+      for (int i = 0; i < finalLint.length(); i++) {
+         LintItem lintItem = finalLint.get(i);
+         DivElement element = Document.get().createDivElement();
+         VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(element);
+
+         vc.submit(lintItem.getText());
+         String renderedText = element.getInnerHTML();
+
+         lintItem.setText(renderedText);
+      }
 
       if (spellcheck && userPrefs_.realTimeSpellchecking().getValue())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -14,11 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.views.output.lint.model;
 
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
-
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 
 public class LintItem extends JavaScriptObject
 {
@@ -69,6 +68,10 @@ public class LintItem extends JavaScriptObject
    public final native String getText() /*-{
       return this["text"];
    }-*/;
+
+   public final native void setText(String text) /*-{
+      this["text"] = text;
+   }-*/;
    
    public final native String getType() /*-{
       return this["type"];
@@ -101,11 +104,11 @@ public class LintItem extends JavaScriptObject
          var type = items[key]["type"];
          if (type === "style" || type === "note")
             type = "info";
-            
+
          aceAnnotations.push({
             row: items[key]["start.row"],
             column: items[key]["start.column"],
-            text: items[key]["text"],
+            html: items[key]["text"],
             type: type
          });
       }


### PR DESCRIPTION
### Intent
Fixes #10062 
The changes for #9010 allows for ANSI codes to add in styling. This updates the gutter tooltip text to render the ASCII codes.
![image](https://user-images.githubusercontent.com/9591545/149575891-5a0703f2-b2af-4f7e-a1be-315e5367effd.png)

### Approach
Use the VirtualConsole to render the text for the lint item. This converts the code, as is done for the source code markers, to HTML for the Ace annotation.

### Automated Tests
None

### QA Notes
Specifying HTML in the source code marker is still escaped so no XSS is possible. The only HTML allowed is what the VirtualConsole renders.
```R
foo <- cli::bg_br_white(cli::col_red("I am red!<br/>"))
markers <- list(
  list(
    type = "error",
    file = "html.R",
    line = 2,
    column = 1,
    message = foo)
)
rstudioapi::sourceMarkers("custom markers", markers)
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


