### PR TITLE
Fix logging regression for certain RSW binaries

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -73,6 +73,11 @@ namespace {
 FilePath defaultLogPathImpl()
 {
 #ifdef RSTUDIO_SERVER
+#ifdef RSTUDIO_PRO_BUILD
+   return FilePath("/var/log/rstudio/rstudio-server");
+#else
+   // For open-source Server, support logging even if RStudio Server is run
+   // as a non-root user.
    if (core::system::effectiveUserIsRoot())
    {
       // server: root uses default documented logging directory
@@ -83,6 +88,7 @@ FilePath defaultLogPathImpl()
       // server: prefer user data directory if we're not running as root
       return core::system::xdg::userDataDir().completePath("log");
    }
+#endif
 #else
    // desktop: always stored in user data directory
    return core::system::xdg::userDataDir().completePath("log");

--- a/src/cpp/core/config.h.in
+++ b/src/cpp/core/config.h.in
@@ -27,3 +27,4 @@
 #cmakedefine HAVE_SETRESUID
 #cmakedefine HAVE_SCANDIR_POSIX
 #cmakedefine RSTUDIO_SERVER
+#cmakedefine RSTUDIO_PRO_BUILD

--- a/version/news/NEWS-2022.02.1-prairie-trillium.md
+++ b/version/news/NEWS-2022.02.1-prairie-trillium.md
@@ -6,3 +6,5 @@
 * Fixed an issue where `list.files()` did not handle "globs" as expected. (#10679)
 * Fixed incorrect label in Global Options for "Show full path to project in window title" (#10688)
 * Fixed hang running Rmd chunks with launcher sessions and other problems the new session-ssl feature of RStudio Workbench (Pro #3301)
+* Fixed failure to create log file for rserver-session-reaper (#3307)
+* Fixed failure to create log file for rserver-acls (#3318)


### PR DESCRIPTION
### Intent

A change to support logging when RStudio Server open source is run as non-root caused logging to fail for some RSW binaries due to permission issues. That change was made here: https://github.com/rstudio/rstudio/pull/10126

Addresses https://github.com/rstudio/rstudio-pro/issues/3307
Addresses https://github.com/rstudio/rstudio-pro/issues/3318

### Approach

When compiling for Pro (RSW), behave the way it was before the regression, but leave the new behaviour for open-source.

Note that binaries such as rsession and rworkspace, which run as non-root, do not rely on the default set in this code; they set their logging locations explicitely when initializing the logging subsystem.

Also, `RSTUDIO_PRO_BUILD` was already defined for pro-builds, just needed to configure that cmake variable into a header file.

https://github.com/rstudio/rstudio/blob/ab97ae298e1258ce54122900b07d9eb9a6027ec5/CMakeGlobals.txt#L60-L65

### Automated Tests

None

### QA Notes

Make sure log files for rserver-session-reaper and rserver-acls are created as expected in RSW. You'll want to up the logging level to `debug` and leave the server running for > 30 minutes for the reaper log to show anything, and enable project sharing for the acls issue.
 
### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


