### PR TITLE
Restore rstudio-themes-flat for 3rd party themes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -269,5 +269,10 @@ public class BrowseCap
          if (isFirefox())
             Document.get().getBody().addClassName("ubuntu_mono_firefox");
       }
+
+      // Add flat theme class. None of our own CSS should use this, but many
+      // third party themes developed against earlier versions of RStudio
+      // (2021.09 and older) use it extensively in selectors.
+      Document.get().getBody().addClassName("rstudio-themes-flat");
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -149,6 +149,11 @@ public class RStudioThemedFrame extends RStudioFrame
             // Add OS tag to the frame so that it can apply OS-specific CSS if
             // needed.
             body.addClassName(BrowseCap.operatingSystem());
+            
+            // Add flat theme class. None of our own CSS should use this, but many
+            // third party themes developed against earlier versions of RStudio
+            // (2021.09 and older) use it extensively in selectors.
+            body.addClassName("rstudio-themes-flat");
          }
       }
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10598.

### Approach

Restore the `rstudio-themes-flat` class to the `<body>` tag. We can feel confident that this is safe since we removed all our own style rules and selectors that used this string. 

### Automated Tests

N/A, visual change that only affects 3rd party themes.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10598.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


