### PR TITLE
use server print impl when printing code

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -53,6 +53,7 @@ import com.google.gwt.user.client.ui.RootPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import org.rstudio.core.client.AceSupport;
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.ExternalJavaScriptLoader;
@@ -1486,7 +1487,7 @@ public class AceEditor implements DocDisplay,
 
    public void print()
    {
-      if (Desktop.hasDesktopFrame())
+      if (Desktop.hasDesktopFrame() && !BrowseCap.isElectron())
       {
          // the desktop frame prints the code directly
          Desktop.getFrame().printText(StringUtil.notNull(getCode()));


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10763.

### Approach

Now that we have access to `window.print()`, we can re-use existing server implementation for Electron.

### Automated Tests

N/A

### QA Notes

Try to print some source documents from the IDE; confirm that you get a printout of the code (e.g. as a PDF)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
