### PR TITLE
Better handles search results in directory starting with `.`

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -982,11 +982,11 @@ private:
             // extract filename from match
             std::string file = module_context::createAliasedPath(FilePath(match[1]));
 
-            // replace the leading '.' with the directory name
+            // replace the leading './' with the directory name
             // (git grep doesn't prepend a '.' so we need to be careful here)
-            if (boost::algorithm::starts_with(file, "."))
+            if (boost::algorithm::starts_with(file, "./"))
             {
-               file = workingDir_ + file.substr(1);
+               file = workingDir_ + file.substr(2);
             }
             else if (findResults().gitFlag())
             {


### PR DESCRIPTION
### Intent

Adresses #10884 

### Approach

instead of replacing the leading `.`, replace the leading `./` so that directories starting with `.` are not mistreated. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

in a project, create a file in a directory that starts with ".", e.g. 

```r
dir.create(".ignore")
writeLines("blablabla", ".ignore/test.txt")
```

Then search for "blabla". The results will appear: 

<img width="586" alt="image" src="https://user-images.githubusercontent.com/2625526/161519312-f407607b-f8ea-4b77-8e33-dea7a0cb8e9a.png">

especially: 

<img width="77" alt="image" src="https://user-images.githubusercontent.com/2625526/161519370-15435f89-f732-41b7-aa8b-96acb6ddeb38.png">

Things in the `.Rproj.user` directory, as in the issue #10884 are dealt with differently. They are ignored no matter if the checkbox is clicked or not, by the `shouldSkipFile()` method: 

```cpp
bool shouldSkipFile(std::string file)
   {
      return (file.find("/.Rproj.user/") != std::string::npos ||
              file.find("/.quarto/") != std::string::npos ||
              file.find("/.git/") != std::string::npos ||
              file.find("/.svn/") != std::string::npos ||
              file.find("/packrat/lib/") != std::string::npos ||
              file.find("/packrat/src/") != std::string::npos ||
              file.find("/renv/library/") != std::string::npos ||
              file.find("/renv/python/") != std::string::npos ||
              file.find("/renv/staging/") != std::string::npos ||
              file.find("/.Rhistory") != std::string::npos);
   }
```

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


