### PR TITLE
find M1 R installed by homebrew on Mac

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -199,8 +199,9 @@ function scanForRPosix(): Expected<string> {
   // otherwise, look in some hard-coded locations
   const defaultLocations = ['/opt/local/bin/R', '/usr/local/bin/R', '/usr/bin/R'];
 
-  // also check framework directory for macOS
+  // also check framework directory and homebrew ARM locations for macOS
   if (process.platform === 'darwin') {
+    defaultLocations.push('/opt/homebrew/bin/R');
     defaultLocations.push('/Library/Frameworks/R.framework/Resources/bin/R');
   }
 


### PR DESCRIPTION
### Intent

Electron desktop should find M1 R installed by homebrew on M1 Mac.

### Approach

Do same thing for Electron as was done for Qt desktop (https://github.com/rstudio/rstudio/pull/9272). Namely, add `/opt/homebrew/bin/R` to the list of locations searched for an R installation on Mac.

### Automated Tests

None

### QA Notes

Try running Electron RStudio on an M1 Mac where the only R installation is native M1 R installed via homebrew to /opt/homebrew.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


