### PR TITLE
enable Electron builds for opensuse15 and centos7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -223,8 +223,10 @@ try {
         def containers = [
           [os: 'opensuse',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'OpenSUSE'],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'OpenSUSE 15'],
+          [os: 'opensuse15', arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'OpenSUSE 15'],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'OpenSUSE 15'],
           [os: 'centos7',    arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'CentOS 7'],
+          [os: 'centos7',    arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'CentOS 7'],
           [os: 'centos7',    arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'CentOS 7'],
           [os: 'bionic',     arch: 'amd64',  flavor: 'server',   variant: '',  package_os: 'Ubuntu Bionic'],
           [os: 'bionic',     arch: 'amd64',  flavor: 'desktop',  variant: '',  package_os: 'Ubuntu Bionic'],

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -41,6 +41,7 @@ RUN yum install -y \
     pango-devel \
     patchelf \
     postgresql-devel \
+    python3 \
     R \
     rpmdevtools \
     rpm-sign \

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -38,6 +38,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     postgresql-devel \
     python \
     python-xml \
+    python3 \
     R \
     rpm-build \
     sqlite-devel \


### PR DESCRIPTION
### Intent

Build Electron desktop for Centos7 and OpenSuse15.

Addresses #10378

### Approach

Add to Jenkinsfile, add python3 dependencies needed for building native node modules.

### Automated Tests

The builds are the test.

### QA Notes

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


