### PR TITLE
Electron zooming

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -160,6 +160,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void zoomIn();
    void zoomOut();
    void zoomActualSize();
+   void getZoomLevel(CommandWithArg<Double> callback);
    
    void setBackgroundColor(JsArrayInteger rgbColor);
    void changeTitleBarColor(int r, int g, int b);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -29,6 +29,7 @@ import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.js.JsUtil;
@@ -61,6 +62,12 @@ import java.util.TreeSet;
 
 public class AppearancePreferencesPane extends PreferencesPane
 {
+   static final String ZOOM_DEFAULT = "1.00";
+   static final String[] ZOOM_VALUES = new String[] {
+           "0.25", "0.50", "0.75", "0.80", "0.90",
+           ZOOM_DEFAULT, "1.10", "1.25", "1.50", "1.75",
+           "2.00", "2.50", "3.00", "4.00", "5.00"
+   };
 
    @Inject
    public AppearancePreferencesPane(PreferencesDialogResources res,
@@ -109,18 +116,22 @@ public class AppearancePreferencesPane extends PreferencesPane
 
       if (Desktop.hasDesktopFrame())
       {
+         String[] zoomLabels = new String[ZOOM_VALUES.length];
+         double currentZoomLevel = DesktopInfo.getZoomLevel();
+
+         if (BrowseCap.isElectron()) {
+            Desktop.getFrame().getZoomLevel(zoomLevel ->
+            {
+               int initialIndex = getInitialZoomIndex(zoomLevel);
+               zoomLevel_.getListBox().setSelectedIndex(initialIndex);
+            });
+         }
+
          int initialIndex = -1;
          int normalIndex = -1;
-         String[] zoomValues = new String[] {
-               "0.25", "0.50", "0.75", "0.80", "0.90",
-               "1.00", "1.10", "1.25", "1.50", "1.75",
-               "2.00", "2.50", "3.00", "4.00", "5.00"
-         };
-         String[] zoomLabels = new String[zoomValues.length];
-         double currentZoomLevel = DesktopInfo.getZoomLevel();
-         for (int i = 0; i < zoomValues.length; i++)
+         for (int i = 0; i < ZOOM_VALUES.length; i++)
          {
-            double zoomValue = Double.parseDouble(zoomValues[i]);
+            double zoomValue = Double.parseDouble(ZOOM_VALUES[i]);
 
             if (zoomValue == 1.0)
                normalIndex = i;
@@ -135,11 +146,11 @@ public class AppearancePreferencesPane extends PreferencesPane
             initialIndex = normalIndex;
 
          zoomLevel_ = new SelectWidget(constants_.appearanceZoomLabelZoom(),
-                                       zoomLabels,
-                                       zoomValues,
-                                       false);
+                 zoomLabels,
+                 ZOOM_VALUES,
+                 false);
          zoomLevel_.getListBox().setSelectedIndex(initialIndex);
-         initialZoomLevel_ = zoomValues[initialIndex];
+         initialZoomLevel_ = ZOOM_VALUES[initialIndex];
 
          leftPanel.add(zoomLevel_);
 
@@ -320,6 +331,24 @@ public class AppearancePreferencesPane extends PreferencesPane
       // asynchronously too. We also need to wait until the next event cycle so that the progress
       // indicator will be ready.
       Scheduler.get().scheduleDeferred(() -> setThemes(themes));
+   }
+
+   private int getInitialZoomIndex(double currentZoomLevel) {
+      int initialIndex = -1;
+      int normalIndex = -1;
+
+      for (int i = 0; i < ZOOM_VALUES.length; i++)
+      {
+         double zoomValue = Double.parseDouble(ZOOM_VALUES[i]);
+
+         if (zoomValue == 1.0)
+            normalIndex = i;
+
+         if (zoomValue == currentZoomLevel)
+            initialIndex = i;
+      }
+      ;
+      return initialIndex == -1 ? normalIndex : initialIndex;
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
@@ -13,10 +13,12 @@
 
 package org.rstudio.studio.client.workbench.views.viewer.export;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Rectangle;
 import org.rstudio.core.client.dom.ElementEx;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.DesktopInfo;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotSizeEditor;
 
@@ -38,9 +40,20 @@ public class DesktopExport
             // hide gripper
             sizeEditor.setGripperVisible(false);
 
-            // get zoom level
-            double zoomLevel = DesktopInfo.getZoomLevel();
+            if (BrowseCap.isElectron())
+            {
+               Desktop.getFrame().getZoomLevel(zoomLevel -> performExport(zoomLevel));
+            }
+            else
+            {
+               // get zoom level
+               double zoomLevel = DesktopInfo.getZoomLevel();
 
+               performExport(zoomLevel);
+            }
+         }
+
+         private void performExport(double zoomLevel) {
             // get the preview iframe rect
             ElementEx iframe = sizeEditor.getPreviewIFrame().<ElementEx>cast();
             final Rectangle viewerRect = new Rectangle(

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -23,6 +23,7 @@ import { URL } from 'url';
 import { logger } from '../core/logger';
 import { appState } from './app-state';
 import { showContextMenu } from './context-menu';
+import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { ToolbarData, ToolbarManager } from './toolbar-manager';
 import { executeJavaScript, isSafeHost } from './utils';
 
@@ -96,7 +97,7 @@ export class DesktopBrowserWindow extends EventEmitter {
     if (this.options.existingWindow) {
       this.window = this.options.existingWindow;
     } else {
-      let preload = DesktopBrowserWindow.getPreload();
+      const preload = DesktopBrowserWindow.getPreload();
 
       this.window = new BrowserWindow({
         // https://github.com/electron/electron/blob/master/docs/faq.md#the-font-looks-blurry-what-is-this-and-what-can-i-do
@@ -259,10 +260,12 @@ export class DesktopBrowserWindow extends EventEmitter {
       this.emit(DesktopBrowserWindow.WINDOW_DESTROYED);
     });
 
-    // set zoom factor
-    // TODO: double zoomLevel = options().zoomLevel();
-    const zoomLevel = 1.0;
-    this.window.webContents.setZoomFactor(zoomLevel);
+    this.window.on('ready-to-show', () => {
+      // set zoom factor when window is ready
+      // https://github.com/electron/electron/issues/10572
+      const zoomLevel = ElectronDesktopOptions().zoomLevel();
+      this.window.webContents.setZoomFactor(zoomLevel);
+    });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -562,8 +562,8 @@ export class GwtCallback extends EventEmitter {
       return '';
     });
 
-    ipcMain.handle('desktop_get_zoom_level', () => {
-      return ElectronDesktopOptions().zoomLevel();
+    ipcMain.on('desktop_get_zoom_level', (event) => {
+      event.returnValue = ElectronDesktopOptions().zoomLevel();
     });
 
     ipcMain.on('desktop_set_zoom_level', (event, zoomLevel) => {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -563,12 +563,11 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_get_zoom_level', () => {
-      GwtCallback.unimpl('desktop_get_zoom_level');
-      return 1.0;
+      return ElectronDesktopOptions().zoomLevel();
     });
 
     ipcMain.on('desktop_set_zoom_level', (event, zoomLevel) => {
-      GwtCallback.unimpl('desktop_set_zoom_level');
+      this.getSender('desktop_zoom_actual_size', event.processId, event.frameId).setZoomLevel(zoomLevel);
     });
 
     ipcMain.on('desktop_zoom_in', (event) => {

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -347,7 +347,7 @@ export class MenuCallback extends EventEmitter {
     // code where we assign shortcuts to these commands and let them flow through
     // our regular command handling
     if (cmdId === 'zoomActualSize') {
-      menuItemOpts.role = 'resetZoom';
+      menuItemOpts.accelerator = 'CommandOrControl+0';
     } else if (cmdId === 'zoomIn') {
       menuItemOpts.accelerator = 'CommandOrControl+=';
     } else if (cmdId === 'zoomOut') {

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -349,9 +349,9 @@ export class MenuCallback extends EventEmitter {
     if (cmdId === 'zoomActualSize') {
       menuItemOpts.role = 'resetZoom';
     } else if (cmdId === 'zoomIn') {
-      menuItemOpts.role = 'zoomIn';
+      menuItemOpts.accelerator = 'CommandOrControl+=';
     } else if (cmdId === 'zoomOut') {
-      menuItemOpts.role = 'zoomOut';
+      menuItemOpts.accelerator = 'CommandOrControl+-';
     } else if (cmdId === 'cutDummy') {
       menuItemOpts.role = 'cut';
     } else if (cmdId === 'copyDummy') {

--- a/src/node/desktop/src/main/preferences/desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/desktop-options.ts
@@ -16,4 +16,5 @@
 
 export default abstract class DesktopOptions {
   abstract fixedWidthFont(): string | undefined;
+  abstract zoomLevel(): number | undefined;
 }

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -177,7 +177,13 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public zoomLevel(): number {
-    return this.config.get(kZoomLevel);
+    let zoomLevel = this.config.get<'View.ZoomLevel', number>(kZoomLevel);
+
+    if (!zoomLevel) {
+      zoomLevel = this.legacyOptions.zoomLevel() ?? kDesktopOptionDefaults.View.ZoomLevel;
+    }
+
+    return zoomLevel;
   }
 
   public saveWindowBounds(bounds: Rectangle): void {

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -155,10 +155,11 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public fixedWidthFont(): string | undefined {
-    let fontName = this.config.get<'Font.FixedWidthFont', string>(kFixedWidthFont);
+    let fontName: string | undefined = this.config.get(kFixedWidthFont);
 
     if (!fontName) {
       fontName = this.legacyOptions.fixedWidthFont() ?? '';
+      this.config.set(kFixedWidthFont, fontName);
     }
 
     return fontName;
@@ -177,10 +178,11 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public zoomLevel(): number {
-    let zoomLevel = this.config.get<'View.ZoomLevel', number>(kZoomLevel);
+    let zoomLevel: number | undefined = this.config.get(kZoomLevel);
 
     if (!zoomLevel) {
       zoomLevel = this.legacyOptions.zoomLevel() ?? kDesktopOptionDefaults.View.ZoomLevel;
+      this.config.set(kZoomLevel, zoomLevel);
     }
 
     return zoomLevel;

--- a/src/node/desktop/src/main/preferences/file-preferences.ts
+++ b/src/node/desktop/src/main/preferences/file-preferences.ts
@@ -41,6 +41,11 @@ class FilePreferences extends DesktopOptions {
   fixedWidthFont(): string | undefined {
     return this.properties?.get(preferenceKeys.fontFixedWidth)?.toString();
   }
+
+  zoomLevel(): number | undefined {
+    const zoomValue = this.properties?.get(preferenceKeys.zoomLevel)?.toString();
+    return zoomValue ? parseFloat(zoomValue) : undefined;
+  }
 }
 
 export default FilePreferences;

--- a/src/node/desktop/src/main/preferences/mac-preferences.ts
+++ b/src/node/desktop/src/main/preferences/mac-preferences.ts
@@ -31,6 +31,10 @@ class MacPreferences extends DesktopOptions {
   fixedWidthFont(): string | undefined {
     return systemPreferences.getUserDefault(preferenceKeys.fontFixedWidth, 'string');
   }
+
+  zoomLevel(): number | undefined {
+    return systemPreferences.getUserDefault(preferenceKeys.zoomLevel, 'double');
+  }
 }
 
 export default MacPreferences;

--- a/src/node/desktop/src/main/preferences/preferences.ts
+++ b/src/node/desktop/src/main/preferences/preferences.ts
@@ -26,6 +26,7 @@ const isMacOS = process.platform === 'darwin';
  */
 export const preferenceKeys = {
   fontFixedWidth: isMacOS ? 'font·fixedWidth' : 'General.font.fixedWidth',
+  zoomLevel: isMacOS ? 'view·zoomLevel' : 'General.view.zoomLevel',
 };
 
 /**

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -68,12 +68,11 @@ export function getDesktopBridge() {
       ipcRenderer
         .invoke('desktop_get_save_file_name', caption, label, dir, defaultExtension, forceDefaultExtension, focusOwner)
         .then((result) => {
-
           // if the result was canceled, bail early
           if (result.canceled as boolean) {
             return callback('');
           }
-          
+
           // if we don't have a default extension, just invoke callback
           let filePath = result.filePath as string;
           if (defaultExtension.length === 0) {
@@ -89,7 +88,6 @@ export function getDesktopBridge() {
 
           // invoke callback
           return callback(filePath);
-
         })
         .catch((error) => reportIpcError('getSaveFileName', error));
     },
@@ -404,10 +402,8 @@ export function getDesktopBridge() {
     },
 
     getZoomLevel: (callback: VoidCallback<number>) => {
-      ipcRenderer
-        .invoke('desktop_get_zoom_level')
-        .then((zoomLevel) => callback(zoomLevel))
-        .catch((error) => reportIpcError('getZoomLevel', error));
+      const zoomLevel = ipcRenderer.sendSync('desktop_get_zoom_level');
+      callback(zoomLevel);
     },
 
     setZoomLevel: (zoomLevel: number) => {

--- a/src/node/desktop/src/renderer/desktop-info-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-info-bridge.ts
@@ -15,7 +15,7 @@
 
 import { ipcRenderer } from 'electron';
 
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+// preload never calls this again so these values are immutable
 export function getDesktopInfoBridge() {
   return {
     platform: '',

--- a/src/node/desktop/src/renderer/desktop-info-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-info-bridge.ts
@@ -25,7 +25,7 @@ export function getDesktopInfoBridge() {
     fixedWidthFont: ipcRenderer.sendSync('desktop_get_fixed_width_font'),
     proportionalFont: ipcRenderer.sendSync('desktop_get_proportional_font'),
     desktopSynctexViewer: '',
-    zoomLevel: 1.0,
+    zoomLevel: ipcRenderer.sendSync('desktop_get_zoom_level'),
     chromiumDevtoolsPort: 0,
   };
 }

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -36,6 +36,9 @@ function testingDesktopOptions(): DesktopOptionsImpl {
     fixedWidthFont(): string | undefined {
       return kDesktopOptionDefaults.Font.FixedWidthFont;
     }
+    zoomLevel(): number | undefined {
+      return kDesktopOptionDefaults.View.ZoomLevel;
+    }
   })();
   return ElectronDesktopOptions(kTestingConfigDirectory, legacyOptions);
 }
@@ -303,6 +306,9 @@ describe('Font tests', () => {
       fixedWidthFont(): string | undefined {
         return 'legacy font';
       }
+      zoomLevel(): number | undefined {
+        return 1.0;
+      }
     })();
     const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
 
@@ -313,6 +319,9 @@ describe('Font tests', () => {
     const mockLegacyOptions = new (class extends DesktopOptions {
       fixedWidthFont(): string | undefined {
         return 'legacy font';
+      }
+      zoomLevel(): number | undefined {
+        return 1.0;
       }
     })();
     const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);


### PR DESCRIPTION
### Intent
Address #10484

This switches from using Electron's zoom levels to our own zoom levels. The option is saved to `electron-store`. If there is no current value from the `electron-store` then it checks the `desktop.ini`. The legacy option is written to the `electron-store` so subsequent checks will read from there.

### Approach
GWT has to handle Electron specifically and will call the desktop bridge instead of the desktop info bridge. The desktop info bridge is immutable and isn't set up for easily adding a callback. Eventually, I think most of desktop info bridge can be moved out of the preload since the immutability of it doesn't allow returning the current value. It's probably better changing desktop info bridge to be async calls since they'll likely read from disk to get these values.

Some work remains to ensure the legacy values are used on an Electron build's first run. Right now, it uses the defaults as set in `electron-desktop-options.ts`.

### Automated Tests
There are existing unit tests that check the default values and setting new ones. There's still some work to be done to be able to properly unit test legacy options.

### QA Notes
Using `electron-store` for preference persistence creates the file in these locations:
MacOS: `~/Library/Application Support/RStudio/config.json`
Linux: `~/.config/RStudio/config.json`
Windows: `~\AppData\Roaming\RStudio\config.json`

If this file does not exist, it still uses the built-in default of 100% zoom level. Reading the legacy value only occurs if this file does not contain a zoom level value.

#7992 is not addressed in this PR but I discovered the issue while working on this. I believe that issue is due to how it calculates the bounds for exporting the viewer pane. This action likely needs a complete rewrite since Electron has changed something with the iframe holding the viewer pane contents.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


