### PR TITLE
Lint all visual editor embedded chunks on save

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -172,7 +172,8 @@ public class LintManager
          public void onSourceFileSaveCompleted(
                SourceFileSaveCompletedEvent event)
          {
-            if (!docDisplay_.isFocused())
+            boolean isEmbedded = docDisplay_.getEditorBehavior().equals(EditorBehavior.AceBehaviorEmbedded);
+            if (!docDisplay_.isFocused() && !isEmbedded)
                return;
             
             if (userPrefs_.diagnosticsOnSave().getValue())


### PR DESCRIPTION
During a save operation we typically check for docDisplay being focused before linting (and bail if it isn't). this was causing us to only lint the focused chunk in visual mode. This PR adds an additional check for embedded mode and always allows the lint in that case.

