### PR TITLE
adding axis label and title to Shiny template files

### DIFF
--- a/src/cpp/session/resources/templates/shiny.qmd
+++ b/src/cpp/session/resources/templates/shiny.qmd
@@ -18,7 +18,7 @@ output$distPlot <- renderPlot({
    x <- faithful[, 2]  # Old Faithful Geyser data
    bins <- seq(min(x), max(x), length.out = input$bins + 1)
    hist(x, breaks = bins, col = 'darkgray', border = 'white',
-        xlab = "Waiting time to next eruption (in mins)",
-        main = "Histogram of waiting times")
+        xlab = 'Waiting time to next eruption (in mins)',
+        main = 'Histogram of waiting times')
 })
 ```

--- a/src/cpp/session/resources/templates/shiny.qmd
+++ b/src/cpp/session/resources/templates/shiny.qmd
@@ -17,6 +17,8 @@ plotOutput("distPlot")
 output$distPlot <- renderPlot({
    x <- faithful[, 2]  # Old Faithful Geyser data
    bins <- seq(min(x), max(x), length.out = input$bins + 1)
-   hist(x, breaks = bins, col = 'darkgray', border = 'white')
+   hist(x, breaks = bins, col = 'darkgray', border = 'white',
+        xlab = "Waiting time to next eruption (in mins)",
+        main = "Histogram of waiting times")
 })
 ```

--- a/src/cpp/session/resources/templates/shiny/app.R
+++ b/src/cpp/session/resources/templates/shiny/app.R
@@ -42,8 +42,8 @@ server <- function(input, output) {
 
         # draw the histogram with the specified number of bins
         hist(x, breaks = bins, col = 'darkgray', border = 'white',
-             xlab = "Waiting time to next eruption (in mins)",
-             main = "Histogram of waiting times")
+             xlab = 'Waiting time to next eruption (in mins)',
+             main = 'Histogram of waiting times')
     })
 }
 

--- a/src/cpp/session/resources/templates/shiny/app.R
+++ b/src/cpp/session/resources/templates/shiny/app.R
@@ -41,7 +41,9 @@ server <- function(input, output) {
         bins <- seq(min(x), max(x), length.out = input$bins + 1)
 
         # draw the histogram with the specified number of bins
-        hist(x, breaks = bins, col = 'darkgray', border = 'white')
+        hist(x, breaks = bins, col = 'darkgray', border = 'white',
+             xlab = "Waiting time to next eruption (in mins)",
+             main = "Histogram of waiting times")
     })
 }
 

--- a/src/cpp/session/resources/templates/shiny/server.R
+++ b/src/cpp/session/resources/templates/shiny/server.R
@@ -19,7 +19,9 @@ shinyServer(function(input, output) {
         bins <- seq(min(x), max(x), length.out = input$bins + 1)
 
         # draw the histogram with the specified number of bins
-        hist(x, breaks = bins, col = 'darkgray', border = 'white')
+        hist(x, breaks = bins, col = 'darkgray', border = 'white',
+             xlab = "Waiting time to next eruption (in mins)",
+             main = "Histogram of waiting times")
 
     })
 

--- a/src/cpp/session/resources/templates/shiny/server.R
+++ b/src/cpp/session/resources/templates/shiny/server.R
@@ -20,8 +20,8 @@ shinyServer(function(input, output) {
 
         # draw the histogram with the specified number of bins
         hist(x, breaks = bins, col = 'darkgray', border = 'white',
-             xlab = "Waiting time to next eruption (in mins)",
-             main = "Histogram of waiting times")
+             xlab = 'Waiting time to next eruption (in mins)',
+             main = 'Histogram of waiting times')
 
     })
 


### PR DESCRIPTION
### Intent

Previously the Shiny template file included x-axis label and a title. That isn't included in the current version, and it makes the template example harder to work with, because 1) it's difficult to understand what the plot is about, because what the labels should be isn't immediately obvious and 2) it's a standard thing that people want to do, so it's nice to have an example of how it's done in the code. 

### Approach

For the shiny/app.R, shiny/server.R and shiny.qmd files, I added in the code to add the x-axis label and title. 

### Automated Tests

I'm not sure how this works with automated tests. I did run locally and it worked fine. 

### QA Notes

Those labels may have been removed for reasons I'm not aware of, including accessibility standards. If this is the case, that rationale likely supersedes template legibility. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

For purposes of the CONTRIBUTING file information, I'm an RStudio employee. 


