### PR TITLE
implement handling for rendering engine prefs

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -620,10 +620,10 @@ public class GeneralPreferencesPane extends PreferencesPane
       });
    }
 
-   private static final String ENGINE_AUTO        = constants_.engineAutoValue();
-   private static final String ENGINE_DESKTOP     = constants_.engineDesktopValue();
+   private static final String ENGINE_AUTO        = "auto";
+   private static final String ENGINE_DESKTOP     = "desktop";
    private static final String ENGINE_GLES        = "gles";
-   private static final String ENGINE_SOFTWARE    = constants_.engineSoftwareValue();
+   private static final String ENGINE_SOFTWARE    = "software";
 
    private boolean desktopMonitoring_ = false;
    private boolean desktopIgnoreGpuExclusions_ = false;

--- a/src/node/desktop/src/main/desktop-options.ts
+++ b/src/node/desktop/src/main/desktop-options.ts
@@ -16,7 +16,7 @@
 
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
-import { logger, logLevel } from '../core/logger';
+import { logger } from '../core/logger';
 
 const kProportionalFont = 'Font.ProportionalFont';
 const kFixWidthFont = 'Font.FixWidthFont';
@@ -30,6 +30,7 @@ const kLastRemoteSessionUrl = 'Session.LastRemoteSessionUrl';
 const kAuthCookies = 'Session.AuthCookies';
 const kTempAuthCookies = 'Session.TempAuthCookies';
 
+const kRenderingEngine = 'General.RenderingEngine';
 const kIgnoredUpdateVersions = 'General.IgnoredUpdateVersions';
 const kClipboardMonitoring = 'General.ClipboardMonitoring';
 
@@ -56,6 +57,7 @@ export const kDesktopOptionDefaults = {
   General: {
     IgnoredUpdateVersions: [],
     ClipboardMonitoring: true,
+    RenderingEngine: 'desktop',
   },
   Platform: {
     Windows: {
@@ -251,6 +253,14 @@ export class DesktopOptionsImpl {
 
   public clipboardMonitoring(): boolean {
     return this.config.get(kClipboardMonitoring);
+  }
+
+  public setRenderingEngine(renderingEngine: string): void {
+    this.config.set(kRenderingEngine, renderingEngine);
+  }
+
+  public renderingEngine(): string {
+    return this.config.get(kRenderingEngine, 'desktop');
   }
 
   // Windows-only option

--- a/src/node/desktop/src/main/desktop-options.ts
+++ b/src/node/desktop/src/main/desktop-options.ts
@@ -30,9 +30,12 @@ const kLastRemoteSessionUrl = 'Session.LastRemoteSessionUrl';
 const kAuthCookies = 'Session.AuthCookies';
 const kTempAuthCookies = 'Session.TempAuthCookies';
 
-const kRenderingEngine = 'General.RenderingEngine';
 const kIgnoredUpdateVersions = 'General.IgnoredUpdateVersions';
 const kClipboardMonitoring = 'General.ClipboardMonitoring';
+
+const kRendererEngine = 'Renderer.Engine';
+const kRendererUseGpuExclusionList = 'Renderer.UseGpuExclusionList';
+const kRendererUseGpuDriverBugWorkarounds = 'Renderer.UseGpuDriverBugWorkarounds';
 
 const kRBinDir = 'Platform.Windows.RBinDir';
 const kPreferR64 = 'Platform.Windows.PreferR64';
@@ -57,7 +60,11 @@ export const kDesktopOptionDefaults = {
   General: {
     IgnoredUpdateVersions: [],
     ClipboardMonitoring: true,
-    RenderingEngine: 'desktop',
+  },
+  Renderer: {
+    Engine: 'auto',
+    UseGpuExclusionList: true,
+    UseGpuDriverBugWorkarounds: true,
   },
   Platform: {
     Windows: {
@@ -256,11 +263,27 @@ export class DesktopOptionsImpl {
   }
 
   public setRenderingEngine(renderingEngine: string): void {
-    this.config.set(kRenderingEngine, renderingEngine);
+    this.config.set(kRendererEngine, renderingEngine);
   }
 
   public renderingEngine(): string {
-    return this.config.get(kRenderingEngine, 'desktop');
+    return this.config.get(kRendererEngine, 'desktop');
+  }
+
+  public setUseGpuExclusionList(value: boolean) {
+    this.config.set(kRendererUseGpuExclusionList, value);
+  }
+
+  public useGpuExclusionList(): boolean {
+    return this.config.get(kRendererUseGpuExclusionList, true);
+  }
+
+  public setUseGpuDriverBugWorkarounds(value: boolean) {
+    this.config.set(kRendererUseGpuDriverBugWorkarounds, value);
+  }
+
+  public useGpuDriverBugWorkarounds(): boolean {
+    return this.config.get(kRendererUseGpuDriverBugWorkarounds, true);
   }
 
   // Windows-only option

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -34,6 +34,7 @@ import { openMinimalWindow } from './minimal-window';
 import { preferenceKeys, preferenceManager } from './preferences/preferences';
 import { filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
 import { activateWindow } from './window-utils';
+import { DesktopOptions } from './desktop-options';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -472,12 +473,11 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_set_desktop_rendering_engine', (event, engine) => {
-      GwtCallback.unimpl('desktop_set_desktop_rendering_engine');
+      DesktopOptions().setRenderingEngine(engine);
     });
 
     ipcMain.handle('desktop_filter_text', (event, text: string) => {
-      GwtCallback.unimpl('desktop_filter_text');
-      return text;
+      return DesktopOptions().renderingEngine();
     });
 
     ipcMain.on('desktop_clean_clipboard', (event, stripHtml) => {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -469,7 +469,7 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_rendering_engine', () => {
-      return '';
+      return DesktopOptions().renderingEngine();
     });
 
     ipcMain.on('desktop_set_desktop_rendering_engine', (event, engine) => {
@@ -477,7 +477,8 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_filter_text', (event, text: string) => {
-      return DesktopOptions().renderingEngine();
+      GwtCallback.unimpl('desktop_filter_text');
+      return text;
     });
 
     ipcMain.on('desktop_clean_clipboard', (event, stripHtml) => {
@@ -621,19 +622,19 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_get_ignore_gpu_exclusion_list', (event, ignore) => {
-      return true;
+      return !DesktopOptions().useGpuExclusionList();
     });
 
-    ipcMain.on('desktop_set_ignore_gpu_exclusion_list', (event, ignore) => {
-      GwtCallback.unimpl('desktop_set_ignore_gpu_exclusion_list');
+    ipcMain.on('desktop_set_ignore_gpu_exclusion_list', (event, ignore: boolean) => {
+      DesktopOptions().setUseGpuExclusionList(!ignore);
     });
 
     ipcMain.handle('desktop_get_disable_gpu_driver_bug_workarounds', () => {
-      return false;
+      return !DesktopOptions().useGpuDriverBugWorkarounds();
     });
 
-    ipcMain.on('desktop_set_disable_gpu_driver_bug_workarounds', (event, disable) => {
-      GwtCallback.unimpl('desktop_set_disable_gpu_driver_bug_workarounds');
+    ipcMain.on('desktop_set_disable_gpu_driver_bug_workarounds', (event, disable: boolean) => {
+      DesktopOptions().setUseGpuDriverBugWorkarounds(!disable);
     });
 
     ipcMain.on('desktop_show_license_dialog', () => {

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -54,8 +54,19 @@ class RStudioMain {
 
   private async initializeRenderingEngine() {
 
+    const options = DesktopOptions();
+
+    if (!options.useGpuDriverBugWorkarounds()) {
+      app.commandLine.appendSwitch('disable-gpu-driver-bug-workarounds');
+    }
+
+    if (!options.useGpuExclusionList()) {
+      app.commandLine.appendSwitch('ignore-gpu-blacklist');
+    }
+
     // read rendering engine, if any
     const engine = DesktopOptions().renderingEngine().toLowerCase();
+
 
     // for whatever reason, setting '--use-gl=desktop' doesn't seem to enable
     // the GPU on macOS; testing on other platforms would be worthwhile but

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -85,12 +85,31 @@ export function augmentCommandLineArguments(): void {
 
   const pieces = user.split(' ');
   pieces.forEach((piece) => {
-    if (piece.startsWith('-')) {
-      app.commandLine.appendSwitch(piece);
-    } else {
+
+    // if this piece doesn't start with '-', treat it as a plain argument
+    if (!piece.startsWith('-')) {
       app.commandLine.appendArgument(piece);
+      return;
     }
+
+    // otherwise, parse it as a switch and add it
+    // switches will have the form '--key=value', so split on the first '='
+    const idx = piece.indexOf('=');
+    if (idx == -1) {
+      return;
+    }
+
+    const lhs = piece.substring(0, idx);
+    const rhs = piece.substring(idx + 1);
+
+    // replace the old switch if needed
+    if (app.commandLine.hasSwitch(lhs)) {
+      app.commandLine.removeSwitch(lhs);
+    }
+
+    app.commandLine.appendSwitch(lhs, rhs);
   });
+
 }
 
 /**


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio/issues/10695. This portion implements the desktop callbacks for saving / storing these as part of our desktop options.

### Approach

Mostly straightforward porting of Qt goo to Electron goo.

### Automated Tests

Not included.

### QA Notes

For testing:

- In Tools -> Global Options... -> Advanced, try changing the rendering engine.
- After applying the changes, close and restart RStudio.
- Return to Tools -> Global Options... -> Advanced, and confirm that the settings you applied from the first step are presented here.
- In Help -> Diagnostics -> Show GPU Diagnostics, confirm that most of the "Graphics Feature Status" are enabled when using auto / desktop, and are disabled (or have something like "Software only, hardware acceleration unavailable") when using software rendering.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
