### PR TITLE
Add log rotation for Electron

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -73,6 +73,6 @@
     "line-reader": "0.4.0",
     "uuid": "8.3.2",
     "winston": "3.5.0",
-    "winston-daily-rotate-file": "^4.6.0"
+    "winston-daily-rotate-file": "4.6.0"
   }
 }

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -72,6 +72,7 @@
     "i18next": "21.6.10",
     "line-reader": "0.4.0",
     "uuid": "8.3.2",
-    "winston": "3.5.0"
+    "winston": "3.5.0",
+    "winston-daily-rotate-file": "^4.6.0"
   }
 }

--- a/src/node/desktop/src/core/winston-logger.ts
+++ b/src/node/desktop/src/core/winston-logger.ts
@@ -14,6 +14,7 @@
  */
 
 import winston from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
 
 import { getenv } from './environment';
 import { safeError } from './err';
@@ -30,7 +31,15 @@ export class WinstonLogger implements Logger {
     this.logger = winston.createLogger({ level: level });
 
     if (!logFile.isEmpty()) {
-      this.logger.add(new winston.transports.File({ filename: logFile.getAbsolutePath() }));
+      const logName = `${logFile.getStem()}.%DATE%${logFile.getExtension()}`;
+      this.logger.add(
+        new DailyRotateFile({
+          filename: logName,
+          dirname: logFile.getParent().getAbsolutePath(),
+          datePattern: 'YYYY-MM-DD',
+          frequency: '1d',
+        }),
+      );
     }
 
     // also log to console if stdout attached to a tty

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -7843,7 +7843,7 @@ wildcard@^2.0.0:
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
-winston-daily-rotate-file@^4.6.0:
+winston-daily-rotate-file@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.6.0.tgz#0295e5b11625e9ee670b0102a3ade3e9dd35ad73"
   integrity sha512-mvpFb1LYmTvh/vz0dIS/aDCwEm0cvDa8D/tE4xWwdUYolD250wf+n0y1PZ2xr7fbvTLF/PQYqXtFIFrmog03Ow==

--- a/src/node/desktop/yarn.lock
+++ b/src/node/desktop/yarn.lock
@@ -3323,6 +3323,13 @@ file-entry-cache@^6.0.1:
   dependencies:
     flat-cache "^3.0.4"
 
+file-stream-rotator@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz#007019e735b262bb6c6f0197e58e5c87cb96cec3"
+  integrity sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==
+  dependencies:
+    moment "^2.29.1"
+
 filename-reserved-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz#abf73dfab735d045440abfea2d91f389ebbfa229"
@@ -5263,6 +5270,11 @@ mocha@8.4.0, mocha@^8.4.0:
     yargs-parser "20.2.4"
     yargs-unparser "2.0.0"
 
+moment@^2.29.1:
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -5552,6 +5564,11 @@ object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.12.0"
@@ -7825,6 +7842,25 @@ wildcard@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
   integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
+
+winston-daily-rotate-file@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.6.0.tgz#0295e5b11625e9ee670b0102a3ade3e9dd35ad73"
+  integrity sha512-mvpFb1LYmTvh/vz0dIS/aDCwEm0cvDa8D/tE4xWwdUYolD250wf+n0y1PZ2xr7fbvTLF/PQYqXtFIFrmog03Ow==
+  dependencies:
+    file-stream-rotator "^0.6.1"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston-transport@^4.4.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
+  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
 
 winston-transport@^4.4.2:
   version "4.4.2"


### PR DESCRIPTION
### Intent
Addresses #10478 

Rotates logs daily and sets the log name to `rdesktop.2022-02-10.log`.

### Approach
The `winston-daily-rotate-file` package has some quirks to it. It only seems to write the log files with the date in the name. So there's no option to have `rdesktop.log` unless we use the symlink option. But that didn't work on Windows and MacOS/Linux can't create the symlink if `rdesktop.log` already exists. I didn't see an option to auto-rotate with incremental filenames either.

Setting a file size limit also didn't play well with the filename. It would rotate but didn't replace the date pattern with the actual date.

So I've settled on these options for consistency across the platforms. No symlinks because it only works on MacOS/Linux with no existing logs. No max file size because there's a bug in setting the filename (you get `rdesktop.%DATE%.log.1` instead of `rdesktop.2022-02-10.log.1`.

### Automated Tests
None

### QA Notes
It should behave the same across MacOS/Linux/Windows. It no longer writes to `rdesktop.log` but uses it as a template to include the date.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


