### PR TITLE
check that a potential cpp related project has a `src/` before scanning it

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -343,12 +343,15 @@ std::string packagePCH(const std::string& linkingTo)
 
 bool packageIsCpp(const std::string& linkingTo, const FilePath& srcDir)
 {
-   if (boost::algorithm::contains(linkingTo, "Rcpp"))
+   if (boost::algorithm::contains(linkingTo, "Rcpp") || boost::algorithm::contains(linkingTo, "cpp11"))
    {
       return true;
    }
    else
    {
+      if (!srcDir.exists())
+         return false;
+      
       std::vector<FilePath> allSrcFiles;
       Error error = srcDir.getChildren(allSrcFiles);
       if (error)


### PR DESCRIPTION
Was getting these errors when opening e.g. `cpp11` because it has no `src/`: 

````
2022-03-02T14:02:40.158499Z [rsession-romainfrancois] ERROR system error 2 (No such file or directory) [path: /Users/romainfrancois/git/cpp11/src]; OCCURRED AT rstudio::core::Error rstudio::core::FilePath::getChildren(std::vector<FilePath> &) const src/cpp/shared_core/FilePath.cpp:927; LOGGED FROM: bool rstudio::session::modules::clang::(anonymous namespace)::packageIsCpp(const std::string &, const rstudio::core::FilePath &) src/cpp/session/modules/clang/RCompilationDatabase.cpp:356
````