### PR TITLE
ensure backslashes in prefix are preserved in list.files hook

### DIFF
--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1510,11 +1510,11 @@ void listFilesDispatch(
          // include '.', '..' if requested
          if (options.allFiles && !options.noDotDot && !options.recursive)
          {
-            for (auto&& path : { kDotPath, kDotDotPath })
+            for (auto&& name : { kDotPath, kDotDotPath })
             {
-               if (accept(path))
+               if (accept(name))
                {
-                  pResult->push_back(listFilesResult(prefix, path));
+                  pResult->push_back(listFilesResult(prefix, name));
                }
             }
          }

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1423,7 +1423,7 @@ boost::filesystem::path listFilesResult(
       return name;
 
    // otherwise, create path and use '/' separator
-   // R preserevs native separators in the prefix, but not in
+   // R preserves native separators in the prefix, but not in
    // any of the listed path entries
    auto path = prefix;
    path += kForwardSlash;

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -70,10 +70,12 @@
 
 #ifdef BOOST_WINDOWS_API
 # define kEmptyString L""
+# define kForwardSlash L"/"
 # define kDotPath L"."
 # define kDotDotPath L".."
 #else
 # define kEmptyString ""
+# define kForwardSlash "/"
 # define kDotPath "."
 # define kDotDotPath ".."
 #endif
@@ -1412,6 +1414,24 @@ class ListFilesInterruptedException : public std::exception
 {
 };
 
+boost::filesystem::path listFilesResult(
+      const boost::filesystem::path& prefix,
+      const boost::filesystem::path& name)
+{
+   // if we don't have a prefix, return the name as-is
+   if (prefix.empty())
+      return name;
+
+   // otherwise, create path and use '/' separator
+   // R preserevs native separators in the prefix, but not in
+   // any of the listed path entries
+   auto path = prefix;
+   path += kForwardSlash;
+   path += name;
+   return path;
+
+}
+
 template <typename F>
 void listFilesImpl(
       const boost::filesystem::path& path,
@@ -1437,7 +1457,7 @@ void listFilesImpl(
             continue;
 
          // construct new prefix
-         auto newPrefix = prefix.empty() ? name : prefix / name;
+         auto newPrefix = listFilesResult(prefix, name);
          
          // check if this file is a directory (ignore errors)
          boost::system::error_code ec;
@@ -1494,7 +1514,7 @@ void listFilesDispatch(
             {
                if (accept(path))
                {
-                  pResult->push_back(prefix.empty() ? path : prefix / path);
+                  pResult->push_back(listFilesResult(prefix, path));
                }
             }
          }
@@ -1539,7 +1559,9 @@ SEXP finalizePaths(const std::vector<boost::filesystem::path>& paths)
             [](const boost::filesystem::path& path)
    {
 #ifdef BOOST_WINDOWS_API
-      return core::string_utils::wideToUtf8(path.generic_wstring());
+      // NOTE: we need to preserve path components (e.g. mixed slashes)
+      // as-is, so avoid using 'generic' APIs
+      return core::string_utils::wideToUtf8(path.wstring());
 #else
       return path.native();
 #endif

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -75,11 +75,6 @@ test_that("file listings are correct", {
 
 test_that("our list.files, list.dirs hooks function as expected", {
    
-   # these tests are only reliable with R 4.2.0, as they need R's native
-   # list.files routine to be able to list files with Chinese names
-   # and setting the locale seems insufficient for some cases
-   skip_if(getRversion() < "4.2.0")
-   
    library(testthat)
    
    # use native R routines
@@ -106,16 +101,19 @@ test_that("our list.files, list.dirs hooks function as expected", {
    dir.create("hasEmptyDir")
    dir.create("hasEmptyDir/empty")
    
-   nihao <- enc2utf8("\u4f60\u597d")  # 你好
-   dir.create(nihao)
-   file.create(paste(nihao, "file", sep = "/"))
-   file.create(paste(nihao, "R", sep = "."))
+   if (identical(R.version$crt, "ucrt")) {
+      nihao <- enc2utf8("\u4f60\u597d")  # 你好
+      dir.create(nihao)
+      file.create(paste(nihao, "file", sep = "/"))
+      file.create(paste(nihao, "R", sep = "."))
+   }
    
    paths <- list(
       ".",
       getwd(),
       chartr("/", "\\", getwd()),
       file.path("..", basename(getwd())),
+      paste("..", basename(getwd()), sep = "\\"),
       "ThisPathDoesNotExist"
    )
    

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -75,6 +75,13 @@ test_that("file listings are correct", {
 
 test_that("our list.files, list.dirs hooks function as expected", {
    
+   # these tests are only reliable with R 4.2.0, as they need R's native
+   # list.files routine to be able to list files with Chinese names
+   # and setting the locale seems insufficient for some cases
+   skip_if(getRversion() < "4.2.0")
+   
+   library(testthat)
+   
    # use native R routines
    .rs.files.restoreBindings()
    on.exit(.rs.files.replaceBindings(), add = TRUE)
@@ -104,14 +111,10 @@ test_that("our list.files, list.dirs hooks function as expected", {
    file.create(paste(nihao, "file", sep = "/"))
    file.create(paste(nihao, "R", sep = "."))
    
-   if (.rs.platform.isWindows && getRversion() < "4.2.0") {
-      Sys.setlocale(locale = "Chinese")
-      on.exit(Sys.setlocale(locale = "English"), add = TRUE)
-   }
-   
    paths <- list(
       ".",
       getwd(),
+      chartr("/", "\\", getwd()),
       file.path("..", basename(getwd())),
       "ThisPathDoesNotExist"
    )


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10573.

### Approach

Ensure that we don't mutate separators within the user-provided path prefix, and ensure we use forward-slashes for any path components constructed following the path prefix.

### Automated Tests

Automated tests updated.

### QA Notes

Test via notes in:

https://github.com/rstudio/rstudio/issues/10573
https://github.com/rstudio/rstudio/issues/10591

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

