### PR TITLE
Propagate R execution error messages in full

### DIFF
--- a/src/cpp/r/RErrorCategory.cpp
+++ b/src/cpp/r/RErrorCategory.cpp
@@ -84,7 +84,7 @@ std::string RErrorCategory::message( int ev ) const
 core::Error rCodeExecutionError(const std::string& errMsg, 
                                 const core::ErrorLocation& location)
 {
-   core::Error error(errc::CodeExecutionError, location);
+   core::Error error(errc::CodeExecutionError, errMsg, location);
    error.addProperty("errormsg", errMsg);
    return error;
 }


### PR DESCRIPTION
### Intent

Addresses #10443. Follow up from #10435, but allows any R code execution error messages to be accessible in the frontend.

### Approach

Instead of using the 2-argument Error constructor `Error::Error(const boost::system::error_code& in_ec, const ErrorLocation& in_location)`, we should use the 3-argument Error constructor `Error::Error(const boost::system::error_code& in_ec, std::string in_message, const ErrorLocation& in_location)`, which already exists, when calling the `rCodeExecutionError` function. This means that instead of using `"R code execution error"` as the error message for all R code execution errors, and not passing any further detailed error messages to the frontend, the frontend will now have access to the actual content of the R error message, and developers can choose to display that error to the user, or handle it further in the frontend if desired.

### Automated Tests

None

### QA Notes

This change is mostly to enable developers, so mostly we'd want to ensure that existing tests don't break. To really kick the tires on it, and test the motivating example:

**OLD BEHAVIOR**
1. Navigate to `PYTHON_PREFIX/lib/pythonX.Y/site-packages/conda/_vendor/toolz/` and rename `itertoolz.py` to `XXXitertoolz.py` (On my computer this is `/Users/jacquelinegutman/Library/miniconda3/lib/python3.9/site-packages/conda/_vendor/toolz/itertoolz.py`. You should then see an error when running `conda env list --json --quiet` in the terminal. (Don't forget to rename it back when you're done testing!)
2. In RStudio, navigate to Tools > Global Options > Python, and under Python interpreters, click Select...
3. If you're running Spotted Wakerobin, let's say version 2022.06.0-daily+208 (prior to the current fix) you will get an error message in the UI like
<img width="280" alt="image" src="https://user-images.githubusercontent.com/7817881/158657329-39e15cf4-6a2b-4570-a638-c82341d5b322.png">
4. When you click OK, you will get a more detailed error message in the console. 
<img width="1071" alt="image" src="https://user-images.githubusercontent.com/7817881/158657459-32fef41c-ad98-4b9f-9faf-6d070221240b.png">

**NEW BEHAVIOR**
In the current version, introduced by this change:
2. In RStudio, navigate to Tools > Global Options > Python, and under Python interpreters, click Select...
3. You will see a much more detailed error message, such as 
<img width="274" alt="Screen Shot 2022-03-16 at 2 08 49 PM" src="https://user-images.githubusercontent.com/7817881/158658325-7d0f5797-5efe-48cd-8794-462dbfbd8ff7.png">
<img width="276" alt="Screen Shot 2022-03-16 at 2 08 57 PM" src="https://user-images.githubusercontent.com/7817881/158658368-d06e6310-5d0b-4157-b41d-3762199a8519.png">
4. Once again when you click OK, you will get the error message in the console as well

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


