### PR TITLE
ensure server GWT modules can serve desktop UI

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudioServer.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioServer.gwt.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN" "http://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+
+<!--
+   While this module is used for compilation of RStudio Server, it also
+   needs to be able to serve the front-end for RStudio Desktop, for remote
+   desktop configurations. For that reason, we don't try to explicitly set
+   'rstudio.desktop' or 'rstudio.electron' below.
+-->
+
 <module rename-to="rstudio">
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
-   <set-property name="rstudio.desktop" value="false"/>
-   <set-property name="rstudio.electron" value="false"/>
 </module>

--- a/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudioSuperDevMode.gwt.xml
@@ -1,10 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.8.2//EN" "http://www.gwtproject.org/doctype/2.9.0/gwt-module.dtd">
+
+<!--
+   While this module is used for compilation of RStudio Server, it also
+   needs to be able to serve the front-end for RStudio Desktop, for remote
+   desktop configurations. For that reason, we don't try to explicitly set
+   'rstudio.desktop' or 'rstudio.electron' below.
+-->
+
 <module rename-to="rstudio">
    <inherits name="org.rstudio.studio.RStudio" />
    <set-property name="compiler.stackMode" value="native"/>
-   <set-property name="rstudio.desktop" value="false"/>
-   <set-property name="rstudio.electron" value="false"/>
    <set-property name="user.agent" value="safari"/>
    <!-- dev language for i18n development -->
    <extend-property name="locale" values="dev"/>


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3248.

### Approach

Ensure that the server GWT module contains a copy of the desktop sources, so they can be served in remote desktop configurations.

### Automated Tests

N/A

### QA Notes

N/A 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
