### PR TITLE
make-package.bat options cleanup

### DIFF
--- a/package/win32/clean-build.bat
+++ b/package/win32/clean-build.bat
@@ -1,11 +1,6 @@
+@echo off
 
-rmdir /s /q build 
-cd ..\..\src\gwt
+if exist build rmdir /s /q build 
+pushd ..\..\src\gwt
 ant clean 
-
-
-
-
-
-
-
+popd

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -8,9 +8,13 @@ if "%CMAKE_BUILD_TYPE%" == "Debug" set WIN32_BUILD_PATH=build32-debug
 set INSTALL_PATH=%1
 if "%INSTALL_PATH%" == "" set INSTALL_PATH=..\..\..\src\qtcreator-build\session
 
-if "%2" == "clean" rmdir /s /q %WIN32_BUILD_PATH%
+for %%A in (%*) do (
+      if /I "%%A" == "clean" set CLEANBUILD=1
+)
 
-setlocal
+if defined CLEANBUILD (
+      if exist %WIN32_BUILD_PATH% rmdir /s /q %WIN32_BUILD_PATH%
+)
 
 REM perform 32-bit build
 mkdir %WIN32_BUILD_PATH%


### PR DESCRIPTION
### Intent

Small tweaks to the make-package.bat (and related) scripts for building Windows packages. A prelude to work to enable building Electron packages on Windows.

### Approach

- make-package.bat now shows usage via "/?", "--help", or "-h".
- added `nogwt` option to skip rebuilding GWT (handy for testing changes to make-package)
- added `electron` option to specify RSTUDIO_TARGET=Electron (actual build NYI)
- small tweaks to the clean-build.bat script to avoid a "The system cannot find the file specified." message if run on an already clean environment, and to restore the cwd when done

### Automated Tests

None, this is purely build stuff. I did run a local `make-package clean` and confirmed it worked.

### QA Notes

Build tooling.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


