### PR TITLE
Don't use the global environment as the caller env for rs API functions

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -27,6 +27,15 @@ assign(".rs.toolsEnv", function()
    .rs.Env
 }, envir = .rs.Env)
 
+# target environment for symbol lookup, with all necessary base packages
+.rs.ApiEnv <- new.env(parent = as.environment("package:stats"))
+
+# allow access to api env from helper function
+assign(".rs.apiEnv", function()
+{
+   .rs.ApiEnv
+}, envir = .rs.ApiEnv)
+
 #' Add a function to the 'tools:rstudio' environment.
 #' 
 #' This environment is placed on the search path, and so is accessible and
@@ -62,7 +71,7 @@ assign(".rs.addFunction", function(name, FN, attrs = list(), envir = .rs.toolsEn
 # force helper function to also execute in tools environment
 environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 
-# add a global (non-scoped) variable to the tools:rstudio environment
+# add a glob    al (non-scoped) variable to the tools:rstudio environment
 .rs.addFunction("addGlobalVariable", function(name, var)
 {
    envir <- .rs.toolsEnv()
@@ -82,7 +91,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("addApiFunction", function(name, FN)
 {
    fullName <- paste("api.", name, sep = "")
-   .rs.addFunction(fullName, FN, envir = globalenv())
+   .rs.addFunction(fullName, FN, envir = .rs.ApiEnv)
 })
 
 .rs.addFunction("setVar", function(name, var)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -28,13 +28,10 @@ assign(".rs.toolsEnv", function()
 }, envir = .rs.Env)
 
 # target environment for symbol lookup, with all necessary base packages
-.rs.ApiEnv <- new.env(parent = as.environment("package:stats"))
-
-# allow access to api env from helper function
-assign(".rs.apiEnv", function()
+assign(".rs.symbolLookupEnv", function()
 {
-   .rs.ApiEnv
-}, envir = .rs.ApiEnv)
+   new.env(parent = .rs.toolsEnv())
+}, envir = .rs.Env)
 
 #' Add a function to the 'tools:rstudio' environment.
 #' 
@@ -91,7 +88,9 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 .rs.addFunction("addApiFunction", function(name, FN)
 {
    fullName <- paste("api.", name, sep = "")
-   .rs.addFunction(fullName, FN, envir = .rs.ApiEnv)
+   envir <- .rs.symbolLookupEnv()
+   environment(FN) <- envir
+   .rs.addFunction(fullName, FN, envir = envir)
 })
 
 .rs.addFunction("setVar", function(name, var)


### PR DESCRIPTION
### Intent

Addresses #8031. 

We use the globalenv() as the caller env for all .rs.api functions, which is not true of other internal .rs non-API functions.
This makes the behavior of these functions brittle, as whether they work properly or not can depend on what's in the user's global environment, and whether or not it masks a base function we might be relying on.

### Approach

Create a new environment for evaluation of .rs.api functions. This environment should have base packages like `base` and `stats` on its search path, but should not inherit from the global environment.