### PR TITLE
Unit test fixes, accomodate nogroup vs nobody

### DIFF
--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -468,15 +468,12 @@ TEST_CASE("TemporarilyDropPrivTests", "[requiresRoot]")
 
 TEST_CASE("PermanentlyDropPrivPrimaryTests", "[requiresRoot]")
 {
-   test_that("init")
-   {
 #ifdef __linux__
-      expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
+   expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
 #endif // __linux__
 #ifdef __APPLE__
-      expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
+   expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
 #endif // __APPLE__
-   }
 
    test_that("permanentlyDropPriv uses primary group")
    {
@@ -501,15 +498,12 @@ TEST_CASE("PermanentlyDropPrivPrimaryTests", "[requiresRoot]")
 
 TEST_CASE("PermanentlyDropPrivAlternateTests", "[requiresRoot]")
 {
-   test_that("init")
-   {
 #ifdef __linux__
-      expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
+   expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
 #endif // __linux__
 #ifdef __APPLE__
-      expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
+   expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
 #endif // __APPLE__
-   }
 
    test_that("permanentlyDropPriv checks group membership with alternate group")
    {

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -20,13 +20,19 @@
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
-
+#include <grp.h>
 #include <tests/TestThat.hpp>
 
 namespace rstudio {
 namespace core {
 namespace system {
 namespace tests {
+
+static std::string getNoGroupName()
+{
+   // Debian has nobody:nogroup, but RHEL has nobody:nobody
+   return getgrnam("nogroup") ? "nogroup" : "nobody";
+}
 
 test_context("PosixSystemTests")
 {
@@ -357,49 +363,50 @@ User s_testUser;
 group::Group s_testGroup;
 group::Group s_testNonMemberGroup;
 
-void initUserAndGroup(std::string username, std::string groupname, std::string nonmember_groupname)
+bool initUserAndGroup(std::string username, std::string groupname, std::string nonmember_groupname)
 {
    bool isRoot = core::system::effectiveUserIsRoot();
-   CHECK(isRoot);
+   expect_true(isRoot);
    if (!isRoot)
-      ::_exit(1);
+      return false;
 
    // get user info
    Error error = User::getUserFromIdentifier(username, s_testUser);
+   expect_false(error);
    if (error)
    {
       LOG_ERROR(error);
-      ::_exit(1);
+      return false;
    }
 
    // get group info. user should be a member of this group.
    error = group::groupFromName(groupname, &s_testGroup);
+   expect_false(error);
    if (error)
    {
       LOG_ERROR(error);
-      ::_exit(1);
+      return false;
    }
 
    // get secondary group info. user should not be a member of this group.
    error = group::groupFromName(nonmember_groupname, &s_testNonMemberGroup);
+   expect_false(error);
    if (error)
    {
       LOG_ERROR(error);
-      ::_exit(1);
+      return false;
    }
+   return true;
 }
 
 TEST_CASE("TemporarilyDropPrivTests", "[requiresRoot]")
 {
-   test_that("init")
-   {
-#ifdef __linux__
-      initUserAndGroup("nobody", "nogroup", "users");
-#endif // __linux__
-#ifdef __APPLE__
-      initUserAndGroup("nobody", "nobody", "daemon");
-#endif // __APPLE__
-   }
+   #ifdef __linux__
+      expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
+   #endif // __linux__
+   #ifdef __APPLE__
+      expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
+   #endif // __APPLE__
 
    test_that("temporarilyDropPriv uses primary group")
    {
@@ -464,10 +471,10 @@ TEST_CASE("PermanentlyDropPrivPrimaryTests", "[requiresRoot]")
    test_that("init")
    {
 #ifdef __linux__
-      initUserAndGroup("nobody", "nogroup", "users");
+      expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
 #endif // __linux__
 #ifdef __APPLE__
-      initUserAndGroup("nobody", "nobody", "daemon");
+      expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
 #endif // __APPLE__
    }
 
@@ -497,10 +504,10 @@ TEST_CASE("PermanentlyDropPrivAlternateTests", "[requiresRoot]")
    test_that("init")
    {
 #ifdef __linux__
-      initUserAndGroup("nobody", "nogroup", "users");
+      expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
 #endif // __linux__
 #ifdef __APPLE__
-      initUserAndGroup("nobody", "nobody", "daemon");
+      expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
 #endif // __APPLE__
    }
 

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -401,12 +401,12 @@ bool initUserAndGroup(std::string username, std::string groupname, std::string n
 
 TEST_CASE("TemporarilyDropPrivTests", "[requiresRoot]")
 {
-   #ifdef __linux__
+#ifdef __linux__
       expect_true(initUserAndGroup("nobody", getNoGroupName(), "users"));
-   #endif // __linux__
-   #ifdef __APPLE__
+#endif // __linux__
+#ifdef __APPLE__
       expect_true(initUserAndGroup("nobody", "nobody", "daemon"));
-   #endif // __APPLE__
+#endif // __APPLE__
 
    test_that("temporarilyDropPriv uses primary group")
    {

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -199,11 +199,11 @@ if has-scope "core"; then
    # Invoke the *DropPrivTests separately because they must run as root
    # We need separate invocations because we cannot restore privs between test cases of PermanentlyDropPrivs
    # Skip these tests in CI for MacOS builds
-   #if [ -z "${JENKINS_URL}" ] || [ "$(uname)" != "Darwin" ]; then
-   #   runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} TemporarilyDropPrivTests"
-   #   runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} PermanentlyDropPrivPrimaryTests"
-   #   runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} PermanentlyDropPrivAlternateTests"
-   #fi
+   if [ -z "${JENKINS_URL}" ] || [ "$(uname)" != "Darwin" ]; then
+      runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} TemporarilyDropPrivTests"
+      runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} PermanentlyDropPrivPrimaryTests"
+      runWatchdogProcess 5m true "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} PermanentlyDropPrivAlternateTests"
+   fi
 
    if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server_core/rstudio-server-core-tests" ]; then
       section "Running 'server_core' tests"


### PR DESCRIPTION
### Intent

Addresses #10683

Unit tests assumed that the `nobody` user was in the `nogroup` group, but this isn't true on non-Debian platforms and the tests always failed. Also the tests weren't reporting errors correctly making it very difficult to figure out why it was failling.

### Approach

Determine if we're on a `nogroup` platform, or a `nobody` platform. Also report failures.

Reenable the tests.

### Automated Tests

Yes. Yes they are.

### QA Notes

Unit tests only.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


