### PR TITLE
Fix `yarn start` for Electron

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -118,7 +118,10 @@ export function removeStaleOptionsLockfile(): void {
 export function rsessionExeName(): string {
 
   switch (process.platform) {
-    case 'darwin': return process.arch === 'arm64' ? 'rsession-arm64' : 'rsession';
+    case 'darwin':
+      // the packaged app renames the arm64 rsession binary to rsession-arm64
+      // a dev build or unpackaged build would still have the binary named rsession
+      return process.arch === 'arm64' && app.isPackaged ? 'rsession-arm64' : 'rsession';
     case 'win32': return 'rsession.exe';
     default: return 'rsession';
   }


### PR DESCRIPTION
### Intent
Running Electron in dev on M1 Macs exits with an error that it cannot find the rsession executable. When building arm64, it creates the binary named `rsession` but it is renamed in the packaging step to `rsession-arm64`. In dev, it's build and run (no packaging) so the binary is not named as expected.

### Approach
Check if `app.isPackaged` in addition to arm64 before using `rsession-arm64` as the executable name.

### Automated Tests
None

### QA Notes
This should affect development flows only. When packaged, it should always be using `rsession-arm64` on M1 Macs.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


