### PR TITLE
Verify group membership before dropping privileges

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2461,10 +2461,18 @@ Error temporarilyDropPriv(const std::string& newUsername,
    boost::optional<GidType> groupOpt;
    if (!newGroupname.empty())
    {
+      // verify that the user is a member of the provided group
+      bool belongs = false;
+      userBelongsToGroup(user, newGroupname, &belongs);
+
+      if (!belongs)
+         return systemError(boost::system::errc::permission_denied, ERROR_LOCATION);
+
       group::Group group;
       error = group::groupFromName(newGroupname, &group);
       if (error)
          return error;
+
       groupOpt = group.groupId;
    }
 
@@ -2503,10 +2511,18 @@ Error permanentlyDropPriv(const std::string& newUsername, const std::string& new
    boost::optional<GidType> groupOpt;
    if (!newGroupname.empty())
    {
+      // verify that the user is a member of the provided group
+      bool belongs = false;
+      userBelongsToGroup(user, newGroupname, &belongs);
+
+      if (!belongs)
+         return systemError(boost::system::errc::permission_denied, ERROR_LOCATION);
+
       group::Group group;
       error = group::groupFromName(newGroupname, &group);
       if (error)
          return error;
+
       groupOpt = group.groupId;
    }
 
@@ -2580,10 +2596,18 @@ Error permanentlyDropPriv(const std::string& newUsername, const std::string& new
    boost::optional<GidType> groupOpt;
    if (!newGroupname.empty())
    {
+      // verify that the user is a member of the provided group
+      bool belongs = false;
+      userBelongsToGroup(user, newGroupname, &belongs);
+
+      if (!belongs)
+         return systemError(boost::system::errc::permission_denied, ERROR_LOCATION);
+
       group::Group group;
       error = group::groupFromName(newGroupname, &group);
       if (error)
          return error;
+
       groupOpt = group.groupId;
    }
 


### PR DESCRIPTION
### Intent

OS companion for https://github.com/rstudio/rstudio-pro/pull/3240

### Approach

The OS side of the changes for the PR above.

### Automated Tests

There were changes automated

### QA Notes

The feature is not directly used by Workbench at this point

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


