### PR TITLE
Fix monospace font list on Electron Windows

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -19,7 +19,7 @@ import { app, BrowserWindow, dialog, ipcMain, screen, shell, webContents, webFra
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
 import i18next from 'i18next';
-import { findFontsSync, IQueryFontDescriptor } from 'node-system-fonts';
+import { getAvailableFontsSync, IQueryFontDescriptor } from 'node-system-fonts';
 import { FilePath } from '../core/file-path';
 import { logger } from '../core/logger';
 import { isCentOS } from '../core/system';
@@ -58,7 +58,7 @@ export class GwtCallback extends EventEmitter {
     this.owners.add(mainWindow);
 
     const fontDescriptors = [
-      ...new Map<string, IQueryFontDescriptor>(findFontsSync({}).map((fd) => [fd.family, fd])).values(),
+      ...new Map<string, IQueryFontDescriptor>(getAvailableFontsSync().map((fd) => [fd.family, fd])).values(),
     ].sort((a, b) => a.family?.localeCompare(b.family ?? '') ?? 0);
     const monospaceFonts = fontDescriptors.filter((fd) => fd.monospace).map((font) => font.family);
     const proportionalFonts = fontDescriptors.filter((fd) => !fd.monospace).map((font) => font.family);
@@ -79,7 +79,6 @@ export class GwtCallback extends EventEmitter {
         canChooseDirectories: boolean,
         focusOwner: boolean,
       ) => {
-
         const openDialogOptions: OpenDialogOptions = {
           title: caption,
           defaultPath: resolveAliasedPath(dir),
@@ -121,7 +120,6 @@ export class GwtCallback extends EventEmitter {
         forceDefaultExtension: boolean,
         focusOwner: boolean,
       ) => {
-
         const saveDialogOptions: SaveDialogOptions = {
           title: caption,
           defaultPath: resolveAliasedPath(dir),
@@ -147,7 +145,6 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_get_existing_directory',
       async (event, caption: string, label: string, dir: string, focusOwner: boolean) => {
-
         const openDialogOptions: OpenDialogOptions = {
           title: caption,
           defaultPath: resolveAliasedPath(dir),
@@ -298,7 +295,6 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on(
       'desktop_open_minimal_window',
       (event: IpcMainEvent, name: string, url: string, width: number, height: number) => {
-
         // handle chrome://gpu specially
         if (url === 'chrome://gpu') {
           const window = new BrowserWindow();
@@ -311,7 +307,6 @@ export class GwtCallback extends EventEmitter {
         minimalWindow.window.once('ready-to-show', () => {
           minimalWindow.window.show();
         });
-
       },
     );
 
@@ -434,7 +429,7 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on('desktop_open_project_in_new_window', (event, projectFilePath) => {
       if (!this.isRemoteDesktop) {
         this.mainWindow.launchRStudio({
-          projectFilePath: resolveAliasedPath(projectFilePath)
+          projectFilePath: resolveAliasedPath(projectFilePath),
         });
       } else {
         // start new Remote Desktop RStudio process with the session URL


### PR DESCRIPTION
### Intent
Resolve the monospace font loading issue on Windows

### Approach
I didn't notice the `getAvailableFontsSync()` that doesn't require options. I guess a blank options object doesn't work well. It was only retrieving proportional fonts so the monospace list was blank.

### Automated Tests
None

### QA Notes
Windows should load Lucida Console by default

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


