### PR TITLE
avoid empty stage on windows electron build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -472,8 +472,8 @@ try {
                     println stdout
                   }
                 }
-                stage('upload debug symbols') {
-                  if (current_container.flavor == "desktop") {
+                if (current_container.flavor == "desktop") {
+                  stage('upload debug symbols') {
                     // convert the PDB symbols to breakpad format (PDB not supported by Sentry)
                     bat '''
                     cd package\\win32\\build


### PR DESCRIPTION
We don't currently upload debug symbols for Electron Windows build. This was showing as an empty stage in the pipeline display:

![Screen Shot 2022-03-11 at 13 44 36](https://user-images.githubusercontent.com/10569626/157983322-22efcc13-305c-4075-9d4e-0bd52a51ef3a.png)

Put the stage inside the conditional so we don't get this.