### PR TITLE
support launching with 32bit R

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -204,6 +204,7 @@ export function detectREnvironment(rPath?: string): Expected<REnvironment> {
   R.home("include"),
   R.home("share"),
   paste(R.version$crt, collapse = ""),
+  .Platform$r_arch,
   Sys.getenv("${kLdLibraryPathVariable}")
 ))`;
 
@@ -228,7 +229,16 @@ export function detectREnvironment(rPath?: string): Expected<REnvironment> {
   }
 
   // unwrap query results
-  const [rVersion, rHome, rDocDir, rIncludeDir, rShareDir, rRuntime, rLdLibraryPath] = result.stdout.split(EOL);
+  const [
+    rVersion,
+    rHome,
+    rDocDir,
+    rIncludeDir,
+    rShareDir,
+    rRuntime,
+    rArch,
+    rLdLibraryPath
+  ] = result.stdout.split(EOL);
 
   // put it all together
   return ok({
@@ -240,6 +250,7 @@ export function detectREnvironment(rPath?: string): Expected<REnvironment> {
       R_INCLUDE_DIR: rIncludeDir,
       R_SHARE_DIR: rShareDir,
       R_RUNTIME: rRuntime,
+      R_ARCH: rArch,
     },
     ldLibraryPath: rLdLibraryPath,
   });

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -498,17 +498,32 @@ export class SessionLauncher {
       setenv('RSTUDIO_SESSION_EXIT_ON_STARTUP', appState().sessionEarlyExitCode.toString());
     }
 
-    // on Windows, if we're using a UCRT build of R, we'll need to use
-    // our rsession-utf8.exe executable (if available)
     if (process.platform === 'win32') {
+
+      // on Windows, if we're using a UCRT build of R, we'll need to use
+      // our rsession-utf8.exe executable (if available)
       const runtime = getenv('R_RUNTIME');
       if (runtime === 'ucrt') {
         const utf8SessionPath = this.sessionPath.getParent().completeChildPath('rsession-utf8.exe');
         if (utf8SessionPath.existsSync()) {
-          logger().logDebug(`R is UCRT; using ${this.sessionPath}`);
           this.sessionPath = utf8SessionPath;
+          logger().logDebug(`R is UCRT; using ${this.sessionPath}`);
         }
       }
+
+      // similarly, if we're using a 32-bit version of R,
+      // we'll need to use the 32-bit copy of our session executable
+      const arch = getenv('R_ARCH');
+      if (arch === 'i386') {
+        const x86SessionPath = this.sessionPath.getParent().completeChildPath('x86/rsession.exe');
+        if (x86SessionPath.existsSync()) {
+          this.sessionPath = x86SessionPath;
+          logger().logDebug(`R is 32-bit; using ${this.sessionPath}`);
+        } else {
+          logger().logWarning('R is 32-bit, but no 32-bit rsession.exe was found');
+        }
+      }
+
     }
 
     // on macOS, we need to look at R and figure out if we should be trying to run


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10954.

### Approach

Use 32-bit rsession.exe path when R declares itself to be 32bit.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
