### PR TITLE
improve handling of trailing separator in prefix

### DIFF
--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -94,6 +94,7 @@ test_that("our list.files, list.dirs hooks function as expected", {
    
    dir.create("dir")
    dir.create("dir/subdir")
+   file.create("dir/file")
    file.create("dir/subdir/file")
    
    dir.create("empty")
@@ -110,6 +111,10 @@ test_that("our list.files, list.dirs hooks function as expected", {
    
    paths <- list(
       ".",
+      "./",
+      ".\\",
+      ".//",
+      ".\\/",
       getwd(),
       chartr("/", "\\", getwd()),
       file.path("..", basename(getwd())),


### PR DESCRIPTION
### Intent

Fixes another issue regarding how trailing separators are handled by R with `list.files()` and `list.dirs()`.

Note: not crucial for the PT release; we could consider as part of the next patch release if we don't want to hold things up.

### Approach

R is inconsistent in how trailing separators in the `path` argument are handled; this PR tweaks how we handle these to conform with R's implementation.

### Automated Tests

Unit tests included.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
