### PR TITLE
Fix duplicate menu separators

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -14,9 +14,9 @@ module.exports = {
     sourceType: 'module',
   },
 
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'prettier'],
 
-  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
+  extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
 
   rules: {
     'no-empty-function': 1, // will only show a warning

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -257,7 +257,7 @@ export class MenuCallback extends EventEmitter {
         const itemTemplate = this.menuItemTemplates.get(item);
         if (!itemTemplate) {
           // no itemTemplate found (separators, for example)
-          targetMenu.append(item);
+          this.addToMenu(targetMenu, item);
           continue;
         }
 
@@ -285,14 +285,33 @@ export class MenuCallback extends EventEmitter {
         }
 
         this.menuItemTemplates.set(newMenuItem, newItemTemplate);
-        targetMenu.append(newMenuItem);
+        this.addToMenu(targetMenu, newMenuItem);
       }
+
+      targetMenu.items = targetMenu.items.filter((item, idx, arr) => {
+        if (item.type !== 'separator') {
+          return true;
+        }
+        const prevItem = arr[idx - 1];
+        return (
+          idx !== 0 && // no separators at the top
+          prevItem.type !== 'separator' && // no consecutive separators
+          idx != arr.length - 1 // no separators at the bottom
+        );
+      });
     };
 
     recursiveCopy(mainMenu, newMenu);
     this.mainMenu = newMenu;
 
     Menu.setApplicationMenu(this.mainMenu);
+  }
+
+  addToMenu(menu: Menu, item: MenuItem) {
+    // invisible items are not added because it interferes with the separator logic
+    if (item.visible) {
+      menu.append(item);
+    }
   }
 
   addCommand(


### PR DESCRIPTION
### Intent
Addresses #9948 

Change the eslint config to address the errors about prettier at the top of every file.

### Approach
This uses similar logic to how Electron handles menu separators. The difference is that Electron only removes separators if they are at the beginning/end or the previous item is also a separator. Our menus have many hidden items so check doesn't work for us. Even not adding the hidden items still means the separators have to be marked as hidden.

I've added in a check to not add hidden items to menus. The caveat is shortcuts won't work for that command. Although, I don't see that as an issue since the item is likely hidden for a reason. The second part of the fix is using the same logic as Electron to filter out unnecessary separators.

This also runs on MacOS but has no difference since it already hides unnecessary separators. I think it's fine to leave in just in case that ever changes and to maintain the same code across all platforms.

### Automated Tests
Added unit tests:
* check that hidden items also remove any trailing separators
* check that separators at beginning/end are removed
* check that multiple separators in a row are condensed to one separator

Unit tests pass on all platforms

### QA Notes
The Build menu was most noticeable with this bug. Using Configure Build Tools to change the type will update the Build menu.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


