### PR TITLE
revert use of UTF-8 code page on Windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ properties([
                               artifactNumToKeepStr: '',
                               daysToKeepStr: '',
                               numToKeepStr: '100')),
-    parameters([string(name: 'RSTUDIO_VERSION_PATCH', defaultValue: '2', description: 'RStudio Patch Version'),
+    parameters([string(name: 'RSTUDIO_VERSION_PATCH', defaultValue: '3', description: 'RStudio Patch Version'),
                 string(name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.'),
                 string(name: 'OS_FILTER', defaultValue: '', description: 'Pattern to limit builds by matching OS'),
                 string(name: 'ARCH_FILTER', defaultValue: '', description: 'Pattern to limit builds by matching ARCH'),

--- a/src/cpp/session/rsession.exe.manifest
+++ b/src/cpp/session/rsession.exe.manifest
@@ -3,11 +3,6 @@
    <assemblyIdentity version="1.0.0.0"
       name="rsession"
       type="win32"/>
-   <application>
-     <windowsSettings>
-       <activeCodePage xmlns="http://schemas.microsoft.com/SMI/2019/WindowsSettings">UTF-8</activeCodePage>
-     </windowsSettings>
-   </application>
    <description>rsession</description>
    <!-- Identify the application security requirements. -->
    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10507. Either a candidate for a patch release for GO, or for PT.

### Approach

Unfortunately, telling RStudio to use a UTF-8 code page doesn't work as expected with older versions of R, which only support non-UTF-8 code pages. We need to revert that change, and reconsider enabling it for a future release.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
