### PR TITLE
Menus are now checkable on Electron

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -330,12 +330,13 @@ export class MenuCallback extends EventEmitter {
       click: (menuItem, _browserWindow, _event) => {
         this.emit(MenuCallback.COMMAND_INVOKED, menuItem.id);
       },
-      type: 'checkbox',
     };
 
     if (checkable) {
+      menuItemOpts.type = 'checkbox';
       menuItemOpts.checked = false;
     }
+
     if (shortcut.length > 0) {
       menuItemOpts.accelerator = this.convertShortcut(shortcut);
     }

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -330,6 +330,7 @@ export class MenuCallback extends EventEmitter {
       click: (menuItem, _browserWindow, _event) => {
         this.emit(MenuCallback.COMMAND_INVOKED, menuItem.id);
       },
+      type: 'checkbox',
     };
 
     if (checkable) {


### PR DESCRIPTION
### Intent

Fix an issue that made menus not be able to be checkable on Electron. Debug and Panes are now working as expected.

### Approach

Added type `checkbox` to menus.

### Automated Tests

None

### QA Notes

None

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests


Addresses #10866