### PR TITLE
detect R in common locations

### DIFF
--- a/src/node/desktop/.prettierrc
+++ b/src/node/desktop/.prettierrc
@@ -1,11 +1,11 @@
 {
+  "bracketSpacing": true,
+  "endOfLine": "auto",
   "printWidth": 120,
+  "quoteProps": "consistent",
   "semi": true,
   "singleQuote": true,
-  "quoteProps": "consistent",
+  "tabWidth": 2,
   "trailingComma": "all",
-  "bracketSpacing": true,
-  "endOfLine": "lf",
-  "useTabs": false,
-  "tabWidth": 2
+  "useTabs": false
 }

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -13,10 +13,10 @@
  *
  */
 
-import path from 'path';
+import path, { join } from 'path';
 
 import { execSync, spawnSync } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync } from 'fs';
 import { EOL } from 'os';
 
 import { Environment, getenv, setenv, setVars } from '../core/environment';
@@ -216,8 +216,8 @@ function scanForRPosix(): Expected<string> {
   return err();
 }
 
-function findRInstallationsWin32() {
-  const rInstallations: string[] = [];
+function findRInstallationsWin32(): string[] {
+  const rInstallations = new Set<string>();
 
   // list all installed versions from registry
   const keyName = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\R-Core';
@@ -225,7 +225,7 @@ function findRInstallationsWin32() {
   const [output, error] = executeCommand(regQueryCommand);
   if (error) {
     logger().logError(error);
-    return rInstallations;
+    return Array.from(rInstallations.values());
   }
 
   // parse the actual path from the output
@@ -235,12 +235,30 @@ function findRInstallationsWin32() {
     if (match != null) {
       const rInstallation = match[1];
       if (isValidInstallationWin32(rInstallation)) {
-        rInstallations.push(rInstallation);
+        rInstallations.add(rInstallation);
       }
     }
   }
 
-  return rInstallations;
+  // look for R installations in some common locations
+  const commonLocations = ['C:/R', `${getenv('ProgramFiles')}/R`, `${getenv('ProgramFiles(x86)')}/R`];
+  for (const location of commonLocations) {
+    // nothing to do if it doesn't exist
+    if (!existsSync(location)) {
+      continue;
+    }
+
+    // read directories and check if they're valid R installations
+    const rDirs = readdirSync(location, { encoding: 'utf-8' });
+    for (const rDir of rDirs) {
+      const path = join(location, rDir);
+      if (isValidInstallationWin32(path)) {
+        rInstallations.add(path);
+      }
+    }
+  }
+
+  return Array.from(rInstallations.values());
 }
 
 function isValidInstallationWin32(installPath: string): boolean {


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio/issues/8815.

Also includes changes to prettierrc; the main change being `"endOfLine": "auto"` to avoid EOL warnings on Windows.
### Approach

Include `C:\R`, `C:\Program Files\R`, and `C:\Program Files (x86)\R` in the set of candidate locations where we look for R installations.

### Automated Tests

N/A

### QA Notes

Check that R installations in the aforementioned locations are visible; e.g.

<img width="412" alt="Screen Shot 2022-02-28 at 11 00 58 AM" src="https://user-images.githubusercontent.com/1976582/156042742-cbc5e5ea-0cb2-419d-97a0-0cbb9996f3b3.png">

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


