### PR TITLE
validate assumption of length-1 input

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -674,10 +674,10 @@
    }
 
    # transform numeric line, column values to integer
-   if (is.numeric(line))
+   if (is.double(line))
       line <- as.integer(line)
    
-   if (is.numeric(col))
+   if (is.double(col))
       col <- as.integer(col)
 
    # validate line/col arguments

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -659,6 +659,9 @@
    if (hasFile && !is.character(path)) {
       stop("path must be a character")
    }
+   if (length(path) > 1L) {
+      stop("path must be a single file")
+   }
    if (hasFile && !file.exists(path)) {
       stop(path, " does not exist.")
    }


### PR DESCRIPTION
```
Sys.setenv("_R_CHECK_LENGTH_1_LOGIC2_"="true")
rstudio::navigateToFile(letters)
```

gives an ugly error without this