### PR TITLE
Update minimum supported R version to 3.3.0

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -213,8 +213,8 @@ endif()
 
 # required R version
 set(RSTUDIO_R_MAJOR_VERSION_REQUIRED 3)
-set(RSTUDIO_R_MINOR_VERSION_REQUIRED 0)
-set(RSTUDIO_R_PATCH_VERSION_REQUIRED 1)
+set(RSTUDIO_R_MINOR_VERSION_REQUIRED 3)
+set(RSTUDIO_R_PATCH_VERSION_REQUIRED 0)
 
 # allow opting out of version checking (for building on older distros)
 if(NOT DEFINED RSTUDIO_VERIFY_R_VERSION)

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 
 - Added support for using the AGG renderer (as provided by the ragg package) as a graphics backend for inline plot execution; also added support for using the backend graphics device requested by the knitr `dev` chunk option (#9931)
 - rstudioapi functions are now always evaluated in a clean environment, and will not be masked by objects in the global environment (#8031)
+- Removed support for versions of R earlier than R 3.3.0. (rstudio-pro#2887)
 
 #### Python
 - RStudio attempts to infer the appropriate version of Python when "Automatically activate project-local Python environments" is checked and the user has not requested a specific version of Python. This Python will be stored in the environment variable "RETICULATE_PYTHON_FALLBACK", available from the R console, the Python REPL, and the RStudio Terminal (#9990)
@@ -39,8 +40,8 @@
 
 - Add a -G option to `rsandbox` to allow configuring the effective group of the process (#3214)
 
-
 ### Deprecated / Removed
 
-There is no deprecated or removed functionality in this release.
+- The minimum supported R version for the IDE has been increased from R 3.0.1 to R 3.3.0 (rstudio-pro#2887)
+
 

--- a/dependencies/linux/README
+++ b/dependencies/linux/README
@@ -6,7 +6,7 @@ RStudio requires relatively recent versions of a number of components. It is
 therefore likely to only correctly configure and build on more recent Linux
 systems. Specific version requirements for various components include:
 
-- R 3.0.1
+- R 3.3.0
 - CMake 3.4.3 or newer
 - Boost 1.78
 - Qt 5.12.8 [Required only for Desktop]

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -44,12 +44,12 @@ RUN "echo 'Remove-Item alias:r' | Out-File $PsHome\Profile.ps1"
 # install R to c:\R, a common c:\Program issue appears to only happen when installing in docker
 RUN $ErrorActionPreference = 'Stop' ;`
   [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://cran.rstudio.com/bin/windows/base/old/3.0.3/R-3.0.3-win.exe', 'c:\R-3.0.3-win.exe') ;`
-  Start-Process c:\R-3.0.3-win.exe -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-3.0.3\"' ;`
-  Remove-Item c:\R-3.0.3-win.exe -Force
+  (New-Object System.Net.WebClient).DownloadFile('https://cran.rstudio.com/bin/windows/base/old/3.3.0/R-3.3.0-win.exe', 'c:\R-3.3.0-win.exe') ;`
+  Start-Process c:\R-3.3.0-win.exe -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-3.3.0\"' ;`
+  Remove-Item c:\R-3.3.0-win.exe -Force
 
 # add R to path
-RUN $env:path += ';C:\R\R-3.0.3\bin\i386\' ;`
+RUN $env:path += ';C:\R\R-3.3.0\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
 # install qt (note that we are using the current directory's context)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -628,7 +628,7 @@ else()
          execute_process(
              COMMAND "${LIBR_EXECUTABLE}" "--vanilla" "-s" "-e" "cat(as.character(getRversion()))"
              OUTPUT_VARIABLE LIBR_VERSION)
-         if (LIBR_VERSION VERSION_LESS "3.0.1")
+         if (LIBR_VERSION VERSION_LESS "3.3.0")
             message(FATAL_ERROR "Minimum R version (${RSTUDIO_R_MAJOR_VERSION_REQUIRED}.${RSTUDIO_R_MINOR_VERSION_REQUIRED}.${RSTUDIO_R_PATCH_VERSION_REQUIRED}) not found; detected version is ${LIBR_VERSION}")
          endif()
       endif()

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -166,7 +166,7 @@
          for (scope in scopes)
          {
             style <- .rs.parseStyles(element$settings)
-            haveStyle <- !is.null(style) && !is.na(style) && (length(style) > 0)
+            haveStyle <- !is.null(style) && any(!is.na(style)) && (length(style) > 0)
             if ((scope %in% supportedScopeNames) && haveStyle)
             {
                styles[[ supportedScopes[[scope]] ]] <- style

--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -166,7 +166,7 @@
          for (scope in scopes)
          {
             style <- .rs.parseStyles(element$settings)
-            haveStyle <- !is.null(style) && any(!is.na(style)) && (length(style) > 0)
+            haveStyle <- !is.null(style) && !is.na(style) && (length(style) > 0)
             if ((scope %in% supportedScopeNames) && haveStyle)
             {
                styles[[ supportedScopes[[scope]] ]] <- style

--- a/vagrant/provision-multi-r.sh
+++ b/vagrant/provision-multi-r.sh
@@ -6,21 +6,21 @@ sudo apt-get -y build-dep r-base
 cd /tmp
 
 # download tarballs
-wget https://cran.r-project.org/src/base/R-2/R-2.15.3.tar.gz
-wget https://cran.r-project.org/src/base/R-3/R-3.0.3.tar.gz
+wget https://cran.r-project.org/src/base/R-3/R-3.6.3.tar.gz
+wget https://cran.r-project.org/src/base/R-4/R-4.1.2.tar.gz
 
 # extract them
-tar xzvf R-2.15.3.tar.gz
-tar xzvf R-3.0.3.tar.gz
+tar xzvf R-3.6.3.tar.gz
+tar xzvf R-4.1.2.tar.gz
 
 # build and install each version
-cd /tmp/R-2.15.3
-./configure --prefix=/opt/R/2.15.3 --enable-R-shlib
+cd /tmp/R-3.6.3
+./configure --prefix=/opt/R/3.6.3 --enable-R-shlib
 make 
 sudo make install
 
-cd /tmp/R-3.0.3
-./configure --prefix=/opt/R/3.0.3 --enable-R-shlib
+cd /tmp/R-4.1.2
+./configure --prefix=/opt/R/4.1.2 --enable-R-shlib
 make 
 sudo make install
 


### PR DESCRIPTION
### Intent
Addresses [rstudio-pro#2887](https://github.com/rstudio/rstudio-pro/issues/2887).

Update minimum supported R version to 3.3.0 in all documentation. Fatal error if using < 3.3.0

Accompanying PRs in [rstudio-pro##3322](https://github.com/rstudio/rstudio-pro/pull/3322), [docs.rstudio.com#820](https://github.com/rstudio/docs.rstudio.com/pull/820), and [rstudio.com#504](https://github.com/rstudio/rstudio.com/pull/504)

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


