### PR TITLE
Fix various typos in `src/gwt`

### DIFF
--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1122,7 +1122,7 @@ var CppCodeModel = function(session, tokenizer,
                indent + tab;
          }
 
-         // If we're looking at a class with the first inheritted member
+         // If we're looking at a class with the first inherited member
          // on the same line, e.g.
          //
          //   class Foo : public A,

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -348,7 +348,7 @@ var MarkdownHighlightRules = function() {
             regex : "^\\s*```\\s*[a-zA-Z]*(?:{.*?\\})?\\s*$",
             next  : "githubblock"
         }, {
-            defaultToken : "text" //do not use markup.list to allow stling leading `*` differntly
+            defaultToken : "text" //do not use markup.list to allow stling leading `*` differently
         }],
 
         "blockquote" : [{ // Blockquotes only escape on blank lines.

--- a/src/gwt/panmirror/src/editor/src/@types/prosemirror-view/index.d.ts
+++ b/src/gwt/panmirror/src/editor/src/@types/prosemirror-view/index.d.ts
@@ -325,7 +325,7 @@ declare module 'prosemirror-view' {
      *
      * This is intended to be able to call things like getBoundingClientRect
      * on that DOM node. Do not mutate the editor DOM directly, or add
-     * styling this way, since that will be immediately overriden by the
+     * styling this way, since that will be immediately overridden by the
      * editor as it redraws the node.
      */
     nodeDOM(pos: number): Node | null | undefined;

--- a/src/gwt/panmirror/src/editor/src/behaviors/completion/completion.ts
+++ b/src/gwt/panmirror/src/editor/src/behaviors/completion/completion.ts
@@ -112,7 +112,7 @@ class CompletionPlugin extends Plugin<CompletionState> {
             return {};
           }
 
-          // calcluate text before cursor
+          // calculate text before cursor
           const textBefore = completionTextBeforeCursor(tr.selection);
 
           // if there is no text then don't handle it
@@ -240,7 +240,7 @@ class CompletionPlugin extends Plugin<CompletionState> {
               }
             }
 
-            // supress event if we handled it
+            // suppress event if we handled it
             if (handled) {
               event.preventDefault();
               event.stopPropagation();
@@ -482,7 +482,7 @@ class CompletionPlugin extends Plugin<CompletionState> {
 }
 
 // extract the text before the cursor, dealing with block separators and
-// non-text leaf chracters (this is based on code in prosemirror-inputrules)
+// non-text leaf characters (this is based on code in prosemirror-inputrules)
 function completionTextBeforeCursor(selection: Selection, maxLength = 500) {
   const { $head } = selection;
   return $head.parent.textBetween(

--- a/src/gwt/panmirror/src/editor/src/behaviors/spelling/spelling-interactive.ts
+++ b/src/gwt/panmirror/src/editor/src/behaviors/spelling/spelling-interactive.ts
@@ -41,7 +41,7 @@ export function getSpellingDoc(
   // alias schema
   const schema = view.state.schema;
 
-  // intialize marks we don't want to check
+  // initialize marks we don't want to check
   const excluded = excludedMarks(schema, marks);
 
   // check begin

--- a/src/gwt/panmirror/src/editor/src/editor/editor.ts
+++ b/src/gwt/panmirror/src/editor/src/editor/editor.ts
@@ -114,7 +114,7 @@ import { defaultEditorUIImages } from './editor-images';
 import { editorMenus, EditorMenus } from './editor-menus';
 import { editorSchema } from './editor-schema';
 
-// import styles before extensions so they can be overriden by extensions
+// import styles before extensions so they can be overridden by extensions
 import './styles/frame.css';
 import './styles/styles.css';
 import { getPresentationEditorLocation, PresentationEditorLocation, positionForPresentationEditorLocation } from '../api/presentation';
@@ -557,7 +557,7 @@ export class Editor {
 
   // flag indicating whether we've ever had setMarkdown (currently we need this
   // because getMarkdown can only be called after setMarkdown b/c it needs
-  // the API version retreived in setMarkdown -- we should remedy this)
+  // the API version retrieved in setMarkdown -- we should remedy this)
   public isInitialDoc() {
     return this.state.doc.attrs.initial;
   }

--- a/src/gwt/panmirror/src/editor/src/marks/raw_inline/raw_tex.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/raw_inline/raw_tex.ts
@@ -188,7 +188,7 @@ function texInputRule(schema: Schema, filter: MarkInputRuleFilter) {
       }
     }
 
-    // didn't find a valid context for a tex comand
+    // didn't find a valid context for a tex command
     return null;
   });
 }

--- a/src/gwt/panmirror/src/editor/src/pandoc/pandoc_converter.ts
+++ b/src/gwt/panmirror/src/editor/src/pandoc/pandoc_converter.ts
@@ -260,7 +260,7 @@ function gridTablesRequired(doc: ProsemirrorNode) {
   const schema = doc.type.schema;
   const isTableCell = (node: ProsemirrorNode) => node.type === schema.nodes.table_cell || node.type === schema.nodes.table_header;
   return findChildren(doc, isTableCell).some(cell => {
-    // various things require grid tables (basically anyting that requires embedded newlines)
+    // various things require grid tables (basically anything that requires embedded newlines)
 
     // multiple blocks
     if (cell.node.childCount > 1) {

--- a/src/gwt/panmirror/src/editor/tools/generate-symbols.ts
+++ b/src/gwt/panmirror/src/editor/tools/generate-symbols.ts
@@ -459,7 +459,7 @@ function isValidSymbol(rawChar: { [x: string]: any }): boolean {
     return false;
   }
 
-  // no exluded characters
+  // no excluded characters
   const codepoint = Number.parseInt(rawChar['@_cp'], 16);
   if (excludedChars.includes(codepoint)) {
     return false;

--- a/src/gwt/src/org/rstudio/core/client/IntervalTracker.java
+++ b/src/gwt/src/org/rstudio/core/client/IntervalTracker.java
@@ -28,7 +28,7 @@ public class IntervalTracker
       lastTime_ = System.currentTimeMillis();
    }
 
-   // alternate verison of reset which will prevent subsequent checks
+   // alternate version of reset which will prevent subsequent checks
    // for only the duration specified (rather than the full intervalMillis)
    public void reset(long preventMillis)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModifyKeyboardShortcutsWidget.java
@@ -1034,7 +1034,7 @@ public class ModifyKeyboardShortcutsWidget extends ModalDialogBase
       {
          @Override
          public void execute() {
-            // run the final comands in order after loading has been completed
+            // run the final commands in order after loading has been completed
             queue.run();
          }
       });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
@@ -939,7 +939,7 @@ public interface CmdConstants extends Constants {
     String quickAddNextButtonLabel();
     @DefaultStringValue("Find and Add Next") // $NON-NLS-1$
     String quickAddNextMenuLabel();
-    @DefaultStringValue("Find and add next occurence") // $NON-NLS-1$
+    @DefaultStringValue("Find and add next occurrence") // $NON-NLS-1$
     String quickAddNextDesc();
     
     // findAll
@@ -953,7 +953,7 @@ public interface CmdConstants extends Constants {
     String findReplaceMenuLabel();
     
     // findNext
-    @DefaultStringValue("Find Next Occurence") // $NON-NLS-1$
+    @DefaultStringValue("Find Next Occurrence") // $NON-NLS-1$
     String findNextLabel();
     @DefaultStringValue("Next") // $NON-NLS-1$
     String findNextButtonLabel();
@@ -963,7 +963,7 @@ public interface CmdConstants extends Constants {
     String findNextDesc();
     
     // findPrevious
-    @DefaultStringValue("Find Previous Occurence") // $NON-NLS-1$
+    @DefaultStringValue("Find Previous Occurrence") // $NON-NLS-1$
     String findPreviousLabel();
     @DefaultStringValue("Prev") // $NON-NLS-1$
     String findPreviousButtonLabel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -1707,7 +1707,7 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
         buttonLabel="Add"
         menuLabel="Find and Add Next"
         context="editor"
-        desc="Find and add next occurence"/>
+        desc="Find and add next occurrence"/>
 
    <cmd id="findAll"
         label="Find All"
@@ -1719,7 +1719,7 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
         menuLabel="_Find..."/>
 
    <cmd id="findNext"
-        label="Find Next Occurence"
+        label="Find Next Occurrence"
         buttonLabel="Next"
         menuLabel="Find _Next"
         desc="Find next occurrence"
@@ -1727,7 +1727,7 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
         rebindable="false"/>
 
    <cmd id="findPrevious"
-        label="Find Previous Occurence"
+        label="Find Previous Occurrence"
         buttonLabel="Prev"
         menuLabel="Find Pre_vious"
         desc="Find previous occurrence"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/PlotsPane.java
@@ -126,7 +126,7 @@ public class PlotsPane extends WorkbenchPane implements Plots.Display,
       panel_.setWidgetLeftRight(frame_, 0, Unit.PX, 0, Unit.PX);
 
       // Provide a widget container where adornments can be added on top of the
-      // plots panel (e.g. manipulator button). Hidden initially so it doens't
+      // plots panel (e.g. manipulator button). Hidden initially so it doesn't
       // block context menu actions such as Copy Image.
       plotsSurface_ = new PlotsSurface(panel_);
       panel_.add(plotsSurface_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/ace-uncompressed.js
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/ace-uncompressed.js
@@ -15203,7 +15203,7 @@ var MarkdownHighlightRules = function() {
         },
         codeBlockStartRule,
         {
-            defaultToken : "list" //do not use markup.list to allow stling leading `*` differntly
+            defaultToken : "list" //do not use markup.list to allow stling leading `*` differently
         } ],
 
         "blockquote" : [ { // Blockquotes only escape on blank lines.

--- a/src/gwt/test/highlight_test_cpp.html
+++ b/src/gwt/test/highlight_test_cpp.html
@@ -37,7 +37,7 @@
 <body>
 
   <h2>C++ Operator Highlight Tester</h2>
-  <div id="editor" style="position: aboluste; width: 600px; height: 600px; border: 1px solid #999"></div>
+  <div id="editor" style="position: absolute; width: 600px; height: 600px; border: 1px solid #999"></div>
 
   <script type="text/javascript">
 

--- a/src/gwt/test/highlight_test_sql.html
+++ b/src/gwt/test/highlight_test_sql.html
@@ -35,7 +35,7 @@
 <body>
 
   <h2>SQL Highlight Tester</h2>
-  <div id="editor" style="position: aboluste; width: 600px; height: 600px; border: 1px solid #999"></div>
+  <div id="editor" style="position: absolute; width: 600px; height: 600px; border: 1px solid #999"></div>
 
   <script type="text/javascript">
 

--- a/src/gwt/tools/build-xterm-README.md
+++ b/src/gwt/tools/build-xterm-README.md
@@ -7,7 +7,7 @@ RStudio 1.4 uses xterm.js 4.x
 RStudio 1.3 uses xterm.js 3.14.5.
 
 ### Getting the Code (1.3+)
-Xterm.js and its addins are distribued via npm. Run the build-xterm script from this folder to 
+Xterm.js and its addins are distributed via npm. Run the build-xterm script from this folder to 
 pull down the release and minify it into the source tree.
 
 ## RStudio 1.1/1.2
@@ -74,7 +74,7 @@ this rule from `tweak-xterm-css.R` and `compile-themes.R`. Ignore
 obsolete selectors, i.e. remove selectors that have been eliminated from 
 `tweak-xterm.css.R` and `compile-themes.R`.
 
-4) Once `build-xterm` runs successfuly and ends with **Done!** examine the
+4) Once `build-xterm` runs successfully and ends with **Done!** examine the
 difference between new and previous
 `rstudio/src/gwt/src/org/rstudio/studio/client/workbench/views/terminal/xterm/xterm.css`
 and look for added instances of `color:` or `background-color:` (ignoring
@@ -91,7 +91,7 @@ they contain the rules removed by `tweak-xterm.cs.R`.
 changes from another dark theme such as Merbivore Soft and copy them over.
 Be careful to preserve foreground and background colors.
 
-### Evaluting the JavaScript Changes (1.2)
+### Evaluating the JavaScript Changes (1.2)
 Ideally, this would be completely handled by running the client-side unit 
 tests via **ant unittest**. This is not currently the case, however on the
 positive side, XTerm.js 2.x releases have rarely required code changes in 

--- a/src/gwt/tools/editor-settings/eclipse-templates.xml
+++ b/src/gwt/tools/editor-settings/eclipse-templates.xml
@@ -63,7 +63,7 @@ public class ${event}Event extends GwtEvent&lt;${event}Event.Handler&gt;
 
    public static final Type&lt;Handler&gt; TYPE = new Type&lt;Handler&gt;();
 }
-</template><template autoinsert="true" context="java" deleted="false" description="Boilerplate for GWT resouces + styles" enabled="true" name="GWTResources">${:import(com.google.gwt.resources.client.CssResource,
+</template><template autoinsert="true" context="java" deleted="false" description="Boilerplate for GWT resources + styles" enabled="true" name="GWTResources">${:import(com.google.gwt.resources.client.CssResource,
           com.google.gwt.resources.client.ClientBundle,
           com.google.gwt.core.client.GWT)}
 

--- a/src/gwt/tools/i18n-helpers/README.md
+++ b/src/gwt/tools/i18n-helpers/README.md
@@ -58,7 +58,7 @@ Run this script from `/src/gwt/src` with syntax `./create_dev_locale.sh`
 
 Auto-generates java interfaces and properties files for all commands and menus defined with `Commands.cmd.xml` using 
 the English text in that file.  This script must be run whenever `Commands.cmd.xml` is edited, and is automatically
-executed whenever chages to this file are detected and the `build`, `desktop`, or `devmode` ant targets are triggered.
+executed whenever changes to this file are detected and the `build`, `desktop`, or `devmode` ant targets are triggered.
 
 Usage below shows how to trigger the scripts manually (instead of via ant buildfile targets) for the creation of English
 and "dev" locales, as discussed above for `create_dev_locale.sh`


### PR DESCRIPTION
### Intent

Fixes typos found within the source code which includes comments and documentation. Follow-up to fea9c7d  

### Approach

Found using `codespell -q 3 -S *_fr.properties -L ba,enque,optionel,ot,parm,parms,pres,prevend,pevent,pevents,ptd,texline`
 but then combing through results pruning upstream 3rd party deps etc...

### Automated Tests

This PR fixes typos. No unit tests needed.

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests


