### PR TITLE
fixups for completion manager delegation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/dialogs/PanmirrorEditListDialog.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:rw="urn:import:org.rstudio.core.client.widget"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -340,9 +340,19 @@ public abstract class CompletionManagerBase
          completionCache_.flush();
    }
    
-   // this is a stub to help handle redirection that's done via
+   // This is a stub to help handle redirection that's done via
    // the DelegatingCompletionManager class, without requiring every
-   // sub-class to know about the delegation being done
+   // sub-class to know about the delegation being done.
+   //
+   // The DelegatingCompletionManager class overrides this method,
+   // thereby allowing CompletionManagerBase to "know" what the active
+   // completion manager is in multi-mode documents.
+   //
+   // For single-mode documents, we just return null, and use the
+   // default implementation's behavior. Or, if the subclass has
+   // overridden our method, then that method will be visible first
+   // and used anyway.
+   
    @Override
    public CompletionManager getActiveCompletionManager()
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerCommon.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerCommon.java
@@ -1,0 +1,20 @@
+/*
+ * CompletionManagerCommon.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.shell.assist;
+
+public interface CompletionManagerCommon
+{
+   CompletionManager getActiveCompletionManager();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
@@ -32,7 +32,9 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Past
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.KeyCodes;
 
-public abstract class DelegatingCompletionManager implements CompletionManager 
+public abstract class DelegatingCompletionManager
+      implements CompletionManager,
+                 CompletionManagerCommon
 {
    public DelegatingCompletionManager(DocDisplay docDisplay, CompletionContext context)
    {
@@ -51,7 +53,7 @@ public abstract class DelegatingCompletionManager implements CompletionManager
    
    protected abstract void initialize(Map<Mode, CompletionManager> managers);
    
-   private CompletionManager getCurrentCompletionManager()
+   public CompletionManager getActiveCompletionManager()
    {
       Mode mode = DocumentMode.getModeForCursorPosition(docDisplay_);
       
@@ -79,7 +81,7 @@ public abstract class DelegatingCompletionManager implements CompletionManager
    @Override
    public boolean previewKeyDown(NativeEvent event)
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       if (manager.previewKeyDown(event))
          return true;
       
@@ -97,35 +99,35 @@ public abstract class DelegatingCompletionManager implements CompletionManager
    @Override
    public boolean previewKeyPress(char charCode)
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       return manager.previewKeyPress(charCode);
    }
 
    @Override
    public void goToHelp()
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       manager.goToHelp();
    }
 
    @Override
    public void goToDefinition()
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       manager.goToDefinition();
    }
 
    @Override
    public void codeCompletion()
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       manager.codeCompletion();
    }
 
    @Override
    public void close()
    {
-      CompletionManager manager = getCurrentCompletionManager();
+      CompletionManager manager = getActiveCompletionManager();
       manager.close();
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -114,8 +114,8 @@ public class StanCompletionManager extends CompletionManagerBase
    }
    
    @Override
-   protected void addExtraCompletions(String token,
-                                      List<QualifiedName> completions)
+   public void addExtraCompletions(String token,
+                                   List<QualifiedName> completions)
    {
       Set<String> discoveredIdentifiers = new HashSet<>();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2798,7 +2798,17 @@ public class AceEditor implements DocDisplay,
    {
       return widget_.getEditor().getCursorPositionScreen();
    }
+   
+   public int getCursorRow()
+   {
+      return getSession().getSelection().getCursor().getRow();
+   }
 
+   public int getCursorColumn()
+   {
+      return getSession().getSelection().getCursor().getColumn();
+   }
+   
    public void setCursorPosition(Position position)
    {
       getSession().getSelection().setSelectionRange(

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputWidget.ui.xml
@@ -1,4 +1,3 @@
-<!DOCTYPE ui:UiBinder SYSTEM "http://dl.google.com/gwt/DTD/xhtml.ent">
 <ui:UiBinder xmlns:ui="urn:ui:com.google.gwt.uibinder"
    xmlns:g="urn:import:com.google.gwt.user.client.ui"
    xmlns:txt="urn:import:org.rstudio.studio.client.workbench.views.source.editors.text">

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -253,6 +253,8 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
 
    Position getCursorPosition();
    void setCursorPosition(Position position);
+   int getCursorRow();
+   int getCursorColumn();
 
    Position getCursorPositionScreen();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
@@ -154,6 +154,12 @@ public class YamlCompletionManager extends CompletionManagerBase
       return true;
    }
    
+   @Override
+   protected boolean isCompletionCharacter(char ch)
+   {
+      return ch != ':' && ch != ' ' && ch != '\t';
+   }
+   
    private final YamlEditorToolsProviders providers_ = new YamlEditorToolsProviders();
 
    private final CompletionContext context_;


### PR DESCRIPTION
### Intent

Fix a couple issues in the way CompletionManagerBase tried to delegate to the "active" completion manager in multi-mode documents, and use those fixes to tidy up YAML completion manager behaviors.

### Approach

CompletionManagerBase can now request the "active" completion manager, which is provided for documents using the DelegatingCompletionManager. When no delegate is available, default implementations are used; otherwise, the methods on the active delegate are used instead.

This approach was taken mainly to avoid the need to re-implement or re-declare methods on all completion manager subclasses.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
