### PR TITLE
Log message fixes

### DIFF
--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -231,7 +231,12 @@ std::string logMessagePropertiesToString(const LogMessageProperties& in_properti
       }
    }
 
-   return "[" + boost::join(properties, ", ") + "]";
+   std::string propStr = "[" + boost::join(properties, ", ") + "]";
+
+   // replace newlines - there should be no newlines within a log line
+   boost::algorithm::replace_all(propStr, "\n", "|||");
+
+   return propStr;
 }
 
 std::string formatLogMessage(

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -301,6 +301,9 @@ std::string formatLogMessage(
          logObject["properties"] = properties;
       }
 
+      if (in_loggedFrom.hasLocation())
+         logObject["location"] = errorLocationToJson(in_loggedFrom);
+
       return logObject.write() + "\n";
    }
 }


### PR DESCRIPTION
### Intent

Currently, log message properties that contain new lines will forward those new lines into the log. This is undesired because log lines themselves should not contain new lines, as that is the delimiter between log lines.

Also, the log location of a log statement is not currently being logged for JSON and should be added.

### Approach

Filter out newlines for log message properties formatted via the pretty formatter. No changes need to be made to the JSON formatting because JSON already encodes newlines as literal `\n`.

If there is a log location associated with a log statement and we are using the JSON log format, simply format it for JSON and put it on the `location` property of the log line.

### Automated Tests

Added two new tests to ensure that newlines in log message properties are not logged.


