### PR TITLE
ensure callback is invoked after setPendingQuit

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -560,7 +560,7 @@ export class GwtCallback extends EventEmitter {
       desktop.cleanClipboard(stripHtml);
     });
 
-    ipcMain.on('desktop_set_pending_quit', (event, pendingQuit: number) => {
+    ipcMain.handle('desktop_set_pending_quit', (event, pendingQuit: number) => {
       this.pendingQuit = pendingQuit;
     });
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -365,8 +365,11 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_clean_clipboard', stripHtml);
     },
 
-    setPendingQuit: (pendingQuit: number) => {
-      ipcRenderer.send('desktop_set_pending_quit', pendingQuit);
+    setPendingQuit: (pendingQuit: number, callback: VoidCallback<unknown>) => {
+      ipcRenderer
+        .invoke('desktop_set_pending_quit', pendingQuit)
+        .then((response) => callback(response))
+        .catch((error) => reportIpcError('setPendingQuit', error));
     },
 
     openProjectInNewWindow: (projectFilePath: string) => {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10969.

### Approach

The Electron implementation for `setPendingQuit()` wasn't accepting (or invoking) a callback to signal when the IPC request had been handled; this PR brings that in.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
