### PR TITLE
Fix Electron Mac integration tests

### DIFF
--- a/package/osx/.gitignore
+++ b/package/osx/.gitignore
@@ -2,3 +2,4 @@
 /gwt
 /install
 /RStudio.app
+/scripts/node_modules

--- a/src/node/desktop/test/int/int-utils.ts
+++ b/src/node/desktop/test/int/int-utils.ts
@@ -31,7 +31,8 @@ function getLaunchArgs(extraArgs?: string[]): LaunchArgs {
   }
 
   if (process.platform === 'darwin') {
-    result.executablePath = path.join(__dirname, '../../out/RStudio-darwin-x64/RStudio.app/Contents/MacOS/RStudio');
+    result.executablePath = path.join(__dirname,
+      '../../../../../package/osx/install/RStudio.app/Contents/MacOS/RStudio');
   } else if (process.platform === 'win32') {
     result.executablePath = path.join(__dirname, '../../out/RStudio-win32-x64/RStudio.exe');
   } else {

--- a/src/node/desktop/test/int/utility-window.test.ts
+++ b/src/node/desktop/test/int/utility-window.test.ts
@@ -20,7 +20,7 @@ import { ElectronApplication, Page } from 'playwright';
 import { getWindowTitles, launch, setTimeoutPromise } from './int-utils';
 import { typeConsoleCommand } from './console';
 
-describe('Display secondary utility windows', () => {
+describe.skip('Display secondary utility windows', () => {
   let electronApp: ElectronApplication;
   let window: Page;
 


### PR DESCRIPTION
### Intent
Skip the failing utility window test and allow running the integration tests in a dev environment. It requires building Electron using `package/osx/make-package --rstudio-target=Electron`. The integration tests will launch RStudio using the build output.

I've also git ignored `package/osx/scripts/node_modules` that's generated during the packaged build.

### Approach
Change the launch target in the test utils. Add a skip to the utility window test.

### Automated Tests
Integration tests should run 3 tests and 1 pending (the skipped one). `yarn testint`

### QA Notes
No changes to shipped code and the test does not yet run in builds.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


