### PR TITLE
Electron preference defaults and legacy priority

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ TODO-INTERNAL
 *.pid
 
 node_modules/
+src/node/desktop/src/types/user-state-schema.d.ts

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -13,10 +13,6 @@
                     "items": {
                         "type": "string"
                     }
-                },
-                "clipboardMonitoring": {
-                    "type": "boolean",
-                    "description": "Linux clipboard monitoring for middle-click paste"
                 }
             },
             "default": {
@@ -32,16 +28,12 @@
                 },
                 "fixedWidthFont": {
                     "type": "string"
-                },
-                "useFontConfigDb": {
-                    "type": "boolean"
                 }
             },
             "description": "Font options from the Appearance category",
             "default": {
                 "proportionalFont": "",
-                "fixedWidthFont": "",
-                "useFontConfigDb": true
+                "fixedWidthFont": ""
             }
         },
         "view": {

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -4,6 +4,139 @@
     "title": "RStudio User State",
     "type": "object",
     "properties": {
+        "general": {
+            "type": "object",
+            "properties": {
+                "ignoredUpdateVersions": {
+                    "type": "array",
+                    "description": "A list of ignored updates. Ignored updates will not trigger an available update.",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "clipboardMonitoring": {
+                    "type": "boolean",
+                    "description": "Linux clipboard monitoring for middle-click paste"
+                }
+            },
+            "default": {
+                "ignoredUpdateVersions": [],
+                "clipboardMonitoring": true
+            }
+        },
+        "font": {
+            "type": "object",
+            "properties": {
+                "proportionalFont": {
+                    "type": "string"
+                },
+                "fixedWidthFont": {
+                    "type": "string"
+                },
+                "useFontConfigDb": {
+                    "type": "boolean"
+                }
+            },
+            "description": "Font options from the Appearance category",
+            "default": {
+                "proportionalFont": "",
+                "fixedWidthFont": "",
+                "useFontConfigDb": true
+            }
+        },
+        "view": {
+            "type": "object",
+            "properties": {
+                "zoomLevel": {
+                    "type": "number",
+                    "description": "UI zoom level, 1.0 == 100%",
+                    "enum": [0.25, 0.5, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0, 5.0]
+                },
+                "windowBounds": {
+                    "type": "object",
+                    "description": "Window location and size",
+                    "properties": {
+                        "width": { "type": "number" },
+                        "height": { "type": "number" },
+                        "x": { "type": "number" },
+                        "y": { "type": "number" }
+                    }
+                },
+                "accessibility": {
+                    "type": "boolean",
+                    "description": "Screen reader support" 
+                }
+            },
+            "default": {
+                "zoomLevel": 1.5,
+                "windowBounds": { "width": 1200, "height": 900, "x": 0, "y": 0 },
+                "accessibility": false
+            }
+        },
+        "session": {
+            "type": "object",
+            "properties": {
+                "lastRemoteSessionUrl": {
+                    "type": "string"
+                },
+                "authCookies": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "tempAuthCookies": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "default": {
+                "lastRemoteSessionUrl": "",
+                "authCookies": [],
+                "tempAuthCookies": []
+            }
+        },
+        "renderer": {
+            "type": "object",
+            "properties": {
+                "engine": {
+                    "type": "string",
+                    "enum": ["auto", "desktop", "gles"]
+                },
+                "useGpuExclusionList": {
+                    "type": "boolean"
+                },
+                "useGpuDriverBugWorkarounds": {
+                    "type": "boolean"
+                }
+            },
+            "default": {
+                "engine": "auto",
+                "useGpuExclusionList": true,
+                "useGpuDriverBugWorkarounds": true
+            }
+        },
+        "platform": {
+            "type": "object",
+            "properties": {
+                "windows": {
+                    "type": "object",
+                    "properties": {
+                        "rBinDir": { "type": "string" },
+                        "preferR64": { "type": "boolean" }
+                    }
+                }
+            },
+            "default": {
+                "windows": {
+                    "rBinDir": "",
+                    "preferR64": true,
+                    "rstudioPath": ""
+                }
+            }
+        },
         "context_id": {
             "type": "string",
             "default": "",

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -42,7 +42,8 @@
                 "zoomLevel": {
                     "type": "number",
                     "description": "UI zoom level, 1.0 == 100%",
-                    "enum": [0.25, 0.5, 0.75, 0.8, 0.9, 1.0, 1.1, 1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 4.0, 5.0]
+                    "minimum": 0.25,
+                    "maximum": 5.0
                 },
                 "windowBounds": {
                     "type": "object",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -324,7 +324,7 @@ public class GeneralPreferencesPane extends PreferencesPane
             useGpuDriverBugWorkarounds_.setValue(!disable);
          });
 
-         if (BrowseCap.isLinuxDesktop())
+         if (BrowseCap.isLinuxDesktop() && !BrowseCap.isElectron())
          {
             clipboardMonitoring_ = new CheckBox(constants_.clipboardMonitoringLabel());
             advanced.add(lessSpaced(clipboardMonitoring_));

--- a/src/node/desktop/NOTICE.electron
+++ b/src/node/desktop/NOTICE.electron
@@ -19,6 +19,7 @@ used by these components are included below):
 - yargs
 - node-system-fonts
 - properties-reader (npm)
+- json-schema-to-typescript (npm)
 
 Electron License
 ----------------------------------------------------------------------
@@ -292,6 +293,29 @@ properties-reader (npm) License
 The MIT License (MIT)
 
 Copyright (c) 2013 Steve King
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+json-schema-to-typescript (npm) License
+----------------------------------------------------------------------
+The MIT License (MIT)
+
+Copyright (c) 2021 bcherny
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -57,6 +57,7 @@
         "eslint-plugin-promise": "5.1.1",
         "fork-ts-checker-webpack-plugin": "6.4.0",
         "json": "11.0.0",
+        "json-schema-to-typescript": "10.1.5",
         "mocha": "9.2.2",
         "node-loader": "2.0.0",
         "nyc": "15.1.0",
@@ -82,6 +83,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -95,27 +108,27 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.3",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.3",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
@@ -181,9 +194,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.17.0",
@@ -204,12 +217,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.16.4",
+        "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
@@ -293,31 +306,31 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -354,13 +367,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0"
       },
       "engines": {
@@ -438,9 +451,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -496,9 +509,9 @@
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -1598,6 +1611,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -1896,7 +1915,6 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
-      "optional": true,
       "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -1963,6 +1981,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "dev": true
+    },
     "node_modules/@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -1973,8 +1997,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/@types/mocha": {
       "version": "9.1.0",
@@ -1992,6 +2015,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/@types/prettier": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
+      "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
     "node_modules/@types/properties-reader": {
@@ -2775,6 +2804,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
     "node_modules/anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -3443,6 +3478,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3619,6 +3660,22 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cli-color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "integrity": "sha512-eBbxZF6fqPUNnf7CLAFOersUnyYzv83tHFLSlts+OAHsNendaqv2tHCq+/MO+b3Y+9JeoUlIvobyxG/Z8GNeOg==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/cli-cursor": {
@@ -4338,6 +4395,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "node_modules/dashdash": {
@@ -6070,11 +6137,59 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es5-ext": {
+      "version": "0.10.58",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.58.tgz",
+      "integrity": "sha512-LHO+KBBaHGwjy32ibSaMY+ZzjpC4K4I5bPoijICMBL7gXEXfrEUrzssmNP+KigbQEp1dRUnGkry/vUnxOqptLQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "node_modules/es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -6766,6 +6881,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "dependencies": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -6954,6 +7079,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "dependencies": {
+        "type": "^2.5.0"
+      }
+    },
+    "node_modules/ext/node_modules/type": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+      "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+      "dev": true
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -7868,6 +8008,21 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/glob-promise": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+      "dev": true,
+      "dependencies": {
+        "@types/glob": "*"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "glob": "*"
       }
     },
     "node_modules/glob-to-regexp": {
@@ -9028,6 +9183,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -9446,6 +9607,59 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
+    "node_modules/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/json-schema-to-typescript": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+      "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
+      "dev": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.6",
+        "@types/lodash": "^4.14.168",
+        "@types/prettier": "^2.1.5",
+        "cli-color": "^2.0.0",
+        "get-stdin": "^8.0.0",
+        "glob": "^7.1.6",
+        "glob-promise": "^3.4.0",
+        "is-glob": "^4.0.1",
+        "json-schema-ref-parser": "^9.0.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.4",
+        "mz": "^2.7.0",
+        "prettier": "^2.2.0"
+      },
+      "bin": {
+        "json2ts": "dist/src/cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/json-schema-to-typescript/node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -9785,6 +9999,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "node_modules/lzma-native": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
@@ -9969,6 +10192,22 @@
       },
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "dev": true,
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
       }
     },
     "node_modules/meow": {
@@ -10600,6 +10839,17 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -10636,6 +10886,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "node_modules/nice-try": {
@@ -14067,6 +14323,27 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
@@ -14112,6 +14389,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "node_modules/timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "dependencies": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "node_modules/tiny-each-async": {
       "version": "2.0.3",
@@ -14382,6 +14669,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "node_modules/type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "node_modules/type-check": {
@@ -15409,6 +15702,18 @@
         "@jridgewell/trace-mapping": "^0.3.0"
       }
     },
+    "@apidevtools/json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-GBD2Le9w2+lVFoc4vswGI/TjkNIZSVp7+9xPf+X3uidBfWnAeUWmquteSyt0+VCrhNMWj/FTABISQrD3Z/YA+w==",
+      "dev": true,
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.16.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
@@ -15419,24 +15724,24 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.0.tgz",
-      "integrity": "sha512-392byTlpGWXMv4FbyWw3sAZ/FrW/DrwqLGXpy0mbyNe9Taqv1mg9yON5/o0cnr8XYCkFTZbC1eV+c+LAROgrng==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
+      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.17.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.4.tgz",
-      "integrity": "sha512-R9x5r4t4+hBqZTmioSnkrW+I6NmbojwjGT8p4G2Gw1thWbXIHGDnmGdLdFw0/7ljucdIrNRp7Npgb4CyBYzzJg==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
       "dev": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.3",
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.16.7",
-        "@babel/helpers": "^7.17.2",
-        "@babel/parser": "^7.17.3",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
         "@babel/template": "^7.16.7",
         "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0",
@@ -15480,9 +15785,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.3.tgz",
-      "integrity": "sha512-+R6Dctil/MgUsZsZAkYgK+ADNSZzJRRy0TvY65T71z/CR854xHQ1EweBYXdfT+HNeN7w0cSJJEzgxZMv40pxsg==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.17.0",
@@ -15499,12 +15804,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
-      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
+      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.4",
+        "@babel/compat-data": "^7.17.7",
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
@@ -15566,28 +15871,28 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
-      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
       "dev": true,
       "requires": {
         "@babel/helper-environment-visitor": "^7.16.7",
         "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-simple-access": "^7.17.7",
         "@babel/helper-split-export-declaration": "^7.16.7",
         "@babel/helper-validator-identifier": "^7.16.7",
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
-      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.17.0"
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -15612,13 +15917,13 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.2.tgz",
-      "integrity": "sha512-0Qu7RLR1dILozr/6M0xgj+DFPmi6Bnulgm9M8BVa9ZCWxDqlSnqt3cf8IDPB5m45sVXUZ0kuQAgUrdSFFH79fQ==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
+      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.0",
+        "@babel/traverse": "^7.17.3",
         "@babel/types": "^7.17.0"
       }
     },
@@ -15677,9 +15982,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.3.tgz",
-      "integrity": "sha512-7yJPvPV+ESz2IUTPbOL+YkIGyCqOyNIzdguKQuJGnH7bg1WTIifuM21YqokFt/THWh1AkCRn9IgoykTRCBVpzA==",
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
       "dev": true
     },
     "@babel/runtime": {
@@ -15720,9 +16025,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -16556,6 +16861,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "@malept/cross-spawn-promise": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
@@ -16820,7 +17131,6 @@
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
       "integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
@@ -16886,6 +17196,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.180",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.180.tgz",
+      "integrity": "sha512-XOKXa1KIxtNXgASAnwj7cnttJxS4fksBRywK/9LzRV5YxrF80BXZIGeQSuoESQ/VkUj30Ae0+YcuHc15wJCB2g==",
+      "dev": true
+    },
     "@types/mime": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
@@ -16896,8 +17212,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
       "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/mocha": {
       "version": "9.1.0",
@@ -16915,6 +17230,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "@types/prettier": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
+      "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
     "@types/properties-reader": {
@@ -17526,6 +17847,12 @@
         }
       }
     },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
     "anymatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -18045,6 +18372,12 @@
         "get-intrinsic": "^1.0.2"
       }
     },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+      "dev": true
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -18174,6 +18507,19 @@
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
       "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
+    },
+    "cli-color": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.1.tgz",
+      "integrity": "sha512-eBbxZF6fqPUNnf7CLAFOersUnyYzv83tHFLSlts+OAHsNendaqv2tHCq+/MO+b3Y+9JeoUlIvobyxG/Z8GNeOg==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-iterator": "^2.0.3",
+        "memoizee": "^0.4.15",
+        "timers-ext": "^0.1.7"
+      }
     },
     "cli-cursor": {
       "version": "3.1.0",
@@ -18714,6 +19060,16 @@
       "dev": true,
       "requires": {
         "array-find-index": "^1.0.1"
+      }
+    },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dashdash": {
@@ -20035,11 +20391,55 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.58",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.58.tgz",
+      "integrity": "sha512-LHO+KBBaHGwjy32ibSaMY+ZzjpC4K4I5bPoijICMBL7gXEXfrEUrzssmNP+KigbQEp1dRUnGkry/vUnxOqptLQ==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "next-tick": "^1.1.0"
+      }
+    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
       "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "ext": "^1.1.2"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.46",
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.1"
+      }
     },
     "escalade": {
       "version": "3.1.1",
@@ -20543,6 +20943,16 @@
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
       "dev": true
     },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
+    },
     "eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -20689,6 +21099,23 @@
       "dev": true,
       "requires": {
         "ws": "^7.4.6"
+      }
+    },
+    "ext": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.6.0.tgz",
+      "integrity": "sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==",
+      "dev": true,
+      "requires": {
+        "type": "^2.5.0"
+      },
+      "dependencies": {
+        "type": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/type/-/type-2.6.0.tgz",
+          "integrity": "sha512-eiDBDOmkih5pMbo9OqsqPRGMljLodLcwd5XD5JbtNB0o89xZAwynY9EdCDsJU7LtcVCClu9DvM7/0Ep1hYX3EQ==",
+          "dev": true
+        }
       }
     },
     "extend": {
@@ -21381,6 +21808,15 @@
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
+      }
+    },
+    "glob-promise": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/glob-promise/-/glob-promise-3.4.0.tgz",
+      "integrity": "sha512-q08RJ6O+eJn+dVanerAndJwIcumgbDdYiUT7zFQl3Wm1xD6fBKtah7H8ZJChj4wP+8C+QfeVy8xautR7rdmKEw==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*"
       }
     },
     "glob-to-regexp": {
@@ -22233,6 +22669,12 @@
         "isobject": "^3.0.1"
       }
     },
+    "is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "dev": true
+    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -22548,6 +22990,46 @@
       "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
       "dev": true
     },
+    "json-schema-ref-parser": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-9.0.9.tgz",
+      "integrity": "sha512-qcP2lmGy+JUoQJ4DOQeLaZDqH9qSkeGCK3suKWxJXS82dg728Mn3j97azDMaOUmJAN4uCq91LdPx4K7E8F1a7Q==",
+      "dev": true,
+      "requires": {
+        "@apidevtools/json-schema-ref-parser": "9.0.9"
+      }
+    },
+    "json-schema-to-typescript": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/json-schema-to-typescript/-/json-schema-to-typescript-10.1.5.tgz",
+      "integrity": "sha512-X8bNNksfCQo6LhEuqNxmZr4eZpPjXZajmimciuk8eWXzZlif9Brq7WuMGD/SOhBKcRKP2SGVDNZbC28WQqx9Rg==",
+      "dev": true,
+      "requires": {
+        "@types/json-schema": "^7.0.6",
+        "@types/lodash": "^4.14.168",
+        "@types/prettier": "^2.1.5",
+        "cli-color": "^2.0.0",
+        "get-stdin": "^8.0.0",
+        "glob": "^7.1.6",
+        "glob-promise": "^3.4.0",
+        "is-glob": "^4.0.1",
+        "json-schema-ref-parser": "^9.0.6",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.20",
+        "minimist": "^1.2.5",
+        "mkdirp": "^1.0.4",
+        "mz": "^2.7.0",
+        "prettier": "^2.2.0"
+      },
+      "dependencies": {
+        "get-stdin": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+          "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+          "dev": true
+        }
+      }
+    },
     "json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -22840,6 +23322,15 @@
         "yallist": "^4.0.0"
       }
     },
+    "lru-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.2"
+      }
+    },
     "lzma-native": {
       "version": "8.0.6",
       "resolved": "https://registry.npmjs.org/lzma-native/-/lzma-native-8.0.6.tgz",
@@ -22986,6 +23477,22 @@
       "dev": true,
       "requires": {
         "fs-monkey": "1.0.3"
+      }
+    },
+    "memoizee": {
+      "version": "0.4.15",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
+      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
+      "dev": true,
+      "requires": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.53",
+        "es6-weak-map": "^2.0.3",
+        "event-emitter": "^0.3.5",
+        "is-promise": "^2.2.2",
+        "lru-queue": "^0.1.0",
+        "next-tick": "^1.1.0",
+        "timers-ext": "^0.1.7"
       }
     },
     "meow": {
@@ -23460,6 +23967,17 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "nan": {
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
@@ -23487,6 +24005,12 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "dev": true
+    },
+    "next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true
     },
     "nice-try": {
@@ -26086,6 +26610,24 @@
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
+    "thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "requires": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+      "dev": true,
+      "requires": {
+        "thenify": ">= 3.1.0 < 4"
+      }
+    },
     "throttleit": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
@@ -26133,6 +26675,16 @@
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
       "dev": true
+    },
+    "timers-ext": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
+      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
+      "dev": true,
+      "requires": {
+        "es5-ext": "~0.10.46",
+        "next-tick": "1"
+      }
     },
     "tiny-each-async": {
       "version": "2.0.3",
@@ -26338,6 +26890,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
+      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
     "type-check": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -20,7 +20,8 @@
     "testintwip": "mocha -c -g WIP  --config ./test/int/mocharc.json",
     "testwip": "electron-mocha -c -g WIP --config ./test/unit/mocharc.json",
     "format": "./scripts/create-prettier-ignore-file.sh && npx prettier --write . --ignore-path .prettier_and_git_ignores",
-    "postinstall": "npx electron-rebuild"
+    "postinstall": "npx electron-rebuild && ts-node scripts/generate.ts",
+    "generate": "ts-node scripts/generate.ts"
   },
   "config": {
     "forge": "./forge.config.js"
@@ -59,6 +60,7 @@
     "eslint-plugin-promise": "5.1.1",
     "fork-ts-checker-webpack-plugin": "6.4.0",
     "json": "11.0.0",
+    "json-schema-to-typescript": "10.1.5",
     "mocha": "9.2.2",
     "node-loader": "2.0.0",
     "nyc": "15.1.0",

--- a/src/node/desktop/scripts/generate.ts
+++ b/src/node/desktop/scripts/generate.ts
@@ -1,0 +1,51 @@
+/*
+ * generate.ts
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { access, constants, mkdir, writeFileSync } from 'fs';
+import { compileFromFile } from 'json-schema-to-typescript';
+import path from 'path';
+
+// schemas to convert to types
+const schemas: string[] = ['../../cpp/session/resources/schema/user-state-schema.json'];
+
+schemas.forEach(generateTypes);
+
+function generateTypes(filename: string) {
+  access(filename, constants.F_OK, (error) => {
+    if (error) {
+      console.warn(`Cannot generate type for ${filename}: ${error.message}`);
+      return;
+    }
+
+    const outputFile = path.parse(filename);
+    console.log(`Generating type for ${outputFile.base}`);
+
+    // generate types from json schema
+    compileFromFile(filename, {
+      style: { singleQuote: true },
+    }).then((output) => {
+      // json-schema-to-typescript generates [k: string]: unknown
+      const searchPattern = /^\s+\[k: string\]: unknown;\n/gm;
+      const filtered = output.replace(searchPattern, '');
+      mkdir('src/types', { recursive: true }, (error) => {
+        if (!error) {
+          writeFileSync(`src/types/${outputFile.name}.d.ts`, filtered);
+        } else {
+          console.log(error);
+        }
+      });
+    });
+  });
+}

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -671,7 +671,8 @@ export class FilePath {
    * Checks whether this file path is a directory.
    */
   isDirectory(): boolean {
-    throw Error('isDirectory is NYI');
+    const stat = fs.lstatSync(this.path);
+    return stat.isDirectory();
   }
 
   /**

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -136,6 +136,7 @@ export class Application implements AppState {
     this.argsManager.handleAppReadyCommands(this);
 
     // on Windows, ask the user what version of R they'd like to use
+    let rPath = '';
     if (process.platform === 'win32') {
       const [path, preflightError] = await promptUserForR();
       if (preflightError) {
@@ -151,10 +152,11 @@ export class Application implements AppState {
       if (path == null) {
         return exitFailure();
       }
+      rPath = path;
     }
 
     // prepare the R environment
-    const prepareError = prepareEnvironment();
+    const prepareError = prepareEnvironment(rPath);
     if (prepareError) {
       await createStandaloneErrorDialog(
         i18next.t('applicationTs.errorFindingR'),

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -28,7 +28,7 @@ import { createStandaloneErrorDialog } from './utils';
 import i18next from 'i18next';
 
 import Store from 'electron-store';
-import { kDesktopOptionDefaults } from './preferences/electron-desktop-options';
+import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 
 let kLdLibraryPathVariable: string;
 if (process.platform === 'darwin') {
@@ -62,7 +62,6 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
   if (platform === 'win32') {
     const desktop = await import('../native/desktop.node');
 
-    const storeConfig = new Store({ defaults: kDesktopOptionDefaults });
     const rstudioPathKey = 'rstudioPath';
 
     const isCtrlKeyDown = desktop.isCtrlKeyDown();
@@ -74,12 +73,10 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
         return ok(rstudioWhichR);
       }
 
-      const rstudioSavedPath = storeConfig.get(rstudioPathKey);
+      const rstudioSavedPath = ElectronDesktopOptions().rBinDir();
 
-      if (rstudioSavedPath != undefined) {
-        const path = '' + rstudioSavedPath;
-
-        return ok(path);
+      if (rstudioSavedPath) {
+        return ok(rstudioSavedPath);
       }
     }
 
@@ -101,7 +98,7 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
       return ok(null);
     }
 
-    storeConfig.set(rstudioPathKey, path);
+    ElectronDesktopOptions().setRBinDir(path);
     // set RSTUDIO_WHICH_R to signal which version of R to be used
     setenv('RSTUDIO_WHICH_R', path);
     return ok(path);

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -295,7 +295,7 @@ function isValidInstallationWin32(installPath: string): boolean {
 
 function findDefaultInstallPathWin32(version: string): string {
   // query registry for R install path
-  const keyName = `HKEY_LOCAL_MACHINE\\SOFTWARE\\R-Core\\R\\${version}`;
+  const keyName = `HKEY_LOCAL_MACHINE\\SOFTWARE\\R-Core\\${version}`;
   const regQueryCommand = `reg query ${keyName} /v InstallPath`;
   const [output, error] = executeCommand(regQueryCommand);
   if (error) {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -597,15 +597,6 @@ export class GwtCallback extends EventEmitter {
       GwtCallback.unimpl('desktop_set_enable_accessibility');
     });
 
-    ipcMain.handle('desktop_get_clipboard_monitoring', () => {
-      GwtCallback.unimpl('desktop_get_clipboard_monitoring');
-      return false;
-    });
-
-    ipcMain.on('desktop_set_clipboard_monitoring', (event, monitoring) => {
-      GwtCallback.unimpl('desktop_set_clipboard_monitoring');
-    });
-
     ipcMain.handle('desktop_get_ignore_gpu_exclusion_list', (event, ignore) => {
       return !ElectronDesktopOptions().useGpuExclusionList();
     });

--- a/src/node/desktop/src/main/preferences/desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/desktop-options.ts
@@ -17,4 +17,5 @@
 export default abstract class DesktopOptions {
   abstract fixedWidthFont(): string | undefined;
   abstract zoomLevel(): number | undefined;
+  abstract rBinDir(): string | undefined;
 }

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -134,6 +134,11 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public setZoomLevel(zoom: number): void {
+    const min = properties.view.properties.zoomLevel.minimum;
+    const max = properties.view.properties.zoomLevel.maximum;
+    if (zoom < min || zoom > max) {
+      throw new Error(`Invalid zoom level: Must be between ${min} and ${max}`);
+    }
     this.config.set(kZoomLevel, zoom);
   }
 

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -24,7 +24,6 @@ import DesktopOptions from './desktop-options';
 
 const kProportionalFont = 'font.proportionalFont';
 const kFixedWidthFont = 'font.fixedWidthFont';
-const kUseFontConfigDb = 'font.useFontConfigDb';
 
 const kZoomLevel = 'view.zoomLevel';
 const kWindowBounds = 'view.windowBounds';
@@ -35,7 +34,6 @@ const kAuthCookies = 'session.authCookies';
 const kTempAuthCookies = 'session.tempAuthCookies';
 
 const kIgnoredUpdateVersions = 'general.ignoredUpdateVersions';
-const kClipboardMonitoring = 'general.clipboardMonitoring';
 
 const kRendererEngine = 'renderer.engine';
 const kRendererUseGpuExclusionList = 'renderer.useGpuExclusionList';
@@ -133,14 +131,6 @@ export class DesktopOptionsImpl implements DesktopOptions {
     }
 
     return fontName;
-  }
-
-  public setUseFontConfigDb(useFontConfigDb: boolean): void {
-    this.config.set(kUseFontConfigDb, useFontConfigDb);
-  }
-
-  public useFontConfigDb(): boolean {
-    return this.config.get(kUseFontConfigDb, properties.font.default.useFontConfigDb);
   }
 
   public setZoomLevel(zoom: number): void {
@@ -246,15 +236,6 @@ export class DesktopOptionsImpl implements DesktopOptions {
 
   public ignoredUpdateVersions(): string[] {
     return this.config.get(kIgnoredUpdateVersions, properties.general.default.ignoredUpdateVersions);
-  }
-
-  public setClipboardMonitoring(clipboardMonitoring: boolean): void {
-    this.config.set(kClipboardMonitoring, clipboardMonitoring);
-  }
-
-  // TODO: check environment variable RSTUDIO_NO_CLIPBOARD_MONITORING, see DesktopGwtCallback.cpp
-  public clipboardMonitoring(): boolean {
-    return this.config.get(kClipboardMonitoring, properties.general.default.clipboardMonitoring);
   }
 
   public setRenderingEngine(renderingEngine: string): void {

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -16,67 +16,37 @@
 
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
+import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { logger } from '../../core/logger';
-import { legacyPreferenceManager } from './../preferences/preferences';
+import { RStudioUserState } from '../../types/user-state-schema';
+import { generateSchema, legacyPreferenceManager } from './../preferences/preferences';
 import DesktopOptions from './desktop-options';
 
-const kProportionalFont = 'Font.ProportionalFont';
-const kFixedWidthFont = 'Font.FixedWidthFont';
-const kUseFontConfigDb = 'Font.UseFontConfigDb';
+const kProportionalFont = 'font.proportionalFont';
+const kFixedWidthFont = 'font.fixedWidthFont';
+const kUseFontConfigDb = 'font.useFontConfigDb';
 
-const kZoomLevel = 'View.ZoomLevel';
-const kWindowBounds = 'View.WindowBounds';
-const kAccessibility = 'View.Accessibility';
+const kZoomLevel = 'view.zoomLevel';
+const kWindowBounds = 'view.windowBounds';
+const kAccessibility = 'view.accessibility';
 
-const kLastRemoteSessionUrl = 'Session.LastRemoteSessionUrl';
-const kAuthCookies = 'Session.AuthCookies';
-const kTempAuthCookies = 'Session.TempAuthCookies';
+const kLastRemoteSessionUrl = 'session.lastRemoteSessionUrl';
+const kAuthCookies = 'session.authCookies';
+const kTempAuthCookies = 'session.tempAuthCookies';
 
-const kIgnoredUpdateVersions = 'General.IgnoredUpdateVersions';
-const kClipboardMonitoring = 'General.ClipboardMonitoring';
+const kIgnoredUpdateVersions = 'general.ignoredUpdateVersions';
+const kClipboardMonitoring = 'general.clipboardMonitoring';
 
-const kRendererEngine = 'Renderer.Engine';
-const kRendererUseGpuExclusionList = 'Renderer.UseGpuExclusionList';
-const kRendererUseGpuDriverBugWorkarounds = 'Renderer.UseGpuDriverBugWorkarounds';
+const kRendererEngine = 'renderer.engine';
+const kRendererUseGpuExclusionList = 'renderer.useGpuExclusionList';
+const kRendererUseGpuDriverBugWorkarounds = 'renderer.useGpuDriverBugWorkarounds';
 
-const kRBinDir = 'Platform.Windows.RBinDir';
-const kPreferR64 = 'Platform.Windows.PreferR64';
+const kRBinDir = 'platform.windows.rBinDir';
+const kPreferR64 = 'platform.windows.preferR64';
+
+const userStateSchema = generateSchema<RStudioUserState>(properties);
 
 export let defaultFonts = ['monospace'];
-
-// exported for unit testing
-export const kDesktopOptionDefaults = {
-  Font: {
-    ProportionalFont: '',
-    FixedWidthFont: '',
-    UseFontConfigDb: true,
-  },
-  View: {
-    ZoomLevel: 1.0,
-    WindowBounds: { width: 1200, height: 900 },
-    Accessibility: false,
-  },
-  Session: {
-    LastRemoteSessionUrl: '',
-    AuthCookies: [],
-    TempAuthCookies: [],
-  },
-  General: {
-    IgnoredUpdateVersions: [],
-    ClipboardMonitoring: true,
-  },
-  Renderer: {
-    Engine: 'auto',
-    UseGpuExclusionList: true,
-    UseGpuDriverBugWorkarounds: true,
-  },
-  Platform: {
-    Windows: {
-      RBinDir: '',
-      PreferR64: true,
-    },
-  },
-};
 
 let options: DesktopOptionsImpl | null = null;
 
@@ -129,13 +99,13 @@ export function firstIsInsideSecond(inner: Rectangle, outer: Rectangle): boolean
  * for creating/getting a DesktopOptionsImpl instance
  */
 export class DesktopOptionsImpl implements DesktopOptions {
-  private config = new Store({ defaults: kDesktopOptionDefaults });
+  private config = new Store<RStudioUserState>({ schema: userStateSchema });
   private legacyOptions = legacyPreferenceManager;
 
   // unit testing constructor to expose directory and DesktopOptions mock
   constructor(directory = '', legacyOptions?: DesktopOptions) {
     if (directory.length != 0) {
-      this.config = new Store({ defaults: kDesktopOptionDefaults, cwd: directory });
+      this.config = new Store<RStudioUserState>({ cwd: directory, schema: userStateSchema });
     }
     if (legacyOptions) {
       this.legacyOptions = legacyOptions;
@@ -147,7 +117,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public proportionalFont(): string {
-    return this.config.get(kProportionalFont);
+    return this.config.get(kProportionalFont, '');
   }
 
   public setFixedWidthFont(fixedWidthFont: string): void {
@@ -170,7 +140,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public useFontConfigDb(): boolean {
-    return this.config.get(kUseFontConfigDb);
+    return this.config.get(kUseFontConfigDb, properties.font.default.useFontConfigDb);
   }
 
   public setZoomLevel(zoom: number): void {
@@ -181,7 +151,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
     let zoomLevel: number | undefined = this.config.get(kZoomLevel);
 
     if (!zoomLevel) {
-      zoomLevel = this.legacyOptions.zoomLevel() ?? kDesktopOptionDefaults.View.ZoomLevel;
+      zoomLevel = this.legacyOptions.zoomLevel() ?? properties.view.default.zoomLevel;
       this.config.set(kZoomLevel, zoomLevel);
     }
 
@@ -193,7 +163,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public windowBounds(): Rectangle {
-    return this.config.get(kWindowBounds);
+    return this.config.get(kWindowBounds, properties.view.default.windowBounds);
   }
 
   // Note: screen can only be used after the 'ready' event has been emitted
@@ -219,8 +189,8 @@ export class DesktopOptionsImpl implements DesktopOptions {
     } else {
       const primaryBounds = screen.getPrimaryDisplay().bounds;
       const newSize = {
-        width: Math.min(kDesktopOptionDefaults.View.WindowBounds.width, primaryBounds.width),
-        height: Math.min(kDesktopOptionDefaults.View.WindowBounds.height, primaryBounds.height),
+        width: Math.min(properties.view.default.windowBounds.width, primaryBounds.width),
+        height: Math.min(properties.view.default.windowBounds.height, primaryBounds.height),
       };
 
       mainWindow.setSize(newSize.width, newSize.height);
@@ -243,7 +213,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public accessibility(): boolean {
-    return this.config.get(kAccessibility);
+    return this.config.get(kAccessibility, properties.view.default.accessibility);
   }
 
   public setLastRemoteSessionUrl(lastRemoteSessionUrl: string): void {
@@ -251,7 +221,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public lastRemoteSessionUrl(): string {
-    return this.config.get(kLastRemoteSessionUrl);
+    return this.config.get(kLastRemoteSessionUrl, properties.session.default.lastRemoteSessionUrl);
   }
 
   public setAuthCookies(authCookies: string[]): void {
@@ -259,7 +229,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public authCookies(): string[] {
-    return this.config.get(kAuthCookies);
+    return this.config.get(kAuthCookies, properties.session.default.authCookies);
   }
 
   public setTempAuthCookies(tempAuthCookies: string[]): void {
@@ -267,7 +237,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public tempAuthCookies(): string[] {
-    return this.config.get(kTempAuthCookies);
+    return this.config.get(kTempAuthCookies, properties.session.default.tempAuthCookies);
   }
 
   public setIgnoredUpdateVersions(ignoredUpdateVersions: string[]): void {
@@ -275,15 +245,16 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public ignoredUpdateVersions(): string[] {
-    return this.config.get(kIgnoredUpdateVersions);
+    return this.config.get(kIgnoredUpdateVersions, properties.general.default.ignoredUpdateVersions);
   }
 
   public setClipboardMonitoring(clipboardMonitoring: boolean): void {
     this.config.set(kClipboardMonitoring, clipboardMonitoring);
   }
 
+  // TODO: check environment variable RSTUDIO_NO_CLIPBOARD_MONITORING, see DesktopGwtCallback.cpp
   public clipboardMonitoring(): boolean {
-    return this.config.get(kClipboardMonitoring);
+    return this.config.get(kClipboardMonitoring, properties.general.default.clipboardMonitoring);
   }
 
   public setRenderingEngine(renderingEngine: string): void {
@@ -299,7 +270,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public useGpuExclusionList(): boolean {
-    return this.config.get(kRendererUseGpuExclusionList, true);
+    return this.config.get(kRendererUseGpuExclusionList, properties.renderer.default.useGpuExclusionList);
   }
 
   public setUseGpuDriverBugWorkarounds(value: boolean) {
@@ -307,7 +278,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public useGpuDriverBugWorkarounds(): boolean {
-    return this.config.get(kRendererUseGpuDriverBugWorkarounds, true);
+    return this.config.get(kRendererUseGpuDriverBugWorkarounds, properties.renderer.default.useGpuDriverBugWorkarounds);
   }
 
   // Windows-only option
@@ -323,7 +294,15 @@ export class DesktopOptionsImpl implements DesktopOptions {
     if (process.platform !== 'win32') {
       return '';
     }
-    return this.config.get(kRBinDir);
+
+    let rBinDir: string = this.config.get(kRBinDir, properties.platform.default.windows.rBinDir);
+
+    if (!rBinDir) {
+      rBinDir = this.legacyOptions.rBinDir() ?? properties.platform.default.windows.rBinDir;
+      this.config.set(kRBinDir, rBinDir);
+    }
+
+    return rBinDir;
   }
 
   // Windows-only option
@@ -340,7 +319,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
     if (process.platform !== 'win32' || !process.arch.includes('64')) {
       return false;
     }
-    return this.config.get(kPreferR64);
+    return this.config.get(kPreferR64, properties.platform.default.windows.preferR64);
   }
 }
 

--- a/src/node/desktop/src/main/preferences/file-preferences.ts
+++ b/src/node/desktop/src/main/preferences/file-preferences.ts
@@ -46,6 +46,14 @@ class FilePreferences extends DesktopOptions {
     const zoomValue = this.properties?.get(preferenceKeys.zoomLevel)?.toString();
     return zoomValue ? parseFloat(zoomValue) : undefined;
   }
+
+  rBinDir(): string | undefined {
+    if (process.platform !== 'win32') {
+      return '';
+    }
+
+    return this.properties?.get(preferenceKeys.rBinDir)?.toString();
+  }
 }
 
 export default FilePreferences;

--- a/src/node/desktop/src/main/preferences/mac-preferences.ts
+++ b/src/node/desktop/src/main/preferences/mac-preferences.ts
@@ -35,6 +35,10 @@ class MacPreferences extends DesktopOptions {
   zoomLevel(): number | undefined {
     return systemPreferences.getUserDefault(preferenceKeys.zoomLevel, 'double');
   }
+
+  rBinDir(): string | undefined {
+    throw new Error('Unsupported platform');
+  }
 }
 
 export default MacPreferences;

--- a/src/node/desktop/src/main/preferences/mac-preferences.ts
+++ b/src/node/desktop/src/main/preferences/mac-preferences.ts
@@ -37,7 +37,7 @@ class MacPreferences extends DesktopOptions {
   }
 
   rBinDir(): string | undefined {
-    throw new Error('Unsupported platform');
+    return '';
   }
 }
 

--- a/src/node/desktop/src/main/preferences/preferences.ts
+++ b/src/node/desktop/src/main/preferences/preferences.ts
@@ -28,7 +28,7 @@ const isMacOS = process.platform === 'darwin';
 export const preferenceKeys = {
   fontFixedWidth: isMacOS ? 'font·fixedWidth' : 'General.font.fixedWidth',
   zoomLevel: isMacOS ? 'view·zoomLevel' : 'General.view.zoomLevel',
-  rBinDir: 'RBinDir',
+  rBinDir: 'General.RBinDir',
 };
 
 /**

--- a/src/node/desktop/src/main/preferences/preferences.ts
+++ b/src/node/desktop/src/main/preferences/preferences.ts
@@ -17,6 +17,7 @@
 import FilePreferences from './file-preferences';
 import MacPreferences from './mac-preferences';
 import DesktopOptions from './desktop-options';
+import { Schema } from 'electron-store';
 
 const isMacOS = process.platform === 'darwin';
 
@@ -27,7 +28,21 @@ const isMacOS = process.platform === 'darwin';
 export const preferenceKeys = {
   fontFixedWidth: isMacOS ? 'font·fixedWidth' : 'General.font.fixedWidth',
   zoomLevel: isMacOS ? 'view·zoomLevel' : 'General.view.zoomLevel',
+  rBinDir: 'RBinDir',
 };
+
+/**
+ * Create the Schema from a JSON schema file. The `Schema` is templated with the
+ * definition created with `scripts/generate.ts`, which is generated from the
+ * JSON schema file. `electron-store` requires a schema passed in when creating
+ * the store. Otherwise, type validation will not work.
+ * @param schemaJson the JSON schema object created from the schema file
+ * @returns a Schema
+ */
+export function generateSchema<T>(schemaJson: object): Schema<T> {
+  // workaround for defining the schema since electron-store cannot be given the file
+  return JSON.parse(JSON.stringify(schemaJson));
+}
 
 /**
  * This is the legacy preference manager. It will read the preferences from platform-specific

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -445,17 +445,6 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_enable_accessibility', enable);
     },
 
-    getClipboardMonitoring: (callback: VoidCallback<boolean>) => {
-      ipcRenderer
-        .invoke('desktop_get_clipboard_monitoring')
-        .then((monitoring) => callback(monitoring))
-        .catch((error) => reportIpcError('getClipboardMonitoring', error));
-    },
-
-    setClipboardMonitoring: (monitoring: boolean) => {
-      ipcRenderer.send('desktop_set_clipboard_monitoring', monitoring);
-    },
-
     getIgnoreGpuExclusionList: (callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_get_ignore_gpu_exclusion_list')

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -344,7 +344,7 @@ describe('Font tests', () => {
     assert.strictEqual(testDesktopOptions.zoomLevel(), 0.5);
   });
 
-  it('WIPhas an error when setting an invalid zoom level', () => {
+  it('has an error when setting an invalid zoom level', () => {
     const mockLegacyOptions = new (class extends DesktopOptionsStub {
       zoomLevel(): number | undefined {
         return 1.5;

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -344,16 +344,20 @@ describe('Font tests', () => {
     assert.strictEqual(testDesktopOptions.zoomLevel(), 0.5);
   });
 
-  it('has an error when setting an invalid zoom level', () => {
+  it('WIPhas an error when setting an invalid zoom level', () => {
     const mockLegacyOptions = new (class extends DesktopOptionsStub {
       zoomLevel(): number | undefined {
         return 1.5;
       }
     })();
     const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
-    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, 0.3333)).to.throw(
-      'Config schema violation: `view/zoomLevel` must be equal to one of the allowed values',
-    );
+    const min = properties.view.properties.zoomLevel.minimum;
+    const max = properties.view.properties.zoomLevel.maximum;
+
+    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, min - 0.1)).to.throw();
+    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, max + 0.1)).to.throw();
+    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, min)).to.not.throw();
+    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, max)).to.not.throw();
   });
 
   it('can get the rBinDir (Windows)', () => {

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -12,7 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  */
 
-import { assert } from 'chai';
+import { assert, expect } from 'chai';
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import { Display } from 'electron/main';
 import { describe } from 'mocha';
@@ -351,6 +351,18 @@ describe('Font tests', () => {
 
     testDesktopOptions.setZoomLevel(0.5);
     assert.strictEqual(testDesktopOptions.zoomLevel(), 0.5);
+  });
+
+  it('has an error when setting an invalid zoom level', () => {
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
+      zoomLevel(): number | undefined {
+        return 1.5;
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+    expect(testDesktopOptions.setZoomLevel.bind(testDesktopOptions, 0.3333)).to.throw(
+      'Config schema violation: `view/zoomLevel` must be equal to one of the allowed values',
+    );
   });
 
   it('can get the rBinDir (Windows)', () => {

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -16,7 +16,6 @@ import { assert, expect } from 'chai';
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import { Display } from 'electron/main';
 import { describe } from 'mocha';
-import { platform } from 'os';
 import sinon from 'sinon';
 import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { Err, isSuccessful } from '../../../src/core/err';
@@ -72,7 +71,6 @@ describe('DesktopOptions', () => {
 
     assert.equal(options.proportionalFont(), properties.font.default.proportionalFont);
     assert.equal(options.fixedWidthFont(), properties.font.default.fixedWidthFont);
-    assert.equal(options.useFontConfigDb(), properties.font.default.useFontConfigDb);
     assert.equal(options.zoomLevel(), properties.view.default.zoomLevel);
     assert.deepEqual(options.windowBounds(), properties.view.default.windowBounds);
     assert.equal(options.accessibility(), properties.view.default.accessibility);
@@ -80,7 +78,6 @@ describe('DesktopOptions', () => {
     assert.deepEqual(options.authCookies(), properties.session.default.authCookies);
     assert.deepEqual(options.tempAuthCookies(), properties.session.default.tempAuthCookies);
     assert.deepEqual(options.ignoredUpdateVersions(), properties.general.default.ignoredUpdateVersions);
-    assert.equal(options.clipboardMonitoring(), properties.general.default.clipboardMonitoring);
     if (process.platform === 'win32') {
       assert.equal(options.rBinDir(), properties.platform.default.windows.rBinDir);
       assert.equal(options.peferR64(), properties.platform.default.windows.preferR64);
@@ -94,7 +91,6 @@ describe('DesktopOptions', () => {
 
     const newProportionalFont = 'testProportionalFont';
     const newFixWidthFont = 'testFixWidthFont';
-    const newUseFontConfigDb = !(properties.font.default.useFontConfigDb as boolean);
     const newZoom = 1.5;
     const newWindowBounds = { width: 123, height: 321, x: 0, y: 0 };
     const newAccessibility = !(properties.view.default.accessibility as boolean);
@@ -102,7 +98,6 @@ describe('DesktopOptions', () => {
     const newAuthCookies = ['test', 'Autht', 'Cookies'];
     const newTempAuthCookies = ['test', 'Temp', 'Auth', 'Cookies'];
     const newIgnoredUpdateVersions = ['test', 'Ignored', 'Update', 'Versions'];
-    const newClipboardMonitoring = !(properties.general.default.clipboardMonitoring as boolean);
     const newRBinDir = 'testRBinDir';
     const newPeferR64 = !(properties.platform.default.windows.preferR64 as boolean);
 
@@ -111,7 +106,6 @@ describe('DesktopOptions', () => {
 
     options.setProportionalFont(newProportionalFont);
     options.setFixedWidthFont(newFixWidthFont);
-    options.setUseFontConfigDb(newUseFontConfigDb);
     options.setZoomLevel(newZoom);
     options.saveWindowBounds(newWindowBounds);
     options.setAccessibility(newAccessibility);
@@ -119,13 +113,11 @@ describe('DesktopOptions', () => {
     options.setAuthCookies(newAuthCookies);
     options.setTempAuthCookies(newTempAuthCookies);
     options.setIgnoredUpdateVersions(newIgnoredUpdateVersions);
-    options.setClipboardMonitoring(newClipboardMonitoring);
     options.setRBinDir(newRBinDir);
     options.setPeferR64(newPeferR64);
 
     assert.equal(options.proportionalFont(), newProportionalFont);
     assert.equal(options.fixedWidthFont(), newFixWidthFont);
-    assert.equal(options.useFontConfigDb(), newUseFontConfigDb);
     assert.equal(options.zoomLevel(), newZoom);
     assert.deepEqual(options.windowBounds(), newWindowBounds);
     assert.equal(options.accessibility(), newAccessibility);
@@ -133,7 +125,6 @@ describe('DesktopOptions', () => {
     assert.deepEqual(options.authCookies(), newAuthCookies);
     assert.deepEqual(options.tempAuthCookies(), newTempAuthCookies);
     assert.deepEqual(options.ignoredUpdateVersions(), newIgnoredUpdateVersions);
-    assert.equal(options.clipboardMonitoring(), newClipboardMonitoring);
     if (process.platform === 'win32') {
       assert.equal(options.rBinDir(), newRBinDir);
       assert.equal(options.peferR64(), newPeferR64);

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -16,7 +16,9 @@ import { assert } from 'chai';
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import { Display } from 'electron/main';
 import { describe } from 'mocha';
+import { platform } from 'os';
 import sinon from 'sinon';
+import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { Err, isSuccessful } from '../../../src/core/err';
 import { FilePath } from '../../../src/core/file-path';
 import DesktopOptions from '../../../src/main/preferences/desktop-options';
@@ -25,21 +27,25 @@ import {
   DesktopOptionsImpl,
   ElectronDesktopOptions,
   firstIsInsideSecond,
-  kDesktopOptionDefaults,
 } from '../../../src/main/preferences/electron-desktop-options';
 import { createSinonStubInstanceForSandbox, tempDirectory } from '../unit-utils';
 
 const kTestingConfigDirectory = tempDirectory('DesktopOptionsTesting').toString();
 
+class DesktopOptionsStub extends DesktopOptions {
+  fixedWidthFont(): string | undefined {
+    return properties.font.default.fixedWidthFont;
+  }
+  zoomLevel(): number | undefined {
+    return properties.view.default.zoomLevel;
+  }
+  rBinDir(): string | undefined {
+    return properties.platform.default.windows.rBinDir;
+  }
+}
+
 function testingDesktopOptions(): DesktopOptionsImpl {
-  const legacyOptions = new (class extends DesktopOptions {
-    fixedWidthFont(): string | undefined {
-      return kDesktopOptionDefaults.Font.FixedWidthFont;
-    }
-    zoomLevel(): number | undefined {
-      return kDesktopOptionDefaults.View.ZoomLevel;
-    }
-  })();
+  const legacyOptions = new DesktopOptionsStub();
   return ElectronDesktopOptions(kTestingConfigDirectory, legacyOptions);
 }
 
@@ -64,20 +70,20 @@ describe('DesktopOptions', () => {
     const nonWindowsRBinDir = '';
     const nonWindowsPreferR64 = false;
 
-    assert.equal(options.proportionalFont(), kDesktopOptionDefaults.Font.ProportionalFont);
-    assert.equal(options.fixedWidthFont(), kDesktopOptionDefaults.Font.FixedWidthFont);
-    assert.equal(options.useFontConfigDb(), kDesktopOptionDefaults.Font.UseFontConfigDb);
-    assert.equal(options.zoomLevel(), kDesktopOptionDefaults.View.ZoomLevel);
-    assert.deepEqual(options.windowBounds(), kDesktopOptionDefaults.View.WindowBounds);
-    assert.equal(options.accessibility(), kDesktopOptionDefaults.View.Accessibility);
-    assert.equal(options.lastRemoteSessionUrl(), kDesktopOptionDefaults.Session.LastRemoteSessionUrl);
-    assert.deepEqual(options.authCookies(), kDesktopOptionDefaults.Session.AuthCookies);
-    assert.deepEqual(options.tempAuthCookies(), kDesktopOptionDefaults.Session.TempAuthCookies);
-    assert.deepEqual(options.ignoredUpdateVersions(), kDesktopOptionDefaults.General.IgnoredUpdateVersions);
-    assert.equal(options.clipboardMonitoring(), kDesktopOptionDefaults.General.ClipboardMonitoring);
+    assert.equal(options.proportionalFont(), properties.font.default.proportionalFont);
+    assert.equal(options.fixedWidthFont(), properties.font.default.fixedWidthFont);
+    assert.equal(options.useFontConfigDb(), properties.font.default.useFontConfigDb);
+    assert.equal(options.zoomLevel(), properties.view.default.zoomLevel);
+    assert.deepEqual(options.windowBounds(), properties.view.default.windowBounds);
+    assert.equal(options.accessibility(), properties.view.default.accessibility);
+    assert.equal(options.lastRemoteSessionUrl(), properties.session.default.lastRemoteSessionUrl);
+    assert.deepEqual(options.authCookies(), properties.session.default.authCookies);
+    assert.deepEqual(options.tempAuthCookies(), properties.session.default.tempAuthCookies);
+    assert.deepEqual(options.ignoredUpdateVersions(), properties.general.default.ignoredUpdateVersions);
+    assert.equal(options.clipboardMonitoring(), properties.general.default.clipboardMonitoring);
     if (process.platform === 'win32') {
-      assert.equal(options.rBinDir(), kDesktopOptionDefaults.Platform.Windows.RBinDir);
-      assert.equal(options.peferR64(), kDesktopOptionDefaults.Platform.Windows.PreferR64);
+      assert.equal(options.rBinDir(), properties.platform.default.windows.rBinDir);
+      assert.equal(options.peferR64(), properties.platform.default.windows.preferR64);
     } else {
       assert.equal(options.rBinDir(), nonWindowsRBinDir);
       assert.equal(options.peferR64(), nonWindowsPreferR64);
@@ -88,17 +94,17 @@ describe('DesktopOptions', () => {
 
     const newProportionalFont = 'testProportionalFont';
     const newFixWidthFont = 'testFixWidthFont';
-    const newUseFontConfigDb = !kDesktopOptionDefaults.Font.UseFontConfigDb;
-    const newZoom = 123;
+    const newUseFontConfigDb = !(properties.font.default.useFontConfigDb as boolean);
+    const newZoom = 1.5;
     const newWindowBounds = { width: 123, height: 321, x: 0, y: 0 };
-    const newAccessibility = !kDesktopOptionDefaults.View.Accessibility;
+    const newAccessibility = !(properties.view.default.accessibility as boolean);
     const newLastRemoteSessionUrl = 'testLastRemoteSessionUrl';
     const newAuthCookies = ['test', 'Autht', 'Cookies'];
     const newTempAuthCookies = ['test', 'Temp', 'Auth', 'Cookies'];
     const newIgnoredUpdateVersions = ['test', 'Ignored', 'Update', 'Versions'];
-    const newClipboardMonitoring = !kDesktopOptionDefaults.General.ClipboardMonitoring;
+    const newClipboardMonitoring = !(properties.general.default.clipboardMonitoring as boolean);
     const newRBinDir = 'testRBinDir';
-    const newPeferR64 = !kDesktopOptionDefaults.Platform.Windows.PreferR64;
+    const newPeferR64 = !(properties.platform.default.windows.preferR64 as boolean);
 
     const nonWindowsRBinDir = '';
     const nonWindowsPreferR64 = false;
@@ -138,9 +144,9 @@ describe('DesktopOptions', () => {
   });
   it('values persist between instances', () => {
     const options1 = testingDesktopOptions();
-    const newZoom = 1234;
+    const newZoom = 2.5;
 
-    assert.equal(options1.zoomLevel(), kDesktopOptionDefaults.View.ZoomLevel);
+    assert.equal(options1.zoomLevel(), properties.view.default.zoomLevel);
     options1.setZoomLevel(newZoom);
     assert.equal(options1.zoomLevel(), newZoom);
 
@@ -175,8 +181,8 @@ describe('DesktopOptions', () => {
   it('restores window bounds to default when saved display no longer present', () => {
     const defaultDisplay = { bounds: { width: 2000, height: 2000, x: 0, y: 0 } };
     const savedWinBounds = { width: 500, height: 500, x: 0, y: 0 };
-    const defaultWinWidth = kDesktopOptionDefaults.View.WindowBounds.width;
-    const defaultWinHeight = kDesktopOptionDefaults.View.WindowBounds.height;
+    const defaultWinWidth = properties.view.default.windowBounds.width;
+    const defaultWinHeight = properties.view.default.windowBounds.height;
 
     const sandbox = sinon.createSandbox();
     sandbox.stub(screen, 'getAllDisplays').returns([]);
@@ -302,12 +308,9 @@ describe('Font tests', () => {
   });
 
   it('can get the legacy font', () => {
-    const mockLegacyOptions = new (class extends DesktopOptions {
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
       fixedWidthFont(): string | undefined {
         return 'legacy font';
-      }
-      zoomLevel(): number | undefined {
-        return 1.0;
       }
     })();
     const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
@@ -316,17 +319,62 @@ describe('Font tests', () => {
   });
 
   it('set font overrides legacy font option', () => {
-    const mockLegacyOptions = new (class extends DesktopOptions {
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
       fixedWidthFont(): string | undefined {
         return 'legacy font';
-      }
-      zoomLevel(): number | undefined {
-        return 1.0;
       }
     })();
     const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
 
     testDesktopOptions.setFixedWidthFont('new font');
     assert.strictEqual(testDesktopOptions.fixedWidthFont(), 'new font');
+  });
+
+  it('can get the zoom level', () => {
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
+      zoomLevel(): number | undefined {
+        return 1.5;
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    assert.strictEqual(testDesktopOptions.zoomLevel(), 1.5);
+  });
+
+  it('set zoom level overrides legacy zoom level', () => {
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
+      zoomLevel(): number | undefined {
+        return 1.5;
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    testDesktopOptions.setZoomLevel(0.5);
+    assert.strictEqual(testDesktopOptions.zoomLevel(), 0.5);
+  });
+
+  it('can get the rBinDir (Windows)', () => {
+    const testRBinDir = 'C:/R/bin/x64';
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
+      rBinDir(): string | undefined {
+        return testRBinDir;
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    assert.strictEqual(testDesktopOptions.rBinDir(), process.platform === 'win32' ? testRBinDir : '');
+  });
+
+  it('set rBinDir overrides the legacy rBinDir (Windows)', () => {
+    const testRBinDir = 'C:/R/bin/x64';
+    const mockLegacyOptions = new (class extends DesktopOptionsStub {
+      rBinDir(): string | undefined {
+        return 'C:/foo/R/bin/x64';
+      }
+    })();
+    const testDesktopOptions = ElectronDesktopOptions(kTestingConfigDirectory, mockLegacyOptions);
+
+    testDesktopOptions.setRBinDir(testRBinDir);
+    assert.strictEqual(testDesktopOptions.rBinDir(), process.platform === 'win32' ? testRBinDir : '');
   });
 });


### PR DESCRIPTION
### Intent
Address #10484

This sets the preference priority to Electron-store > legacy Qt > default value for zoom level, fixed font, and R path. All other preferences can follow these as examples for preference priority. There is now a generated type for the user state based on `user-state-schema.json`. The file is also included during the webpack so that default values are taken from there. Hard-coded defaults have now been removed.

There is a new step in `postinstall` to generate the type. So running `npm ci` or `npm install` will generate the necessary type for the user state schema. The default values are pulled in at runtime and directly read from `user-state-schema.json`.

### Approach
The default values are taken directly from `user-state-schema.json` now and there is type validation when setting values. An error is returned if the value is invalid.

The `rBinDir` looks to have stored the selected R version for Windows. So this is now used for `rstudiopath` and will read the legacy value if available. There is a difference where the legacy value does not include the executable so that is checked before using the file path. There's also a mixture of how the path separator is defined (`\\` vs. `/`) but that still works. It's caused by the legacy value using `\\` and Electron using `/`.

I tried to set a webpack alias for importing `user-state-schema.json` but `mocha` couldn't understand the alias. There are some packages available to handle translating the file path but have since been deprecated and/or don't work with Mocha 9.x.

Any issues with VS Code intellisense with the json values might require restarting the TS server using the command palette (or restarting VS Code).

### Automated Tests
There are unit tests for being able to set the value and get a legacy value if that's all that is available.

### QA Notes
MacOS is the only vastly different platform that stored legacy values in Mac defaults. For the most part, legacy values can be set using a PT build. Clearing these places of Electron user state can trigger reading the legacy values:

Windows: `C:\Users\<user>\AppData\Roaming\RStudio\config.json`
MacOS: `/Users/<user>/Library/Application Support/RStudio/config.json`
Linux: `/home/<user>/.config/RStudio/config.json`

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


