### PR TITLE
Electron preferences part 2: Writing to electron-store, reading from electron-store

### DIFF
--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint ./src ./test",
     "package": "npm ci && electron-forge package",
     "start": "electron-forge start",
+    "debug": "electron-forge start --inspect-electron",
     "fullstart": "npm install && electron-forge start",
     "test": "electron-mocha -c --config ./test/unit/mocharc.json",
     "testcover": "nyc electron-mocha -c --config ./test/unit/mocharc.json",

--- a/src/node/desktop/src/main/gwt-window.ts
+++ b/src/node/desktop/src/main/gwt-window.ts
@@ -13,13 +13,10 @@
  *
  */
 
-import { BrowserWindow, WebContents } from 'electron';
-import { logger } from '../core/logger';
-
 import { nextHighest, nextLowest } from '../core/array-utils';
-
+import { logger } from '../core/logger';
 import { DesktopBrowserWindow, WindowConstructorOptions } from './desktop-browser-window';
-import { DesktopOptions } from './desktop-options';
+import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 
 export abstract class GwtWindow extends DesktopBrowserWindow {
   // initialize zoom levels (synchronize with AppearancePreferencesPane.java)
@@ -39,7 +36,7 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
   }
 
   zoomIn(): void {
-    const zoomLevel = DesktopOptions().zoomLevel();
+    const zoomLevel = ElectronDesktopOptions().zoomLevel();
 
     // get next greatest value
     const newZoomLevel = nextHighest(zoomLevel, this.zoomLevels);
@@ -50,7 +47,7 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
 
   zoomOut(): void {
     // get next smallest value
-    const zoomLevel = DesktopOptions().zoomLevel();
+    const zoomLevel = ElectronDesktopOptions().zoomLevel();
     const newZoomLevel = nextLowest(zoomLevel, this.zoomLevels);
     if (newZoomLevel != zoomLevel) {
       this.setWindowZoomLevel(newZoomLevel);
@@ -76,7 +73,7 @@ export abstract class GwtWindow extends DesktopBrowserWindow {
   }
 
   private setWindowZoomLevel(zoomLevel: number): void {
-    DesktopOptions().setZoomLevel(zoomLevel);
+    ElectronDesktopOptions().setZoomLevel(zoomLevel);
     this.window.webContents.setZoomFactor(zoomLevel);
   }
 }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -26,7 +26,7 @@ import { SessionLauncher } from './session-launcher';
 import { ApplicationLaunch, LaunchRStudioOptions } from './application-launch';
 import { GwtWindow } from './gwt-window';
 import { appState } from './app-state';
-import { DesktopOptions } from './desktop-options';
+import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { RemoteDesktopSessionLauncher } from './remote-desktop-session-launcher-overlay';
 import { CloseServerSessions } from './session-servers-overlay';
 import { waitForUrlWithTimeout } from './utils';
@@ -334,7 +334,7 @@ export class MainWindow extends GwtWindow {
 
     if (!this.geometrySaved) {
       const bounds = this.window.getBounds();
-      DesktopOptions().saveWindowBounds(bounds);
+      ElectronDesktopOptions().saveWindowBounds(bounds);
       this.geometrySaved = true;
     }
 

--- a/src/node/desktop/src/main/preferences/desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/desktop-options.ts
@@ -1,6 +1,6 @@
 /**
  *
- * legacy-desktop-options.ts
+ * desktop-options.ts
  *
  * Copyright (C) 2022 by RStudio, PBC
  *

--- a/src/node/desktop/src/main/preferences/desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/desktop-options.ts
@@ -1,6 +1,6 @@
 /**
  *
- * mac-preferences.ts
+ * legacy-desktop-options.ts
  *
  * Copyright (C) 2022 by RStudio, PBC
  *
@@ -14,23 +14,6 @@
  *
  */
 
-import { systemPreferences } from 'electron';
-import { preferenceKeys } from './preferences';
-import DesktopOptions from './desktop-options';
-
-/**
- * MacOS specific implementation
- *
- * The preferences are stored in defauls, which is MacOS specific.
- */
-class MacPreferences extends DesktopOptions {
-  constructor() {
-    super();
-  }
-
-  fixedWidthFont(): string | undefined {
-    return systemPreferences.getUserDefault(preferenceKeys.fontFixedWidth, 'string');
-  }
+export default abstract class DesktopOptions {
+  abstract fixedWidthFont(): string | undefined;
 }
-
-export default MacPreferences;

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -18,6 +18,7 @@ import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
 import { logger } from '../../core/logger';
 import { legacyPreferenceManager } from './../preferences/preferences';
+import DesktopOptions from './desktop-options';
 
 const kProportionalFont = 'Font.ProportionalFont';
 const kFixedWidthFont = 'Font.FixedWidthFont';
@@ -78,9 +79,9 @@ let options: DesktopOptionsImpl | null = null;
  *
  * @returns The DesktopOptions singleton
  */
-export function ElectronDesktopOptions(directory = ''): DesktopOptionsImpl {
+export function ElectronDesktopOptions(directory = '', legacyOptions?: DesktopOptions): DesktopOptionsImpl {
   if (!options) {
-    options = new DesktopOptionsImpl(directory);
+    options = new DesktopOptionsImpl(directory, legacyOptions);
   }
   return options;
 }
@@ -120,11 +121,15 @@ export function firstIsInsideSecond(inner: Rectangle, outer: Rectangle): boolean
  */
 export class DesktopOptionsImpl {
   private config = new Store({ defaults: kDesktopOptionDefaults });
+  private legacyOptions = legacyPreferenceManager;
 
-  // Directory exposed for unit testing
-  constructor(directory = '') {
+  // unit testing constructor to expose directory and DesktopOptions mock
+  constructor(directory = '', legacyOptions?: DesktopOptions) {
     if (directory.length != 0) {
       this.config = new Store({ defaults: kDesktopOptionDefaults, cwd: directory });
+    }
+    if (legacyOptions) {
+      this.legacyOptions = legacyOptions;
     }
   }
 
@@ -140,11 +145,11 @@ export class DesktopOptionsImpl {
     this.config.set(kFixedWidthFont, fixedWidthFont);
   }
 
-  public fixedWidthFont(): string | undefined{
+  public fixedWidthFont(): string | undefined {
     let fontName = this.config.get<'Font.FixedWidthFont', string>(kFixedWidthFont);
 
     if (!fontName) {
-      fontName = legacyPreferenceManager.fixedWidthFont() ?? '';
+      fontName = this.legacyOptions.fixedWidthFont() ?? '';
     }
 
     return fontName;

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -119,7 +119,7 @@ export function firstIsInsideSecond(inner: Rectangle, outer: Rectangle): boolean
  * Exported for unit testing only, use the DesktopOptions() function
  * for creating/getting a DesktopOptionsImpl instance
  */
-export class DesktopOptionsImpl {
+export class DesktopOptionsImpl implements DesktopOptions {
   private config = new Store({ defaults: kDesktopOptionDefaults });
   private legacyOptions = legacyPreferenceManager;
 

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -1,6 +1,6 @@
 /**
  *
- * desktop-options.ts
+ * electron-desktop-options.ts
  *
  * Copyright (C) 2022 by RStudio, PBC
  *

--- a/src/node/desktop/src/main/preferences/file-preferences.ts
+++ b/src/node/desktop/src/main/preferences/file-preferences.ts
@@ -1,20 +1,45 @@
-import { UserDefaultTypes } from 'electron';
-import PropertiesReader from 'properties-reader';
-import { PlatformPreferences } from './preferences';
+/**
+ *
+ * file-preferences.ts
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
 
-class FilePreferences implements PlatformPreferences {
+import { homedir } from 'os';
+import PropertiesReader from 'properties-reader';
+import DesktopOptions from './desktop-options';
+import { preferenceKeys } from './preferences';
+
+const INI_FILE = 'desktop.ini';
+
+class FilePreferences extends DesktopOptions {
+  private iniFile: string; // existing location for some preferences
   private properties: PropertiesReader.Reader;
 
-  constructor(file: string) {
-    this.properties = PropertiesReader(file);
+  constructor() {
+    super();
+    if (process.platform === 'win32') {
+      this.iniFile = `${homedir()}\\AppData\\Roaming\\RStudio\\${INI_FILE}`;
+    } else if (process.platform === 'linux') {
+      this.iniFile = `${homedir()}/.config/RStudio/${INI_FILE}`;
+    } else {
+      throw new Error('unsupported platform');
+    }
+
+    this.properties = PropertiesReader(this.iniFile);
   }
 
-  getValue(key: string, _type: keyof UserDefaultTypes) {
-    return this.properties.get(key) ?? '';
-  }
-
-  setValue(_key: string, _type: keyof UserDefaultTypes, _value: keyof UserDefaultTypes): never {
-    throw new Error('unimplemented');
+  fixedWidthFont(): string | undefined {
+    return this.properties.get(preferenceKeys.fontFixedWidth)?.toString();
   }
 }
 

--- a/src/node/desktop/src/main/preferences/preferences.ts
+++ b/src/node/desktop/src/main/preferences/preferences.ts
@@ -1,15 +1,22 @@
-import { UserDefaultTypes } from 'electron';
-import { homedir } from 'os';
+/**
+ *
+ * preferences.ts
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
 import FilePreferences from './file-preferences';
 import MacPreferences from './mac-preferences';
-
-export interface PlatformPreferences {
-  getValue(
-    key: string,
-    type?: keyof UserDefaultTypes,
-  ): string | number | boolean | unknown[] | Record<string, unknown> | undefined;
-  setValue(key: string, type: keyof UserDefaultTypes, value: string): void;
-}
+import DesktopOptions from './desktop-options';
 
 const isMacOS = process.platform === 'darwin';
 
@@ -21,17 +28,20 @@ export const preferenceKeys = {
   fontFixedWidth: isMacOS ? 'font·fixedWidth' : 'General.font.fixedWidth',
 };
 
-export let preferenceManager: PlatformPreferences;
+/**
+ * This is the legacy preference manager. It will read the preferences from platform-specific
+ * location. Settings should only be used from here if the new location does not contain a
+ * value for the preference.
+ */
+export let legacyPreferenceManager: DesktopOptions;
 
 switch (process.platform) {
   case 'darwin':
-    preferenceManager = new MacPreferences();
+    legacyPreferenceManager = new MacPreferences();
     break;
   case 'win32':
-    preferenceManager = new FilePreferences(`${homedir()}\\AppData\\Roaming\\RStudio\\desktop.ini`);
-    break;
   case 'linux':
-    preferenceManager = new FilePreferences(`${homedir()}/.config/RStudio/desktop.ini`);
+    legacyPreferenceManager = new FilePreferences();
     break;
   default:
     throw new Error('unsupported platform');

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -39,7 +39,7 @@ import {
   waitForUrlWithTimeout,
 } from './utils';
 import { buildInfo } from './build-info';
-import { DesktopOptions } from './desktop-options';
+import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import i18next from 'i18next';
 import path from 'path';
 
@@ -187,7 +187,7 @@ export class SessionLauncher {
     this.mainWindow.appLauncher = this.appLaunch;
     this.appLaunch.setActivationWindow(this.mainWindow);
 
-    DesktopOptions().restoreMainWindowBounds(this.mainWindow.window);
+    ElectronDesktopOptions().restoreMainWindowBounds(this.mainWindow.window);
 
     logger().logDiagnostic('\nConnected to R session, attempting to initialize...\n');
 

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -19,12 +19,12 @@ import sinon from 'sinon';
 import { createSinonStubInstanceForSandbox } from '../unit-utils';
 
 import {
-  DesktopOptions,
+  ElectronDesktopOptions,
   DesktopOptionsImpl,
   kDesktopOptionDefaults,
   clearOptionsSingleton,
   firstIsInsideSecond,
-} from '../../../src/main/desktop-options';
+} from '../../../src/main/preferences/electron-desktop-options';
 import { FilePath } from '../../../src/core/file-path';
 import { Err, isSuccessful } from '../../../src/core/err';
 import { tempDirectory } from '../unit-utils';
@@ -33,7 +33,7 @@ import { Display } from 'electron/main';
 const kTestingConfigDirectory = tempDirectory('DesktopOptionsTesting').toString();
 
 function testingDesktopOptions(): DesktopOptionsImpl {
-  return DesktopOptions(kTestingConfigDirectory);
+  return ElectronDesktopOptions(kTestingConfigDirectory);
 }
 
 function deleteTestingDesktopOptions(): Err {
@@ -58,7 +58,7 @@ describe('DesktopOptions', () => {
     const nonWindowsPreferR64 = false;
 
     assert.equal(options.proportionalFont(), kDesktopOptionDefaults.Font.ProportionalFont);
-    assert.equal(options.fixWidthFont(), kDesktopOptionDefaults.Font.FixWidthFont);
+    assert.equal(options.fixedWidthFont(), kDesktopOptionDefaults.Font.FixedWidthFont);
     assert.equal(options.useFontConfigDb(), kDesktopOptionDefaults.Font.UseFontConfigDb);
     assert.equal(options.zoomLevel(), kDesktopOptionDefaults.View.ZoomLevel);
     assert.deepEqual(options.windowBounds(), kDesktopOptionDefaults.View.WindowBounds);
@@ -97,7 +97,7 @@ describe('DesktopOptions', () => {
     const nonWindowsPreferR64 = false;
 
     options.setProportionalFont(newProportionalFont);
-    options.setFixWidthFont(newFixWidthFont);
+    options.setFixedWidthFont(newFixWidthFont);
     options.setUseFontConfigDb(newUseFontConfigDb);
     options.setZoomLevel(newZoom);
     options.saveWindowBounds(newWindowBounds);
@@ -111,7 +111,7 @@ describe('DesktopOptions', () => {
     options.setPeferR64(newPeferR64);
 
     assert.equal(options.proportionalFont(), newProportionalFont);
-    assert.equal(options.fixWidthFont(), newFixWidthFont);
+    assert.equal(options.fixedWidthFont(), newFixWidthFont);
     assert.equal(options.useFontConfigDb(), newUseFontConfigDb);
     assert.equal(options.zoomLevel(), newZoom);
     assert.deepEqual(options.windowBounds(), newWindowBounds);
@@ -149,7 +149,7 @@ describe('DesktopOptions', () => {
     const savedWinBounds = { width: 500, height: 500, x: 2100, y: 100 };
 
     // Save bounds onto a secondary display on the right
-    DesktopOptions().saveWindowBounds(savedWinBounds);
+    ElectronDesktopOptions().saveWindowBounds(savedWinBounds);
 
     const sandbox = sinon.createSandbox();
     sandbox.stub(screen, 'getAllDisplays').returns(displays as Display[]);
@@ -157,7 +157,7 @@ describe('DesktopOptions', () => {
     testMainWindow.setBounds.withArgs(savedWinBounds);
     testMainWindow.getSize.returns([savedWinBounds.width, savedWinBounds.height]);
 
-    DesktopOptions().restoreMainWindowBounds(testMainWindow);
+    ElectronDesktopOptions().restoreMainWindowBounds(testMainWindow);
 
     sandbox.assert.calledOnceWithExactly(testMainWindow.setBounds, savedWinBounds);
     sandbox.assert.calledOnce(testMainWindow.setSize);
@@ -179,9 +179,9 @@ describe('DesktopOptions', () => {
     testMainWindow.getSize.returns([defaultWinWidth, defaultWinHeight]);
 
     // Make sure some bounds are already saved
-    DesktopOptions().saveWindowBounds(savedWinBounds);
+    ElectronDesktopOptions().saveWindowBounds(savedWinBounds);
 
-    DesktopOptions().restoreMainWindowBounds(testMainWindow);
+    ElectronDesktopOptions().restoreMainWindowBounds(testMainWindow);
 
     sandbox.assert.calledTwice(testMainWindow.setSize);
     sandbox.assert.alwaysCalledWith(testMainWindow.setSize, defaultWinWidth, defaultWinHeight);
@@ -225,8 +225,12 @@ describe('FirstIsInsideSecond', () => {
         rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y),
       ),
     ); // entirely inside
-    assert.isTrue(firstIsInsideSecond(rec(), rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y))); // top and left boarders shared
-    assert.isTrue(firstIsInsideSecond(rec(), rec())); // same size rectangles is valid
+
+    // top and left boarders shared
+    assert.isTrue(firstIsInsideSecond(rec(), rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y)));
+
+    // same size rectangles is valid
+    assert.isTrue(firstIsInsideSecond(rec(), rec()));
   });
   it('backwards case', () => {
     assert.isFalse(firstIsInsideSecond(rec(OUTER_WIDTH, OUTER_HEIGHT, OUTER_X, OUTER_Y), rec()));

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -12,28 +12,32 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  */
 
-import { BrowserWindow, Rectangle, screen } from 'electron';
-import { describe } from 'mocha';
 import { assert } from 'chai';
-import sinon from 'sinon';
-import { createSinonStubInstanceForSandbox } from '../unit-utils';
-
-import {
-  ElectronDesktopOptions,
-  DesktopOptionsImpl,
-  kDesktopOptionDefaults,
-  clearOptionsSingleton,
-  firstIsInsideSecond,
-} from '../../../src/main/preferences/electron-desktop-options';
-import { FilePath } from '../../../src/core/file-path';
-import { Err, isSuccessful } from '../../../src/core/err';
-import { tempDirectory } from '../unit-utils';
+import { BrowserWindow, Rectangle, screen } from 'electron';
 import { Display } from 'electron/main';
+import { describe } from 'mocha';
+import sinon from 'sinon';
+import { Err, isSuccessful } from '../../../src/core/err';
+import { FilePath } from '../../../src/core/file-path';
+import DesktopOptions from '../../../src/main/preferences/desktop-options';
+import {
+  clearOptionsSingleton,
+  DesktopOptionsImpl,
+  ElectronDesktopOptions,
+  firstIsInsideSecond,
+  kDesktopOptionDefaults,
+} from '../../../src/main/preferences/electron-desktop-options';
+import { createSinonStubInstanceForSandbox, tempDirectory } from '../unit-utils';
 
 const kTestingConfigDirectory = tempDirectory('DesktopOptionsTesting').toString();
 
 function testingDesktopOptions(): DesktopOptionsImpl {
-  return ElectronDesktopOptions(kTestingConfigDirectory);
+  const legacyOptions = new (class extends DesktopOptions {
+    fixedWidthFont(): string | undefined {
+      return kDesktopOptionDefaults.Font.FixedWidthFont;
+    }
+  })();
+  return ElectronDesktopOptions(kTestingConfigDirectory, legacyOptions);
 }
 
 function deleteTestingDesktopOptions(): Err {

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -292,3 +292,32 @@ describe('FirstIsInsideSecond', () => {
     );
   });
 });
+
+describe('Font tests', () => {
+  afterEach(() => {
+    assert(isSuccessful(deleteTestingDesktopOptions()));
+  });
+
+  it('can get the legacy font', () => {
+    const mockLegacyOptions = new (class extends DesktopOptions {
+      fixedWidthFont(): string | undefined {
+        return 'legacy font';
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    assert.strictEqual(testDesktopOptions.fixedWidthFont(), 'legacy font');
+  });
+
+  it('set font overrides legacy font option', () => {
+    const mockLegacyOptions = new (class extends DesktopOptions {
+      fixedWidthFont(): string | undefined {
+        return 'legacy font';
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    testDesktopOptions.setFixedWidthFont('new font');
+    assert.strictEqual(testDesktopOptions.fixedWidthFont(), 'new font');
+  });
+});


### PR DESCRIPTION
### Intent
Address saving font selection #10438

Saves the editor font selection to the electron-store. Reading will check electron-store first and fallback to the legacy option store. Cleaned up the way GWT gets the fixed font. It falls back to the default font list if both option stores return nothing.

### Approach
Refactored the `preferenceManager` to be an interface. Rename the preference manager to `legacyPreferenceManager` since that should only be used for reading and handles platform specific storage. `DesktopOptions` has been renamed to `ElectronDesktopOptions` as it is specific to how Electron will be handling preferences (falling back to legacy options). `PlatformPreferences` is now the interface `DesktopOptions` so that it defines the options available. For now, it's just `fixedWidthFont` but others will be added in a follow-up.

Added an npm launch for debugging. I couldn't debug from VS Code in Windows so I've added this launch so it's possible to connect using Chrome's `chrome://inspect`.

### Automated Tests
I've added tests to check:
* if the font isn't set in electron-store then it's retrieved from the legacy options
* if the font is set in electron-store then it's returned

### QA Notes
All platforms are able to select the font in the Appearance Options. The prompt to restart is required to see the font change. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


