### PR TITLE
disable chromium renderer a11y based on user setting

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -612,12 +612,11 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on('desktop_sync_to_editor_theme', (event, isDark) => {});
 
     ipcMain.handle('desktop_get_enable_accessibility', () => {
-      GwtCallback.unimpl('desktop_get_enable_accessibility');
-      return true;
+      return ElectronDesktopOptions().accessibility();
     });
 
     ipcMain.on('desktop_set_enable_accessibility', (event, enable) => {
-      GwtCallback.unimpl('desktop_set_enable_accessibility');
+      ElectronDesktopOptions().setAccessibility(enable);
     });
 
     ipcMain.handle('desktop_get_ignore_gpu_exclusion_list', (event, ignore) => {

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -83,8 +83,18 @@ class RStudioMain {
     }
   }
 
+  private async initializeAccessibility() {
+    // disable chromium renderer accessibility by default (it can cause 
+    // slowdown when used in conjunction with some applications; see e.g. 
+    // https://github.com/rstudio/rstudio/issues/1990) 
+    if (!ElectronDesktopOptions().accessibility()) {
+      app.commandLine.appendSwitch('disable-renderer-accessibility');
+    }
+  }
+
   private async startup(): Promise<void> {
     await this.initializeRenderingEngine();
+    await this.initializeAccessibility();
 
     // NOTE: On Linux it looks like Electron prefers using ANGLE for GPU
     // rendering; however, we've seen in at least one case (Ubuntu 20.04 in


### PR DESCRIPTION
### Intent

Addresses #10895

### Approach

Port the behaviour from Qt, namely, ensure the desktop setting is synchronized with the session setting, and use that value to decide if we should disable renderer accessibility at startup.

After changing the "screen reader support" toggle it is necessary to restart Electron for it to take effect, but the restart performed is insufficient. Same problem as described here for gpu settings: #10748

### Automated Tests

None

### QA Notes

Verify that when screen reader support is off, Electron doesn't expose the accessibility tree. You can use a screen reader to tell, or more easily, look at the accessibility diagnostics once #10901 is merged.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


