### PR TITLE
Fix Quarto location for Electron

### DIFF
--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -677,15 +677,15 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
    if(QUARTO_ENABLED)
       # install some quarto folders into Resources, as needed
       if(APPLE)
-         install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
-               DESTINATION "${RSTUDIO_INSTALL_BIN}"
-               USE_SOURCE_PERMISSIONS
-               PATTERN "*/share" EXCLUDE)
          if (RSTUDIO_ELECTRON)
-            install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
-                  DESTINATION "${RSTUDIO_INSTALL_RESOURCES}/quarto"
+            install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}" 
+                  DESTINATION "${RSTUDIO_INSTALL_RESOURCES}/app"
                   USE_SOURCE_PERMISSIONS)
          else()
+            install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
+                  DESTINATION "${RSTUDIO_INSTALL_BIN}"
+                  USE_SOURCE_PERMISSIONS
+                  PATTERN "*/share" EXCLUDE)
             install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
                   DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/quarto"
                   USE_SOURCE_PERMISSIONS)

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -507,7 +507,12 @@ FilePath macBinaryPath(const FilePath& resourcePath,
    
    if (electronPath.exists())
       return electronPath;
-   
+
+   // alternate Electron binary path
+   electronPath = resourcePath.completePath(stem);
+   if (electronPath.exists())
+      return electronPath;
+
    // otherwise, look in default Qt location
    FilePath qtPath = resourcePath.getParent().completePath("MacOS").completePath(stem);
    return qtPath;


### PR DESCRIPTION
### Intent
The first fix had an issue with finding Quarto. This resolves the packaged location and how it is found.

### Approach
The Electron binary path now checks the resources root folder as well now that all of Quarto is packaged there.

### Automated Tests
None.

### QA Notes
Packaged locally and tested to check that the new Quarto document dialog works.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


