### PR TITLE
wire up launching of separate RStudio instances

### DIFF
--- a/src/node/desktop/src/core/r-user-data.ts
+++ b/src/node/desktop/src/core/r-user-data.ts
@@ -13,8 +13,6 @@
  *
  */
 
-import { Err } from './err';
-
 export const kRStudioInitialWorkingDir = 'RS_INITIAL_WD';
 export const kRStudioInitialEnvironment = 'RS_INITIAL_ENV';
 export const kRStudioInitialProject = 'RS_INITIAL_PROJECT';

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -418,8 +418,9 @@ export class GwtCallback extends EventEmitter {
 
     ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
       if (!this.isRemoteDesktop) {
-        const args = [resolveAliasedPath(projectFilePath)];
-        this.mainWindow.launchRStudio(args);
+        this.mainWindow.launchRStudio({
+          projectFilePath: resolveAliasedPath(projectFilePath)
+        });
       } else {
         // start new Remote Desktop RStudio process with the session URL
         this.mainWindow.launchRemoteRStudioProject(projectFilePath);
@@ -428,8 +429,9 @@ export class GwtCallback extends EventEmitter {
 
     ipcMain.on('desktop_open_session_in_new_window', (event, workingDirectoryPath) => {
       if (!this.isRemoteDesktop) {
-        workingDirectoryPath = resolveAliasedPath(workingDirectoryPath);
-        this.mainWindow.launchRStudio([], workingDirectoryPath);
+        this.mainWindow.launchRStudio({
+          workingDirectory: resolveAliasedPath(workingDirectoryPath),
+        });
       } else {
         // start the new session on the currently connected server
         this.mainWindow.launchRemoteRStudio();

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -23,7 +23,7 @@ import { GwtCallback, PendingQuit } from './gwt-callback';
 import { MenuCallback, showPlaceholderMenu } from './menu-callback';
 import { RCommandEvaluator } from './r-command-evaluator';
 import { SessionLauncher } from './session-launcher';
-import { ApplicationLaunch } from './application-launch';
+import { ApplicationLaunch, LaunchRStudioOptions } from './application-launch';
 import { GwtWindow } from './gwt-window';
 import { appState } from './app-state';
 import { DesktopOptions } from './desktop-options';
@@ -191,8 +191,8 @@ export class MainWindow extends GwtWindow {
     }
   }
 
-  launchRStudio(args: string[] = [], initialDir = ''): void {
-    this.appLauncher?.launchRStudio(args, initialDir);
+  launchRStudio(options: LaunchRStudioOptions): void {
+    this.appLauncher?.launchRStudio(options);
   }
 
   saveRemoteAuthCookies(): void {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10687.

### Approach

Wire up existing skeleton for `launchRStudio`, making use of existing session facilities for selecting a project file / working directory on launch.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10687.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
