### PR TITLE
Electron: Include font styles for Mac

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -84,9 +84,13 @@ export class GwtCallback extends EventEmitter {
   // https://github.com/foliojs/font-manager/issues/15
   // the fork did not correct usage of Fontconfig
   // getAvailableFontsSync() incorrectly sets the monospace property
-  monospaceFonts = [...new Set<string>(findFontsSync({ monospace: true }).map((fd) => fd.postscriptName))].sort(
-    (a, b) => a.localeCompare(b),
-  );
+  monospaceFonts = [
+    ...new Set<string>(
+      findFontsSync({ monospace: true }).map((fd) => {
+        return process.platform === 'darwin' ? fd.postscriptName : fd.family;
+      }),
+    ),
+  ].sort((a, b) => a.localeCompare(b));
   proportionalFonts = [...new Set<string>(findFontsSync({ monospace: false }).map((fd) => fd.family))].sort((a, b) =>
     a.localeCompare(b),
   );


### PR DESCRIPTION
### Intent
Address #10438

Uses the postscript name on Mac to select a specific font style.

![image](https://user-images.githubusercontent.com/9591545/161139207-ce8111a9-cf65-4aa5-a79f-9b0d35a6804e.png)


### Approach
This seems to work well for MacOS. Linux and Windows only seems to take the font family name as a valid way to specify the font. Actually, Linux allows with certain fonts to append the style to the end of the family name. So `Fira Code Light` would work. However, `Fira Code Bold` is invalid (not sure why or what is different about that font file). There are likely further improvements that could be made in this area. It's probably better to port the old Qt code to get that specific querying logic as `node-system-fonts` sets up different parameters for `font-config`.

### Automated Tests
None

### QA Notes
There should be a _much_ longer font list for Mac now. Linux is still missing font styles and Windows already has a full list of fonts with styles.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


