### PR TITLE
Fix failing unit tests and remove all warnings in test-themes

### DIFF
--- a/src/cpp/session/modules/SessionThemes.R
+++ b/src/cpp/session/modules/SessionThemes.R
@@ -166,7 +166,7 @@
          for (scope in scopes)
          {
             style <- .rs.parseStyles(element$settings)
-            haveStyle <- !is.null(style) && !is.na(style) && (length(style) > 0)
+            haveStyle <- !is.null(style) && any(!is.na(style)) && (length(style) > 0)
             if ((scope %in% supportedScopeNames) && haveStyle)
             {
                styles[[ supportedScopes[[scope]] ]] <- style
@@ -980,8 +980,9 @@
       warning("Removing the active theme - setting the current theme to ", nextTheme)
       .rs.applyTheme(nextTheme, themeList)
    }
-
+   
    filePath <- .rs.getThemeDirFromUrl(themeList[[lowerCaseName]]$url)
+   
    if (is.null(filePath))
    {
       stop("Please verify that the theme is installed as a custom theme.")

--- a/src/cpp/tests/testthat/test-themes.R
+++ b/src/cpp/tests/testthat/test-themes.R
@@ -18,7 +18,7 @@ context("themes")
 # We need this file for .rs.parseCss
 source(file.path("..", "..", "session", "resources", "themes", "compile-themes.R"))
 
-inputFileLocation <- file.path(path.expand("."), "themes")
+inputFileLocation <- file.path(normalizePath("."), "themes")
 tempOutputDir <- file.path(inputFileLocation, "temp")
 localInstallDir <- file.path(inputFileLocation, "localInstall")
 globalInstallDir <- file.path(inputFileLocation, "globalInstall")
@@ -1675,9 +1675,9 @@ test_that_wrapped("addTheme gives error when the theme already exists", {
    themePath <- file.path(inputFileLocation, "rsthemes", paste0(themes[[40]]$fileName, ".rstheme"))
    # suppress warning for theme overwrite
    suppressWarnings(
-      .rs.addTheme(themePath, FALSE, FALSE, FALSE))
+      .rs.addTheme(themePath, FALSE, force=TRUE, globally=FALSE))
    expect_error(
-      .rs.addTheme(themePath, FALSE, FALSE, FALSE),
+      .rs.addTheme(themePath, FALSE, force=FALSE, globally=FALSE),
       paste0(
          "The specified theme, \"",
          names(themes)[40],
@@ -1929,3 +1929,4 @@ AFTER_FUN = function() {
    Sys.chmod(dir(noPermissionDir, full.names = TRUE, all.files = TRUE), mode = "0777")
    file.remove(file.path(noPermissionDir, paste0(themes[[32]]$fileName, ".rstheme")))
 })
+


### PR DESCRIPTION
### Intent

Addresses #10744 . All unit tests in test-themes.R now passing, and fixed all warnings too.

<img width="554" alt="image" src="https://user-images.githubusercontent.com/7817881/157967830-5fb655d1-5194-41c1-a35a-46fc31f69b84.png">


### Approach

Fixed warnings for elements with more than one style element by wrapping in `any`
Fixed failure to return full absolute path by using normalizePath to set Theme Locations
Fixed typo calling test with incorrect arguments

### Automated Tests

Fixed! 
### QA Notes
NA

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


