### PR TITLE
Fixed main thread issues with onDetectChanges event

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -35,6 +35,7 @@
 #include <core/Macros.hpp>
 #include <core/Log.hpp>
 #include <core/DateTime.hpp>
+#include <core/Thread.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RErrorCategory.hpp>
@@ -374,6 +375,9 @@ void listEnvironment(SEXP env,
                      Protect* pProtect,
                      std::vector<Variable>* pVariables)
 {
+   if (!ASSERT_MAIN_THREAD())
+      return;
+
    // reset passed vars
    pVariables->clear();
    
@@ -425,6 +429,9 @@ void listEnvironment(SEXP env,
 
 void listNamedAttributes(SEXP obj, Protect *pProtect, std::vector<Variable>* pVariables)
 {
+   if (!ASSERT_MAIN_THREAD())
+      return;
+
    // reset passed vars
    pVariables->clear();
 

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -847,6 +847,9 @@ void detectReposChanges()
 
 void onDetectChanges(module_context::ChangeSource source)
 {
+   if (!core::thread::isMainThread())
+      return;
+
    if (source == module_context::ChangeSourceREPL)
       detectReposChanges();
 

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -21,6 +21,7 @@
 #include <shared_core/Error.hpp>
 #include <core/Log.hpp>
 #include <core/Exec.hpp>
+#include <core/Thread.hpp>
 #include <core/Predicate.hpp>
 #include <shared_core/FilePath.hpp>
 #include <core/BoostErrors.hpp>
@@ -738,6 +739,8 @@ void detectChanges(bool activatePlots)
 
 void onDetectChanges(module_context::ChangeSource source)
 {
+   if (!core::thread::isMainThread())
+      return;
    bool activatePlots = source == module_context::ChangeSourceREPL;
    detectChanges(activatePlots);
 }

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -942,6 +942,9 @@ void onDetectChanges(module_context::ChangeSource source)
 {
    DROP_RECURSIVE_CALLS;
 
+   if (!core::thread::isMainThread())
+      return;
+
    // unlikely that data will change outside of a REPL
    if (source != module_context::ChangeSourceREPL) 
       return;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -820,6 +820,10 @@ void onDetectChanges(module_context::ChangeSource /* source */)
    if (!s_monitoring)
       return;
 
+   // This operation may use the R runtime so don't run it if this RPC was run in the offline thread
+   if (!core::thread::isMainThread())
+      return;
+
    // Check for Python changes
    if (s_environmentLanguage == kEnvironmentLanguagePython &&
        !s_monitoredPythonModule.empty())


### PR DESCRIPTION
### Intent

Addresses issue: https://github.com/rstudio/rstudio/issues/10424

### Approach

- SessionEnvironment calls an internal R function and so should not run off the main thread
- SessionPlots uses the graphics display object and since we are only running offline RPCs
none of those operations will affect the plots or data viewer
- SessionPackrat need the main thread

Added asserts to the listEnvironments apis

### Automated Tests

Reproduced with the existing automated tests with this custom setting to ensure all offlineable code runs in a thread other than main:

--- /etc/rstudio/rsession.conf:

session-handle-offline-timeout-ms=0

### QA Notes

Even with session-handle-offline-timeout-ms=0, this does not reproduce every time. When I run the test_VisualMarkdownEditor tests the "recursive gc invocation" error would show up in the console in one of the 13 tests every other time I ran it. Since the tests clear the console, and that message is not logged, it's hard to tell it's happening.  I was only able to catch it by setting this environment variable in rsession-run 

     _R_GC_FAIL_ON_ERROR_=true
     export _R_GC_FAIL_ON_ERROR_

With this setting, R will exit after printing that message. It calls the rsession's exit callback and there I was able to log the stack trace to figure out where it was coming from. 



