### PR TITLE
use objects as constructor args (electron)

### DIFF
--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -18,28 +18,15 @@ import { logger } from '../core/logger';
 
 import { nextHighest, nextLowest } from '../core/array-utils';
 
-import { DesktopBrowserWindow } from './desktop-browser-window';
+import { DesktopBrowserWindow, WindowConstructorOptions } from './desktop-browser-window';
 import { DesktopOptions } from './desktop-options';
 
 export abstract class GwtWindow extends DesktopBrowserWindow {
   // initialize zoom levels (synchronize with AppearancePreferencesPane.java)
   zoomLevels = [0.25, 0.5, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0, 5.0];
 
-  constructor(
-    showToolbar: boolean,
-    adjustTitle: boolean,
-    autohideMenu: boolean,
-    name: string,
-    baseUrl?: string,
-    parent?: DesktopBrowserWindow,
-    opener?: WebContents,
-    isRemoteDesktop = false,
-    addedCallbacks: string[] = [],
-    existingWindow?: BrowserWindow,
-  ) {
-    super(showToolbar, adjustTitle, autohideMenu, name, baseUrl, parent, opener,
-      isRemoteDesktop, addedCallbacks, existingWindow);
-
+  constructor(options: WindowConstructorOptions) {
+    super(options);
     this.window.on('focus', this.onActivated.bind(this));
   }
 

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -79,7 +79,15 @@ export class MainWindow extends GwtWindow {
   //#endif
 
   constructor(url: string, public isRemoteDesktop = false) {
-    super(false, false, false, '', url, undefined, undefined, isRemoteDesktop, ['desktop', 'desktopMenuCallback']);
+    super({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: '',
+      baseUrl: url,
+      allowExternalNavigate: isRemoteDesktop,
+      addApiKeys: ['desktop', 'desktopMenuCallback'],
+    });
 
     appState().gwtCallback = new GwtCallback(this, isRemoteDesktop);
     this.menuCallback = new MenuCallback();
@@ -388,7 +396,7 @@ export class MainWindow extends GwtWindow {
       return;
     }
     reloadCount++;
-    this.loadUrl(this.baseUrl ?? '').catch(logger().logError);
+    this.loadUrl(this.options.baseUrl ?? '').catch(logger().logError);
   }
 
   onLoadFinished(ok: boolean): void {
@@ -403,7 +411,7 @@ export class MainWindow extends GwtWindow {
         // session has failed to load. let the user know that the R
         // session is still initializing, and then reload the page.
         this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY).catch(logger().logError);
-        waitForUrlWithTimeout(this.baseUrl ?? '', reloadWaitDuration, reloadWaitDuration, 10)
+        waitForUrlWithTimeout(this.options.baseUrl ?? '', reloadWaitDuration, reloadWaitDuration, 10)
           .then((error: Err) => {
             if (error) {
               logger().logError(error);
@@ -428,7 +436,7 @@ export class MainWindow extends GwtWindow {
     }
 
     const vars = new Map<string, string>();
-    vars.set('retry_url', this.baseUrl ?? '');
+    vars.set('retry_url', this.options.baseUrl ?? '');
     appState().gwtCallback?.setErrorPageInfo(vars);
     this.loadUrl(CONNECT_WINDOW_WEBPACK_ENTRY).catch(logger().logError);
   }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -80,9 +80,6 @@ export class MainWindow extends GwtWindow {
 
   constructor(url: string, public isRemoteDesktop = false) {
     super({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
       name: '',
       baseUrl: url,
       allowExternalNavigate: isRemoteDesktop,

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -29,7 +29,6 @@ class MinimalWindow extends DesktopBrowserWindow {
     allowExternalNavigate?: boolean;
   }) {
     super({
-      showToolbar: false,
       adjustTitle: options.adjustTitle,
       autohideMenu: true,
       name: options.name,

--- a/src/node/desktop/src/main/minimal-window.ts
+++ b/src/node/desktop/src/main/minimal-window.ts
@@ -20,15 +20,24 @@ import { DesktopBrowserWindow } from './desktop-browser-window';
 import { GwtWindow } from './gwt-window';
 
 class MinimalWindow extends DesktopBrowserWindow {
-  constructor(
-    adjustTitle: boolean,
-    name: string,
-    baseUrl?: string,
-    parent?: DesktopBrowserWindow,
-    opener?: WebContents,
-    allowExternalNavigate = false,
-  ) {
-    super(false, adjustTitle, true/*autohideMenu*/, name, baseUrl, parent, opener, allowExternalNavigate);
+  constructor(options: {
+    adjustTitle: boolean;
+    name: string;
+    baseUrl?: string;
+    parent?: DesktopBrowserWindow;
+    opener?: WebContents;
+    allowExternalNavigate?: boolean;
+  }) {
+    super({
+      showToolbar: false,
+      adjustTitle: options.adjustTitle,
+      autohideMenu: true,
+      name: options.name,
+      baseUrl: options.baseUrl,
+      parent: options.parent,
+      opener: options.opener,
+      allowExternalNavigate: options.allowExternalNavigate,
+    });
 
     // ensure minimal windows can be closed with Ctrl+W (Cmd+W on macOS)
     this.window.webContents.on('before-input-event', (event, input) => {
@@ -41,11 +50,11 @@ class MinimalWindow extends DesktopBrowserWindow {
 
     // ensure this window closes when the creating window closes
     this.parentWindowDestroyed = this.parentWindowDestroyed.bind(this);
-    parent?.on(DesktopBrowserWindow.WINDOW_DESTROYED, this.parentWindowDestroyed);
+    this.options.parent?.on(DesktopBrowserWindow.WINDOW_DESTROYED, this.parentWindowDestroyed);
 
     this.window.on('close', () => {
       // release external event listeners
-      parent?.removeListener(DesktopBrowserWindow.WINDOW_DESTROYED, this.parentWindowDestroyed);
+      this.options.parent?.removeListener(DesktopBrowserWindow.WINDOW_DESTROYED, this.parentWindowDestroyed);
     });
   }
 
@@ -73,13 +82,12 @@ export function openMinimalWindow(
 
     // pass along our own base URL so that the new window's WebProfile knows how to
     // apply the appropriate headers
-    browser = new MinimalWindow(
-      !isViewerZoomWindow,
-      name,
-      '', // TODO pMainWindow_->webView()->baseUrl()
-      sender,
-      undefined /* opener */,
-    );
+    browser = new MinimalWindow({
+      adjustTitle: !isViewerZoomWindow,
+      name: name,
+      baseUrl: '', // TODO pMainWindow_->webView()->baseUrl()
+      parent: sender,
+    });
 
     if (named) {
       appState().windowTracker.addWindow(name, browser);

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -29,13 +29,20 @@ export class SatelliteWindow extends GwtWindow {
   closeStage: CloseStage = 'CloseStageOpen';
 
   constructor(mainWindow: MainWindow, name: string, opener: WebContents, existingWindow?: BrowserWindow) {
-    super(false, true, true, name, undefined, undefined, opener, mainWindow.isRemoteDesktop, ['desktop'], existingWindow);
+    super({
+      showToolbar: false,
+      adjustTitle: true,
+      autohideMenu: true,
+      name: name,
+      opener: opener,
+      allowExternalNavigate: mainWindow.isRemoteDesktop,
+      addApiKeys: ['desktop'],
+      existingWindow: existingWindow,
+    });
+
     appState().gwtCallback?.registerOwner(this);
 
     this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
-
-    // TODO
-    // satellites don't have a menu, so connect zoom keyboard shortcuts directly
   }
 
   onActivated(): void {
@@ -60,7 +67,7 @@ export class SatelliteWindow extends GwtWindow {
     // its parent or by the OS, we don't prompt since in those cases unsaved document accumulation
     // and prompting is handled by the parent.
     if (
-      this.name.startsWith(SOURCE_WINDOW_PREFIX) &&
+      this.options.name.startsWith(SOURCE_WINDOW_PREFIX) &&
       this.closeStage === 'CloseStageOpen' /*&& event->spontaneous()*/
     ) {
       // ignore this event; we need to make sure the window can be closed ourselves

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -30,7 +30,6 @@ export class SatelliteWindow extends GwtWindow {
 
   constructor(mainWindow: MainWindow, name: string, opener: WebContents, existingWindow?: BrowserWindow) {
     super({
-      showToolbar: false,
       adjustTitle: true,
       autohideMenu: true,
       name: name,

--- a/src/node/desktop/src/main/secondary-window.ts
+++ b/src/node/desktop/src/main/secondary-window.ts
@@ -26,7 +26,17 @@ export class SecondaryWindow extends DesktopBrowserWindow {
     allowExternalNavigate = false,
     existingWindow?: BrowserWindow,
   ) {
-    super(showToolbar, true, true, name, baseUrl, parent, opener, allowExternalNavigate, undefined, existingWindow);
+    super({
+      showToolbar: showToolbar,
+      adjustTitle: true,
+      autohideMenu: true,
+      name: name,
+      baseUrl: baseUrl,
+      parent: parent,
+      opener: opener,
+      allowExternalNavigate: allowExternalNavigate,
+      existingWindow: existingWindow,
+    });
 
     this.on(DesktopBrowserWindow.CLOSE_WINDOW_SHORTCUT, this.onCloseWindowShortcut.bind(this));
   }

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -20,12 +20,7 @@ import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
 
 describe('DesktopBrowserWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const win = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: '_blank',
-    });
+    const win = new DesktopBrowserWindow({ name: '_blank' });
     assert.isObject(win);
     assert.isObject(win.window);
     assert.isFalse(win.window.isVisible());

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -20,7 +20,12 @@ import { DesktopBrowserWindow } from '../../../src/main/desktop-browser-window';
 
 describe('DesktopBrowserWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const win = new DesktopBrowserWindow(false, false, false, '_blank');
+    const win = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: '_blank',
+    });
     assert.isObject(win);
     assert.isObject(win.window);
     assert.isFalse(win.window.isVisible());

--- a/src/node/desktop/test/unit/main/gwt-window.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-window.test.ts
@@ -26,7 +26,12 @@ class TestGwtWindow extends GwtWindow {
 
 describe('GwtWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const gwtWin = new TestGwtWindow(false, false, false, 'some name');
+    const gwtWin = new TestGwtWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'some name',
+    });
     assert.isObject(gwtWin);
     assert.isObject(gwtWin.window);
     assert.isFalse(gwtWin.window.isVisible());

--- a/src/node/desktop/test/unit/main/gwt-window.test.ts
+++ b/src/node/desktop/test/unit/main/gwt-window.test.ts
@@ -26,12 +26,7 @@ class TestGwtWindow extends GwtWindow {
 
 describe('GwtWindow', () => {
   it('construction creates a hidden BrowserWindow', () => {
-    const gwtWin = new TestGwtWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'some name',
-    });
+    const gwtWin = new TestGwtWindow({ name: 'some name' });
     assert.isObject(gwtWin);
     assert.isObject(gwtWin.window);
     assert.isFalse(gwtWin.window.isVisible());

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -36,7 +36,12 @@ describe('minimal-window', () => {
   });
 
   it('can be constructed', () => {
-    const gwtWindow = new TestGwtWindow(false, false, false, '');
+    const gwtWindow = new TestGwtWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: '',
+    });
     const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
     assert.isObject(minWin);
   });

--- a/src/node/desktop/test/unit/main/minimal-window.test.ts
+++ b/src/node/desktop/test/unit/main/minimal-window.test.ts
@@ -36,12 +36,7 @@ describe('minimal-window', () => {
   });
 
   it('can be constructed', () => {
-    const gwtWindow = new TestGwtWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: '',
-    });
+    const gwtWindow = new TestGwtWindow({ name: '' });
     const minWin = openMinimalWindow(gwtWindow, 'test-win', 'about:blank', 640, 480);
     assert.isObject(minWin);
   });

--- a/src/node/desktop/test/unit/main/window-tracker.test.ts
+++ b/src/node/desktop/test/unit/main/window-tracker.test.ts
@@ -42,12 +42,7 @@ describe('window-tracker', () => {
   });
   it('tracks and returns a window by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'some name',
-    });
+    const oneWin = new DesktopBrowserWindow({ name: 'some name' });
     tracker.addWindow('one', oneWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -56,19 +51,9 @@ describe('window-tracker', () => {
   });
   it('tracks and returns two windows by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'some name',
-    });
+    const oneWin = new DesktopBrowserWindow({ name: 'some name' });
     tracker.addWindow('one', oneWin);
-    const twoWin = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'another name',
-    });
+    const twoWin = new DesktopBrowserWindow({ name: 'another name' });
     tracker.addWindow('two', twoWin);
     const twoResult = tracker.getWindow('two');
     const oneResult = tracker.getWindow('one');
@@ -79,19 +64,9 @@ describe('window-tracker', () => {
   });
   it('duplicate name replaces the original', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'some name',
-    });
+    const oneWin = new DesktopBrowserWindow({ name: 'some name' });
     tracker.addWindow('one', oneWin);
-    const twoWin = new TestGwtWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'the gwt window',
-    });
+    const twoWin = new TestGwtWindow({ name: 'the gwt window' });
     tracker.addWindow('one', twoWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -99,12 +74,7 @@ describe('window-tracker', () => {
   });
   it('delete window removes it from map', async function () {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow({
-      showToolbar: false,
-      adjustTitle: false,
-      autohideMenu: false,
-      name: 'some name',
-    });
+    const oneWin = new DesktopBrowserWindow({ name: 'some name' });
     tracker.addWindow('one', oneWin);
     oneWin.window.close();
     await setTimeoutPromise(200); // TODO: yuck, find a better way to do this

--- a/src/node/desktop/test/unit/main/window-tracker.test.ts
+++ b/src/node/desktop/test/unit/main/window-tracker.test.ts
@@ -42,7 +42,12 @@ describe('window-tracker', () => {
   });
   it('tracks and returns a window by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'some name',
+    });
     tracker.addWindow('one', oneWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -51,9 +56,19 @@ describe('window-tracker', () => {
   });
   it('tracks and returns two windows by name', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'some name',
+    });
     tracker.addWindow('one', oneWin);
-    const twoWin = new DesktopBrowserWindow(false, false, false, 'another name');
+    const twoWin = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'another name',
+    });
     tracker.addWindow('two', twoWin);
     const twoResult = tracker.getWindow('two');
     const oneResult = tracker.getWindow('one');
@@ -64,9 +79,19 @@ describe('window-tracker', () => {
   });
   it('duplicate name replaces the original', () => {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'some name',
+    });
     tracker.addWindow('one', oneWin);
-    const twoWin = new TestGwtWindow(false, false, false, 'the gwt window');
+    const twoWin = new TestGwtWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'the gwt window',
+    });
     tracker.addWindow('one', twoWin);
     assert.equal(tracker.length(), 1);
     const result = tracker.getWindow('one');
@@ -74,7 +99,12 @@ describe('window-tracker', () => {
   });
   it('delete window removes it from map', async function () {
     const tracker = new WindowTracker();
-    const oneWin = new DesktopBrowserWindow(false, false, false, 'some name');
+    const oneWin = new DesktopBrowserWindow({
+      showToolbar: false,
+      adjustTitle: false,
+      autohideMenu: false,
+      name: 'some name',
+    });
     tracker.addWindow('one', oneWin);
     oneWin.window.close();
     await setTimeoutPromise(200); // TODO: yuck, find a better way to do this


### PR DESCRIPTION
### Intent

The window classes ported straight from C++ include long list of constructor arguments, leading to things like:

```
    const win = new DesktopBrowserWindow(false, false, false, 'some name');
```

### Approach

Use a more TypeScripty object approach so arguments at call sites are more self-documenting, i.e.:

```
    const win = new DesktopBrowserWindow({
      showToolbar: false,
      adjustTitle: false,
      autohideMenu: false,
      name: 'some name',
    });
```

Still kinda ugly and could use more tidying / consolidation / defaults, but I think this is somewhat better.

### Automated Tests

Updated existing tests, no new tests.

### QA Notes

Internal code cleanup, nothing specifically to test.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


