### PR TITLE
Fix blank recent file/project menu items in Electron

### DIFF
--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -234,7 +234,8 @@ void MenuCallback::addCommand(QString commandId,
                               QString label,
                               QString tooltip,
                               QString shortcut,
-                              bool checkable)
+                              bool checkable,
+                              bool isVisible)
 {
 
    adjustShortcutForPlatform(&shortcut);
@@ -292,6 +293,7 @@ void MenuCallback::addCommand(QString commandId,
       pAction->setToolTip(tooltip);
       if (checkable)
          pAction->setCheckable(true);
+      pAction->setVisible(isVisible);
 
       auto* pBinder = new MenuActionBinder(menuStack_.top(), pAction);
       connect(pBinder, SIGNAL(manageCommand(QString, QAction*)),

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -45,7 +45,8 @@ public Q_SLOTS:
                     QString label,
                     QString tooltip,
                     QString shortcut,
-                    bool isCheckable);
+                    bool isCheckable,
+                    bool isVisible);
     void addSeparator();
     void endMenu();
     void endMainMenu();

--- a/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
+++ b/src/gwt/src/org/rstudio/core/client/command/impl/DesktopMenuCallback.java
@@ -39,15 +39,17 @@ public class DesktopMenuCallback implements MenuCallback
                  StringUtil.notNull(command.getMenuLabel(true)),
                  StringUtil.notNull(command.getTooltip()),
                  StringUtil.notNull(command.getShortcutRaw()),
-                 command.isCheckable());
+                 command.isCheckable(),
+                 command.isVisible());
    }
 
    private native void addCommand(String cmdId,
                                   String label,
                                   String tooltip,
                                   String shortcut,
-                                  boolean isCheckable) /*-{
-      $wnd.desktopMenuCallback.addCommand(cmdId, label, tooltip, shortcut, isCheckable);
+                                  boolean isCheckable,
+                                  boolean isVisible) /*-{
+      $wnd.desktopMenuCallback.addCommand(cmdId, label, tooltip, shortcut, isCheckable, isVisible);
    }-*/;
 
    public native final void addSeparator() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.DuplicateHelper;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.command.CommandHandler;
+import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.widget.OperationWithInput;
 
 import java.util.*;
@@ -128,6 +129,7 @@ public class MRUList
       if (hideClearOnEmpty_)
          clearCommand_.setVisible(clearCommand_.isEnabled());
       manageCommands(mruEntries_, mruCmds_);
+      DesktopMenuCallback.commitCommandShortcuts();
    }
 
    protected void manageCommands(List<String> entries, AppCommand[] commands)

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -112,8 +112,16 @@ export class MenuCallback extends EventEmitter {
 
     ipcMain.on(
       'menu_add_command',
-      (event, cmdId: string, label: string, tooltip: string, shortcut: string, checkable: boolean) => {
-        this.addCommand(cmdId, label, tooltip, shortcut, checkable);
+      (
+        event,
+        cmdId: string,
+        label: string,
+        tooltip: string,
+        shortcut: string,
+        checkable: boolean,
+        visible: boolean,
+      ) => {
+        this.addCommand(cmdId, label, tooltip, shortcut, checkable, visible);
       },
     );
 
@@ -279,7 +287,14 @@ export class MenuCallback extends EventEmitter {
     Menu.setApplicationMenu(this.mainMenu);
   }
 
-  addCommand(cmdId: string, label: string, tooltip: string, shortcut: string, checkable: boolean): void {
+  addCommand(
+    cmdId: string,
+    label: string,
+    tooltip: string,
+    shortcut: string,
+    checkable: boolean,
+    visible: boolean,
+  ): void {
     const menuItemOpts: MenuItemConstructorOptions = {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       label: label,
@@ -295,6 +310,7 @@ export class MenuCallback extends EventEmitter {
     if (shortcut.length > 0) {
       menuItemOpts.accelerator = this.convertShortcut(shortcut);
     }
+    menuItemOpts.visible = visible;
 
     // some shortcuts (namely, the Edit shortcuts) don't have bindings on the client side.
     // populate those here when discovered

--- a/src/node/desktop/src/renderer/menu-bridge.ts
+++ b/src/node/desktop/src/renderer/menu-bridge.ts
@@ -26,8 +26,15 @@ export function getMenuBridge() {
       ipcRenderer.send('menu_begin', label);
     },
 
-    addCommand: (cmdId: string, label: string, tooltip: string, shortcut: string, isChecked: boolean) => {
-      ipcRenderer.send('menu_add_command', cmdId, label, tooltip, shortcut, isChecked);
+    addCommand: (
+      cmdId: string,
+      label: string,
+      tooltip: string,
+      shortcut: string,
+      isChecked: boolean,
+      isVisible: boolean,
+    ) => {
+      ipcRenderer.send('menu_add_command', cmdId, label, tooltip, shortcut, isChecked, isVisible);
     },
 
     addSeparator: () => {


### PR DESCRIPTION
### Intent
Fixes the blank menu items in the recent files/projects submenus.

### Approach
Electron creates menu items visible by default and the GWT commands for the recent items are not visible to start. The `addCommand` to `DesktopMenuCallback` doesn't specify visibility so Electron and GWT are out-of-sync. Adding visibility to `addCommand` resolves the bug.

The changes to the C++ side is for compatibility with Qt RStudio.

### Automated Tests
I'd like to add some kind of automated test around this but an integrated test might not be possible. I'm getting familiar with the unit tests and thinking of a way that it could be verified.

### QA Notes
The recent items should update immediately when opening a file or project. The item order should also update when opening new files or projects. Clearing the list should clear immediately and restarting should still show a cleared list (if a project was already open, it would add that item back).

The Qt version could have an impact but there should be no change to how the recent items work.

All menu items should also behave the same as before. Visible menu items by default should still be visible.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


