### PR TITLE
extra precautions to not get out of index error in R tokenizer

### DIFF
--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -556,7 +556,7 @@ wchar_t RTokenizer::peek()
 
 wchar_t RTokenizer::peek(std::size_t lookahead)
 {
-   if ((pos_ + lookahead) >= data_.end())
+   if (lookahead < data_.size() && pos_ >= data_.end() - lookahead)
       return 0;
    else
       return *(pos_ + lookahead);


### PR DESCRIPTION
Solves the painful iterator indexer error on startup (for debug builds)
![Screen Shot 2022-02-15 at 12 42 07 PM](https://user-images.githubusercontent.com/7817881/154560616-f65bdd13-c191-436a-a8ab-d9c2fb76a6ab.png)
 