### PR TITLE
fix regression in C++ autocompletion

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -290,24 +290,25 @@ std::vector<std::string> parseCompilationResults(const std::string& results)
       if (regex_utils::search(line, re))
       {
          // extract compilation args
-         std::vector<std::string> args = extractCompileArgs(line);
-
-#ifdef _WIN32
-         // remove collision with built-in compilation arguments
-         // (we need to ensure system headers are included in the right order)
-         auto version = r::version_info::currentRVersion();
-         if (version.versionMajor() == 4 && version.versionMinor() >= 2)
-         {
-            for (auto&& arg : args)
-               if (arg.find("x86_64-w64-mingw32.static.posix") == std::string::npos)
-                  compileArgs.push_back(arg);
-         }
-#endif
-
+         compileArgs = extractCompileArgs(line);
+         
          // we found the compilation line; we're done parsing
          break;
       }
    }
+   
+#ifdef _WIN32
+   // remove collision with built-in compilation arguments
+   // (we need to ensure system headers are included in the right order)
+   auto version = r::version_info::currentRVersion();
+   if (version.versionMajor() == 4 && version.versionMinor() >= 2)
+   {
+      core::algorithm::expel_if(compileArgs, [](const std::string& arg)
+      {
+         return arg.find("x86_64-w64-mingw32.static.posix") != std::string::npos;
+      });
+   }
+#endif
 
    if (verbose(3))
    {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10514. Regressed in https://github.com/rstudio/rstudio/pull/10343.

### Approach

Fixes a regression that unfortunately snuck in when I was working on getting Windows C++ autocompletion up and running. 

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
