### PR TITLE
handle chrome://gpu specially

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -40,7 +40,7 @@ module.exports = {
     '@typescript-eslint/no-confusing-non-null-assertion': ['error'],
     '@typescript-eslint/no-floating-promises': ['warn'],
     '@typescript-eslint/no-invalid-void-type': ['error'],
-    '@typescript-eslint/no-misused-promises': ['error'],
+    '@typescript-eslint/no-misused-promises': ['error', { 'checksVoidReturn': false }],
     '@typescript-eslint/no-throw-literal': ['error'],
     '@typescript-eslint/no-unnecessary-condition': ['error'],
     '@typescript-eslint/promise-function-async': ['warn'],

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -293,11 +293,20 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on(
       'desktop_open_minimal_window',
       (event: IpcMainEvent, name: string, url: string, width: number, height: number) => {
+
+        // handle chrome://gpu specially
+        if (url === 'chrome://gpu') {
+          const window = new BrowserWindow();
+          return window.loadURL('chrome://gpu');
+        }
+
+        // regular path for other windows
         const sender = this.getSender('desktop_open_minimal_window', event.processId, event.frameId);
         const minimalWindow = openMinimalWindow(sender, name, url, width, height);
         minimalWindow.window.once('ready-to-show', () => {
           minimalWindow.window.show();
         });
+
       },
     );
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10425. The approach is lazy, but it works? I'm not sure if it's worth delving in further to figure out why Electron crashes when we try to open `chrome://gpu` through our existing pipeline.

### Approach

Use a plain old BrowserWindow when opening `chrome://gpu`.

### Automated Tests

Already tested by existing integration tests.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
