### PR TITLE
Tutorials pane wants shiny >= 1.6.0

### DIFF
--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -190,12 +190,32 @@ void handleTutorialRunRequest(const http::Request& request,
    pResponse->setFile(loadingPath, request);
 }
 
+bool haveMinimumShinyForTutorials() {
+   return module_context::isPackageVersionInstalled("shiny", "1.6.0");
+}
+
 void handleTutorialHomeRequest(const http::Request& request,
                                http::Response* pResponse)
 {
    using namespace string_utils;
    
    std::stringstream ss;
+
+   bool ok = haveMinimumShinyForTutorials();
+   if (!ok)
+   {
+      std::stringstream clickHere;
+      clickHere << "<a"
+                   << " aria-label\"Install learnr\""
+                   << " class=\"rstudio-tutorials-install-learnr-link\""
+                   << " href=\"javascript:void(0)\""
+                   << " onclick=\"window.parent.tutorialUpdateShiny(); return false;\">"
+                   << "click here"
+                   << "</a>";
+         
+      ss << "<p>Version 1.6.0 of the <code>shiny</code> package is required to run tutorials for RStudio.</p>"
+         << "<p>Please " << clickHere.str() << " to update the <code>shiny</code> package.</p>";
+   }
    
    if (tutorialIndex().empty())
    {
@@ -223,78 +243,81 @@ void handleTutorialHomeRequest(const http::Request& request,
       ss << "</div>";
    }
    
-   for (auto entry : tutorialIndex())
+   if (ok)
    {
-      std::string pkgName = entry.first;
-      std::vector<TutorialInfo> tutorials = entry.second;
-      if (tutorials.empty())
-         continue;
-
-      for (auto tutorial : tutorials)
+      for (auto entry : tutorialIndex())
       {
-         ss << "<div class=\"rstudio-tutorials-section\">";
-         
-         ss << "<div class=\"rstudio-tutorials-label-container\">";
-         
-         std::string title = (tutorial.title.empty())
-               ? "[Untitled tutorial]"
-               : htmlEscape(tutorial.title);
-         
-         ss << "<span role=\"heading\" aria-level=\"2\" class=\"rstudio-tutorials-label\">"
-            << title
-            << "</span>";
-         
-         ss << "<span class=\"rstudio-tutorials-run-container\">"
+         std::string pkgName = entry.first;
+         std::vector<TutorialInfo> tutorials = entry.second;
+         if (tutorials.empty())
+            continue;
+
+         for (auto tutorial : tutorials)
+         {
+            ss << "<div class=\"rstudio-tutorials-section\">";
             
-            << "<button"
-            << " class=\"rstudio-tutorials-run-button\""
-            << " aria-label=\"Start tutorial '" << htmlEscape(tutorial.name, true) << "' from package '" << htmlEscape(pkgName, true) << "'\""
-            << " onclick=\"window.parent.tutorialRun('" << htmlEscape(tutorial.name, true) << "', '" << htmlEscape(pkgName, true) << "')\""
-            << ">"
+            ss << "<div class=\"rstudio-tutorials-label-container\">";
+            
+            std::string title = (tutorial.title.empty())
+                  ? "[Untitled tutorial]"
+                  : htmlEscape(tutorial.title);
+            
+            ss << "<span role=\"heading\" aria-level=\"2\" class=\"rstudio-tutorials-label\">"
+               << title
+               << "</span>";
+            
+            ss << "<span class=\"rstudio-tutorials-run-container\">"
                
-            << "<span class=\"rstudio-tutorials-run-button-label\">Start Tutorial</span>"
-            << "<span class=\"rstudio-tutorials-run-button-icon\">&#x25b6</span>"
-            << "</button>"
-            << "</span>";
-         
-         ss << "</div>";
-         
-         ss << "<div class=\"rstudio-tutorials-sublabel\">"
-            << pkgName << ": " << htmlEscape(tutorial.name)
-            << "</div>";
-         
-         if (tutorial.description.empty())
-         {
-            ss << "<div class=\"rstudio-tutorials-description rstudio-tutorials-description-empty\">"
-               << "<p>[No description available.]</p>"
-               << "</div>";
-         }
-         else
-         {
-            std::string descriptionHtml;
-            Error error = core::markdown::markdownToHTML(
-                     tutorial.description,
-                     core::markdown::Extensions(),
-                     core::markdown::HTMLOptions(),
-                     &descriptionHtml);
+               << "<button"
+               << " class=\"rstudio-tutorials-run-button\""
+               << " aria-label=\"Start tutorial '" << htmlEscape(tutorial.name, true) << "' from package '" << htmlEscape(pkgName, true) << "'\""
+               << " onclick=\"window.parent.tutorialRun('" << htmlEscape(tutorial.name, true) << "', '" << htmlEscape(pkgName, true) << "')\""
+               << ">"
+                  
+               << "<span class=\"rstudio-tutorials-run-button-label\">Start Tutorial</span>"
+               << "<span class=\"rstudio-tutorials-run-button-icon\">&#x25b6</span>"
+               << "</button>"
+               << "</span>";
             
-            if (error)
+            ss << "</div>";
+            
+            ss << "<div class=\"rstudio-tutorials-sublabel\">"
+               << pkgName << ": " << htmlEscape(tutorial.name)
+               << "</div>";
+            
+            if (tutorial.description.empty())
             {
-               LOG_ERROR(error);
-               descriptionHtml = tutorial.description;
+               ss << "<div class=\"rstudio-tutorials-description rstudio-tutorials-description-empty\">"
+                  << "<p>[No description available.]</p>"
+                  << "</div>";
+            }
+            else
+            {
+               std::string descriptionHtml;
+               Error error = core::markdown::markdownToHTML(
+                        tutorial.description,
+                        core::markdown::Extensions(),
+                        core::markdown::HTMLOptions(),
+                        &descriptionHtml);
+               
+               if (error)
+               {
+                  LOG_ERROR(error);
+                  descriptionHtml = tutorial.description;
+               }
+               
+               ss << "<div class=\"rstudio-tutorials-description\">"
+                  << descriptionHtml
+                  << "</div>";
             }
             
-            ss << "<div class=\"rstudio-tutorials-description\">"
-               << descriptionHtml
-               << "</div>";
+            ss << "</div>";
+            
          }
          
-         ss << "</div>";
-         
       }
-      
    }
-   
+
    std::map<std::string, std::string> vars;
    
    std::string tutorialsHtml = ss.str();

--- a/src/cpp/session/modules/SessionTutorial.cpp
+++ b/src/cpp/session/modules/SessionTutorial.cpp
@@ -206,8 +206,8 @@ void handleTutorialHomeRequest(const http::Request& request,
    {
       std::stringstream clickHere;
       clickHere << "<a"
-                   << " aria-label\"Install learnr\""
-                   << " class=\"rstudio-tutorials-install-learnr-link\""
+                   << " aria-label\"Install shiny\""
+                   << " class=\"rstudio-tutorials-install-shiny-link\""
                    << " href=\"javascript:void(0)\""
                    << " onclick=\"window.parent.tutorialUpdateShiny(); return false;\">"
                    << "click here"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialConstants.java
@@ -80,4 +80,31 @@ public interface TutorialConstants extends com.google.gwt.i18n.client.Messages {
     @Key("installingLearnrCaption")
     String installingLearnrCaption();
 
+    /**
+     * Translated "Error installing shiny".
+     *
+     * @return translated "Error installing shiny"
+     */
+    @DefaultMessage("Error installing shiny")
+    @Key("errorInstallingShiny")
+    String errorInstallingShiny();
+
+    /**
+     * Translated "RStudio was unable to install the shiny package.".
+     *
+     * @return translated "RStudio was unable to install the shiny package."
+     */
+    @DefaultMessage("RStudio was unable to install the shiny package.")
+    @Key("errorInstallingShinyMessage")
+    String errorInstallingShinyMessage();
+
+    /**
+     * Translated "Installing shiny...".
+     *
+     * @return translated "Installing shiny..."
+     */
+    @DefaultMessage("Installing shiny...")
+    @Key("installingShinyCaption")
+    String installingShinyCaption();
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.css
@@ -29,6 +29,7 @@
 @external rstudio-tutorials-footer;
 @external rstudio-tutorials-footer-text;
 @external rstudio-tutorials-install-learnr-link;
+@external rstudio-tutorials-install-shiny-link;
 
 /* Scrollbars */
 
@@ -214,6 +215,10 @@
 }
 
 .rstudio-themes-dark-menus .rstudio-tutorials-install-learnr-link:link {
+   color: rgb(118, 171, 221);
+}
+
+.rstudio-themes-dark-menus .rstudio-tutorials-install-shiny-link:link {
    color: rgb(118, 171, 221);
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/tutorial/TutorialPane.java
@@ -382,6 +382,61 @@ public class TutorialPane
       return frame_.addHandler(handler, TutorialNavigateEvent.TYPE);
    }
 
+   private void updateShiny()
+   {
+      new ImmediatelyInvokedFunctionExpression()
+      {
+         private HandlerRegistration handler_;
+         private ProgressIndicator progress_;
+
+         private final String errorCaption = constants_.errorInstallingShiny();
+         private final String errorMessage =
+               constants_.errorInstallingShinyMessage();
+
+         @Override
+         protected void invoke()
+         {
+            // double-check that we were able to successfully install shiny
+            progress_ = globalDisplay_.getProgressIndicator(errorCaption);
+            handler_ = events_.addHandler(ConsolePromptEvent.TYPE, new ConsolePromptEvent.Handler()
+            {
+               @Override
+               public void onConsolePrompt(ConsolePromptEvent event)
+               {
+                  handler_.removeHandler();
+
+                  server_.isPackageInstalled("shiny", "1.6.0", new ServerRequestCallback<Boolean>()
+                  {
+                     @Override
+                     public void onResponseReceived(Boolean installed)
+                     {
+                        if (!installed)
+                        {
+                           progress_.onError(errorMessage);
+                           return;
+                        }
+
+                        progress_.onCompleted();
+                     }
+
+                     @Override
+                     public void onError(ServerError error)
+                     {
+                        Debug.logError(error);
+                        progress_.onError(errorMessage);
+                     }
+                  });
+               }
+            });
+
+            // fire console event installing learnr
+            progress_.onProgress(constants_.installingShinyCaption());
+            SendToConsoleEvent event = new SendToConsoleEvent("install.packages(\"shiny\")", true);
+            events_.fireEvent(event);
+         }
+      };
+   }
+
    private void installLearnr()
    {
       new ImmediatelyInvokedFunctionExpression()
@@ -450,6 +505,11 @@ public class TutorialPane
       $wnd.tutorialInstallLearnr = $entry(function() {
          self.@org.rstudio.studio.client.workbench.views.tutorial.TutorialPane::installLearnr()();
       });
+
+      $wnd.tutorialUpdateShiny = $entry(function() {
+         self.@org.rstudio.studio.client.workbench.views.tutorial.TutorialPane::updateShiny()();
+      });
+
 
    }-*/;
 


### PR DESCRIPTION
### Intent

adresses #10552

### Approach

When an older shiny is available, the tutorial pane shows: 

<img width="660" alt="image" src="https://user-images.githubusercontent.com/2625526/153445438-a24039bd-c6a1-4505-a262-05350f96153d.png">

The when clicked: 

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/2625526/153445538-ef26f7c0-a697-4e5e-99ff-270018f7126f.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


