### PR TITLE
enable electron unit tests on rhel8 and centos7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,8 @@ def run_tests(os, type, flavor) {
     unstable("C++ unit tests failed (${flavor.capitalize()} ${type} on ${os})")
   }
 
-  if (flavor == "electron" && os == "bionic") {
+  if (flavor == "electron" && 
+      (os == "bionic" || os == "centos7" || os == "rhel8")) {
     try {
       // run the Electron unit tests
       sh "cd src/node/desktop && ./scripts/docker-run-unit-tests.sh"

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -25,6 +25,7 @@ RUN yum install -y \
     libacl-devel \
     libcap-devel \ 
     libffi \
+    libuser-devel \
     libuuid-devel \
     libxml2-devel \
     libXcursor-devel \
@@ -49,8 +50,8 @@ RUN yum install -y \
     sudo \
     wget \
     xml-commons-apis \
-    zlib-devel \
-    libuser-devel
+    xorg-x11-server-Xvfb \
+    zlib-devel
 
 # add scl repo and install additional dependencies
 RUN yum install -y \

--- a/docker/jenkins/Dockerfile.rhel8-x86_64
+++ b/docker/jenkins/Dockerfile.rhel8-x86_64
@@ -54,6 +54,7 @@ RUN yum install -y \
     sudo \
     valgrind \
     wget \
+    xorg-x11-server-Xvfb \
     zlib-devel
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)


### PR DESCRIPTION
### Intent

Part of #10732

### Approach

Install xvfb and enable Electron unit tests on rhel8 and centos7. Only opensuse15 remaining to enable.

### Automated Tests

Yes

### QA Notes

Self-testing

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


