### PR TITLE
Find in Files grep code cleanup and logging

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1315,11 +1315,11 @@ void addDirectoriesToCommand(
 {
    *pCmd << "--";
    if (!(packageSourceFlag || packageTestsFlag))
-      *pCmd << string_utils::utf8ToSystem(directoryPath);
+      *pCmd << directoryPath;
    else if (packageSourceFlag)
    {
-      FilePath rPath(string_utils::utf8ToSystem(directoryPath + "/R"));
-      FilePath srcPath(string_utils::utf8ToSystem(directoryPath + "/src"));
+      FilePath rPath(directoryPath + "/R");
+      FilePath srcPath(directoryPath + "/src");
       if (rPath.exists())
          *pCmd << rPath;
       if (srcPath.exists())
@@ -1330,7 +1330,7 @@ void addDirectoriesToCommand(
    }
    else
    {
-      FilePath testsPath(string_utils::utf8ToSystem(directoryPath + "/tests"));
+      FilePath testsPath(directoryPath + "/tests");
       if (testsPath.exists())
          *pCmd << testsPath;
       else
@@ -1351,7 +1351,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    FilePath gnuGrepPath = session::options().gnugrepPath();
    core::system::addToPath(
             &childEnv,
-            string_utils::utf8ToSystem(gnuGrepPath.getAbsolutePath()));
+            gnuGrepPath.getAbsolutePathNative());
 #endif
    options.environment = childEnv;
 
@@ -1387,7 +1387,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    // Filepaths received from the client will be UTF-8 encoded;
    // convert to system encoding here.
    FilePath dirPath = module_context::resolveAliasedPath(grepOptions.directory());
-   std::string dirPathAbsolute = dirPath.getAbsolutePath();
+   std::string dirPathNative = dirPath.getAbsolutePathNative();
 
 #ifdef _WIN32
    shell_utils::ShellCommand cmd(gnuGrepPath.completePath("grep"));
@@ -1404,7 +1404,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-c" << "grep.extendedRegexp=false";
       cmd << "-c" << "grep.fullName=false";
       cmd << "-C";
-      cmd << string_utils::utf8ToSystem(dirPathAbsolute);
+      cmd << dirPathNative;
       cmd << "grep";
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...
@@ -1422,7 +1422,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       else
          cmd << "-F";
       addDirectoriesToCommand(
-         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathAbsolute, &cmd);
+         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathNative, &cmd);
 
       if (grepOptions.anyPackageFlag() &&
           !grepOptions.includeArgs().empty())
@@ -1455,7 +1455,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       for (std::string arg : grepOptions.excludeArgs())
          cmd << arg;
       addDirectoriesToCommand(
-         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathAbsolute, &cmd);
+         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathNative, &cmd);
    }
 
    // Clear existing results

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1311,30 +1311,30 @@ struct ReplaceOptions
 
 void addDirectoriesToCommand(
    bool packageSourceFlag, bool packageTestsFlag,
-   const FilePath& directoryPath, shell_utils::ShellCommand* pCmd)
+   const std::string directoryPath, shell_utils::ShellCommand* pCmd)
 {
    *pCmd << "--";
    if (!(packageSourceFlag || packageTestsFlag))
-      *pCmd << string_utils::utf8ToSystem(directoryPath.getAbsolutePath());
+      *pCmd << string_utils::utf8ToSystem(directoryPath);
    else if (packageSourceFlag)
    {
-      FilePath rPath(string_utils::utf8ToSystem(directoryPath.getAbsolutePath() + "/R"));
-      FilePath srcPath(string_utils::utf8ToSystem(directoryPath.getAbsolutePath() + "/src"));
+      FilePath rPath(string_utils::utf8ToSystem(directoryPath + "/R"));
+      FilePath srcPath(string_utils::utf8ToSystem(directoryPath + "/src"));
       if (rPath.exists())
          *pCmd << rPath;
       if (srcPath.exists())
          *pCmd << srcPath;
       else if (!rPath.exists())
          LOG_WARNING_MESSAGE(
-            "Package source directories not found in " + directoryPath.getAbsolutePath());
+            "Package source directories not found in " + directoryPath);
    }
    else
    {
-      FilePath testsPath(string_utils::utf8ToSystem(directoryPath.getAbsolutePath() + "/tests"));
+      FilePath testsPath(string_utils::utf8ToSystem(directoryPath + "/tests"));
       if (testsPath.exists())
          *pCmd << testsPath;
       else
-         LOG_WARNING_MESSAGE("Package test directory not found in " + directoryPath.getAbsolutePath());
+         LOG_WARNING_MESSAGE("Package test directory not found in " + directoryPath);
    }
 }
 
@@ -1387,6 +1387,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    // Filepaths received from the client will be UTF-8 encoded;
    // convert to system encoding here.
    FilePath dirPath = module_context::resolveAliasedPath(grepOptions.directory());
+   std::string dirPathAbsolute = dirPath.getAbsolutePath();
 
 #ifdef _WIN32
    shell_utils::ShellCommand cmd(gnuGrepPath.completePath("grep"));
@@ -1403,7 +1404,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-c" << "grep.extendedRegexp=false";
       cmd << "-c" << "grep.fullName=false";
       cmd << "-C";
-      cmd << string_utils::utf8ToSystem(dirPath.getAbsolutePath());
+      cmd << string_utils::utf8ToSystem(dirPathAbsolute);
       cmd << "grep";
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...
@@ -1421,7 +1422,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       else
          cmd << "-F";
       addDirectoriesToCommand(
-         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPath, &cmd);
+         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathAbsolute, &cmd);
 
       if (grepOptions.anyPackageFlag() &&
           !grepOptions.includeArgs().empty())
@@ -1454,7 +1455,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       for (std::string arg : grepOptions.excludeArgs())
          cmd << arg;
       addDirectoriesToCommand(
-         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPath, &cmd);
+         grepOptions.packageSourceFlag(), grepOptions.packageTestsFlag(), dirPathAbsolute, &cmd);
    }
 
    // Clear existing results

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1313,7 +1313,6 @@ void addDirectoriesToCommand(
    bool packageSourceFlag, bool packageTestsFlag,
    const FilePath& directoryPath, shell_utils::ShellCommand* pCmd)
 {
-   // not sure if EscapeFilesOnly can be removed or is necessary for an edge case
    *pCmd << "--";
    if (!(packageSourceFlag || packageTestsFlag))
       *pCmd << string_utils::utf8ToSystem(directoryPath.getAbsolutePath());

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1314,7 +1314,7 @@ void addDirectoriesToCommand(
    const FilePath& directoryPath, shell_utils::ShellCommand* pCmd)
 {
    // not sure if EscapeFilesOnly can be removed or is necessary for an edge case
-   *pCmd << shell_utils::EscapeFilesOnly << "--" << shell_utils::EscapeAll;
+   *pCmd << "--";
    if (!(packageSourceFlag || packageTestsFlag))
       *pCmd << string_utils::utf8ToSystem(directoryPath.getAbsolutePath());
    else if (packageSourceFlag)
@@ -1464,8 +1464,12 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    error = module_context::processSupervisor().runCommand(cmd,
                                                           options,
                                                           callbacks);
-   if (error)
+   if (error){
+      LOG_ERROR_MESSAGE("Failed when executing: " + std::string(cmd));
+      LOG_ERROR(error);
       return error;
+   }
+
 
    findResults().onFindBegin(ptrGrepOp->handle(),
                              grepOptions.searchPattern(),


### PR DESCRIPTION
This works in my local development build on main as well as on this branch, but doesn't seem to work on the daily installed build. These changes are really no-op, but adding more logging when the grep command fails, as well as replacing seemingly redundant calls to `string_utils::utf8ToSystem(path.getAbsolutePath())` with `path.getAbsolutePathNative()`