### PR TITLE
update to soci 4.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,6 @@
 
 ## RStudio 2022-06.0 "Spotted Wakerobin" Release Notes
 
-
 ### New
 
 - Source marker `message` can contain ANSI SGR codes for setting style and color (#9010)
@@ -10,8 +9,10 @@
 - "Clean and Rebuild" and "Install and Restart" have been merged into "Install Package", the "Project Options > Build" gains a "clean before install" option to toggle the --preclean flag. The Build toolbar changes to "Install | Test | Check | More v" (#4289)
 - The source button uses `cpp11::source_cpp()` on C++ files that have `[[cpp11::register]]` decorations (#10387)
 - New *Relative Line Numbers* preference for showing line numbers relative to the current line, rather than the first line (#1774)
+- Upgraded SOCI library dependency from version 4.0.0 to 4.0.3 (#10792)
 
 #### Find in Files
+
 - Fixed Find in Files whole-word replace option, so that when "Whole word" is checked, only file matches containing the whole word are replaced, as displayed in the preview (#9813)
 - Adds support for POSIX extended regular expressions with backreferences in Find in Files find and replace modes, so that special regex characters such as `+` and `?`, `|`, `(`, etc do not need to be escaped, and other ERE escape sequences such as `\b`, `\w`, and `\d` are now supported. This matches the behavior of R's own `grep()` function, but note that backslashes do not need to be escaped (as they typically are in R strings) (#9344)
 - The "Common R source files" option in Find in Files has been updated to "Common source files", with support for searching Markdown (of any type, including .Rmd), JS, and YAML files (#10526)
@@ -25,6 +26,7 @@
 - Removed support for versions of R earlier than R 3.3.0. (rstudio-pro#2887)
 
 #### Python
+
 - RStudio attempts to infer the appropriate version of Python when "Automatically activate project-local Python environments" is checked and the user has not requested a specific version of Python. This Python will be stored in the environment variable "RETICULATE_PYTHON_FALLBACK", available from the R console, the Python REPL, and the RStudio Terminal (#9990)
 
 ### Fixed
@@ -44,5 +46,3 @@
 ### Deprecated / Removed
 
 - The minimum supported R version for the IDE has been increased from R 3.0.1 to R 3.3.0 (rstudio-pro#2887)
-
-

--- a/dependencies/common/install-soci
+++ b/dependencies/common/install-soci
@@ -21,9 +21,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing SOCI"
 
 # vars
-SOCI_DIR=$RSTUDIO_TOOLS_ROOT/soci
-SOCI_BIN_DIR=$SOCI_DIR/build
-SOCI_URL=https://s3.amazonaws.com/rstudio-buildtools/soci.tar.gz
+SOCI_VERSION="4.0.3"
+SOCI_DIR="$RSTUDIO_TOOLS_ROOT/soci-${SOCI_VERSION}"
+SOCI_BIN_DIR="${SOCI_DIR}/build"
+SOCI_ARCHIVE=soci-${SOCI_VERSION}.tar.gz
+SOCI_URL="https://s3.amazonaws.com/rstudio-buildtools/${SOCI_ARCHIVE}"
 BOOST_VERSION="1_78_0"
 BOOST_DIR="$RSTUDIO_TOOLS_ROOT/boost/boost_$BOOST_VERSION"
 
@@ -38,8 +40,8 @@ cd "${RSTUDIO_TOOLS_ROOT}"
 
 # download and unpack SOCI sources
 if ! [ -d "$SOCI_DIR" ]; then
-   download "${SOCI_URL}" soci.tar.gz
-   tar zxvf soci.tar.gz
+   download "${SOCI_URL}" ${SOCI_ARCHIVE}
+   tar zxvf ${SOCI_ARCHIVE}
 fi
 cd "${SOCI_DIR}"
 
@@ -64,7 +66,15 @@ rm -f CMakeCache.txt
 : "${CMAKE=cmake}"
 : "${MAKE=make}"
 
-"${CMAKE}" -G "Unix Makefiles"                         \
+if has-program ninja
+then 
+   CMAKE_GENERATOR="Ninja"
+   MAKEFLAGS="-w dupbuild=warn ${MAKEFLAGS}"
+else
+   CMAKE_GENERATOR="Unix Makefiles"
+fi
+
+"${CMAKE}" -G"${CMAKE_GENERATOR}"                      \
    -DCMAKE_POLICY_DEFAULT_CMP0063="NEW"                \
    -DCMAKE_POLICY_DEFAULT_CMP0074="NEW"                \
    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=true         \
@@ -91,7 +101,7 @@ rm -f CMakeCache.txt
    -DWITH_ODBC=OFF                                     \
    ..
 
-"${MAKE}"
+"${CMAKE}" --build . --target all -- ${MAKEFLAGS}
 
 # fix up permissions so bin dir will be readable by others
 chmod -R 777 "$SOCI_BIN_DIR"

--- a/dependencies/windows/.gitignore
+++ b/dependencies/windows/.gitignore
@@ -23,6 +23,7 @@ install-soci/postgresql
 install-soci/soci.tar
 install-soci/soci.tar.gz
 install-soci/soci
+install-soci/soci-4*
 install-soci/sqlite
 
 sentry-cli.exe

--- a/dependencies/windows/install-soci/install-soci.R
+++ b/dependencies/windows/install-soci/install-soci.R
@@ -1,4 +1,4 @@
-# some laziness to ensure we move to the 'install-crashpad' folder
+# some laziness to ensure we move to the 'install-soci' folder
 if (file.exists("rstudio.Rproj"))
    setwd("dependencies/windows/install-soci")
 
@@ -23,10 +23,13 @@ if (length(msvc) == 0)
 PATH$prepend(msvc)
 
 # initialize variables
+soci_version="4.0.3"
+soci_tar <- paste0("soci-", soci_version, ".tar")
+soci_archive <- paste0(soci_tar, ".gz")
 output_dir <- normalizePath(file.path(owd, ".."), winslash = "\\")
 boost_dir <- normalizePath(file.path(output_dir, "boost-1.78.0-win-msvc141-release-static\\boost64"), winslash = "\\")
-soci_url <- "https://rstudio-buildtools.s3.amazonaws.com/soci.tar.gz"
-soci_dir <- file.path(owd, "soci")
+soci_url <- paste0("https://rstudio-buildtools.s3.amazonaws.com/soci-", soci_version, ".tar.gz")
+soci_dir <- file.path(owd, paste0("soci-", soci_version))
 soci_build_dir <- file.path(soci_dir, "build")
 sqlite_dir <- file.path(owd, "sqlite")
 postgresql_dir <- file.path(owd, "postgresql")
@@ -64,10 +67,10 @@ if (!file.exists(normalizePath(file.path(soci_build_dir, "x64\\lib\\Release\\lib
    # clone repository if we dont already have it
    if (!file.exists("soci")) {
       section("Downloading SOCI sources")
-      download(soci_url, destfile = "soci.tar.gz")
+      download(soci_url, destfile = soci_archive)
 	  section("Unzipping SOCI sources")
-	  exec("7z.exe", "-aoa", "e", "soci.tar.gz")
-	  exec("7z.exe", "-aoa", "x", "soci.tar")
+	  exec("7z.exe", "-aoa", "e", soci_archive)
+	  exec("7z.exe", "-aoa", "x", soci_tar)
    }
 
    # create build directories

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -427,10 +427,10 @@ endif()
 
 # SOCI
 if(UNIX)
-   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_TOOLS_ROOT}/soci")
+   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_TOOLS_ROOT}/soci-4.0.3")
    set(SOCI_INCLUDE_BUILD_DIR "${RSTUDIO_TOOLS_SOCI}/build/include")
 else()
-   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/install-soci/soci")
+   set(RSTUDIO_TOOLS_SOCI "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/install-soci/soci-4.0.3")
    if(RSTUDIO_SESSION_WIN32)
       set(SOCI_ARCH "x86")
    else()


### PR DESCRIPTION
### Intent

Addresses #10792

Prompted by a newer macOS toolchain causing our older SOCI to stop building.

### Approach

Update to latest 4.x SOCI, and make the installation versioned.

### Automated Tests

None specifically, this impacts the internal database.

I did apply and build Workbench with these changes and was able to use it with Postgres as the database as usual. Also did local test builds of desktop on Mac and Windows.

### QA Notes

Nothing to specifically test, just general usage especially of features that leverage the internal database.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


