### PR TITLE
resolve aliased paths in file dialog APIs

### DIFF
--- a/src/node/desktop/envvars.sh
+++ b/src/node/desktop/envvars.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 
 # Run this script to add node to the PATH.
-NODE_PATH=$(realpath ../../../dependencies/common/node/16.14.0/bin)
+if [ "$(uname -ms)" = "Darwin arm64" ]; then
+	NODE_PATH=$(realpath ../../../dependencies/common/node/16.14.0-arm64/bin)
+else
+	NODE_PATH=$(realpath ../../../dependencies/common/node/16.14.0/bin)
+fi
+
 PATH="${NODE_PATH}:${PATH}"
+export PATH
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -23,7 +23,6 @@ import { FilePath } from '../core/file-path';
 import { logger } from '../core/logger';
 import { isCentOS } from '../core/system';
 import { resolveTemplateVar } from '../core/template-filter';
-import { userHomePath } from '../core/user';
 import { appState } from './app-state';
 import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
@@ -74,9 +73,10 @@ export class GwtCallback extends EventEmitter {
         canChooseDirectories: boolean,
         focusOwner: boolean,
       ) => {
+
         const openDialogOptions: OpenDialogOptions = {
           title: caption,
-          defaultPath: dir,
+          defaultPath: resolveAliasedPath(dir),
           buttonLabel: label,
         };
 
@@ -116,11 +116,10 @@ export class GwtCallback extends EventEmitter {
         forceDefaultExtension: boolean,
         focusOwner: boolean,
       ) => {
-        const resolvedDir = FilePath.resolveAliasedPathSync(dir, userHomePath()).toString();
 
         const saveDialogOptions: SaveDialogOptions = {
           title: caption,
-          defaultPath: resolvedDir,
+          defaultPath: resolveAliasedPath(dir),
           buttonLabel: label,
         };
 
@@ -143,9 +142,10 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_get_existing_directory',
       async (event, caption: string, label: string, dir: string, focusOwner: boolean) => {
+
         const openDialogOptions: OpenDialogOptions = {
           title: caption,
-          defaultPath: dir,
+          defaultPath: resolveAliasedPath(dir),
           buttonLabel: label,
           properties: ['openDirectory', 'createDirectory', 'promptToCreate'],
         };
@@ -154,6 +154,7 @@ export class GwtCallback extends EventEmitter {
         if (focusOwner) {
           focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;
         }
+
         if (focusedWindow) {
           return dialog.showOpenDialog(focusedWindow, openDialogOptions);
         } else {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10684.

### Approach

Make use of `resolveAliasedPath()` in more places where it's required.

### Automated Tests

Not included, but theoretically could.

### QA Notes

Test that, when opening file dialogs on desktop which default to a path in the home directory, that the directory is actually used as the default path when the dialog is opened.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
