### PR TITLE
Not showing menus with empty submenu object

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -312,6 +312,26 @@ export class MenuCallback extends EventEmitter {
    *
    */
   updateMenus(): void {
+    /*
+     * This function will remove items that has a submenu array with no items
+     */
+    const removeItemsWithEmptySubmenuList = (item: MenuItemConstructorOptions) => {
+      if (Object.prototype.hasOwnProperty.call(item, 'submenu')) {
+        if (Array.isArray(item.submenu)) {
+          if (item.submenu.length > 0) {
+            item.submenu = item.submenu.filter((submenu) => {
+              return removeItemsWithEmptySubmenuList(submenu);
+            });
+            return true;
+          } else {
+            return false;
+          }
+        }
+      }
+
+      return true;
+    };
+
     /**
      * Builds the final list of menu items using the given menu template
      *
@@ -351,8 +371,9 @@ export class MenuCallback extends EventEmitter {
 
       return newMenuTemplate.filter((item, idx, arr) => {
         if (item.type !== 'separator') {
-          return true;
+          return removeItemsWithEmptySubmenuList(item);
         }
+
         const prevItem = arr[idx - 1];
         return idx !== 0 && prevItem.type !== 'separator' && idx != arr.length - 1;
       });
@@ -388,8 +409,7 @@ export class MenuCallback extends EventEmitter {
       // difference unless screen-reader mode is on.
       menuItemOpts.type = ElectronDesktopOptions().accessibility() ? 'radio' : 'checkbox';
       menuItemOpts.checked = false;
-    }
-    else if (checkable) {
+    } else if (checkable) {
       menuItemOpts.type = 'checkbox';
       menuItemOpts.checked = false;
     }


### PR DESCRIPTION
### Intent

Remove `Launcher` item from `Tools` menu.

### Approach

All menus with a present `submenu` object with no items are now hidden as it's supposed they are present due to a bug or unintendedly present.

### Automated Tests

None

### QA Notes

Open the app and check `Tools -> Launcher`. This submenu should not show up

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #10900