### PR TITLE
Handle no R code differently from R code with 0 dependencies

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2240,11 +2240,11 @@
                       "^[\t >]*```+\\s*\\{[Rr]\\b.*\\}\\s*$",
                       "^[\t >]*```+\\s*$")
    if (is.null(code))
-      return(character())
+      return(NULL)
    # If Quarto and no R code chunks, don't parse further
    # Rmd may have yaml front matter to parse even if no R chunks
    if (identical(code, .rs.scalar("")) && identical(extension, ".qmd"))
-      return(character())
+      return(NULL)
 
    # attempt to parse extracted R code
    parsed <- .rs.tryCatch(parse(text = code, encoding = "UTF-8"))
@@ -2455,7 +2455,7 @@
    # parse to find packages
    packages <- .rs.parsePackageDependencies(contents, extension)
    # return early if no R code is parsed
-   if (length(packages) == 0)
+   if (is.null(packages))
       return(character())
 
    # If file is qmd or rmd, and there is R code, rmarkdown is REQUIRED

--- a/src/cpp/tests/testthat/test-pkg-deps.R
+++ b/src/cpp/tests/testthat/test-pkg-deps.R
@@ -137,5 +137,5 @@ test_that("Quarto files with no R chunks have no dependencies", {
       "```",
       "", sep = "\n")
    packages <- .rs.parsePackageDependencies(contents, ".qmd")
-   expect_equal(packages, character())
+   expect_null(packages)
 })


### PR DESCRIPTION
Followup to #10864 and #10878