### PR TITLE
Bump R to 3.6.3

### DIFF
--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 ENV OPERATING_SYSTEM=debian_9
 
-# update apt repository to cloudfront's mirror and add cran 3.4 to apt sources
+# update apt repository to cloudfront's mirror and add cran35 to apt sources
 RUN set -x \
     && sed -i "s/deb.debian.org/cloudfront.debian.net/" /etc/apt/sources.list \
     && sed -i "s/security.debian.org/cloudfront.debian.net/" /etc/apt/sources.list \

--- a/docker/jenkins/Dockerfile.debian9-x86_64
+++ b/docker/jenkins/Dockerfile.debian9-x86_64
@@ -2,10 +2,16 @@ FROM debian:stretch
 
 ENV OPERATING_SYSTEM=debian_9
 
-# update apt repository to cloudfront's mirror
+# update apt repository to cloudfront's mirror and add cran 3.4 to apt sources
 RUN set -x \
     && sed -i "s/deb.debian.org/cloudfront.debian.net/" /etc/apt/sources.list \
-    && sed -i "s/security.debian.org/cloudfront.debian.net/" /etc/apt/sources.list
+    && sed -i "s/security.debian.org/cloudfront.debian.net/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y gnupg1 \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys '95C0FAF38DB3CCAD0C080A7BDC78B2DDEABC47B7' \
+    && echo 'deb http://cran.rstudio.com/bin/linux/debian stretch-cran35/' >> /etc/apt/sources.list \
+    && apt-get update
 
 # update system
 RUN set -x \


### PR DESCRIPTION
### Intent

Get our tests passing on debian 9 again

### Approach

The version of R installed by default doesn't have test that any more. Bump the version of R to fix.

### Automated Tests

This is to fix them

### QA Notes

Build change only

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


