### PR TITLE
install xvfb for electron unit tests

### DIFF
--- a/docker/jenkins/Dockerfile.debian10-x86_64
+++ b/docker/jenkins/Dockerfile.debian10-x86_64
@@ -53,6 +53,7 @@ RUN apt-get update -y && apt-get install -y \
     uuid-dev \
     valgrind \
     wget \
+    xvfb \
     zlib1g
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)


### PR DESCRIPTION
### Intent

Electron unit tests (will) fail on debian10 build because dockerfile didn't install xvfb.

### Approach

Add xvfb to the dockerfile.

### Automated Tests

Metaphysical

### QA Notes

Nothing to test directly

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


