### PR TITLE
fix pref label

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
@@ -5008,4 +5008,12 @@ public interface PrefsConstants extends com.google.gwt.i18n.client.Messages {
     @Key("diagnosticsBackgroundDiagnosticsDelayMsLabel")
     String diagnosticsBackgroundDiagnosticsDelayMsLabel();
     
+    /**
+     * Translated "Show full path to project in window title"
+     *
+     * @return translated "Show full path to project in window title"
+     */
+    @DefaultMessage("Show full path to project in window title")
+    @Key("fullProjectPathInWindowTitleLabel")
+    String fullProjectPathInWindowTitleLabel();
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
@@ -544,3 +544,4 @@ diagnosticsShowDiagnosticsOtherLabel=Show diagnostics for JavaScript, HTML, and 
 diagnosticsOnSaveLabel=Show diagnostics whenever source files are saved
 diagnosticsBackgroundDiagnosticsLabel=Show diagnostics after keyboard is idle for a period of time
 diagnosticsBackgroundDiagnosticsDelayMsLabel=Keyboard idle time (ms):
+fullProjectPathInWindowTitleLabel=Show full path to project in window title

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
@@ -544,3 +544,4 @@ diagnosticsShowDiagnosticsOtherLabel=Afficher les diagnostics dans d''autres lan
 diagnosticsOnSaveLabel=Vérifier les problèmes du code lors de l''enregistrement
 diagnosticsBackgroundDiagnosticsLabel=Exécuter les diagnostics du code R en arrière-plan
 diagnosticsBackgroundDiagnosticsDelayMsLabel=Exécuter les diagnostics du code R après (ms)
+fullProjectPathInWindowTitleLabel=Afficher le chemin complet du projet dans le titre de la fenêtre

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -335,7 +335,7 @@ public class GeneralPreferencesPane extends PreferencesPane
             });
          }
 
-         fullPathInTitle_ = new CheckBox(constants_.clipboardMonitoringLabel());
+         fullPathInTitle_ = new CheckBox(constants_.fullProjectPathInWindowTitleLabel());
          advanced.add(lessSpaced(fullPathInTitle_));
       }
 


### PR DESCRIPTION
### Intent

Addresses #10688

Loc work put the wrong label on the Global Options / General / Advanced "Show full path to project in window title" checkbox.

This will also likely be backported to PT.

### Approach

Use the correct label string.

### Automated Tests

None

### QA Notes

Verify that the label now displays as it did in prior versions.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


