### PR TITLE
handle launch of x64 R when on arm64 macOS

### DIFF
--- a/package/osx/scripts/codesign-package.sh
+++ b/package/osx/scripts/codesign-package.sh
@@ -29,7 +29,6 @@ shift
 codesign_args=("$@")
 
 codesign-file () {
-	echo "codesign: '$1'"
 	codesign "${codesign_args[@]}" "$1"
 }
 

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -598,7 +598,7 @@ export class FilePath {
    * Gets the parent directory of this file path.
    */
   getParent(): FilePath {
-    throw Error('getParent is NYI');
+    return new FilePath(path.dirname(this.path));
   }
 
   /**

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -503,7 +503,6 @@ export class SessionLauncher {
 
     // on macOS, we need to look at R and figure out if we should be trying to run
     // with the arm64 session binary (rsession-arm64) or with the x64 session binary (rsession)
-    let sessionPath = this.sessionPath;
     if (app.isPackaged && process.platform === 'darwin') {
       const rHome = getenv('R_HOME');
       const rLibPath = `${rHome}/lib/libR.dylib`
@@ -511,14 +510,14 @@ export class SessionLauncher {
       const fileInfo = execSync(`/usr/bin/file "${rLibPath}"`, { encoding: 'utf-8' });
       logger().logDebug(fileInfo);
       if (fileInfo.indexOf('arm64') !== -1) {
-        sessionPath = sessionPath.getParent().completeChildPath('rsession-arm64');
-        logger().logDebug(`R is arm64; using ${sessionPath}`);
+        this.sessionPath = this.sessionPath.getParent().completeChildPath('rsession-arm64');
+        logger().logDebug(`R is arm64; using ${this.sessionPath}`);
       } else {
-        logger().logDebug(`R is x86_64; using ${sessionPath}`);
+        logger().logDebug(`R is x86_64; using ${this.sessionPath}`);
       }
     }
 
-    const sessionProc = launchProcess(sessionPath, argList);
+    const sessionProc = launchProcess(this.sessionPath, argList);
     sessionProc.on('error', (err) => {
       // Unable to start rsession (at all)
       logger().logError(err);

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -71,7 +71,6 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
   const env = Object.assign({}, process.env);
 
   if (process.platform === 'darwin') {
-
     // Create fallback library path (use TMPDIR so it's user-specific):
     // reticulate needs to do some DYLD_FALLBACK_LIBRARY_PATH shenanigans to work with Anaconda Python;
     // the solution is to have RStudio launch with a special DYLD_FALLBACK_LIBRARY_PATH, and let
@@ -94,7 +93,6 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     // x86 or arm64 versions of the libraries in the launched rsession
     const path = absPath.getAbsolutePath();
     if (process.arch === 'arm64') {
-
       const fileInfo = execSync(`/usr/bin/file "${rLib}"`, { encoding: 'utf-8' });
       if (fileInfo.indexOf('arm64') === -1 && fileInfo.indexOf('x86_64') !== -1) {
         argList = ['-x86_64', '-e', dyldArg, path, ...argList];
@@ -103,12 +101,10 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
         argList = ['-arm64', '-e', dyldArg, path, ...argList];
         absPath = new FilePath('/usr/bin/arch');
       }
-
     } else {
       argList = ['-x86_64', '-e', dyldArg, path, ...argList];
       absPath = new FilePath('/usr/bin/arch');
     }
-
   }
 
   logger().logDebug(`Launching: ${absPath.getAbsolutePath()} ${argList.join(' ')}`);

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import { app, dialog } from 'electron';
-import { spawn, ChildProcess } from 'child_process';
+import { app } from 'electron';
+import { spawn, ChildProcess, execSync } from 'child_process';
 import fs from 'fs';
 
 import { logger } from '../core/logger';
@@ -66,36 +66,58 @@ function fallbackLibraryPath(): string {
 }
 
 function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
+
+  // create local copy of environment
+  const env = Object.assign({}, process.env);
+
   if (process.platform === 'darwin') {
-    // on macOS with the hardened runtime, we can no longer rely on dyld
-    // to lazy-load symbols from libR.dylib; to resolve this, we use
-    // DYLD_INSERT_LIBRARIES to inject the library we wish to use on
-    // launch
-    const rHome = new FilePath(getenv('R_HOME'));
-    const rLib = rHome.completePath('lib/libR.dylib');
-    if (rLib.existsSync()) {
-      setenv('DYLD_INSERT_LIBRARIES', rLib.getAbsolutePath());
-    }
 
     // Create fallback library path (use TMPDIR so it's user-specific):
-    // Reticulate needs to do some DYLD_FALLBACK_LIBRARY_PATH shenanigans to work with Anaconda Python;
+    // reticulate needs to do some DYLD_FALLBACK_LIBRARY_PATH shenanigans to work with Anaconda Python;
     // the solution is to have RStudio launch with a special DYLD_FALLBACK_LIBRARY_PATH, and let
     // reticulate set the associated path to a symlink of its choosing on load.
     const libraryPath = fallbackLibraryPath();
-
-    // set it in environment variable (to be used by R)
-    setenv('RSTUDIO_FALLBACK_LIBRARY_PATH', libraryPath);
+    env['RSTUDIO_FALLBACK_LIBRARY_PATH'] = libraryPath;
 
     // and ensure it's placed on the fallback library path
     const dyldFallbackLibraryPath = `${getenv('DYLD_FALLBACK_LIBRARY_PATH')}:${libraryPath}`;
-    setenv('DYLD_FALLBACK_LIBRARY_PATH', dyldFallbackLibraryPath);
+    env['DYLD_FALLBACK_LIBRARY_PATH'] = dyldFallbackLibraryPath;
+
+    // on macOS with the hardened runtime, we can no longer rely on dyld
+    // to lazy-load symbols from libR.dylib; to resolve this, we use
+    // DYLD_INSERT_LIBRARIES to inject the library we wish to use
+    const rHome = new FilePath(getenv('R_HOME'));
+    const rLib = rHome.completePath('lib/libR.dylib');
+    const dyldArg = `DYLD_INSERT_LIBRARIES=${rLib.getAbsolutePath()}`;
+
+    // launch via /usr/bin/arch, so we can control whether the OS requests
+    // x86 or arm64 versions of the libraries in the launched rsession
+    const path = absPath.getAbsolutePath();
+    if (process.arch === 'arm64') {
+
+      const fileInfo = execSync(`/usr/bin/file "${rLib}"`, { encoding: 'utf-8' });
+      if (fileInfo.indexOf('arm64') === -1 && fileInfo.indexOf('x86_64') !== -1) {
+        argList = ['-x86_64', '-e', dyldArg, path, ...argList];
+        absPath = new FilePath('/usr/bin/arch');
+      } else {
+        argList = ['-arm64', '-e', dyldArg, path, ...argList];
+        absPath = new FilePath('/usr/bin/arch');
+      }
+
+    } else {
+      argList = ['-x86_64', '-e', dyldArg, path, ...argList];
+      absPath = new FilePath('/usr/bin/arch');
+    }
+
   }
 
+  logger().logDebug(`Launching: ${absPath.getAbsolutePath()} ${argList.join(' ')}`);
+
   if (!appState().runDiagnostics) {
-    return spawn(absPath.getAbsolutePath(), argList);
+    return spawn(absPath.getAbsolutePath(), argList, { env: env });
   } else {
     // for diagnostics, redirect child process stdio to this process
-    return spawn(absPath.getAbsolutePath(), argList, { stdio: 'inherit' });
+    return spawn(absPath.getAbsolutePath(), argList, { stdio: 'inherit', env: env });
   }
 }
 
@@ -131,6 +153,7 @@ export class SessionLauncher {
   // but that isn't a thing in TypeScript (at least not without some ugly workarounds)
   // so giving a different name.
   private launchFirst(): Err {
+
     // build a new new launch context
     const launchContext = this.buildLaunchContext();
 
@@ -461,6 +484,7 @@ export class SessionLauncher {
   }
 
   private launchSession(argList: string[]): ChildProcess {
+
     // always remove the abend log path before launching
     const error = abendLogPath().removeIfExistsSync();
     if (error) {
@@ -477,11 +501,24 @@ export class SessionLauncher {
       setenv('RSTUDIO_SESSION_EXIT_ON_STARTUP', appState().sessionEarlyExitCode.toString());
     }
 
-    // TODO
-    // we need indirection through arch to handle arm64
-    // see C++ sources...
+    // on macOS, we need to look at R and figure out if we should be trying to run
+    // with the arm64 session binary (rsession-arm64) or with the x64 session binary (rsession)
+    let sessionPath = this.sessionPath;
+    if (app.isPackaged && process.platform === 'darwin') {
+      const rHome = getenv('R_HOME');
+      const rLibPath = `${rHome}/lib/libR.dylib`
+      logger().logDebug(`$ /usr/bin/file "${rLibPath}"`);
+      const fileInfo = execSync(`/usr/bin/file "${rLibPath}"`, { encoding: 'utf-8' });
+      logger().logDebug(fileInfo);
+      if (fileInfo.indexOf('arm64') !== -1) {
+        sessionPath = sessionPath.getParent().completeChildPath('rsession-arm64');
+        logger().logDebug(`R is arm64; using ${sessionPath}`);
+      } else {
+        logger().logDebug(`R is x86_64; using ${sessionPath}`);
+      }
+    }
 
-    const sessionProc = launchProcess(this.sessionPath, argList);
+    const sessionProc = launchProcess(sessionPath, argList);
     sessionProc.on('error', (err) => {
       // Unable to start rsession (at all)
       logger().logError(err);

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -118,10 +118,6 @@ export function removeStaleOptionsLockfile(): void {
 export function rsessionExeName(): string {
 
   switch (process.platform) {
-    case 'darwin':
-      // the packaged app renames the arm64 rsession binary to rsession-arm64
-      // a dev build or unpackaged build would still have the binary named rsession
-      return process.arch === 'arm64' && app.isPackaged ? 'rsession-arm64' : 'rsession';
     case 'win32': return 'rsession.exe';
     default: return 'rsession';
   }


### PR DESCRIPTION
### Intent

Port over x64 vs. arm64 detection code; ensure RStudio can launch x64 R sessions.

### Approach

Use `/usr/bin/arch`; pass `DYLD_INSERT_LIBRARIES` to force the R library to be loaded on start.

### Automated Tests

N/A

### QA Notes

Test that you can force RStudio to use an x64 R; e.g. with

```
RSTUDIO_WHICH_R=/path/to/R /Applications/RStudio.app/Contents/MacOS/RStudio
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
