### PR TITLE
Unit tests for Electron recent item menus

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -77,37 +77,11 @@ export class MenuCallback extends EventEmitter {
   constructor() {
     super();
     ipcMain.on('menu_begin_main', () => {
-      this.mainMenu = new Menu();
-      if (process.platform === 'darwin') {
-        this.mainMenu.append(new MenuItem({ role: 'appMenu' }));
-      }
+      this.beginMain();
     });
 
     ipcMain.on('menu_begin', (event, label: string) => {
-      const subMenu = new Menu();
-      const opts: MenuItemConstructorOptions = { submenu: subMenu, label: label, id: menuIdFromLabel(label) };
-      if (label === '&File') {
-        opts.role = 'fileMenu';
-      } else if (label === '&Edit') {
-        opts.role = 'editMenu';
-      } else if (label === '&View') {
-        opts.role = 'viewMenu';
-      } else if (label === '&Help') {
-        opts.role = 'help';
-      } else if (label === '&Tools') {
-        this.lastWasTools = true;
-      } else if (label === 'Dia&gnostics') {
-        this.lastWasDiagnostics = true;
-      }
-
-      const menuItem = new MenuItem(opts);
-      this.menuItemTemplates.set(menuItem, opts);
-      if (this.menuStack.length == 0) {
-        this.mainMenu?.append(menuItem);
-      } else {
-        this.addToCurrentMenu(menuItem);
-      }
-      this.menuStack.push(subMenu);
+      this.menuBegin(label);
     });
 
     ipcMain.on(
@@ -230,6 +204,40 @@ export class MenuCallback extends EventEmitter {
       this.updateMenus(Array.from(this.setShortcutQueue.values()));
       this.setShortcutQueue.clear();
     });
+  }
+
+  beginMain(): void {
+    this.mainMenu = new Menu();
+    if (process.platform === 'darwin') {
+      this.mainMenu.append(new MenuItem({ role: 'appMenu' }));
+    }
+  }
+
+  menuBegin(label: string): void {
+    const subMenu = new Menu();
+    const opts: MenuItemConstructorOptions = { submenu: subMenu, label: label, id: menuIdFromLabel(label) };
+    if (label === '&File') {
+      opts.role = 'fileMenu';
+    } else if (label === '&Edit') {
+      opts.role = 'editMenu';
+    } else if (label === '&View') {
+      opts.role = 'viewMenu';
+    } else if (label === '&Help') {
+      opts.role = 'help';
+    } else if (label === '&Tools') {
+      this.lastWasTools = true;
+    } else if (label === 'Dia&gnostics') {
+      this.lastWasDiagnostics = true;
+    }
+
+    const menuItem = new MenuItem(opts);
+    this.menuItemTemplates.set(menuItem, opts);
+    if (this.menuStack.length == 0) {
+      this.mainMenu?.append(menuItem);
+    } else {
+      this.addToCurrentMenu(menuItem);
+    }
+    this.menuStack.push(subMenu);
   }
 
   /**

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -13,14 +13,52 @@
  *
  */
 
-import { describe } from 'mocha';
 import { assert } from 'chai';
-
+import { describe } from 'mocha';
 import { MenuCallback } from '../../../src/main/menu-callback';
 
 describe('MenuCallback', () => {
   it('can be constructed', () => {
     const callback = new MenuCallback();
     assert.isObject(callback);
+  });
+
+  it('can add a command', () => {
+    const callback = new MenuCallback();
+    callback.addCommand('a_new_command', 'Test Command', '', 'Cmd+Shift+T', false, true);
+    assert.isObject(callback.getMenuItemById('a_new_command'));
+  });
+
+  it('can set initial visibility for command', () => {
+    const callback = new MenuCallback();
+
+    callback.addCommand('an_invisible_command', 'Invisible Command', '', 'Cmd+Shift+I', false, false);
+    callback.addCommand('a_visible_command', 'Visible Command', '', 'Cmd+Shift+V', false, true);
+
+    const invisibleCommand = callback.getMenuItemById('an_invisible_command');
+    const visibleCommand = callback.getMenuItemById('a_visible_command');
+
+    assert.isObject(invisibleCommand);
+    assert.isObject(visibleCommand);
+    assert.isFalse(invisibleCommand?.visible, 'expected menu item to be invisible');
+    assert.isTrue(visibleCommand?.visible, 'expected menu item to be visible');
+  });
+
+  it('can update command', () => {
+    const callback = new MenuCallback();
+    callback.beginMain();
+    callback.menuBegin('&File');
+    callback.addCommand('a_command', 'Command', '', '', false, true);
+    
+    const command = callback.getMenuItemById('a_command');
+    assert.isObject(command);
+    assert.strictEqual(command?.label, 'Command');
+    
+    callback.updateMenus([{id: 'a_command', label: 'New Label', visible: false, checked: true}]);
+    
+    const updatedCommand = callback.getMenuItemById('a_command');
+    assert.strictEqual(updatedCommand?.label, 'New Label');
+    assert.isFalse(updatedCommand?.visible);
+    assert.isTrue(updatedCommand?.checked);
   });
 });


### PR DESCRIPTION
### Intent
A couple of tests to cover that `menu-callback` can set the initial command visibility and that command properties are updated.

### Approach
Moved the event handling code to its own function so it can be called in the unit test. This allows proper initialization of the menu so it can be updated.

### Automated Tests
Tests that a command can be added, visibility set, and updated.

### QA Notes
Code was refactored so nothing different in behaviour. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


