### PR TITLE
log HRESULT error values as hex instead of decimal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 
 ### Fixed
 
+- Fixed logging of `HRESULT` error values by logging them as hexadecimal instead of decimal (#10310)
 - Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE (#9436)
 - Fixed plot export to PDF options (#9185)
 - `.rs.formatDataColumnDispatch()` iterates through classes of `x` (#10073)

--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -335,7 +335,7 @@ FilePath userSettingsPath(const FilePath& userHomeDirectory,
    if (hr != S_OK)
    {
       LOG_ERROR_MESSAGE("Unable to retrieve user home path. HRESULT:  " +
-                        safe_convert::numberToString(hr));
+                        safe_convert::numberToHexString(hr));
       return FilePath();
    }
 
@@ -353,7 +353,7 @@ FilePath systemSettingsPath(const std::string& appName, bool create)
    if (hr != S_OK)
    {
       LOG_ERROR_MESSAGE("Unable to retrieve per machine configuration path. HRESULT:  " +
-                        safe_convert::numberToString(hr));
+                        safe_convert::numberToHexString(hr));
       return FilePath();
    }
 
@@ -368,7 +368,7 @@ FilePath systemSettingsPath(const std::string& appName, bool create)
       if (hr != S_OK)
       {
          LOG_ERROR_MESSAGE("Cannot create folder under per machine configuration path. HRESULT:  " +
-                           safe_convert::numberToString(hr));
+                           safe_convert::numberToHexString(hr));
          return FilePath();
       }
    }

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -124,7 +124,7 @@ FilePath resolveXdgDir(
       else
       {
          LOG_ERROR_MESSAGE("Unable to retrieve app settings path. HRESULT:  " +
-                           safe_convert::numberToString(hr));
+                           safe_convert::numberToHexString(hr));
       }
 
       // Free memory if allocated

--- a/src/cpp/shared_core/include/shared_core/SafeConvert.hpp
+++ b/src/cpp/shared_core/include/shared_core/SafeConvert.hpp
@@ -25,6 +25,7 @@
 #define SHARED_CORE_SAFE_CONVERT_HPP
 
 #include <string>
+#include <iomanip>
 #include <ios>
 #include <iostream>
 #include <locale>
@@ -107,6 +108,34 @@ T stringTo(const std::string& in_strValue,
    if ((iss >> in_f >> result).fail())
       return in_defaultValue;
    return result;
+}
+
+/**
+ * @brief Converts a number to string value in hexadecimal representation.
+ *
+ * @param in_input                  The number to convert.
+ * @param in_localeIndependent      Whether to perform the conversion independent of locale. Default: true.
+ *
+ * @return The converted string on successful conversion; empty string otherwise.
+ */
+inline std::string numberToHexString(long in_input, bool in_localeIndependent = true)
+{
+   try
+   {
+      std::ostringstream stream;
+      if (in_localeIndependent)
+         stream.imbue(std::locale::classic()); // force locale-independence
+      stream << "0x";
+      // ensure remainder of string after "0x" is 8 characters by adding 0's if needed (e.g. 0x00030201)
+      stream << std::setfill('0') << std::setw(8) << std::right;
+      stream << std::hex;
+      stream << in_input;
+      return stream.str();
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+
+   // return empty string for unexpected error
+   return std::string();
 }
 
 /**

--- a/src/cpp/shared_core/system/Win32User.cpp
+++ b/src/cpp/shared_core/system/Win32User.cpp
@@ -78,7 +78,7 @@ FilePath currentCSIDLPersonalHomePath()
    else
    {
       log::logWarningMessage("Unable to retrieve user home path. HRESULT:  " +
-                          safe_convert::numberToString(hr));
+                          safe_convert::numberToHexString(hr));
       return FilePath();
    }
 }
@@ -101,7 +101,7 @@ FilePath defaultCSIDLPersonalHomePath()
    else
    {
       log::logWarningMessage("Unable to retrieve user home path. HRESULT:  " +
-                          safe_convert::numberToString(hr));
+                          safe_convert::numberToHexString(hr));
       return FilePath();
    }
 }


### PR DESCRIPTION
### Intent

> Fixed #10310. HRESULT error values are now logged in hexadecimal representation as specified by [this Microsoft reference](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/705fb797-2175-4a90-b5a3-3918024b10b8).
>
> Apologies for cluttering #10310 with multiple commits referencing that issue. I ran `git push --force` after discovering that I needed to make changes to a pushed commit. For example, adding an entry to the `Fixed` section of `News.md`. For future reference, would you prefer I add multiple commits or squash the commits into one using `git push --force`?

### Approach

> Created a new function `safe_converter::numberToHexString(long, bool)` based on the previous function `safe_converter::numberToString(double, bool)`. Then replaced calls to the previous function with calls to the new function for converting HRESULT error values to strings.
>
> Added header `#include <iomanip>` in order to use `std::setw` and `std::setfill`. These are used in the new function to ensure that hex strings smaller than `0x10000000` are always have 8 characters after the initial `0x` by padding the hex string with leading 0's. For example, a `long` that stores the value `0x00030200` STG_S_CONVERTED without the padding becomes `0x30200` in string format.
> 
> Kept `safe_converter::numberToString(double, bool)` because I was unsure if the function is used anywhere other than converting HRESULT values. There is another function of the same name but with a different type signature that uses a template, called `safe_converter::numberToString(T, bool)`. It was not clear to me if the other function would be able to handle all number to string conversions if `safe_converter::numberToString(double, bool)` were deleted. I would appreciate guidance from a reviewer on whether `safe_converter::numberToString(double, bool)` should be kept or deleted.
>
> I assumed that the input HRESULT error values are of type `long` instead of `double` like the previous function because:
> - `windef.h` contains definition `typedef LONG HRESULT;`
> - `winnt.h` contains definition `typedef long		LONG;`
> - When treated as a `double`, HRESULT values that are greater than `0x7FFFFFFF` (max value of signed 32-bit integer), such as `0xC02625E0` ERROR_GRAPHICS_ONLY_CONSOLE_SESSION_SUPPORTED, have scientific notation characters in the output string. For example, the double representation of `0xC02625E0` is `3.22373e+09`, which when converted to a hex string becomes `0x3.22373e+09`. I assumed we don't want the `e+09` scientific notation.
> 
> I have attached links to code snippets on GDB online for comparison:
> - [HRESULT values of type `long` as input - no scientific notation](https://onlinegdb.com/Z_UD1OQfg)
> - [HRESULT values of type `double` as input - has scientific notation](https://onlinegdb.com/o_pIR1cak)

### Automated Tests

> None currently, but open to suggestions from a reviewer. The reasons are:
> - I could not find existing tests for `safe_converter::numberToString(double, bool)` or the functions call it.
> - I am not sure where to add new test functions and/or new test files.
>
> If someone can guide me to where I should write test functions in existing test files and/or in new test files, I will be happy to add tests. Also, I am wondering is it possible to run individual test files instead of all tests?
>
> The code snippets links I provided above can be used as a starting point for unit tests. I have provided inputs of HRESULT values in both decimal and hexadecimal form as proof that the new function `safe_converter::numberToHexString` works as intended.

### QA Notes

> I have not run the unit tests yet but will do so ASAP. Currently I am stuck on [this part](https://github.com/rstudio/rstudio/tree/main/dependencies/windows#clone-the-repo-and-run-batch-file) of the installation process for Windows. I get the following error about soci not have a CMakeLists.txt file:
```
> cmake -G "Visual Studio 15 2017" -A Win32 -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_INCLUDE_PATH="C:\Users\zishi\Desktop\rstudio\dependencies\windows\boost-1.78.0-win-msvc141-release-static\boost64/include" -DBoost_USE_STATIC_LIBS=ON -DCMAKE_LIBRARY_PATH="C:\Users\zishi\Desktop\rstudio\dependencies\windows\boost-1.78.0-win-msvc141-release-static\boost64/lib" -DSOCI_TESTS=OFF -DSOCI_SHARED=OFF -DWITH_POSTGRESQL=ON -DWITH_SQLITE3=ON -DSQLITE3_INCLUDE_DIR="C:/Users/zishi/Desktop/rstudio/dependencies/windows/install-soci/sqlite/sqlite-amalgamation-3310100" -DSQLITE3_LIBRARY="C:/Users/zishi/Desktop/rstudio/dependencies/windows/install-soci/sqlite/sqlite3-debug-x86.lib" -DPOSTGRESQL_INCLUDE_DIR="C:/Users/zishi/Desktop/rstudio/dependencies/windows/install-soci/postgresql/include" -DPOSTGRESQL_LIBRARY="C:/Users/zishi/Desktop/rstudio/dependencies/windows/install-soci/postgresql/lib/x86/Debug/libpq.lib" ..\..
FATAL: Command exited with status 1.
Logs written to C:\Users\zishi\Desktop\rstudio\dependencies\windows\install-soci\logs\cmake-output-50804ac23cd.txt:
CMake Error: The source directory "C:/Users/zishi/Desktop/rstudio/dependencies/windows/install-soci/soci" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
```

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I have signed the contributor agreement as described in CONTRIBUTING.md.
