### PR TITLE
Lint entire visual editor doc on save

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -391,12 +391,28 @@ public class LintManager
       else
          source_.showLint(finalLint);
    }
-   
+
+   /**
+    * Schedule a lint operation.
+    *
+    * @param milliseconds The number of milliseconds to delay before linting.
+    */
    public void schedule(int milliseconds)
    {
       timer_.schedule(milliseconds);
    }
-   
+
+   /**
+    * Cancel a pending lint operation, if any.
+    */
+   public void cancelPending()
+   {
+      if (timer_ != null && timer_.isRunning())
+      {
+         timer_.cancel();
+      }
+   }
+
    public void lint(boolean showMarkers,
                     boolean explicit,
                     boolean excludeCurrentStatement)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -172,7 +172,9 @@ public class LintManager
          public void onSourceFileSaveCompleted(
                SourceFileSaveCompletedEvent event)
          {
-            if (!docDisplay_.isFocused())
+            // Skip if source doesn't want to be linted on save (this can change based on
+            // the source's focus status so we have to check every time)
+            if (!source_.lintOnSave())
                return;
             
             if (userPrefs_.diagnosticsOnSave().getValue())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintSource.java
@@ -94,4 +94,11 @@ public interface LintSource
     * @return Code to lint, or empty string for all code.
     */
    public String getCode();
+
+   /**
+    * Indicates whether the document should be linted after a save operation.
+    *
+    * @return Whether to lint the document on save.
+    */
+   public boolean lintOnSave();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
@@ -104,5 +104,20 @@ public class TextEditingTargetLintSource implements LintSource
       return "";
    }
 
+   @Override
+   public boolean lintOnSave()
+   {
+      // If the source editor is focused, we should lint when the document is saved.
+      if (target_.getDocDisplay().isFocused())
+         return true;
+
+      // Alternately, if this is the active tab and the visual editor is active, we should
+      // still lint on save; the lint results will be forward to the visual editor.
+      else if (target_.isActivated() && target_.isVisualEditorActive())
+         return true;
+
+      return false;
+   }
+
    private final TextEditingTarget target_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunk.java
@@ -222,7 +222,7 @@ public class VisualModeChunk
             @Override
             public void execute(Boolean showLineNumbers)
             {
-               showLint(lint_);
+               showLint(lint_, false);
             }
          }
       ));
@@ -819,8 +819,9 @@ public class VisualModeChunk
     * Shows lint results in the chunk.
     *
     * @param lint The lint results to show.
+    * @param cancelPending Whether to cancel pending lint requests after showing this lint.
     */
-   public void showLint(JsArray<LintItem> lint)
+   public void showLint(JsArray<LintItem> lint, boolean cancelPending)
    {
       // Save lint so we can redraw it when necessary
       lint_ = lint;
@@ -872,6 +873,13 @@ public class VisualModeChunk
                state.setTitle(item.getText());
             }
          }
+      }
+
+      // Cancel any pending lint operation if requested. This ensures that lint arriving from the
+      // outer editor doesn't get immediately overwritten by pending lint requests from this inner editor.
+      if (cancelPending)
+      {
+         lintManager_.cancelPending();
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeChunks.java
@@ -379,7 +379,7 @@ public class VisualModeChunks implements ChunkDefinition.Provider
          JsArray<LintItem> items = chunkLint.get(chunk);
          if (items != null && items.length() > 0)
          {
-            chunk.showLint(items);
+            chunk.showLint(items, true);
          }
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeLintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeLintSource.java
@@ -97,7 +97,7 @@ public class VisualModeLintSource implements LintSource
          item.setEndRow(item.getEndRow() + 1);
       }
 
-      chunk_.showLint(lint);
+      chunk_.showLint(lint, false);
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeLintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeLintSource.java
@@ -110,6 +110,15 @@ public class VisualModeLintSource implements LintSource
          chunk_.getAceInstance().getDocumentEnd());
    }
 
+   @Override
+   public boolean lintOnSave()
+   {
+      // Individual chunks of code aren't linted on save in visual mode;
+      // lint on save happens in the outer editor and results are forwarded
+      // into chunks.
+      return false;
+   }
+
    private final VisualModeChunk chunk_;
    private final TextEditingTarget parent_;
 }


### PR DESCRIPTION
### Intent

Before this change, only the active chunk was linted when the document was saved in visual mode. After it, diagnostics are generated for the entire doc when it's saved.

### Approach

Use the `LintSource` to select this behavior; turn off save-on-lint for individual visual chunks, and turn it on for the source editor when it's active in visual mode. The mechanism for forwarding lint results from the source editor already exists and works as-is with this change.

There's also a possible race condition here wherein the user (a) makes a change, (b) saves quickly, then (c) the background linter from the change (a) overwrites the lint results generated from the save (b). To address this, forcing lint results from the outer editor into the chunks now cancels any pending lint operations for that chunk.

### Automated Tests

N/A

### QA Notes

There are some lint items such as "no symbol in scope" that are not emitted when linting incrementally (only when doing a whole doc lint). You can use them as indicators that a whole-doc lint has been run.

Note also that running diagnostics (lint) on save is something you can enable/disable with a preference.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

