### PR TITLE
Fix File > New File > Quarto Document

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -297,6 +297,8 @@ if (APPLE)
    if (RSTUDIO_ELECTRON)
       set(RSTUDIO_INSTALL_BIN        RStudio.app/Contents/Resources/app/bin)
       set(RSTUDIO_INSTALL_SUPPORTING RStudio.app/Contents/Resources/app)
+      # handles Quarto share when not stored alongside bin
+      set(RSTUDIO_INSTALL_RESOURCES RStudio.app/Contents/Resources)
    else()
       set(RSTUDIO_INSTALL_BIN        RStudio.app/Contents/MacOS)
       set(RSTUDIO_INSTALL_SUPPORTING RStudio.app/Contents/Resources)

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -681,9 +681,15 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
                DESTINATION "${RSTUDIO_INSTALL_BIN}"
                USE_SOURCE_PERMISSIONS
                PATTERN "*/share" EXCLUDE)
-         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
-               DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/quarto"
-               USE_SOURCE_PERMISSIONS)
+         if (RSTUDIO_ELECTRON)
+            install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
+                  DESTINATION "${RSTUDIO_INSTALL_RESOURCES}/quarto"
+                  USE_SOURCE_PERMISSIONS)
+         else()
+            install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
+                  DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/quarto"
+                  USE_SOURCE_PERMISSIONS)
+         endif()
       else()
          install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
                DESTINATION "${RSTUDIO_INSTALL_BIN}"


### PR DESCRIPTION
### Intent
Addresses #10871 

Quarto only searches for the `share` directory in specific locations. With the difference in Electron packaging, Quarto can't find `share` in `RStudio.app/Contents/Resources/app`. Calling Quarto normally is fine until the new file dialog calls `quarto capabilities` which can't find the `share` directory.

### Approach
Move the Quarto `share` directory to root of `Resources` where Quarto can find it using the relative path check. This option was chosen since it keeps the Quarto `bin` with the other `bin` files while keeping the `share` out of it. I believe this is intended with how Mac apps, in general, are packaged. The alternative is placing both Quarto `bin` and `share` directories together.

### Automated Tests
None. Must be built to reproduce the error as dev environments use Quarto from your installed dependencies location.

### QA Notes
Ran `package/osx/make-package --electron` to check that it what it builds has resolved the issue.

Note: The issue is only reproduced when using `File > New File > Quarto Document`. The new file action in the Files pane bypasses the dialog that calls `quarto capabilities`.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


