### PR TITLE
Add support for relative line numbers in the editor.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Added support for hyperlinks in the console and build pane (#1941)
 - "Clean and Rebuild" and "Install and Restart" have been merged into "Install Package", the "Project Options > Build" gains a "clean before install" option to toggle the --preclean flag. The Build toolbar changes to "Install | Test | Check | More v" (#4289)
 - The source button uses `cpp11::source_cpp()` on C++ files that have `[[cpp11::register]]` decorations (#10387)
+- New *Relative Line Numbers* preference for showing line numbers relative to the current line, rather than the first line (#1774)
 
 #### Find in Files
 - Fixed Find in Files whole-word replace option, so that when "Whole word" is checked, only file matches containing the whole word are replaced, as displayed in the preview (#9813)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -70,6 +70,7 @@ namespace prefs {
 #define kCustomShellCommand "custom_shell_command"
 #define kCustomShellOptions "custom_shell_options"
 #define kShowLineNumbers "show_line_numbers"
+#define kRelativeLineNumbers "relative_line_numbers"
 #define kHighlightSelectedWord "highlight_selected_word"
 #define kHighlightSelectedLine "highlight_selected_line"
 #define kPanes "panes"
@@ -508,6 +509,12 @@ public:
     */
    bool showLineNumbers();
    core::Error setShowLineNumbers(bool val);
+
+   /**
+    * Show relative, rather than absolute, line numbers in RStudio's code editor.
+    */
+   bool relativeLineNumbers();
+   core::Error setRelativeLineNumbers(bool val);
 
    /**
     * Highlight the selected word in RStudio's code editor.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -245,6 +245,19 @@ core::Error UserPrefValues::setShowLineNumbers(bool val)
 }
 
 /**
+ * Show relative, rather than absolute, line numbers in RStudio's code editor.
+ */
+bool UserPrefValues::relativeLineNumbers()
+{
+   return readPref<bool>("relative_line_numbers");
+}
+
+core::Error UserPrefValues::setRelativeLineNumbers(bool val)
+{
+   return writePref("relative_line_numbers", val);
+}
+
+/**
  * Highlight the selected word in RStudio's code editor.
  */
 bool UserPrefValues::highlightSelectedWord()
@@ -3059,6 +3072,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCustomShellCommand,
       kCustomShellOptions,
       kShowLineNumbers,
+      kRelativeLineNumbers,
       kHighlightSelectedWord,
       kHighlightSelectedLine,
       kPanes,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -136,6 +136,12 @@
             "title": "Show line numbers in editor",
             "description": "Show line numbers in RStudio's code editor."
         },
+        "relative_line_numbers": {
+            "type": "boolean",
+            "default": false,
+            "title": "Use relative line numbers in editor",
+            "description": "Show relative, rather than absolute, line numbers in RStudio's code editor."
+        },
         "highlight_selected_word": {
             "type": "boolean",
             "default": true,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants.java
@@ -4646,7 +4646,16 @@ public interface PrefsConstants extends com.google.gwt.i18n.client.Messages {
     @DefaultMessage("Show line numbers")
     @Key("displayShowLineNumbersLabel")
     String displayShowLineNumbersLabel();
-    
+
+    /**
+     * Translated "Relative line numbers"
+     *
+     * @return translated "Relative line numbers"
+     */
+    @DefaultMessage("Relative line numbers")
+    @Key("displayRelativeLineNumbersLabel")
+    String displayRelativeLineNumbersLabel();
+
     /**
      * Translated "Show margin"
      *

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_en.properties
@@ -504,6 +504,7 @@ editingExecutionBehaviorLabel=Ctrl+Enter executes:
 displayHighlightSelectedWordLabel=Highlight selected word
 displayHighlightSelectedLineLabel=Highlight selected line
 displayShowLineNumbersLabel=Show line numbers
+displayRelativeLineNumbersLabel=Relative line numbers
 displayShowMarginLabel=Show margin
 displayShowInvisiblesLabel=Show whitespace characters
 displayShowIndentGuidesLabel=Show indent guides

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
@@ -504,6 +504,7 @@ editingExecutionBehaviorLabel=Unité d''exécution du code R
 displayHighlightSelectedWordLabel=Surligner le mot sélectionné dans l''éditeur
 displayHighlightSelectedLineLabel=Surligner la ligne sélectionnée dans l''éditeur
 displayShowLineNumbersLabel=Afficher les numéros de ligne dans l''éditeur
+displayRelativeLineNumbersLabel=Afficher les numéros de ligne relatifs dans l''éditeur
 displayShowMarginLabel=Afficher la marge dans l''éditeur
 displayShowInvisiblesLabel=Afficher les caractères invisibles dans l''éditeur
 displayShowIndentGuidesLabel=Afficher les caractères invisibles dans l''éditeur

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -333,6 +333,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Show relative, rather than absolute, line numbers in RStudio's code editor.
+    */
+   public PrefValue<Boolean> relativeLineNumbers()
+   {
+      return bool(
+         "relative_line_numbers",
+         _constants.relativeLineNumbersTitle(), 
+         _constants.relativeLineNumbersDescription(), 
+         false);
+   }
+
+   /**
     * Highlight the selected word in RStudio's code editor.
     */
    public PrefValue<Boolean> highlightSelectedWord()
@@ -3354,6 +3366,8 @@ public class UserPrefsAccessor extends Prefs
          customShellOptions().setValue(layer, source.getString("custom_shell_options"));
       if (source.hasKey("show_line_numbers"))
          showLineNumbers().setValue(layer, source.getBool("show_line_numbers"));
+      if (source.hasKey("relative_line_numbers"))
+         relativeLineNumbers().setValue(layer, source.getBool("relative_line_numbers"));
       if (source.hasKey("highlight_selected_word"))
          highlightSelectedWord().setValue(layer, source.getBool("highlight_selected_word"));
       if (source.hasKey("highlight_selected_line"))
@@ -3805,6 +3819,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(customShellCommand());
       prefs.add(customShellOptions());
       prefs.add(showLineNumbers());
+      prefs.add(relativeLineNumbers());
       prefs.add(highlightSelectedWord());
       prefs.add(highlightSelectedLine());
       prefs.add(panes());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -159,6 +159,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String showLineNumbersDescription();
 
    /**
+    * Show relative, rather than absolute, line numbers in RStudio's code editor.
+    */
+   @DefaultStringValue("Use relative line numbers in editor")
+   String relativeLineNumbersTitle();
+   @DefaultStringValue("Show relative, rather than absolute, line numbers in RStudio's code editor.")
+   String relativeLineNumbersDescription();
+
+   /**
     * Highlight the selected word in RStudio's code editor.
     */
    @DefaultStringValue("Highlight selected word in editor")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -84,6 +84,10 @@ customShellOptionsDescription = The command-line options to pass to the custom s
 showLineNumbersTitle = Show line numbers in editor
 showLineNumbersDescription = Show line numbers in RStudio's code editor.
 
+# Show relative, rather than absolute, line numbers in RStudio's code editor.
+relativeLineNumbersTitle = Use relative line numbers in editor
+relativeLineNumbersDescription = Show relative, rather than absolute, line numbers in RStudio's code editor.
+
 # Highlight the selected word in RStudio's code editor.
 highlightSelectedWordTitle = Highlight selected word in editor
 highlightSelectedWordDescription = Highlight the selected word in RStudio's code editor.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -167,6 +167,7 @@ public class EditingPreferencesPane extends PreferencesPane
       displayPanel.add(checkboxPref(constants_.displayHighlightSelectedWordLabel(), prefs_.highlightSelectedWord()));
       displayPanel.add(checkboxPref(constants_.displayHighlightSelectedLineLabel(), prefs_.highlightSelectedLine()));
       displayPanel.add(checkboxPref(constants_.displayShowLineNumbersLabel(), prefs_.showLineNumbers()));
+      displayPanel.add(checkboxPref(constants_.displayRelativeLineNumbersLabel(), prefs_.relativeLineNumbers()));
       displayPanel.add(tight(showMargin_ = checkboxPref(constants_.displayShowMarginLabel(), prefs_.showMargin(), false /*defaultSpace*/)));
       displayPanel.add(indent(marginCol_ = numericPref(prefs_.marginColumn())));
       displayPanel.add(checkboxPref(constants_.displayShowInvisiblesLabel(), prefs_.showInvisibles()));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2425,6 +2425,11 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().getRenderer().setShowGutter(on);
    }
 
+   public void setRelativeLineNumbers(boolean relative)
+   {
+      widget_.getEditor().setRelativeLineNumbers(relative);
+   }
+
    public boolean getUseSoftTabs()
    {
       return getSession().getUseSoftTabs();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -186,6 +186,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setHighlightSelectedLine(boolean on);
    void setHighlightSelectedWord(boolean on);
    void setShowLineNumbers(boolean on);
+   void setRelativeLineNumbers(boolean relative);
    void setUseSoftTabs(boolean on);
    void setUseWrapMode(boolean on);
    boolean getUseWrapMode();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
@@ -180,6 +180,11 @@ public class TextEditingTargetPrefsHelper
             {
                docDisplay.setDragEnabled(arg);
             }));
+      releaseOnDismiss.add(prefs.relativeLineNumbers().bind(
+            (arg) ->
+            {
+               docDisplay.setRelativeLineNumbers(arg);
+            }));
 
       // Full editors get additional prefs (we don't use these in embedded editors)
       if (prefsSet == PrefsSet.Full)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -75,6 +75,10 @@ public class AceEditorNative extends JavaScriptObject
    public native final void setHighlightActiveLine(boolean highlight) /*-{
       this.setHighlightActiveLine(highlight);
    }-*/;
+
+   public native final void setRelativeLineNumbers(boolean relative) /*-{
+      this.setOption("relativeLineNumbers", relative);
+   }-*/;
    
    public native final void setHighlightGutterLine(boolean highlight) /*-{
       this.setHighlightGutterLine(highlight);


### PR DESCRIPTION
### Intent

Adds a new preference that causes the editor to show line numbers in the gutter relative to the cursor position, instead of relative to the top of the document. This is a model preferred by many people who use Vim mode since it makes it easier to specify jump targets and ranges. 

When the preference is enabled, the absolute line number is shown at the cursor, but all other line numbers are shown as an offset from the current line. 

<img width="753" alt="image" src="https://user-images.githubusercontent.com/470418/156229042-6784bdc9-a233-4e98-a11d-d76edc85661c.png">

Addresses https://github.com/rstudio/rstudio/issues/1774. 

### Approach

This feature is already implemented in Ace; we're just exposing it. See https://github.com/ajaxorg/ace/issues/3461. 

The new preference can be set via the Command Palette and also gets a new entry next to "line numbers" in the preference UI. 

### Automated Tests

N/A, this change affects gutter rendering only.

### QA Notes

Note that this is a global setting, not per editor. Also note that the implementation of the offset calculations and rendering happens in Ace, not RStudio; if the behavior looks buggy, compare with the effect of the Relative Line Numbers setting in Ace's Kitchen Sink demo:

https://ace.c9.io/build/kitchen-sink.html

Also note that this setting can be toggled in real time, so if you switch it on/off via the Palette, you should see the editor react immediately.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

