### PR TITLE
implement back / forward mouse handlers

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -272,13 +272,20 @@ bool handleRShowDocFile(const core::FilePath& filePath)
 }
 
 // javascript callbacks to inject into page
-const char * const kJsCallbacks =
-      "<script type=\"text/javascript\">\n"
-      "if (window.parent.helpNavigated)\n"
-      "   window.parent.helpNavigated(document, window);\n"
-      "if (window.parent.helpKeydown)\n"
-      "   window.onkeydown = function(e) {window.parent.helpKeydown(e);}\n"
-      "</script>\n";
+const char * const kJsCallbacks = R"EOF(
+<script type="text/javascript">
+
+   if (window.parent.helpNavigated)
+      window.parent.helpNavigated(document, window);
+
+   if (window.parent.helpKeydown)
+      window.onkeydown = function(e) { window.parent.helpKeydown(e); }
+
+   if (window.parent.helpMousedown)
+      window.onmousedown = function(e) { window.parent.helpMousedown(e); }
+
+</script>
+)EOF";
 
 
 class HelpFontSizeFilter : public boost::iostreams::aggregate_filter<char>

--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -81,7 +81,6 @@ public class BrowseCap
    public static boolean isMacintoshDesktopMojave()
    {
       return isMacintoshDesktop() && isUserAgent("mac os x 10_14");
-
    }
 
    public static boolean isWindows()
@@ -102,6 +101,11 @@ public class BrowseCap
    public static boolean isLinuxDesktop()
    {
       return (Desktop.hasDesktopFrame()) && isLinux();
+   }
+   
+   public static boolean isElectron()
+   {
+      return Desktop.hasDesktopFrame() && isUserAgent("electron");
    }
 
    public static boolean hasUbuntuFonts()

--- a/src/gwt/src/org/rstudio/core/client/Debug.java
+++ b/src/gwt/src/org/rstudio/core/client/Debug.java
@@ -214,5 +214,9 @@ public class Debug
    public static native void breakpoint() /*-{
       debugger;
    }-*/;
+   
+   public static native String stringify(JavaScriptObject object) /*-{
+      return JSON.stringify(object);
+   }-*/;
 
 }

--- a/src/gwt/src/org/rstudio/core/client/dom/EventProperty.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/EventProperty.java
@@ -19,5 +19,18 @@ import com.google.gwt.dom.client.NativeEvent;
 public class EventProperty
 {
    public static final native String key(NativeEvent event) /*-{ return event.key; }-*/;
+   
+   // This helper is provided to avoid GWT's normalization of MouseEvent
+   // buttons in the 'event.getButton()' accessor.
+   public static final native int button(NativeEvent event)
+   /*-{
+      return event.button;
+   }-*/;
+   
+   public static final int MOUSE_MAIN       = 0;
+   public static final int MOUSE_AUXILIARY  = 1;
+   public static final int MOUSE_SECONDARY  = 2;
+   public static final int MOUSE_BACKWARD   = 3;
+   public static final int MOUSE_FORWARD    = 4;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -44,6 +44,7 @@ import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.Point;
 import org.rstudio.core.client.StringUtil;
@@ -51,6 +52,7 @@ import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.command.ShortcutManager;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.ElementEx;
+import org.rstudio.core.client.dom.EventProperty;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.events.NativeKeyDownEvent;
@@ -117,6 +119,7 @@ public class HelpPane extends WorkbenchPane
          null,
          false,
          true);
+      
       frame_.setSize("100%", "100%");
       frame_.setStylePrimaryName("rstudio-HelpFrame");
       frame_.addStyleName("ace_editor_theme");
@@ -263,12 +266,14 @@ public class HelpPane extends WorkbenchPane
       }
 
       var thiz = this;
+      
       $wnd.helpNavigated = function(document, win) {
          thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::helpNavigated(Lcom/google/gwt/dom/client/Document;)(document);
          addEventHandler(win, "unload", function () {
             thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::unload()();
          });
       };
+      
       $wnd.helpNavigate = function(url) {
          if (url.length)
             thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::showHelp(Ljava/lang/String;)(url);
@@ -277,6 +282,11 @@ public class HelpPane extends WorkbenchPane
       $wnd.helpKeydown = function(e) {
          thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::handleKeyDown(Lcom/google/gwt/dom/client/NativeEvent;)(e);
       };
+      
+      $wnd.helpMousedown = function(e) {
+         thiz.@org.rstudio.studio.client.workbench.views.help.HelpPane::handleMouseDown(*)(e);
+      };
+      
    }-*/;
 
 
@@ -331,6 +341,23 @@ public class HelpPane extends WorkbenchPane
          // since this is a shortcut handled by the main window
          // we set focus to it
          WindowEx.get().focus();
+      }
+   }
+   
+   private void handleMouseDown(NativeEvent event)
+   {
+      int button = EventProperty.button(event);
+      if (button == EventProperty.MOUSE_BACKWARD)
+      {
+         event.stopPropagation();
+         event.preventDefault();
+         commands_.helpBack().execute();
+      }
+      else if (button == EventProperty.MOUSE_FORWARD)
+      {
+         event.stopPropagation();
+         event.preventDefault();
+         commands_.helpForward().execute();
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10501.

### Approach

Straight-forward implementation of mouse handlers on the GWT side. Previously, these were implemented on the desktop side in https://github.com/rstudio/rstudio/blob/10d7d434c336c60c48c280f2dae9e94435f35cf6/src/cpp/desktop/DesktopWebView.cpp#L74-L105 to work around a Qt issue; now that this is no longer an issue, we can just implement it on the front-end ourselves.

### Automated Tests

Not included.

### QA Notes

Test that back / forward mouse buttons navigate through the source history, rather than causing RStudio to "exit" (especially on back).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


