### PR TITLE
update Search label on preview replace event

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -238,6 +238,11 @@ public class FindOutputPresenter extends BasePresenter
                                       {
                                          view_.clearMatches();
                                          currentFindHandle_ = handle;
+                                         updateSearchLabel(dialogState_.getQuery(),
+                                            dialogState_.getPath(),
+                                            dialogState_.isWholeWord(),
+                                            dialogState_.isRegex(),
+                                            view_.getReplaceText());
                                          if (dialogState_ != null)
                                             dialogState_.clearResultsCount();
                                       }


### PR DESCRIPTION
### Intent

Addresses #10626.

### Approach

When the previewReplace event fires (only when isRegex is True), the searchLabel is cleared (with stopAndClear) but not repopulated, as is done when the completeReplace event fires. Adding that bit when the RPC response is received appears to fix the clearing out of the search label in regex preview results

### Automated Tests

NA, just ran RStudio Desktop locally.

### QA Notes

See example in the #10626. Run Find in Files, with "Regular expression" checked, and in the preview results, enter a replacement. The search label at the top of the Find in Files pane should update from `Replace results for /hello/` to `Replace results for /hello/ with /bye/` rather than clearing out.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


