### PR TITLE
PT: Fix session restore when pandoc location does not exist

### DIFF
--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -194,7 +194,7 @@ void setEnvVar(const std::string& name, const std::string& value)
    if (name == "RSTUDIO_SESSION_RSA_PRIVATE_KEY" && !core::system::getenv(name).empty())
       return;
 
-   if (name == "RSTUDIO_PANDOC" && !core::system::getenv(name).empty() && !FilePath(value).exists())
+   if (name == "RSTUDIO_PANDOC" && !FilePath(value).exists())
       return;
 
    core::system::setenv(name, value);

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -194,6 +194,9 @@ void setEnvVar(const std::string& name, const std::string& value)
    if (name == "RSTUDIO_SESSION_RSA_PRIVATE_KEY" && !core::system::getenv(name).empty())
       return;
 
+   if (name == "RSTUDIO_PANDOC" && !core::system::getenv(name).empty() && !FilePath(value).exists())
+      return;
+
    core::system::setenv(name, value);
 }
 

--- a/version/news/NEWS-2022.02.1-prairie-trillium.md
+++ b/version/news/NEWS-2022.02.1-prairie-trillium.md
@@ -8,3 +8,4 @@
 * Fixed hang running Rmd chunks with launcher sessions and other problems the new session-ssl feature of RStudio Workbench (Pro #3301)
 * Fixed failure to create log file for rserver-session-reaper (#3307)
 * Fixed failure to create log file for rserver-acls (#3318)
+* Fixed restoring session containing invalid `RSTUDIO_PANDOC` value


### PR DESCRIPTION
### Intent
Handle PT resuming a session created with GO. Since Pandoc moved locations, the restored `RSTUDIO_PANDOC` location does not exist.

### Approach
When restoring the `RSTUDIO_PANDOC` env var, use the value if the directory exists. Otherwise, use the system set location.

### Automated Tests
None

### QA Notes
I have not been able to reproduce this in a dev environment so I cannot test if this actually works. I'm still working on reproducing so I can test this.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


