### PR TITLE
Hide menubar on secondary windows

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -51,6 +51,7 @@ export class DesktopBrowserWindow extends EventEmitter {
   constructor(
     private showToolbar: boolean,
     private adjustTitle: boolean,
+    private autohideMenu: boolean,
     protected name: string,
     readonly baseUrl?: string,
     private parent?: DesktopBrowserWindow,
@@ -71,6 +72,7 @@ export class DesktopBrowserWindow extends EventEmitter {
       this.window = new BrowserWindow({
         // https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
         backgroundColor: '#fff',
+        autoHideMenuBar: autohideMenu,
         webPreferences: {
           nodeIntegration: false,
           contextIsolation: true,

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -28,6 +28,7 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
   constructor(
     showToolbar: boolean,
     adjustTitle: boolean,
+    autohideMenu: boolean,
     name: string,
     baseUrl?: string,
     parent?: DesktopBrowserWindow,
@@ -36,7 +37,8 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
     addedCallbacks: string[] = [],
     existingWindow?: BrowserWindow,
   ) {
-    super(showToolbar, adjustTitle, name, baseUrl, parent, opener, isRemoteDesktop, addedCallbacks, existingWindow);
+    super(showToolbar, adjustTitle, autohideMenu, name, baseUrl, parent, opener,
+      isRemoteDesktop, addedCallbacks, existingWindow);
 
     this.window.on('focus', this.onActivated.bind(this));
   }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -79,7 +79,7 @@ export class MainWindow extends GwtWindow {
   //#endif
 
   constructor(url: string, public isRemoteDesktop = false) {
-    super(false, false, '', url, undefined, undefined, isRemoteDesktop, ['desktop', 'desktopMenuCallback']);
+    super(false, false, false, '', url, undefined, undefined, isRemoteDesktop, ['desktop', 'desktopMenuCallback']);
 
     appState().gwtCallback = new GwtCallback(this, isRemoteDesktop);
     this.menuCallback = new MenuCallback();

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -28,7 +28,7 @@ class MinimalWindow extends DesktopBrowserWindow {
     opener?: WebContents,
     allowExternalNavigate = false,
   ) {
-    super(false, adjustTitle, name, baseUrl, parent, opener, allowExternalNavigate);
+    super(false, adjustTitle, true/*autohideMenu*/, name, baseUrl, parent, opener, allowExternalNavigate);
 
     // ensure minimal windows can be closed with Ctrl+W (Cmd+W on macOS)
     this.window.webContents.on('before-input-event', (event, input) => {

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -95,6 +95,7 @@ export class SatelliteWindow extends GwtWindow {
     return {
       action: 'allow',
       overrideBrowserWindowOptions: {
+        autoHideMenuBar: true,
         webPreferences: {
           additionalArguments: ['--apiKeys=desktopInfo|desktop'],
           preload: DesktopBrowserWindow.getPreload(),

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -29,7 +29,7 @@ export class SatelliteWindow extends GwtWindow {
   closeStage: CloseStage = 'CloseStageOpen';
 
   constructor(mainWindow: MainWindow, name: string, opener: WebContents, existingWindow?: BrowserWindow) {
-    super(false, true, name, undefined, undefined, opener, mainWindow.isRemoteDesktop, ['desktop'], existingWindow);
+    super(false, true, true, name, undefined, undefined, opener, mainWindow.isRemoteDesktop, ['desktop'], existingWindow);
     appState().gwtCallback?.registerOwner(this);
 
     this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -48,6 +48,7 @@ export class SecondaryWindow extends DesktopBrowserWindow {
     return {
       action: 'allow',
       overrideBrowserWindowOptions: {
+        autoHideMenuBar: true,
         width: width,
         height: height,
         webPreferences: {

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -26,7 +26,7 @@ export class SecondaryWindow extends DesktopBrowserWindow {
     allowExternalNavigate = false,
     existingWindow?: BrowserWindow,
   ) {
-    super(showToolbar, true, name, baseUrl, parent, opener, allowExternalNavigate, undefined, existingWindow);
+    super(showToolbar, true, true, name, baseUrl, parent, opener, allowExternalNavigate, undefined, existingWindow);
 
     this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
   }

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -20,7 +20,7 @@ import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
 
 describe('DesktopBrowserWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const win = new DesktopBrowserWindow(false, false, '_blank');
+    const win = new DesktopBrowserWindow(false, false, false, '_blank');
     assert.isObject(win);
     assert.isObject(win.window);
     assert.isFalse(win.window.isVisible());

--- a/src/node/desktop/test/unit/main/gwt-window.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-window.test.ts
@@ -26,7 +26,7 @@ class TestGwtWindow extends GwtWindow {
 
 describe('GwtWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const gwtWin = new TestGwtWindow(false, false, 'some name');
+    const gwtWin = new TestGwtWindow(false, false, false, 'some name');
     assert.isObject(gwtWin);
     assert.isObject(gwtWin.window);
     assert.isFalse(gwtWin.window.isVisible());

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -36,7 +36,7 @@ describe('minimal-window', () => {
   });
 
   it('can be constructed', () => {
-    const gwtWindow = new TestGwtWindow(false, false, '');
+    const gwtWindow = new TestGwtWindow(false, false, false, '');
     const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
     assert.isObject(minWin);
   });

--- a/src/node/desktop/test/unit/main/window-tracker.test.ts
+++ b/src/node/desktop/test/unit/main/window-tracker.test.ts
@@ -42,7 +42,7 @@ describe('window-tracker', () => {
   });
   it('tracks and returns a window by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
     tracker.addWindow('one', oneWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -51,9 +51,9 @@ describe('window-tracker', () => {
   });
   it('tracks and returns two windows by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
     tracker.addWindow('one', oneWin);
-    const twoWin = new DesktopBrowserWindow(false, false, 'another name');
+    const twoWin = new DesktopBrowserWindow(false, false, false, 'another name');
     tracker.addWindow('two', twoWin);
     const twoResult = tracker.getWindow('two');
     const oneResult = tracker.getWindow('one');
@@ -64,9 +64,9 @@ describe('window-tracker', () => {
   });
   it('duplicate name replaces the original', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
     tracker.addWindow('one', oneWin);
-    const twoWin = new TestGwtWindow(false, false, 'the gwt window');
+    const twoWin = new TestGwtWindow(false, false, false, 'the gwt window');
     tracker.addWindow('one', twoWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -74,7 +74,7 @@ describe('window-tracker', () => {
   });
   it('delete window removes it from map', async function () {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
     tracker.addWindow('one', oneWin);
     oneWin.window.close();
     await setTimeoutPromise(200); // TODO: yuck, find a better way to do this


### PR DESCRIPTION
### Intent

Addresses #10610

Secondary windows such as popped-out-editors or the git window were showing the menubar on Windows and Linux, which they didn't do on the Qt desktop.

### Approach

We load secondary windows in the same renderer process as the main window. This is for efficiency and also because we rely on the pattern `window.opener.doSomething()` and that can't work if each window is in its own renderer process.

As a result each window shares the same application menu. Using the autohide feature to hide the menu by default on secondary windows. It can still be displayed by tapping the Alt key.

This problem of having the menu on secondary windows is also true on Mac QtWebEngine desktop, so this actually isn't new. Just more noticable, perhaps, on Windows/Linux where menus are attached directly to the window instead of at the top.

On all three platforms the menu triggers actions in the main window (typically), even when it doesn't currently have focus. Not always great, but this isn't a new problem.

### Automated Tests

None

### QA Notes

Verify that secondary windows such as source control, editors, help content, zoomed plots, etc. don't show a menu by default on Windows and Linux.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


