### PR TITLE
Fix detection/invocation of yarn from Linux make-package

### DIFF
--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -11,14 +11,14 @@
 #     docker-compile.sh IMAGE-NAME FLAVOR-NAME [VERSION]
 #
 # where the image name is the platform and architecture, the flavor name is
-# the kind of package you wish to build (desktop or server), and the version
-# is the number to assign to the resulting build.
+# the kind of package you wish to build (desktop, electron or server), and the
+# version is the number to assign to the resulting build.
 #
 # For example:
 # 
-#     docker-compile.sh centos7-amd64 desktop 1.2.345
+#     docker-compile.sh rhel8-x86_64 desktop 1.2.345
 #
-# will produce an RPM of RStudio Desktop from the 64bit CentOS 7 container, 
+# will produce an RPM of RStudio Desktop from the 64bit RHEL8 container, 
 # with build version 1.2.345, in your package/linux/ directory.
 #
 # For convenience, this script will build the required image if it doesn't
@@ -59,6 +59,7 @@ if [ -z "$IMAGE" ] || [ -z "$FLAVOR" ]; then
     ls -f docker/jenkins/Dockerfile.* | sed -e 's/.*Dockerfile.//'
     echo -e "\nValid flavors:\n"
     echo -e "desktop"
+    echo -e "electron"
     echo -e "server"
     exit 1
 fi
@@ -121,7 +122,7 @@ ENV="$ENV GIT_COMMIT=$(git rev-parse HEAD)"
 ENV="$ENV BUILD_ID=local"
 
 # infer make parallelism
-if hash sysctl 2>/dev/null; then
+if [ "$(uname)" = "Darwin" ]; then
     # macos; Docker for Mac defaults to half of host's cores
     JVALUE=$(( `sysctl -n hw.ncpu` / 2 ))
     ENV="$ENV MAKEFLAGS=-j${JVALUE}"

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -163,9 +163,19 @@ fi
 
 ELECTRON_SOURCE_DIR="${PKG_DIR}/../../src/node/desktop"
 
-# find yarn -- TODO gary - work in progress, commenting out to unbreak build
-# find-program YARN yarn \
-#    "${HOME}/.yarn/bin"
+# find node
+RSTUDIO_NODE_VERSION=14.17.5
+find-program NODE node \
+   "../../dependencies/common/node/${RSTUDIO_NODE_VERSION}bin" \
+   "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
+
+# yarn needs node on the path
+NODE_PATH=$(dirname "${NODE}")
+PATH="${NODE_PATH}:${PATH}"
+
+# find yarn
+find-program YARN yarn \
+   "${HOME}/.yarn/bin"
 
 # build RStudio version suffix
 RSTUDIO_VERSION_ARRAY=(


### PR DESCRIPTION
### Intent

Fix detection of YARN in make-package for Linux builds. This is currently unused (until I reenable attempting to build Electron on Linux) but have verified it locally in docker.

### Approach

For yarn to work, need to put node on the path.

Also a tweak to the dev helper script `docker-compile.sh` to fix an issue with incorrectly detecting if Mac or Linux, and to mention Electron as a build target.

### Automated Tests

None, build stuff.

### QA Notes

None, build stuff.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


