### PR TITLE
add libfmt dependency; use for log macros

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -55,6 +55,7 @@ used by these components are included below):
 - Deno
 - Dart Sass
 - esbuild
+- fmt
 
 RStudio also includes a binary copy of libclang. This component is
 licensed to you under the University of Illinois/NCSA Open Source

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -559,6 +559,7 @@ endif()
 
 # external libraries
 add_subdirectory(ext)
+include_directories(SYSTEM "${FMT_SOURCE_DIR}/include")
 
 # shared library
 add_subdirectory(shared_core)

--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -16,12 +16,12 @@
 #ifndef CORE_LOG_HPP
 #define CORE_LOG_HPP
 
-#include <shared_core/Logger.hpp>
+#include <fmt/format.h>
 
 #include <string>
 
 #include <shared_core/Error.hpp>
-#include <boost/function.hpp>
+#include <shared_core/Logger.hpp>
 
 namespace rstudio {
 namespace core {
@@ -96,6 +96,31 @@ std::string errorAsLogEntry(const Error& error);
                                                                                       action)
 
 #define LOG_PASSTHROUGH_MESSAGE(source, message) rstudio::core::log::logPassthroughMessage(source, message)
+
+#define DLOGF(__FMT__, ...)                                                    \
+  do {                                                                         \
+    std::string message = fmt::format(FMT_STRING(__FMT__), ##__VA_ARGS__);     \
+    ::rstudio::core::log::logDebugMessage(message);                            \
+  } while (0)
+
+#define ILOGF(__FMT__, ...)                                                    \
+  do {                                                                         \
+    std::string message = fmt::format(FMT_STRING(__FMT__), ##__VA_ARGS__);     \
+    ::rstudio::core::log::logInfoMessage(message);                             \
+  } while (0)
+
+#define WLOGF(__FMT__, ...)                                                    \
+  do {                                                                         \
+    std::string message = fmt::format(FMT_STRING(__FMT__), ##__VA_ARGS__);     \
+    ::rstudio::core::log::logWarningMessage(message);                          \
+  } while (0)
+
+#define ELOGF(__FMT__, ...)                                                    \
+  do {                                                                         \
+    std::string message = fmt::format(FMT_STRING(__FMT__), ##__VA_ARGS__);     \
+    ::rstudio::core::log::logErrorMessage(message);                            \
+  } while (0)
+
 
 // define named logging sections
 #define kFileLockingLogSection "file-locking"

--- a/src/cpp/ext/CMakeLists.txt
+++ b/src/cpp/ext/CMakeLists.txt
@@ -15,3 +15,5 @@
 
 project (EXT)
 
+add_subdirectory(fmt)
+

--- a/src/cpp/ext/fmt/CMakeLists.txt
+++ b/src/cpp/ext/fmt/CMakeLists.txt
@@ -1,0 +1,8 @@
+include(FetchContent)
+FetchContent_Declare(fmt
+   GIT_REPOSITORY https://github.com/fmtlib/fmt
+   GIT_TAG b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9 # 8.1.1
+   )
+
+FetchContent_MakeAvailable(fmt)
+

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -20,10 +20,11 @@
 
 #include <boost/bind/bind.hpp>
 
-#include <core/Algorithm.hpp>
 #include <shared_core/Error.hpp>
-#include <core/Log.hpp>
 #include <shared_core/FilePath.hpp>
+
+#include <core/Algorithm.hpp>
+#include <core/Log.hpp>
 #include <core/FileSerializer.hpp>
 
 #include <core/system/System.hpp>


### PR DESCRIPTION
### Intent

This PR adds [fmt](https://fmt.dev/latest/index.html) as a dependency, to be used for type-safe string formatting. The utility macros `DLOGF()` and friends are added to make it easier to build larger format strings made up of many component pieces.

This PR is mostly a draft for discussion -- we can discuss whether or not we're comfortable adding `fmt` as a dependency; IMHO having a type-safe and ergonomic way to format strings will be very useful. (We do technically have `boost::format()` but I prefer the ergonomics of `fmt`. In addition, it has some extra facilities for compile-time checking where supported by the compiler.)

### Approach

Straightforward bundling + building of `fmt` components.

### Automated Tests

Not included.

### QA Notes

Developer-only change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
