### PR TITLE
Move Electron path test to after Qt path test for Mac

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -503,7 +503,8 @@ FilePath macBinaryPath(const FilePath& resourcePath,
 {
    // otherwise, look in default Qt location
    FilePath qtPath = resourcePath.getParent().completePath("MacOS").completePath(stem);
-   return qtPath;
+   if (qtPath.exists())
+      return qtPath;
 
    FilePath electronPath =
          resourcePath.completePath("bin").completePath(stem);
@@ -513,8 +514,7 @@ FilePath macBinaryPath(const FilePath& resourcePath,
 
    // alternate Electron binary path
    electronPath = resourcePath.completePath(stem);
-   if (electronPath.exists())
-      return electronPath;
+   return electronPath;
 }
 
 } // end anonymous namespace

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -501,7 +501,10 @@ namespace {
 FilePath macBinaryPath(const FilePath& resourcePath,
                        const std::string& stem)
 {
-   // first check for Electron binary path
+   // otherwise, look in default Qt location
+   FilePath qtPath = resourcePath.getParent().completePath("MacOS").completePath(stem);
+   return qtPath;
+
    FilePath electronPath =
          resourcePath.completePath("bin").completePath(stem);
    
@@ -512,10 +515,6 @@ FilePath macBinaryPath(const FilePath& resourcePath,
    electronPath = resourcePath.completePath(stem);
    if (electronPath.exists())
       return electronPath;
-
-   // otherwise, look in default Qt location
-   FilePath qtPath = resourcePath.getParent().completePath("MacOS").completePath(stem);
-   return qtPath;
 }
 
 } // end anonymous namespace


### PR DESCRIPTION
### Intent
Fix Qt accidentally using Resources/quarto as the quarto binary path. This caused the IDE to not show File > New File > Quarto Document/Presentation

### Approach
Move the Electron path check to after Qt. It turns out that the Electron portion of the check would look in `app` for Quarto. In a Qt package, it looks in `Resources` which holds the Quarto `share` directory. The session ends up using that path and the Quarto checks for the menu items would see that Quarto is not available at that location so the items aren't shown.

The Electron path check was first but I don't think it has to be the first location to check for the binary.

### Automated Tests
None

### QA Notes
I've locally patched a daily Qt build and local Electron build and it works now.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


