### PR TITLE
fix project-related strings that were overlocalized

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -1237,7 +1237,8 @@ public class Projects implements OpenProjectFileEvent.Handler,
    private final ProjectOpener opener_;
    private final SessionOpener sessionOpener_;
 
-   public static final String NONE = constants_.noneLabel();
-   public static final Pattern PACKAGE_NAME_PATTERN =
-         Pattern.create("^[a-zA-Z][a-zA-Z0-9.]*$", "");
+   // This string cannot be localized, currently, because it is hardcoded as "none" in the C++ code
+   // #define kProjectNone           "none"
+   public static final String NONE = "none"; // constants_.noneLabel();
+   public static final Pattern PACKAGE_NAME_PATTERN = Pattern.create("^[a-zA-Z][a-zA-Z0-9.]*$", "");
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -173,11 +173,18 @@ public class RProjectConfig extends JavaScriptObject
       this.root_document = rootDocument;
    }-*/;
    
-   public static final String BUILD_TYPE_NONE = constants_.noneProjectLabel();
-   public static final String BUILD_TYPE_PACKAGE = constants_.buildTypePackageLabel();
+   // The following cannot be localized, currently, because they are hardcoded in the C++ code.
+   //   const char * const kBuildTypeNone = "None";
+   //   const char * const kBuildTypePackage = "Package";
+   //   const char * const kBuildTypeMakefile = "Makefile";
+   //   const char * const kBuildTypeWebsite = "Website";
+   //   const char * const kBuildTypeCustom = "Custom";
+   //   const char * const kBuildTypeQuarto = "Quarto";
+   public static final String BUILD_TYPE_NONE = "None"; // constants_.noneProjectLabel();
+   public static final String BUILD_TYPE_PACKAGE = "Package"; // constants_.buildTypePackageLabel();
    public static final String BUILD_TYPE_MAKEFILE = "Makefile";
-   public static final String BUILD_TYPE_WEBSITE = constants_.buildTypeWebsiteLabel();
-   public static final String BUILD_TYPE_CUSTOM = constants_.buildTypeCustomLabel();
+   public static final String BUILD_TYPE_WEBSITE = "Website"; // constants_.buildTypeWebsiteLabel();
+   public static final String BUILD_TYPE_CUSTOM = "Custom"; // constants_.buildTypeCustomLabel();
    
    public native final String getBuildType() /*-{
       return this.build_type;


### PR DESCRIPTION
### Intent

Addresses: #10704

Case where strings were localized in the UI code (GWT) but the C++ code has them hardcoded and requires that they match.

### Approach

Put back hardcoded strings.

Problem here is we have UI strings that should be localizable but are used internally as enum constants, existing in both the C++ and GWT code. This is objectively horrible, but not going to try and unravel that now.

### Automated Tests

None

### QA Notes

Test scenario described in the issue. You'll need to be running UI in French.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


