### PR TITLE
Add warnings for missing cookie

### DIFF
--- a/src/cpp/server/auth/ServerAuthHandler.cpp
+++ b/src/cpp/server/auth/ServerAuthHandler.cpp
@@ -380,8 +380,21 @@ std::string getUserIdentifier(const core::http::Request& request,
 
    if (requireUserListCookie)
    {
-      if (!overlay::isUserListCookieValid(request.cookieValue(kUserListCookie)))
+      std::string userListCookie = request.cookieValue(kUserListCookie);
+      if (!overlay::isUserListCookieValid(userListCookie))
+      {
+         if (userListCookie.empty())
+         {
+            LOG_WARNING_MESSAGE("Request contains a user-identifier but is missing the "
+                                "user-list-id cookie required for named user licensing.");
+         }
+         else
+         {
+            LOG_WARNING_MESSAGE("Request contains a user-indentifier with an invalid user-list-id "
+                                "cookie");
+         }
          return std::string();
+      }
    }
 
    return userIdentifier;


### PR DESCRIPTION
### Intent

Add some warning messages that would've been helpful in debugging a customer support issue. 

### Approach

Log a warning when the server receives a message with a `user-id` cookie but an empty or invalid `user-list-id` cookie - when the server is using a named user license. Even though this code is in open source, it only will ever be reached by RSW users.

### Automated Tests

N/A

### QA Notes
N/A

### Checklist

- [] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


