### PR TITLE
initialize lang on macOS

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -30,6 +30,7 @@ import { Err } from '../core/err';
 
 import { MainWindow } from './main-window';
 import i18next from 'i18next';
+import { execSync, spawnSync } from 'child_process';
 
 // work around Electron resolving the application path to 'app.asar'
 const appPath = path.join(path.dirname(app.getAppPath()), 'app');
@@ -390,19 +391,45 @@ export function isSafeHost(host: string): boolean {
   return false;
 }
 
+// this code follows in the footsteps of R.app
+function initializeLangDarwin(): string {
+
+  {
+    // if 'force.LANG' is set, that takes precedencec
+    const args = ['read', 'org.R-project.R', 'force.LANG'];
+    const result = spawnSync('/usr/bin/defaults', args, { encoding: 'utf-8' });
+    if (result.status === 0) {
+      return result.stdout.trim();
+    }
+  }
+
+  {
+    // if 'ignore.system.locale' is set, we'll use a UTF-8 locale
+    const args = ['read', 'org.R-project.R', 'ignore.system.locale'];
+    const result = spawnSync('/usr/bin/defaults', args, { encoding: 'utf-8' });
+    if (result.status === 0 && result.stdout.trim() === 'YES') {
+      return 'en_US.UTF-8';
+    }
+  }
+
+  // next, check the LANG environment variable
+  const lang = getenv('LANG');
+  if (lang.length !== 0) {
+    return lang;
+  }
+
+  // otherwise, just use UTF-8 locale
+  return 'en_US.UTF-8';
+
+}
+
 export function initializeLang(): void {
   if (process.platform === 'darwin') {
-    // TODO: port full language detection, see initializeLang() in DesktopUtilsMac.mm
-
-    let lang = getenv('LANG');
-
-    // None of the above worked. Just hard code it.
-    if (!lang) {
-      lang = 'en_US.UTF-8';
+    const lang = initializeLangDarwin();
+    if (lang.length !== 0) {
+      setenv('LANG', lang);
+      setenv('LC_CTYPE', lang);
     }
-
-    setenv('LANG', lang);
-    setenv('LC_CTYPE', lang);
   }
 }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10450.

### Approach

Use the `defaults` command line utility to read (and respect) the various options as handled in Qt desktop.

### Automated Tests

Not included.

### QA Notes

Run the following in the terminal:

```
defaults write org.R-project.R force.LANG C
```

Then, try starting RStudio. You should see a warning, e.g.

```
Warning: Character set is not UTF-8; please change your locale
```

and executing `Sys.getlocale()` should report a C locale:

```
> Sys.getlocale()
[1] "C"
```

Then, revert your options by running in the terminal:

```
defaults delete org.R-project.R force.LANG
```

and restart RStudio, and confirm the warning is gone.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
