### PR TITLE
fixups for list.files on Windows

### DIFF
--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1611,6 +1611,16 @@ std::vector<boost::filesystem::path> initializePaths(SEXP pathSEXP)
          continue;
 
       const char* utf8Path = Rf_translateCharUTF8(charSEXP);
+
+      // ensure paths are expanded -- note that R does not
+      // preserve the tilde prefix in e.g.
+      //
+      //    list.files("~/hello", full.names = TRUE)
+      //
+      // rather, the expanded path is used when filling
+      // the names of listed files
+      utf8Path = R_ExpandFileName(utf8Path);
+
 #ifdef BOOST_WINDOWS_API
       paths.push_back(string_utils::utf8ToWide(utf8Path));
 #else

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1398,9 +1398,9 @@ public:
       // paying the cost to rebuild this call on every invocation
       callSEXP_ = Rf_lang4(
                Rf_install("grepl"),    // function
-               patternSEXP,           // pattern
-               R_NilValue,             // x
-               ignoreCaseSEXP);       // ignore.case
+               patternSEXP,            // pattern
+               R_NilValue,             // x (filled in below)
+               ignoreCaseSEXP);        // ignore.case
 
       preserver_.add(callSEXP_);
    }

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1720,7 +1720,7 @@ SEXP rs_listFiles(SEXP pathSEXP,
       options.noDotDot               = noDotDot;
       options.checkTrailingSeparator = true;
 
-      if (LENGTH(patternSEXP) == 0)
+      if (patternSEXP == R_NilValue || LENGTH(patternSEXP) == 0)
       {
          listFilesDispatch(
                   paths,

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -46,7 +46,7 @@ if (.rs.platform.isWindows)
 {
    setHook("rstudio.sessionInit", function(...)
    {
-      enabled <- getOption("rstudio.enableFileHooks", default = TRUE)
+      enabled <- getOption("rstudio.enableFileHooks", default = FALSE)
       if (identical(enabled, TRUE))
          .rs.files.replaceBindings()
    })

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -46,7 +46,7 @@ if (.rs.platform.isWindows)
 {
    setHook("rstudio.sessionInit", function(...)
    {
-      enabled <- getOption("rstudio.enableFileHooks", default = TRUE)
+      enabled <- getOption("rstudio.enableFileHooks", default = getRversion() < "4.2.0")
       if (identical(enabled, TRUE))
          .rs.files.replaceBindings()
    })

--- a/src/cpp/session/modules/SessionPatches.R
+++ b/src/cpp/session/modules/SessionPatches.R
@@ -46,7 +46,7 @@ if (.rs.platform.isWindows)
 {
    setHook("rstudio.sessionInit", function(...)
    {
-      enabled <- getOption("rstudio.enableFileHooks", default = FALSE)
+      enabled <- getOption("rstudio.enableFileHooks", default = TRUE)
       if (identical(enabled, TRUE))
          .rs.files.replaceBindings()
    })

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -91,6 +91,7 @@ test_that("our list.files, list.dirs hooks function as expected", {
    file.create(".hidden")
    
    file.create("file")
+   file.create("test.csv")
    
    dir.create("dir")
    dir.create("dir/subdir")
@@ -115,6 +116,7 @@ test_that("our list.files, list.dirs hooks function as expected", {
       ".\\",
       ".//",
       ".\\/",
+      "*.csv",  # not technically a valid regex but R accepts it
       getwd(),
       chartr("/", "\\", getwd()),
       file.path("..", basename(getwd())),

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -103,6 +103,12 @@ test_that("our list.files, list.dirs hooks function as expected", {
    dir.create("hasEmptyDir")
    dir.create("hasEmptyDir/empty")
    
+   dir.create("~/RStudioTestDirectory")
+   file.create("~/RStudioTestDirectory/file")
+   dir.create("~/RStudioTestDirectory/dir")
+   file.create("~/RStudioTestDirectory/dir/file2")
+   on.exit(unlink("~/RStudioTestDirectory", recursive = TRUE), add = TRUE)
+   
    if (identical(R.version$crt, "ucrt")) {
       nihao <- enc2utf8("\u4f60\u597d")  # 你好
       dir.create(nihao)
@@ -117,6 +123,9 @@ test_that("our list.files, list.dirs hooks function as expected", {
       ".//",
       ".\\/",
       "*.csv",  # not technically a valid regex but R accepts it
+      "~/RStudioTestDirectory",
+      "~/RStudioTestDirectory/",
+      "~/RStudioTestDirectory//",
       getwd(),
       chartr("/", "\\", getwd()),
       file.path("..", basename(getwd())),
@@ -171,5 +180,6 @@ test_that("our list.files, list.dirs hooks function as expected", {
    
    setwd(owd)
    unlink(tdir, recursive = TRUE)
+   unlink("~/RStudioTestDirectory", recursive = TRUE)
    
 })

--- a/version/news/NEWS-2022.02.1-prairie-trillium.md
+++ b/version/news/NEWS-2022.02.1-prairie-trillium.md
@@ -1,0 +1,7 @@
+## RStudio 2022-02.1 "Prairie Trillium" Release Notes
+
+### Bugfixes
+
+- Fixed an issue preventing deployment of applications on Windows. (#10672)
+- Fixed an issue where `list.files()` did not handle "globs" as expected. (#10679)
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10679.
Addresses https://github.com/rstudio/rstudio/issues/10672.

### Approach

Use R's own `grepl()` rather than `boost::regex`, to avoid incompatibilities between the two regular expression engines.

Also make sure we expand tilde-prefixed paths before attempting to list files. 😭 

### Automated Tests

Tests included and updated.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10679.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
