### PR TITLE
Update initial editor preview with selected font

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
@@ -34,7 +34,7 @@ public class ThemeFonts
 
    public static String getFixedWidthFont()
    {
-      return fontLoader.getFixedWidthFont() + ", monospace";
+      return fontLoader.getFixedWidthFont();
    }
 
    static interface ThemeFontLoader

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -171,10 +171,11 @@ public class AceEditorPreview extends DynamicIFrame
          webFont_ = font;
       }
 
+      String quotedFont = font.startsWith("\"") && font.endsWith("\"") ? font : "\"" + font + "\"";
       StyleElement style = document.createStyleElement();
       style.setAttribute("type", "text/css");
       style.setInnerText(".ace_editor, .ace_text-layer {\n" +
-                         "font-family: \"" + font + "\" !important;\n" +
+                         "font-family: " + quotedFont + ", monospace !important;\n" +
                          "}");
 
       document.getBody().appendChild(style);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -466,7 +466,7 @@ export class GwtCallback extends EventEmitter {
 
       let defaultFonts: string[];
       if (process.platform === 'darwin') {
-        defaultFonts = ['Monaco'];
+        defaultFonts = ['Menlo', 'Monaco'];
       } else if (process.platform === 'win32') {
         defaultFonts = ['Lucida Console', 'Consolas'];
       } else {


### PR DESCRIPTION
### Intent
Address #10463 

The editor preview wouldn't use the selected font when the appearance pane is first viewed. Switching to another font and back would show the correct font. I'm not sure when this broke but it's also an issue in Prairie Trillium.

Also, sets the MacOS default font to Menlo then Monaco if unavailable.

### Approach
When retrieving the selected font, it comes back in quotes. This has `!important` and `monospace` appended before setting the style element. The problem was adding another set of quotes (`""Menlo", monospace" !important`) that resulted in an invalid font name. This will properly set the font attribute to `"Menlo", monospace !important`.

### Automated Tests
None

### QA Notes
This fixes RStudio web, Qt, and Electron. Although, this was probably unnoticed since the invalid attribute meant falling back to Ace's default monospace list. It just happens to use the same font as what we would have wanted (on most OS'es). I only noticed this now because changing the default to Menlo showed Monaco (Ace's default monospace).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


