### PR TITLE
Move where events are added on chunks to maintain scrolling fix on pages

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputFrame.java
@@ -39,6 +39,8 @@ public class ChunkOutputFrame extends DynamicIFrame
 
       getElement().getStyle().setProperty("pointerEvents", "none");
       getElement().getStyle().setProperty("opacity", "0.7");
+      getElement().getStyle().setProperty("border", "1px dashed rgb(128,128,128,25%)");
+      getElement().getStyle().setProperty("borderRadius", "4px");
    }
 
    void loadUrl(String url, Command onCompleted)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -82,8 +82,6 @@ public class ChunkOutputStream extends FlowPanel
 
          getElement().getStyle().setOverflow(Overflow.AUTO);
       }
-
-      setUpEvents(getElement());
    }
 
    @Override
@@ -677,85 +675,6 @@ public class ChunkOutputStream extends FlowPanel
    }
    
    // Private methods ---------------------------------------------------------
-   
-   /** 
-    * A native hack function to workaround {@code <iframes>} stealing all pointer events.
-    *  
-    * @param el the Element to target for event setup, which should always be {@code this}
-    */
-   private native void setUpEvents(Element el) /*-{
-                                             
-      // debounce user inputs to make scrolling behavior more forgiving: the user does not have to keep their
-      // mouse exactly in place to continue scrolling. The user most pause over the sub-content after
-      // scrolling before we allow them to enable it with a mousemove.
-      var debounceId = -1
-      var debounceHandler = function(dispatch) {
-         return function() {
-            el.removeEventListener("mouseover", overEventHandler);
-            el.removeEventListener("mousemove", moveEventHandler);
-            el.addEventListener("mouseout", outEventHandler, { once: true });
-            clearTimeout(debounceId);
-            debounceId = setTimeout(function() {
-
-               if (dispatch)
-                  moveEventHandler();
-               else
-                  el.addEventListener("mousemove", moveEventHandler, { once: true });
-            }, 333);
-         };
-      };
-
-      var overEventHandler = debounceHandler(true);
-
-      // create two event handlers: 
-      // - one to handle when the mouse leaves the iframe,
-      // - another to handle when the mouse moves inside the current widget
-      //
-      // mousemove events signal user intent to do something with the current iframe, which will
-      // "unlock" the frame for interaction. When the mouse leaves, the frame is disabled, which prevents the
-      // frame from eating mouse events (like scroll). This makes it possible to scroll across iframes
-      // without interruptions, assuming the user keeps their mouse perfectly still.
-      //
-      // Each event sets up the other in such a way that they can only ever trigger once at a time.
-      var moveEventHandler = function() {
-         // need to remove the mouseout event on the parent el, stop it from firing when the
-         // iframe starts intercepting events -- it actually counts as a mouseout on the parent.
-         el.removeEventListener("mouseout", outEventHandler);
-         var frames = el.querySelectorAll("iframe");
-         if (!frames.length)
-            return;
-
-         frames.forEach(function(frame) {
-            frame.style.pointerEvents = "all";
-            frame.style.opacity = 1;
-            frame.addEventListener("mouseout", outEventHandler, { once: true });
-         });
-      };
-
-      var outEventHandler = function() {
-         clearTimeout(debounceId);
-         var frames = el.querySelectorAll("iframe");
-
-         if (!frames.length)
-            return;
-
-         frames.forEach(function(frame) {
-            frame.style.pointerEvents = "none"; 
-            frame.style.opacity = 0.7;
-         });
-
-         el.addEventListener("mouseover", overEventHandler, { once: true });
-      }
-
-      el.addEventListener("click", function() { 
-         clearTimeout(debounceId);
-         el.removeEventListener("mouseover", overEventHandler);
-         el.removeEventListener("mousemove", moveEventHandler);
-         moveEventHandler(); 
-      });
-      el.addEventListener("wheel", debounceHandler());
-      el.addEventListener("mouseover", overEventHandler, { once: true });
-   }-*/;
    
    private String classOfOutput(int type)
    {


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio/issues/10836

### Intent

Fix an issue identified with multi-page rmarkdown chunk output in which iframe-based (HTML) content cannot be interacted with, and remains permanently greyed-out.

### Approach

I have moved where the event listeners are added which are responsible for managing the interactivity of the iframes. This means we can maintain the desirable behavior of "smart" uninterrupted scrolling but also allow it to work for multi-output rmarkdown chunks, such as the case identified by the user.

I have also made all frame-based outputs show a very subtle, dashed border around their content to mark where the interactive zone triggers a response. This dashed border becomes solid when the frame becomes interactive.

Not interacting: 
![image](https://user-images.githubusercontent.com/5544965/160491778-30d2b242-c979-42c4-b674-4091d5c0a3c8.png)

Interacting:
![image](https://user-images.githubusercontent.com/5544965/160491859-7f004ec0-8ca2-4316-a791-4f75b99aa69b.png)

### Automated Tests

There are no automated tests yet, and I don't think it is worth the effort of testing this behavior with automation. This behavior involves a complex sequence of mouse maneuvers which more easily tested manually.

### QA Notes

Use this Rmd to produce a paginated output: 

~~~rmarkdown
---
title: "leaflet_test"
output: html_document
date: '2022-03-28'
---

```{r cars}
library(compareDF)
data(mtcars)

mtcars_minus_10 <- mtcars[1:21,]

a <- compare_df(mtcars_minus_10, mtcars)
create_output_table(a)
```
~~~

Use this Rmd to produce a kable to verify existing functionality is not broken:

~~~rmarkdown
---
title: "Untitled"
author: "Ron Blum"
date: "2/14/2018"
output: html_document
---

```{r setup, include=FALSE}
knitr::opts_chunk$set(echo = TRUE)
library(knitr)
```

```{r kable_long}
kable(matrix(1:100), col.names = "Long")
```
~~~

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


