### PR TITLE
Properly handle successful conda execution, status attr will be NULL

### DIFF
--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -636,8 +636,9 @@
    args <- c("env", "list", "--json", "--quiet")
    tmp <- tempfile()
    output <- system2(conda, args, stdout = TRUE, stderr = tmp)
-   exit_code <- attr(output, "status")
-   if ( !is.null(exit_code) && !identical(exit_code, 0)) {
+   
+   status <- .rs.nullCoalesce(attr(output, "status", exact = TRUE), 0L)
+   if (!identical(status, 0L)) {
      errors <- paste(readLines(tmp), collapse = "\n")
      .rs.stopf("Error executing %s %s:\n%s", conda, paste(args, collapse = " "), errors)
    }

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -636,9 +636,9 @@
    args <- c("env", "list", "--json", "--quiet")
    tmp <- tempfile()
    output <- system2(conda, args, stdout = TRUE, stderr = tmp)
-   if (attr(output, "status") != 0) {
+   exit_code <- attr(output, "status")
+   if ( !is.null(exit_code) && !identical(exit_code, 0)) {
      errors <- paste(readLines(tmp), collapse = "\n")
-     
      .rs.stopf("Error executing %s %s:\n%s", conda, paste(args, collapse = " "), errors)
    }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))


### PR DESCRIPTION
Previously only checked if status was not equal to 0, however, if the command executes successfully, it will generally not have a status attribute. Followup to #10435 to fix that. 