### PR TITLE
remove some punctuation exclusions from cite ids

### DIFF
--- a/src/gwt/panmirror/src/editor/src/marks/cite/cite.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/cite/cite.ts
@@ -57,7 +57,7 @@ const kCiteCitationsIndex = 0;
 // This is only because when writing in text citations, it will be common to follow a citation with 
 // punctuation, and we should be smart enough to filter that punctuation out of the citation itself.
 const kCiteIdPrefixPattern = '-?@';
-const kCiteIdCharsPattern = '[^@;\\[\\]\\s\\!\\,\\.\\?\\:]*';
+const kCiteIdCharsPattern = '[^@;\\[\\]\\s\\!\\,]*';
 const kCiteIdBasePattern = `${kCiteIdPrefixPattern}${kCiteIdCharsPattern}`;
 
 // Completions examine all the text inside the citation mark, so they need to only be interested


### PR DESCRIPTION
These punctuation characters (".", "?", and ":") are in fact allowed the pandoc spec:

> Unless a citation key start with a letter, digit, or `_`, and contains only alphanumerics and single internal punctuation characters (`:.#$%&-+?<>~/`), it must be surrounded by curly braces, which are not considered part of the key. In `@Foo_bar.baz.`, the key is `Foo_bar.baz` because the final period is not *internal* punctuation, so it is not included in
the key.  In `@{Foo_bar.baz.}`, the key is `Foo_bar.baz.`, including the final period. In `@Foo_bar--baz`, the key is `Foo_bar` because the repeated internal punctuation characters terminate the key. The curly braces are recommended if you use URLs as keys: `[@{https://example.com/bib?name=foobar&date=2000}, p.  33]`.

We have added them to our exclusion list over the past 9 months in the following PRs/commits:

- PR https://github.com/rstudio/rstudio/pull/9640 , commit https://github.com/rstudio/rstudio/commit/46bd0318e1051b6052c50494b34eb5b6627642ca
- PR https://github.com/rstudio/rstudio/pull/9633, commit https://github.com/rstudio/rstudio/commit/eb2dea9b5172d418885d9f52b5c202403e17ae0c

It seems like these changes should definitely be reverted, however I'm not sure what other functionality might be dependent on these changes (and requires an additional fix/workaround).

Addresses https://github.com/rstudio/rstudio/issues/10075

