### PR TITLE
improve handling of invalid R installations

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -46,7 +46,13 @@ module.exports = {
     '@typescript-eslint/require-array-sort-compare': ['error'],
     '@typescript-eslint/return-await': ['warn'],
     '@typescript-eslint/no-implicit-any-catch': ['error'],
-    '@typescript-eslint/no-unused-vars': ['warn', {"argsIgnorePattern": "^_"}],
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        "varsIgnorePattern": "^_",
+        "argsIgnorePattern": "^_"
+      }
+    ],
 
     '@typescript-eslint/strict-boolean-expressions': [
       'error',

--- a/src/node/desktop/src/core/expected.ts
+++ b/src/node/desktop/src/core/expected.ts
@@ -15,9 +15,23 @@
 
 export type Expected<T> = [T, Error | null];
 
+// Execute a callback wrapped within 'try-catch', and return
+// the result as an Expected<T>.
+//
+// On success, returns `ok(callback())`.
+// On error, return `err(error)`.
+//
+// This can be useful for wrapping execution of a function
+// which might throw an exception within the expectation style.
+//
+// Example usage:
+//
+// const [result, error] = expect(() => {
+//   return mightThrow();
+// });
 export function expect<T>(callback: () => T): Expected<T> {
   try {
-    const result : T = callback();
+    const result = callback();
     return ok(result);
   } catch (error: unknown) {
     return err(error as any);

--- a/src/node/desktop/src/core/expected.ts
+++ b/src/node/desktop/src/core/expected.ts
@@ -15,6 +15,15 @@
 
 export type Expected<T> = [T, Error | null];
 
+export function expect<T>(callback: () => T): Expected<T> {
+  try {
+    const result : T = callback();
+    return ok(result);
+  } catch (error: unknown) {
+    return err(error as any);
+  }
+}
+
 export function ok<T>(value: T): Expected<T> {
   return [value, null];
 }

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -20,7 +20,7 @@ import { logger } from './logger';
 import path from 'path';
 import { Err, success, safeError } from './err';
 import { userHomePath } from './user';
-import { err, Expected, ok } from './expected';
+import { err, expect, Expected, ok } from './expected';
 
 /** An Error containing 'path' that triggered the error */
 export class FilePathError extends Error {
@@ -671,8 +671,13 @@ export class FilePath {
    * Checks whether this file path is a directory.
    */
   isDirectory(): boolean {
-    const stat = fs.lstatSync(this.path);
-    return stat.isDirectory();
+    
+    const stat = fs.lstatSync(this.path, {
+      throwIfNoEntry: false,
+    });
+
+    return stat != null && stat.isDirectory();
+
   }
 
   /**

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -52,7 +52,7 @@ function showRNotFoundError(error?: Error): void {
 
 function executeCommand(command: string): Expected<string> {
   return expect(() => {
-    return execSync(command, { encoding: 'utf-8' });
+    return execSync(command, { encoding: 'utf-8' }).trim();
   });
 }
 

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -39,6 +39,20 @@ ipcRenderer.on('css', (event, data) => {
 // initialize select input
 ipcRenderer.on('initialize', (event, data) => {
 
+  // if we have a default 32-bit R installation, enable it
+  const default32Bit = data.default32bitPath as string;
+  if (default32Bit) {
+    const el = document.getElementById('use-default-32');
+    el?.removeAttribute('disabled');
+  }
+
+  // if we have a default 64-bit R installation, enable it
+  const default64Bit = data.default64bitPath as string;
+  if (default64Bit) {
+    const el = document.getElementById('use-default-64');
+    el?.removeAttribute('disabled');
+  }
+
   // cast received data
   const rInstalls = data.rInstalls as string[];
   const renderingEngine = data.renderingEngine as string;

--- a/src/node/desktop/src/ui/widgets/choose-r/ui.html
+++ b/src/node/desktop/src/ui/widgets/choose-r/ui.html
@@ -9,12 +9,12 @@
     <p data-i18n="subtitle"></p>
 
     <div>
-      <input type="radio" id="use-default-64" name="r" value="use-default-64" checked />
+      <input type="radio" id="use-default-64" name="r" value="use-default-64" checked disabled />
       <label for="use-default-64" data-i18n="use64BitR"></label>
     </div>
 
     <div>
-      <input type="radio" id="use-default-32" name="r" value="use-default-32" />
+      <input type="radio" id="use-default-32" name="r" value="use-default-32" disabled />
       <label for="use-default-32" data-i18n="use32BitR"></label>
     </div>
 


### PR DESCRIPTION
### Intent

Improves handling of invalid R installations; in particular, this allows us to properly handle the case where no valid installation has been registered as the default.

### Approach

Validate that the R installation referenced in the registry exists + is valid.

### Automated Tests

Should be covered by existing tests.

### QA Notes

Using `regedit.exe`, try editing the InstallPath registry value here, and change it to an invalid value.

![image](https://user-images.githubusercontent.com/1976582/162837700-64c1eb56-2bad-496f-869a-27267f6af46c.png)

Then, try launching RStudio with Ctrl held down, to trigger the "Show R" prompt. You should see the top radio button now disabled:

![image](https://user-images.githubusercontent.com/1976582/162838118-78c31775-58fd-4703-8af0-ecda4e3e8112.png)


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

