### PR TITLE
install python for Windows Docker builds

### DIFF
--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -205,11 +205,13 @@ pushd ..\..\src\gwt\panmirror\src\editor
 call yarn install
 popd
 
-if exist C:\Windows\py.exe (
-  pushd ..\..\src\gwt\tools\i18n-helpers\
-  py -3 -m venv VENV
-  VENV\Scripts\pip install --disable-pip-version-check -r commands.cmd.xml\requirements.txt
-  popd
+if not defined JENKINS_URL (
+  if exist C:\Windows\py.exe (
+    pushd ..\..\src\gwt\tools\i18n-helpers\
+    py -3 -m venv VENV
+    VENV\Scripts\pip install --disable-pip-version-check -r commands.cmd.xml\requirements.txt
+    popd
+  )
 )
 
 call install-packages.cmd

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -22,7 +22,8 @@ RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-o
   choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
   choco install -y 7zip; `
-  choco install -y ninja --version "1.10.0"
+  choco install -y ninja --version "1.10.0"; `
+  choco install -y python
 
 # install NSIS - we do not do this via Chocolatey because the hosting URL of the NSIS
 # executable has gone defunct


### PR DESCRIPTION
Fixes build errors on Windows.

Re: https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003

```
[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-20)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-21)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-22)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-23)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-24)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-25)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-26)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-27)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-28)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-29)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-30)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-31)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-32)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-33)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-34)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-35)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-36)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-37)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-38)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-39)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-40)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-41)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-42)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-43)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-44)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-45)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-46)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-47)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-48)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-49)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-50)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-51)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-52)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-53)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-54)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-55)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-56)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-57)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-58)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-59)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-60)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-61)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-62)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-63)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-64)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-65)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-66)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-67)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-68)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-69)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-70)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-71)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-72)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-73)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-74)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-75)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-76)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-77)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-78)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-79)[2022-02-22T23:53:29.057Z] gyp ERR! find Python 

[2022-02-22T23:53:29.057Z] gyp ERR! find Python Python is not set from command line or npm configuration

[2022-02-22T23:53:29.057Z] gyp ERR! find Python Python is not set from environment variable PYTHON

[2022-02-22T23:53:29.057Z] gyp ERR! find Python checking if "python3" can be used

[2022-02-22T23:53:29.057Z] gyp ERR! find Python - "python3" is not in PATH or produced an error

[2022-02-22T23:53:29.057Z] gyp ERR! find Python checking if "python" can be used

[2022-02-22T23:53:29.057Z] gyp ERR! find Python - "python" is not in PATH or produced an error

[2022-02-22T23:53:29.057Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python39\python.exe

[2022-02-22T23:53:29.057Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python39\python.exe" could not be run

[2022-02-22T23:53:29.057Z] gyp ERR! find Python checking if Python is C:\Program Files\Python39\python.exe

[2022-02-22T23:53:29.057Z] gyp ERR! find Python - "C:\Program Files\Python39\python.exe" could not be run

[2022-02-22T23:53:29.057Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python39-32\python.exe

[2022-02-22T23:53:29.057Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python39-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python39-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python39-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files (x86)\Python39-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files (x86)\Python39-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python38\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python38\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python38\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python38\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python38-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python38-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python38-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python38-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files (x86)\Python38-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files (x86)\Python38-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python37\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python37\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python37\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python37\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python37-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python37-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python37-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python37-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files (x86)\Python37-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files (x86)\Python37-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python36\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python36\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python36\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python36\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python36-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Users\ContainerAdministrator\AppData\Local\Programs\Python\Python36-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files\Python36-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files\Python36-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if Python is C:\Program Files (x86)\Python36-32\python.exe

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "C:\Program Files (x86)\Python36-32\python.exe" could not be run

[2022-02-22T23:53:29.058Z] gyp ERR! find Python checking if the py launcher can be used to find Python 3

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - "py.exe" is not in PATH or produced an error

[2022-02-22T23:53:29.058Z] gyp ERR! find Python 

[2022-02-22T23:53:29.058Z] gyp ERR! find Python **********************************************************

[2022-02-22T23:53:29.058Z] gyp ERR! find Python You need to install the latest version of Python.

[2022-02-22T23:53:29.058Z] gyp ERR! find Python Node-gyp should be able to find and use Python. If not,

[2022-02-22T23:53:29.058Z] gyp ERR! find Python you can try one of the following options:

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - Use the switch --python="C:\Path\To\python.exe"

[2022-02-22T23:53:29.058Z] gyp ERR! find Python   (accepted by both node-gyp and npm)

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - Set the environment variable PYTHON

[2022-02-22T23:53:29.058Z] gyp ERR! find Python - Set the npm configuration variable python:

[2022-02-22T23:53:29.058Z] gyp ERR! find Python   npm config set python "C:\Path\To\python.exe"

[2022-02-22T23:53:29.058Z] gyp ERR! find Python For more information consult the documentation at:

[2022-02-22T23:53:29.058Z] gyp ERR! find Python https://github.com/nodejs/node-gyp#installation[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-80)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-81)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-82)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-83)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-84)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-85)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-86)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-87)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-88)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-89)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-90)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-91)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-92)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-93)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-94)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-95)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-96)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-97)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-98)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-99)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-100)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-101)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-102)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-103)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-104)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-105)[](https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/922/pipeline/1003#step-1004-log-106)

[2022-02-22T23:53:29.058Z] gyp ERR! find Python **********************************************************

[2022-02-22T23:53:29.058Z] gyp ERR! find Python 

[2022-02-22T23:53:29.058Z] gyp ERR! configure error 

[2022-02-22T23:53:29.058Z] gyp ERR! stack Error: Could not find any Python installation to use

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at PythonFinder.fail (c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop\node_modules\node-gyp\lib\find-python.js:330:47)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at PythonFinder.runChecks (c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop\node_modules\node-gyp\lib\find-python.js:159:21)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at PythonFinder.<anonymous> (c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop\node_modules\node-gyp\lib\find-python.js:228:18)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at PythonFinder.execFileCallback (c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop\node_modules\node-gyp\lib\find-python.js:294:16)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at exithandler (node:child_process:406:5)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at ChildProcess.errorhandler (node:child_process:418:5)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at ChildProcess.emit (node:events:520:28)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at Process.ChildProcess._handle.onexit (node:internal/child_process:289:12)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at onErrorNT (node:internal/child_process:478:16)

[2022-02-22T23:53:29.058Z] gyp ERR! stack     at processTicksAndRejections (node:internal/process/task_queues:83:21)

[2022-02-22T23:53:29.058Z] gyp ERR! System Windows_NT 10.0.17763

[2022-02-22T23:53:29.058Z] gyp ERR! command "c:\\Users\\jenkins\\workspace\\ide\\open-source-pipeline\\main\\package\\win32\\..\\..\\dependencies\\common\\node\\16.14.0\\node.exe" "c:\\Users\\jenkins\\workspace\\ide\\open-source-pipeline\\main\\src\\node\\desktop\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"

[2022-02-22T23:53:29.058Z] gyp ERR! cwd c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop

[2022-02-22T23:53:29.058Z] gyp ERR! node -v v16.14.0

[2022-02-22T23:53:29.058Z] gyp ERR! node-gyp -v v8.4.1

[2022-02-22T23:53:29.058Z] gyp ERR! not ok 

[2022-02-22T23:53:29.058Z] npm ERR! code 1

[2022-02-22T23:53:29.058Z] npm ERR! path c:\Users\jenkins\workspace\ide\open-source-pipeline\main\src\node\desktop

[2022-02-22T23:53:29.058Z] npm ERR! command failed

[2022-02-22T23:53:29.058Z] npm ERR! command C:\Windows\system32\cmd.exe /d /s /c node-gyp rebuild

[2022-02-22T23:53:29.058Z] 

[2022-02-22T23:53:29.058Z] npm ERR! A complete log of this run can be found in:

[2022-02-22T23:53:29.058Z] npm ERR!     C:\Users\ContainerAdministrator\AppData\Local\npm-cache\_logs\2022-02-22T23_52_21_981Z-debug-0.log
```