### PR TITLE
use CSS workaround for Safari rendering bug

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/BrowseCap.java
+++ b/src/gwt/src/org/rstudio/core/client/BrowseCap.java
@@ -249,6 +249,15 @@ public class BrowseCap
    static
    {
       Document.get().getBody().addClassName(OPERATING_SYSTEM);
+      
+      if (isSafari())
+      {
+         Document.get().getBody().addClassName("safari");
+      }
+      else if (isChrome())
+      {
+         Document.get().getBody().addClassName("chrome");
+      }
 
       if (isWindowsDesktop())
       {

--- a/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ThemedPopupPanel.css
@@ -12,6 +12,7 @@
    suggestPopupContent, suggestPopupTop, suggestPopupBottom;
 @external gwt-MenuBar-vertical;
 
+@external safari;
 @external rstudio-themes-dark-menus;
 
 @external menuPopupTop, menuPopupBottom, menuPopupMiddle;
@@ -23,6 +24,11 @@
 
 @eval THEME_DARKGREY_MENU_BACKGROUND org.rstudio.core.client.theme.ThemeColors.darkGreyMenuBackground;
 @eval THEME_DARKGREY_MENU_BORDER org.rstudio.core.client.theme.ThemeColors.darkGreyMenuBorder;
+
+/* https://github.com/rstudio/rstudio/issues/10821 */
+.safari .themedPopupPanel, .safari .gwt-MenuBarPopup {
+   transform: translateZ(0);
+}
 
 .themedPopupPanel {
    margin: -6px;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10821.

This is probably eligible for backporting; if so I'll re-target to PT.

### Approach

Use a CSS hack to force Safari try to render / layout popup elements in a way that avoids the default buggy rendering behavior. There's a bit of justification for this technique in https://stackoverflow.com/questions/10814178/css-performance-relative-to-translatez0.

### Automated Tests

Not included; automated testing here is not really feasible.

### QA Notes

Check that menu items are rendered properly. See https://github.com/rstudio/rstudio/issues/10821 for more details.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
