### PR TITLE
OS companion commit to fix defaults for callbacksRequireMainThread for rsession

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -442,6 +442,10 @@ private:
    boost::recursive_mutex mutex_;
 };
 
+bool enableCallbacksRequireMainThread();
+
+void setEnableCallbacksRequireMainThread(bool enforce);
+
 } // namespace system
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -1017,8 +1017,11 @@ void AsyncChildProcess::poll()
 {
    // skip polling if we're not on the main thread,
    // and the process options request we run on the main thread only
-   if (options().callbacksRequireMainThread && !core::thread::isMainThread())
+   if (enableCallbacksRequireMainThread() && options().callbacksRequireMainThread && !core::thread::isMainThread())
+   {
+      LOG_DEBUG_MESSAGE("Skipping poll events for child process - not on main thread");
       return;
+   }
    
    // call onStarted if we haven't yet
    if (!(pAsyncImpl_->calledOnStarted_))

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -36,6 +36,8 @@ namespace rstudio {
 namespace core {
 namespace system {
 
+bool s_enableCallbacksRequireMainThread = false;
+
 const char* const kSmartTerm = "xterm-256color";
 const char* const kDumbTerm = "dumb";
 
@@ -400,6 +402,16 @@ bool ProcessSupervisor::wait(
    }
 
    return true;
+}
+
+void setEnableCallbacksRequireMainThread(bool enabled)
+{
+   s_enableCallbacksRequireMainThread = enabled;
+}
+
+bool enableCallbacksRequireMainThread()
+{
+   return s_enableCallbacksRequireMainThread;
 }
 
 } // namespace system

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -684,7 +684,7 @@ void AsyncChildProcess::poll()
 {
    // skip polling if we're not on the main thread,
    // and the process options request we run on the main thread only
-   if (options().callbacksRequireMainThread && !core::thread::isMainThread())
+   if (enableCallbacksRequireMainThread() && options().callbacksRequireMainThread && !core::thread::isMainThread())
       return;
    
    // call onStarted if we haven't yet

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1820,6 +1820,7 @@ int main(int argc, char * const argv[])
       
       // initialize thread id
       core::thread::initializeMainThreadId(boost::this_thread::get_id());
+      core::system::setEnableCallbacksRequireMainThread(true);
 
       // terminate immediately with given exit code (for testing/debugging)
       std::string exitOnStartup = core::system::getenv("RSTUDIO_SESSION_EXIT_ON_STARTUP");


### PR DESCRIPTION
companion to: https://github.com/rstudio/rstudio-pro/pull/3207

This one should have gone into OS first since almost all of the files touched are here. It was reviewed by Kevin in rstudio-pro. 