### PR TITLE
create nobody user and group for unit tests

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -105,6 +105,10 @@ RUN cd /tmp && \
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
+# create nobody user and group, used by unit tests
+RUN groupadd -g 65534 nobody && \
+    useradd -m -d /var/lib/nobody -u 65534 -g nobody nobody
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999


### PR DESCRIPTION
### Intent

Addresses: #10683 (take three)

The OpenSUSE15 build container doesn't have a nobody user or group, breaking some unit tests.

### Approach

Create the nobody user and group via the Dockerfile. I tried this locally via Docker and was able to run the previously failing unit tests.

### Automated Tests

This is for the automated tests.

### QA Notes

Build/unit test stuff.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


