### PR TITLE
Extend fix from #9796 to also include building site, not only knitting

### DIFF
--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -37,6 +37,7 @@
 #include <core/r_util/RPackageInfo.hpp>
 
 #include <session/SessionOptions.hpp>
+#include "../modules/rmarkdown/SessionRMarkdown.hpp"
 
 #ifdef _WIN32
 #include <core/r_util/RToolsInfo.hpp>
@@ -353,7 +354,8 @@ private:
             core::system::setenv(&environment, "R_LIBS", rLibs);
 
          // pass along RSTUDIO_VERSION
-         core::system::setenv(&environment, "RSTUDIO_VERSION", RSTUDIO_VERSION);
+         core::system::setenv(&environment, "RSTUDIO_VERSION", modules::rmarkdown::parsableRStudioVersion());
+         core::system::setenv(&environment, "RSTUDIO_LONG_VERSION", RSTUDIO_VERSION);
 
          options.environment = environment;
          

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -271,21 +271,6 @@ enum RenderTerminateType
 std::vector<std::string> s_renderOutputs(kMaxRenderOutputs);
 int s_currentRenderOutput = 0;
 
-std::string parsableRStudioVersion()
-{
-   std::string version(RSTUDIO_VERSION_MAJOR);
-   version.append(".")
-      .append(RSTUDIO_VERSION_MINOR)
-      .append(".")
-      .append(RSTUDIO_VERSION_PATCH)
-      .append(".")
-      .append(boost::regex_replace(
-         std::string(RSTUDIO_VERSION_SUFFIX),
-         boost::regex("[a-zA-Z\\-+]"),
-         ""));
-   return version;
-}
-
 FilePath outputCachePath()
 {
    return module_context::sessionScratchPath().completeChildPath("rmd-outputs");
@@ -1710,6 +1695,21 @@ bool isSiteProject(const std::string& site)
    if (error)
       LOG_ERROR(error);
    return isSite;
+}
+
+std::string parsableRStudioVersion()
+{
+   std::string version(RSTUDIO_VERSION_MAJOR);
+   version.append(".")
+         .append(RSTUDIO_VERSION_MINOR)
+         .append(".")
+         .append(RSTUDIO_VERSION_PATCH)
+         .append(".")
+         .append(boost::regex_replace(
+               std::string(RSTUDIO_VERSION_SUFFIX),
+               boost::regex("[a-zA-Z\\-+]"),
+               ""));
+   return version;
 }
 
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.hpp
@@ -45,6 +45,8 @@ bool pptAvailable();
 
 core::Error evaluateRmdParams(const std::string& docId);
 
+std::string parsableRStudioVersion();
+
 core::Error initialize();
 
 } // namespace rmarkdown


### PR DESCRIPTION
### Intent

Addresses #9903, followup to PR #9796

### Approach

PR 9796 fixed the values of environment variables RSTUDIO_VERSION and RSTUDIO_LONG_VERSION so they would be sent correctly to Rmarkdown when knitting. However, the same fix needed to also be applied when building an RMarkdown website using the Build pane. This applies the same approach and function used in the previous PR to get called with the build pane

### Automated Tests

None

### QA Notes

See reprex in issue #9903 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


