### PR TITLE
Fix recent items breaking due to menu separators fix

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -47,6 +47,7 @@ module.exports = {
     '@typescript-eslint/require-array-sort-compare': ['error'],
     '@typescript-eslint/return-await': ['warn'],
     '@typescript-eslint/no-implicit-any-catch': ['error'],
+    '@typescript-eslint/no-unused-vars': ['warn', {"argsIgnorePattern": "^_"}],
 
     '@typescript-eslint/strict-boolean-expressions': [
       'error',

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -68,7 +68,6 @@ export class MenuCallback extends EventEmitter {
   private menuItemTemplates = new Map<string, MenuItemConstructorOptions>();
 
   // keep a list of templates referenced by menu so we can re-build the menu
-  private menuTemplates = new Map<Menu, Array<MenuItemConstructorOptions>>();
   private mainMenuTemplate: MenuItemConstructorOptions[] = new Array<MenuItemConstructorOptions>();
 
   lastWasTools = false;
@@ -253,7 +252,7 @@ export class MenuCallback extends EventEmitter {
   }
 
   /**
-   * Reconstructs the entire app menu using the _menuTemplates_. Do not update the menu item.
+   * Reconstructs the entire app menu using the _mainMenuTemplate_. Do not update the menu item.
    *
    * This function performs will also clean up unnecessary menu items such as hidden items or
    * unnecessary separators. It is important that this updates the menu templates since hidden items
@@ -313,7 +312,6 @@ export class MenuCallback extends EventEmitter {
 
     const newMainMenuTemplate = recursiveCopy(this.mainMenuTemplate);
     this.mainMenu = Menu.buildFromTemplate(newMainMenuTemplate);
-    this.menuTemplates.set(this.mainMenu, this.mainMenuTemplate);
 
     Menu.setApplicationMenu(this.mainMenu);
   }
@@ -379,7 +377,6 @@ export class MenuCallback extends EventEmitter {
       menu = this.menuStack[this.menuStack.length - 1];
     } else {
       menu = new Array<MenuItemConstructorOptions>();
-      this.menuTemplates.set(this.mainMenu, this.mainMenuTemplate);
       this.mainMenuTemplate.push(itemTemplate);
     }
     menu.push(itemTemplate);

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -63,7 +63,6 @@ export class MenuCallback extends EventEmitter {
 
   mainMenu: Menu | null = null;
   menuStack: MenuItemConstructorOptions[][] = [];
-  actions = new Map<string, MenuItem>();
 
   // keep a list of templates referenced by id so we can re-build the menus with them
   private menuItemTemplates = new Map<string, MenuItemConstructorOptions>();
@@ -75,7 +74,6 @@ export class MenuCallback extends EventEmitter {
   lastWasDiagnostics = false;
 
   private setShortcutDebounceId?: NodeJS.Timeout;
-  private setShortcutQueue = new Set<MenuItemConstructorOptions>();
 
   constructor() {
     super();
@@ -83,14 +81,14 @@ export class MenuCallback extends EventEmitter {
       this.beginMain();
     });
 
-    ipcMain.on('menu_begin', (event, label: string) => {
+    ipcMain.on('menu_begin', (_event, label: string) => {
       this.menuBegin(label);
     });
 
     ipcMain.on(
       'menu_add_command',
       (
-        event,
+        _event,
         cmdId: string,
         label: string,
         tooltip: string,
@@ -155,40 +153,13 @@ export class MenuCallback extends EventEmitter {
     });
 
     ipcMain.on('menu_set_command_shortcut', (_event, commandId: string, shortcut: string | null) => {
-      // Electron doesn't support modifying shortcut of an existing MenuItem;
-      // We have to recreate the application menus whenever* we
-      // get this call. For more on this Electron limitation:
-      // https://github.com/electron/electron/issues/528
-      //
-      // You'd think you could remove the old menu item and replace it with an updated
-      // version, but no such thing as menu.remove:
-      // https://github.com/electron/electron/issues/527
-      //
-      // * this call automatically commits changes after 5 seconds
-      //   if the "commit" event is not called before then
-      const item = this.getMenuItemById(commandId);
-      if (item) {
-        const template = this.menuItemTemplates.get(item.id);
-        if (!template) return;
-
-        const accelerator = this.convertShortcut(shortcut);
-        template.accelerator = accelerator;
-        this.setShortcutQueue.add({ ...template, accelerator });
-
-        if (this.setShortcutDebounceId) clearTimeout(this.setShortcutDebounceId);
-
-        this.setShortcutDebounceId = setTimeout(() => {
-          this.updateMenus(Array.from(this.setShortcutQueue.values()));
-          this.setShortcutQueue.clear();
-        }, 5000);
-      }
+      this.setCommandShortcut(commandId, shortcut);
     });
 
     ipcMain.on('menu_commit_command_shortcuts', () => {
       if (this.setShortcutDebounceId) clearTimeout(this.setShortcutDebounceId);
 
-      this.updateMenus(Array.from(this.setShortcutQueue.values()));
-      this.setShortcutQueue.clear();
+      this.updateMenus();
     });
   }
 
@@ -229,6 +200,31 @@ export class MenuCallback extends EventEmitter {
     this.menuStack.push(subMenu);
   }
 
+  setCommandShortcut(id: string, shortcut: string | null) {
+    // Electron doesn't support modifying shortcut of an existing MenuItem;
+    // We have to recreate the application menus whenever* we
+    // get this call. For more on this Electron limitation:
+    // https://github.com/electron/electron/issues/528
+    //
+    // You'd think you could remove the old menu item and replace it with an updated
+    // version, but no such thing as menu.remove:
+    // https://github.com/electron/electron/issues/527
+    //
+    // * this call automatically commits changes after 5 seconds
+    //   if the "commit" event is not called before then
+    const template = this.menuItemTemplates.get(id);
+    if (!template) return;
+
+    const accelerator = this.convertShortcut(shortcut);
+    template.accelerator = accelerator;
+
+    if (this.setShortcutDebounceId) clearTimeout(this.setShortcutDebounceId);
+
+    this.setShortcutDebounceId = setTimeout(() => {
+      this.updateMenus();
+    }, 5000);
+  }
+
   setCommandVisibility(id: string, newVisibility: boolean) {
     const template = this.menuItemTemplates.get(id);
     if (template) template.visible = newVisibility;
@@ -249,20 +245,39 @@ export class MenuCallback extends EventEmitter {
     if (template) template.label = newLabel;
   }
 
-  updateMenus(items: MenuItemConstructorOptions[]): void {
+  /**
+   * Reconstructs the entire app menu using the _menuTemplates_. Do not update the menu item.
+   *
+   * This function performs will also clean up unnecessary menu items such as hidden items or
+   * unnecessary separators. It is important that this updates the menu templates since hidden items
+   * and unnecessary separators are not added to menus. Hidden items are not added so that the
+   * separator logic can remove unnecessary separators. Unnecessary separators and items are removed
+   * because it is easier than figuring out which ones to hide.
+   *
+   * Use caution when calling this because this it is an expensive call.
+   *
+   */
+  updateMenus(): void {
     const mainMenu = this.mainMenu;
     if (!mainMenu) return;
 
+    /**
+     * Builds the final list of menu items using the given menu template
+     *
+     * @param menuItemTemplates a list of menu item templates representing the full menu (may include hidden items)
+     * @returns the final template list after removing unnecessary separators and hidden items
+     */
     const recursiveCopy = (menuItemTemplates: MenuItemConstructorOptions[]) => {
       const newMenuTemplate = new Array<MenuItemConstructorOptions>();
 
       for (const menuItemTemplate of menuItemTemplates) {
-        const foundMenuItemTemplate = items.find((item) => item.id === menuItemTemplate.id);
         let referenceMenuItemTemplate;
         if (menuItemTemplate.id) {
           referenceMenuItemTemplate = this.menuItemTemplates.get(menuItemTemplate.id) ?? {};
         }
-        const newMenuItemTemplate = { ...menuItemTemplate, ...referenceMenuItemTemplate, ...foundMenuItemTemplate };
+        // the new menu item is based on foundMenuItemTemplate then the referenceMenuItemTemplate
+        // menuItemTemplate is the current state (i.e. checkbox state)
+        const newMenuItemTemplate = { ...menuItemTemplate, ...referenceMenuItemTemplate };
 
         if (newMenuItemTemplate.type === 'separator') {
           newMenuTemplate.push(newMenuItemTemplate);
@@ -302,82 +317,6 @@ export class MenuCallback extends EventEmitter {
     Menu.setApplicationMenu(this.mainMenu);
   }
 
-  /**
-   * Uses a list of templates to update existing menu items by reconstructing the entire app menu.
-   *
-   * This function performs will also clean up unnecessary menu items such as hidden items or
-   * unnecessary separators. It is important that this updates the menu templates since hidden items
-   * and unnecessary separators are not added to menus. Hidden items are not added so that the
-   * separator logic can remove unnecessary separators. Unnecessary separators are removed b
-   * ecause
-   * they cannot be hidden on Linux/Windows.
-   * @param items a list of MenuItemConstructorOptions that will overwrite existing menu items
-   */
-  // updateMenus(items: MenuItemConstructorOptions[]): void {
-  //   const mainMenu = this.mainMenu;
-  //   if (!mainMenu) return;
-
-  //   // const newMenu = new Menu();
-
-  //   const recursiveCopy = (currentMenu: Menu) => {
-  //     const currentMenuTemplate = this.menuTemplates.get(currentMenu) ?? [];
-  //     let newMenuTemplate = new Array<MenuItemConstructorOptions>();
-
-  //     for (const currentMenuItemTemplate of currentMenuTemplate) {
-  //       const foundMenuItemTemplate = items.find((item) => item.id === currentMenuItemTemplate.id);
-  //       const newMenuItemTemplate = { ...currentMenuItemTemplate, ...foundMenuItemTemplate };
-
-  //       if (newMenuItemTemplate.type === 'separator') {
-  //         // this.addToMenu(targetMenu, new MenuItem(newMenuItemTemplate));
-  //         newMenuTemplate.push(newMenuItemTemplate);
-  //         continue;
-  //       }
-
-  //       currentMenuItemTemplate.visible = newMenuItemTemplate.visible;
-  //       if (!newMenuItemTemplate.visible && !newMenuItemTemplate.role) continue;
-
-  //       const { submenu } = currentMenuItemTemplate;
-  //       if (submenu instanceof Menu) {
-  //         const submenuTemplate = recursiveCopy(submenu as Menu);
-  //         newMenuItemTemplate.submenu = submenuTemplate;
-  //       }
-
-  //       const newMenuItem = new MenuItem(newMenuItemTemplate);
-  //       this.actions.set(newMenuItem.id, newMenuItem);
-  //       // this.addToMenu(targetMenu);
-  //       if (newMenuItemTemplate.visible) newMenuTemplate.push(newMenuItemTemplate);
-  //     }
-
-  //     // this.menuTemplates.set(targetMenu, currentMenuTemplate);
-
-  //     newMenuTemplate = newMenuTemplate.filter((item, idx, arr) => {
-  //       if (item.type !== 'separator') {
-  //         return true;
-  //       }
-  //       const prevItem = arr[idx - 1];
-  //       return idx !== 0 && prevItem.type !== 'separator' && idx != arr.length - 1;
-  //     });
-  //     return newMenuTemplate;
-  //     // targetMenu.items = targetMenu.items.filter((item, idx, arr) => {
-  //     //   if (item.type !== 'separator') {
-  //     //     return true;
-  //     //   }
-  //     //   const prevItem = arr[idx - 1];
-  //     //   return (
-  //     //     idx !== 0 && // no separators at the top
-  //     //     prevItem.type !== 'separator' && // no consecutive separators
-  //     //     idx != arr.length - 1 // no separators at the bottom
-  //     //   );
-  //     // });
-  //   };
-
-  //   const template = recursiveCopy(mainMenu);
-  //   this.mainMenu = Menu.buildFromTemplate(template);
-  //   this.menuTemplates.set(this.mainMenu, template);
-
-  //   Menu.setApplicationMenu(this.mainMenu);
-  // }
-
   addToMenu(menu: Menu, item: MenuItem) {
     // invisible items are not added because it interferes with the separator logic
     if (item.visible) {
@@ -388,7 +327,7 @@ export class MenuCallback extends EventEmitter {
   addCommand(
     cmdId: string,
     label: string,
-    tooltip: string,
+    _tooltip: string,
     shortcut: string,
     checkable: boolean,
     visible: boolean,
@@ -397,7 +336,7 @@ export class MenuCallback extends EventEmitter {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       label: label,
       id: cmdId,
-      click: (menuItem, browserWindow, event) => {
+      click: (menuItem, _browserWindow, _event) => {
         this.emit(MenuCallback.COMMAND_INVOKED, menuItem.id);
       },
     };
@@ -437,12 +376,11 @@ export class MenuCallback extends EventEmitter {
     }
 
     const menuItem = new MenuItem(menuItemOpts);
-    this.actions.set(cmdId, menuItem);
     this.menuItemTemplates.set(menuItem.id, menuItemOpts);
     this.addToCurrentMenu(menuItem, menuItemOpts);
   }
 
-  addToCurrentMenu(menuItem: MenuItem, itemTemplate: MenuItemConstructorOptions): void {
+  addToCurrentMenu(_menuItem: MenuItem, itemTemplate: MenuItemConstructorOptions): void {
     let menu: MenuItemConstructorOptions[] | undefined;
     if (this.menuStack.length > 0) {
       menu = this.menuStack[this.menuStack.length - 1];
@@ -457,16 +395,10 @@ export class MenuCallback extends EventEmitter {
       }
     }
     menu.push(itemTemplate);
-    // let menuItemsTemplate = this.menuTemplates.get(menu);
-    // if (!menuItemsTemplate) {
-    //   menuItemsTemplate = new Array<MenuItemConstructorOptions>();
-    //   this.menuTemplates.set(menu, menuItemsTemplate);
-    // }
-    // menuItemsTemplate.push(itemTemplate);
   }
 
-  getMenuItemById(id: string): MenuItem | undefined {
-    return this.actions.get(id);
+  getMenuItemById(id: string): MenuItemConstructorOptions | undefined {
+    return this.menuItemTemplates.get(id);
   }
 
   cleanUpActions(): void {

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -277,6 +277,7 @@ export class MenuCallback extends EventEmitter {
           continue;
         }
 
+        currentMenuItemTemplate.visible = newMenuItemTemplate.visible;
         if (!newMenuItemTemplate.visible && !newMenuItemTemplate.role) continue;
 
         const { submenu } = newMenuItemTemplate;

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -168,7 +168,6 @@ export class MenuCallback extends EventEmitter {
     if (process.platform === 'darwin') {
       const appMenu: MenuItemConstructorOptions = { role: 'appMenu', visible: true };
       this.addToCurrentMenu(new MenuItem(appMenu), appMenu);
-      // this.mainMenu.append(new MenuItem(appMenu));
     }
   }
 
@@ -315,13 +314,6 @@ export class MenuCallback extends EventEmitter {
     }
 
     Menu.setApplicationMenu(this.mainMenu);
-  }
-
-  addToMenu(menu: Menu, item: MenuItem) {
-    // invisible items are not added because it interferes with the separator logic
-    if (item.visible) {
-      menu.append(item);
-    }
   }
 
   addCommand(

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { assert } from 'chai';
+import { debug } from 'console';
 import { MenuItem, MenuItemConstructorOptions } from 'electron';
 import { describe } from 'mocha';
 import { MenuCallback } from '../../../src/main/menu-callback';
@@ -58,7 +59,8 @@ describe('WIPMenuCallback', () => {
     assert.strictEqual(command?.label, 'Command');
 
     callback.updateMenus([{ id: 'a_command', label: 'New Label' }]);
-    const updatedCommand = callback.getMenuItemById('a_command');
+
+    const updatedCommand = callback.mainMenu?.getMenuItemById('a_command');
     assert.strictEqual(updatedCommand?.label, 'New Label');
     assert.isTrue(updatedCommand?.visible);
     assert.isFalse(updatedCommand?.checked);
@@ -80,7 +82,7 @@ describe('WIPMenuCallback', () => {
 
     assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 1);
 
-    const updatedCommand = callback.getMenuItemById('a_command');
+    const updatedCommand = callback.mainMenu?.getMenuItemById('a_command');
     assert.isTrue(updatedCommand?.visible);
   });
 
@@ -158,14 +160,15 @@ describe('WIPMenuCallback', () => {
     callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
     callback.addCommand('configure_build', 'Configure Build Tools', '', '', false, true);
 
-    // debugger;
     callback.updateMenus([]);
     assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 3, 'expected 3 menu items to start');
 
-    callback.updateMenus([{ id: 'buildAll', visible: false }]);
-    callback.updateMenus([{ id: 'buildSourcePackage', visible: true }]);
-    callback.updateMenus([{ id: 'buildBinaryPackage', visible: true }]);
-    callback.updateMenus([{ id: 'testPackage', visible: true }]);
+    callback.setCommandVisibility('buildAll', false);
+    callback.setCommandVisibility('buildSourcePackage', true);
+    callback.setCommandVisibility('buildBinaryPackage', true);
+    callback.setCommandVisibility('testPackage', true);
+
+    callback.updateMenus([]);
 
     assert.strictEqual(
       callback.mainMenu?.items[menuIdx].submenu?.items.length,

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -14,9 +14,11 @@
  */
 
 import { assert } from 'chai';
-import { MenuItem } from 'electron';
+import { MenuItem, MenuItemConstructorOptions } from 'electron';
 import { describe } from 'mocha';
 import { MenuCallback } from '../../../src/main/menu-callback';
+
+const separatorTemplate: MenuItemConstructorOptions = { type: 'separator' };
 
 describe('MenuCallback', () => {
   it('can be constructed', () => {
@@ -45,7 +47,7 @@ describe('MenuCallback', () => {
     assert.isTrue(visibleCommand?.visible, 'expected menu item to be visible');
   });
 
-  it('can update command', () => {
+  it('can change label for a command', () => {
     const callback = new MenuCallback();
     callback.beginMain();
     callback.menuBegin('&File');
@@ -55,12 +57,31 @@ describe('MenuCallback', () => {
     assert.isObject(command);
     assert.strictEqual(command?.label, 'Command');
 
-    callback.updateMenus([{ id: 'a_command', label: 'New Label', visible: false, checked: true }]);
-
+    callback.updateMenus([{ id: 'a_command', label: 'New Label' }]);
     const updatedCommand = callback.getMenuItemById('a_command');
     assert.strictEqual(updatedCommand?.label, 'New Label');
-    assert.isFalse(updatedCommand?.visible);
-    assert.isTrue(updatedCommand?.checked);
+    assert.isTrue(updatedCommand?.visible);
+    assert.isFalse(updatedCommand?.checked);
+  });
+
+  it('can change visibility for a command', () => {
+    const callback = new MenuCallback();
+    const menuIdx = process.platform === 'darwin' ? 1 : 0; // adjust for MacOS app menu
+
+    callback.beginMain();
+    callback.menuBegin('&File');
+    callback.addCommand('a_command', 'Initially hidden', '', '', false, false);
+
+    callback.updateMenus([]);
+
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 0);
+
+    callback.updateMenus([{ id: 'a_command', visible: true }]);
+
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 1);
+
+    const updatedCommand = callback.getMenuItemById('a_command');
+    assert.isTrue(updatedCommand?.visible);
   });
 
   it('can remove unnecessary separators', () => {
@@ -70,12 +91,12 @@ describe('MenuCallback', () => {
     callback.beginMain();
     callback.menuBegin('&File');
 
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' }));
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
     callback.addCommand('a_command', 'Command', '', '', false, true); // expected
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' })); // expected
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' }));
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate); // expected
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
     callback.addCommand('another_command', 'Another Command', '', '', false, true); // expected
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' }));
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
 
     callback.updateMenus([]);
 
@@ -89,13 +110,36 @@ describe('MenuCallback', () => {
     callback.beginMain();
     callback.menuBegin('&File');
 
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' }));
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
     callback.addCommand('a_command', 'Command', '', '', false, true); // expected
-    callback.addToCurrentMenu(new MenuItem({ type: 'separator' }));
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
     callback.addCommand('a_hidden_command', 'Hidden Command', '', '', false, false);
 
     callback.updateMenus([]);
 
     assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 1);
+  });
+
+  it('can contain submenus', () => {
+    const callback = new MenuCallback();
+    const menuIdx = process.platform === 'darwin' ? 1 : 0; // adjust for MacOS app menu
+
+    callback.beginMain();
+    callback.menuBegin('&File');
+    callback.menuBegin('Recent Files');
+
+    callback.addCommand('mru0', '', '', '', false, false);
+    callback.addCommand('mru1', '', '', '', false, false);
+    callback.addCommand('mru2', '', '', '', false, false);
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
+    callback.addCommand('clear_recent', 'Clear recent', '', '', false, true);
+
+    callback.updateMenus([]);
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 1, 'expected "Recent files" menu');
+    assert.strictEqual(
+      callback.mainMenu?.items[menuIdx].submenu?.items[0].submenu?.items.length,
+      1,
+      'expected "Clear recent" menu item',
+    );
   });
 });

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -20,7 +20,7 @@ import { MenuCallback } from '../../../src/main/menu-callback';
 
 const separatorTemplate: MenuItemConstructorOptions = { type: 'separator' };
 
-describe('MenuCallback', () => {
+describe('WIPMenuCallback', () => {
   it('can be constructed', () => {
     const callback = new MenuCallback();
     assert.isObject(callback);
@@ -141,5 +141,80 @@ describe('MenuCallback', () => {
       1,
       'expected "Clear recent" menu item',
     );
+  });
+
+  it('can change a command visibility that causes unnecessary separators', () => {
+    const callback = new MenuCallback();
+    const menuIdx = process.platform === 'darwin' ? 1 : 0; // adjust for MacOS app menu
+
+    callback.beginMain();
+    callback.menuBegin('&Build');
+
+    callback.addCommand('buildAll', 'Build All', '', '', false, true);
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
+    callback.addCommand('buildSourcePackage', 'Build Source Package', '', '', false, false);
+    callback.addCommand('buildBinaryPackage', 'Build Binary Package', '', '', false, false);
+    callback.addCommand('testPackage', 'Test Package', '', '', false, false);
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
+    callback.addCommand('configure_build', 'Configure Build Tools', '', '', false, true);
+
+    // debugger;
+    callback.updateMenus([]);
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items.length, 3, 'expected 3 menu items to start');
+
+    callback.updateMenus([{ id: 'buildAll', visible: false }]);
+    callback.updateMenus([{ id: 'buildSourcePackage', visible: true }]);
+    callback.updateMenus([{ id: 'buildBinaryPackage', visible: true }]);
+    callback.updateMenus([{ id: 'testPackage', visible: true }]);
+
+    assert.strictEqual(
+      callback.mainMenu?.items[menuIdx].submenu?.items.length,
+      5,
+      'expected 5 menu items after changing text',
+    );
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items[0].id, 'buildSourcePackage');
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items[1].id, 'buildBinaryPackage');
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items[2].id, 'testPackage');
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items[3].type, 'separator');
+    assert.strictEqual(callback.mainMenu?.items[menuIdx].submenu?.items[4].id, 'configure_build');
+  });
+
+  /*
+        <menu label="_Build">
+         <cmd refid="devtoolsLoadAll"/>
+         <cmd refid="buildAll"/>
+         <cmd refid="rebuildAll"/>
+         <cmd refid="cleanAll"/>
+         <separator/>
+         <cmd refid="serveQuartoSite"/>
+         <separator/>
+         <cmd refid="testPackage"/>
+         <separator/>
+         <cmd refid="checkPackage"/>
+         <separator/>
+         <cmd refid="buildSourcePackage"/>
+         <cmd refid="buildBinaryPackage"/>
+         <separator/>
+         <cmd refid="roxygenizePackage"/>
+         <separator/>
+         <cmd refid="stopBuild"/>
+         <separator/>
+         <cmd refid="buildToolsProjectSetup"/>
+      </menu>
+  */
+
+  it('can update menu item visibility', () => {
+    const callback = new MenuCallback();
+    const menuIdx = process.platform === 'darwin' ? 1 : 0; // adjust for MacOS app menu
+
+    callback.beginMain();
+    callback.menuBegin('&Build');
+
+    callback.addCommand('build_all', 'Build All', '', '', false, true);
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
+    callback.addCommand('install_package', 'Install Package', '', '', false, false);
+    callback.addCommand('test_package', 'Test Package', '', '', false, false);
+    callback.addToCurrentMenu(new MenuItem(separatorTemplate), separatorTemplate);
+    callback.addCommand('configure_build', 'Configure Build Tools', '', '', false, true);
   });
 });


### PR DESCRIPTION
### Intent
Undo the damage from fixing the menu separators. This is a refactor of how the menus are constructed and the menu model. I took a quick peek at the menus and everything looked the same (as far as I can tell from my limited use of the IDE). Added a few unit tests to cover the scenarios where the menus are updated in different ways: changing a menu item label/visibility, full menu rebuild due to reloading the UI, and updating shortcuts.

I've also updated the lint warnings about unused variables. There's an ignore added so that variables prefixed with `_` are ignored for this rule.

### Approach
Change the menu model as `MenuItemConstructorOptions`. This makes it easy to pass a template to `Menu.buildFromTemplate()` to create the application menu. The menu model is copied into a new template with unnecessary menu items and separators. The model will retain the state of menu items like visibility and the menu item order. GWT only needs to make calls to Electron to update commands and eventually call `menu_commit_command_shortcuts` to refresh the menu.

### Automated Tests
There are a few more unit tests to cover changing visibility, labels, shortcuts, and completely rebuilding the menu. 

### QA Notes
* Changing projects should update the recent projects submenu
* Opening files using the Files pane should update the recent files submenu
* Changing the project build options should rebuild the entire menu and show the new options
* Reloading the UI using the Help > Diagnostics > Reload UI action should rebuild the menu

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


