### PR TITLE
use msvc 2019 toolchain to build Windows Desktop

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -60,7 +60,7 @@ c) There are additional considerations on Windows. First, RStudio Server
    Desktop. Second, you need to add an extra -G parameter to specify the
    correct build toolchain, for example:
 
-   cmake .. -G "Visual Studio 15 2017 Win64" -DCMAKE_BUILD_TYPE=Release
+   cmake .. -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release
 
    To build on Windows:
 

--- a/INSTALL
+++ b/INSTALL
@@ -60,7 +60,7 @@ c) There are additional considerations on Windows. First, RStudio Server
    Desktop. Second, you need to add an extra -G parameter to specify the
    correct build toolchain, for example:
 
-   cmake .. -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release
+   cmake .. -G "Visual Studio 16 2019" -A Win64 -DCMAKE_BUILD_TYPE=Release
 
    To build on Windows:
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -424,9 +424,9 @@ try {
                   def packageName = "RStudio-${packageVersion}-RelWithDebInfo"
 
                   withCredentials([file(credentialsId: 'ide-windows-signing-pfx', variable: 'pfx-file'), string(credentialsId: 'ide-pfx-passphrase', variable: 'pfx-passphrase')]) {
-                    bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17134.0\\x86\\signtool\" sign /f %pfx-file% /p %pfx-passphrase% /v /debug /n \"RStudio PBC\" /t http://timestamp.digicert.com  package\\win32\\build\\${packageName}.exe"
+                    bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" sign /f %pfx-file% /p %pfx-passphrase% /v /debug /n \"RStudio PBC\" /t http://timestamp.digicert.com  package\\win32\\build\\${packageName}.exe"
 
-                    bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.17134.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${packageName}.exe"
+                    bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${packageName}.exe"
                   }
                 }
                 stage('upload') {

--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -71,8 +71,8 @@ choco install -y 7zip
 choco install -y git
 choco install -y ninja
 choco install -y windows-sdk-10.1 --version 10.1.18362.1
-choco install -y visualstudio2017buildtools --version 15.9.41.0
-choco install -y visualstudio2017-workload-vctools --version 1.3.3
+choco install -y visualstudio2019buildtools --version 16.11.10.0
+choco install -y visualstudio2019-workload-vctools --version 1.0.1
 choco install -y nsis
 choco install -y python
 

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -218,7 +218,7 @@ call install-packages.cmd
 
 popd
 
-regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\DIA SDK\bin\msdia140.dll"
+regsvr32 /s "C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\DIA SDK\bin\msdia140.dll"
 
 call install-crashpad.cmd
 call install-soci.cmd

--- a/dependencies/windows/install-openssl/install-openssl.R
+++ b/dependencies/windows/install-openssl/install-openssl.R
@@ -11,11 +11,11 @@ perl <- head(Filter(file.exists, c("C:/Perl64/bin", "C:/Perl/bin")), n = 1)
 if (length(perl) == 0)
    fatal("No perl installation detected (please install ActiveState Perl via 'choco install activeperl')")
 
-# try to find MSVC 2017
-msvc <- head(Filter(file.exists, c("C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build",
-                                   "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build")), n = 1)
+# try to find MSVC 2019
+msvc <- head(Filter(file.exists, c("C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build",
+                                   "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build")), n = 1)
 if (length(msvc) == 0)
-   fatal("No MSVC 2017 installation detected (please install Visual Studio 2017 using 'Install-RStudio-Prereqs.ps1')")
+   fatal("No MSVC 2019 installation detected (please install Visual Studio 2019 using 'Install-RStudio-Prereqs.ps1')")
 
 PATH$prepend("../tools")
 PATH$prepend(msvc)

--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -15,11 +15,11 @@ options(log.dir = normalizePath("logs"))
 # put RStudio tools on PATH
 PATH$prepend("../tools")
 
-# try to find MSVC 2017
-msvc <- head(Filter(file.exists, c("C:/Program Files (x86)/Microsoft Visual Studio/2017/Community/VC/Auxiliary/Build",
-                                   "C:/Program Files (x86)/Microsoft Visual Studio/2017/BuildTools/VC/Auxiliary/Build")), n = 1)
+# try to find MSVC 2019
+msvc <- head(Filter(file.exists, c("C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build",
+                                   "C:/Program Files (x86)/Microsoft Visual Studio/2019/BuildTools/VC/Auxiliary/Build")), n = 1)
 if (length(msvc) == 0)
-   fatal("No MSVC 2017 installation detected (please install Visual Studio 2017 using 'Install-RStudio-Prereqs.ps1')")
+   fatal("No MSVC 2019 installation detected (please install Visual Studio 2019 using 'Install-RStudio-Prereqs.ps1')")
 PATH$prepend(msvc)
 
 # initialize variables
@@ -79,7 +79,7 @@ if (!file.exists(normalizePath(file.path(soci_build_dir, "x64\\lib\\Release\\lib
 
    # run CMAKE for each platform (x86, x64) and each configuration (Debug, Release)
    setwd("x86")
-   cmake_args <- paste0("-G \"Visual Studio 15 2017\" ",
+   cmake_args <- paste0("-G \"Visual Studio 16 2019\" ",
                         "-A Win32 ",
                         "-DCMAKE_VERBOSE_MAKEFILE=ON ",
                         "-DCMAKE_INCLUDE_PATH=\"", file.path(boost_dir, "include"), "\" ",

--- a/dependencies/windows/install-yaml-cpp/install-yaml-cpp.R
+++ b/dependencies/windows/install-yaml-cpp/install-yaml-cpp.R
@@ -31,7 +31,7 @@ dir.create(YAML_CPP_BUILD_32, recursive = TRUE, showWarnings = FALSE)
 setwd(YAML_CPP_BUILD_32)
 
 args <- c(
-   "-G", shQuote("Visual Studio 15 2017"),
+   "-G", shQuote("Visual Studio 16 2019"),
    "-A", "Win32",
    "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebugDLL",
    "-DYAML_CPP_BUILD_TESTS=Off",
@@ -51,7 +51,7 @@ dir.create(YAML_CPP_BUILD_64, recursive = TRUE, showWarnings = FALSE)
 setwd(YAML_CPP_BUILD_64)
 
 args <- c(
-   "-G", shQuote("Visual Studio 15 2017"),
+   "-G", shQuote("Visual Studio 16 2019"),
    "-A", "x64",
    "-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDLL",
    "-DYAML_CPP_BUILD_TESTS=Off",

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -20,7 +20,7 @@ RUN $env:chocolateyUseWindowsCompression = 'true'; `
 RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; `
   choco install -y jdk8; `
   choco install -y -i ant; `
-  choco install -y windows-sdk-10.1 --version 10.1.17134.12; `
+  choco install -y windows-sdk-10.1 --version 10.1.18362.1; `
   choco install -y 7zip; `
   choco install -y ninja --version "1.10.0"; `
   choco install -y python
@@ -32,8 +32,8 @@ RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tl
   Start-Process c:\nsis-3.06.1-setup.exe -Wait -ArgumentList '/S' ;`
   Remove-Item c:\nsis-3.06.1-setup.exe -Force
   
-RUN choco install -y visualstudio2017buildtools --version 15.8.2.0; `
-  choco install -y visualstudio2017-workload-vctools --version 1.3.0
+RUN choco install -y visualstudio2019buildtools --version 16.11.10.0; `
+  choco install -y visualstudio2019-workload-vctools --version 1.0.1
 
 # install aws cli
 RUN choco install -y awscli

--- a/package/win32/codesign.bat
+++ b/package/win32/codesign.bat
@@ -1,6 +1,6 @@
 set SIGN_TARGET=%1%
 
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.17134.0\x86\signtool" sign /sha1 E5D84022D15FD10154AA7A75EC6CA055EE7E52A7 /v /ac "cert\After_10-10-10_MSCV-VSClass3.cer" /s MY /n "RStudio, Inc." /t http://timestamp.VeriSign.com/scripts/timstamp.dll %SIGN_TARGET%
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool" sign /sha1 E5D84022D15FD10154AA7A75EC6CA055EE7E52A7 /v /ac "cert\After_10-10-10_MSCV-VSClass3.cer" /s MY /n "RStudio, Inc." /t http://timestamp.VeriSign.com/scripts/timstamp.dll %SIGN_TARGET%
 
-"C:\Program Files (x86)\Windows Kits\10\bin\10.0.17134.0\x86\signtool" verify /v /kp %SIGN_TARGET%
+"C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x86\signtool" verify /v /kp %SIGN_TARGET%
  

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -22,13 +22,13 @@ cd %WIN32_BUILD_PATH%
 if exist CMakeCache.txt del CMakeCache.txt
 
 REM Build the project
-set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools"
-if not exist %VS_TOOLS% set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools"
-if not exist %VS_TOOLS% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2017 Build tools are installed." && exit /b 1
+set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\Common7\Tools"
+if not exist %VS_TOOLS% set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools"
+if not exist %VS_TOOLS% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2019 Build tools are installed." && exit /b 1
 
 pushd %VS_TOOLS%
 call VsDevCmd.bat -clean_env -no_logo || goto :error
-call VsDevCmd.bat -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.17134.0 -no_logo || goto :error
+call VsDevCmd.bat -arch=x86 -startdir=none -host_arch=x86 -winsdk=10.0.19041.0 -no_logo || goto :error
 popd
 
 cmake -G "Ninja" ^

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -119,13 +119,13 @@ if exist "%PKG_TEMP_DIR%/_CPack_Packages" rmdir /s /q "%PKG_TEMP_DIR%\_CPack_Pac
 
 REM Configure and build the project. (Note that Windows / MSVC builds require
 REM that we specify the build type both at configure time and at build time)
-set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\BuildTools\Common7\Tools"
-if not exist %VS_TOOLS% set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\Common7\Tools"
-if not exist %VS_TOOLS% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2017 Build tools are installed." && exit /b 1
+set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\Common7\Tools"
+if not exist %VS_TOOLS% set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\Common7\Tools"
+if not exist %VS_TOOLS% echo "Could not find VsDevCmd.bat. Please ensure Microsoft Visual Studio 2019 Build tools are installed." && exit /b 1
 
 pushd %VS_TOOLS%
 call VsDevCmd.bat -clean_env -no_logo || goto :error
-call VsDevCmd.bat -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.17134.0 -no_logo || goto :error
+call VsDevCmd.bat -arch=amd64 -startdir=none -host_arch=amd64 -winsdk=10.0.19041.0 -no_logo || goto :error
 popd
 
 cmake -G "Ninja" ^


### PR DESCRIPTION
### Intent

Addresses: #10717

Bumping up our Windows compiler toolchain from VS2017 to VS 2019.

Mainstream support for Visual Studio 2017 ends in April of 2022 so seems like a good time to bump up to something a bit less ancient.

Marking this as draft PR until I've run my own dockerfile-based tests. Past changes to this sort of thing have proven rather finicky in Window's docker environment.

### Approach

Update scripts, etc.

### Automated Tests

The build is the automated test.

### QA Notes

No end-user differences expected, nothing to specifically test other than the application builds, installs, and "works".

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


