### PR TITLE
dodge path re-encoding issues on Windows in list.files() and friends

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1147,10 +1147,6 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # get reference to original binding
    original <- get(binding, envir = namespace)
    
-   # remove srcref on override
-   if (is.function(override))
-      override <- utils::removeSource(override)
-   
    # replace the binding
    if (is.function(override))
       environment(override) <- namespace

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1422,11 +1422,11 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # iconv will return NA for any strings that we couldn't
    # re-encode into the native encoding -- replace those
    # back with their UTF-8 originals
-   native[is.na(native)] <- text[is.na(native)]
+   failed <- is.na(native)
+   native[failed] <- text[failed]
    
    # return the converted string
    native
-   
 })
 
 .rs.addFunction("initTools", function()

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1147,6 +1147,10 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # get reference to original binding
    original <- get(binding, envir = namespace)
    
+   # remove srcref on override
+   if (is.function(override))
+      override <- utils::removeSource(override)
+   
    # replace the binding
    if (is.function(override))
       environment(override) <- namespace
@@ -1408,6 +1412,21 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    
    # perform navigation
    utils::browseURL(url)
+})
+
+.rs.addFunction("enc2native", function(text)
+{
+   # try converting to native encoding
+   native <- iconv(text, from = "UTF-8", to = "")
+   
+   # iconv will return NA for any strings that we couldn't
+   # re-encode into the native encoding -- replace those
+   # back with their UTF-8 originals
+   native[is.na(native)] <- text[is.na(native)]
+   
+   # return the converted string
+   native
+   
 })
 
 .rs.addFunction("initTools", function()

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -37,7 +37,7 @@
                                                      include.dirs = FALSE,
                                                      no.. = FALSE)
    {
-      "RStudio hook: restore original with `.rs.files.replaceBindings()`."
+      "RStudio hook: restore original with `.rs.files.replaceBindings()`"
       .rs.listFiles(
          path,
          pattern,
@@ -54,7 +54,7 @@
                                                     full.names = TRUE,
                                                     recursive = TRUE)
    {
-      "RStudio hook: restore original with `.rs.files.replaceBindings()`."
+      "RStudio hook: restore original with `.rs.files.replaceBindings()`"
       .rs.listDirs(path, full.names, recursive)
    })
    
@@ -78,7 +78,7 @@
    # the native encoding, so just move to that directory, list the available
    # files, then return that list
    owd <- tryCatch(setwd(path), condition = identity)
-   if (inherits(owd, "error"))
+   if (inherits(owd, "condition"))
       return(character())
    
    # return home when we're done

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -37,7 +37,7 @@
                                                      include.dirs = FALSE,
                                                      no.. = FALSE)
    {
-      "RStudio hook: restore original with `.rs.files.replaceBindings()`"
+      "RStudio hook: restore original with `.rs.files.restoreBindings()`"
       .rs.listFiles(
          path,
          pattern,
@@ -54,7 +54,7 @@
                                                     full.names = TRUE,
                                                     recursive = TRUE)
    {
-      "RStudio hook: restore original with `.rs.files.replaceBindings()`"
+      "RStudio hook: restore original with `.rs.files.restoreBindings()`"
       .rs.listDirs(path, full.names, recursive)
    })
    

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1300,6 +1300,18 @@ void handleFileExportRequest(const http::Request& request,
    }
 }
 
+SEXP rs_getACP()
+{
+   int codepage = 0;
+
+#ifdef _WIN32
+   codepage = GetACP();
+#endif
+
+   r::sexp::Protect protect;
+   return r::sexp::create(codepage, &protect);
+}
+
 SEXP rs_pathInfo(SEXP pathSEXP)
 {
    try
@@ -1397,8 +1409,9 @@ Error initialize()
    // subscribe to events
    events().onClientInit.connect(bind(onClientInit));
 
-   RS_REGISTER_CALL_METHOD(rs_readLines, 1);
-   RS_REGISTER_CALL_METHOD(rs_pathInfo, 1);
+   RS_REGISTER_CALL_METHOD(rs_getACP);
+   RS_REGISTER_CALL_METHOD(rs_pathInfo);
+   RS_REGISTER_CALL_METHOD(rs_readLines);
 
    // install handlers
    using boost::bind;

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1429,10 +1429,10 @@ Error initialize()
       (bind(registerRpcMethod, "move_files", moveFiles))
       (bind(registerRpcMethod, "rename_file", renameFile))
       (bind(registerRpcMethod, "touch_file", touchFile))
-      (bind(registerUriHandler, "/files", handleFilesRequest))
-      (bind(registerUploadHandler, "/upload", handleFileUploadRequestAsync))
-      (bind(registerUriHandler, "/export", handleFileExportRequest))
       (bind(registerRpcMethod, "complete_upload", completeUpload))
+      (bind(registerUriHandler, "/files", handleFilesRequest))
+      (bind(registerUriHandler, "/export", handleFileExportRequest))
+      (bind(registerUploadHandler, "/upload", handleFileUploadRequestAsync))
       (bind(sourceModuleRFile, "SessionFiles.R"))
       (bind(quotas::initialize));
    return initBlock.execute();

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1406,6 +1406,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
       cmd <<  "grep";
       cmd << "-I"; // ignore binaries
+      cmd << "-E"; // extended regexp
       cmd << "--untracked"; // include files not tracked by git...
       cmd << "--exclude-standard"; // but exclude gitignore
       cmd << "-rHn";
@@ -1431,6 +1432,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    }
    else
    {
+      cmd << "-E"; // extended regexp
       cmd << "--binary-files=without-match";
       cmd << "-rHn";
       cmd << "--color=always";
@@ -1753,7 +1755,7 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::grep | boost::regex::icase);
+      boost::regex find(findRegex, boost::regex::icase);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;
@@ -1778,7 +1780,7 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::grep);
+      boost::regex find(findRegex);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1406,7 +1406,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
       cmd <<  "grep";
       cmd << "-I"; // ignore binaries
-      cmd << "-E"; // extended regexp
       cmd << "--untracked"; // include files not tracked by git...
       cmd << "--exclude-standard"; // but exclude gitignore
       cmd << "-rHn";
@@ -1432,7 +1431,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    }
    else
    {
-      cmd << "-E"; // extended regexp
       cmd << "--binary-files=without-match";
       cmd << "-rHn";
       cmd << "--color=always";
@@ -1755,7 +1753,7 @@ core::Error Replacer::replaceRegexIgnoreCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex, boost::regex::icase);
+      boost::regex find(findRegex, boost::regex::grep | boost::regex::icase);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;
@@ -1780,7 +1778,7 @@ core::Error Replacer::replaceRegexWithCase(size_t matchOn, size_t matchOff,
 {
    try
    {
-      boost::regex find(findRegex);
+      boost::regex find(findRegex, boost::regex::grep);
       core::Error error = completeReplace(find, replaceRegex, matchOn, matchOff, pLine,
          pReplaceMatchOff);
       return error;

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -44,5 +44,10 @@
 # and dir() have their encoding properly marked. We do this here.
 if (.rs.platform.isWindows)
 {
-   .rs.files.replaceBindings()
+   setHook("rstudio.sessionInit", function(...)
+   {
+      enabled <- getOption("rstudio.enableFileHooks", default = TRUE)
+      if (identical(enabled, TRUE))
+         .rs.files.replaceBindings()
+   })
 }

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -39,3 +39,59 @@
    parallel:::setDefaultClusterOptions(setup_strategy = "sequential")
 })
 
+# On Windows, because we now set the active code page to UTF-8,
+# we need to be careful to ensure the outputs from list.files(), list.dirs()
+# and dir() have their encoding properly marked. We do this here.
+if (.rs.platform.isWindows && getRversion() < "4.2.0")
+{
+   .rs.replaceBinding("list.files", "base", function(path = ".",
+                                                     pattern = NULL,
+                                                     all.files = FALSE,
+                                                     full.names = FALSE,
+                                                     recursive = FALSE,
+                                                     ignore.case = FALSE,
+                                                     include.dirs = FALSE,
+                                                     no.. = FALSE)
+   {
+      .rs.listFiles(
+         path,
+         pattern,
+         all.files,
+         full.names,
+         recursive,
+         ignore.case,
+         include.dirs,
+         no..
+      )
+   })
+   
+   .rs.replaceBinding("dir", "base", function(path = ".",
+                                              pattern = NULL,
+                                              all.files = FALSE,
+                                              full.names = FALSE,
+                                              recursive = FALSE,
+                                              ignore.case = FALSE,
+                                              include.dirs = FALSE,
+                                              no.. = FALSE)
+   {
+      .rs.listFiles(
+         path,
+         pattern,
+         all.files,
+         full.names,
+         recursive,
+         ignore.case,
+         include.dirs,
+         no..
+      )
+   })
+   
+   .rs.replaceBinding("list.dirs", "base", function(path = ".",
+                                                    full.names = TRUE,
+                                                    recursive = TRUE)
+   {
+      .rs.listDirs(path, full.names, recursive)
+   })
+   
+}
+   

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -42,56 +42,7 @@
 # On Windows, because we now set the active code page to UTF-8,
 # we need to be careful to ensure the outputs from list.files(), list.dirs()
 # and dir() have their encoding properly marked. We do this here.
-if (.rs.platform.isWindows && getRversion() < "4.2.0")
+if (.rs.platform.isWindows)
 {
-   .rs.replaceBinding("list.files", "base", function(path = ".",
-                                                     pattern = NULL,
-                                                     all.files = FALSE,
-                                                     full.names = FALSE,
-                                                     recursive = FALSE,
-                                                     ignore.case = FALSE,
-                                                     include.dirs = FALSE,
-                                                     no.. = FALSE)
-   {
-      .rs.listFiles(
-         path,
-         pattern,
-         all.files,
-         full.names,
-         recursive,
-         ignore.case,
-         include.dirs,
-         no..
-      )
-   })
-   
-   .rs.replaceBinding("dir", "base", function(path = ".",
-                                              pattern = NULL,
-                                              all.files = FALSE,
-                                              full.names = FALSE,
-                                              recursive = FALSE,
-                                              ignore.case = FALSE,
-                                              include.dirs = FALSE,
-                                              no.. = FALSE)
-   {
-      .rs.listFiles(
-         path,
-         pattern,
-         all.files,
-         full.names,
-         recursive,
-         ignore.case,
-         include.dirs,
-         no..
-      )
-   })
-   
-   .rs.replaceBinding("list.dirs", "base", function(path = ".",
-                                                    full.names = TRUE,
-                                                    recursive = TRUE)
-   {
-      .rs.listDirs(path, full.names, recursive)
-   })
-   
+   .rs.files.replaceBindings()
 }
-   

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -73,3 +73,23 @@ test_that("file listings are correct", {
 
 })
 
+test_that("we can list UTF-8 file paths", {
+   
+   tdir <- tempfile()
+   dir.create(tdir)
+   owd <- setwd(tdir)
+   on.exit(setwd(owd), add = TRUE)
+   
+   name <- enc2utf8("\u4e2d\u6587")    # "中文"
+   dir.create(name)
+   file.create(paste(name, name, sep = "/"))
+   
+   expect_equal(list.files(), name)
+   expect_equal(list.files(getwd()), name)
+   expect_equal(list.files(getwd(), full.names = TRUE), paste(getwd(), name, sep = "/"))
+   
+   all <- list.files(recursive = TRUE)
+   expect_equal(all, paste(name, name, sep = "/"))
+   
+})
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10451.

### Approach

The fix here is somewhat heavy-handed: we overwrite R's implementation of `list.files()`, `list.dirs()`, and `dir()`, with our own versions that better handle different combinations of {system encoding} vs {path encoding}.

This is necessary because RStudio now declares itself to be compatible with the UTF-8 codepage 65001, and so paths returned from R's `list.files()` are actually UTF-8 encoded. However, R does not mark the returned files as such, and so they're mis-interpreted in the native encoding, which may not be UTF-8 for older versions of R.

We still make use of the same underlying internal `list.files()` implementation; we just massage the file encodings + how these functions are invoked in a way that makes sure they behave regardless of the current locale.

### Automated Tests

Tests included, but since they're not run on Windows we'll need extra QA testing.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10451. This _definitely_ needs extra scrutiny since we're messing with a base R function!

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
