### PR TITLE
Gnugreppath windows -- fix default path

### DIFF
--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -341,7 +341,7 @@ protected:
       value<std::string>(&gnudiffPath_)->default_value("bin/gnudiff"),
       "Specifies the path to gnudiff utilities (Windows-only).")
       ("external-gnugrep-path",
-      value<std::string>(&gnugrepPath_)->default_value("bin/gnugrep"),
+      value<std::string>(&gnugrepPath_)->default_value("bin/gnugrep/3.0"),
       "Specifies the path to gnugrep utilities (Windows-only).")
       ("external-msysssh-path",
       value<std::string>(&msysSshPath_)->default_value("bin/msys-ssh-1000-18"),

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -652,7 +652,7 @@
             "name": "external-gnugrep-path",
             "type": "core::FilePath",
             "memberName": "gnugrepPath_",
-            "defaultValue": "bin/gnugrep",
+            "defaultValue": "bin/gnugrep/3.0",
             "description": "Specifies the path to gnugrep utilities (Windows-only)."
          },
          {


### PR DESCRIPTION
### Intent
As a follow-up to #10380 (addressing #3572), we updated the installation path for grep (GNU grep 3.0) to `bin/grep/3.0`. Previously lived at `bin/grep`.  Forgot to update the default value of `gnugrepPath` in the previous PR, which is necessary for Find in Files functionality in Windows

