### PR TITLE
Fix Electron recent menu items

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/MRUList.java
@@ -19,7 +19,9 @@ import org.rstudio.core.client.DuplicateHelper;
 import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.command.AppMenuItem;
 import org.rstudio.core.client.command.CommandHandler;
+import org.rstudio.core.client.command.impl.DesktopMenuCallback;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.application.Desktop;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -129,6 +131,10 @@ public class MRUList
       if (hideClearOnEmpty_)
          clearCommand_.setVisible(clearCommand_.isEnabled());
       manageCommands(mruEntries_, mruCmds_);
+      if (Desktop.hasDesktopFrame())
+      {
+         DesktopMenuCallback.commitCommandShortcuts();
+      }
    }
 
    protected void manageCommands(List<String> entries, AppCommand[] commands)


### PR DESCRIPTION
### Intent
Fix the changes committed for #10445 that prevented the server from initializing the menus.

### Approach
Only use the `DesktopMenuCallback` if there's a desktop frame.

### Automated Tests
None

### QA Notes
Electron still updates after opening files and projects. This change addresses how updating commands needs to rebuild the Electron menus.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


