### PR TITLE
Let page table output use custom format methods for vctrs_vctr classes

### DIFF
--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -230,6 +230,10 @@
     paste0(" [", dim_desc(x), "]" )
   }
 
+  needs_obj_sum <- function(x) {
+	  is.list(x) && !is(x, "vctrs_vctr")
+  }
+
   obj_sum.default <- function(x) {
     paste0(type_sum(x), size_sum(x))
   }
@@ -293,8 +297,8 @@
 
   columns <- unname(columns)
 
-  is_list <- vapply(data, is.list, logical(1))
-  data[is_list] <- lapply(data[is_list], function(x) {
+  needs_obj_sums <- vapply(data, needs_obj_sum, logical(1))
+  data[needs_obj_sums] <- lapply(data[needs_obj_sums], function(x) {
         summary <- obj_sum(x)
         paste0("<", summary, ">")
       })

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -231,7 +231,13 @@
   }
 
   needs_obj_sum <- function(x) {
-	  is.list(x) && !is(x, "vctrs_vctr")
+    if (!is.list(x)) return(FALSE)
+    if (!is(x, "vctrs_vctr")) return(TRUE)
+    for (cl in class(x)) {
+      if (cl == "vctrs_vctr") return(TRUE)
+      if (!is.null(getS3Method("format", cl, optional = T))) return(FALSE)
+    }
+    TRUE
   }
 
   obj_sum.default <- function(x) {


### PR DESCRIPTION
### Intent

This PR is meant to fix #6878 and allow custom representations for vctrs-derived classes in Rstudio notebook chunk output.

Before:
![Screenshot from 2022-03-12 13-12-32](https://user-images.githubusercontent.com/1994318/158035227-7f6df566-ca28-4cf4-a7b0-f9fe89ff3d9a.png)

After:
![Screenshot from 2022-03-12 13-14-09](https://user-images.githubusercontent.com/1994318/158035229-afcd1405-d256-4c57-9f5c-f45da749b6c1.png)

### Approach

Because vectors based on vctrs_vctr are, internally, lists, they are treated as such in the chunk output, and the only information the user gets about the vector in the output is the class name. This makes these vector types difficult to use.

Of the people who reported desire for this on issue #6878, there was a consistent theme that we encountered this behavior in regards to a vctrs_vctr class. This is reasonable considering the philosophy of vctrs, which is meant to enable custom behavior while still maintaining the user-facing conventions of common vector classes. Therefore this may be as easy as allowing this custom formatting behavior for vctrs_vctr classes only.

It feels strange to me to hardcode only one class type, but in my judgement it is the solution least likely to have unintended consequences. Other, more open approaches may work just as well.

### Automated Tests

I would like some help on this. I'd like to include an object of class vctrs_vctr with and without a custom format method. I'm not sure where that testing code would go, though.

### QA Notes

None I am aware of.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

I have yet to sign the contributor agreement.

