### PR TITLE
add in missing tutorial dependencies

### DIFF
--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -35,6 +35,11 @@
             "location": "cran",
             "source": false
         },
+        "checkmate": {
+            "version": "1.0",
+            "location": "cran",
+            "source": false
+        },
         "crayon": {
             "version": "1.3.4",
             "location": "cran",
@@ -62,6 +67,11 @@
         },
         "evaluate": {
             "version": "0.13",
+            "location": "cran",
+            "source": false
+        },
+        "fastmap": {
+            "version": "1.1.0",
             "location": "cran",
             "source": false
         },
@@ -190,6 +200,11 @@
             "location": "cran",
             "source": false
         },
+        "rappdirs": {
+            "version": "0.3.0",
+            "location": "cran",
+            "source": false
+        },
         "rJava": {
             "version": "0.4-15",
             "location": "cran",
@@ -227,6 +242,11 @@
         },
         "roxygen2": {
             "version": "6.0.1",
+            "location": "cran",
+            "source": false
+        },
+        "rprojroot": {
+            "version": "1.0",
             "location": "cran",
             "source": false
         },
@@ -280,6 +300,11 @@
             "location": "cran",
             "source": false
         },
+        "withr": {
+            "version": "1.0.0",
+            "location": "cran",
+            "source": false
+        },
         "xfun": {
             "version": "0.21",
             "location": "cran",
@@ -304,23 +329,23 @@
     "features": {
         "roxygen": {
             "description": "R Package Documentation",
-            "packages": [ 
-                "roxygen2" 
+            "packages": [
+                "roxygen2"
             ]
         },
         "theme_conversion": {
             "description": "Theme Conversion",
-            "packages": [ 
-                "xm2" 
+            "packages": [
+                "xml2"
             ]
         },
         "r2d3": {
             "description": "R2D3",
-            "packages": [ 
-                "htmltools", 
-                "htmlwidgets", 
-                "jsonlite", 
-                "r2d3" 
+            "packages": [
+                "htmltools",
+                "htmlwidgets",
+                "jsonlite",
+                "r2d3"
             ]
         },
         "packrat": {
@@ -331,10 +356,10 @@
         },
         "plumber": {
             "description": "Plumber R APIs",
-            "packages": [ 
-                "R6", 
-                "stringi", 
-                "jsonlite", 
+            "packages": [
+                "R6",
+                "stringi",
+                "jsonlite",
                 "httpuv",
                 "crayon",
                 "plumber"


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10549. Also catches a case where the package name for theme conversion was misspelled.

### Approach

Bring back package entries from https://github.com/rstudio/rstudio/commit/9e1d4997464716d2330a6b5aa25e0849fba0afa2 that were deleted.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
