### PR TITLE
build fix, accomodate choco's removal of cpack alias

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -77,7 +77,8 @@ choco install -y nsis
 choco install -y python
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
-Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
+# Newer choco doesn't have this so don't fail if not found
+Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe' -ea ig
 
 [System.Net.ServicePointManager]::SecurityProtocol = $securityProtocolSettingsOriginal
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -59,7 +59,8 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
   Remove-Item c:\QtSDK-5.12.8-msvc2017_64.7z -Force
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
-RUN Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe'
+# Newer choco doesn't have this so don't fail if not found
+RUN if Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe' -ea ig
 
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####


### PR DESCRIPTION
The choco package manager used to create an alias named "cpack" which clashes with cmake's cpack, so we would delete the alias when setting up the machine.

Windows docker image creation failing because recent version of choco no longer create that alias.

Fix by appending `-ea ig` (shorthand for `-ErrorAction Ignore`) to the command. We could eventually remove this command altogether but let's leave in for the moment in case some machines still pull an older choco.