### PR TITLE
Fix group member verification when group member lookup is disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@
 - The `Session > Load Workspace` menu option now explicitly namespaces `base::load` if the `load` function has been masked in the global environment (#10089)
 - The data viewer truncates large list cells to 50 characters by default, this can be changed with the command palette or `rstudioapi::writeRStudioPreference("data_viewer_max_cell_size", 10L)` (#5100)
 - The R version and logo displayed in the top left of the console will update to the current R version whenever the R session is restarted (#10458)
+- Fixed issue where `core::system::userBelongsToGroup` errors under specific sssd configurations (`ignore_group_members = true`) (#10829)
 
 ### RStudio Workbench
 

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -2470,7 +2470,7 @@ Error userBelongsToGroup(const User& user,
    // if the user is a member of the target groupName.
    Error groupListError = userBelongsToGroupViaGroupList(user, groupName, pBelongs);
 
-   // if the user belongs, then we can return early.
+   // if there was no error, then we can return early.
    // otherwise, we fallback to the legacy implementation
    if (!groupListError)
       return Success();


### PR DESCRIPTION
### Intent

fixes #10829  

### Approach

First we try to use getgrouplist(3) to determine if one of the
user's groups is the target group. If not, then we fall back
to the legacy implementation, using getgrnam_r(3) to attempt
a group member lookup.

### Automated Tests

Covered by existing tests

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


