### PR TITLE
Add Qmd to list of Common R source files

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -57,7 +57,7 @@
          <rw:FormListBox ui:field="listPresetFilePatterns_"
                     styleName="{style.presetFilePatterns}">
             <g:item value=""><ui:msg key="allFiles">All Files</ui:msg></g:item>
-            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.qmd, *.Qmd, *.md, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp"><ui:msg key="commonRSourceFiles">Common R source files (R, C/C++, Rnw, Rmd, Rhtml)</ui:msg></g:item>
+            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.qmd, *.Qmd, *.md, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp"><ui:msg key="commonRSourceFiles">Common source files (R, C/C++, Markdown, Rnw, Rhtml)</ui:msg></g:item>
             <g:item value="*.r, *.R"><ui:msg key="rScripts">R Scripts</ui:msg></g:item>
             <g:item value="packageSource"><ui:msg key="packageSources">Package Sources (R/ , src/)</ui:msg></g:item>
             <g:item value="packageTests"><ui:msg key="packageTests">Package Tests (tests/)</ui:msg></g:item>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.ui.xml
@@ -57,7 +57,7 @@
          <rw:FormListBox ui:field="listPresetFilePatterns_"
                     styleName="{style.presetFilePatterns}">
             <g:item value=""><ui:msg key="allFiles">All Files</ui:msg></g:item>
-            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.qmd, *.Qmd, *.md, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp"><ui:msg key="commonRSourceFiles">Common source files (R, C/C++, Markdown, Rnw, Rhtml)</ui:msg></g:item>
+            <g:item value="*.r, *.R, *.rnw, *.Rnw, *.rmd, *.Rmd, *.rmarkdown, *.Rmarkdown, *.qmd, *.Qmd, *.md, *.rhtml, *.Rhtml, *.h, *.hpp, *.c, *.cpp, *.js, *.yml, *.yaml"><ui:msg key="commonSourceFiles">Common source files (R, C/C++, Markdown, Rnw, Rhtml, JS, YAML)</ui:msg></g:item>
             <g:item value="*.r, *.R"><ui:msg key="rScripts">R Scripts</ui:msg></g:item>
             <g:item value="packageSource"><ui:msg key="packageSources">Package Sources (R/ , src/)</ui:msg></g:item>
             <g:item value="packageTests"><ui:msg key="packageTests">Package Tests (tests/)</ui:msg></g:item>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
@@ -5,7 +5,7 @@ allFiles=All Files
 
 caseSensitiveText=Case sensitive
 
-commonRSourceFiles=Common source files (R, C/C++, Markdown, Rnw, Rhtml)
+commonSourceFiles=Common source files (R, C/C++, Markdown, Rnw, Rhtml, JS, YAML)
 
 customFilter=Custom Filter
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_en.properties
@@ -5,7 +5,7 @@ allFiles=All Files
 
 caseSensitiveText=Case sensitive
 
-commonRSourceFiles=Common R source files (R, C/C++, Rnw, Rmd, Rhtml)
+commonRSourceFiles=Common source files (R, C/C++, Markdown, Rnw, Rhtml)
 
 customFilter=Custom Filter
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
@@ -5,7 +5,7 @@ allFiles=Tous les fichiers
 
 caseSensitiveText=Sensible à la casse
 
-commonRSourceFiles=Fichiers sources courants (R, C/C++, Markdown, Rnw, Rhtml)
+commonSourceFiles=Fichiers sources courants (R, C/C++, Markdown, Rnw, Rhtml, JS, YAML)
 
 customFilter=Filtre personnalisé
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialogBinderImplGenMessages_fr.properties
@@ -5,7 +5,7 @@ allFiles=Tous les fichiers
 
 caseSensitiveText=Sensible à la casse
 
-commonRSourceFiles=Fichiers sources R courants (R, C/C++, Rnw, Rmd, Rhtml)
+commonRSourceFiles=Fichiers sources courants (R, C/C++, Markdown, Rnw, Rhtml)
 
 customFilter=Filtre personnalisé
 
@@ -23,7 +23,7 @@ packageSources=Sources des paquets (R/ , src/)
 
 packageTests=Tests du paquet (tests/)
 
-rScripts=Scripts R 
+rScripts=Scripts R
 
 regularExpressionText=Expression régulière
 


### PR DESCRIPTION
### Intent

Addresses #10469. Tweaked from "Common R source files" to "Common source files", replaced Rmd with Markdown (includes *.md, *.rmd, *.qmd), added yml/yaml and js as possible source files as well.