### PR TITLE
Use `reticulate::py_len()` instead of `builtins$len()`

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -121,8 +121,12 @@
       .rs.reticulate.usePython(python)
       
       if (packageVersion("reticulate") >= "1.23")
-         .rs.addFunction("reticulate.describeObjectLength",
-                         function(object) reticulate::py_len(object, -1L))
+      {
+         .rs.addFunction("reticulate.describeObjectLength", function(object)
+         {
+            reticulate::py_len(object, -1L)
+         })
+      }
    })
    
 })

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1658,7 +1658,7 @@ def _rstudio_html_generator_():
 {
    tryCatch(
       .rs.reticulate.describeObjectContentsImpl(object),
-      error = function(e) warning
+      error = warning
    )
 })
 

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -119,6 +119,10 @@
    {
       python <- .rs.readUiPref("python_path")
       .rs.reticulate.usePython(python)
+      
+      if (packageVersion("reticulate") >= "1.23")
+         .rs.addFunction("reticulate.describeObjectLength",
+                         function(object) reticulate::py_len(object, -1L))
    })
    
 })
@@ -1647,6 +1651,8 @@ def _rstudio_html_generator_():
 
 .rs.addFunction("reticulate.describeObjectLength", function(object)
 {
+   # this function is overwritten in .rs.registerPackageLoadHook if 
+   # reticulate version >= 1.23
    builtins <- reticulate::import_builtins(convert = TRUE)
    tryCatch(
       builtins$len(object),


### PR DESCRIPTION
### Intent

Currently, the IDE calls Python's builtin `len()` on defined Python objects, and wraps the call in an R `tryCatch()` in case the object doesn't define a `__len__` method. While the exception is handled on the R side, it is unfortunately allowed to persist in the Python session, resulting in a less-than-useful value for `reticulate::py_last_error()` in interactive sessions.

Related: https://github.com/rstudio/reticulate/issues/1134, cc @kevinushey 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

A recent patch to reticulate introduced the R function `py_len()`, which can optionally restore the state of the Python session exception global variables.

### Automated Tests

`py_len()` is tested in reticulate.

### QA Notes


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


