### PR TITLE
install x64 and M1 node via dependency scripts on MacOS

### DIFF
--- a/dependencies/common/install-node
+++ b/dependencies/common/install-node
@@ -54,6 +54,6 @@ download "${NODE_URL}" "${NODE_ARCHIVE}"
 extract "${NODE_ARCHIVE}"
 rm -f "${NODE_ARCHIVE}"
 
-# rename to use just the version
-mv "${NODE_FILE}" "${NODE_VERSION}"
+# rename to expected folder name
+mv "${NODE_FILE}" "${NODE_FOLDER}"
 

--- a/dependencies/common/install-npm-dependencies
+++ b/dependencies/common/install-npm-dependencies
@@ -26,11 +26,19 @@ fi
 
 # set up node variables common to scripts
 export NODE_VERSION="${RSTUDIO_NODE_VERSION}"
+export NODE_FOLDER="${NODE_VERSION}"
 export NODE_ROOT="node"
-export NODE_SUBDIR="${NODE_ROOT}/${NODE_VERSION}"
+export NODE_SUBDIR="${NODE_ROOT}/${NODE_FOLDER}"
 export NODE_BASE_URL="https://nodejs.org/dist/v${NODE_VERSION}/"
 
-# install node
+# special case for building on M1 Mac: install x64 node in the 
+# default location (so GWT build can easily find it), but also a
+# separate M1 node install (for the Electron build to use)
+if is-m1-mac; then
+	export NODE_FOLDER="${NODE_VERSION}-arm64"
+	export NODE_SUBDIR="${NODE_ROOT}/${NODE_FOLDER}"
+fi
+
 ./install-node
 
 # install yarn

--- a/dependencies/common/install-yarn
+++ b/dependencies/common/install-yarn
@@ -27,9 +27,9 @@ INSTALL_PATH="${NODE_BIN}:${PATH}"
 
 # check for yarn installation
 # TODO: do we want to allow yarn installs from other PATH locations?
-if command -v yarn 2> /dev/null; then
+if has-program yarn; then
   YARN_VERSION=$(PATH="${INSTALL_PATH}" yarn --version)
-  echo "yarn ${YARN_VERSION} already installed at '${NODE_BIN}/yarn'"
+  echo "yarn ${YARN_VERSION} already installed at '$(which yarn)'"
 else
   # download the yarn installer
   YARN_INSTALL_URL="https://yarnpkg.com/install.sh"
@@ -43,6 +43,13 @@ else
 
   # update INSTALL_PATH
   INSTALL_PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${INSTALL_PATH}"
+fi
+
+if is-m1-mac; then
+  # GWT always builds with x64 node on M1 Mac, so no need to reinstall dependencies in an
+  # M1 context.
+  info "Skipping panmirror dependency install for M1 architecture"
+  exit 0
 fi
 
 # install panmirror dependencies

--- a/dependencies/osx/install-dependencies-osx-arch
+++ b/dependencies/osx/install-dependencies-osx-arch
@@ -45,8 +45,6 @@ FORMULAS=(
    openjdk@11
    openssl@1.1
    ninja
-   node
-   npm
    pidof
    postgresql
    r

--- a/dependencies/tools/rstudio-tools.sh
+++ b/dependencies/tools/rstudio-tools.sh
@@ -200,7 +200,7 @@ is-verbose () {
 }
 
 is-m1-mac () {
-	[ "$(arch)" = "arm64" ]
+	[ "$(arch)" = "arm64" ] && [ "$(uname)" = "Darwin" ]
 }
 
 # Download a single file

--- a/package/osx/cmake/merge-electron.cmake
+++ b/package/osx/cmake/merge-electron.cmake
@@ -18,7 +18,9 @@ function(echo MESSAGE)
    execute_process(COMMAND echo "-- ${MESSAGE}")
 endfunction()
 
+
 # run yarn to ensure required packages are installed
+set(ENV{PATH} "@NODEJS_PATH@:$ENV{PATH}")
 execute_process(
 	COMMAND
 		"@YARN@"

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -206,8 +206,7 @@ find-program ANT ant            \
 
 # find node
 find-program NODE node \
-   "../../dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin" \
-   "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
+   "../../dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
  
 # find yarn
 find-program YARN yarn \

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -112,10 +112,14 @@ restore-java-home () {
    fi
 }
 
+invoke-yarn() {
+   PATH="${NODE_PATH}:${PATH}" ${YARN} "$@"
+}
+
 YARN_INSTALLED=0
 install-yarn-packages() {
    if [ "${YARN_INSTALLED}" = "0" ]; then
-      ${YARN}
+      invoke-yarn
       YARN_INSTALLED=1
    fi
 }
@@ -132,7 +136,7 @@ set-version () {
       pushd ${ELECTRON_SOURCE_DIR}
       install-yarn-packages
       save-original-file package.json
-      ${YARN} json -I -f package.json -e "this.version=\"$1\""
+      invoke-yarn json -I -f package.json -e "this.version=\"$1\""
 
       # Keep a backup of build-info.ts so we can restore it
       save-original-file src/main/build-info.ts
@@ -206,8 +210,10 @@ find-program ANT ant            \
 
 # find node
 find-program NODE node \
-   "../../dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
- 
+   "${PKG_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin" \
+   "${PKG_DIR}../../dependencies/common/node/${RSTUDIO_NODE_VERSION}/bin"
+NODE_PATH=`dirname ${NODE}`
+
 # find yarn
 find-program YARN yarn \
    "${HOME}/.yarn/bin"

--- a/src/node/CMakeNodeTools.txt
+++ b/src/node/CMakeNodeTools.txt
@@ -30,13 +30,14 @@ endif()
 if(APPLE AND UNAME_M STREQUAL arm64)
 
    # make sure we're using arm64 binaries of node / npm for arm64 builds
-   set(NODEJS "${HOMEBREW_PREFIX}/bin/node")
-   set(NPM "${HOMEBREW_PREFIX}/bin/npm")
+   set(NODEJS 
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin/node")
+   set(NPM 
+      "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}-arm64/bin/npm")
 
 else()
 
-   # Detect node.js, npm, and yarn; prefer versions supplied by the dependency
-   # scripts but fall back to whatever is found on path.
+   # Detect node.js, npm, and yarn; use versions supplied by the dependency scripts
 
    # node.js
    find_program(NODEJS
@@ -44,17 +45,6 @@ else()
       NO_DEFAULT_PATH PATH_SUFFIXES "bin"
       PATHS "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
-
-   if(NOT NODEJS)
-      # fall back on any available node.js
-      find_program(NODEJS NAMES node)
-   endif()
-
-   if(NODEJS)
-      message(STATUS "Using node.js: ${NODEJS}")
-   else()
-      message(FATAL_ERROR "node.js not found (required)")
-   endif()
 
    # npm
    find_program(NPM
@@ -64,16 +54,18 @@ else()
       PATHS "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
 
-   if (NOT NPM)
-      find_program(NPM NAMES npm)
-   endif()
-
-   if(NPM)
-      message(STATUS "Using npm: ${NPM}")
-   else()
-      message(FATAL_ERROR "npm not found (required for rsw-homepage)")
-   endif()
-
+endif()
+   
+if(NODEJS)
+   message(STATUS "Using node.js: ${NODEJS}")
+else()
+   message(FATAL_ERROR "node.js not found (required)")
+endif()
+   
+if(NPM)
+   message(STATUS "Using npm: ${NPM}")
+else()
+   message(FATAL_ERROR "npm not found (required for rsw-homepage)")
 endif()
 
 get_filename_component(NODEJS_PATH ${NODEJS} DIRECTORY CACHE)


### PR DESCRIPTION
### Intent

We're building Mac (Electron) using multiple versions of node; in some places we use node 16.14 as installed by the dependency scripts, in other places we're using a newer node (17+) installed by "brew install node".

We should build everything with the same version.

### Approach

- Stop installing node via homebrew.
- Install both x64 and M1 node (on an M1 Mac) via the dependency scripts, and update references to make sure the correct one is referenced either directly or is on the path when `yarn` is invoked.
- x64 node goes to the same place as before (`dependencies/common/node/16.14.0`) so GWT build.xml can find it, and M1 node goes into `dependencies/common/node/16.14.0-arm64`)
- Don't fallback to finding node on the path, only use the version we installed
- I tested by making sure I didn't have `node` on the path (`brew remove node` and `nvm deactivate`) then doing a full package build on M1 Mac.

### Automated Tests

None, build stuff.

### QA Notes

Build stuff.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


