### PR TITLE
Add package install prompt for Quarto markdown filetype

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2234,7 +2234,10 @@
       .rs.extractRCode(contents,
                        "^\\s*<<(.*)>>=.*$",
                        "^\\s*@\\s*(%+.*|)$")
-   
+   else if (identical(extension, ".qmd"))
+     .rs.extractRCode(contents,
+                      "^[\t >]*```+\\s*\\{([a-zA-Z0-9_]+.*)\\}\\s*$",
+                      "^[\t >]*```+\\s*$")
    if (is.null(code))
       return(character())
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPackageDependencyHelper.java
@@ -112,7 +112,8 @@ public class TextEditingTargetPackageDependencyHelper
       boolean canDiscoverDependencies =
             docDisplay_.getFileType().isR() ||
             docDisplay_.getFileType().isRmd() ||
-            docDisplay_.getFileType().isRnw();
+            docDisplay_.getFileType().isRnw() ||
+            docDisplay_.getFileType().isQuartoMarkdown();
       
       if (!canDiscoverDependencies)
          return;


### PR DESCRIPTION
### Intent

Addresses #10767

### Approach

Adds package install prompt for documents of type qmd -- previously checked only .R, .Rmd, and .Rnw filetypes

### Automated Tests

NA

### QA Notes

Create new quarto document, add `library(pkg)` for some not currently installed package. Save file. Info bar should show up prompting for installation of missing package, same as it does for .R and .Rmd files

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


