### PR TITLE
Use eval.expr explicitly for YAML to prevent warnings and future deprecation

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2276,7 +2276,7 @@
          front <- NULL
 
          tryCatch({
-            front <- yaml::read_yaml(text = front_matter)
+            front <- yaml::read_yaml(text = front_matter, eval.expr = TRUE)
          }, error = function(e) {
             # ignore errors when reading YAML; it's very possible that the document's YAML will not
             # be correct at all times (e.g. during editing) 

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -250,7 +250,7 @@
 })
 
 .rs.addFunction("getTemplateDetails", function(templateYaml) {
-   yaml::yaml.load_file(templateYaml)
+   yaml::yaml.load_file(templateYaml, eval.expr = TRUE)
 })
 
 # given a path to a folder on disk, return information about the R Markdown


### PR DESCRIPTION
### Intent

Addresses #7545 

### Approach

Add the `eval.expr = TRUE`, especially in parsing the yaml front-matter

### QA Notes

See #7545 reprex

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


