### PR TITLE
alternate mechanism for R_ResetConsole on Windows

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -86,6 +86,9 @@ if(MSVC)
   # multi-process compilation
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
 
+  # incremental linking
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /INCREMENTAL")
+
   # silence some warnings (mostly out of our control) + set debug level
   add_definitions(
     -D_CRT_NONSTDC_NO_DEPRECATE

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -319,7 +319,17 @@ add_definitions(-DRSTUDIO_BOOST_SIGNALS_VERSION=2)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 if(NOT DEFINED RSTUDIO_CRASHPAD_ENABLED)
-   
+
+   # linking of crashpad relies on link-time code generation (/LTCG),
+   # which precludes the use of incremental linking (/INCREMENTAL). this implies
+   # that, when crashpad is enabled, incremental re-builds of RStudio
+   # will be very slow, because RStudio is built as a giant static executable.
+   # for that reason, we disable crashpad by default in development builds
+   if(WIN32 AND NOT RSTUDIO_PACKAGE_BUILD)
+      message(STATUS "Crashpad disabled by default in Windows development builds")
+      set(RSTUDIO_CRASHPAD_ENABLED FALSE)
+    endif()
+
    if(APPLE AND UNAME_M STREQUAL arm64)
       message(STATUS "Crashpad not yet supported on M1 macOS machines; disabling Crashpad")
       set(RSTUDIO_CRASHPAD_ENABLED FALSE)

--- a/src/cpp/core/include/core/system/LibraryLoader.hpp
+++ b/src/cpp/core/include/core/system/LibraryLoader.hpp
@@ -18,17 +18,61 @@
 
 #include <string>
 
+#include <boost/noncopyable.hpp>
+
+#include <shared_core/Error.hpp>
+
+#include <core/Log.hpp>
+
 namespace rstudio {
 namespace core {
 
-class Error;
-
 namespace system {
 
-Error loadLibrary(const std::string& libPath, void** ppLib);
-Error verifyLibrary(const std::string& libPath);
-Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol);
-Error closeLibrary(void* pLib);
+core::Error loadLibrary(const std::string& libPath, void** ppLib);
+core::Error verifyLibrary(const std::string& libPath);
+core::Error loadSymbol(void* pLib, const std::string& name, void** ppSymbol);
+core::Error closeLibrary(void* pLib);
+
+class Library : boost::noncopyable
+{
+public:
+
+   explicit Library(const std::string& library)
+      : pLib_(nullptr)
+   {
+      core::Error error = loadLibrary(library, &pLib_);
+      if (error)
+         LOG_ERROR(error);
+   }
+
+   ~Library()
+   {
+      try
+      {
+         if (pLib_)
+         {
+            core::Error error = closeLibrary(pLib_);
+            if (error)
+               LOG_ERROR(error);
+         }
+      }
+      catch (...)
+      {
+
+      }
+   }
+
+   operator void*() const
+   {
+      return pLib_;
+   }
+
+private:
+   void* pLib_;
+};
+
+
 
 } // namespace system
 } // namespace core

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -301,7 +301,9 @@ void runEmbeddedR(const core::FilePath& rHome,
       if (rLibrary != nullptr)
       {
          // added with R 4.2.0
-         setHook(rLibrary, "ptr_R_ResetConsole", callbacks.resetConsole);
+         Error error = setHook(rLibrary, "ptr_R_ResetConsole", callbacks.resetConsole);
+         if (error)
+            LOG_ERROR(error);
       }
    }
 

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -301,9 +301,7 @@ void runEmbeddedR(const core::FilePath& rHome,
       if (rLibrary != nullptr)
       {
          // added with R 4.2.0
-         Error error = setHook(rLibrary, "ptr_R_ResetConsole", callbacks.resetConsole);
-         if (error)
-            LOG_ERROR(error);
+         setHook(rLibrary, "ptr_R_ResetConsole", callbacks.resetConsole);
       }
    }
 


### PR DESCRIPTION
### Intent

R Core is currently exploring an alternate mechanism for introducing the R_ResetConsole hook on Windows; in particular, a change that would be binary-compatible with previous releases of R.

This PR supports the use of the `ptr_R_ResetConsole` hook when available on Windows.

It also bundles some changes to speed up incremental compilation of RStudio in development builds on Windows. In particular, linking to crashpad required compile time code generation, which precludes the use of incremental linking.

### Approach

Because we can't rely on this hook being available with older versions of R, we instead dynamically load and set the symbol when initializing R.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


