### PR TITLE
reduce chance of collisions when generating port for desktop <-> rsession communication

### DIFF
--- a/src/cpp/core/include/core/Random.hpp
+++ b/src/cpp/core/include/core/Random.hpp
@@ -16,22 +16,11 @@
 #ifndef CORE_RANDOM_HPP
 #define CORE_RANDOM_HPP
 
-#ifndef _WIN32
-# include <unistd.h>
-#else
-# include <process.h>
-#endif
-
-#include <ctime>
-#include <functional>
 #include <limits>
-#include <random>
 
 #include <boost/chrono.hpp>
 #include <boost/random.hpp>
 #include <boost/thread.hpp>
-
-#include <core/system/System.hpp>
 
 namespace rstudio {
 namespace core {

--- a/src/cpp/core/include/core/Random.hpp
+++ b/src/cpp/core/include/core/Random.hpp
@@ -38,9 +38,9 @@ T uniformRandomInteger(
       T minValue = std::numeric_limits<T>::min(),
       T maxValue = std::numeric_limits<T>::max())
 {
-   boost::random::mt19937 rng(getpid() + std::time(NULL));
-   boost::random::uniform_int_distribution<> generator(minValue, maxValue);
-   return generator(rng);
+   boost::random::mt19937 gen(getpid() + std::time(NULL));
+   boost::random::uniform_int_distribution<> dist(minValue, maxValue);
+   return dist(gen);
 }
 } // namespace random
 } // namespace core

--- a/src/cpp/core/include/core/Random.hpp
+++ b/src/cpp/core/include/core/Random.hpp
@@ -22,10 +22,14 @@
 # include <process.h>
 #endif
 
-#include <limits>
 #include <ctime>
+#include <functional>
+#include <limits>
+#include <random>
 
+#include <boost/chrono.hpp>
 #include <boost/random.hpp>
+#include <boost/thread.hpp>
 
 #include <core/system/System.hpp>
 
@@ -38,10 +42,17 @@ T uniformRandomInteger(
       T minValue = std::numeric_limits<T>::min(),
       T maxValue = std::numeric_limits<T>::max())
 {
-   boost::random::mt19937 gen(getpid() + std::time(NULL));
+   // choose random seed
+   long long seed = boost::chrono::high_resolution_clock::now().time_since_epoch().count();
+
+   // construct our generator
+   boost::random::mt19937 gen(seed);
    boost::random::uniform_int_distribution<> dist(minValue, maxValue);
+
+   // generate a value
    return dist(gen);
 }
+
 } // namespace random
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/Random.hpp
+++ b/src/cpp/core/include/core/Random.hpp
@@ -23,6 +23,7 @@
 #endif
 
 #include <limits>
+#include <ctime>
 
 #include <boost/random.hpp>
 
@@ -33,12 +34,12 @@ namespace core {
 namespace random {
 
 template <typename T>
-T uniformRandomInteger()
+T uniformRandomInteger(
+      T minValue = std::numeric_limits<T>::min(),
+      T maxValue = std::numeric_limits<T>::max())
 {
    boost::random::mt19937 rng(getpid() + std::time(NULL));
-   boost::random::uniform_int_distribution<> generator(
-            std::numeric_limits<T>::min(),
-            std::numeric_limits<T>::max());
+   boost::random::uniform_int_distribution<> generator(minValue, maxValue);
    return generator(rng);
 }
 } // namespace random

--- a/src/cpp/core/include/core/Random.hpp
+++ b/src/cpp/core/include/core/Random.hpp
@@ -16,10 +16,17 @@
 #ifndef CORE_RANDOM_HPP
 #define CORE_RANDOM_HPP
 
+#ifndef _WIN32
+# include <unistd.h>
+#else
+# include <process.h>
+#endif
+
 #include <limits>
-#include <ctime>
 
 #include <boost/random.hpp>
+
+#include <core/system/System.hpp>
 
 namespace rstudio {
 namespace core {
@@ -28,21 +35,12 @@ namespace random {
 template <typename T>
 T uniformRandomInteger()
 {
-  // setup generator and distribution
-  typedef boost::mt19937 GeneratorType;
-  typedef boost::uniform_int<T> DistributionType;
-  GeneratorType generator(std::time(nullptr));
-  DistributionType distribution(std::numeric_limits<T>::min(),
-                                std::numeric_limits<T>::max());
-
-  // create variate generator
-  boost::variate_generator<GeneratorType, DistributionType> vg(generator,
-                                                               distribution);
-
-  // return random number
-  return vg();
+   boost::random::mt19937 rng(getpid() + std::time(NULL));
+   boost::random::uniform_int_distribution<> generator(
+            std::numeric_limits<T>::min(),
+            std::numeric_limits<T>::max());
+   return generator(rng);
 }
-
 } // namespace random
 } // namespace core
 } // namespace rstudio

--- a/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
+++ b/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
@@ -89,7 +89,10 @@ inline Error initTcpIpAcceptor(
    acceptor.open(endpoint.protocol(), ec);
    if (ec)
       return Error(ec, ERROR_LOCATION);
-   
+
+   // TODO: is this the desired behavior on Windows and desktop?
+   // this could allow multiple clients to try connecting to the
+   // same session
    acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
    if (ec)
       return Error(ec, ERROR_LOCATION);

--- a/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
+++ b/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
@@ -90,12 +90,28 @@ inline Error initTcpIpAcceptor(
    if (ec)
       return Error(ec, ERROR_LOCATION);
 
-   // TODO: is this the desired behavior on Windows and desktop?
-   // this could allow multiple clients to try connecting to the
-   // same session
+   // NOTE: The semantics of SO_REUSEADDR are different between Unix and Windows; see:
+   //
+   // https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse
+   //
+   // In particular:
+   //
+   // > The SO_REUSEADDR socket option allows a socket to forcibly bind to a port in use by another socket.
+   //
+   // The rough equivalent of the Unix behavior we want here is SO_EXCLUSIVEADDRUSE.
+#ifndef _WIN32
    acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
    if (ec)
       return Error(ec, ERROR_LOCATION);
+#else
+   typedef boost::asio::detail::socket_option::boolean<
+         BOOST_ASIO_OS_DEF(SOL_SOCKET),
+         SO_EXCLUSIVEADDRUSE
+   > exclusive_addr_use;
+   acceptor.set_option(exclusive_addr_use(true), ec);
+   if (ec)
+      return Error(ec, ERROR_LOCATION);
+#endif
    
    acceptor.set_option(tcp::no_delay(true), ec);
    if (ec)

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -117,9 +117,7 @@ Error removeStaleOptionsLockfile()
 
 void initializeSharedSecret()
 {
-   sharedSecret = QString::number(rand())
-                  + QString::number(rand())
-                  + QString::number(rand());
+   sharedSecret = QString::fromStdString(core::system::generateUuid());
    std::string value = sharedSecret.toUtf8().constData();
    core::system::setenv("RS_SHARED_SECRET", value);
 }

--- a/src/cpp/desktop/DesktopMain.cpp
+++ b/src/cpp/desktop/DesktopMain.cpp
@@ -517,6 +517,8 @@ int main(int argc, char* argv[])
                                   desktop::userLogPath(),
                                   true);
 
+      LOG_DEBUG_MESSAGE("Initialized logs (pid=" + std::to_string(getpid()) + ")");
+
       // ignore SIGPIPE
       Error error = core::system::ignoreSignal(core::system::SigPipe);
       if (error)

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -172,7 +172,8 @@ QString Options::portNumber() const
    for (int i = 0; i < 100; i++)
    {
       // generate a port number
-      int port = core::random::uniformRandomInteger<int>(8080, 40000);
+      // RFC 6335 suggests the range 49152-65535 for dynamic ports
+      int port = core::random::uniformRandomInteger<int>(49152, 65535);
       LOG_DEBUG_MESSAGE("Trying port " + std::to_string(port));
 
       // try to bind to it -- if this fails, try a new port number

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -190,9 +190,14 @@ QString Options::portNumber() const
       localPeer_ = localPeer.toUtf8().constData();
       core::system::setenv("RS_LOCAL_PEER", localPeer_);
 #endif
+    
+      // return discovered port
+      return portNumber_;
    }
 
-   return portNumber_;
+   // if we get here, we failed to find an open port
+   LOG_WARNING_MESSAGE("failed to find open port; defaulting to port 8789");
+   return QStringLiteral("8789");
 }
 
 QString Options::newPortNumber()

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -151,6 +151,16 @@ void Options::saveMainWindowBounds(QMainWindow* win)
 
 QString Options::portNumber() const
 {
+#ifndef RSTUDIO_PACKAGE_BUILD
+   // allow for hard-coded port, for debugging
+   std::string port = core::system::getenv("RSTUDIO_RSESSION_PORT");
+   if (!port.empty())
+   {
+      portNumber_ = QString::fromStdString(port);
+      return portNumber_;
+   }
+#endif
+
    // if we already have a port number, use it
    if (!portNumber_.isEmpty())
    {

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -179,7 +179,7 @@ QString Options::portNumber() const
       QTcpSocket socket;
       if (!socket.bind(port))
       {
-         LOG_DEBUG_MESSAGE("Couldn't bind to port " + std::to_string(port) + "; trying again");
+         LOG_DEBUG_MESSAGE("Couldn't bind to port " + std::to_string(port) + "; trying new port");
          continue;
       }
 

--- a/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
+++ b/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
@@ -24,6 +24,10 @@
 
 #include "SessionTcpIpHttpConnectionListener.hpp"
 
+#ifdef DEBUG
+# undef DEBUG
+#endif
+
 using namespace rstudio::core;
 
 namespace rstudio {

--- a/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
+++ b/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
@@ -50,11 +50,18 @@ void initializeHttpConnectionListener()
       const char* fmt =
             "Initializing HTTP connection listener [address=%s; port=%s; secret=%s]";
 
+      std::string sharedSecret;
+#ifdef RSTUDIO_PACKAGE_BUILD
+      sharedSecret = "<redacted>";
+#else
+      sharedSecret = options.sharedSecret();
+#endif
+
       std::string msg = core::string_utils::sprintf(
                fmt,
                options.wwwAddress().c_str(),
                options.wwwPort().c_str(),
-               options.sharedSecret().c_str());
+               sharedSecret.c_str());
 
       LOG_DEBUG_MESSAGE(msg);
    }

--- a/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
+++ b/src/cpp/session/http/SessionWin32HttpConnectionListener.cpp
@@ -40,6 +40,21 @@ HttpConnectionListener* s_pHttpConnectionListener = nullptr;
 void initializeHttpConnectionListener()
 {
    session::Options& options = session::options();
+
+   if (log::isLogLevel(log::LogLevel::DEBUG))
+   {
+      const char* fmt =
+            "Initializing HTTP connection listener [address=%s; port=%s; secret=%s]";
+
+      std::string msg = core::string_utils::sprintf(
+               fmt,
+               options.wwwAddress().c_str(),
+               options.wwwPort().c_str(),
+               options.sharedSecret().c_str());
+
+      LOG_DEBUG_MESSAGE(msg);
+   }
+
    s_pHttpConnectionListener = new TcpIpHttpConnectionListener(
                                       options.wwwAddress(),
                                       options.wwwPort(),


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10488. Candidate for backport.

### Approach

- Adjust the random seed used by our RNG, so that the process PID is included. This should help reduce the chance of collisions when multiple RStudio sessions are launched at the same time.

- Use a UUID for the desktop shared secret, rather than just the system RNG.

- Validate that the port we've selected is actually open via TCP, and use it only if it appears open.

### Automated Tests

Not included; this fix is hard to test via automation.

### QA Notes

On Windows, in a command prompt, try launching RStudio in the following way:

```
REM Change path below with wherever you have RStudio installed.
cd "C:\Program Files\RStudio\bin"  
for %i in (1 2 3) do start /b rstudio.exe
```

You should see 3 separate instances of RStudio launched. Try to execute some code in one of those sessions, and confirm that output is seen only in that 1 session, and not in the other 2 sessions.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
