### PR TITLE
Enable sqlite testing by default

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -222,7 +222,9 @@ if has-scope "rserver"; then
 
    if [ -e "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests" ]; then
       section "Running 'rserver' tests..."
+      cd server
       runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/server/rserver-tests"
+      cd ..
    fi
 
 fi

--- a/src/cpp/server/ServerDatabaseMigrationTests.cpp
+++ b/src/cpp/server/ServerDatabaseMigrationTests.cpp
@@ -59,7 +59,7 @@ PostgresqlConnectionOptions postgresConnectionOptions()
    return options;
 }
 
-TEST_CASE("Upgrading Sqlite Database","[.database][.integration][.upgrade][.sqlite]")
+TEST_CASE("Upgrading Sqlite Database","[database][integration][upgrade][sqlite]")
 {
     overlay::overlayDatasetPath(datasetPath);
     GIVEN("An Empty Sqlite Database")
@@ -187,7 +187,7 @@ TEST_CASE("Upgrading Sqlite Database","[.database][.integration][.upgrade][.sqli
     }
 }
 
-TEST_CASE("Upgrading Postgres Database", "[.database][.integration][.upgrade][.postgres]")
+TEST_CASE("Upgrading Postgres Database", "[database][integration][upgrade][.postgres]")
 {
     overlay::overlayDatasetPath(datasetPath);
     GIVEN("An empty Postgres Database")


### PR DESCRIPTION
Sqlite tests are now run by default since they don't require additional
setup.

These tests run database upgrade tests
rstudio-tests now changes the cwd to server when running the rserver-tests.


### Intent
Enable automatic use of databse test cases. SQLite only right now, as it won't add additional burden to the infrastructure.

### Approach

The previously hidden sqlite tests have been unhidden, since the tests depend on files to create and upgrade the database, the working directory needs to be known before hand. The `rstudio-tests` now steps into the server directory before running the `rserver-tests`.

The postgresql tests remain hidden.

### Automated Tests

This enables automated tests.

### QA Notes

If the automated build works, it passes. Should have little to no QA impact.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


