### PR TITLE
Data viewer: truncate large list cells

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -1518,7 +1518,7 @@ public:
    core::Error setDataViewerMaxColumns(int val);
 
    /**
-    * The maximum number of characters to show in a data viewer cell
+    * The maximum number of characters to show in a data viewer cell.
     */
    int dataViewerMaxCellSize();
    core::Error setDataViewerMaxCellSize(int val);

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -318,6 +318,7 @@ namespace prefs {
 #define kDefaultRVersionLabel "label"
 #define kDefaultRVersionModule "module"
 #define kDataViewerMaxColumns "data_viewer_max_columns"
+#define kDataViewerMaxCellSize "data_viewer_max_cell_size"
 #define kEnableScreenReader "enable_screen_reader"
 #define kTypingStatusDelayMs "typing_status_delay_ms"
 #define kReducedMotion "reduced_motion"
@@ -1515,6 +1516,12 @@ public:
     */
    int dataViewerMaxColumns();
    core::Error setDataViewerMaxColumns(int val);
+
+   /**
+    * The maximum number of characters to show in a data viewer cell
+    */
+   int dataViewerMaxCellSize();
+   core::Error setDataViewerMaxCellSize(int val);
 
    /**
     * Support accessibility aids such as screen readers (RStudio Server).

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -35,6 +35,8 @@
    # otherwise, delegate to internal methods
    if (is.numeric(col))
       .rs.formatDataColumnNumeric(col, ...)
+   else if (is.list(col))
+      .rs.formatDataColumnList(col, ...)
    else
       .rs.formatDataColumnDefault(col, ...)
 })
@@ -83,6 +85,15 @@
    
    # return formatted values
    vals
+})
+
+.rs.addFunction("formatDataColumnList", function(col, ...)
+{
+   classes <- sapply(col, function(x) {
+      class(x)[[1L]]
+   })
+   sizes <- sapply(col, length)
+   paste0("<", classes, " [", sizes, "]>" )
 })
 
 .rs.addFunction("formatDataColumnDefault", function(col, ...)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -89,11 +89,11 @@
 
 .rs.addFunction("formatDataColumnList", function(col, ...)
 {
-   classes <- sapply(col, function(x) {
-      class(x)[[1L]]
-   })
-   sizes <- sapply(col, length)
-   paste0("<", classes, " [", sizes, "]>" )
+   formatted <- as.character(col)
+   large <- nchar(formatted) > 50L
+   formatted <- substr(formatted, 1, 50L)
+   formatted <- paste0(formatted, ifelse(large, " (...)", ""))
+   formatted
 })
 
 .rs.addFunction("formatDataColumnDefault", function(col, ...)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -89,9 +89,14 @@
 
 .rs.addFunction("formatDataColumnList", function(col, ...)
 {
+   limit <- .rs.readUserPref("data_viewer_max_cell_size")
+   if (is.null(limit)) {
+      limit <- 50L
+   }
+
    formatted <- as.character(col)
-   large <- nchar(formatted) > 50L
-   formatted <- substr(formatted, 1, 50L)
+   large <- nchar(formatted) > limit
+   formatted <- substr(formatted, 1, limit)
    formatted <- paste0(formatted, ifelse(large, " [...]", ""))
    formatted
 })

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -92,7 +92,7 @@
    formatted <- as.character(col)
    large <- nchar(formatted) > 50L
    formatted <- substr(formatted, 1, 50L)
-   formatted <- paste0(formatted, ifelse(large, " (...)", ""))
+   formatted <- paste0(formatted, ifelse(large, " [...]", ""))
    formatted
 })
 

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -35,7 +35,7 @@
    # otherwise, delegate to internal methods
    if (is.numeric(col))
       .rs.formatDataColumnNumeric(col, ...)
-   else if (is.list(col))
+   else if (is.list(col) && !is.data.frame(col))
       .rs.formatDataColumnList(col, ...)
    else
       .rs.formatDataColumnDefault(col, ...)

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2429,7 +2429,7 @@ core::Error UserPrefValues::setDataViewerMaxColumns(int val)
 }
 
 /**
- * The maximum number of characters to show in a data viewer cell
+ * The maximum number of characters to show in a data viewer cell.
  */
 int UserPrefValues::dataViewerMaxCellSize()
 {

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2429,6 +2429,19 @@ core::Error UserPrefValues::setDataViewerMaxColumns(int val)
 }
 
 /**
+ * The maximum number of characters to show in a data viewer cell
+ */
+int UserPrefValues::dataViewerMaxCellSize()
+{
+   return readPref<int>("data_viewer_max_cell_size");
+}
+
+core::Error UserPrefValues::setDataViewerMaxCellSize(int val)
+{
+   return writePref("data_viewer_max_cell_size", val);
+}
+
+/**
  * Support accessibility aids such as screen readers (RStudio Server).
  */
 bool UserPrefValues::enableScreenReader()
@@ -3214,6 +3227,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kSubmitCrashReports,
       kDefaultRVersion,
       kDataViewerMaxColumns,
+      kDataViewerMaxCellSize,
       kEnableScreenReader,
       kTypingStatusDelayMs,
       kReducedMotion,

--- a/src/cpp/session/resources/grid/dtstyles.css
+++ b/src/cpp/session/resources/grid/dtstyles.css
@@ -151,6 +151,12 @@ table.dataTable {
     min-width: 35px;
 }
 
+.truncated {
+    color: #abacad;
+    font-size: smaller;
+    font-style: italic;
+}
+
 .filterPopup {
     position: absolute;
     overflow: hidden;
@@ -325,10 +331,6 @@ th:focus {
 
 .manualSize, .autoSize {
     table-layout: fixed;
-}
-
-#rsGridData.manualSize {
-    display: table;
 }
 
 .cell, .headerCell {

--- a/src/cpp/session/resources/grid/dtstyles.css
+++ b/src/cpp/session/resources/grid/dtstyles.css
@@ -151,12 +151,6 @@ table.dataTable {
     min-width: 35px;
 }
 
-.truncated {
-    color: #abacad;
-    font-size: smaller;
-    font-style: italic;
-}
-
 .filterPopup {
     position: absolute;
     overflow: hidden;

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -322,16 +322,10 @@
     // special additional rendering for cells which themselves contain data frames or lists:
     // these include an icon that can be clicked to view contents
     if (clazz === "dataCell" || clazz === "listCell") {
-      var truncated = escaped.endsWith("(...)");
-      if (clazz == "listCell" && truncated) {
-        escaped = escaped.replace(/[(][.][.][.][)]$/, "");
-      } 
-
       escaped =
         "<i>" +
         escaped +
         "</i> " +
-        (truncated ? "<span class='truncated'>(...)</span>" : "" ) + 
         '<a class="viewerLink" href="javascript:window.' +
         (clazz === "dataCell" ? "dataViewerCallback" : "listViewerCallback") +
         "(" +
@@ -1274,6 +1268,7 @@
       type: "POST",
     })
       .done(function (result) {
+        console.log(result);
         callback(result);
       })
       .fail(function (jqXHR) {

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -318,14 +318,22 @@
     }
 
     var escaped = escapeHtml(data);
-
+    
     // special additional rendering for cells which themselves contain data frames or lists:
     // these include an icon that can be clicked to view contents
     if (clazz === "dataCell" || clazz === "listCell") {
+      var truncated = escaped.endsWith("(...)");
+      if (clazz == "listCell" && truncated) {
+        escaped = escaped.replace(/[(][.][.][.][)]$/, "");
+      } 
+
+      console.log(meta);
+
       escaped =
         "<i>" +
         escaped +
         "</i> " +
+        (truncated ? "<span class='truncated'>(...)</span>" : "" ) + 
         '<a class="viewerLink" href="javascript:window.' +
         (clazz === "dataCell" ? "dataViewerCallback" : "listViewerCallback") +
         "(" +

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -327,8 +327,6 @@
         escaped = escaped.replace(/[(][.][.][.][)]$/, "");
       } 
 
-      console.log(meta);
-
       escaped =
         "<i>" +
         escaped +

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1268,7 +1268,6 @@
       type: "POST",
     })
       .done(function (result) {
-        console.log(result);
         callback(result);
       })
       .fail(function (jqXHR) {

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1260,6 +1260,12 @@
             "title": "Maximum number of columns in data viewer",
             "description": "The maximum number of columns to show at once in the data viewer."
         },
+        "data_viewer_max_cell_size": {
+            "type": "integer",
+            "default": 50,
+            "title": "Maximum number of character in data viewer cells", 
+            "description": "The maximum number of characters to show in a data viewer cell"
+        },
         "enable_screen_reader": {
             "type": "boolean",
             "default": false,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1264,7 +1264,7 @@
             "type": "integer",
             "default": 50,
             "title": "Maximum number of character in data viewer cells", 
-            "description": "The maximum number of characters to show in a data viewer cell"
+            "description": "The maximum number of characters to show in a data viewer cell."
         },
         "enable_screen_reader": {
             "type": "boolean",

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -39,7 +39,7 @@ test_that(".rs.formatDataColumn() truncates lists", {
     )
     x <- .rs.formatDataColumn(col, 1, 2)
     expect_equal(
-        grepl("[(][.]{3}[)]$", x), 
+        grepl("\\[\\.{3}\\]$", x), 
         c(TRUE, FALSE)
     )
 })

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -32,6 +32,18 @@ test_that(".rs.formatDataColumnDispatch() iterates over the classes", {
     expect_equal(.rs.formatDataColumn(x, 1, 1), "Hi there!")
 })
 
+test_that(".rs.formatDataColumn() truncates lists", {
+    col <- list(
+        paste0(rep("a", 100), collapse = ""), 
+        "small"
+    )
+    x <- .rs.formatDataColumn(col, 1, 2)
+    expect_equal(
+        grepl("[(][.]{3}[)]$", x), 
+        c(TRUE, FALSE)
+    )
+})
+
 test_that(".rs.flattenFrame() handles matrices and data frames", {
    tbl1 <- data.frame(x = 1:2)
    df_col <- data.frame(y = 1:2, z = 1:2)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2646,7 +2646,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * The maximum number of characters to show in a data viewer cell
+    * The maximum number of characters to show in a data viewer cell.
     */
    public PrefValue<Integer> dataViewerMaxCellSize()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2646,6 +2646,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * The maximum number of characters to show in a data viewer cell
+    */
+   public PrefValue<Integer> dataViewerMaxCellSize()
+   {
+      return integer(
+         "data_viewer_max_cell_size",
+         _constants.dataViewerMaxCellSizeTitle(), 
+         _constants.dataViewerMaxCellSizeDescription(), 
+         50);
+   }
+
+   /**
     * Support accessibility aids such as screen readers (RStudio Server).
     */
    public PrefValue<Boolean> enableScreenReader()
@@ -3678,6 +3690,8 @@ public class UserPrefsAccessor extends Prefs
          defaultRVersion().setValue(layer, source.getObject("default_r_version"));
       if (source.hasKey("data_viewer_max_columns"))
          dataViewerMaxColumns().setValue(layer, source.getInteger("data_viewer_max_columns"));
+      if (source.hasKey("data_viewer_max_cell_size"))
+         dataViewerMaxCellSize().setValue(layer, source.getInteger("data_viewer_max_cell_size"));
       if (source.hasKey("enable_screen_reader"))
          enableScreenReader().setValue(layer, source.getBool("enable_screen_reader"));
       if (source.hasKey("typing_status_delay_ms"))
@@ -3959,6 +3973,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(submitCrashReports());
       prefs.add(defaultRVersion());
       prefs.add(dataViewerMaxColumns());
+      prefs.add(dataViewerMaxCellSize());
       prefs.add(enableScreenReader());
       prefs.add(typingStatusDelayMs());
       prefs.add(reducedMotion());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1541,11 +1541,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String dataViewerMaxColumnsDescription();
 
    /**
-    * The maximum number of characters to show in a data viewer cell
+    * The maximum number of characters to show in a data viewer cell.
     */
    @DefaultStringValue("Maximum number of character in data viewer cells")
    String dataViewerMaxCellSizeTitle();
-   @DefaultStringValue("The maximum number of characters to show in a data viewer cell")
+   @DefaultStringValue("The maximum number of characters to show in a data viewer cell.")
    String dataViewerMaxCellSizeDescription();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1541,6 +1541,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String dataViewerMaxColumnsDescription();
 
    /**
+    * The maximum number of characters to show in a data viewer cell
+    */
+   @DefaultStringValue("Maximum number of character in data viewer cells")
+   String dataViewerMaxCellSizeTitle();
+   @DefaultStringValue("The maximum number of characters to show in a data viewer cell")
+   String dataViewerMaxCellSizeDescription();
+
+   /**
     * Support accessibility aids such as screen readers (RStudio Server).
     */
    @DefaultStringValue("Enable support for screen readers in RStudio Server")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -775,6 +775,10 @@ defaultRVersionDescription = The R version to use by default.
 dataViewerMaxColumnsTitle = Maximum number of columns in data viewer
 dataViewerMaxColumnsDescription = The maximum number of columns to show at once in the data viewer.
 
+# The maximum number of characters to show in a data viewer cell
+dataViewerMaxCellSizeTitle = Maximum number of character in data viewer cells
+dataViewerMaxCellSizeDescription = The maximum number of characters to show in a data viewer cell
+
 # Support accessibility aids such as screen readers (RStudio Server).
 enableScreenReaderTitle = Enable support for screen readers in RStudio Server
 enableScreenReaderDescription = Support accessibility aids such as screen readers (RStudio Server).

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -775,9 +775,9 @@ defaultRVersionDescription = The R version to use by default.
 dataViewerMaxColumnsTitle = Maximum number of columns in data viewer
 dataViewerMaxColumnsDescription = The maximum number of columns to show at once in the data viewer.
 
-# The maximum number of characters to show in a data viewer cell
+# The maximum number of characters to show in a data viewer cell.
 dataViewerMaxCellSizeTitle = Maximum number of character in data viewer cells
-dataViewerMaxCellSizeDescription = The maximum number of characters to show in a data viewer cell
+dataViewerMaxCellSizeDescription = The maximum number of characters to show in a data viewer cell.
 
 # Support accessibility aids such as screen readers (RStudio Server).
 enableScreenReaderTitle = Enable support for screen readers in RStudio Server

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -767,6 +767,10 @@ defaultRVersionDescription= La version de R à utiliser par défaut.
 dataViewerMaxColumnsTitle= Nombre maximal de colonnes dans le visualiseur de données
 dataViewerMaxColumnsDescription= Le nombre maximum de colonnes à afficher en même temps dans le visualisateur de données.
 
+# The maximum number of characters to show in a data viewer cell.
+dataViewerMaxCellSizeTitle = Nombre maximal de caractères dans les cellules du visualiseur de données
+dataViewerMaxCellSizeDescription = Le nombre maximal de caractères à afficher dans une cellule du visualiseur de données.
+
 # Support accessibility aids such as screen readers (RStudio Server).
 enableScreenReaderTitle= Activer la prise en charge des lecteurs d''écran dans RStudio Server
 enableScreenReaderDescription= Prise en charge des aides à l''accessibilité telles que les lecteurs d''écran (RStudio Server).


### PR DESCRIPTION
### Intent

addresses #5100, the example gives: 

![image](https://user-images.githubusercontent.com/2625526/151168123-2116c63e-fd10-4614-ace0-d9efef5d4a29.png)

### Approach

Calling `as.character()` on a list column can quickly make big character vectors that make the ui struggle. This truncates them, adding `(...)` at the end. The data viewer ui picks up the suffix and displays it discretely. 

cc @jgutman as this is related to other data viewer work. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


