### PR TITLE
exclude directory `cloud.noindex` from search

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1265,6 +1265,7 @@ private:
                excludeArgs_.push_back("--exclude=" + filePattern.getString());
          }
       }
+      excludeArgs_.push_back("--exclude-dir=cloud.noindex");
    }
 
    void processIncludeFilePatterns()


### PR DESCRIPTION
### Intent

Adresses #10529

### Approach

Add `--exclude-dir=cloud.noindex` to the grep command. 

This is a bit brute force, but we don't think we would ever want to search in this directory. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


