### PR TITLE
allow request for editor context by id

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -392,19 +392,19 @@
 # of the 'rstudioapi' package -- it is superceded by
 # '.rs.getLastActiveEditorContext()'.
 .rs.addApiFunction("getActiveDocumentContext", function() {
-   .Call("rs_getEditorContext", 0L, PACKAGE = "(embedding)")
+   .Call("rs_getEditorContext", 0L, NULL, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getLastActiveEditorContext", function() {
-   .Call("rs_getEditorContext", 0L, PACKAGE = "(embedding)")
+   .Call("rs_getEditorContext", 0L, NULL, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getConsoleEditorContext", function() {
-   .Call("rs_getEditorContext", 1L, PACKAGE = "(embedding)")
+   .Call("rs_getEditorContext", 1L, NULL, PACKAGE = "(embedding)")
 })
 
-.rs.addApiFunction("getSourceEditorContext", function() {
-   .Call("rs_getEditorContext", 2L, PACKAGE = "(embedding)")
+.rs.addApiFunction("getSourceEditorContext", function(id = NULL) {
+   .Call("rs_getEditorContext", 2L, id, PACKAGE = "(embedding)")
 })
 
 .rs.addApiFunction("getActiveProject", function() {

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -72,13 +72,17 @@ namespace {
 
 module_context::WaitForMethodFunction s_waitForEditorContext;
 
-SEXP rs_getEditorContext(SEXP typeSEXP)
+SEXP rs_getEditorContext(SEXP typeSEXP, SEXP idSEXP)
 {
    int type = r::sexp::asInteger(typeSEXP);
    
+   json::Object payload;
+   payload["type"] = type;
+   payload["id"] = r::sexp::safeAsString(idSEXP, "");
+   
    json::Object eventData;
    eventData["type"] = "editor_context";
-   eventData["data"] = type;
+   eventData["data"] = payload;
    
    // send the event
    ClientEvent editorContextEvent(client_events::kEditorCommand, eventData);

--- a/src/gwt/src/org/rstudio/studio/client/events/GetEditorContextEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/GetEditorContextEvent.java
@@ -29,8 +29,16 @@ public class GetEditorContextEvent extends CrossWindowEvent<GetEditorContextEven
    {
       protected Data() {}
 
-      public static final native Data create() /*-{ return 0; }-*/;
-      public final native int getType() /*-{ return this; }-*/;
+      public static final native Data create()
+      /*-{
+         return {
+            type: 0,
+            id: ""
+         };
+      }-*/;
+      
+      public final native int getType()     /*-{ return this["type"]; }-*/;
+      public final native String getDocId() /*-{ return this["id"];   }-*/;
    }
 
    public static class DocumentSelection extends JavaScriptObject

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -2902,6 +2902,7 @@ public class Source implements InsertSourceEvent.Handler,
    {
       GetEditorContextEvent.Data data = event.getData();
       int type = data.getType();
+      String id = data.getDocId();
 
       if (type == GetEditorContextEvent.TYPE_ACTIVE_EDITOR)
       {
@@ -2922,8 +2923,16 @@ public class Source implements InsertSourceEvent.Handler,
       }
       else if (type == GetEditorContextEvent.TYPE_SOURCE_EDITOR)
       {
-         if (columnManager_.requestActiveEditorContext())
-            return;
+         if (StringUtil.isNullOrEmpty(id))
+         {
+            if (columnManager_.requestActiveEditorContext())
+               return;
+         }
+         else
+         {
+            if (columnManager_.requestEditorContext(id))
+               return;
+         }
       }
 
       // We need to ensure a 'getEditorContext' event is always

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -856,6 +856,26 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
       editingTarget.getEditorContext();
       return true;
    }
+   
+   public boolean requestEditorContext(String id)
+   {
+      for (SourceColumn column : columnList_)
+      {
+         for (EditingTarget target : column.getEditors())
+         {
+            if (target instanceof TextEditingTarget)
+            {
+               if (StringUtil.equals(target.getId(), id))
+               {
+                  ((TextEditingTarget) target).getEditorContext();
+                  return true;
+               }
+            }
+         }
+      }
+      
+      return false;
+   }
 
    public void activateCodeBrowser(
       final String codeBrowserPath,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudioapi/issues/251.

### Approach

Extend the existing `getSourceEditorContext()` API to allow the user to specify an explicit document ID.

### Automated Tests

Not included.

### QA Notes

We'll request verification from Garrick.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
