### PR TITLE
Support for `rs.api.sendToConsole(echo = FALSE)` and `animate=`

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -459,7 +459,8 @@
 .rs.addApiFunction("sendToConsole", function(code,
                                              echo = TRUE,
                                              execute = TRUE,
-                                             focus = TRUE)
+                                             focus = TRUE, 
+                                             animate = FALSE)
 {
    if (!is.character(code))
       stop("'code' should be a character vector", call. = FALSE)
@@ -470,6 +471,7 @@
       echo = .rs.scalar(as.logical(echo)),
       execute = .rs.scalar(as.logical(execute)),
       focus = .rs.scalar(as.logical(focus)),
+      animate = .rs.scalar(as.logical(animate)),
       language = "R"
    )
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -30,6 +30,7 @@
 
 #define kConsoleInputCancel 1
 #define kConsoleInputEof    2
+#define kConsoleInputNoEcho 4
 
 #define EX_CONTINUE                         100
 #define EX_FORCE                            101
@@ -147,6 +148,11 @@ struct RConsoleInput
    bool isEof()
    {
       return (flags & kConsoleInputEof) != 0;
+   }
+
+   bool isNoEcho()
+   {
+      return (flags & kConsoleInputNoEcho) != 0;
    }
    
    // typically used for hand-constructed RPC requests

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -362,8 +362,7 @@ bool rConsoleRead(const std::string& prompt,
    if (!pConsoleInput->isCancel())
    {
       module_context::events().onBeforeExecute();
-      if (!pConsoleInput->isNoEcho())
-         module_context::events().onConsoleInput(pConsoleInput->text);
+      module_context::events().onConsoleInput(pConsoleInput->text);
    }
 
    // we are about to return input to r so set the flag indicating that state

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -362,7 +362,8 @@ bool rConsoleRead(const std::string& prompt,
    if (!pConsoleInput->isCancel())
    {
       module_context::events().onBeforeExecute();
-      module_context::events().onConsoleInput(pConsoleInput->text);
+      if (!pConsoleInput->isNoEcho())
+         module_context::events().onConsoleInput(pConsoleInput->text);
    }
 
    // we are about to return input to r so set the flag indicating that state
@@ -376,9 +377,12 @@ bool rConsoleRead(const std::string& prompt,
                pConsoleInput->text);
    }
 
-   ClientEvent promptEvent(client_events::kConsoleWritePrompt, prompt);
-   clientEventQueue().add(promptEvent);
-   enqueueConsoleInput(*pConsoleInput);
+   if (!pConsoleInput->isNoEcho()) 
+   {
+      ClientEvent promptEvent(client_events::kConsoleWritePrompt, prompt);
+      clientEventQueue().add(promptEvent);
+      enqueueConsoleInput(*pConsoleInput);
+   }
 
    // always return true (returning false causes the process to exit)
    return true;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleInputEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleInputEvent.java
@@ -19,8 +19,9 @@ import com.google.gwt.event.shared.GwtEvent;
 
 public class ConsoleInputEvent extends GwtEvent<ConsoleInputEvent.Handler>
 {
-   public static final int FLAG_CANCEL = 1;
-   public static final int FLAG_EOF    = 2;
+   public static final int FLAG_CANCEL  = 1;
+   public static final int FLAG_EOF     = 2;
+   public static final int FLAG_NO_ECHO = 4;
    
    public ConsoleInputEvent(String input,
                             String console,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
@@ -18,7 +18,6 @@ import com.google.gwt.event.shared.EventHandler;
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 
 @JavaScriptSerializable

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/SendToConsoleEvent.java
@@ -18,6 +18,7 @@ import com.google.gwt.event.shared.EventHandler;
 import org.rstudio.core.client.js.JavaScriptSerializable;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 
 @JavaScriptSerializable
@@ -41,6 +42,7 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
       public final native boolean shouldRaise()   /*-{ return !!this["raise"];   }-*/;
       public final native boolean shouldFocus()   /*-{ return !!this["focus"];   }-*/;
       public final native boolean shouldAnimate() /*-{ return !!this["animate"]; }-*/;
+      public final native boolean shouldEcho()    /*-{ return !!this["echo"]; }-*/;
    }
   
    public SendToConsoleEvent()
@@ -76,7 +78,8 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
             data.shouldExecute(),
             data.shouldRaise(),
             data.shouldFocus(),
-            data.shouldAnimate());
+            data.shouldAnimate(), 
+            data.shouldEcho());
    }
    
    public SendToConsoleEvent(String code, 
@@ -103,12 +106,24 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
                              boolean focus,
                              boolean animate)
    {
+      this(code, language, execute, raise, focus, animate, true);
+   }
+
+   public SendToConsoleEvent(String code,
+                             String language,
+                             boolean execute, 
+                             boolean raise,
+                             boolean focus,
+                             boolean animate, 
+                             boolean echo)
+   {
       code_ = code;
       language_ = language;
       execute_ = execute;
       raise_ = raise;
       focus_ = focus;
       animate_ = animate;
+      echo_ = echo;
    }
    
 
@@ -141,6 +156,11 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
    {
       return animate_;
    }
+
+   public boolean shouldEcho()
+   {
+      return echo_;
+   }
    
    @Override
    public int focusMode()
@@ -167,4 +187,5 @@ public class SendToConsoleEvent extends CrossWindowEvent<SendToConsoleEvent.Hand
    private boolean focus_;
    private boolean raise_;
    private boolean animate_;
+   private boolean echo_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -422,7 +422,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          eventBus_.fireEvent(new ConsoleInputEvent(commandText, ""));
       } else 
       {
-         eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", ConsoleInputEvent.FLAG_NO_ECHO);
+         eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", ConsoleInputEvent.FLAG_NO_ECHO));
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -417,13 +417,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
 
       // fire event
-      if (echo) 
-      {
-         eventBus_.fireEvent(new ConsoleInputEvent(commandText, ""));
-      } else 
-      {
-         eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", ConsoleInputEvent.FLAG_NO_ECHO));
-      }
+      eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", echo ? 0 : ConsoleInputEvent.FLAG_NO_ECHO));
    }
 
    public void onSendToConsole(final SendToConsoleEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -408,12 +408,22 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    private void processCommandEntry()
    {
-      String commandText = view_.processCommandEntry();
+      processCommandEntry(view_.processCommandEntry(), true);
+   }
+
+   private void processCommandEntry(String commandText, boolean echo)
+   {
       if (addToHistory_ && (commandText.length() > 0))
-         eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
+      eventBus_.fireEvent(new ConsoleHistoryAddedEvent(commandText));
 
       // fire event
-      eventBus_.fireEvent(new ConsoleInputEvent(commandText, ""));
+      if (echo) 
+      {
+         eventBus_.fireEvent(new ConsoleInputEvent(commandText, ""));
+      } else 
+      {
+         eventBus_.fireEvent(new ConsoleInputEvent(commandText, "", ConsoleInputEvent.FLAG_NO_ECHO);
+      }
    }
 
    public void onSendToConsole(final SendToConsoleEvent event)
@@ -463,7 +473,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          {
             if (event.shouldExecute())
             {
-               processCommandEntry();
+               processCommandEntry(event.getCode(), event.shouldEcho());
+
                if (previousInput.length() > 0)
                   display.setText(previousInput);
             }
@@ -480,7 +491,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       if (!event.shouldAnimate())
       {
          display.clear();
-         display.setText(event.getCode());
+         if (event.shouldEcho()) 
+            display.setText(event.getCode());
          finishSendToConsole.execute();
       }
       else


### PR DESCRIPTION
### Intent

addresses #8884 

### Approach

This uses the existing flag, with a new `kConsoleInputNoEcho` on the server side that cancels prompt and console input events. 

The flag is set on the client side when `echo` is set to FALSE. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


