### PR TITLE
Copy viewer plot to clipboard

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -15,7 +15,18 @@
 
 // TODO clean this up
 
-import { app, BrowserWindow, clipboard, dialog, ipcMain, screen, shell, webContents, webFrameMain } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  clipboard,
+  dialog,
+  ipcMain,
+  Rectangle,
+  screen,
+  shell,
+  webContents,
+  webFrameMain,
+} from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
 import { mkdtempSync, writeFileSync } from 'fs';
@@ -411,10 +422,18 @@ export class GwtCallback extends EventEmitter {
       GwtCallback.unimpl('desktop_close_named_window');
     });
 
-    ipcMain.on(
+    ipcMain.handle(
       'desktop_copy_page_region_to_clipboard',
-      (event, left: number, top: number, width: number, height: number) => {
-        GwtCallback.unimpl('desktop_copy_page_region_to_clipboard');
+      (_event, x: number, y: number, width: number, height: number) => {
+        const rect: Rectangle = { x, y, width, height };
+        this.mainWindow.window
+          .capturePage(rect)
+          .then((image) => {
+            clipboard.writeImage(image);
+          })
+          .catch((error) => {
+            logger().logError(error);
+          });
       },
     );
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -281,8 +281,11 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_close_named_window', name);
     },
 
-    copyPageRegionToClipboard: (left: number, top: number, width: number, height: number) => {
-      ipcRenderer.send('desktop_copy_page_region_to_clipboard', left, top, width, height);
+    copyPageRegionToClipboard: (x: number, y: number, width: number, height: number, callback: () => void) => {
+      ipcRenderer
+        .invoke('desktop_copy_page_region_to_clipboard', x, y, width, height)
+        .then(() => callback())
+        .catch((error) => reportIpcError('desktop_copy_page_region_to_clipboard', error));
     },
 
     exportPageRegionToFile: (


### PR DESCRIPTION
### Intent
Address #7992

Implements the feature for Electron. This fixes the export to clipboard issue present in Qt builds when the zoom level has been changed.

### Approach
From GWT, it can still do the same thing and the values can be used with Electron's API to call `capturePage`. The preview can be resized and the zoom level can be adjusted without affecting what is copied to the clipboard.

### Automated Tests
None

### QA Notes
I discovered that in #7992 that the issue occurs when changing the zoom level before exporting the plot. This does not fix the issue in Qt but the Electron implementation fixes the issue.

Sample code to generate something in the Viewer pane:
```R
library(gt)
library(tidyverse)
library(glue)

# Define the start and end dates for the data range
start_date <- "2010-03-07"
end_date <- "2010-06-14"

# Create a gt table based on preprocessed
# `sp500` table data
sp500 %>%
  filter(date >= start_date & date <= end_date) %>%
  select(-adj_close) %>%
  gt() %>%
  tab_header(
    title = "S&P 500",
    subtitle = glue("{start_date} to {end_date}")
  ) %>%
  fmt_date(
    columns = date,
    date_style = 3
  ) %>%
  fmt_currency(
    columns = c(open, high, low, close),
    currency = "USD"
  ) %>%
  fmt_number(
    columns = volume,
    suffixing = TRUE
  )
```

Generates an image like:
![image](https://user-images.githubusercontent.com/9591545/160634223-013afc82-bc37-4006-8b04-40e682e180b0.png)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


