### PR TITLE
Implement undo/redo menu actions in Electron

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -299,7 +299,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
    }
 
    private void redoAce() {
-      // Undo on the ACE editor has to be called manually since Electron cannot trigger it
+      // Redo on the ACE editor has to be called manually since Electron cannot trigger it
       AceEditorNative editorNative = AceEditorNative.getEditor(DomUtils.getActiveElement());
       if (editorNative != null) {
          editorNative.execCommand("redo");

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -288,16 +288,43 @@ public class DesktopApplicationHeader implements ApplicationHeader,
 
    private static final DesktopApplicationHeader.Resources RESOURCES =  (DesktopApplicationHeader.Resources) GWT.create(DesktopApplicationHeader.Resources.class);
 
+   private void undoAce() {
+      // Undo on the ACE editor has to be called manually since Electron cannot trigger it
+      AceEditorNative editorNative = AceEditorNative.getEditor(DomUtils.getActiveElement());
+      if (editorNative != null) {
+         editorNative.execCommand("undo");
+      } else {
+         Desktop.getFrame().undo();
+      }
+   }
+
+   private void redoAce() {
+      // Undo on the ACE editor has to be called manually since Electron cannot trigger it
+      AceEditorNative editorNative = AceEditorNative.getEditor(DomUtils.getActiveElement());
+      if (editorNative != null) {
+         editorNative.execCommand("redo");
+      } else {
+         Desktop.getFrame().redo();
+      }
+   }
+
    @Handler
-   void onUndoDummy()
-   {
-      Desktop.getFrame().undo();
+   void onUndoDummy() {
+      if (BrowseCap.isElectron()) {
+         undoAce();
+      } else {
+         Desktop.getFrame().undo();
+      }
    }
 
    @Handler
    void onRedoDummy()
    {
-      Desktop.getFrame().redo();
+      if (BrowseCap.isElectron()) {
+         redoAce();
+      } else {
+         Desktop.getFrame().redo();
+      }
    }
 
    @Handler

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -15,24 +15,21 @@
 
 // TODO clean this up
 
-import { ipcMain, dialog, BrowserWindow, webFrameMain, shell, screen, app } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, screen, shell, webContents, webFrameMain } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
-
 import EventEmitter from 'events';
-
-import { logger } from '../core/logger';
+import i18next from 'i18next';
 import { FilePath } from '../core/file-path';
+import { logger } from '../core/logger';
 import { isCentOS } from '../core/system';
 import { resolveTemplateVar } from '../core/template-filter';
-
-import { MainWindow } from './main-window';
-import { GwtWindow } from './gwt-window';
-import { openMinimalWindow } from './minimal-window';
-import { appState } from './app-state';
-import { filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
 import { userHomePath } from '../core/user';
+import { appState } from './app-state';
+import { GwtWindow } from './gwt-window';
+import { MainWindow } from './main-window';
+import { openMinimalWindow } from './minimal-window';
+import { filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
 import { activateWindow } from './window-utils';
-import i18next from 'i18next';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -168,11 +165,13 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_undo', () => {
-      GwtCallback.unimpl('desktop_undo');
+      // unless the active element is the ACE editor, the web page will handle it
+      webContents.getFocusedWebContents().undo();
     });
 
     ipcMain.on('desktop_redo', () => {
-      GwtCallback.unimpl('desktop_redo');
+      // unless the active element is the ACE editor, the web page will handle it
+      webContents.getFocusedWebContents().redo();
     });
 
     ipcMain.on('desktop_clipboard_cut', () => {
@@ -703,7 +702,6 @@ export class GwtCallback extends EventEmitter {
   }
 
   static unimpl(ipcName: string): void {
-
     if (app.isPackaged) {
       return;
     }
@@ -720,7 +718,6 @@ export class GwtCallback extends EventEmitter {
     } else {
       void dialog.showMessageBox(dialogOptions);
     }
-
   }
 
   collectPendingQuitRequest(): PendingQuit {

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -361,9 +361,9 @@ export class MenuCallback extends EventEmitter {
     } else if (cmdId === 'pasteWithIndentDummy') {
       menuItemOpts.role = 'pasteAndMatchStyle';
     } else if (cmdId === 'undoDummy') {
-      menuItemOpts.role = 'undo';
+      menuItemOpts.accelerator = 'CommandOrControl+Z';
     } else if (cmdId === 'redoDummy') {
-      menuItemOpts.role = 'redo';
+      menuItemOpts.accelerator = 'CommandOrControl+Shift+Z';
     }
 
     const menuItem = new MenuItem(menuItemOpts);


### PR DESCRIPTION
### Intent
The undo/redo menu actions were being handled by Electron. Electron can perform these actions for input elements but not on the ACE editor. This allows editor actions to be undone/redone using the menu.

### Approach
The menu actions are implemented without the `undo` and `redo` roles. Instead, they emit the event for GWT to handle. If GWT detects Electron then it handles the action differently. For focus on an ACE editor, it will invoke the ACE undo/redo. For everything else, it calls back to Electron where it will use `webContents.undo()`.

### Automated Tests
None

### QA Notes
Technically, the menu and keyboard shortcut should be the same now that the shortcut is tied directly to the menu item.

The actions are the same in the editor and the console as both use ACE. Everywhere else should be handled by Electron calling `webContents.undo()`/`redo()`.

All platforms behaved slightly differently before but this change should make the actions work the same now.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


