### PR TITLE
Fix various typos

### DIFF
--- a/dependencies/common/install-crashpad
+++ b/dependencies/common/install-crashpad
@@ -78,7 +78,7 @@ if [ -n "${FLAVOR}" ]; then
    download "$CRASHPAD_PRE_BUILT_ROOT_URL/$ARCHIVE_FOLDER/crashpad-${FLAVOR}$ARCHIVE_EXT"
    tar xvf "crashpad-${FLAVOR}$ARCHIVE_EXT"
    if ! test -e "$CRASHPAD_BIN_DIR/crashpad_handler"; then
-      echo "An error occured installing pre-built Crashpad binaries - $CRASHPAD_BIN_DIR/crashpad_handler does not exist"
+      echo "An error occurred installing pre-built Crashpad binaries - $CRASHPAD_BIN_DIR/crashpad_handler does not exist"
       exit 1
    else
       rm "./crashpad-${FLAVOR}$ARCHIVE_EXT"

--- a/src/cpp/OPTIONS.md
+++ b/src/cpp/OPTIONS.md
@@ -82,7 +82,7 @@ The following sections list all of the properties that can be specified within a
 
 ### options
 
-The options property is a string dictionary, where each entry is a category of options to specify. Within each category, you may specfy multiple `option` objects that may have the following properties.
+The options property is a string dictionary, where each entry is a category of options to specify. Within each category, you may specify multiple `option` objects that may have the following properties.
 
 | Property   |      Description     | 
 |----------|-------------|

--- a/src/cpp/core/BoostErrors.cpp
+++ b/src/cpp/core/BoostErrors.cpp
@@ -18,7 +18,7 @@
 #include <core/BoostThread.hpp>
 
 // we define BOOST_USE_WINDOWS_H on mingw64 to work around some
-// incompatabilities. however, this prevents the interprocess headers
+// incompatibilities. however, this prevents the interprocess headers
 // from compiling so we undef it in this localized context
 #if defined(__GNUC__) && defined(_WIN64)
    #undef BOOST_USE_WINDOWS_H

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -923,7 +923,7 @@ Error SchemaUpdater::getSchemaTableColumnCount(int* pColumnCount)
    Error error;
    if (connection_->driverName() == SQLITE_DRIVER)
    {
-      // This query is explicity a SELECT * because we use the # of columns to determine if 
+      // This query is explicitly a SELECT * because we use the # of columns to determine if 
       // we're pre- or post- GhostOrchid
       Query query = connection_->query(std::string("SELECT * FROM ") + SCHEMA_TABLE);
       Rowset rows;

--- a/src/cpp/core/Thread.cpp
+++ b/src/cpp/core/Thread.cpp
@@ -30,7 +30,7 @@ namespace thread {
 namespace {
 
 // main thread id
-// we initialize this statically but the value can be overriden
+// we initialize this statically but the value can be overridden
 // via initializeMainThreadId() if necessary
 boost::thread::id s_mainThreadId = boost::this_thread::get_id();
 

--- a/src/cpp/core/file_lock/AdvisoryFileLock.cpp
+++ b/src/cpp/core/file_lock/AdvisoryFileLock.cpp
@@ -36,7 +36,7 @@
    } while (0)
 
 // we define BOOST_USE_WINDOWS_H on mingw64 to work around some
-// incompatabilities. however, this prevents the interprocess headers
+// incompatibilities. however, this prevents the interprocess headers
 // from compiling so we undef it in this localized context
 #if defined(__GNUC__) && defined(_WIN64)
    #undef BOOST_USE_WINDOWS_H

--- a/src/cpp/core/http/Message.cpp
+++ b/src/cpp/core/http/Message.cpp
@@ -162,7 +162,7 @@ void Message::reset()
    headers_.clear();
    body_.clear();
    
-   // allow additional reseting by subclasses
+   // allow additional resetting by subclasses
    resetMembers();
 }
 
@@ -217,7 +217,7 @@ std::vector<boost::asio::const_buffer> Message::headerBuffers(
    for (Headers::const_iterator
         it = headers_.begin(); it != headers_.end(); ++it)
    {
-      // add the header if it isn't being overriden
+      // add the header if it isn't being overridden
       if (it->name != overrideHeader_.name)
          appendHeader(*it, &buffers);
    }

--- a/src/cpp/core/http/Response.cpp
+++ b/src/cpp/core/http/Response.cpp
@@ -323,7 +323,7 @@ void Response::setPrivateCacheForeverHeaders()
 {
    // NOTE: the Google article referenced above indicates that for the 
    // private scenario you should set the Expires header in the past so 
-   // that HTTP 1.0 proxies never cache it. Unfortuantely when running 
+   // that HTTP 1.0 proxies never cache it. Unfortunately when running 
    // against localhost in Firefox we observed that this prevented Firefox
    // from caching.
    setCacheForeverHeaders(false);

--- a/src/cpp/core/include/core/FileInfo.hpp
+++ b/src/cpp/core/include/core/FileInfo.hpp
@@ -25,7 +25,7 @@
 
 #include <shared_core/FilePath.hpp>
 
-// TODO: satisfy outselves that it is safe to query for symlink status
+// TODO: satisfy ourselves that it is safe to query for symlink status
 // in all cases and eliminate its "optional" semantics
 
 namespace rstudio {
@@ -46,7 +46,7 @@ public:
 
    // NOTE: this constructor will NOT read symlink info from the passed
    // FilePath object. this is because we want to restrict reading of
-   // symlink to status to funcitons that are expressly symlink aware
+   // symlink to status to functions that are expressly symlink aware
    // (this is because the behavior of reading symlink status is not
    // fully known and we don't want to make a change underneath our
    // entire codebase which does this universally (note that we've been

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -273,7 +273,7 @@ Error readStructVectorFromFile(const core::FilePath& filePath,
 
 
 
-// convenince methods for simple string collections
+// convenience methods for simple string collections
 ReadCollectionAction parseString(const std::string& line, std::string* pStr);
 std::string stringifyString(const std::string& str);
 

--- a/src/cpp/core/include/core/collection/Tree.hpp
+++ b/src/cpp/core/include/core/collection/Tree.hpp
@@ -26,7 +26,7 @@
 //
 // If you have received this program directly from RStudio pursuant
 // to the terms of a commercial license then tree.hh is covered 
-// under this same commerical license.
+// under this same commercial license.
 //
 
 /** \mainpage tree.hh

--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -134,7 +134,7 @@ public:
       if (request_.host().empty())
          request_.setHost(getDefaultHostHeader());
 
-      // connect and write request (implmented in a protocol
+      // connect and write request (implemented in a protocol
       // specific manner by subclassees)
       connectAndWriteRequest();
    }
@@ -369,7 +369,7 @@ private:
             }
          }
 
-         // if we aren't alrady past the maximum wait time then
+         // if we aren't already past the maximum wait time then
          // wait the appropriate interval and attempt connection again
          if (boost::posix_time::microsec_clock::universal_time() <
              connectionRetryContext_.stopTryingTime)

--- a/src/cpp/core/include/core/http/AsyncServerImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncServerImpl.hpp
@@ -259,7 +259,7 @@ public:
 
       // gracefully stop all open connections to ensure they are freed
       // before our io service (socket acceptor) is freed - if this is
-      // not gauranteed, boost will crash when attempting to free socket objects
+      // not guaranteed, boost will crash when attempting to free socket objects
       //
       // note that we create a copy of the connections list here because as connections
       // are closed, they will remove themselves from the list

--- a/src/cpp/core/include/core/http/Message.hpp
+++ b/src/cpp/core/include/core/http/Message.hpp
@@ -163,7 +163,7 @@ private:
    mutable std::string httpVersion_;
 
    // grant friendship to subclasses and parsers so they can 
-   // direclty manipulate fields
+   // directly manipulate fields
    friend class Response; // done to ensure body_ can be assigned to directly
                           // with no intermediate std::string copies made
    friend class RequestParser;

--- a/src/cpp/core/include/core/http/URL.hpp
+++ b/src/cpp/core/include/core/http/URL.hpp
@@ -26,7 +26,7 @@ namespace core {
 namespace http {
 
 // NOTE: The URL class is a part of shared endpoint and association caches
-// in our open-id implemetnation. we therefore need to make sure that
+// in our open-id implementation. we therefore need to make sure that
 // copying a URL or accessing its members never falls prey to ref-counted 
 // strings which are (potentially) not threadsafe. To work around this we do
 // manual assignment of all strings during copy and assignment and have 

--- a/src/cpp/core/include/core/http/Util.hpp
+++ b/src/cpp/core/include/core/http/Util.hpp
@@ -174,7 +174,7 @@ bool isIpAddress(const std::string& addr);
 // querying the DNS system
 bool isNetworkAddress(const std::string& str);
 
-// determins if the given request is request to upgrade the connection to a websocket
+// determines if the given request is request to upgrade the connection to a websocket
 bool isWSUpgradeRequest(const Request& request);
 
 // does the given error represent SSL truncation/shutdown?

--- a/src/cpp/core/include/core/system/Environment.hpp
+++ b/src/cpp/core/include/core/system/Environment.hpp
@@ -61,7 +61,7 @@ void setenv(Options* pEnvironment,
             const std::string& name,
             const std::string& value);
 
-// remove an enviroment variable from an Options structure
+// remove an environment variable from an Options structure
 void unsetenv(Options* pEnvironment,
               const std::string& name);
 
@@ -76,7 +76,7 @@ void addToPath(std::string* pPath,
                const std::string& filePath,
                bool prepend = false);
 
-// add to the PATH within an Options struture
+// add to the PATH within an Options structure
 void addToPath(Options* pEnvironment,
                const std::string& filePath,
                bool prepend = false);
@@ -95,7 +95,7 @@ std::string expandEnvVars(const Options& environment, const std::string& str);
 // to the desired environment object
 void forwardEnvVars(const std::vector<std::string>& vars, Options* pEnvironment);
 
-// set an environment variable in some scope (overridding and
+// set an environment variable in some scope (overriding and
 // later restoring a previously-set environment variable)
 class EnvironmentScope : boost::noncopyable
 {

--- a/src/cpp/core/include/core/system/FileChangeEvent.hpp
+++ b/src/cpp/core/include/core/system/FileChangeEvent.hpp
@@ -105,7 +105,7 @@ void collectFileChangeEvents(PreviousIterator prevBegin,
    std::copy(currBegin, currEnd, std::back_inserter(curr));
    std::sort(curr.begin(), curr.end(), fileInfoPathLessThan);
 
-   // initalize the iterators
+   // initialize the iterators
    std::vector<FileInfo>::iterator prevIt = prev.begin();
    std::vector<FileInfo>::iterator currIt = curr.begin();
 

--- a/src/cpp/core/include/core/system/FileMonitor.hpp
+++ b/src/cpp/core/include/core/system/FileMonitor.hpp
@@ -51,7 +51,7 @@ void stop();
 
 // opaque handle to a registration (used to unregister). the id field
 // is included so that handles have additional uniqueness beyond the
-// value of the pData pointer (which could be duplicated accross monitors
+// value of the pData pointer (which could be duplicated across monitors
 // depending upon the order of allocations/deallocations)
 struct Handle
 {

--- a/src/cpp/core/include/core/system/PosixChildProcess.hpp
+++ b/src/cpp/core/include/core/system/PosixChildProcess.hpp
@@ -30,7 +30,7 @@ namespace core {
 namespace system {
 
 // interface for AsioAsyncChildProcess
-// primarly used for testing
+// primarily used for testing
 class IAsioAsyncChildProcess
 {
 public:

--- a/src/cpp/core/include/core/system/PosixSystem.hpp
+++ b/src/cpp/core/include/core/system/PosixSystem.hpp
@@ -95,7 +95,7 @@ core::Error pidof(const std::string& process, std::vector<PidType>* pPids);
 typedef boost::function<bool (const ProcessInfo&)> ProcessFilter;
 
 // get process by process name, or all processes if process name is empty
-// optionally allows supressing of errors - recommended in most cases
+// optionally allows suppressing of errors - recommended in most cases
 // as such errors are generally transient and benign
 core::Error processInfo(const std::string& process,
                         std::vector<ProcessInfo>* pInfo,

--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -90,7 +90,7 @@ FilePath systemConfigFile(const std::string& filename);
 // and why.
 FilePath findSystemConfigFile(const std::string& context, const std::string& filename);
 
-// Sets relevant XDG environment varibles
+// Sets relevant XDG environment variables
 void forwardXdgEnvVars(Options *pEnvironment);
 
 } // namespace xdg

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -174,5 +174,5 @@ namespace
         return std::make_shared<FileActiveSessionStorage>(FileActiveSessionStorage(scratchPath));
     }
 } // namespace r_util
-} // namepsace core
+} // namespace core
 } // namespace rstudio

--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -310,7 +310,7 @@ bool validateRScriptPath(const std::string& rScriptPath,
       return false;
    }
 
-   // error if it is a directry
+   // error if it is a directory
    else if (rBinaryPath.isDirectory())
    {
       *pErrMsg = "R script path (" + rBinaryPath.getAbsolutePath() +
@@ -823,7 +823,7 @@ std::string rLibraryPath(const FilePath& rHomePath,
    // place R library path at front
    libraryPaths.push_back(rLibPath.getAbsolutePath());
    
-   // pass along default (inheritted) library paths
+   // pass along default (inherited) library paths
    std::string defaultLibraryPaths = core::system::getenv(kLibraryPathEnvVariable);
  
    // on macOS, we need to initialize with a default set of library paths
@@ -831,7 +831,7 @@ std::string rLibraryPath(const FilePath& rHomePath,
 #ifdef __APPLE__
    if (defaultLibraryPaths.empty())
    {
-      // if this isn't set explicitly then initalize it with the default
+      // if this isn't set explicitly then initialize it with the default
       // of $HOME/lib:/usr/local/lib:/usr/lib. See documentation here:
       // http://developer.apple.com/library/ios/#documentation/system/conceptual/manpages_iphoneos/man3/dlopen.3.html
       //
@@ -957,7 +957,7 @@ Error rVersion(const FilePath& rHomePath,
 
 /*
 We've observed that Ubuntu 14.10 no longer passes the LANG environment
-variable to daemon processes so we lose the automatic inheritence of
+variable to daemon processes so we lose the automatic inheritance of
 LANG from the system default. For this case we'll do automatic detection
 and setting of LANG.
 */

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -457,7 +457,7 @@ std::string generateScopeId(const std::vector<std::string>& reserved)
    std::string id = core::string_utils::toLower(
                                  core::system::generateShortenedUuid());
 
-   // ensure 8 chracters
+   // ensure 8 characters
    if (id.length() != kProjectIdLen)
    {
       if (id.length() > kProjectIdLen)

--- a/src/cpp/core/r_util/RVersionsPosix.cpp
+++ b/src/cpp/core/r_util/RVersionsPosix.cpp
@@ -311,7 +311,7 @@ std::vector<RVersion> enumerateRVersions(
 #endif
 
    // sort the versions using stable sort
-   // this gaurantees that versions specified in the versions file will come first
+   // this guarantees that versions specified in the versions file will come first
    // this makes sure that versions that have user-defined metadata (such as labels)
    // will not be erased in the subsequent erase call, but the equivalent default versions that were
    // found will be erased instead

--- a/src/cpp/core/spelling/HunspellSpellingEngine.cpp
+++ b/src/cpp/core/spelling/HunspellSpellingEngine.cpp
@@ -50,7 +50,7 @@ void removeMorphologicalDescription(std::string* pText)
 }
 
 // extract the word from the dic_delta line -- remove the
-// optional affix and then replace escaped / chracters
+// optional affix and then replace escaped / characters
 bool parseDicDeltaLine(std::string line,
                        std::string* pWord,
                        std::string* pAffix)
@@ -93,14 +93,14 @@ bool parseDicDeltaLine(std::string line,
 // The hunspell api allows you to add words with affixes by providing an
 // example word already in the dictionary that has the same affix. The google
 // english .dic_delta files use the hard-coded integer values 6 and 7 to
-// (respecitvely) indicate possesive (M) and possesive/plural (MS) affixes.
+// (respectively) indicate possessive (M) and possessive/plural (MS) affixes.
 // Therefore, this function needs to return words that are marked as
 // M or MS consistently in the main dictionaries of the 4 english variations.
 // If we want to extend affix support to other languages we'll need to
-// do a simillar mapping
+// do a similar mapping
 std::string exampleWordForEnglishAffix(const std::string& affix)
 {
-   if (affix == "6") // possesive (M)
+   if (affix == "6") // possessive (M)
       return "Arcadia";
    else if (affix == "7") // possessive or plural (MS)
       return "beverage";

--- a/src/cpp/core/spelling/hunspell/affentry.cxx
+++ b/src/cpp/core/spelling/hunspell/affentry.cxx
@@ -926,7 +926,7 @@ specific character position in the word.
 For prefixes, it does this by setting bit 0 if that char is valid 
 in the first position, bit 1 if valid in the second position, and so on. 
 
-If a bit is not set, then that char is not valid for that postion in the
+If a bit is not set, then that char is not valid for that position in the
 word.
 
 If working with suffixes bit 0 is used for the character closest 

--- a/src/cpp/core/spelling/hunspell/affixmgr.cxx
+++ b/src/cpp/core/spelling/hunspell/affixmgr.cxx
@@ -528,7 +528,7 @@ int  AffixMgr::parse_file(const char * affpath, const char * key)
           }
        }
 
-       /* parse in the ignored characters (for example, Arabic optional diacretics charachters */
+       /* parse in the ignored characters (for example, Arabic optional diacretics characters */
        if (strncmp(line,"IGNORE",6) == 0) {
           if (parse_array(line, &ignorechars, &ignorechars_utf16, &ignorechars_utf16_len, utf8, afflst->getlinenum())) {
              delete afflst;

--- a/src/cpp/core/spelling/hunspell/hashmgr.hxx
+++ b/src/cpp/core/spelling/hunspell/hashmgr.hxx
@@ -29,7 +29,7 @@ class LIBHUNSPELL_DLL_EXPORTED HashMgr
   int               numaliasf; // flag vector `compression' with aliases
   unsigned short ** aliasf;
   unsigned short *  aliasflen;
-  int               numaliasm; // morphological desciption `compression' with aliases
+  int               numaliasm; // morphological description `compression' with aliases
   char **           aliasm;
 
 

--- a/src/cpp/core/spelling/hunspell/htypes.hxx
+++ b/src/cpp/core/spelling/hunspell/htypes.hxx
@@ -25,7 +25,7 @@ struct hentry
   unsigned short * astr;  // affix flag vector
   struct   hentry * next; // next word with same hash code
   struct   hentry * next_homonym; // next homonym word (with same hash code)
-  char     var;       // variable fields (only for special pronounciation yet)
+  char     var;       // variable fields (only for special pronunciation yet)
   char     word[1];   // variable-length word (8-bit or UTF-8 encoding)
 };
 

--- a/src/cpp/core/spelling/hunspell/hunspell.cxx
+++ b/src/cpp/core/spelling/hunspell/hunspell.cxx
@@ -552,7 +552,7 @@ int Hunspell::spell(const char * word, int * info, char ** root)
           if (spell(cw)) return 1; // check the first part with dash
           s[1] = r;
 	}
-        // end of LANG speficic region
+        // end of LANG specific region
 
       }
     }
@@ -656,7 +656,7 @@ struct hentry * Hunspell::checkword(const char * w, int * info, char ** root)
              he = pAMgr->compound_check(dup, len-1, -5, 0, 100, 0, NULL, 1, 0, info);
              free(dup);
           }
-          // end of LANG speficic region
+          // end of LANG specific region
           if (he) {
                 if (root) {
                     *root = mystrdup(he->word);

--- a/src/cpp/core/spelling/hunspell/hunspell.hxx
+++ b/src/cpp/core/spelling/hunspell/hunspell.hxx
@@ -123,7 +123,7 @@ public:
 
   /* other */
 
-  /* get extra word characters definied in affix file for tokenization */
+  /* get extra word characters defined in affix file for tokenization */
   const char * get_wordchars();
   unsigned short * get_wordchars_utf16(int * len);
 

--- a/src/cpp/core/spelling/hunspell/suggestmgr.cxx
+++ b/src/cpp/core/spelling/hunspell/suggestmgr.cxx
@@ -1090,7 +1090,7 @@ int SuggestMgr::ngsuggest(char** wlst, char * w, int ns, HashMgr** pHMgr, int md
     sc = ngram(3, word, HENTRY_WORD(hp), NGRAM_LONGER_WORSE + low) +
 	leftcommonsubstring(word, HENTRY_WORD(hp));
 
-    // check special pronounciation
+    // check special pronunciation
     if ((hp->var & H_OPT_PHON) && copy_field(f, HENTRY_DATA(hp), MORPH_PHON)) {
 	int sc2 = ngram(3, word, f, NGRAM_LONGER_WORSE + low) +
 		+ leftcommonsubstring(word, f);
@@ -1138,7 +1138,7 @@ int SuggestMgr::ngsuggest(char** wlst, char * w, int ns, HashMgr** pHMgr, int md
   }}
 
   // find minimum threshold for a passable suggestion
-  // mangle original word three differnt ways
+  // mangle original word three different ways
   // and score them to generate a minimum acceptable score
   int thresh = 0;
   for (int sp = 1; sp < 4; sp++) {

--- a/src/cpp/core/system/Environment.cpp
+++ b/src/cpp/core/system/Environment.cpp
@@ -82,7 +82,7 @@ void setenv(Options* pEnvironment,
       pEnvironment->push_back(std::make_pair(name, value));
 }
 
-// remove an enviroment variable from an Options structure
+// remove an environment variable from an Options structure
 void unsetenv(Options* pEnvironment, const std::string& name)
 {
    pEnvironment->erase(std::remove_if(pEnvironment->begin(),
@@ -127,7 +127,7 @@ void addToPath(std::string* pPath,
    *pPath = modifyPath(*pPath, filePath, prepend);
 }
 
-// add to the PATH within an Options struture
+// add to the PATH within an Options structure
 void addToPath(Options* pEnvironment,
                const std::string& filePath,
                bool prepend)

--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -836,7 +836,7 @@ Error ChildProcess::run()
          pImpl_->init(pid, fdMaster);
       }
 
-      // standard mode: close unused pipes & wire streams to approprite fds
+      // standard mode: close unused pipes & wire streams to appropriate fds
       else
       {
          // close unused pipes
@@ -1053,7 +1053,7 @@ void AsyncChildProcess::poll()
    {
       if (!callbacks_.onContinue(*this))
       {
-         // terminate the proces
+         // terminate the process
          Error error = terminate();
          if (error)
             LOG_ERROR(error);

--- a/src/cpp/core/system/PosixChildProcessTracker.cpp
+++ b/src/cpp/core/system/PosixChildProcessTracker.cpp
@@ -28,7 +28,7 @@ namespace system {
 
 namespace {
 
-// wraper for waitPid which tries again for EINTR
+// wrapper for waitPid which tries again for EINTR
 int waitPid(PidType pid, int* pStatus)
 {
    for (;;)
@@ -54,7 +54,7 @@ void ChildProcessTracker::addProcess(PidType pid, ExitHandler exitHandler)
 
 void ChildProcessTracker::notifySIGCHILD()
 {
-   // We make a copy of hte active pids so that we can do the reaping
+   // We make a copy of the active pids so that we can do the reaping
    // outside of the pidsMutex_. This is an extra conservative precaution
    // in case there is ever an issue with waitpid blocking.
    std::map<PidType,ExitHandler> processes = activeProcesses();
@@ -108,7 +108,7 @@ void ChildProcessTracker::attemptToReapProcess(
          LOG_WARNING_MESSAGE(boost::str(fmt % pid % status));
       }
    }
-   // error occured
+   // error occurred
    else if (result == -1)
    {
       Error error = systemError(errno, ERROR_LOCATION);

--- a/src/cpp/core/system/PosixEnvironment.cpp
+++ b/src/cpp/core/system/PosixEnvironment.cpp
@@ -64,7 +64,7 @@ void unsetenv(const std::string& name)
 }
 
 
-} // namespace sytem
+} // namespace system
 } // namespace core
 } // namespace rstudio
 

--- a/src/cpp/core/system/PosixFileScanner.cpp
+++ b/src/cpp/core/system/PosixFileScanner.cpp
@@ -183,7 +183,7 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
                // try to scan the files in the subdirectory -- if we fail
                // we continue because we don't want one "bad" directory
                // to cause us to abort the entire scan. yes the tree
-               // will be incomplete however it will be even more incompete
+               // will be incomplete however it will be even more incomplete
                // if we fail entirely
                Error error = scanFiles(child, options, pTree);
                if (error)

--- a/src/cpp/core/system/PosixProcess.cpp
+++ b/src/cpp/core/system/PosixProcess.cpp
@@ -53,7 +53,7 @@ struct AsioProcessSupervisor::Impl
       Error error = pChild->run(callbacks);
       if (error)
       {
-         // error occured - remove the child
+         // error occurred - remove the child
          LOCK_MUTEX(mutex_)
          {
             children_.erase(pChild);
@@ -151,10 +151,10 @@ struct AsioProcessSupervisor::Impl
       LOCK_MUTEX(mutex_)
       {
          // upgrade this weak pointer to a shared pointer
-         // this should be gauranteed to work but we do a null check just to be safe
+         // this should be guaranteed to work but we do a null check just to be safe
          // this should always work because the actual child cannot die until we've erased it from
          // our collection. the weak pointer is used to ensure that the callbacks stored by the child
-         // do not store a strong reference to itself, thus preventing the child from ever beeing freed
+         // do not store a strong reference to itself, thus preventing the child from ever being freed
          if (boost::shared_ptr<AsioAsyncChildProcess> child = pChild.lock())
             children_.erase(child);
       }

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -566,7 +566,7 @@ namespace {
 // worst case scenario - close all file descriptors possible
 // this can be EXTREMELY slow when max fd is set to a high value
 // note: this conditional should actually never be true
-// as all linux systems have /proc/self - this is perserved in the codebase
+// as all linux systems have /proc/self - this is preserved in the codebase
 // as a remainder of what was being done in the recent past
 Error closeFileDescriptorsFrom(int fdStart)
 {

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -345,7 +345,7 @@ bool ProcessSupervisor::poll()
       // executing R code (e.g. via onContinue) which can in term end up
       // executing background tasks that result in a call to processSupervisor
       // runProgram or runCommand. This would then result in a push_back on
-      // the children vector and if this requried a realloc would invalidate
+      // the children vector and if this required a realloc would invalidate
       // all of the iterators currently pointing into the container
       std::vector<boost::shared_ptr<AsyncChildProcess> > children = pImpl_->children;
       std::for_each(children.begin(),

--- a/src/cpp/core/system/Win32FileScanner.cpp
+++ b/src/cpp/core/system/Win32FileScanner.cpp
@@ -67,7 +67,7 @@ FileInfo convertToFileInfo(const FilePath& filePath, bool yield, int *pCount)
 // enumerated however we merely log errors for children. this reflects
 // the notion that a top-level failure will report major problems
 // (e.g. permission to access a volume/drive) whereas errors which
-// occur in children are more likely to refect some idiosyncratic
+// occur in children are more likely to reflect some idiosyncratic
 // problem with a child dir or file, and we don't want that to
 // interfere with the caller getting a listing of everything else
 // and proceeding with its work
@@ -99,8 +99,8 @@ Error scanFiles(const tree<FileInfo>::iterator_base& fromNode,
    if (error)
       return error;
 
-   // convert to FileInfo and sort using alphasort equivilant (for
-   // compatability with scandir, which is what is used in our
+   // convert to FileInfo and sort using alphasort equivalent (for
+   // compatibility with scandir, which is what is used in our
    // posix-specific implementation
    int count = 0;
    std::vector<FileInfo> childrenFileInfo;

--- a/src/cpp/core/system/Win32Resources.cpp
+++ b/src/cpp/core/system/Win32Resources.cpp
@@ -64,7 +64,7 @@ Error getTotalMemory(long *pTotalKb, MemoryProvider *pProvider)
    return Success();
 }
 
-} // namespace sytem
+} // namespace system
 } // namespace core
 } // namespace rstudio
 

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -759,7 +759,7 @@ Error copyMetafileToClipboard(const FilePath& path)
    if (error)
       return error;
 
-   // emtpy the clipboard
+   // empty the clipboard
    if (!::EmptyClipboard())
    {
       return LAST_SYSTEM_ERROR();

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -99,7 +99,7 @@ FilePath resolveXdgDir(
    std::string env = getenv(rstudioEnvVar);
    if (env.empty())
    {
-      // The RStudio environment variable specifices the final path; if it isn't
+      // The RStudio environment variable specifies the final path; if it isn't
       // set we will need to append "rstudio" to the path later.
       finalPath = false;
       env = getenv(xdgEnvVar);

--- a/src/cpp/core/system/file_monitor/FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/FileMonitor.cpp
@@ -299,7 +299,7 @@ Error discoverAndProcessFileChanges(
    if (error)
       return error;
 
-   // handle recursive vs. non-recursive scan differnetly
+   // handle recursive vs. non-recursive scan differently
    if (recursive)
    {
       // check for changes on full subtree
@@ -404,7 +404,7 @@ Handle registerMonitor(const core::FilePath& filePath,
 // unregister a file monitor
 void unregisterMonitor(Handle handle);
 
-// stop the monitor. allows for optinal global cleanup and/or waiting
+// stop the monitor. allows for optional global cleanup and/or waiting
 // for termination state on the monitor thread
 void stop();
 

--- a/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
+++ b/src/cpp/core/system/file_monitor/Win32FileMonitor.cpp
@@ -318,7 +318,7 @@ bool isRecoverableByRestart(const Error& error)
       // (see: http://blogs.msdn.com/b/oldnewthing/archive/2011/08/12/10195186.aspx)
       error.getCode() == ERROR_NOTIFY_ENUM_DIR ||
 
-      // error which some users have observed occuring if a network
+      // error which some users have observed occurring if a network
       // volume is being monitored and there are too many simultaneous
       // reads and writes
       error.getCode() == ERROR_TOO_MANY_CMDS;
@@ -439,7 +439,7 @@ VOID CALLBACK FileChangeCompletionRoutine(DWORD dwErrorCode,
    }
 
    // check for buffer overflow. this means there are too many file changes
-   // for the systme to keep up with -- in this case try to restart monitoring
+   // for the system to keep up with -- in this case try to restart monitoring
    // (after a 1 second delay) and repeat the restart up to 10 times
    if (dwNumberOfBytesTransfered == 0)
    {

--- a/src/cpp/core/terminal/PrivateCommandTests.cpp
+++ b/src/cpp/core/terminal/PrivateCommandTests.cpp
@@ -254,7 +254,7 @@ test_context("Private Terminal Command Tests")
       expect_true(ops.writesEof.size() == ops.writes.size());
    }
 
-   test_that("command not issued if user hasn't entered a new command since last private comand")
+   test_that("command not issued if user hasn't entered a new command since last private command")
    {
       PrivateCommand cmd(kCommand, kPrivate, kUser, kTimeout, kPostTimeout, kOncePerUserEnter);
 

--- a/src/cpp/core/text/TermBufferParser.cpp
+++ b/src/cpp/core/text/TermBufferParser.cpp
@@ -168,7 +168,7 @@ struct ParseMetadata
    // was a supported escape sequence found?
    bool haveSupportedSeq;
 
-   // number string as it is extraced from sequence
+   // number string as it is extracted from sequence
    std::string numberStr;
 
    // current character

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -22,7 +22,7 @@ cmake_policy(SET CMP0043 NEW)
 if(NOT RSTUDIO_ELECTRON)
 
    # on unix prefer qtsdk installs over system-level libraries. note this
-   # can be overriden by defining QT_QMAKE_EXECUTABLE when invoking cmake
+   # can be overridden by defining QT_QMAKE_EXECUTABLE when invoking cmake
    if(NOT WIN32)
       # prefer rstudio qtsdk install then home qtsdk install
       if(NOT QT_QMAKE_EXECUTABLE)

--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -113,7 +113,7 @@ QAction* MenuCallback::addCustomAction(QString commandId,
    }
    
    // on macOS, these bindings are hooked up on the GWT side (mainly to ensure
-   // that zoom requests targetted to a GWT window work as expected)
+   // that zoom requests targeted to a GWT window work as expected)
 #ifndef Q_OS_MAC
    else if (commandId == QStringLiteral("zoomActualSize"))
    {

--- a/src/cpp/desktop/DesktopSynctex.cpp
+++ b/src/cpp/desktop/DesktopSynctex.cpp
@@ -20,7 +20,7 @@
 #include <core/RegexUtils.hpp>
 #include <shared_core/SafeConvert.hpp>
 
-// per-platform synctex implemetnations
+// per-platform synctex implementations
 #if defined(Q_OS_MAC)
 
 #elif defined(Q_OS_WIN)
@@ -123,7 +123,7 @@ SynctexViewerInfo Synctex::desktopViewerInfo()
 
 Synctex* Synctex::create(MainWindow* pMainWindow)
 {
-   // per-platform synctex implemetnations
+   // per-platform synctex implementations
 #if defined(Q_OS_MAC)
    return new Synctex(pMainWindow);
 #elif defined(Q_OS_WIN)

--- a/src/cpp/desktop/install/LinuxInstallQt.sh.in
+++ b/src/cpp/desktop/install/LinuxInstallQt.sh.in
@@ -89,7 +89,7 @@ printf "%s\n" "${QTCONF}" > libexec/qt.conf
 
 # now, force RPATHS (not RUNPATHS) so that LD_LIBRARY_PATH
 # shenanigans don't cause RStudio to load an incompatible
-# verison of Qt and crash inexplicably
+# version of Qt and crash inexplicably
 rewrite-rpath () {
 	patchelf --remove-rpath "$1"
 	patchelf --set-rpath '$ORIGIN/../lib' --force-rpath "$1"

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -1143,7 +1143,7 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 })
 
 # API for sending + receiving arbitrary requests from rstudioapi
-# added in RStudio v1.4; not used univerally by older APIs but useful
+# added in RStudio v1.4; not used universally by older APIs but useful
 # as a framework for any new functions that might be added
 
 #' @param type The event type. See '.rs.api.events' for the set

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -591,7 +591,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # TODO: figure out how to print the args (...) as part of the message
    
-   # run the original function (f). setup condition handlers soley so that
+   # run the original function (f). setup condition handlers solely so that
    # we can correctly print the name of the function called in error
    # and warning messages -- otherwise R prints "original(...)"
    withCallingHandlers(

--- a/src/cpp/r/RExec.cpp
+++ b/src/cpp/r/RExec.cpp
@@ -489,7 +489,7 @@ Error RFunction::call(SEXP evalNS,
    // assign the function to the first element of the call
    SETCAR(callSEXP, functionSEXP_);
    
-   // assign parameters to the subseqent elements of the call
+   // assign parameters to the subsequent elements of the call
    SEXP nextSlotSEXP = CDR(callSEXP);
    for (auto it = params_.begin(); it != params_.end(); ++it)
    {

--- a/src/cpp/r/RJson.cpp
+++ b/src/cpp/r/RJson.cpp
@@ -15,7 +15,7 @@
 
 /* Convert R objects to json, conversions are performed as follows:
 
-1) R nil values are converted to null. you can explicity return nil
+1) R nil values are converted to null. you can explicitly return nil
    from a function using "return ()"
 
 2) R vectors of primitive types are returned to json & GWT as follows:
@@ -30,7 +30,7 @@
    json objects (with each named list element constituting an object field)
  
 4) R new style lists (VECSXP) without named elements (or with only some elements
-   named) are returned as a json array. this array may be heterogenous and 
+   named) are returned as a json array. this array may be heterogeneous and 
    therefore not readily mappable to a JS overlay type so in general this 
    scenario should be avoided.
  

--- a/src/cpp/r/RJsonRpc.cpp
+++ b/src/cpp/r/RJsonRpc.cpp
@@ -40,7 +40,7 @@
   that these and any other errors which occur during json rpc calls are
   both reported as errors to the rpc caller as well as printed to the 
   console (this is because we use r::engine::evaluateExpressions for calling
-  the method and have yet to figure out how to supress it from printing
+  the method and have yet to figure out how to suppress it from printing
   messages to the console). 
 */
 
@@ -84,7 +84,7 @@ Error callRHandler(const std::string& functionName,
                    SEXP* pResult,
                    sexp::Protect* pProtect)
 {
-   // intialize the function
+   // initialize the function
    r::exec::RFunction rFunction(functionName);
    
    // add params

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -382,7 +382,7 @@ void listEnvironment(SEXP env,
    pVariables->clear();
    
    // get the list of environment vars (protect locally because we 
-   // we don't acutally return this list to the caller
+   // we don't actually return this list to the caller
    SEXP envVarsSEXP;
    Protect rProtect(envVarsSEXP = R_lsInternal(env, includeAll ? TRUE : FALSE));
 

--- a/src/cpp/r/include/r/RExec.hpp
+++ b/src/cpp/r/include/r/RExec.hpp
@@ -44,7 +44,7 @@ namespace rstudio {
 namespace r {
 namespace exec {
 
-// safe (no r error longjump) execution of abritrary nullary function
+// safe (no r error longjump) execution of arbitrary nullary function
 core::Error executeSafely(boost::function<void()> function);
 
 typedef boost::function<bool()> MainThreadFunction;
@@ -66,7 +66,7 @@ private:
    T* pReturn_;
 };
  
-// safe (no r error longjump) execution of abritrary nullary function w/ return
+// safe (no r error longjump) execution of arbitrary nullary function w/ return
 template <typename T>
 core::Error executeSafely(boost::function<T()> function, T* pReturn)
 {

--- a/src/cpp/r/session/RConsoleHistory.cpp
+++ b/src/cpp/r/session/RConsoleHistory.cpp
@@ -83,7 +83,7 @@ void ConsoleHistory::add(const std::string& command)
          if (line.empty())
             continue;
          
-         // add this line if its not a duplciate
+         // add this line if its not a duplicate
          if (!removeDuplicates_ ||
              historyBuffer_.empty() ||
              (line != historyBuffer_.back()))

--- a/src/cpp/r/session/REmbeddedPosix.cpp
+++ b/src/cpp/r/session/REmbeddedPosix.cpp
@@ -91,7 +91,7 @@ void runEmbeddedR(const core::FilePath& /*rHome*/,    // ignored on posix
    //
    //   1) set R_Quiet so we startup without a banner
    //
-   //   2) set LoadInitFile to supress execution of .Rprofile
+   //   2) set LoadInitFile to suppress execution of .Rprofile
    //
    //   3) we also need to make sure that .First is not executed. this is
    //      taken care of via the fact that we set RestoreAction to SA_NORESTORE
@@ -201,7 +201,7 @@ void logDLError(const std::string& message, const ErrorLocation& location)
 // state which we couldn't rid ourselves of.
 //
 // Note that in researching the way R implements QCF_SET_FRONT I discovered
-// that a depricated API is called AND an explicit call to SetFront. Another
+// that a deprecated API is called AND an explicit call to SetFront. Another
 // way to go would be to call the TransformProcessType API:
 //
 //   http://www.cocoadev.com/index.pl?TransformProcessType
@@ -337,7 +337,7 @@ void initializePolledEventHandler(void (*newPolledEventHandler)(void))
 // to make sure all subsequent R code is executed without any
 // event handlers (appropriate since the forked child is headless).
 // the prefix "permanently" is used because we explicitly don't
-// handle the abilty to restore event handling by calling
+// handle the ability to restore event handling by calling
 // initializePolledEventHandler -- this is because we overwrite
 // s_oldPolledEventHandler with NULL, thus losing any reference
 // we have to a R_PolledEvents value that existed before our

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -250,7 +250,7 @@ Error save(const FilePath& statePath)
    if (error)
       return error;
    
-   // iterate throught the search path (build a list as we go). set 
+   // iterate through the search path (build a list as we go). set 
    // .GlobalEnv and package:base as bookends of the list (note this code
    // is based on the implementation of do_search)
    std::vector<std::string> searchPathElements;
@@ -260,7 +260,7 @@ Error save(const FilePath& statePath)
         envSEXP != R_BaseEnv;
         envSEXP = ENCLOS(envSEXP))
    {
-      // screen out UserDefinedDatabase elements (attempting to perisist
+      // screen out UserDefinedDatabase elements (attempting to persist
       // a UserDefinedDatabase caused mischief in at least one case (e.g. see
       // RProtoBuf:DescriptorPool) so we exclude it globally.
       if (r::sexp::inherits(envSEXP, "UserDefinedDatabase"))

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -288,7 +288,7 @@ void saveDevMode(Settings* pSettings)
       // turn dev mode off -- this is important so that dev mode undoes
       // its manipulations of the prompt and libpaths before they are saved
       // suppress output to eliminate dev_mode OFF message
-      // ignore error on purpose -- will happen if devtools isn't intalled
+      // ignore error on purpose -- will happen if devtools isn't installed
       r::session::utils::SuppressOutputInScope suppressOutput;
       error = r::exec::RFunction("devtools:::dev_mode", false).call();
    }

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -112,7 +112,7 @@ SA_TYPE saveAsk()
       // The Rf_jump_to_top_level doesn't work (freezes the process) with
       // 64-bit mingw due to the way it does stack unwinding. Since this is
       // a farily obscure gesture (quit from command line then cancel the quit)
-      // we just eliminate the possiblity of it on windows
+      // we just eliminate the possibility of it on windows
 #ifndef _WIN32
       prompt += "/c";
 #endif
@@ -360,7 +360,7 @@ int RReadConsole(const char *pmt,
             std::string::size_type inputLen = rInput.length();
             
             // add to console actions and history (if requested). note that
-            // we add the user's input rather than any tranformed input we
+            // we add the user's input rather than any transformed input we
             // created as a result of a shell escape
             consoleActions().add(kConsoleActionInput, consoleInput.text);
             if (addToHistory && !isInjectedBrowserCommand(consoleInput.text))
@@ -634,7 +634,7 @@ void Raddhistory(SEXP call, SEXP op, SEXP args, SEXP env)
 void RSuicide(const char* s)
 {
    // We need to write this to stderr so the parent process (rstudio) can pick up the error message and display it 
-   // to the user in case the session log file is not accessbile.
+   // to the user in case the session log file is not accessible.
    std::cerr << s << std::endl;
    s_callbacks.suicide(s);
    s_internalCallbacks.suicide(s);
@@ -668,7 +668,7 @@ void rSuicide(const std::string& msg)
 //   (2) In desktop mode we don't receive termination oriented events such
 //       as quit, suicide, and cleanup. This means that the desktop process
 //       must simply detect that we have exited and terminate itself. It also
-//       means that cleanup of our http damons, file monitoring, etc. never
+//       means that cleanup of our http daemons, file monitoring, etc. never
 //       occurs (not an issue b/c our process is going away but worth noting)
 //
 void RCleanUp(SA_TYPE saveact, int status, int runLast)

--- a/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevDesc.cpp
@@ -28,7 +28,7 @@ namespace dev_desc {
 
 namespace {
 
-// this template is used to copy graphics device paramters
+// this template is used to copy graphics device parameters
 // common to all graphics device versions; newly-added
 // members should be initialized explicitly separately
 template <typename T>

--- a/src/cpp/r/session/graphics/RGraphicsDevice.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsDevice.cpp
@@ -363,7 +363,7 @@ void GD_Close(pDevDesc dev)
       handler::destroy(pDC);
 
       // explicitly free and then null out the dev pointer of the GEDevDesc
-      // This is to avoid incompatabilities between the heap we are compiled with
+      // This is to avoid incompatibilities between the heap we are compiled with
       // and the heap R is compiled with (we observed this to a problem with
       // 64-bit R)
       std::free(s_pGEDevDesc->dev);
@@ -705,7 +705,7 @@ Error saveSnapshot(const core::FilePath& snapshotFile,
    if (error)
       return error;
    
-   // save snaphot file
+   // save snapshot file
    error = r::exec::RFunction(".rs.saveGraphics",
                               string_utils::utf8ToSystem(snapshotFile.getAbsolutePath())).call();
    if (error)
@@ -826,7 +826,7 @@ Error initialize(
 void setSize(int width, int height, double devicePixelRatio)
 {
    // only set if the values have changed (prevents unnecessary plot 
-   // invalidations from occuring)
+   // invalidations from occurring)
    if ( width != s_width || height != s_height || devicePixelRatio != s_devicePixelRatio)
    {
       s_width = width;

--- a/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
+++ b/src/cpp/r/session/graphics/RGraphicsPlotManager.cpp
@@ -639,7 +639,7 @@ Error PlotManager::savePlotsState()
       plots.push_back(plotInfo);
    }
    
-   // suppres all device events after suspend
+   // suppress all device events after suspend
    suppressDeviceEvents_ = true;
    
    // write plot list
@@ -658,7 +658,7 @@ Error PlotManager::restorePlotsState()
    if (error)
       return error;
 
-   // if it is empty then return succes
+   // if it is empty then return success
    if (plots.empty())
       return Success();
 

--- a/src/cpp/report-options.sh
+++ b/src/cpp/report-options.sh
@@ -107,18 +107,18 @@ scanPublicOptions "session"
 
 echo "## Hidden Options"
 
-# Indicates whether a hidden server option is errornously present in the documentation
+# Indicates whether a hidden server option is erroneously present in the documentation
 scanSomeOptions "server" "isHidden"
 
-# Indicates whether a hidden session option is errornously present in the documentation. A server option with the same name may be there instead.
+# Indicates whether a hidden session option is erroneously present in the documentation. A server option with the same name may be there instead.
 scanSomeOptions "session" "isHidden"
 
 echo "## Deprecated Options"
 
-# Indicates whether a deprecated session option is errornously present in the documentation. A server option with the same name may be there instead.
+# Indicates whether a deprecated session option is erroneously present in the documentation. A server option with the same name may be there instead.
 scanSomeOptions "session" "isDeprecated"
 
-# Indicates whether a deprecated server option is errornously present in the documentation
+# Indicates whether a deprecated server option is erroneously present in the documentation
 scanSomeOptions "server" "isDeprecated"
 
 echo "## Code Options"

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -15,7 +15,7 @@ read -r -d '' USAGE <<- EOF
 Run RStudio unit tests. Available flags:
 
 --help    Show this help.
---scope   Run only tests wtih the given scope (core, rserver, rsession, r).
+--scope   Run only tests with the given scope (core, rserver, rsession, r).
 --filter  Run a subset of R tests, matching the requested filter.
 EOF
 
@@ -44,7 +44,7 @@ findLibSegFault() {
       return 0
    fi
 
-   # if already set, nothign to do
+   # if already set, nothing to do
    if [ -n "${RSESSION_DIAGNOSTICS_LIBSEGFAULT}" ]; then
       return 0
    fi
@@ -195,7 +195,7 @@ if has-scope "core"; then
    runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} '~[requiresRoot]'"
 
    # Invoke the *DropPrivTests separately because they must run as root
-   # We need separate invokations because we cannot restore privs between test cases of PermanentlyDropPrivs
+   # We need separate invocations because we cannot restore privs between test cases of PermanentlyDropPrivs
    # Skip these tests in CI for MacOS builds
    if [ -z "${JENKINS_URL}" ] || [ "$(uname)" != "Darwin" ]; then
       runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} TemporarilyDropPrivTests"

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -597,7 +597,7 @@ int main(int argc, char * const argv[])
          if (error)
             return core::system::exitFailure(error, ERROR_LOCATION);
 
-         // Refresh the loggers after succesful daemonize to clear out old FDs
+         // Refresh the loggers after successful daemonize to clear out old FDs
          core::log::refreshAllLogDestinations();
 
          // set file creation mask to 022 (might have inherted 0 from init)

--- a/src/cpp/server/ServerPAMAuth.cpp
+++ b/src/cpp/server/ServerPAMAuth.cpp
@@ -155,7 +155,7 @@ void doSignIn(const http::Request& request,
       password = request.formFieldValue("password");
    }
 
-   // tranform to local username
+   // transform to local username
    username = auth::handler::userIdentifierToLocalUsername(username);
 
    overlay::onUserPasswordUnavailable(username);

--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -118,7 +118,7 @@ Error launchSessionRecovery(
       const r_util::SessionContext& context)
 {
    // if this request is marked as requiring an existing
-   // session then return session unavilable error
+   // session then return session unavailable error
    if (requiresSession(request))
    {
       LOG_DEBUG_MESSAGE("Failed to connect to session for user: " + context.username +

--- a/src/cpp/server/db/README.md
+++ b/src/cpp/server/db/README.md
@@ -18,7 +18,7 @@ It can be cumbersome to generate the correct schema file names as they include a
 
 This will generate a file like `20200226141952248123456_AddNewTable.sql`. To generate schemas files that are database specific, leave off the `sql` part of the command, which will generate a schema file for each supported database type.
 
-You should not generate both a `.sql` and specific database extension types for the same migration. In this case, both migrations would be run, but this is nonsensical. You should either generate one `.sql` migration for the generic case, or one migration for each specific targetted database, not both.
+You should not generate both a `.sql` and specific database extension types for the same migration. In this case, both migrations would be run, but this is nonsensical. You should either generate one `.sql` migration for the generic case, or one migration for each specific targeted database, not both.
 
 ### Dev Schema Updates
 

--- a/src/cpp/server_core/sessions/SessionSignature.cpp
+++ b/src/cpp/server_core/sessions/SessionSignature.cpp
@@ -74,7 +74,7 @@ Error signRequest(const std::string& rsaPrivateKey,
    if (error)
       return error;
 
-   // stamp signature on the reuqest
+   // stamp signature on the request
    request.setHeader(kRStudioMessageSignature, signatureHeader);
    return Success();
 }

--- a/src/cpp/session/modules/SessionSource.R
+++ b/src/cpp/session/modules/SessionSource.R
@@ -77,7 +77,7 @@
       'ISO-8859-7', #'Windows-1253',
       # Cyrillic
       #'ISO-8859-5', 'MacCyrillic', 'KOI8-R', 'Windows-1251',
-      # Ukranian
+      # Ukrainian
       #'KOI8-U',
       # Simplified Chinese
       'GB2312', #'HZ-GB-2312',

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -191,7 +191,7 @@ Error ProjectContext::startup(const FilePath& projectFile,
       return pathNotFoundError(projectFile.getAbsolutePath(), ERROR_LOCATION);
    }
 
-   // test for writeabilty of parent
+   // test for writeability of parent
    if (!file_utils::isDirectoryWriteable(projectFile.getParent()))
    {
       *pUserErrMsg = "the project directory is not writeable";

--- a/src/cpp/shared_core/include/shared_core/PImpl.hpp
+++ b/src/cpp/shared_core/include/shared_core/PImpl.hpp
@@ -55,7 +55,7 @@
  * This macro should be included in the private or protected section of a classes declaration.
  * struct OwningClass::Impl should be defined in the definition file before defining OwningClass.
  *
- * @param in_memeberName    The name of the private implementation member variable (e.g. m_impl).
+ * @param in_memberName    The name of the private implementation member variable (e.g. m_impl).
  */
 #define PRIVATE_IMPL_SHARED(in_memberName)   \
    PRIVATE_IMPL_START                        \

--- a/src/cpp/shared_core/include/shared_core/SafeConvert.hpp
+++ b/src/cpp/shared_core/include/shared_core/SafeConvert.hpp
@@ -110,7 +110,7 @@ T stringTo(const std::string& in_strValue,
 }
 
 /**
- * @brief Coverts a number to string value.
+ * @brief Converts a number to string value.
  *
  * @param in_input                  The number to convert.
  * @param in_localeIndependent      Whether to perform the conversion independent of locale. Default: true.
@@ -135,7 +135,7 @@ inline std::string numberToString(double in_input, bool in_localeIndependent = t
 }
 
 /**
- * @brief Coverts a number to string value.
+ * @brief Converts a number to string value.
  *
  * @tparam T                        The type of the number.
  * @param in_input                  The number to convert.
@@ -162,7 +162,7 @@ std::string numberToString(T input, bool localeIndependent = true)
 }
 
 /**
- * @brief Coverts a number to the specified type.
+ * @brief Converts a number to the specified type.
  *
  * @tparam TInput                   The type of the number.
  * @tparam TOutput                  The type to which to convert the number.
@@ -185,7 +185,7 @@ TOutput numberTo(TInput input, TOutput defaultValue)
 }
 
 /**
- * @brief Coverts a number to the specified type.
+ * @brief Converts a number to the specified type.
  *
  * @tparam TInput                   The type of the number.
  * @tparam TOutput                  The type to which to convert the number.

--- a/src/cpp/shared_core/include/shared_core/json/Json.hpp
+++ b/src/cpp/shared_core/include/shared_core/json/Json.hpp
@@ -1430,14 +1430,14 @@ public:
    /**
     * @brief Gets the value at the back of the JSON array.
     *
-    * @return The value at the back of the JSON array or an empty value, if the array is emtpy.
+    * @return The value at the back of the JSON array or an empty value, if the array is empty.
     */
    Value getBack() const;
 
    /**
     * @brief Gets the value at the front of the JSON array.
     *
-    * @return The value at the front of the JSON array or an empty value, if the array is emtpy.
+    * @return The value at the front of the JSON array or an empty value, if the array is empty.
     */
    Value getFront() const;
 
@@ -1918,7 +1918,7 @@ enum class JsonReadError
 Error jsonReadError(JsonReadError in_errorCode, const std::string& in_message, const ErrorLocation& in_errorLocation);
 
 /**
- * @brief Checks whether the supplied error is a "missing memeber" error.
+ * @brief Checks whether the supplied error is a "missing member" error.
  *
  * @param in_error      The error to check.
  *

--- a/src/cpp/shared_core/include/shared_core/json/rapidjson/document.h
+++ b/src/cpp/shared_core/include/shared_core/json/rapidjson/document.h
@@ -1736,7 +1736,7 @@ public:
     uint64_t GetUint64() const  { RAPIDJSON_ASSERT(data_.f.flags & kUint64Flag); return data_.n.u64; }
 
     //! Get the value as double type.
-    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessDouble() to check whether the converison is lossless.
+    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessDouble() to check whether the conversion is lossless.
     */
     double GetDouble() const {
         RAPIDJSON_ASSERT(IsNumber());
@@ -1748,7 +1748,7 @@ public:
     }
 
     //! Get the value as float type.
-    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessFloat() to check whether the converison is lossless.
+    /*! \note If the value is 64-bit integer type, it may lose precision. Use \c IsLosslessFloat() to check whether the conversion is lossless.
     */
     float GetFloat() const {
         return static_cast<float>(GetDouble());

--- a/src/cpp/shared_core/include/shared_core/json/rapidjson/reader.h
+++ b/src/cpp/shared_core/include/shared_core/json/rapidjson/reader.h
@@ -2002,7 +2002,7 @@ private:
         case IterativeParsingObjectInitialState:
         case IterativeParsingArrayInitialState:
         {
-            // Push the state(Element or MemeberValue) if we are nested in another array or value of member.
+            // Push the state(Element or MemberValue) if we are nested in another array or value of member.
             // In this way we can get the correct state on ObjectFinish or ArrayFinish by frame pop.
             IterativeParsingState n = src;
             if (src == IterativeParsingArrayInitialState || src == IterativeParsingElementDelimiterState)

--- a/src/cpp/shared_core/system/Crypto.cpp
+++ b/src/cpp/shared_core/system/Crypto.cpp
@@ -319,7 +319,7 @@ Error decryptAndBase64Decode(
    if (error)
       return error;
 
-   // covert the decrypted bytes into the original string
+   // convert the decrypted bytes into the original string
    out_decrypted.reserve(decrypted.size());
    std::copy(decrypted.begin(), decrypted.end(), std::back_inserter(out_decrypted));
 

--- a/src/cpp/shared_core/system/PosixSystem.cpp
+++ b/src/cpp/shared_core/system/PosixSystem.cpp
@@ -303,7 +303,7 @@ Error temporarilyDropPrivileges(const User& in_user, const boost::optional<GidTy
    if (::geteuid() != in_user.getUserId())
       return systemError(EACCES, ERROR_LOCATION);
 
-   // save privilleged user id
+   // save privileged user id
    s_privUid = oldEUID;
 
    // success

--- a/src/cpp/shared_core/system/Win32User.cpp
+++ b/src/cpp/shared_core/system/Win32User.cpp
@@ -77,7 +77,7 @@ FilePath currentCSIDLPersonalHomePath()
    }
    else
    {
-      log::logWarningMessage("Unable to retreive user home path. HRESULT:  " +
+      log::logWarningMessage("Unable to retrieve user home path. HRESULT:  " +
                           safe_convert::numberToString(hr));
       return FilePath();
    }
@@ -100,7 +100,7 @@ FilePath defaultCSIDLPersonalHomePath()
    }
    else
    {
-      log::logWarningMessage("Unable to retreive user home path. HRESULT:  " +
+      log::logWarningMessage("Unable to retrieve user home path. HRESULT:  " +
                           safe_convert::numberToString(hr));
       return FilePath();
    }

--- a/src/cpp/tests/testthat/test-themes.R
+++ b/src/cpp/tests/testthat/test-themes.R
@@ -283,7 +283,7 @@ makeGlobalThemeDir <- function()
 }
 
 # Test getRgbColor =================================================================================
-test_that("rgb coversion from hex format works", {
+test_that("rgb conversion from hex format works", {
    # All lowercase
    expect_equal(.rs.getRgbColor("#ffffff"), c(255, 255, 255))
 

--- a/src/cpp/tools/install-r-devel.cmd
+++ b/src/cpp/tools/install-r-devel.cmd
@@ -174,7 +174,7 @@ cacls %TMPDIR% /T /E /G BUILTIN\Users:R > NUL
 
 REM Make it!
 REM For this part, we ensure only Rtools is on the PATH. This
-REM is important as if the wrong command line utilites are picked
+REM is important as if the wrong command line utilities are picked
 REM up things can fail for strange reason. In particular, we
 REM _must_ use the Rtools 'sort', _not_ the Windows 'sort', or
 REM else we will get strange errors from 'comm' when attempting

--- a/src/node/desktop/README.md
+++ b/src/node/desktop/README.md
@@ -14,7 +14,7 @@ Instead of using the `showErrorBox` function from the `electron` module.
 
 ## Formatting
 
-To format the entire project just run `yarn format`. You are encouraged to run this before every commit to avoid unecessary merge conflicts in the future.
+To format the entire project just run `yarn format`. You are encouraged to run this before every commit to avoid unnecessary merge conflicts in the future.
 Some code errors shall also arise due to it. Please install `Prettier` VS Code extension so you can run the formatter from a shortcut, or run it from the terminal.
 
 ## Command-line

--- a/src/node/desktop/src/core/system.ts
+++ b/src/node/desktop/src/core/system.ts
@@ -40,7 +40,7 @@ export function generateRandomPort(): number {
 }
 
 export function localPeer(port: number): string {
-  // local peer used for named-pipe communcation on Windows
+  // local peer used for named-pipe communication on Windows
   return `\\\\.\\pipe\\${port.toString()}-rsession`;
 }
 

--- a/src/node/desktop/src/ui/README.md
+++ b/src/node/desktop/src/ui/README.md
@@ -40,7 +40,7 @@ behaviours in the widget.
 An optional CSS stylesheet. To be applied to the HTML content after the page
 has been loaded. Note that the CSS stylesheet contents are transferred via
 Electron IPC, so if your widget has a custom stylesheet you should ensure
-`preload.ts` receives that CSS and applies the style in an appropraite channel.
+`preload.ts` receives that CSS and applies the style in an appropriate channel.
 
 ## Modal Widgets
 

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -52,7 +52,7 @@ describe('Utils', () => {
   it('devicePixelRatio returns 1.0', () => {
     assert.strictEqual(Utils.devicePixelRatio(), 1.0);
   });
-  it('randomString genereates a random string', () => {
+  it('randomString generates a random string', () => {
     const str1 = Utils.randomString();
     const str2 = Utils.randomString();
     const str3 = Utils.randomString();


### PR DESCRIPTION
### Intent

> Fixes typos found within the source code which includes comments and documentation. Follow-up to 5e99ff41806b

### Approach

> Found using `codespell -q 3 -S *_fr.properties,./src/gwt -L ba,enque,optionel,ot,parm,parms,pres,prevend,pevent,pevents,ptd,texline`

### Automated Tests

> This PR fixes typos. No unit tests needed.

### QA Notes

> N/A 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
