### PR TITLE
fuzzy finder: ignore things from "do not edit by hand" files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Label commit timestamps as being in UTC (#2544)
 - The choice of pipe operator (`magrittr` or native R 4.1+) inserted with the "Insert Pipe Operator" keyboard shortcut can now be configured at the project level as well as the global level (#9409)
 - The Git/SVN pane now supports creating ED25519-encrypted SSH keys by default. Newly created RSA SSH keys will now be 4096 bits instead of 2048 to increase security (#8255)
+- Read only R files (marked by "do not edit by hand") are ignored by the fuzzy file finder (#10912)
 
 #### Find in Files
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,7 +16,7 @@
 - Label commit timestamps as being in UTC (#2544)
 - The choice of pipe operator (`magrittr` or native R 4.1+) inserted with the "Insert Pipe Operator" keyboard shortcut can now be configured at the project level as well as the global level (#9409)
 - The Git/SVN pane now supports creating ED25519-encrypted SSH keys by default. Newly created RSA SSH keys will now be 4096 bits instead of 2048 to increase security (#8255)
-- Read only R files (marked by "do not edit by hand") are ignored by the fuzzy file finder (#10912)
+- Read only R and C++ files (marked by "do not edit by hand") are ignored by the fuzzy file finder (#10912)
 
 #### Find in Files
 

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -77,7 +77,7 @@ public:
    };
 
 public:
-   RSourceItem() : type_(None), braceLevel_(0), line_(0), column_(0)
+   RSourceItem() : type_(None), braceLevel_(0), line_(0), column_(0), hidden_(false)
    {
    }
 
@@ -86,13 +86,15 @@ public:
                const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
-               std::size_t column)
+               std::size_t column, 
+               bool hidden)
       : type_(type),
         name_(name),
         signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
-        column_(column)
+        column_(column), 
+        hidden_(hidden)
    {
    }
 
@@ -107,14 +109,16 @@ private:
                const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
-               std::size_t column)
+               std::size_t column, 
+               bool hidden)
       : context_(context),
         type_(type),
         name_(name),
         signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
-        column_(column)
+        column_(column), 
+        hidden_(hidden)
    {
    }
 
@@ -131,6 +135,7 @@ public:
    const int braceLevel() const { return braceLevel_; }
    int line() const { return core::safe_convert::numberTo<std::size_t, int>(line_,0); }
    int column() const { return core::safe_convert::numberTo<std::size_t, int>(column_,0); }
+   bool hidden() const { return hidden_; }
 
    // support for RSourceIndex::search
 
@@ -170,7 +175,8 @@ public:
                          signature_,
                          braceLevel_,
                          line_,
-                         column_);
+                         column_, 
+                         hidden_);
    }
 
 private:
@@ -181,6 +187,7 @@ private:
    int braceLevel_;
    std::size_t line_;
    std::size_t column_;
+   bool hidden_;
 };
 
 

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -558,10 +558,6 @@ RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
    // clear any (source-local) inferred packages
    inferredPkgNames_.clear();
 
-   // tokenize and create token cursor
-   if (boost::algorithm::contains(code, "do not edit by hand"))
-      return;
-      
    std::wstring wCode = string_utils::utf8ToWide(code, context);
    RTokens rTokens(wCode, RTokens::StripWhitespace | RTokens::StripComments);
    if (rTokens.empty())

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -312,6 +312,7 @@ void addSourceItem(RSourceItem::Type type,
                    const std::vector<RS4MethodParam>& signature,
                    const RToken& token,
                    const IndexStatus& status,
+                   bool hidden, 
                    RSourceIndex* pIndex)
 {
    pIndex->addSourceItem(RSourceItem(
@@ -320,13 +321,15 @@ void addSourceItem(RSourceItem::Type type,
                             signature,
                             status.count(RToken::LBRACE),
                             token.row() + 1,
-                            token.column() + 1));
+                            token.column() + 1, 
+                            hidden));
 }
 
-typedef boost::function<void(const RTokenCursor&, const IndexStatus&, RSourceIndex*)> Indexer;
+typedef boost::function<void(const RTokenCursor&, const IndexStatus&, bool isReadOnlyFile, RSourceIndex*)> Indexer;
 
 void libraryCallIndexer(const RTokenCursor& cursor,
                         const IndexStatus& status,
+                        bool isReadOnlyFile, 
                         RSourceIndex* pIndex)
 {
    if (!cursor.isType(RToken::ID))
@@ -365,6 +368,7 @@ void libraryCallIndexer(const RTokenCursor& cursor,
 
 void s4MethodIndexer(const RTokenCursor& cursor,
                      const IndexStatus& status,
+                     bool isReadOnlyFile, 
                      RSourceIndex* pIndex)
 {
    if (isMethodOrClassDefinition(cursor))
@@ -418,6 +422,7 @@ void s4MethodIndexer(const RTokenCursor& cursor,
                     signature,
                     rTokens.at(i + 2),
                     status,
+                    isReadOnlyFile,
                     pIndex);
    }
 }
@@ -462,6 +467,7 @@ bool isVariableIndexable(const RTokenCursor& cursor,
 
 void variableAssignmentIndexer(const RTokenCursor& cursor,
                                const IndexStatus& status,
+                               bool isReadOnlyFile, 
                                RSourceIndex* pIndex)
 {
    // check for indexable location
@@ -531,7 +537,8 @@ void variableAssignmentIndexer(const RTokenCursor& cursor,
             std::vector<RS4MethodParam>(),
             status.count(RToken::LBRACE),
             prevToken.row() + 1,
-            prevToken.column() + 1);
+            prevToken.column() + 1, 
+            isReadOnlyFile);
    
    pIndex->addSourceItem(item);
    
@@ -558,6 +565,9 @@ RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
    // clear any (source-local) inferred packages
    inferredPkgNames_.clear();
 
+   bool isReadOnlyFile = boost::algorithm::contains(code, "do not edit by hand");
+
+   // tokenize and create token cursor
    std::wstring wCode = string_utils::utf8ToWide(code, context);
    RTokens rTokens(wCode, RTokens::StripWhitespace | RTokens::StripComments);
    if (rTokens.empty())
@@ -574,7 +584,7 @@ RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
       
       for (const Indexer& indexer : indexers)
       {
-         indexer(cursor, status, this);
+         indexer(cursor, status, isReadOnlyFile, this);
       }
    }
    while (cursor.moveToNextToken());

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -559,6 +559,9 @@ RSourceIndex::RSourceIndex(const std::string& context, const std::string& code)
    inferredPkgNames_.clear();
 
    // tokenize and create token cursor
+   if (boost::algorithm::contains(code, "do not edit by hand"))
+      return;
+      
    std::wstring wCode = string_utils::utf8ToWide(code, context);
    RTokens rTokens(wCode, RTokens::StripWhitespace | RTokens::StripComments);
    if (rTokens.empty())

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1787,7 +1787,11 @@ Error searchCode(const json::JsonRpcRequest& request,
       // don't index auto-generated files
       const std::string& context = item.context();
       if (boost::algorithm::ends_with(context, "RcppExports.R") ||
-          boost::algorithm::ends_with(context, "RcppExports.cpp"))
+          boost::algorithm::ends_with(context, "RcppExports.cpp") ||
+          boost::algorithm::ends_with(context, "arrowExports.R") ||
+          boost::algorithm::ends_with(context, "arrowExports.cpp") ||
+          boost::algorithm::ends_with(context, "cpp11.R") || 
+          boost::algorithm::ends_with(context, "cpp11.cpp"))
          continue;
          
       int score = scoreMatch(item.name(), term, false);

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1800,7 +1800,12 @@ Error searchCode(const json::JsonRpcRequest& request,
       // don't index auto-generated files
       const std::string& context = item.context();
       if (boost::algorithm::ends_with(context, "RcppExports.R") ||
-          boost::algorithm::ends_with(context, "RcppExports.cpp"))
+          boost::algorithm::ends_with(context, "RcppExports.cpp") ||
+          boost::algorithm::ends_with(context, "cpp11.R") ||
+          boost::algorithm::ends_with(context, "cpp11.cpp") ||
+          boost::algorithm::ends_with(context, "arrowExports.R") ||
+          boost::algorithm::ends_with(context, "arrowExports.cpp")
+          )
          continue;
          
       int score = scoreMatch(item.name(), term, false);

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1787,11 +1787,7 @@ Error searchCode(const json::JsonRpcRequest& request,
       // don't index auto-generated files
       const std::string& context = item.context();
       if (boost::algorithm::ends_with(context, "RcppExports.R") ||
-          boost::algorithm::ends_with(context, "RcppExports.cpp") ||
-          boost::algorithm::ends_with(context, "arrowExports.R") ||
-          boost::algorithm::ends_with(context, "arrowExports.cpp") ||
-          boost::algorithm::ends_with(context, "cpp11.R") || 
-          boost::algorithm::ends_with(context, "cpp11.cpp"))
+          boost::algorithm::ends_with(context, "RcppExports.cpp"))
          continue;
          
       int score = scoreMatch(item.name(), term, false);

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1585,7 +1585,7 @@ SourceItem fromCppDefinition(const clang::CppDefinition& cppDefinition)
       module_context::createAliasedPath(cppDefinition.location.filePath),
       safe_convert::numberTo<int>(cppDefinition.location.line, 1),
       safe_convert::numberTo<int>(cppDefinition.location.column, 1), 
-      false /* hidden */);
+      cppDefinition.hidden);
 }
 
 void fillFromCrossrefs(const std::string& term,
@@ -1803,17 +1803,9 @@ Error searchCode(const json::JsonRpcRequest& request,
    for (std::size_t i = 0; i < srcItems.size(); ++i)
    {
       const SourceItem& item = srcItems[i];
-      // items are hidden() when coming from read-only R files
-      // i.e. files that contain the text "do not edit by hand" 
+      // items are hidden() when coming from R and C++ files
+      // that contain the text "do not edit by hand" 
       if (item.hidden())
-         continue;
-      
-      // don't index auto-generated cpp files
-      const std::string& context = item.context();
-      if (boost::algorithm::ends_with(context, "RcppExports.cpp") ||
-          boost::algorithm::ends_with(context, "cpp11.cpp") ||
-          boost::algorithm::ends_with(context, "arrowExports.cpp")
-          )
          continue;
       
       int score = scoreMatch(item.name(), term, false);

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1299,6 +1299,23 @@ void searchFiles(const std::string& term,
    }
 }
 
+bool isUninterestingFile(const std::string& filename) 
+{
+   if (filename == "RcppExports.R" ||
+       filename == "RcppExports.cpp" ||
+       filename == "cpp11.R" ||
+       filename == "cpp11.cpp" ||
+       filename == "arrowExports.R" ||
+       filename == "arrowExports.cpp")
+      return true;
+
+   std::string extension = string_utils::getExtension(filename);
+   if (boost::algorithm::to_lower_copy(extension) == ".rd")
+      return true;
+   
+   return false;
+}
+
 // NOTE: When modifying this code, you should ensure that corresponding
 // changes are made to the client side scoreMatch function as well
 // (See: CodeSearchOracle.java)
@@ -1343,20 +1360,9 @@ int scoreMatch(std::string const& suggestion,
       ++totalPenalty;
 
       // More penalty for 'uninteresting' files
-      if (suggestion == "RcppExports.R" ||
-          suggestion == "RcppExports.cpp" ||
-          suggestion == "cpp11.R" ||
-          suggestion == "cpp11.cpp" ||
-          suggestion == "arrowExports.R" ||
-          suggestion == "arrowExports.cpp")
-         totalPenalty += 6;
-      
-      // More penalty for 'uninteresting' extensions (e.g. .Rd)
-      std::string extension = string_utils::getExtension(suggestion);
-      if (boost::algorithm::to_lower_copy(extension) == ".rd")
+      if (isUninterestingFile(suggestion))
          totalPenalty += 6;
    }
-      
    
    // Penalize unmatched characters
    totalPenalty += gsl::narrow_cast<int>((query.size() - matches.size()) * query.size());

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1334,22 +1334,29 @@ int scoreMatch(std::string const& suggestion,
       // Less penalty for perfect match (ie, reward case-sensitive match)
       penalty -= suggestion[matchPos] == query[j];
       
-      // More penalty for 'uninteresting' files
-      if (suggestion == "RcppExports.R" ||
-          suggestion == "RcppExports.cpp")
-         penalty += 6;
-      
-      // More penalty for 'uninteresting' extensions (e.g. .Rd)
-      std::string extension = string_utils::getExtension(suggestion);
-      if (boost::algorithm::to_lower_copy(extension) == ".rd")
-         penalty += 6;
-
       totalPenalty += penalty;
    }
    
    // Penalize files
    if (isFile)
+   {
       ++totalPenalty;
+
+      // More penalty for 'uninteresting' files
+      if (suggestion == "RcppExports.R" ||
+          suggestion == "RcppExports.cpp" ||
+          suggestion == "cpp11.R" ||
+          suggestion == "cpp11.cpp" ||
+          suggestion == "arrowExports.R" ||
+          suggestion == "arrowExports.cpp")
+         totalPenalty += 6;
+      
+      // More penalty for 'uninteresting' extensions (e.g. .Rd)
+      std::string extension = string_utils::getExtension(suggestion);
+      if (boost::algorithm::to_lower_copy(extension) == ".rd")
+         totalPenalty += 6;
+   }
+      
    
    // Penalize unmatched characters
    totalPenalty += gsl::narrow_cast<int>((query.size() - matches.size()) * query.size());

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -50,7 +50,6 @@ struct CppDefinitions
 {
    std::string file;
    std::time_t fileLastWrite;
-   bool hidden;
    std::deque<CppDefinition> definitions;
 };
 
@@ -238,7 +237,6 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
          CppDefinitions definitions;
          definitions.file = file;
          definitions.fileLastWrite = event.fileInfo().lastWriteTime();
-         definitions.hidden = isGeneratedFile(core::FilePath(event.fileInfo().absolutePath()));
          s_definitionsByFile[file] = definitions;
          DefinitionVisitor visitor =
             boost::bind(insertDefinition, _1, &s_definitionsByFile[file]);

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -50,6 +50,7 @@ struct CppDefinitions
 {
    std::string file;
    std::time_t fileLastWrite;
+   bool hidden;
    std::deque<CppDefinition> definitions;
 };
 
@@ -65,7 +66,7 @@ bool insertDefinition(const CppDefinition& definition,
    return true;
 }
 
-typedef boost::function<bool(const CppDefinition&)> DefinitionVisitor;
+typedef std::pair<bool, boost::function<bool(const CppDefinition&)>> DefinitionVisitor;
 
 CXChildVisitResult cursorVisitor(CXCursor cxCursor,
                                  CXCursor,
@@ -144,18 +145,20 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
       parentName = parent.displayName();
    }
 
+   DefinitionVisitor& visitor = *((DefinitionVisitor*)clientData);
+
    // create the definition
    CppDefinition definition(cursor.getUSR(),
                             kind,
                             parentName,
                             name,
+                            visitor.first,
                             cursor.getSourceLocation().getSpellingLocation());
 
    // yield the definition if it's not a namespace (break if requested)
    if (kind != CppNamespaceDefinition)
    {
-      DefinitionVisitor& visitor = *((DefinitionVisitor*)clientData);
-      if (!visitor(definition))
+      if (!visitor.second(definition))
          return CXChildVisit_Break;
    }
 
@@ -237,16 +240,18 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
          CppDefinitions definitions;
          definitions.file = file;
          definitions.fileLastWrite = event.fileInfo().lastWriteTime();
+         definitions.hidden = isGeneratedFile(FilePath(definitions.file));
          s_definitionsByFile[file] = definitions;
-         DefinitionVisitor visitor =
-            boost::bind(insertDefinition, _1, &s_definitionsByFile[file]);
 
-         // visit the cursors
+         DefinitionVisitor visitor = std::make_pair(
+            definitions.hidden,
+            boost::bind(insertDefinition, _1, &s_definitionsByFile[file])
+         );
          libclang::clang().visitChildren(
               libclang::clang().getTranslationUnitCursor(tu),
               cursorVisitor,
               (CXClientData)&visitor);
-
+         
          // dispose translation unit and index
          libclang::clang().disposeTranslationUnit(tu);
          libclang::clang().disposeIndex(index);
@@ -350,7 +355,12 @@ FileLocation findDefinitionLocation(const FileLocation& location)
       {
          // search for the definition
          CppDefinition def;
-         DefinitionVisitor visitor = boost::bind(findUSR, USR, _1, &def);
+         DefinitionVisitor visitor = std::make_pair(
+            // hidden: does not matter. This CppDefinition is only used for location
+            //         can consider that the definition is not hidden
+            false, 
+            boost::bind(findUSR, USR, _1, &def)
+         );
 
          // visit the cursors
          libclang::clang().visitChildren(
@@ -427,6 +437,7 @@ json::Object cppDefinitionToJson(const CppDefinition& definition)
    definitionJson["file"] = definition.location.filePath.getAbsolutePath();
    definitionJson["line"] = numberTo<int>(definition.location.line, 1);
    definitionJson["column"] = numberTo<int>(definition.location.column, 1);
+   definitionJson["hidden"] = definition.hidden;
    return definitionJson;
 }
 
@@ -444,7 +455,9 @@ CppDefinition cppDefinitionFromJson(const json::Object& object)
                                   "name", definition.name,
                                   "file", file,
                                   "line", line,
-                                  "column", column);
+                                  "column", column, 
+                                  "hidden", definition.hidden
+                                  );
    if (error)
    {
       LOG_ERROR(error);
@@ -518,6 +531,12 @@ void loadDefinitionIndex()
       if (!FilePath::exists(definitions.file))
          continue;
 
+      // if the json does not have the hidden field, bail
+      // so that the file is parsed again
+      error = json::readObject(definitionsJson.getObject(), "hidden", definitions.hidden);
+      if (error)
+         continue;
+
       for (const json::Value& defJson : defsArrayJson)
       {
          if (!json::isType<json::Object>(defJson))
@@ -554,6 +573,7 @@ void saveDefinitionIndex()
                      std::back_inserter(defsArrayJson),
                      cppDefinitionToJson);
       definitionsJson["definitions"] = defsArrayJson;
+      definitionsJson["hidden"] = definitions.hidden;
 
       indexJson.push_back(definitionsJson);
    }
@@ -586,16 +606,23 @@ void searchDefinitions(const std::string& term,
    // first search translation units we have an in-memory index for
    // (this will reflect unsaved changes in editor buffers)
    TranslationUnits units = rSourceIndex().getIndexedTranslationUnits();
-   for (const TranslationUnits::value_type& unit : units)
+   for (TranslationUnits::iterator it = units.begin(); it != units.end(); ++it)
    {
+      const TranslationUnit& unit = it->second;
+      const std::string& filename = it->first;
+
+      bool hidden = isGeneratedFile(FilePath(filename));
+      
       // search for matching definitions
-      DefinitionVisitor visitor =
-         boost::bind(insertMatching, term, pattern, _1, pDefinitions);
+      DefinitionVisitor visitor = std::make_pair(
+         hidden, 
+         boost::bind(insertMatching, term, pattern, _1, pDefinitions)
+      );
 
       // visit the cursors
       libclang::clang().visitChildren(
            libclang::clang().getTranslationUnitCursor(
-                                 unit.second.getCXTranslationUnit()),
+                                 unit.getCXTranslationUnit()),
            cursorVisitor,
            (CXClientData)&visitor);
    }

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -50,6 +50,7 @@ struct CppDefinitions
 {
    std::string file;
    std::time_t fileLastWrite;
+   bool hidden;
    std::deque<CppDefinition> definitions;
 };
 
@@ -173,6 +174,12 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
    }
 }
 
+bool isGeneratedFile(const FilePath& inputFile) {
+   std::string contents;
+   Error error = core::readStringFromFile(inputFile, &contents);
+   return boost::algorithm::contains(contents, "do not edit by hand");
+}
+
 void fileChangeHandler(const core::system::FileChangeEvent& event)
 {
    // alias the filename
@@ -231,6 +238,7 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
          CppDefinitions definitions;
          definitions.file = file;
          definitions.fileLastWrite = event.fileInfo().lastWriteTime();
+         definitions.hidden = isGeneratedFile(core::FilePath(event.fileInfo().absolutePath()));
          s_definitionsByFile[file] = definitions;
          DefinitionVisitor visitor =
             boost::bind(insertDefinition, _1, &s_definitionsByFile[file]);

--- a/src/cpp/session/modules/clang/DefinitionIndex.hpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.hpp
@@ -59,11 +59,13 @@ struct CppDefinition
                  CppDefinitionKind kind,
                  const std::string& parentName,
                  const std::string& name,
+                 bool hidden,
                  const core::libclang::FileLocation& location)
       : USR(USR),
         kind(kind),
         parentName(parentName),
         name(name),
+        hidden(hidden),
         location(location)
    {
    }
@@ -74,6 +76,7 @@ struct CppDefinition
    CppDefinitionKind kind;
    std::string parentName; // e.g. containing C++ class
    std::string name;
+   bool hidden;
    core::libclang::FileLocation location;
 };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -71,6 +71,7 @@ public class CodeSearchOracle extends SuggestOracle
       
       // Get query matches in string (ordered)
       List<Integer> matches = StringUtil.subsequenceIndices(suggestionLower, queryLower);
+      GWT.log("" + matches.size() + " matches");
       
       // Loop over the matches and assign a score
       for (int j = 0, n = matches.size(); j < n; j++)
@@ -86,35 +87,41 @@ public class CodeSearchOracle extends SuggestOracle
             char prevChar = StringUtil.charAt(suggestionLower, matchPos - 1);
             if (prevChar == '_' || prevChar == '-' ||
                   (!isFile && prevChar == '.'))
-            {
                penalty = j + 1;
-            }
          }
          
          // Less penalty for case-sensitive matches
          if (StringUtil.charAt(suggestion, matchPos) == query.charAt(j))
             penalty--;
-         
-         // More penalty for 'uninteresting' files
-         if (suggestion == "RcppExports.R" ||
-             suggestion == "RcppExports.cpp")
-            penalty += 6;
-         
-         // More penalty for 'uninteresting' extensions (e.g. .Rd)
-         String extension = StringUtil.getExtension(suggestionLower);
-         if (extension.toLowerCase() == "rd")
-            penalty += 6;
-         
+            
          totalPenalty += penalty;
       }
       
       // Penalize file targets
       if (isFile)
+      {
          totalPenalty++;
+
+         // More penalty for 'uninteresting' files
+         if (suggestion == "RcppExports.R" ||
+         suggestion == "RcppExports.cpp" ||
+         suggestion == "cpp11.R" ||
+         suggestion == "cpp11.cpp" ||
+         suggestion == "arrowExports.R" ||
+         suggestion == "arrowExports.cpp")
+         totalPenalty += 6;
+
+         // More penalty for 'uninteresting' extensions (e.g. .Rd)
+         String extension = StringUtil.getExtension(suggestionLower);
+         if (extension.toLowerCase() == "rd")
+         totalPenalty += 6;
+      }
       
       // Penalize unmatched characters
       totalPenalty += (query.length() - matches.size()) * query.length();
       
+      GWT.log("suggestion = "+ suggestion + ", query = " + query + ", penalty = " + totalPenalty);
+
       return totalPenalty;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -71,7 +71,6 @@ public class CodeSearchOracle extends SuggestOracle
       
       // Get query matches in string (ordered)
       List<Integer> matches = StringUtil.subsequenceIndices(suggestionLower, queryLower);
-      GWT.log("" + matches.size() + " matches");
       
       // Loop over the matches and assign a score
       for (int j = 0, n = matches.size(); j < n; j++)
@@ -120,8 +119,6 @@ public class CodeSearchOracle extends SuggestOracle
       // Penalize unmatched characters
       totalPenalty += (query.length() - matches.size()) * query.length();
       
-      GWT.log("suggestion = "+ suggestion + ", query = " + query + ", penalty = " + totalPenalty);
-
       return totalPenalty;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -102,24 +102,31 @@ public class CodeSearchOracle extends SuggestOracle
          totalPenalty++;
 
          // More penalty for 'uninteresting' files
-         if (suggestion == "RcppExports.R" ||
-             suggestion == "RcppExports.cpp" ||
-             suggestion == "cpp11.R" ||
-             suggestion == "cpp11.cpp" ||
-             suggestion == "arrowExports.R" ||
-             suggestion == "arrowExports.cpp")
-         totalPenalty += 6;
-
-         // More penalty for 'uninteresting' extensions (e.g. .Rd)
-         String extension = StringUtil.getExtension(suggestionLower);
-         if (extension.toLowerCase() == "rd")
-         totalPenalty += 6;
+         if (isUninterestingFile(suggestion))
+            totalPenalty += 6;
       }
       
       // Penalize unmatched characters
       totalPenalty += (query.length() - matches.size()) * query.length();
       
       return totalPenalty;
+   }
+
+   public static boolean isUninterestingFile(String filename)
+   {
+      if (filename == "RcppExports.R" ||
+          filename == "RcppExports.cpp" ||
+          filename == "cpp11.R" ||
+          filename == "cpp11.cpp" ||
+          filename == "arrowExports.R" ||
+          filename == "arrowExports.cpp")
+         return true;
+
+      String extension = StringUtil.getExtension(filename);
+      if (extension.toLowerCase() == "rd")
+         return true;
+      
+      return false;
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchOracle.java
@@ -104,11 +104,11 @@ public class CodeSearchOracle extends SuggestOracle
 
          // More penalty for 'uninteresting' files
          if (suggestion == "RcppExports.R" ||
-         suggestion == "RcppExports.cpp" ||
-         suggestion == "cpp11.R" ||
-         suggestion == "cpp11.cpp" ||
-         suggestion == "arrowExports.R" ||
-         suggestion == "arrowExports.cpp")
+             suggestion == "RcppExports.cpp" ||
+             suggestion == "cpp11.R" ||
+             suggestion == "cpp11.cpp" ||
+             suggestion == "arrowExports.R" ||
+             suggestion == "arrowExports.cpp")
          totalPenalty += 6;
 
          // More penalty for 'uninteresting' extensions (e.g. .Rd)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
@@ -72,6 +72,10 @@ public class SourceItem extends JavaScriptObject
    public final native JsObject getMetadata() /*-{
       return this.metadata || {};
    }-*/;
+
+   public final native boolean getHidden() /*-{
+      return this.hidden;
+   }-*/;
    
    public final boolean hasXRef()
    {


### PR DESCRIPTION
### Intent

adresses #10912

### Approach

For R files and c++ files: ignore items from files that have "do not edit by hand"

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


