### PR TITLE
read PATH from default shell on startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 - The source button uses `cpp11::source_cpp()` on C++ files that have `[[cpp11::register]]` decorations (#10387)
 - New *Relative Line Numbers* preference for showing line numbers relative to the current line, rather than the first line (#1774)
 - Upgraded SOCI library dependency from version 4.0.0 to 4.0.3 (#10792)
-- RStudio now reads the PATH from the user's default shell on startup (#10551)
+- (macOS only) RStudio now reads the PATH from the user's default shell on startup (#10551)
 
 #### Find in Files
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - The source button uses `cpp11::source_cpp()` on C++ files that have `[[cpp11::register]]` decorations (#10387)
 - New *Relative Line Numbers* preference for showing line numbers relative to the current line, rather than the first line (#1774)
 - Upgraded SOCI library dependency from version 4.0.0 to 4.0.3 (#10792)
+- RStudio now reads the PATH from the user's default shell on startup (#10551)
 
 #### Find in Files
 

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -365,7 +365,7 @@ inline core::Error readLinesFromFile(const core::FilePath& filePath, std::vector
       return error;
 
    string_utils::convertLineEndings(&contents, string_utils::LineEndingPosix);
-   *pLines = algorithm::split(contents, "\n");
+   core::algorithm::append(pLines, core::algorithm::split(contents, "\n"));
    return Success();
 }
 

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include <boost/bind/bind.hpp>
+#include <boost/regex.hpp>
 #include <boost/system/errc.hpp>
 
 #include <shared_core/Error.hpp>
@@ -105,7 +106,13 @@ Error initializePathViaShell(const std::string& shellPath,
 // might.
 std::string initializePath()
 {
-   std::string path;
+   // if the user's path already contains '/usr/local/bin', assume that
+   // they're running RStudio through a shell / terminal and so we don't
+   // need to re-read the shell PATH
+   std::string defaultPath = core::system::getenv("PATH");
+   boost::regex reUsrLocalbin("(^|:)/usr/local/bin(:|$)");
+   if (boost::regex_search(defaultPath, reUsrLocalbin))
+      return defaultPath;
    
    // first, try to initialize with user's default shell
    // (RSTUDIO_SESSION_SHELL is primarily for internal use)

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -95,7 +95,8 @@ Error initializePathViaShell(const std::string& shellPath,
    {
       // only include last line of output, in case the shell printed
       // something extra during login / processing of scripts
-      std::vector<std::string> lines = core::algorithm::split(result.stdOut, "\n");
+      std::string output = core::string_utils::trimWhitespace(result.stdOut);
+      std::vector<std::string> lines = core::algorithm::split(output, "\n");
       auto n = lines.size();
       if (n == 0)
       {

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -122,6 +122,7 @@ std::string initializePath()
    
    if (!shell.empty())
    {
+      std::string path;
       Error error = initializePathViaShell(shell, &path);
       if (!error)
          return path;
@@ -130,6 +131,7 @@ std::string initializePath()
    // next, try to initialize with default shell
    if (shell != "/bin/sh")
    {
+      std::string path;
       Error error = initializePathViaShell("/bin/sh", &path);
       if (!error)
          return path;

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -34,10 +34,6 @@
 
 #include <session/SessionModuleContext.hpp>
 
-#if !defined(_WIN32) && !defined(RSTUDIO_PRO_BUILD)
-# define RSTUDIO_INITIALIZE_PATH_VIA_SHELL
-#endif
-
 using namespace rstudio::core;
 using namespace boost::placeholders;
 
@@ -136,13 +132,20 @@ std::string initializePath()
    return core::system::getenv("PATH");
 }
 
+std::string homePath(const std::string& suffix)
+{
+   return module_context::userHomePath()
+         .completeChildPath(suffix)
+         .getAbsolutePath();
+}
+
 } // anonymous namespace
 
 
 Error initialize()
 {
    
-#ifdef RSTUDIO_INITIALIZE_PATH_VIA_SHELL
+#ifdef __APPLE__
    std::string path = initializePath();
    
    // split into parts
@@ -150,16 +153,9 @@ Error initialize()
    
    // check for some components that we might need to append to the path
    std::vector<std::string> extraEntries = {
-      
-   #ifdef __APPLE__
-      module_context::userHomePath()
-         .completeChildPath("Applications/quarto/bin")
-         .getAbsolutePath(),
-      
+      homePath("Applications/quarto/bin"),
       "/Library/TeX/texbin",
       "/usr/texbin",
-   #endif
-      
    };
    
    for (const std::string& entry : extraEntries)

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -93,9 +93,23 @@ Error initializePathViaShell(const std::string& shellPath,
    }
    else
    {
-      pPath->assign(result.stdOut);
+      // only include last line of output, in case the shell printed
+      // something extra during login / processing of scripts
+      std::vector<std::string> lines = core::algorithm::split(result.stdOut, "\n");
+      auto n = lines.size();
+      if (n == 0)
+      {
+         return systemError(
+                  boost::system::errc::state_not_recoverable,
+                  result.stdErr,
+                  ERROR_LOCATION);
+      }
+      
+      // extract last line of output
+      std::string path = lines[n - 1];
+      pPath->assign(path);
       return Success();
-   }   
+   }
 }   
 
 // this routine is a little awkward -- if RStudio was launched from a terminal,

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -125,7 +125,7 @@ std::string initializePath()
    // they're running RStudio through a shell / terminal and so we don't
    // need to re-read the shell PATH
    std::string defaultPath = core::system::getenv("PATH");
-   boost::regex reUsrLocalbin("(^|:)/usr/local/bin(:|$)");
+   boost::regex reUsrLocalbin("(^|:)/usr/local/bin/?(:|$)");
    if (boost::regex_search(defaultPath, reUsrLocalbin))
       return defaultPath;
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10551.

### Approach

Rather than attempt to read the PATH via `/etc/paths` and `/etc/paths.d`, invoke the user's default shell as a login shell and ask that shell what the PATH is. This approach has the added bonus in that we can respect the user's configured PATH on Linux as well.

### Automated Tests

TODO

### QA Notes

Test that the PATH entries within a new RStudio session match what you see in a new terminal session. That is,

```
Sys.getenv("PATH")
```

and

```
echo $PATH
```

should print the same things in an RStudio session and a terminal session (assuming you aren't modifying your PATH within `.Renviron` or `.Rprofile`).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
