### PR TITLE
Undo font change to monospace fallback

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/ThemeFonts.java
@@ -34,7 +34,7 @@ public class ThemeFonts
 
    public static String getFixedWidthFont()
    {
-      return fontLoader.getFixedWidthFont();
+      return fontLoader.getFixedWidthFont() + ", monospace";
    }
 
    static interface ThemeFontLoader


### PR DESCRIPTION
### Intent
Fix the monospace fallback when selecting an invalid font. Addresses #10939  

### Approach
As part of the Electron font selection work, this bit of code was removed but it's actually the fallback in case the specified font is invalid. It's likely that `Courier 10 Pitch` is an invalid font family and the monospace fallback was defaulting to a monospace font.

### Automated Tests
None

### QA Notes
Selecting `Courier 10 Pitch` will have a fixed width font for the console but it may not actually be `Courier` but should be fixed width. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


