### PR TITLE
implement own list.files list.dirs methods built on Boost.Filesystem

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 * RStudio now supports the experimental UTF-8 UCRT builds of R (#9824)
 * Preliminary support for R graphics engine version 15 in R 4.2.0. (#10058)
 * Default file download method in Windows for R 4.2 and above changed from `wininet` to `libcurl` (#10163)
+* `list.files()` and `list.dirs()` now handle international characters on Windows (#10451)
 
 #### Misc
 

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1517,9 +1517,8 @@ SEXP createUtf8(const std::string& data, Protect* pProtect)
    SEXP strSEXP;
    pProtect->add(strSEXP = Rf_allocVector(STRSXP, 1));
 
-   SEXP charSEXP;
-   pProtect->add(charSEXP = Rf_mkCharLenCE(data.c_str(), data.size(), CE_UTF8));
-
+   // protection not required as long as we immediately assign into protected STRSXP
+   SEXP charSEXP = Rf_mkCharLenCE(data.c_str(), data.size(), CE_UTF8);
    SET_STRING_ELT(strSEXP, 0, charSEXP);
    return strSEXP;
 }
@@ -1536,8 +1535,8 @@ SEXP createUtf8(const std::vector<std::string>& data, Protect* pProtect)
    
    for (std::size_t i = 0, n = data.size(); i < n; i++)
    {
-      SEXP charSEXP;
-      pProtect->add(charSEXP = Rf_mkCharLenCE(data[i].c_str(), data[i].size(), CE_UTF8));
+      // protection not required as long as we immediately assign into protected STRSXP
+      SEXP charSEXP = Rf_mkCharLenCE(data[i].c_str(), data[i].size(), CE_UTF8);
       SET_STRING_ELT(strSEXP, i, charSEXP);
    }
    

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1529,6 +1529,21 @@ SEXP createUtf8(const FilePath& filePath, Protect* pProtect)
    return createUtf8(filePath.getAbsolutePath(), pProtect);
 }
 
+SEXP createUtf8(const std::vector<std::string>& data, Protect* pProtect)
+{
+   SEXP strSEXP;
+   pProtect->add(strSEXP = Rf_allocVector(STRSXP, data.size()));
+   
+   for (std::size_t i = 0, n = data.size(); i < n; i++)
+   {
+      SEXP charSEXP;
+      pProtect->add(charSEXP = Rf_mkCharLenCE(data[i].c_str(), data[i].size(), CE_UTF8));
+      SET_STRING_ELT(strSEXP, i, charSEXP);
+   }
+   
+   return strSEXP;
+}
+
 SEXP createRawVector(const std::string& data, Protect* pProtect)
 {
    SEXP rawSEXP;

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -170,6 +170,7 @@ SEXP create(const std::map<std::string, SEXP> &value,
 // Create a UTF-8 encoded character vector
 SEXP createUtf8(const std::string& data, Protect* pProtect);
 SEXP createUtf8(const core::FilePath& filePath, Protect* pProtect);
+SEXP createUtf8(const std::vector<std::string>& data, Protect* pProtect);
 
 // Create a raw vector (binary data)
 SEXP createRawVector(const std::string& data, Protect* pProtect);

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -38,7 +38,8 @@
                                                      no.. = FALSE)
    {
       "RStudio hook: restore original with `.rs.files.restoreBindings()`"
-      .rs.listFiles(
+      .Call(
+         "rs_listFiles",
          path,
          pattern,
          all.files,
@@ -46,7 +47,8 @@
          recursive,
          ignore.case,
          include.dirs,
-         no..
+         no..,
+         PACKAGE = "(embedding)"
       )
    })
 
@@ -55,7 +57,13 @@
                                                     recursive = TRUE)
    {
       "RStudio hook: restore original with `.rs.files.restoreBindings()`"
-      .rs.listDirs(path, full.names, recursive)
+      .Call(
+         "rs_listDirs",
+         path,
+         full.names,
+         recursive,
+         PACKAGE = "(embedding)"
+      )
    })
 
    # dir and list.files should refer to the same thing
@@ -83,14 +91,14 @@
 {
    .Call(
       "rs_listFiles",
-      path.expand(as.character(path)),
-      as.character(pattern),
-      as.logical(all.files),
-      as.logical(full.names),
-      as.logical(recursive),
-      as.logical(ignore.case),
-      as.logical(include.dirs),
-      as.logical(no..),
+      path,
+      pattern,
+      all.files,
+      full.names,
+      recursive,
+      ignore.case,
+      include.dirs,
+      no..,
       PACKAGE = "(embedding)"
    )
 })
@@ -101,9 +109,9 @@
 {
    .Call(
       "rs_listDirs",
-      path.expand(as.character(path)),
-      as.logical(full.names),
-      as.logical(recursive),
+      path,
+      full.names,
+      recursive,
       PACKAGE = "(embedding)"
    )
 })

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -13,6 +13,29 @@
 #
 #
 
+.rs.addFunction("listFiles", function(path = ".",
+                                      pattern = NULL,
+                                      all.files = FALSE,
+                                      full.names = FALSE,
+                                      recursive = FALSE,
+                                      ignore.case = FALSE,
+                                      include.dirs = FALSE,
+                                      no.. = FALSE)
+{
+   .Call(
+      "rs_listFiles",
+      path.expand(as.character(path)),
+      as.character(pattern),
+      as.logical(all.files),
+      as.logical(full.names),
+      as.logical(recursive),
+      as.logical(ignore.case),
+      as.logical(include.dirs),
+      as.logical(no..),
+      PACKAGE = "(embedding)"
+   )
+})
+
 .rs.addFunction("listZipFile", function(zipfile)
 {
    as.character(utils::unzip(zipfile, list=TRUE)$Name)

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -13,6 +13,65 @@
 #
 #
 
+.rs.setVar("files.savedBindings", new.env(parent = emptyenv()))
+
+# these hooks are added to support RStudio's transition into
+# the use of a UTF-8 code page
+.rs.addFunction("files.replaceBindings", function()
+{
+   # save old implementations, in case we need to restore them
+   bindings <- c("list.files", "list.dirs", "dir")
+   for (binding in bindings)
+   {
+      original <- get(binding, envir = baseenv(), inherits = FALSE)
+      assign(binding, original, envir = .rs.files.savedBindings)
+   }
+
+   # now, replace bindings
+   .rs.replaceBinding("list.files", "base", function(path = ".",
+                                                     pattern = NULL,
+                                                     all.files = FALSE,
+                                                     full.names = FALSE,
+                                                     recursive = FALSE,
+                                                     ignore.case = FALSE,
+                                                     include.dirs = FALSE,
+                                                     no.. = FALSE)
+   {
+      "RStudio hook: restore original with `.rs.files.restoreBindings()`"
+      .rs.listFiles(
+         path,
+         pattern,
+         all.files,
+         full.names,
+         recursive,
+         ignore.case,
+         include.dirs,
+         no..
+      )
+   })
+
+   .rs.replaceBinding("list.dirs", "base", function(path = ".",
+                                                    full.names = TRUE,
+                                                    recursive = TRUE)
+   {
+      "RStudio hook: restore original with `.rs.files.restoreBindings()`"
+      .rs.listDirs(path, full.names, recursive)
+   })
+
+   # dir and list.files should refer to the same thing
+   .rs.replaceBinding("dir", "base", list.files)
+
+})
+
+# this is provided just in case users need an escape hatch
+# from our overridden list.files() implementations on windows
+.rs.addFunction("files.restoreBindings", function()
+{
+   bindings <- ls(envir = .rs.files.savedBindings)
+   for (binding in bindings)
+      .rs.replaceBinding(binding, "base", .rs.files.savedBindings[[binding]])
+})
+
 .rs.addFunction("listFiles", function(path = ".",
                                       pattern = NULL,
                                       all.files = FALSE,

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -15,19 +15,18 @@
 
 .rs.setVar("files.savedBindings", new.env(parent = emptyenv()))
 
+# save old implementations, in case we need to restore them
+bindings <- c("list.files", "list.dirs", "dir")
+for (binding in bindings)
+{
+   original <- get(binding, envir = baseenv(), inherits = FALSE)
+   assign(binding, original, envir = .rs.files.savedBindings)
+}
+
 # these hooks are added to support RStudio's transition into
 # the use of a UTF-8 code page
 .rs.addFunction("files.replaceBindings", function()
 {
-   # save old implementations, in case we need to restore them
-   bindings <- c("list.files", "list.dirs", "dir")
-   for (binding in bindings)
-   {
-      original <- get(binding, envir = baseenv(), inherits = FALSE)
-      assign(binding, original, envir = .rs.files.savedBindings)
-   }
-
-   # now, replace bindings
    .rs.replaceBinding("list.files", "base", function(path = ".",
                                                      pattern = NULL,
                                                      all.files = FALSE,

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -36,6 +36,19 @@
    )
 })
 
+.rs.addFunction("listDirs", function(path = ".",
+                                     full.names = TRUE,
+                                     recursive = TRUE)
+{
+   .Call(
+      "rs_listDirs",
+      path.expand(as.character(path)),
+      as.logical(full.names),
+      as.logical(recursive),
+      PACKAGE = "(embedding)"
+   )
+})
+
 .rs.addFunction("listZipFile", function(zipfile)
 {
    as.character(utils::unzip(zipfile, list=TRUE)$Name)

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1431,7 +1431,9 @@ void listFilesImpl(
          // construct new prefix
          auto newPrefix = prefix.empty() ? name : prefix / name;
          
-         if (boost::filesystem::is_directory(it->status()))
+         // check if this file is a directory (ignore errors)
+         boost::system::error_code ec;
+         if (boost::filesystem::is_directory(it->status(ec)))
          {
             if (options.recursive)
             {
@@ -1467,7 +1469,9 @@ void listFilesDispatch(
    // iterate through other files
    for (auto&& path : paths)
    {
-      if (boost::filesystem::exists(path))
+      // check for existence (swallow other errors)
+      boost::system::error_code ec;
+      if (boost::filesystem::exists(path, ec))
       {
          auto prefix = options.fullNames ? path : kEmptyString;
          listFilesImpl(path, prefix, options, accept, pResult);

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1560,13 +1560,29 @@ void validatePath(SEXP pathSEXP)
 
 void validatePattern(SEXP patternSEXP)
 {
-   bool validPattern =
+   // allow NULL
+   if (TYPEOF(patternSEXP) == NILSXP)
+      return;
+
+   // allow character vectors
+   // note that all elements but the first are ignored
+   bool hasValidPattern =
          TYPEOF(patternSEXP) == STRSXP &&
          LENGTH(patternSEXP) > 0 &&
          STRING_ELT(patternSEXP, 0) != NA_STRING;
 
-   if (!validPattern && LENGTH(patternSEXP) != 0)
-      Rf_error("invalid '%s' argument", "pattern");
+   if (hasValidPattern)
+      return;
+
+   // allow empty character vectors
+   bool isEmptyCharacterVector =
+         TYPEOF(patternSEXP) == STRSXP &&
+         LENGTH(patternSEXP) == 0;
+
+   if (isEmptyCharacterVector)
+      return;
+
+   Rf_error("invalid '%s' argument", "pattern");
 }
 
 bool validateLogical(SEXP valueSEXP, const char* name)

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1715,7 +1715,14 @@ SEXP rs_listDirs(SEXP pathSEXP,
 
       return finalizePaths(result);
    }
+   catch (ListFilesInterruptedException&)
+   {
+      // nothing to do (no need to log)
+   }
    CATCH_UNEXPECTED_EXCEPTION;
+   
+   // note: will longjmp if an interrupt is pending
+   r::exec::checkUserInterrupt();
    
    return R_NilValue;
 }

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1639,14 +1639,18 @@ SEXP rs_listDirs(SEXP pathSEXP,
       listFilesDispatch(paths, options, ListFilesAcceptAll(), &result);
       
       // for recursive list.dirs() calls, we need to also include
-      // the requested path itself
+      // the requested path itself, but only if it exists
       if (options.recursive)
       {
          for (auto&& path : paths)
          {
-            result.insert(
-                     result.begin(), 
-                     options.fullNames ? path : boost::filesystem::path());
+            boost::system::error_code ec;
+            if (boost::filesystem::exists(path, ec))
+            {
+               result.insert(
+                        result.begin(),
+                        options.fullNames ? path : boost::filesystem::path());
+            }
          }
       }
 

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -39,3 +39,15 @@
    parallel:::setDefaultClusterOptions(setup_strategy = "sequential")
 })
 
+# On Windows, because we now set the active code page to UTF-8,
+# we need to be careful to ensure the outputs from list.files(), list.dirs()
+# and dir() have their encoding properly marked. We do this here.
+if (.rs.platform.isWindows)
+{
+   setHook("rstudio.sessionInit", function(...)
+   {
+      enabled <- getOption("rstudio.enableFileHooks", default = TRUE)
+      if (identical(enabled, TRUE))
+         .rs.files.replaceBindings()
+   })
+}

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -13,6 +13,21 @@
 #
 #
 
+.rs.addFunction("enc2native", function(text)
+{
+   # try converting to native encoding
+   native <- iconv(text, from = "UTF-8", to = "")
+
+   # iconv will return NA for any strings that we couldn't
+   # re-encode into the native encoding -- replace those
+   # back with their UTF-8 originals
+   failed <- is.na(native)
+   native[failed] <- text[failed]
+
+   # return the converted string
+   native
+})
+
 .rs.addFunction("isNullExternalPointer", function(object)
 {
    .Call("rs_isNullExternalPointer", object, PACKAGE = "(embedding)")


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10451. Alternate to https://github.com/rstudio/rstudio/pull/10464.

### Approach

Implement our own file listing routines, using Boost.Filesystem. Might be worth discussing if we like this more than https://github.com/rstudio/rstudio/pull/10464.

### Automated Tests

Extensive tests are included.

### QA Notes

Note that these changes should only effect Windows. Test something like the following:

```
# restore the original R bindings
.rs.files.restoreBindings()

# try comparing R's output to ours
lhs <- list.files("~", recursive = TRUE)
rhs <- list.files("~", recursive = TRUE)

# hopefully TRUE
all.equal(lhs, rhs)
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
