### PR TITLE
tweak PATH initialization on macOS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - The source button uses `cpp11::source_cpp()` on C++ files that have `[[cpp11::register]]` decorations (#10387)
 - New *Relative Line Numbers* preference for showing line numbers relative to the current line, rather than the first line (#1774)
 - Upgraded SOCI library dependency from version 4.0.0 to 4.0.3 (#10792)
+- (macOS only) Fixed an issue where `/usr/local/bin` is placed on the wrong location on the PATH (#10551)
 
 #### Find in Files
 

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -121,11 +121,6 @@ std::vector<std::string> initializePath()
 
    }
 
-   // add in components from paths.d etc.
-   std::for_each(paths.begin(),
-                 paths.end(),
-                 boost::bind(addToPathIfNecessary, _1, &paths));
-   
    return paths;
 }
 

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -95,7 +95,7 @@ std::vector<std::string> initializePath()
    // we're running RStudio through a terminal and so the PATH
    // has already been initialized
    std::string path = core::system::getenv("PATH");
-   boost::regex reUsrLocalBin("(^|:)/usr/local/bin(:|$)");
+   boost::regex reUsrLocalBin("(^|:)/usr/local/bin/?(:|$)");
    if (boost::regex_search(path, reUsrLocalBin))
       return core::algorithm::split(path, ":");
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10551.
Narrower alternative of https://github.com/rstudio/rstudio/pull/10907.

### Approach

Detect if `/usr/local/bin` is on the PATH, and if so, assume the PATH is already initialized. Otherwise, ignore the current state of the PATH and initialize it manually by reading `/etc/paths` and `/etc/paths.d`.

### Automated Tests

Not included.

### QA Notes

Try launching RStudio with something like:

```
PATH=/usr/bin:/bin:/usr/sbin:/sbin /Applications/RStudio.app/Contents/MacOS/RStudio
```

and check that `Sys.getenv("PATH")` reports that `/usr/local/bin` is on the PATH in the right location.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
