### PR TITLE
fix path to Windows install

### DIFF
--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -44,7 +44,7 @@ RUN "echo 'Remove-Item alias:r' | Out-File $PsHome\Profile.ps1"
 # install R to c:\R, a common c:\Program issue appears to only happen when installing in docker
 RUN $ErrorActionPreference = 'Stop' ;`
   [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
-  (New-Object System.Net.WebClient).DownloadFile('https://cran.rstudio.com/bin/windows/base/old/3.3.0/R-3.3.0-win.exe', 'c:\R-3.3.0-win.exe') ;`
+  (New-Object System.Net.WebClient).DownloadFile('https://cran-archive.r-project.org/bin/windows/base/old/3.3.0/R-3.3.0-win.exe', 'c:\R-3.3.0-win.exe') ;`
   Start-Process c:\R-3.3.0-win.exe -Wait -ArgumentList '/VERYSILENT /DIR="C:\R\R-3.3.0\"' ;`
   Remove-Item c:\R-3.3.0-win.exe -Force
 


### PR DESCRIPTION
### Intent

The Windows dockerfile was trying to download `https://cran.rstudio.com/bin/windows/base/old/3.3.0/R-3.3.0-win.exe`. It does not exist. Change was made here: https://github.com/rstudio/rstudio/pull/10769

### Approach

Use `https://cran-archive.r-project.org/bin/windows/base/old/3.3.0/R-3.3.0-win.exe` instead.

### Automated Tests

Build-stuff

### QA Notes

Build-stuff

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


