### PR TITLE
Fix missing custom markers in gutter

### DIFF
--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -834,7 +834,8 @@ struct SourceMarker
    };
 
    SourceMarker()
-      : type(Empty)
+      : type(Empty),
+      isCustom(false)
    {
    }
 
@@ -849,7 +850,8 @@ struct SourceMarker
         line(line),
         column(column),
         message(message),
-        showErrorList(showErrorList)
+        showErrorList(showErrorList),
+        isCustom(false)
    {
    }
 
@@ -895,7 +897,8 @@ struct SourceMarkerSet
    SourceMarkerSet(const std::string& name,
                    const std::vector<SourceMarker>& markers)
       : name(name),
-        markers(markers)
+        markers(markers),
+        isDiagnostics(false)
    {
    }
 
@@ -913,7 +916,8 @@ struct SourceMarkerSet
                    const std::vector<SourceMarker>& markers)
       : name(name),
         basePath(basePath),
-        markers(markers)
+        markers(markers),
+        isDiagnostics(false)
    {
    }
 


### PR DESCRIPTION
### Intent
Addresses #10062 
Custom source markers wouldn't show in the editor's gutter.

### Approach
The `isDiagnostics` flag wasn't initialized for `SourceMarkerSet` so some instances worked but others did not. Setting an initial value fixed the issue. I've also set an initial value for `isCustom` in `SourceMarker` where I had added a flag to distinguish customer source markers so that on the GWT side it can choose the correct way to render the content.

### Automated Tests
None

### QA Notes
I was only able to reproduce using a packaged build and with x86 R.

* Clear any custom source marker sets
* Use RS API to add source markers
* Go to one of the files and allow the linter to run

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


