### PR TITLE
Fix source marker formatting

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -852,6 +852,23 @@ struct SourceMarker
         showErrorList(showErrorList)
    {
    }
+
+   SourceMarker(Type type,
+                const core::FilePath& path,
+                int line,
+                int column,
+                const core::html_utils::HTML& message,
+                bool showErrorList,
+                bool isCustom)
+      : type(type),
+        path(path),
+        line(line),
+        column(column),
+        message(message),
+        showErrorList(showErrorList),
+        isCustom(isCustom)
+   {
+   }
    
    explicit operator bool() const
    {
@@ -864,6 +881,7 @@ struct SourceMarker
    int column;
    core::html_utils::HTML message;
    bool showErrorList;
+   bool isCustom;
 };
 
 SourceMarker::Type sourceMarkerTypeFromString(const std::string& type);
@@ -882,6 +900,15 @@ struct SourceMarkerSet
    }
 
    SourceMarkerSet(const std::string& name,
+                   const std::vector<SourceMarker>& markers,
+                   bool isDiagnostics)
+      : name(name),
+        markers(markers),
+        isDiagnostics(isDiagnostics)
+   {
+   }
+
+   SourceMarkerSet(const std::string& name,
                    const core::FilePath& basePath,
                    const std::vector<SourceMarker>& markers)
       : name(name),
@@ -890,11 +917,23 @@ struct SourceMarkerSet
    {
    }
 
+   SourceMarkerSet(const std::string& name,
+                   const core::FilePath& basePath,
+                   const std::vector<SourceMarker>& markers,
+                   bool isDiagnostics)
+      : name(name),
+        basePath(basePath),
+        markers(markers),
+        isDiagnostics(isDiagnostics)
+   {
+   }
+
    bool empty() const { return name.empty(); }
 
    std::string name;
    core::FilePath basePath;
    std::vector<SourceMarker> markers;
+   bool isDiagnostics;
 };
 
 enum MarkerAutoSelect

--- a/src/cpp/session/modules/SessionDiagnostics.R
+++ b/src/cpp/session/modules/SessionDiagnostics.R
@@ -84,7 +84,8 @@
    .rs.api.sourceMarkers(
       name = "Diagnostics",
       markers = markers,
-      basePath = .rs.getProjectDirectory()
+      basePath = .rs.getProjectDirectory(),
+      isDiagnostics = true
    )
 })
 

--- a/src/cpp/session/modules/SessionDiagnostics.cpp
+++ b/src/cpp/session/modules/SessionDiagnostics.cpp
@@ -751,7 +751,7 @@ module_context::SourceMarkerSet asSourceMarkerSet(const LintItems& items,
                            core::html_utils::HTML(item.message),
                            true));
    }
-   return SourceMarkerSet("Diagnostics", markers);
+   return SourceMarkerSet("Diagnostics", markers, true);
 }
 
 module_context::SourceMarkerSet asSourceMarkerSet(
@@ -777,7 +777,7 @@ module_context::SourceMarkerSet asSourceMarkerSet(
       }
    }
    
-   return SourceMarkerSet("Diagnostics", markers);
+   return SourceMarkerSet("Diagnostics", markers, true);
 }
 
 Error lintRSourceDocument(const json::JsonRpcRequest& request,

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -110,6 +110,11 @@ public class VirtualConsole
       virtualizedDisableOverride_ = override;
    }
 
+   public void setPreserveHTML(boolean preserveHTML)
+   {
+      preserveHTML_ = preserveHTML;
+   }
+
    public boolean isVirtualized()
    {
       return !virtualizedDisableOverride_ && prefs_.limitConsoleVisible() && parent_ != null;
@@ -248,7 +253,7 @@ public class VirtualConsole
       else
       {
          // create a new output range with this class
-         final ClassRange newRange = new ClassRange(cursor_, clazz, text);
+         final ClassRange newRange = new ClassRange(cursor_, clazz, text, preserveHTML_);
          appendChild(newRange.element);
          class_.put(cursor_, newRange);
       }
@@ -401,7 +406,8 @@ public class VirtualConsole
                ClassRange remainder = new ClassRange(
                      end,
                      overlap.clazz,
-                     text.substring((text.length() - (amountTrimmed - range.length))));
+                     text.substring((text.length() - (amountTrimmed - range.length))),
+                       preserveHTML_);
                insertions.add(remainder);
                if (parent_ != null)
                   range.element.getParentElement().insertAfter(remainder.element, range.element);
@@ -462,7 +468,7 @@ public class VirtualConsole
          if (cursor_ == output_.length() && !class_.isEmpty())
             appendText(text, clazz, forceNewRange);
          else
-            insertText(new ClassRange(start, clazz, text));
+            insertText(new ClassRange(start, clazz, text, preserveHTML_));
       }
 
       output_.replace(start, end, text);
@@ -697,39 +703,52 @@ public class VirtualConsole
    }
    private class ClassRange
    {
-      public ClassRange(int pos, String className, String text)
+      public ClassRange(int pos, String className, String text, boolean isHTML)
       {
          clazz  = className;
          start = pos;
          length = text.length();
          element = Document.get().createSpanElement();
+         isHTML_ = isHTML;
          if (className != null)
             element.addClassName(clazz);
-         element.setInnerText(text);
+         setText(text);
 
          if (captureNewElements_)
             newElements_.add(element);
+      }
+
+      private void setText(String text)
+      {
+         if (isHTML_)
+         {
+            element.setInnerHTML(text);
+         }
+         else
+         {
+            element.setInnerText(text);
+         }
       }
 
       public void trimLeft(int delta)
       {
          length -= delta;
          start += delta;
-         element.setInnerText(element.getInnerText().substring(delta));
+         setText(element.getInnerText().substring(delta));
       }
 
       public void trimRight(int delta)
       {
          length -= delta;
          String text = element.getInnerText();
-         element.setInnerText(text.substring(0, text.length() - delta));
+         setText(text.substring(0, text.length() - delta));
       }
 
       public void appendLeft(String content, int delta)
       {
          length += content.length() - delta;
          start -= (content.length() - delta);
-         element.setInnerText(content +
+         setText(content +
                element.getInnerText().substring(delta));
       }
 
@@ -737,21 +756,21 @@ public class VirtualConsole
       {
          length += content.length() - delta;
          String text = text();
-         element.setInnerText(text.substring(0,
+         setText(text.substring(0,
                text.length() - delta) + content);
       }
 
       public void overwrite(String content, int pos)
       {
          String text = element.getInnerText();
-         element.setInnerText(
+         setText(
                text.substring(0, pos) + content +
                text.substring(pos + content.length()));
       }
 
       public String text()
       {
-         return element.getInnerText();
+         return isHTML_ ? element.getInnerHTML() : element.getInnerText();
       }
 
       public void clearText()
@@ -769,12 +788,16 @@ public class VirtualConsole
       public int length;
       public int start;
       public final SpanElement element;
+      private boolean isHTML_;
    }
 
    private static final Pattern CONTROL = Pattern.create("[\r\b\f\n]");
 
    // only a select few panes should be virtualized. default it to off everywhere.
    private boolean virtualizedDisableOverride_ = true;
+
+   // allows &entity_name; entities like &amp;
+   private boolean preserveHTML_ = false;
 
    private final StringBuilder output_ = new StringBuilder();
    private final TreeMap<Integer, ClassRange> class_ = new TreeMap<>();

--- a/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerItemCodec.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/sourcemarkers/SourceMarkerItemCodec.java
@@ -98,6 +98,7 @@ public class SourceMarkerItemCodec
       tdMsg.setClassName(resources_.styles().messageCell());
 
       VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(tdMsg);
+      vc.setPreserveHTML(true);
       vc.submit(entry.getMessage());
 
       tr.appendChild(tdMsg);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -17,8 +17,6 @@ package org.rstudio.studio.client.workbench.views.output.lint;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.DivElement;
-import com.google.gwt.dom.client.Document;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
@@ -27,7 +25,6 @@ import com.google.inject.Inject;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.Invalidation;
 import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.RetinaStyleInjector;
@@ -369,17 +366,6 @@ public class LintManager
       }
       else
          finalLint = lint;
-
-      for (int i = 0; i < finalLint.length(); i++) {
-         LintItem lintItem = finalLint.get(i);
-         DivElement element = Document.get().createDivElement();
-         VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(element);
-
-         vc.submit(lintItem.getText());
-         String renderedText = element.getInnerHTML();
-
-         lintItem.setText(renderedText);
-      }
 
       if (spellcheck && userPrefs_.realTimeSpellchecking().getValue())
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
@@ -15,7 +15,11 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 import com.google.gwt.core.client.JsArray;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Command;
+import org.rstudio.core.client.VirtualConsole;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
 import org.rstudio.studio.client.workbench.views.output.lint.model.LintSource;
@@ -92,6 +96,18 @@ public class TextEditingTargetLintSource implements LintSource
       }
       else
       {
+         for (int i = 0; i < lint.length(); i++) {
+            LintItem lintItem = lint.get(i);
+            DivElement element = Document.get().createDivElement();
+            VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(element);
+
+            vc.setPreserveHTML(true);
+            vc.submit(lintItem.getText());
+            String renderedText = element.getInnerHTML();
+
+            lintItem.setText(renderedText);
+         }
+
          target_.getDocDisplay().showLint(lint);
       }
    }


### PR DESCRIPTION
### Intent
Fixes #10430 and #10062

The gutter would show duplicate issues and the duplicate would be incorrectly formatted. RMarkdown files in visual mode literally rendered the HTML in the tooltip. The issues would manifest after code diagnostics had run and the R session was restarted.

### Approach
For duplicate gutter issues, this came from adding the custom source markers to the gutter. Code diagnostics already had the issues and they would be added a second time to the lint result. Adding a flag to the marker set that it is a diagnostic issue allows a check to prevent adding it to lint items returned.

For the formatting issues with tooltips, a flag was added to `VirtualConsole` to render the text as HTML. This allowed the HTML entities to show up properly in the tooltips. If the source editor was in visual mode then it would not apply any formatting since the tooltip sets the text using a `title` attribute.

The session restart wrote the source markers to file so they could be reloaded. The file now writes the marker set flag that indicates the markers are diagnostic issues. Upon read, it sets the flag again so the linter can only retrieve the custom source markers.

### Automated Tests
An existing test covers the visual mode tooltip.

### QA Notes
See #10430 for reproduction steps.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


