### PR TITLE
typo in cpp11 template

### DIFF
--- a/src/cpp/session/resources/templates/cpp11.cpp
+++ b/src/cpp/session/resources/templates/cpp11.cpp
@@ -11,7 +11,7 @@
 double sum(cpp11::doubles x) {
     double total = 0.0;
     for (double value: x) {
-        total += x;
+        total += value;
     }
     return total;
 }


### PR DESCRIPTION
typo in template used for cpp11 code. part of #10397 that was merged into spotted-wakerobin. 