### PR TITLE
implement choose r callbacks

### DIFF
--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -33,7 +33,9 @@
     "renderingEngineOptionDesktop": "Desktop",
     "renderingEngineOptionSoftware": "Software",
     "renderingEngineChangedTitle": "Rendering Engine Changed",
-    "renderingEngineChangedMessage": "The rendering engine has been changed.\nPlease restart RStudio for these changes to take effect."
+    "renderingEngineChangedMessage": "The rendering engine has been changed.\nPlease restart RStudio for these changes to take effect.",
+    "rLaunchFailedTitle": "R Failed to Launch",
+    "rLaunchFailedMessage": "RStudio was unable to run this version of R.\n\nYou may need to select a different version of R."
   },
   "uiFolder": {
     "chooseRExecutable": "Choose R Executable",

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -156,6 +156,7 @@ export class Application implements AppState {
     }
 
     // prepare the R environment
+    logger().logDebug(`Preparing environment using R: ${rPath}`);
     const prepareError = prepareEnvironment(rPath);
     if (prepareError) {
       await createStandaloneErrorDialog(

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -108,7 +108,8 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
     }
   }
 
-  logger().logDebug(`Launching: ${absPath.getAbsolutePath()} ${argList.join(' ')}`);
+  logger().logDebug(`Launching rsession: ${absPath.getAbsolutePath()} ${argList.join(' ')}`);
+  logger().logDebug(`R_HOME: ${getenv('R_HOME')}`);
 
   if (!appState().runDiagnostics) {
     return spawn(absPath.getAbsolutePath(), argList, { env: env });

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -18,6 +18,7 @@ import { err, Expected, ok } from '../core/expected';
 import { safeError } from '../core/err';
 
 export abstract class ModalDialog<T> extends BrowserWindow {
+
   abstract onShowModal(): Promise<T>;
 
   private readonly widgetUrl: string;
@@ -53,6 +54,7 @@ export abstract class ModalDialog<T> extends BrowserWindow {
   }
 
   async showModalImpl(): Promise<T> {
+
     // load the associated HTML
     await this.loadURL(this.widgetUrl);
 
@@ -61,5 +63,6 @@ export abstract class ModalDialog<T> extends BrowserWindow {
 
     const result = await this.onShowModal();
     return result;
+
   }
 }

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -14,25 +14,86 @@
  */
 
 import { dialog, ipcMain } from 'electron';
-import { findDefault32Bit, findDefault64Bit } from '../../main/detect-r';
+import { detectREnvironment, findDefault32Bit, findDefault64Bit } from '../../main/detect-r';
 import { logger } from '../../core/logger';
 import { ModalDialog } from '../modal-dialog';
 
 import { initI18n } from '../../main/i18n-manager';
-import i18next from 'i18next';
+import i18next, { t } from 'i18next';
 import { CallbackData } from './choose-r/preload';
 import { ElectronDesktopOptions } from '../../main/preferences/electron-desktop-options';
 
 declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
 
+function checkValid(data: CallbackData) {
+
+  // get path to R
+  const rBinaryPath = data.binaryPath as string;
+
+  // try to run it
+  const [rEnvironment, err] = detectREnvironment(rBinaryPath);
+  if (err) {
+    
+    const response = dialog.showMessageBoxSync({
+      title: t('chooseRDialog.rLaunchFailedTitle'),
+      message: t('chooseRDialog.rLaunchFailedMessage'),
+      buttons: [
+        t('common.buttonOk'),
+        t('common.buttonCancel')
+      ],
+    });
+
+    return response === 0;
+
+  }
+
+  logger().logDebug(`Validated R: ${rEnvironment.rScriptPath}`);
+  return true;
+
+}
+
 export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
   private rInstalls: string[];
 
+  private channels: string[] = [
+    'use-default-32bit',
+    'use-default-64bit',
+    'use-custom',
+    'browse-r-exe',
+    'cancel',
+    'closed',
+  ];
+
   constructor(rInstalls: string[]) {
+
     super(CHOOSE_R_WEBPACK_ENTRY, CHOOSE_R_PRELOAD_WEBPACK_ENTRY);
+
     this.rInstalls = rInstalls;
+
+    // ensure handlers are emoved after close
+    this.on('closed', () => {
+      for (const channel of this.channels) {
+        ipcMain.removeHandler(channel);
+      }
+    });
+
     initI18n();
+
+  }
+
+  async maybeResolve(resolve: (data: CallbackData) => void, data: CallbackData) {
+
+    if (checkValid(data)) {
+      resolve(data);
+      for (const channel of this.channels) {
+        ipcMain.removeHandler(channel);
+      }
+      return true;
+    } else {
+      return false;
+    }
+
   }
 
   async onShowModal(): Promise<CallbackData | null> {
@@ -45,39 +106,42 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
     // listen for messages from the window
     return new Promise((resolve) => {
-      ipcMain.on('use-default-32bit', (event, data: CallbackData) => {
+      ipcMain.handle('use-default-32bit', (event, data: CallbackData) => {
         const installPath = findDefault32Bit();
         data.binaryPath = `${installPath}/bin/i386/R.exe`;
-        logger().logDebug(`Using default 32-bit R (${data.binaryPath})`);
-        return resolve(data);
+        logger().logDebug(`Using default 32-bit version of R (${data.binaryPath})`);
+        return this.maybeResolve(resolve, data);
       });
 
-      ipcMain.on('use-default-64bit', (event, data: CallbackData) => {
+      ipcMain.handle('use-default-64bit', (event, data: CallbackData) => {
         const installPath = findDefault64Bit();
         data.binaryPath = `${installPath}/bin/x64/R.exe`;
-        logger().logDebug(`Using default 64-bit R (${data.binaryPath})`);
-        return resolve(data);
+        logger().logDebug(`Using default 64-bit version of R (${data.binaryPath})`);
+        return this.maybeResolve(resolve, data);
       });
 
-      ipcMain.on('use-custom', (event, data: CallbackData) => {
+      ipcMain.handle('use-custom', (event, data: CallbackData) => {
         logger().logDebug(`Using user-selected version of R (${data.binaryPath})`);
-        return resolve(data);
+        return this.maybeResolve(resolve, data);
       });
 
       ipcMain.handle('browse-r-exe', async (event, data: CallbackData) => {
+
         const response = dialog.showOpenDialogSync(this, {
           title: i18next.t('uiFolder.chooseRExecutable'),
           properties: ['openFile'],
           filters: [{ name: i18next.t('uiFolder.rExecutable'), extensions: ['exe'] }],
         });
 
+        
         if (response) {
           data.binaryPath = response[0];
           logger().logDebug(`Using user-selected version of R (${data.binaryPath})`);
-          resolve(data);
+          return this.maybeResolve(resolve, data);
         }
 
-        return !!response;
+        return false;
+
       });
 
       ipcMain.on('cancel', () => {

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -60,18 +60,23 @@ function callbackData(binaryPath?: string): CallbackData {
   };
 }
 
-buttonOk.addEventListener('click', () => {
+buttonOk.addEventListener('click', async () => {
+
   const useDefault32Radio = document.getElementById('use-default-32') as HTMLInputElement;
   if (useDefault32Radio.checked) {
-    window.callbacks.useDefault32bit(callbackData());
-    window.close();
+    const shouldCloseWindow = await window.callbacks.useDefault32bit(callbackData());
+    if (shouldCloseWindow) {
+      window.close();
+    }
     return;
   }
 
   const useDefault64Radio = document.getElementById('use-default-64') as HTMLInputElement;
   if (useDefault64Radio.checked) {
-    window.callbacks.useDefault64bit(callbackData());
-    window.close();
+    const shouldCloseWindow = await window.callbacks.useDefault64bit(callbackData());
+    if (shouldCloseWindow) {
+      window.close();
+    }
     return;
   }
 
@@ -79,9 +84,13 @@ buttonOk.addEventListener('click', () => {
   if (useCustomRadio.checked) {
     const selectWidget = document.getElementById('select') as HTMLSelectElement;
     const selection = selectWidget.value;
-    window.callbacks.use(callbackData(selection));
-    window.close();
+    const shouldCloseWindow = await window.callbacks.use(callbackData(selection));
+    if (shouldCloseWindow) {
+      window.close();
+    }
+    return;
   }
+
 });
 
 buttonCancel.addEventListener('click', () => {

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -22,9 +22,9 @@ export interface CallbackData {
 }
 
 export interface Callbacks {
-  useDefault32bit(data: CallbackData): void;
-  useDefault64bit(data: CallbackData): void;
-  use(data: CallbackData): void;
+  useDefault32bit(data: CallbackData): Promise<boolean>;
+  useDefault64bit(data: CallbackData): Promise<boolean>;
+  use(data: CallbackData): Promise<boolean>;
   browse(data: CallbackData): Promise<boolean>;
   cancel(): void;
 }
@@ -92,16 +92,19 @@ ipcRenderer.on('initialize', (event, data) => {
 
 // export callbacks
 const callbacks: Callbacks = {
-  useDefault32bit: (data: CallbackData) => {
-    ipcRenderer.send('use-default-32bit', data);
+  useDefault32bit: async (data: CallbackData) => {
+    const shouldCloseDialog = await ipcRenderer.invoke('use-default-32bit', data);
+    return shouldCloseDialog;
   },
 
-  useDefault64bit: (data: CallbackData) => {
-    ipcRenderer.send('use-default-64bit', data);
+  useDefault64bit: async (data: CallbackData) => {
+    const shouldCloseDialog = await ipcRenderer.invoke('use-default-64bit', data);
+    return shouldCloseDialog;
   },
 
-  use: (data: CallbackData) => {
-    ipcRenderer.send('use-custom', data);
+  use: async (data: CallbackData) => {
+    const shouldCloseDialog = await ipcRenderer.invoke('use-custom', data);
+    return shouldCloseDialog;
   },
 
   browse: async (data: CallbackData) => {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10932.
Addresses https://github.com/rstudio/rstudio/issues/10933.

### Approach

Push buttons on the keyboard so that the right bits are flipped on the storage medium.

Sorry, I should be more specific:

- Hook up existing callbacks to Choose R Dialog
- Add some additional validation, to confirm that the user has selected a version of R that appears to actually run
- Fix up an issue where attempting to open the Choose R Dialog twice in a session would cause Electron to complain about duplicate IPC handlers

### Automated Tests

Not included.

### QA Notes

Test via notes in associated issues.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


