### PR TITLE
fix issue when adding default extension

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -68,6 +68,7 @@ export function getDesktopBridge() {
       ipcRenderer
         .invoke('desktop_get_save_file_name', caption, label, dir, defaultExtension, forceDefaultExtension, focusOwner)
         .then((result) => {
+
           // if the result was canceled, bail early
           if (result.canceled as boolean) {
             return callback('');
@@ -83,7 +84,8 @@ export function getDesktopBridge() {
           const dotIndex = filePath.lastIndexOf('.');
           const ext = dotIndex > 0 ? filePath.substring(dotIndex) : '';
           if (ext.length === 0 || (forceDefaultExtension && ext !== defaultExtension)) {
-            filePath = filePath.substring(0, dotIndex) + defaultExtension;
+            const name = dotIndex > 0 ? filePath.substring(0, dotIndex) : filePath;
+            filePath = name + defaultExtension;
           }
 
           // invoke callback


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10905.

### Approach

Fixes an issue with computing the filename when the user doesn't provide a file extension in the save dialog box.

### Automated Tests

TBA

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10905.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
