### PR TITLE
Fix typos in src/cpp/session comments and documentation

### DIFF
--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -101,7 +101,7 @@ void AsyncRProcess::start(const char* rCommand,
    // On Windows, we turn the vector of strings into a single
    // string to send over the command line, so we must ensure
    // that the arguments following '-e' are quoted, so that
-   // they are all interpretted as a single argument (rather
+   // they are all interpreted as a single argument (rather
    // than multiple arguments) to '-e'.
 
 #ifdef _WIN32

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -300,7 +300,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
       {
          // Manually adding message to the console here instead of using consoleWriteOutput()
          // to avoid it ending up in the history and printing out every time this session
-         // resumes/reloads and potentially resulting in an unecessarily long list of
+         // resumes/reloads and potentially resulting in an unnecessarily long list of
          // previous resumed messages
          actionsObject["data"].getArray().push_back(resumeMsg);
          actionsObject["type"].getArray().push_back(kConsoleActionOutput);

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -309,7 +309,7 @@ bool rConsoleRead(const std::string& prompt,
    // this is an invalid state in a forked (multicore) process
    if (main_process::wasForked())
    {
-      LOG_WARNING_MESSAGE("rConsoleRead called in forked processs");
+      LOG_WARNING_MESSAGE("rConsoleRead called in forked process");
       return false;
    }
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -780,7 +780,7 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
             // Discard any buffered input
             console_input::clearConsoleInputBuffer();
 
-            // aknowledge request
+            // acknowledge request
             ptrConnection->sendJsonRpcResponse();
 
             // only accept interrupts while R is processing input

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2009,7 +2009,7 @@ int main(int argc, char * const argv[])
          core::system::setenv(kRSessionStandalonePortNumber, options.wwwPort());
       }
 
-      // ensure we aren't being started as a low (priviliged) account
+      // ensure we aren't being started as a low (privileged) account
       if (serverMode &&
           !options.verifyInstallation() &&
           core::system::currentUserIsPrivilleged(options.authMinimumUserId()))
@@ -2333,7 +2333,7 @@ int main(int argc, char * const argv[])
       error = rstudio::r::session::run(rOptions, rCallbacks);
       if (error)
       {
-          // this is logically equivilant to R_Suicide
+          // this is logically equivalent to R_Suicide
           logExitEvent(Event(kSessionScope, kSessionSuicideEvent));
 
           // return failure

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1600,7 +1600,7 @@ Error installPackage(const std::string& pkgPath, const std::string& libPath)
       installCommand << "\"" + libPath + "\"";
    }
 
-   // add pakage path
+   // add package path
    installCommand << "\"" + pkgPath + "\"";
    core::system::ProcessResult result;
 

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -323,7 +323,7 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
       rpostback. However, we really ought to communicate
       it in a more secure manner than this, at least on
       Windows where even within the same user session some
-      processes can have different priviliges (integrity
+      processes can have different privileges (integrity
       levels) than others. For example, using a named pipe
       with proper SACL to retrieve the shared secret, where
       the name of the pipe is in an environment variable. */

--- a/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
+++ b/src/cpp/session/SessionSourceDatabaseSupervisor.cpp
@@ -403,7 +403,7 @@ Error removeAndRecreate(const FilePath& dir)
 //      a lock on them -- for volumes that don't support locks this will
 //      always be an error so we'll never be able to recover an orphan dir
 //
-// In some multi-machine cases it's actually possible for two proccesses
+// In some multi-machine cases it's actually possible for two processes
 // to both get a lock on the same file. For this reason if we are running
 // multi-machine (i.e. load balancing enabled) we don't attempt orphan
 // recovery because it could result in one session stealing the other's

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -477,7 +477,7 @@ std::string getResumedMessage()
 {
    boost::posix_time::ptime suspensionTimestamp = module_context::activeSession().suspensionTime();
 
-   // Assume suspension never occured if there's no suspensionTimestamp
+   // Assume suspension never occurred if there's no suspensionTimestamp
    if (suspensionTimestamp == boost::posix_time::not_a_date_time)
    {
       boost::posix_time::ptime lastResumed = module_context::activeSession().lastResumed();

--- a/src/cpp/session/include/session/SessionAsyncRProcess.hpp
+++ b/src/cpp/session/include/session/SessionAsyncRProcess.hpp
@@ -1,5 +1,5 @@
 /*
- * SessionAsyncRProcesss.hpp
+ * SessionAsyncRProcess.hpp
  *
  * Copyright (C) 2022 by RStudio, PBC
  *

--- a/src/cpp/session/include/session/SessionHttpConnectionListener.hpp
+++ b/src/cpp/session/include/session/SessionHttpConnectionListener.hpp
@@ -32,7 +32,7 @@
       be handled and foreground R thread will continue waiting in a loop.
 
    2) Periodically during R_PolledEvents. This allows the client to remain
-      responsive even while computations are being peformed.
+      responsive even while computations are being performed.
 
  If a request pulled off the queue by the main thread can potentially be
  executed in a background thread (e.g. file or source operation) then it
@@ -50,8 +50,8 @@
  required package could be unloaded during a computation). This sort of
  interaction is currently permitted by the OSX client and is considered OK
  presumably because the user directly manipulated the environment and therefore
- won't be suprised if his computation changes. The tradeoff is that operations
- that are read-only and highly useful to peform during computations (e.g.
+ won't be surprised if his computation changes. The tradeoff is that operations
+ that are read-only and highly useful to perform during computations (e.g.
  requesting completions or syntax checking in source mode, browsing objects,
  searching and viewing help, etc.) are allowed to execute thus maintaining
  a high level of interactivity in the client even when long computations
@@ -61,7 +61,7 @@
  http handlers as requiring more stringent serialization. For example, they
  could be queued and executed only when the REPL loop comes back to the top.
  Note however that if too many of these requests are queued then browser
- request throttling may come into play and start queing ALL requests which
+ request throttling may come into play and start queueing ALL requests which
  exceed the browser limit. For this reason we will start with the position
  that nested execution of R handlers during computation is OK and back off
  only as necessary.
@@ -79,7 +79,7 @@ namespace core {
 namespace rstudio {
 namespace session {
 
-// global initialization (allows instantation of listener which
+// global initialization (allows instantiation of listener which
 // implements the protocol appropriate for our current configuration)
 void initializeHttpConnectionListener();
 

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -520,7 +520,7 @@ std::string normalizeVcsOverride(const std::string& vcsOverride);
 
 core::FilePath shellWorkingDirectory();
 
-// persist state accross suspend and resume
+// persist state across suspend and resume
    
 typedef boost::function<void (const r::session::RSuspendOptions&,
                               core::Settings*)> SuspendFunction;

--- a/src/cpp/session/modules/NotebookHtmlWidgets.R
+++ b/src/cpp/session/modules/NotebookHtmlWidgets.R
@@ -134,7 +134,7 @@
    x$sizingPolicy$viewer.padding <- 0
    x$sizingPolicy$viewer.fill <- TRUE
 
-   # make width dinamic to size correctly non-figured
+   # make width dynamic to size correctly non-figured
    if (!is.null(x$sizingPolicy$knitr) && identical(x$sizingPolicy$knitr$figure, FALSE)) {
       x$sizingPolicy$defaultWidth <- "auto"
       x$sizingPolicy$browser$fill <- FALSE

--- a/src/cpp/session/modules/SessionAskPass.hpp
+++ b/src/cpp/session/modules/SessionAskPass.hpp
@@ -48,7 +48,7 @@ core::Error askForPassword(const std::string& prompt,
 core::Error initialize();
    
 } // namespace ask_pass
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionAskSecret.hpp
+++ b/src/cpp/session/modules/SessionAskSecret.hpp
@@ -52,7 +52,7 @@ core::Error askForSecret(const std::string& name,
 core::Error initialize();
    
 } // namespace ask_secret
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionBreakpoints.cpp
+++ b/src/cpp/session/modules/SessionBreakpoints.cpp
@@ -258,7 +258,7 @@ Error getFunctionState(const json::JsonRpcRequest& request,
 }
 
 // Sets a breakpoint on a single copy of a function. Invoked several times to
-// look for function copies in alternate environemnts. Returns true if a
+// look for function copies in alternate environments. Returns true if a
 // breakpoint was set; false otherwise.
 bool setBreakpoint(const std::string& functionName,
                    const std::string& fileName,

--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -27,7 +27,7 @@
 })
 
 .rs.addFunction("isClangAvailable", function() {
-   cat("Attemping to load libclang for", R.version$platform, "\n")
+   cat("Attempting to load libclang for", R.version$platform, "\n")
    .Call("rs_isLibClangAvailable", PACKAGE = "(embedding)")
 })
 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -538,7 +538,7 @@ public:
          if (!entry.hasIndex())
             continue;
 
-         // bail if this is an exluded context
+         // bail if this is an excluded context
          if (excludeContexts.find(entry.pIndex->context()) !=
              excludeContexts.end())
          {
@@ -575,7 +575,7 @@ public:
          if (!entry.hasIndex())
             continue;
 
-         // bail if this is an exluded context
+         // bail if this is an excluded context
          if (excludeContexts.find(entry.pIndex->context()) !=
              excludeContexts.end())
          {
@@ -1498,7 +1498,7 @@ SourceItem fromRSourceItem(const r_util::RSourceItem& rSourceItem)
       break;
    }
 
-   // calcluate extra info
+   // calculate extra info
    std::string extraInfo;
    if (rSourceItem.signature().size() > 0)
    {
@@ -2164,7 +2164,7 @@ json::Object createFunctionDefinition(const std::string& name,
       }
    }
 
-   // check find status and return appropriate definiton
+   // check find status and return appropriate definition
    if (!error)
    {
       if (!r::sexp::isNull(functionSEXP))

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1925,7 +1925,7 @@
       })
    })
    
-   # Convert to a list, and ensure each element is interpretted as a scalar
+   # Convert to a list, and ensure each element is interpreted as a scalar
    # (rather than an array containing a single element)
    result <- as.list(chunkOptionsEnv)
    for (i in seq_along(result))

--- a/src/cpp/session/modules/SessionDirty.cpp
+++ b/src/cpp/session/modules/SessionDirty.cpp
@@ -54,7 +54,7 @@ namespace {
 // end up with a 'dirty' workspace. not a big deal considering how infrequently
 // quit occurs in server mode.
 // TODO: this now affects switching projects after a suspend. we should try
-// to figure out how to preserve dirty state of the workspace accross suspend
+// to figure out how to preserve dirty state of the workspace across suspend
 int s_lastSaveAction = r::session::kSaveActionAsk;
 
 // list of dirty documents (if it's empty then no document save is required)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -473,7 +473,7 @@
    )
    
    # some calls might be very large when deparsed, especially when
-   # they include R objects which have already been evaluted. this
+   # they include R objects which have already been evaluated. this
    # happens most often with calls like:
    #
    #   do.call("fn", list(object))

--- a/src/cpp/session/modules/SessionErrors.hpp
+++ b/src/cpp/session/modules/SessionErrors.hpp
@@ -33,7 +33,7 @@ core::Error initialize();
 core::json::Value errorStateAsJson();
 
 } // namespace errors
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -97,7 +97,7 @@ namespace {
 // monitor for file listings
 FilesListingMonitor s_filesListingMonitor;
 
-// make sure that monitoring persists accross suspended sessions
+// make sure that monitoring persists across suspended sessions
 const char * const kFilesMonitoredPath = "files.monitored-path";
 
 void onSuspend(Settings* pSettings)
@@ -551,7 +551,7 @@ void handleFilesRequest(const http::Request& request,
    // validate the uri
    if (prefix.length() >= uri.length() ||    // prefix longer than uri
        uri.find(prefix) != 0 ||              // uri doesn't start with prefix
-       uri.find("..") != std::string::npos)  // uri has inavlid char sequence
+       uri.find("..") != std::string::npos)  // uri has invalid char sequence
    {
       pResponse->setNotFoundError(request);
       return;
@@ -1035,7 +1035,7 @@ bool handleFileUploadRequestAsync(const http::Request& request,
    {
       if (pUploadState->targetDirectory.empty())
       {
-         // now we need to read the target directory metadata field by reading backwords from the buffer
+         // now we need to read the target directory metadata field by reading backwards from the buffer
          std::string searchStr = "\r\n" + getBoundary(request) + "\r\n";
          size_t pos = formData.rfind(searchStr);
          if (pos == std::string::npos)
@@ -1340,7 +1340,7 @@ SEXP rs_pathInfo(SEXP pathSEXP)
       if (filePath.isEmpty())
          throw r::exec::RErrorException("invalid path: " + path);
 
-      // create path info vector (use json repsesentation to force convertion
+      // create path info vector (use json repsesentation to force conversion
       // to VECSXP rather than STRSXP)
       json::Object pathInfo;
       pathInfo["path"] = filePath.getAbsolutePath();

--- a/src/cpp/session/modules/SessionFiles.hpp
+++ b/src/cpp/session/modules/SessionFiles.hpp
@@ -33,7 +33,7 @@ bool isMonitoringDirectory(const core::FilePath& directory);
 core::Error initialize();
                        
 } // namespace files
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionFilesListingMonitor.hpp
+++ b/src/cpp/session/modules/SessionFilesListingMonitor.hpp
@@ -94,7 +94,7 @@ private:
 
    
 } // namespace files
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionFilesQuotas.cpp
+++ b/src/cpp/session/modules/SessionFilesQuotas.cpp
@@ -114,7 +114,7 @@ Error parseQuotaInfo(const std::string& quotaInfo, QuotaInfo* pInfo)
       {
          switch(resultIndex++)
          {
-            // ingore first entry (device)
+            // ignore first entry (device)
             case 0:
                break;
             

--- a/src/cpp/session/modules/SessionFilesQuotas.hpp
+++ b/src/cpp/session/modules/SessionFilesQuotas.hpp
@@ -34,7 +34,7 @@ void checkQuotaStatus();
    
 } // namespace quotas
 } // namespace files
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -503,7 +503,7 @@ private:
          return (Error(
                   errc::findCategory(),
                   errc::PermissionsError,
-                  "A permissions error occured during replace operation.",
+                  "A permissions error occurred during replace operation.",
                   ERROR_LOCATION));
       }
       return Success();
@@ -576,7 +576,7 @@ private:
             inputStream_.reset();
             outputStream_.reset();
 
-// Unneccesary on Windows because this only sets write permissions which we
+// Unnecessary on Windows because this only sets write permissions which we
 // already know are correct if we are writing.
 // This needs to happen after outputStream is flushed
 #ifndef _WIN32
@@ -684,7 +684,7 @@ private:
    void subtractOffsetIntegerToJsonArray(
        json::Value newValue, int offset, json::Array* pJsonArray)
    {
-      // make sure negative values (errors) don't become positve
+      // make sure negative values (errors) don't become positive
       if (newValue.getInt() < 0)
          newValue = json::Value(newValue.getInt() - offset);
       pJsonArray->push_back(gsl::narrow_cast<int>(newValue.getInt() + offset));

--- a/src/cpp/session/modules/SessionHTMLPreview.cpp
+++ b/src/cpp/session/modules/SessionHTMLPreview.cpp
@@ -907,7 +907,7 @@ void handleInternalMarkdownPreviewRequest(
             LOG_ERROR(error);
       }
 
-      // modify outpout then write back to client
+      // modify output then write back to client
       modifyOutputForPreview(&previewHtml);
       pResponse->setDynamicHtml(previewHtml, request);
    }

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -402,7 +402,7 @@ options(help_type = "html")
 .rs.addFunction("getHelpFunction", function(name, src, envir = parent.frame())
 {
    # If 'src' is the name of something on the searchpath, get that object
-   # from the seach path, then attempt to get help based on that object
+   # from the search path, then attempt to get help based on that object
    pos <- match(src, search(), nomatch = -1L)
    if (pos >= 0)
    {

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -182,7 +182,7 @@ bool isHttpdErrorPayload(SEXP payloadSEXP)
 
 // hook the browseURL function to look for calls to the R internal http
 // server. for custom URLs remap the address to remote and then fire
-// the browse_url event. for help URLs fire the appropraite show_help event
+// the browse_url event. for help URLs fire the appropriate show_help event
 bool handleLocalHttpUrl(const std::string& url)
 {
    // check for custom
@@ -400,7 +400,7 @@ void handleHttpdResult(SEXP httpdSEXP,
    // NOTE: this function is a port of process_request in Rhttpd.c
    // (that function is coupled to sending its results via the R http daemon, 
    // since we need to send the results via our daemon we need our own
-   // implemetnation of the function). The port was completed 10/28/2009 so 
+   // implementation of the function). The port was completed 10/28/2009 so 
    // diffs in this function subsequent to that should be accounted for
    
    // defaults
@@ -698,7 +698,7 @@ void handleRdPreviewRequest(const http::Request& request,
                             const Filter& filter,
                             http::Response* pResponse)
 {
-   // read parmaeters
+   // read parameters
    std::string file = request.queryParamValue("file");
    if (file.empty())
    {
@@ -831,7 +831,7 @@ void handleHttpdRequest(const std::string& location,
       return;
    }
 
-   // evalute the handler
+   // evaluate the handler
    r::sexp::Protect rp;
    SEXP httpdSEXP;
    Error error = r::exec::executeSafely<SEXP>(

--- a/src/cpp/session/modules/SessionHelpHome.hpp
+++ b/src/cpp/session/modules/SessionHelpHome.hpp
@@ -37,7 +37,7 @@ void handleHelpHomeRequest(const core::http::Request& request,
 
    
 } // namespace help
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionMarkers.hpp
+++ b/src/cpp/session/modules/SessionMarkers.hpp
@@ -38,7 +38,7 @@ std::vector<module_context::SourceMarker> markersForFile(const std::string& path
 core::Error initialize();
    
 } // namespace markers
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -40,7 +40,7 @@
 # delegate to the system tar binary specified in TAR. On OS X, R may set TAR to
 # /usr/bin/gnutar, which exists prior to Mavericks (10.9) but not in later
 # rleases of the OS. In the special case wherein the TAR environment variable
-# on OS X is set to a non-existant gnutar and there exists a tar at
+# on OS X is set to a non-existent gnutar and there exists a tar at
 # /usr/bin/tar, tell R to use that binary instead.
 if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
     identical(Sys.getenv("TAR"), "/usr/bin/gnutar") && 

--- a/src/cpp/session/modules/SessionPackages.cpp
+++ b/src/cpp/session/modules/SessionPackages.cpp
@@ -110,7 +110,7 @@ public:
       Error error = r::exec::evaluateString(code, &packages);
       if (error)
       {
-         // log error if it wasn't merly a null return value
+         // log error if it wasn't merely a null return value
          if (error != r::errc::UnexpectedDataTypeError)
             LOG_ERROR(error);
          return;

--- a/src/cpp/session/modules/SessionPackrat.R
+++ b/src/cpp/session/modules/SessionPackrat.R
@@ -88,7 +88,7 @@
       substr(libraryPaths, 1, nchar(projectPath)) == projectPath
 
    # resolve symlinks (use normalizePath rather than Sys.readlink since we want
-   # to resolve symlinks anywhere in the heirarchy)
+   # to resolve symlinks anywhere in the hierarchy)
    resolvedLinks <- normalizePath(by(libraryList, 1:nrow(libraryList),
                                      function(pkg) {
                                         system.file(package = pkg$name, lib.loc = pkg$library)

--- a/src/cpp/session/modules/SessionPackrat.cpp
+++ b/src/cpp/session/modules/SessionPackrat.cpp
@@ -542,7 +542,7 @@ bool getPendingActions(PackratActionType action, bool useCached,
       return (cachedResult[action] = true);
    }
 
-   // if an empty list comes back, we can savely resolve the state
+   // if an empty list comes back, we can safely resolve the state
    if (r::sexp::length(actions) == 0)
       return (cachedResult[action] = false);
 

--- a/src/cpp/session/modules/SessionPath.hpp
+++ b/src/cpp/session/modules/SessionPath.hpp
@@ -32,7 +32,7 @@ namespace path {
 core::Error initialize();
    
 } // namespace path
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -132,7 +132,7 @@ Error savePlotAs(const json::JsonRpcRequest& request,
    // resolve path
    FilePath plotPath = module_context::resolveAliasedPath(path);
 
-   // if it already exists and we aren't ovewriting then return false
+   // if it already exists and we aren't overwriting then return false
    if (plotPath.exists() && !overwrite)
    {
       pResponse->setResult(boolObject(false));
@@ -175,7 +175,7 @@ Error savePlotAsPdf(const json::JsonRpcRequest& request,
    // resolve path
    FilePath plotPath = module_context::resolveAliasedPath(path);
 
-   // if it already exists and we aren't ovewriting then return false
+   // if it already exists and we aren't overwriting then return false
    if (plotPath.exists() && !overwrite)
    {
       pResponse->setResult(boolObject(false));
@@ -362,7 +362,7 @@ Error getUniqueSavePlotStem(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   // set resposne
+   // set response
    pResponse->setResult(stem);
    return Success();
 }
@@ -627,7 +627,7 @@ void handlePngRequest(const http::Request& request,
 }
 
 
-// NOTE: this function assumes it is retreiving the image for the currently
+// NOTE: this function assumes it is retrieving the image for the currently
 // active plot (the assumption is implied by the fact that file not found
 // on the requested png results in a redirect to the currently active
 // plot's png). to handle this redirection we should always maintain an
@@ -753,7 +753,7 @@ void onBackgroundProcessing(bool isIdle)
       // verify that the last change is more than 50ms old. the reason
       // we check for changes in the background is so we can respect
       // plot animations (typically implemented using Sys.sleep). however,
-      // we don't want this to spill over inot incrementally rendering all
+      // we don't want this to spill over into incrementally rendering all
       // plots as this will slow down overall plotting performance
       // considerably.
       using namespace boost::posix_time;

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -702,7 +702,7 @@ assign(x = ".rs.acCompletionTypes",
       if (any(sapply(readers, identical, object)))
          object <- utils::read.table
       
-      # Similarily for write.csv
+      # Similarly for write.csv
       writers <- list(
          utils::write.csv,
          utils::write.csv2
@@ -2214,7 +2214,7 @@ assign(x = ".rs.acCompletionTypes",
       if (token == "")
          return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
       
-      # Otherwise, complete from the seach path + available packages
+      # Otherwise, complete from the search path + available packages
       completions <- Reduce(.rs.appendCompletions, list(
          .rs.getCompletionsSearchPath(token),
          .rs.getCompletionsNAMESPACE(token, documentId),
@@ -3443,7 +3443,7 @@ assign(x = ".rs.acCompletionTypes",
    
    ## If we detect that particular 'library' calls are in the source document,
    ## and those packages are actually available (but the package is not currently loaded),
-   ## then we get an asynchronously-updated set of completions. We enocde them as 'context'
+   ## then we get an asynchronously-updated set of completions. We encode them as 'context'
    ## completions just so the user has a small hint that, even though we provide the
    ## completions, the package isn't actually loaded.
    packages <- .rs.listInferredPackages(documentId)

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -167,7 +167,7 @@
      (is.null(yamlFrontMatter[["output"]]) && !is.null(yamlFrontMatter[["format"]])) ||
      # quarto extended type
      identical(.Call("rs_detectExtendedType", file), "quarto-document") ||
-     # plain markdown file w/ "jupyter" metdata
+     # plain markdown file w/ "jupyter" metadata
      (.rs.endsWith(file, ".md") && !is.null(yamlFrontMatter[["jupyter"]]))
   }
 
@@ -188,7 +188,7 @@
             "html"))
           "rmarkdown::run"
        else 
-          # this situation is nonsensical (runtime: shiny only makse sense for
+          # this situation is nonsensical (runtime: shiny only makes sense for
           # HTML-based output formats)
           ""
      }, error = function(e) {

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1044,7 +1044,7 @@ bool extractInfoFromFunctionDefinition(
 
 
 // Extract formals from the underlying object mapped by the symbol, or expression,
-// at the cursor. This involves (potentially) evaluating the expresion forming
+// at the cursor. This involves (potentially) evaluating the expression forming
 // the function object, e.g.
 //
 //     foo$bar(baz, bat)
@@ -1370,7 +1370,7 @@ public:
       if (cursor.contentEquals(L"file_test"))
          pCall->functionInfo().infoForFormal("y").setMissingnessHandled(true);
       
-      // 'globalVariables' doens't need 'package' argument
+      // 'globalVariables' doesn't need 'package' argument
       if (cursor.contentEquals(L"globalVariables") ||
           cursor.contentEquals(L"vignetteEngine"))
       {
@@ -1794,7 +1794,7 @@ void validateFunctionCall(RTokenCursor cursor,
    }
    
    // Error on missing arguments to call. If the user is passing down '...',
-   // we'll avoid this check and assume it's being inheritted from the parent
+   // we'll avoid this check and assume it's being inherited from the parent
    // function.
    if (!core::algorithm::contains(matched.unnamedArguments(), "..."))
    {

--- a/src/cpp/session/modules/SessionRParser.hpp
+++ b/src/cpp/session/modules/SessionRParser.hpp
@@ -922,7 +922,7 @@ public:
       
       // NOTE: We record a definition at the same position of 
       // each reference as well, so a symbol is effectively defined
-      // but not used if there is only one defintion, and one reference,
+      // but not used if there is only one definition, and one reference,
       // and they both map to the same position.
       if (definitionCount == 1 &&
           useCount == 1)

--- a/src/cpp/session/modules/SessionRPubs.hpp
+++ b/src/cpp/session/modules/SessionRPubs.hpp
@@ -33,7 +33,7 @@ namespace rpubs {
 core::Error initialize();
    
 } // namespace rpubs
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -114,7 +114,7 @@
    if (engine %in% c("", "qt5agg"))
       Sys.setenv(MPLENGINE = "tkAgg")
    
-   # update default version of Python to be used when reticulate is laoded
+   # update default version of Python to be used when reticulate is loaded
    .rs.registerPackageLoadHook("reticulate", function(...)
    {
       python <- .rs.readUiPref("python_path")
@@ -1092,7 +1092,7 @@
              cursor$moveToPreviousToken() &&
              (cursor$tokenValue() == "]" || cursor$tokenType() %in% "identifier"))
          {
-            # find code to be evaluted that will produce function
+            # find code to be evaluated that will produce function
             endToken   <- cursor$peek()
             cursor$moveToStartOfEvaluation()
             startToken <- cursor$peek()

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -286,7 +286,7 @@
                     gsub(
                        "([^0-9A-Z])([A-Z])", # Insert hyphen before capital letters which are not immediately preceded by a digit or another capital letter
                        "\\1-\\2",
-                       gsub("(?:'|\"|\\(([^\\)]*)\\))", "\\1", # Remove special characters and antyhing encased in parantheses
+                       gsub("(?:'|\"|\\(([^\\)]*)\\))", "\\1", # Remove special characters and anything encased in parentheses
                             gsub("&","-and-", # Replace & with And
                                  gsub("\\s", "-", string)))))))) # Replace whitespace with hyphen
    }
@@ -501,7 +501,7 @@
    value
 })
 
-# Recursivley parses a dictionary element from a tmtheme document and raises the correct errors.
+# Recursively parses a dictionary element from a tmtheme document and raises the correct errors.
 #
 # @param dictElement    The element to parse.
 # @param keyName        The name of the dictionary.
@@ -845,7 +845,7 @@
    # Get the name of the file without extension.
    fileName <- basename(themePath)
    
-   # Get the name of the theme either from the first occurence of "rs-theme-name:" in the css or 
+   # Get the name of the theme either from the first occurrence of "rs-theme-name:" in the css or 
    # the name of the file.
    themeLines <- readLines(themePath, encoding = "UTF-8", warn = FALSE)
    name <- .rs.getThemeName(paste0(themeLines, collapse = "\n"), fileName)

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -541,7 +541,7 @@ Error addTheme(const json::JsonRpcRequest& request,
  *
  * @param request       The request to remove the theme. The first parameter should be the name of
  *                      the theme.
- * @param pResponse     The response. Empty if succesful; error otherwise.
+ * @param pResponse     The response. Empty if successful; error otherwise.
  *
  * @return `Success` on a successful removal; an error otherwise.
  */

--- a/src/cpp/session/modules/SourceWithProgress.R
+++ b/src/cpp/session/modules/SourceWithProgress.R
@@ -26,7 +26,7 @@ sourceWithProgress <- function(script,               # path to R script
                                importRdata = NULL,   # RData file to import on start 
                                exportRdata = NULL    # RData file to export when done
                                ) {
-   # create a new enviroment to host any values created; make its parent the global env so any
+   # create a new environment to host any values created; make its parent the global env so any
    # variables inside this function's environment aren't visible to the script
    sourceEnv <- new.env(parent = globalenv())
 

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -113,7 +113,7 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
     if (rToolsOnPath)
     {
        // perform an extra check to see if the version on the path is not
-       // compatible with the currenly running version of R
+       // compatible with the currently running version of R
        r_util::RToolsInfo rTools = scanPathForRTools();
        if (!rTools.empty())
        {

--- a/src/cpp/session/modules/clang/CodeCompletion.hpp
+++ b/src/cpp/session/modules/clang/CodeCompletion.hpp
@@ -34,7 +34,7 @@ core::Error getCppCompletions(const core::json::JsonRpcRequest& request,
 void discoverSystemIncludePaths(std::vector<std::string>* pIncludePaths);
 
 } // namespace clang
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/DefinitionIndex.hpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.hpp
@@ -88,7 +88,7 @@ void searchDefinitions(const std::string& term,
 core::Error initializeDefinitionIndex();
 
 } // namespace clang
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/Diagnostics.hpp
+++ b/src/cpp/session/modules/clang/Diagnostics.hpp
@@ -38,7 +38,7 @@ core::Error getCppDiagnostics(const core::json::JsonRpcRequest& request,
                               core::json::JsonRpcResponse* pResponse);
    
 } // namespace clang
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/FindReferences.cpp
+++ b/src/cpp/session/modules/clang/FindReferences.cpp
@@ -100,7 +100,7 @@ CXChildVisitResult findReferencesVisitor(CXCursor cxCursor,
       // check for matching USR
       if (equalUSR(referencedCursor.getUSR(), pData->USR))
       {
-         // tokenize to extract identifer location for cursors that
+         // tokenize to extract identifier location for cursors that
          // represent larger source constructs
          FileRange foundRange;
          libclang::Tokens tokens(pData->tu, cursor.getExtent());
@@ -108,7 +108,7 @@ CXChildVisitResult findReferencesVisitor(CXCursor cxCursor,
 
          // for constructors & destructors we search backwards so that the
          // match is for the constructor identifier rather than the class
-         // identifer
+         // identifier
          unsigned numTokens = tokens.numTokens();
          if (referencedCursor.getKind() == CXCursor_Constructor ||
              referencedCursor.getKind() == CXCursor_Destructor)

--- a/src/cpp/session/modules/clang/FindReferences.hpp
+++ b/src/cpp/session/modules/clang/FindReferences.hpp
@@ -43,7 +43,7 @@ core::Error findUsages(const core::json::JsonRpcRequest& request,
                        core::json::JsonRpcResponse* pResponse);
    
 } // namespace clang
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/GoToDefinition.hpp
+++ b/src/cpp/session/modules/clang/GoToDefinition.hpp
@@ -29,7 +29,7 @@ core::Error goToCppDefinition(const core::json::JsonRpcRequest& request,
                               core::json::JsonRpcResponse* pResponse);
    
 } // namespace clang
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -136,7 +136,7 @@ core::libclang::CompilationDatabase rCompilationDatabase();
 
 
 } // namespace clang
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/RSourceIndex.hpp
+++ b/src/cpp/session/modules/clang/RSourceIndex.hpp
@@ -36,7 +36,7 @@ bool isIndexableFile(const core::FileInfo& fileInfo,
                      const core::FilePath& pkgIncludeDir);
 
 } // namespace clang
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/clang/SessionClang.hpp
+++ b/src/cpp/session/modules/clang/SessionClang.hpp
@@ -36,7 +36,7 @@ bool isAvailable();
 core::Error initialize();
    
 } // namespace clang
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -122,7 +122,7 @@ namespace {
  *    
  *    When a request for data arrives, we check to see if the data requested is
  *    a subset of the data already in our working copy. If it is, we use the
- *    working copy as a starting postion rather than the original or cached
+ *    working copy as a starting position rather than the original or cached
  *    object.
  *
  *    This allows us to efficiently perform operations on very large datasets
@@ -189,7 +189,7 @@ bool isFilterSubset(const std::string& outer, const std::string& inner)
    else if (outerType == "character")
    {
       // characters are a subset if the outer string is within the inner one
-      // (i.e. a seach for "walnuts" (inner) is within "walnut" (outer))
+      // (i.e. a search for "walnuts" (inner) is within "walnut" (outer))
       return inner.find(outer) != std::string::npos;
    }
    
@@ -204,7 +204,7 @@ typedef enum
 } DimType;
 
 // returns dimensions of an object safely--assumes dimension to be 0 unless we
-// can succesfully obtain dimensions
+// can successfully obtain dimensions
 int safeDim(SEXP data, DimType dimType)
 {
    r::sexp::Protect protect;

--- a/src/cpp/session/modules/data/SessionData.hpp
+++ b/src/cpp/session/modules/data/SessionData.hpp
@@ -32,7 +32,7 @@ namespace data {
 core::Error initialize();
    
 } // namespace data
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -86,7 +86,7 @@ class LineDebugState
       int lastDebugLine;
 };
 
-// The environment monitor and friends do work in reponse to events in R.
+// The environment monitor and friends do work in response to events in R.
 // In rare cases, this work can trigger the same events in R that are
 // being responded to, leading to unwanted recursion. This simple guard
 // increments the given counter on construction (and decrements on destruction)
@@ -226,9 +226,9 @@ SEXP rs_isAltrep(SEXP obj)
 
 // Construct a simulated source reference from a context containing a
 // function being debugged, and either the context containing the current
-// invocation or a string containing the last debug ouput from R.
+// invocation or a string containing the last debug output from R.
 // We use this to highlight portions of deparsed functions when visually
-// stepping through code for which source references are unvailable.
+// stepping through code for which source references are unavailable.
 SEXP simulatedSourceRefsOfContext(const r::context::RCntxt& context,
                                   const r::context::RCntxt& lineContext,
                                   const LineDebugState* pLineDebugState)
@@ -894,7 +894,7 @@ void onConsolePrompt(boost::shared_ptr<int> pContextDepth,
          pLineDebugState->reset();
       }
 
-      // start monitoring the enviroment at the new depth
+      // start monitoring the environment at the new depth
       s_pEnvironmentMonitor->setMonitoredEnvironment(environmentTop);
       *pContextDepth = depth;
       *pCurrentContext = context;

--- a/src/cpp/session/modules/environment/SessionEnvironment.hpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.hpp
@@ -40,7 +40,7 @@ bool isSuspendable();
 core::Error initialize();
    
 } // namespace environment
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
+++ b/src/cpp/session/modules/presentation/SlideRequestHandler.cpp
@@ -448,7 +448,7 @@ std::string fixupLink(const boost::cmatch& match)
          return match[0];
       }
 
-      // bulid the call
+      // build the call
       std::string onClick;
       if (href.size() > colonLoc+2)
       {

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -832,7 +832,7 @@ bool handleQuartoPreview(const core::FilePath& sourceFile,
                          const std::string& renderOutput,
                          bool validateExtendedType)
 {
-   // don't do anyting if user prefs are set to no preview
+   // don't do anything if user prefs are set to no preview
    if (prefs::userPrefs().rmdViewerType() == kRmdViewerTypeNone)
       return false;
 
@@ -944,7 +944,7 @@ QuartoConfig quartoConfig(bool refresh)
          // look for a config file in the project directory
          FilePath configFile = quartoConfigFilePath(context.directory());
 
-         // if we don't find one, then chase up the directory heirarchy until we find one
+         // if we don't find one, then chase up the directory hierarchy until we find one
          if (!configFile.exists())
             configFile = quartoProjectConfigFile(context.directory());
 

--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -78,7 +78,7 @@ Error QuartoJob::start()
    using namespace jobs;
    JobActions jobActions;
    // note that we pass raw 'this' b/c the "stop" action will never be executed after we
-   // hit onCompleted (becuase our status won't be "running"). if we passed shared_from_this
+   // hit onCompleted (because our status won't be "running"). if we passed shared_from_this
    // then we'd be keeping this object around forever (because jobs are never discarded).
    jobActions.push_back(std::make_pair("stop", boost::bind(&QuartoJob::stop, this)));
    pJob_ = addJob(name(), "", "", 0, false, JobRunning, JobTypeSession, false, R_NilValue, jobActions, true, {});

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -479,7 +479,7 @@ Error initialize()
    return initBlock.execute();
 }
 
-} // namespace prevew
+} // namespace preview
 } // namespace quarto
 } // namespace modules
 

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -227,7 +227,7 @@ void onDocPendingRemove(boost::shared_ptr<source_database::SourceDocument> pDoc)
                pDoc->path(), pDoc->id(), kSavedCtx);
 
       // only perform the copy if the saved branch is stale (older than the
-      // uncomitted branch)
+      // uncommitted branch)
       if (target.getLastWriteTime() < chunkDefsFile.getLastWriteTime())
       {
          // remove the old chunk definition file to make way for the new one 

--- a/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.hpp
+++ b/src/cpp/session/modules/rmarkdown/RMarkdownPresentation.hpp
@@ -40,7 +40,7 @@ void ammendResults(const std::string& formatName,
 
 } // namespace presentation
 } // namespace rmarkdown
-} // namepace modules
+} // namespace modules
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/rmarkdown/SessionBookdownXRefs.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionBookdownXRefs.cpp
@@ -358,7 +358,7 @@ json::Array indexEntriesToXRefs(const std::vector<XRefIndexEntry>& entries, bool
       }
    }
 
-   // read in referece-keys.txt so we can detect entires w/ suffixes
+   // read in referece-keys.txt so we can detect entries w/ suffixes
    std::map<std::string,int> multiKeys;
    if (isBookdownProject)
       multiKeys = readMultiKeys();

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -695,7 +695,7 @@ private:
          // it's conceivable that there would be other forceMaximize
          // scenarios or that other types of previews where an output file
          // was already in hand would NOT want to do a forceMaximize. We're
-         // leaving this coupling for now to minimze the scope of the change
+         // leaving this coupling for now to minimize the scope of the change
          // required to allow website previews to restore the viewer pane, we
          // may want a more intrusive change if/when we discover other
          // scenarios.
@@ -779,7 +779,7 @@ private:
                                                    (targetFile_.getParent(), allOutput_);
       if (!outputFile.isEmpty())
       {
-         // record ouptut file
+         // record output file
          outputFile_ = outputFile;
 
          // see if the quarto module wants to handle the preview

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -48,7 +48,7 @@ core::Error evaluateRmdParams(const std::string& docId);
 core::Error initialize();
 
 } // namespace rmarkdown
-} // namepace handlers
+} // namespace handlers
 } // namespace session
 } // namespace rstudio
 

--- a/src/cpp/session/modules/sql/SessionSql.R
+++ b/src/cpp/session/modules/sql/SessionSql.R
@@ -372,7 +372,7 @@
 .rs.addFunction("db.listTables", function(conn, schema = NULL)
 {
    # work around issue in odbc where requests for table names
-   # faile when a schema is specified
+   # fail when a schema is specified
    if ("odbc" %in% loadedNamespaces() && inherits(conn, "OdbcConnection"))
       return(odbc::dbListTables(conn, schema = schema))
    

--- a/src/cpp/session/modules/tex/SessionCompilePdf.cpp
+++ b/src/cpp/session/modules/tex/SessionCompilePdf.cpp
@@ -321,7 +321,7 @@ bool includeLogEntry(const core::tex::LogEntry& logEntry)
    return true;
 }
 
-// filter out log entries which we view as superflous or distracting
+// filter out log entries which we view as superfluous or distracting
 void filterLatexLog(const core::tex::LogEntries& logEntries,
                     core::tex::LogEntries* pFilteredLogEntries)
 {
@@ -483,7 +483,7 @@ public:
    {
       if (!basePath_.empty())
       {
-         // remove known auxillary files
+         // remove known auxiliary files
          remove(".out");
          remove(".aux");
 
@@ -528,7 +528,7 @@ private:
 };
 
 // implement pdf compilation within a class so we can maintain state
-// accross the various async callbacks the compile is composed of
+// across the various async callbacks the compile is composed of
 class AsyncPdfCompiler : boost::noncopyable,
                     public boost::enable_shared_from_this<AsyncPdfCompiler>
 {
@@ -842,7 +842,7 @@ private:
       // list or within the console
       bool showIssuesList = !isTargetRnw() || !concords.empty();
 
-      // notify the cleanp context of log entries (so it can
+      // notify the cleanup context of log entries (so it can
       // preserve any referenced files)
       auxillaryFileCleanupContext_.preserveLogReferencedFiles(
                                                       logEntries);

--- a/src/cpp/session/modules/tex/SessionPdfLatex.cpp
+++ b/src/cpp/session/modules/tex/SessionPdfLatex.cpp
@@ -348,7 +348,7 @@ bool latexProgramForFile(const core::tex::TexMagicComments& magicComments,
 //
 //  http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=534458
 //
-// this code is a port of the simillar logic which exists in the
+// this code is a port of the similar logic which exists in the
 // tools::texi2dvi function (but the regex for detecting citation
 // warnings was made a bit more liberal)
 //

--- a/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwConcordance.cpp
@@ -277,7 +277,7 @@ FileAndLine Concordances::texLine(const FileAndLine& rnwLine) const
    if (rnwLine.filePath().isEmpty())
       return FileAndLine();
 
-   // inspect concordance where input file is equivilant to rnw file
+   // inspect concordance where input file is equivalent to rnw file
    std::vector<Concordance> rnwFileConcords;
    algorithm::copy_if(
       concordances_.begin(),

--- a/src/cpp/session/modules/tex/SessionRnwWeave.cpp
+++ b/src/cpp/session/modules/tex/SessionRnwWeave.cpp
@@ -123,7 +123,7 @@ public:
    {
       // split into lines so we can determine the line numbers for the chunks
       // NOTE: will need to read this using global/project encoding if we
-      // want to look for text outside of theh orignal error parsing
+      // want to look for text outside of theh original error parsing
       // scenario (which only required ascii)
       std::string rnwContents;
       Error error = core::readStringFromFile(rnwFilePath, &rnwContents);

--- a/src/cpp/session/modules/zotero/ZoteroCollectionsWeb.cpp
+++ b/src/cpp/session/modules/zotero/ZoteroCollectionsWeb.cpp
@@ -638,7 +638,7 @@ void getWebCollectionsForUser(std::string key,
          }
       }
 
-      // associate cache specs with download requests (so we can propogate the version)
+      // associate cache specs with download requests (so we can propagate the version)
       for (ZoteroCollectionSpec cacheSpec : cacheSpecs)
       {
          auto it = std::find_if(pDownloads->begin(), pDownloads->end(), [cacheSpec](const DownloadRequest& request) {

--- a/src/cpp/session/resources/markdown_help.html
+++ b/src/cpp/session/resources/markdown_help.html
@@ -132,7 +132,7 @@ summary(cars$speed)
 </code></pre>
 
 <h4>Plain Code Blocks</h4>
-<p>Plain code blocks are displayed in a fixed-width font but not evaulated</p>
+<p>Plain code blocks are displayed in a fixed-width font but not evaluated</p>
 <pre><code>```
 This text is displayed verbatim / preformatted
 ```

--- a/src/cpp/session/resources/xref.lua
+++ b/src/cpp/session/resources/xref.lua
@@ -66,7 +66,7 @@ function CodeBlock(s, attr)
     end
   end
   
-  -- thereom
+  -- theorem
   -- https://bookdown.org/yihui/bookdown/markdown-extensions-by-bookdown.html#theorems
   local theorem_types = 
   {


### PR DESCRIPTION

### Intent

> Fixes typos found within the source code which includes comments and documentation. 

### Approach

> Found using `codespell -q 3 -S *_fr.properties -L ba,enque,ot,prevend,pevent,pevents,ptd,texline src/cpp/session/`

### Automated Tests

> This PR fixes typos. No unit tests needed.

### QA Notes

> N/A 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests


