### PR TITLE
be more permissive when finding the R help argument table

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -18,6 +18,7 @@ import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.dom.client.*;
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.DomUtils.NodePredicate;
 
@@ -150,30 +151,27 @@ public class HelpInfo extends JavaScriptObject
          }
       }
    }
+   
+   private Element findArgumentTable(Element heading)
+   {
+      for (Node node = (Node) heading; node != null; node = node.getNextSibling())
+      {
+         if (node.getNodeType() != node.ELEMENT_NODE)
+            continue;
+         
+         if (StringUtil.equals(node.getNodeName(), "TABLE"))
+            return (Element) node;
+      }
+      
+      return null;
+   }
 
    private void parseArguments(HashMap<String, String> args,
                                Element heading)
    {
-      Element table = (Element) DomUtils.findNode(heading, true, true, 
-                                                  new NodePredicate() {
-         public boolean test(Node n)
-         {
-            if (n.getNodeType() != Node.ELEMENT_NODE)
-               return false;
-            
-            Element el = (Element) n;
-            
-            return el.getTagName().toUpperCase().equals("TABLE")
-               && "R argblock".equals(el.getAttribute("summary"));
-         }
-      });
+      Element table = findArgumentTable(heading);
+      assert table != null : "Unexpected help format, no argblock table found";
       
-      if (table == null)
-      {
-         assert false : "Unexpected help format, no argblock table found"; 
-         return;
-      }
-
       TableElement t = (TableElement) table;
       NodeList<TableRowElement> rows = t.getRows();
       for (int i = 0; i < rows.getLength(); i++)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10844.

### Approach

With the new enhanced help system for R 4.2.0, the argument table is no longer given the attribute `summary="R argblock"`. However, because we know that the argument table must come after the "Arguments:" header, it's safe to just iterate forward over siblings and use the first table we find.

### Automated Tests

Should already be covered by existing Help pane tests.

### QA Notes

Check that the Help popup tooltip displays R help appropriately.

<img width="669" alt="Screen Shot 2022-03-25 at 11 37 15 AM" src="https://user-images.githubusercontent.com/1976582/160181558-f70c94cc-3bdb-444d-829f-1556f1379784.png">

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
