### PR TITLE
build Electron on Debian10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,6 +242,7 @@ try {
           [os: 'bionic',     arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Bionic'],
           [os: 'debian9',    arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 9'],
           [os: 'debian9',    arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 9'],
+          [os: 'debian10',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Debian 10'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'RHEL 8']

--- a/docker/jenkins/Dockerfile.debian10-x86_64
+++ b/docker/jenkins/Dockerfile.debian10-x86_64
@@ -1,0 +1,98 @@
+FROM debian:buster
+
+ENV OPERATING_SYSTEM=debian_10
+
+# update system
+RUN set -x \
+    && apt-get update -y
+
+# install necessary packages
+RUN apt-get update -y && apt-get install -y \
+    ant \
+    bzip2 \
+    clang \
+    cmake \
+    curl \
+    debsigs \
+    dpkg-sig \
+    expect \
+    fakeroot \
+    gcc \
+    git \
+    gnupg1 \
+    libacl1-dev \
+    libacl1-dev \
+    libattr1-dev \
+    libboost-all-dev \
+    libcap-dev \
+    libcap-dev \
+    libcurl4-openssl-dev \
+    libffi-dev \
+    libfontconfig-dev \
+    libglib2.0-dev \
+    libpam0g-dev \
+    libpango-1.0-0 \
+    libpq-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libuser1-dev \
+    libxml-commons-external-java \
+    libxml2-dev \
+    lsof \
+    make \
+    mesa-common-dev \
+    ninja-build \
+    openjdk-11-jdk  \
+    patchelf \
+    p7zip-full \
+    procps \
+    python \
+    r-base \
+    rrdtool \
+    sudo \
+    uuid-dev \
+    valgrind \
+    wget \
+    zlib1g
+
+# copy RStudio tools (needed so that our other dependency scripts can find it)
+RUN mkdir -p /tools
+COPY dependencies/tools/rstudio-tools.sh /tools/rstudio-tools.sh
+
+RUN mkdir -p /opt/rstudio-tools/dependencies/tools
+COPY dependencies/tools/rstudio-tools.sh /opt/rstudio-tools/dependencies/tools/rstudio-tools.sh
+
+# run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+# https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# add clang to system path
+ENV PATH=/usr/lib/llvm-7/bin:$PATH
+
+# install crashpad and its dependencies
+COPY dependencies/common/install-crashpad /tmp/
+RUN bash /tmp/install-crashpad debian9
+
+# copy common dependency installation scripts
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
+
+# copy panmirror project setup (so install-common can install needed deps)
+RUN mkdir -p /opt/rstudio-tools/panmirror
+COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
+COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
+
+# install common dependencies
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common debian10
+
+# set github login from build argument if defined
+ARG GITHUB_LOGIN
+ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.debian10-x86_64
+++ b/docker/jenkins/Dockerfile.debian10-x86_64
@@ -72,7 +72,7 @@ ENV PATH=/usr/lib/llvm-7/bin:$PATH
 
 # install crashpad and its dependencies
 COPY dependencies/common/install-crashpad /tmp/
-RUN bash /tmp/install-crashpad debian9
+RUN bash /tmp/install-crashpad debian10
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common


### PR DESCRIPTION
### Intent

Addresses #10676

### Approach

Create dockerfile for a debian10 build machine, and generate Debian builds of Electron Desktop on it.

I tested locally via Docker, and was able to produce an Electron build that installed and ran on a Debian 11 machine.

Because this is is only being used for Electron, the Dockerfile doesn't bother installing the Qt SDK.

Similarly, I didn't do changes that would be needed for building workbench/session bundles, etc. Those will continue on debian9 for the time being.

### Automated Tests

Build stuff.

### QA Notes

The resulting builds should be usable on Debian 10 (Buster) or Debian 11 (Bullseye). I did not try on a Debian 9 machine (debian 9 is about to go out of support altogether so don't think we care for Electron).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


