### PR TITLE
fix path lookup for pandoc etc. in electron builds

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -214,7 +214,7 @@ private:
    RToken matchOperator();
    bool eol();
    wchar_t peek();
-   wchar_t peek(std::size_t lookahead);
+   wchar_t peek(int lookahead);
    wchar_t eat();
    std::size_t tokenLength(const boost::wregex& regex);
    void eatUntil(const boost::wregex& regex);

--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -554,7 +554,7 @@ wchar_t RTokenizer::peek()
    return peek(0);
 }
 
-wchar_t RTokenizer::peek(std::size_t lookahead)
+wchar_t RTokenizer::peek(int lookahead)
 {
    // NOTE: MSVC is extra picky in debug mode, so when we compare
    // iterators here we need to make sure we don't construct an iterator

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -20,16 +20,16 @@
 #include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
 
+#include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
-#include <core/ProgramStatus.hpp>
 #include <shared_core/SafeConvert.hpp>
+
+#include <core/Log.hpp>
+#include <core/ProgramStatus.hpp>
 #include <core/system/Crypto.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/Xdg.hpp>
-
-#include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 
 #include <core/r_util/RProjectFile.hpp>
 #include <core/r_util/RUserData.hpp>
@@ -496,6 +496,25 @@ void Options::resolvePath(const FilePath& resourcePath,
 
 #ifdef __APPLE__
 
+namespace {
+
+FilePath macBinaryPath(const FilePath& resourcePath,
+                       const std::string& stem)
+{
+   // first check for Electron binary path
+   FilePath electronPath =
+         resourcePath.completePath("bin").completePath(stem);
+   
+   if (electronPath.exists())
+      return electronPath;
+   
+   // otherwise, look in default Qt location
+   FilePath qtPath = resourcePath.getParent().completePath("MacOS").completePath(stem);
+   return qtPath;
+}
+
+} // end anonymous namespace
+
 void Options::resolvePostbackPath(const FilePath& resourcePath,
                                   std::string* pPath)
 {
@@ -504,7 +523,7 @@ void Options::resolvePostbackPath(const FilePath& resourcePath,
    // when the default postback path has been passed
    if (*pPath == kDefaultPostbackPath && programMode() == kSessionProgramModeDesktop)
    {
-      FilePath path = resourcePath.getParent().completePath("MacOS/postback/rpostback");
+      FilePath path = macBinaryPath(resourcePath, "rpostback");
       *pPath = path.getAbsolutePath();
    }
    else
@@ -518,7 +537,7 @@ void Options::resolvePandocPath(const FilePath& resourcePath,
 {
    if (*pPath == kDefaultPandocPath && programMode() == kSessionProgramModeDesktop)
    {
-      FilePath path = resourcePath.getParent().completePath("MacOS/quarto/bin");
+      FilePath path = macBinaryPath(resourcePath, "quarto/bin");
       *pPath = path.getAbsolutePath();
    }
    else
@@ -532,7 +551,7 @@ void Options::resolveQuartoPath(const FilePath& resourcePath,
 {
    if (*pPath == kDefaultQuartoPath && programMode() == kSessionProgramModeDesktop)
    {
-      FilePath path = resourcePath.getParent().completePath("MacOS/quarto");
+      FilePath path = macBinaryPath(resourcePath, "quarto");
       *pPath = path.getAbsolutePath();
    }
    else
@@ -546,7 +565,7 @@ void Options::resolveRsclangPath(const FilePath& resourcePath,
 {
    if (*pPath == kDefaultRsclangPath && programMode() == kSessionProgramModeDesktop)
    {
-      FilePath path = resourcePath.getParent().completePath("MacOS/rsclang");
+      FilePath path = macBinaryPath(resourcePath, "rsclang");
       *pPath = path.getAbsolutePath();
    }
    else

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1059,6 +1059,7 @@ void initEnvironment()
    std::string rstudioPandoc = core::system::getenv(kRStudioPandoc);
    if (rstudioPandoc.empty())
       rstudioPandoc = session::options().pandocPath().getAbsolutePath();
+   
    r::exec::RFunction sysSetenv("Sys.setenv");
    sysSetenv.addParam(kRStudioPandoc, rstudioPandoc);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10674.

### Approach

Tweaks to ensure pandoc and friends are solved to the right locations on Electron.

### Automated Tests

Not included; other unit tests would already cover this.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10674.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
