### PR TITLE
unset MAKEFLAGS when running npm install

### DIFF
--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -54,7 +54,7 @@ exit 1
 NPM_INSTALLED=0
 install-npm-packages() {
    if [ "${NPM_INSTALLED}" = "0" ]; then
-      MAKEFLAGS= ${NPM} ci
+      MAKEFLAGS="" ${NPM} ci
       NPM_INSTALLED=1
    fi
 }

--- a/package/linux/make-package
+++ b/package/linux/make-package
@@ -54,7 +54,7 @@ exit 1
 NPM_INSTALLED=0
 install-npm-packages() {
    if [ "${NPM_INSTALLED}" = "0" ]; then
-      ${NPM} ci
+      MAKEFLAGS= ${NPM} ci
       NPM_INSTALLED=1
    fi
 }

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -115,7 +115,7 @@ restore-java-home () {
 NPM_INSTALLED=0
 install-npm-packages() {
    if [ "${NPM_INSTALLED}" = "0" ]; then
-      ${NPM} ci
+      MAKEFLAGS="" ${NPM} ci
       NPM_INSTALLED=1
    fi
 }

--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -159,7 +159,12 @@ else()
       DEPENDS "${DESKTOP_SOURCES}"
       COMMENT "Building desktop (Electron ${UNAME_M})"
       WORKING_DIRECTORY "${ELECTRON_BUILD_DIR}"
-      COMMAND ${CMAKE_COMMAND} -E env "PATH=${MODIFIED_PATH}" "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1" ${NPM} run package
+      COMMAND
+         ${CMAKE_COMMAND} -E env
+         "PATH=${MODIFIED_PATH}"
+         "PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1"
+         "MAKEFLAGS="
+         ${NPM} run package
    )
 
 endif()

--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -185,15 +185,25 @@ endif()
 
 # install binary (except on macOS, which uses a different approach for bundling Electron due
 # to additional steps related to creation of a Universal x64/M1 image)
-if (WIN32)
+if(WIN32)
+
    install(
       DIRECTORY "${ELECTRON_BUILD_DIR}/out/RStudio-win32-x64/"
       DESTINATION "${RSTUDIO_INSTALL_ELECTRON}"
    )
-elseif (LINUX)
+
+elseif(LINUX)
+
+   if(UNAME_M STREQUAL aarch64)
+      set(ELECTRON_ARCH arm64)
+   else()
+      set(ELECTRON_ARCH x64)
+   endif()
+
    install(
-      DIRECTORY "${ELECTRON_BUILD_DIR}/out/rstudio-linux-x64/"
+      DIRECTORY "${ELECTRON_BUILD_DIR}/out/rstudio-linux-${ELECTRON_ARCH}/"
       DESTINATION "${RSTUDIO_INSTALL_ELECTRON}"
       USE_SOURCE_PERMISSIONS
    )
+
 endif()

--- a/src/node/desktop/envvars.sh
+++ b/src/node/desktop/envvars.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Run this script to add node to the PATH.
+NODE_PATH=$(realpath ../../../dependencies/common/node/16.14.0/bin)
+PATH="${NODE_PATH}:${PATH}"
+


### PR DESCRIPTION
`node-gyp` barfs if you try to build its targets in parallel.