### PR TITLE
Error message propagate to console when conda cannot find environments

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -639,7 +639,7 @@
    if (attr(output, "status") != 0) {
      errors <- paste(readLines(tmp), collapse = "\n")
      
-     .rs.stopf("Error while executing %s %s:\n%s", conda, paste(args, collapse=" "), errors)
+     .rs.stopf("Error executing %s %s:\n%s", conda, paste(args, collapse = " "), errors)
    }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))
    envList <- unlist(json$envs)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -634,7 +634,13 @@
    
    # ask it for environments
    args <- c("env", "list", "--json", "--quiet")
-   output <- system2(conda, args, stdout = TRUE, stderr = FALSE)
+   tmp <- tempfile()
+   output <- system2(conda, args, stdout = TRUE, stderr = tmp)
+   if (attr(output, "status") != 0) {
+     errors <- paste(readLines(tmp), collapse = "\n")
+     
+     stop(conda, args, ":\n", errors)
+   }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))
    envList <- unlist(json$envs)
    

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -639,7 +639,7 @@
    if (attr(output, "status") != 0) {
      errors <- paste(readLines(tmp), collapse = "\n")
      
-     stop(conda, args, ":\n", errors)
+     .rs.stopf("Error while executing %s %s:\n%s", conda, paste(args, collapse=" "), errors)
    }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))
    envList <- unlist(json$envs)


### PR DESCRIPTION
### Intent

Addresses #10103.

### Approach
Take the error message from conda system command and send to console via stop. They might also hit this error via the UI (via Tools > Global Options > Python > Select python interpreter), so it could be worth showing the error in the UI as well instead of just
![image](https://user-images.githubusercontent.com/7817881/151217083-8a1b0b10-fded-43c9-8b01-676363f6d116.png)


### Automated Tests

NA

### QA Notes

Would be best to have a way to trigger an error upon running `conda env list --json --quiet` in the shell in order to be able to properly test the error handling

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


