### PR TITLE
Added new unit test for qmd and fixed existing tests for Rmd

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2239,7 +2239,11 @@
      .rs.extractRCode(contents,
                       "^[\t >]*```+\\s*\\{[Rr]\\b.*\\}\\s*$",
                       "^[\t >]*```+\\s*$")
-   if (is.null(code) || identical(code, .rs.scalar("")))
+   if (is.null(code))
+      return(character())
+   # If Quarto and no R code chunks, don't parse further
+   # Rmd may have yaml front matter to parse even if no R chunks
+   if (identical(code, .rs.scalar("")) && identical(extension, ".qmd"))
       return(character())
 
    # attempt to parse extracted R code

--- a/src/cpp/tests/testthat/test-pkg-deps.R
+++ b/src/cpp/tests/testthat/test-pkg-deps.R
@@ -123,3 +123,19 @@ test_that("HTML comments are not treated like YAML delimiters", {
    expect_equal(sort(packages), sort(c("callr", "crayon")))
 })
 
+
+test_that("Quarto files with no R chunks have no dependencies", {
+   contents <- paste(
+      "",
+      "---",
+      "title: Test Doc 5",
+      "format: html",
+      "editor: visual",
+      "---",
+      "```{python}",
+      "import shiny",
+      "```",
+      "", sep = "\n")
+   packages <- .rs.parsePackageDependencies(contents, ".qmd")
+   expect_equal(packages, character())
+})


### PR DESCRIPTION
### Intent

Followup to #10864 which was merged yesterday and broke unit tests
### Approach

- Add a new unit test for quarto
- Fix behavior of `.rs.parsePackageDependencies for non-qmd files (specifically Rmd) by continuing to parse even if there are no R code chunks, since for Rmd we need to make sure we still parse the yaml front matter

### Automated Tests

Updated to pass.  Ran locally and all good 👍 

### QA Notes

NA, should be QA'd as part of previous issue, [pro 3310](https://github.com/rstudio/rstudio-pro/issues/3310). This specific PR just relates to the testthat failure

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


