### PR TITLE
use logging instead of console.log for Electron

### DIFF
--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -22,6 +22,7 @@ export interface Logger {
   logLevel(): winston.level;
   setLogLevel(level: winston.level): void;
   logError(err: unknown): void;
+  logErrorAtLevel(level: winston.level, err: unknown): void;
   logErrorMessage(message: string): void;
   logWarning(warning: string): void;
   logInfo(message: string): void;
@@ -44,7 +45,10 @@ export class NullLogger implements Logger {
   setLogLevel(level: winston.level): void {
     this.level = level;
   }
-  logError(err: unknown): void {}
+  logError(err: unknown): void {
+    this.logErrorAtLevel('error', err);
+  }
+  logErrorAtLevel(level: winston.level, err: unknown): void {}
   logErrorMessage(message: string): void {}
   logInfo(message: string): void {}
   logWarning(warning: string): void {}

--- a/src/node/desktop/src/core/winston-logger.ts
+++ b/src/node/desktop/src/core/winston-logger.ts
@@ -48,8 +48,12 @@ export class WinstonLogger implements Logger {
   }
 
   logError(err: unknown): void {
+    this.logErrorAtLevel('error', err);
+  }
+
+  logErrorAtLevel(level: winston.level, err: unknown): void {
     const safeErr = safeError(err);
-    this.logger.log('error', err);
+    this.logger.log(level, err);
   }
 
   logErrorMessage(message: string): void {

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -151,7 +151,7 @@ export class Application implements AppState {
           'Error Finding R',
           'RStudio failed to find any R installations on the system.',
         );
-        console.log(preflightError);
+        logger().logError(preflightError);
         return exitFailure();
       }
 
@@ -165,7 +165,7 @@ export class Application implements AppState {
     const prepareError = prepareEnvironment();
     if (prepareError) {
       await createStandaloneErrorDialog('Error Finding R', 'RStudio failed to find any R installations on the system.');
-      console.log(prepareError);
+      logger().logError(prepareError);
       return exitFailure();
     }
 

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -96,11 +96,10 @@ export class DesktopBrowserWindow extends EventEmitter {
           cssOrigin: 'author',
         })
         .then((result) => {
-          console.log('Custom Styles Added Successfully');
+          logger().logDebug('Custom Styles Added Successfully');
         })
         .catch((error) => {
-          console.log('Error when adding custom styles');
-          console.log(error);
+          logger().logError(error);
         });
 
       // Uncomment to have all windows show dev tools by default

--- a/src/node/desktop/src/main/desktop-options.ts
+++ b/src/node/desktop/src/main/desktop-options.ts
@@ -16,7 +16,7 @@
 
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
-import { logLevel } from '../core/logger';
+import { logger, logLevel } from '../core/logger';
 
 const kProportionalFont = 'Font.ProportionalFont';
 const kFixWidthFont = 'Font.FixWidthFont';
@@ -168,9 +168,7 @@ export class DesktopOptionsImpl {
     try {
       this.restoreMainWindowBoundsImpl(mainWindow);
     } catch (e: unknown) {
-      if (logLevel() == 'debug') {
-        console.log(e);
-      }
+      logger().logErrorAtLevel('debug', e);
     }
   }
 


### PR DESCRIPTION
### Intent

We should generally use the logging API in Electron desktop, not `console.log()`.

### Approach

Converted several; there are still some instances of `console.log()` for code that might fail before logging is initialized.

Also added a logging method override for logging errors (exceptions) at a level other than 'error'.

### Automated Tests

No new tests.

### QA Notes

Nothing specifically to test here. Internal cleanup.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


