### PR TITLE
suppress a number of compiler warnings

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2572,10 +2572,6 @@ Error permanentlyDropPriv(const std::string& newUsername, const std::string& new
 // privilege manipulation for systems that don't support setresuid/getresuid
 #else
 
-namespace {
-   uid_t s_privUid;
-}
-
 Error permanentlyDropPriv(const std::string& newUsername)
 {
    return permanentlyDropPriv(newUsername, std::string());

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -45,6 +45,7 @@ static std::string getNoGroupName()
    else if (getgrnam("nogroup"))
       group = "nogroup"; // Debian/Ubuntu
 
+   expect_false(group.empty());
    return group;
 }
 

--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -28,6 +28,8 @@ namespace core {
 namespace system {
 namespace tests {
 
+#ifdef __linux__
+
 static std::string getNoGroupName()
 {
    std::string group;
@@ -43,9 +45,10 @@ static std::string getNoGroupName()
    else if (getgrnam("nogroup"))
       group = "nogroup"; // Debian/Ubuntu
 
-   expect_false(group.empty());
    return group;
 }
+
+#endif
 
 test_context("PosixSystemTests")
 {

--- a/src/cpp/server_core/include/server_core/ServerKeyObfuscation.hpp
+++ b/src/cpp/server_core/include/server_core/ServerKeyObfuscation.hpp
@@ -16,6 +16,7 @@
 #ifndef SERVER_CORE_SERVER_KEY_OBFUSCATION_HPP
 #define SERVER_CORE_SERVER_KEY_OBFUSCATION_HPP
 
-#define OBFUSCATE_KEY(key) (key)
+// stub for open source
+#define OBFUSCATE_KEY(key) (key[0] = key[0])
 
 #endif /* SERVER_CORE_SERVER_KEY_OBFUSCATION_HPP */

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1723,7 +1723,8 @@ SEXP rs_listFiles(SEXP pathSEXP,
       bool includeDirs  = validateLogical(includeDirsSEXP, "include.dirs");
       bool noDotDot     = validateLogical(noDotDotSEXP,    "no..");
 
-      // suppress warning
+      // suppress warning -- we use 'ignoreCaseSEXP' as-is after validation,
+      // but keeping the parallel code structure above is nice
       (void) ignoreCase;
       
       std::vector<boost::filesystem::path> result;

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -1723,6 +1723,9 @@ SEXP rs_listFiles(SEXP pathSEXP,
       bool includeDirs  = validateLogical(includeDirsSEXP, "include.dirs");
       bool noDotDot     = validateLogical(noDotDotSEXP,    "no..");
 
+      // suppress warning
+      (void) ignoreCase;
+      
       std::vector<boost::filesystem::path> result;
       std::vector<boost::filesystem::path> paths = initializePaths(pathSEXP);
 


### PR DESCRIPTION
Small changes to suppress some compiler warnings on macOS, e.g.

```
[125/535] Building CXX object core/CMakeFiles/rstudio-core.dir/system/PosixSystem.cpp.o
/Users/kevin/rstudio/src/cpp/core/system/PosixSystem.cpp:2576:10: warning: unused variable 's_privUid' [-Wunused-variable]
   uid_t s_privUid;
         ^
1 warning generated.
[144/535] Building CXX object core/CMakeFiles/rstudio-core-tests.dir/system/PosixSystemTests.cpp.o
/Users/kevin/rstudio/src/cpp/core/system/PosixSystemTests.cpp:31:20: warning: unused function 'getNoGroupName' [-Wunused-function]
static std::string getNoGroupName()
                   ^
1 warning generated.
[171/535] Building CXX object server_core/CMakeFiles/rstudio-server-core.dir/ServerDatabase.cpp.o
/Users/kevin/rstudio/src/cpp/server_core/ServerDatabase.cpp:190:21: warning: expression result unused [-Wunused-value]
      OBFUSCATE_KEY(secureKey);
                    ^~~~~~~~~
/Users/kevin/rstudio/src/cpp/server_core/include/server_core/ServerKeyObfuscation.hpp:19:29: note: expanded from macro 'OBFUSCATE_KEY'
#define OBFUSCATE_KEY(key) (key)
                            ^~~
1 warning generated.
[278/535] Building CXX object session/CMakeFiles/rsession.dir/modules/SessionFiles.cpp.o
/Users/kevin/rstudio/src/cpp/session/modules/SessionFiles.cpp:1722:12: warning: unused variable 'ignoreCase' [-Wunused-variable]
      bool ignoreCase   = validateLogical(ignoreCaseSEXP,  "ignore.case");
           ^
1 warning generated.
```