### PR TITLE
prevent brackets inside cite marks from being escaped

### DIFF
--- a/src/gwt/panmirror/src/editor/src/api/pandoc.ts
+++ b/src/gwt/panmirror/src/editor/src/api/pandoc.ts
@@ -309,7 +309,12 @@ export interface PandocMarkWriter {
 
 export type PandocMarkWriterFn = (output: PandocOutput, mark: Mark, parent: Fragment) => void;
 
-export type PandocOutputOption = 'writeSpaces';
+export const kWriteSpaces = 'writeSpaces';
+export const kPreventBracketEscape = 'preventBracketEscape';
+
+export type PandocOutputOption = typeof kWriteSpaces | typeof kPreventBracketEscape;
+
+
 
 export interface PandocOutput {
   extensions: PandocExtensions;

--- a/src/gwt/panmirror/src/editor/src/marks/cite/cite.ts
+++ b/src/gwt/panmirror/src/editor/src/marks/cite/cite.ts
@@ -21,7 +21,7 @@ import { EditorView } from 'prosemirror-view';
 import uniqby from 'lodash.uniqby';
 
 import { FocusEvent } from '../../api/event-types';
-import { PandocTokenType, PandocToken, PandocOutput, ProsemirrorWriter, PandocServer } from '../../api/pandoc';
+import { PandocTokenType, PandocToken, PandocOutput, ProsemirrorWriter, PandocServer, kPreventBracketEscape } from '../../api/pandoc';
 import { fragmentText } from '../../api/fragment';
 import { markIsActive, splitInvalidatedMarks, getMarkRange, detectAndApplyMarks } from '../../api/mark';
 import { MarkTransaction, kPasteTransaction } from '../../api/transaction';
@@ -166,7 +166,9 @@ const extension = (context: ExtensionContext): Extension | null => {
                   fragmentText(closeCite) === ']'
                 ) {
                   output.writeRawMarkdown('[');
-                  output.writeInlines(cite);
+                  output.withOption(kPreventBracketEscape, true, () => {
+                    output.writeInlines(cite);
+                  });
                   output.writeRawMarkdown(']');
 
 

--- a/src/gwt/panmirror/src/editor/src/nodes/line_block.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/line_block.ts
@@ -16,7 +16,7 @@
 import { Node as ProsemirrorNode, Schema, DOMOutputSpec } from 'prosemirror-model';
 
 import { ExtensionContext } from '../api/extension';
-import { PandocOutput, PandocTokenType, PandocToken } from '../api/pandoc';
+import { PandocOutput, PandocTokenType, PandocToken, kWriteSpaces } from '../api/pandoc';
 
 import { EditorCommandId, WrapCommand } from '../api/command';
 import { OmniInsertGroup } from '../api/omni_insert';
@@ -58,7 +58,7 @@ const extension = (context: ExtensionContext) => {
             },
           ],
           writer: (output: PandocOutput, node: ProsemirrorNode) => {
-            output.withOption('writeSpaces', false, () => {
+            output.withOption(kWriteSpaces, false, () => {
               output.writeToken(PandocTokenType.LineBlock, () => {
                 node.forEach(line => {
                   output.writeArray(() => {

--- a/src/gwt/panmirror/src/editor/src/pandoc/pandoc_from_prosemirror.ts
+++ b/src/gwt/panmirror/src/editor/src/pandoc/pandoc_from_prosemirror.ts
@@ -27,6 +27,7 @@ import {
   PandocOutputOption,
   PandocExtensions,
   marksByPriority,
+  kPreventBracketEscape,
 } from '../api/pandoc';
 
 import { PandocFormat, kGfmFormat } from '../api/pandoc_format';
@@ -210,7 +211,10 @@ class PandocWriter implements PandocOutput {
 
   public writeText(text: string | null) {
     // determine which characters we shouldn't escape
-    const preventEscapeCharacters = this.preventEscapeCharacters;
+    const preventEscapeCharacters = [ ...this.preventEscapeCharacters ];
+    if (this.options[kPreventBracketEscape]) {
+      preventEscapeCharacters.push('[', ']');
+    }
 
     if (text) {
       let textRun = '';


### PR DESCRIPTION
Addresses https://github.com/quarto-dev/quarto-cli/issues/543

Should be backported to PT patch once merged.

@dragonstyle Could you review this?