### PR TITLE
handle sequencing of setPendingQuit callback

### DIFF
--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -445,7 +445,7 @@ void SessionLauncher::onRSessionExited(int, QProcess::ExitStatus)
       }
 
       // close all satellite windows if we are reloading
-      bool reload = (pendingQuit == PendingQuitRestartAndReload);
+      bool reload = pendingQuit == PendingQuitRestartAndReload;
       if (reload)
          closeAllSatellites();
 

--- a/src/cpp/server/crash-handler-proxy/CrashHandlerProxyMain.cpp
+++ b/src/cpp/server/crash-handler-proxy/CrashHandlerProxyMain.cpp
@@ -26,6 +26,9 @@ void runCrashHandler(const char* argv[])
    else
       handlerPath = exePath.getParent().completeChildPath("crashpad_handler");
 
+   if (!handlerPath.exists())
+      return;
+   
    std::string handlerPathStr = handlerPath.getAbsolutePath();
    const char* handlerExe = handlerPathStr.c_str();
    argv[0] = handlerExe;

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1468,6 +1468,11 @@ public class StringUtil
 
       return result;
    }
+   
+   public static final String nullCoalesce(String value, String defaultValue)
+   {
+      return value == null ? defaultValue : value;
+   }
 
    /**
     * Perform a natural order comparison between two strings. Natural ordering

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -143,7 +143,7 @@ public interface DesktopFrame extends JavaScriptPassthrough
    public static final int PENDING_QUIT_RESTART_AND_RELOAD = 3;
    
    void setPendingQuit(int pendingQuit, CommandWithArg<Void> callback);
-   void setPendingProject(String projectFilePath, CommandWithArg<Void> callback);
+   void setPendingProject(String projectFilePath);
    void launchSession(boolean reload);
    
    void openProjectInNewWindow(String projectFilePath);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -142,8 +142,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    public static final int PENDING_QUIT_AND_RESTART = 2;
    public static final int PENDING_QUIT_RESTART_AND_RELOAD = 3;
    
-   void setPendingQuit(int pendingQuit);
-   void setPendingProject(String projectFilePath);
+   void setPendingQuit(int pendingQuit, CommandWithArg<Void> callback);
+   void setPendingProject(String projectFilePath, CommandWithArg<Void> callback);
    void launchSession(boolean reload);
    
    void openProjectInNewWindow(String projectFilePath);

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrameHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrameHelper.java
@@ -1,0 +1,41 @@
+/*
+ * DesktopFrameHelper.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.application;
+
+import com.google.gwt.user.client.Command;
+
+public class DesktopFrameHelper
+{
+   public static void setPendingQuit(int quitType, Command command)
+   {
+      if (Desktop.isDesktop() && Desktop.hasDesktopFrame())
+      {
+         Desktop.getFrame().setPendingQuit(quitType, (value) ->
+         {
+            if (command != null)
+            {
+               command.execute();
+            }
+         });
+      }
+      else
+      {
+         if (command != null)
+         {
+            command.execute();
+         }
+      }
+   }
+}


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10962.

### Approach

- Ensure that calls to `setPendingQuit()` are properly sequenced, so we can be sure that the desktop front-end has handled our message before actually attempting to quit.
- Revert https://github.com/rstudio/rstudio/commit/6a2e343a8de14ee4b47c7fbbf391258671875e8e.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10962.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
