### PR TITLE
Update to Electron 18.0.1

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -40,7 +40,7 @@
         "chai": "4.3.6",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "6.5.1",
-        "electron": "17.1.2",
+        "electron": "18.0.1",
         "electron-mocha": "11.0.2",
         "eslint": "^7.12.1",
         "eslint-config-prettier": "8.3.0",
@@ -4289,14 +4289,14 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.1.tgz",
+      "integrity": "sha512-8y3nxmK+v/tiuaR8yd4K83ApHxgomMIPAEl3J+2Jfv/D5G6M3KnvxNlNiNoTXI8uOegfmoqiDm5/2xlWFLzfLQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
       "bin": {
@@ -4742,9 +4742,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "14.18.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-      "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
+      "version": "16.11.26",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+      "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -17432,20 +17432,20 @@
       "dev": true
     },
     "electron": {
-      "version": "17.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-17.1.2.tgz",
-      "integrity": "sha512-hqKQaUIRWX5Y2eAD8FZINWD/e5TKdpkbBYbkcZmJS4Bd1PKQsaDVc9h5xoA8zZQkPymE9rss+swjRpAFurOPGQ==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.0.1.tgz",
+      "integrity": "sha512-8y3nxmK+v/tiuaR8yd4K83ApHxgomMIPAEl3J+2Jfv/D5G6M3KnvxNlNiNoTXI8uOegfmoqiDm5/2xlWFLzfLQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",
-        "@types/node": "^14.6.2",
+        "@types/node": "^16.11.26",
         "extract-zip": "^1.0.3"
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.12",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
-          "integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A==",
+          "version": "16.11.26",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.26.tgz",
+          "integrity": "sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==",
           "dev": true
         }
       }

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -44,7 +44,7 @@
     "chai": "4.3.6",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "6.5.1",
-    "electron": "17.1.2",
+    "electron": "18.0.1",
     "electron-mocha": "11.0.2",
     "eslint": "^7.12.1",
     "eslint-config-prettier": "8.3.0",

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -106,7 +106,6 @@ export class DesktopBrowserWindow extends EventEmitter {
         webPreferences: {
           additionalArguments: apiKeys,
           contextIsolation: true,
-          nativeWindowOpen: true,
           nodeIntegration: false,
           preload: preload,
           sandbox: true,


### PR DESCRIPTION
### Intent

Latest and greatest Electron build. This bumps us up to latest major version (17 to 18).

https://www.electronjs.org/blog/electron-18-0

### Approach

Usual npm upgrade song & dance. Required a one-line code change to remove obsolete property. I built and ran dev build, and a full package build, on Mac.

### Automated Tests

Confirmed the unit tests and the integration tests pass (only tried on Mac, will let build pipeline exercise the rest).

### QA Notes

Nothing specific to test.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


