### PR TITLE
Discard pending input on error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ### New
 - Source marker `message` can contain ANSI SGR codes for setting style and color (#9010)
+- Linux/MacOS: Executing a code selection that encounters an error will stop execution of remaining code (#3014)
 
 #### R
 - Added support for using the AGG renderer (as provided by the ragg package) as a graphics backend for inline plot execution; also added support for using the backend graphics device requested by the knitr `dev` chunk option (#9931)

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -188,6 +188,7 @@ struct RCallbacks
    boost::function<void(const std::string&, core::FilePath&, bool)> showFile;
    boost::function<void(const std::string&, int)> consoleWrite;
    boost::function<void()> consoleHistoryReset;
+   boost::function<void()> consoleReset;
    boost::function<bool(double*, double*)> locator;
    boost::function<core::FilePath(bool)> chooseFile;
    boost::function<int(const std::string&)> editFile;

--- a/src/cpp/r/session/REmbedded.hpp
+++ b/src/cpp/r/session/REmbedded.hpp
@@ -45,6 +45,7 @@ struct Callbacks
    void (*showMessage)(const char*);
    int (*readConsole)(const char *, CONSOLE_BUFFER_CHAR*, int, int);
    void (*writeConsoleEx)(const char *, int, int);
+   void (*resetConsole)();
    int (*editFile)(const char*);
    void (*busy)(int);
    int (*chooseFile)(int, char *, int);

--- a/src/cpp/r/session/REmbeddedPosix.cpp
+++ b/src/cpp/r/session/REmbeddedPosix.cpp
@@ -125,6 +125,7 @@ void runEmbeddedR(const core::FilePath& /*rHome*/,    // ignored on posix
    ptr_R_ReadConsole = callbacks.readConsole;
    ptr_R_WriteConsole = nullptr; // must set this to NULL for Ex to be called
    ptr_R_WriteConsoleEx = callbacks.writeConsoleEx;
+   ptr_R_ResetConsole = callbacks.resetConsole;
    ptr_R_EditFile = callbacks.editFile;
    ptr_R_Busy = callbacks.busy;
 

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -401,6 +401,7 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
       cb.readConsole = RReadConsole;
       cb.writeConsoleEx = RWriteConsoleEx;
       cb.cleanUp = RCleanUp;
+      cb.resetConsole = RResetConsole;
    }
    else
    {

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -469,6 +469,11 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
    CATCH_UNEXPECTED_EXCEPTION
 }
 
+void RResetConsole()
+{
+   s_callbacks.consoleReset();
+}
+
 // NOTE: Win32 doesn't receive this callback
 int REditFile(const char* file)
 {

--- a/src/cpp/r/session/RStdCallbacks.hpp
+++ b/src/cpp/r/session/RStdCallbacks.hpp
@@ -32,6 +32,7 @@ InternalCallbacks* stdInternalCallbacks();
 int RReadConsole(const char *pmt, CONSOLE_BUFFER_CHAR* buf, int buflen, int hist);
 void RShowMessage(const char* msg);
 void RWriteConsoleEx (const char *buf, int buflen, int otype);
+void RResetConsole();
 int REditFile(const char* file);
 void RBusy(int which);
 int RChooseFile (int newFile, char *buf, int len);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -954,6 +954,11 @@ void rConsoleHistoryReset()
    rsession::clientEventQueue().add(event);
 }
 
+void rConsoleReset()
+{
+   rsession::console_input::clearConsoleInputBuffer();
+}
+
 bool rLocator(double* x, double* y)
 {
    // since locator can be called in a loop we need to checkForChanges
@@ -2302,6 +2307,7 @@ int main(int argc, char * const argv[])
       rCallbacks.busy = rBusy;
       rCallbacks.consoleWrite = rConsoleWrite;
       rCallbacks.consoleHistoryReset = rConsoleHistoryReset;
+      rCallbacks.consoleReset = rConsoleReset;
       rCallbacks.locator = rLocator;
       rCallbacks.deferredInit = rDeferredInit;
       rCallbacks.suspended = rSuspended;


### PR DESCRIPTION
### Intent
Addresses #3014
Stops further execution of selected code when encountering an error. The last output in the console will be the last statement executed so that it is easier to see what occurred during execution.

### Approach
Add callback for console reset to clear console input. This appears to be called when an error occurs. Any pending input can be cleared. The callback is only set when executing a code selection. It is not used when submitting the entire script for execution.

### Automated Tests
None

### QA Notes
This only addresses Linux/MacOS. R does not have a console reset callback for Windows.

The code selection sends each line of code as a separate console input. If executing one of the lines produces an error, subsequent lines should not execute. Below, the call to `stop` should be the end when executing these lines. The call to `install.packages` stylizes output like an error but should not halt execution.

```R
print("65")
install.packages("rmarkdown")
stop("something went wrong")
print("3")
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


