### PR TITLE
OS companion commit for socket security patch 2

### DIFF
--- a/src/cpp/core/include/core/http/SocketProxy.hpp
+++ b/src/cpp/core/include/core/http/SocketProxy.hpp
@@ -35,11 +35,13 @@ class SocketProxy : public boost::enable_shared_from_this<SocketProxy>
 public:
    static void create(boost::shared_ptr<core::http::Socket> ptrClient,
                       boost::shared_ptr<core::http::Socket> ptrServer,
-                      boost::function<bool()> checkFunction = 0)
+                      boost::function<bool()> checkFunction = 0,
+                      boost::function<void()> closeFunction = 0)
    {
       boost::shared_ptr<SocketProxy> pProxy(new SocketProxy(ptrClient,
                                                             ptrServer,
-                                                            checkFunction));
+                                                            checkFunction,
+                                                            closeFunction));
       pProxy->readClient();
       pProxy->readServer();
    }
@@ -47,8 +49,10 @@ public:
 private:
    SocketProxy(boost::shared_ptr<core::http::Socket> ptrClient,
                boost::shared_ptr<core::http::Socket> ptrServer,
-               boost::function<bool()> checkFunction)
-      : ptrClient_(ptrClient), ptrServer_(ptrServer), checkFunction_(checkFunction)
+               boost::function<bool()> checkFunction,
+               boost::function<void()> closeFunction)
+      : ptrClient_(ptrClient), ptrServer_(ptrServer),
+        checkFunction_(checkFunction), closeFunction_(closeFunction), closed_(false)
    {
    }
 
@@ -73,8 +77,10 @@ private:
    boost::shared_ptr<core::http::Socket> ptrServer_;
    boost::array<char, 8192> clientBuffer_;
    boost::array<char, 8192> serverBuffer_;
-   boost::mutex socketMutex_;
+   boost::recursive_mutex socketMutex_;
    boost::function<bool()> checkFunction_;
+   boost::function<void()> closeFunction_;
+   bool closed_ = false;
 };
 
 } // namespace http

--- a/src/cpp/server/ServerSessionProxy.cpp
+++ b/src/cpp/server/ServerSessionProxy.cpp
@@ -110,12 +110,33 @@ Error runVerifyInstallationSession(core::system::User& user,
 
 } // namespace overlay
 
-bool sessionCookieValid(const std::string& cookieValue)
+/*
+ * This is called from the socket proxy before it reads data from the socket to ensure
+ * the socket connection is still valid. When there's no valid UserSession, false is returned
+ * to cause the connection to be closed.
+ *
+ * When the session is alive, the socket's last activity time is updated to 'now' to preserve the
+ * UserSession for the case where the websocket is actively being used, but the rserver session
+ * has passively timed out.
+ *
+ * With normal rserver RPCs, we differentiate between background requests and those that represent real
+ * user interactivity but do not have a way to do that for websockets. Tying websocket activity to
+ * normal session activity is probably too permissive, but closing the socket when a user is actively
+ * using the session causes them to lose work.
+ */
+bool checkForValidUserSession(const std::string& username)
 {
-   bool res = !auth::handler::isCookieRevoked(cookieValue);
+   bool res = auth::handler::UserSession::userSessionValid(username);
    if (!res)
-      LOG_DEBUG_MESSAGE("Closing socket connection - cookie has been revoked due to user signout");
+      LOG_DEBUG_MESSAGE("Closing socket connection - user session for: " + username + " has been invalidated");
+   else
+       auth::handler::UserSession::updateSocketLastActiveTime(username);
    return res;
+}
+
+void socketConnectionClosed(const std::string& username)
+{
+   auth::handler::UserSession::removeUserSessionConnection(username);
 }
    
 namespace {
@@ -333,6 +354,7 @@ void sendSparkUIResponse(
 void handleLocalhostResponse(
       boost::shared_ptr<core::http::AsyncConnection> ptrConnection,
       boost::shared_ptr<http::IAsyncClient> ptrLocalhost,
+      const std::string& username,
       const std::string& port,
       const std::string& baseAddress,
       bool ipv6,
@@ -352,8 +374,12 @@ void handleLocalhostResponse(
       boost::shared_ptr<http::Socket> ptrServer =
          boost::static_pointer_cast<http::Socket>(ptrLocalhost);
 
+      auth::handler::UserSession::addUserSessionConnection(username);
+
       // connect the sockets
-      http::SocketProxy::create(ptrClient, ptrServer, boost::bind(sessionCookieValid, ptrConnection->request().cookieValue(kUserIdCookie)));
+      http::SocketProxy::create(ptrClient, ptrServer,
+                                boost::bind(checkForValidUserSession, username),
+                                boost::bind(socketConnectionClosed, username));
    }
    // normal response, write and close (handle redirects if necessary)
    else
@@ -956,6 +982,8 @@ void proxyRpcRequest(
    bool refreshCredentials = shouldRefreshCredentials(ptrConnection->request());
    if (refreshCredentials)
    {
+      auth::handler::UserSession::updateSessionLastActiveTime(username);
+
       auth::handler::refreshAuthCookies(userIdentifier,
                                         ptrConnection->request(),
                                         &ptrConnection->response());
@@ -1104,7 +1132,7 @@ void proxyLocalhostRequest(
    }
 
    LocalhostResponseHandler onResponse =
-         boost::bind(handleLocalhostResponse, ptrConnection, _3, port, _2, ipv6, _1);
+         boost::bind(handleLocalhostResponse, ptrConnection, _3, username, port, _2, ipv6, _1);
    http::ErrorHandler onError = boost::bind(handleLocalhostError, ptrConnection, _1);
 
    // see if the request should be handled by the overlay (unless it should be handled by the server)
@@ -1134,7 +1162,7 @@ void proxyLocalhostRequest(
 
    // execute request
    pClient->execute(
-            boost::bind(handleLocalhostResponse, ptrConnection, pClient, port, address, ipv6, _1),
+            boost::bind(handleLocalhostResponse, ptrConnection, pClient, username, port, address, ipv6, _1),
             onError);
 }
 

--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -80,7 +80,6 @@ void refreshCredentialsThenContinue(
 }
 
 // implemented below
-boost::optional<boost::posix_time::time_duration> getCookieExpiry(bool staySignedIn);
 bool isSecureCookie(const core::http::Request& request);
 
 void signIn(const core::http::Request& request,
@@ -104,6 +103,10 @@ void signIn(const core::http::Request& request,
          appUri = "./" + appUri;
       }
       LOG_DEBUG_MESSAGE("Signed in user: " + username + " redirecting to: " + appUri);
+
+      // Create this on signin to set the initial lastActiveTime and lastCookieRefreshTime. It's also created if it does not exist
+      // the first time we try to update the session's last activity in a user-initiated RPC request.
+      boost::shared_ptr<auth::handler::UserSession> pUserSession = auth::handler::UserSession::createUserSession(username);
 
       pResponse->setMovedTemporarily(request, appUri);
       return;
@@ -139,6 +142,18 @@ bool validateSignIn(const core::http::Request& request,
 
 ErrorType checkUser(const std::string& username, bool authenticated)
 {
+   if (!authenticated) {
+      LOG_DEBUG_MESSAGE("Failed to authenticate username: " + username);
+      // register failed login with monitor
+      using namespace monitor;
+      client().logEvent(Event(kAuthScope,
+                              kAuthLoginFailedEvent,
+                              "",
+                              username));
+
+      return kErrorInvalidLogin;
+   }
+
    // ensure user is valid
    if (!server::auth::validateUser(username))
    {
@@ -191,17 +206,6 @@ ErrorType checkUser(const std::string& username, bool authenticated)
                               username));
 
       return kErrorUserLicenseLimitReached;
-   }
-
-   if (!authenticated) {
-      // register failed login with monitor
-      using namespace monitor;
-      client().logEvent(Event(kAuthScope,
-                              kAuthLoginFailedEvent,
-                              "",
-                              username));
-
-      return kErrorInvalidLogin;
    }
 
    using namespace monitor;
@@ -268,8 +272,11 @@ std::string signOut(const core::http::Request& request,
    }
 
    // invalidate the auth cookie so that it can no longer be used
-   clearSignInCookies(request, pResponse);
    auth::handler::invalidateAuthCookie(request.cookieValue(kUserIdCookie));
+
+   clearSignInCookies(request, pResponse);
+
+   auth::handler::UserSession::invalidateUserSession(username);
 
    // adjust sign out url point internally
    if (!signOutUrl.empty() && signOutUrl[0] == '/')

--- a/src/cpp/server/auth/ServerAuthHandler.cpp
+++ b/src/cpp/server/auth/ServerAuthHandler.cpp
@@ -26,8 +26,11 @@
 #include <core/json/JsonRpc.hpp>
 #include <core/system/PosixUser.hpp>
 #include <core/Thread.hpp>
+#include <core/PeriodicCommand.hpp>
+#include <server/ServerScheduler.hpp>
 
 #include <server_core/ServerDatabase.hpp>
+#include <server_core/http/SecureCookie.hpp>
 
 #include <server/ServerConstants.hpp>
 #include <server/ServerObject.hpp>
@@ -35,6 +38,7 @@
 #include <server/ServerUriHandlers.hpp>
 
 #include <server/auth/ServerSecureUriHandler.hpp>
+#include <server/auth/ServerAuthCommon.hpp>
 
 #include <session/SessionScopes.hpp>
 
@@ -70,12 +74,15 @@ std::map<std::string, boost::posix_time::ptime> s_loginTimes;
 // allows for quickly removing the first element
 std::deque<RevokedCookie> s_revokedCookies;
 
+// Tracks the set of cookies that are authorized for the user session, so they can all be revoked on signout
+std::map<std::string,boost::shared_ptr<UserSession>> s_userSessions;
+
 boost::posix_time::ptime s_lastCookieCheckTime = boost::posix_time::second_clock::universal_time();
 boost::posix_time::time_duration s_cookieCheckDuration = boost::posix_time::seconds(5);
 
 // mutex for providing concurrent access to internal structures
 // necessary because auth happens on the thread pool
-boost::mutex s_mutex;
+boost::recursive_mutex s_mutex;
 
 // global auth handler
 Handler s_handler;
@@ -179,7 +186,7 @@ Error writeRevokedCookiesToDatabase()
    boost::shared_ptr<IConnection> connection = server_core::database::getConnection();
    Transaction transaction(connection);
 
-   LOCK_MUTEX(s_mutex)
+   RECURSIVE_LOCK_MUTEX(s_mutex)
    {
       for (auto it = s_revokedCookies.begin(); it != s_revokedCookies.end(); ++it)
       {
@@ -218,15 +225,83 @@ Error readRevocationListFromFile(const FilePath& revocationList,
    return Success();
 }
 
+bool invalidateExpiredSessions()
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      if (s_userSessions.size() == 0)
+      {
+         return true;
+      }
+
+      boost::posix_time::time_duration timeoutInterval = common::getCookieExpiry(true).get();
+
+      boost::posix_time::ptime expireTime = boost::posix_time::second_clock::universal_time() - timeoutInterval;
+      for (auto it = s_userSessions.begin(); it != s_userSessions.end();)
+      {
+         const boost::shared_ptr<UserSession> pUserSession = it->second;
+         if (pUserSession->lastActiveTime() < expireTime)
+         {
+            if (pUserSession->numConnections() == 0 || pUserSession->lastSocketActiveTime() < expireTime)
+            {
+               // Because the user's session has passively expired, we are not going to actively revoke the cookies across the cluster.
+               // Each cookie has an expire time built in so it will expire on its own in the browser
+               // pUserSession->invalidateSessionCookies();
+               LOG_DEBUG_MESSAGE("Expired UserSession for: " + pUserSession->username());
+
+               it = s_userSessions.erase(it);
+            }
+            else
+            {
+               LOG_DEBUG_MESSAGE("Preserving expired UserSession with: " + std::to_string(pUserSession->numConnections()) +
+                                 " for: " + pUserSession->username());
+               ++it;
+            }
+         }
+         else
+         {
+            ++it;
+         }
+      }
+   }
+   END_LOCK_MUTEX
+
+   return true;
+}
+
+void addToUserSessionConnections(const std::string& username, int val)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = UserSession::lookupUserSession(username);
+      if (pUserSession)
+      {
+         int newCt = pUserSession->numConnections() + val;
+         if (newCt < 0)
+         {
+            LOG_ERROR_MESSAGE("Invalid negative UserSession connection count: " + std::to_string(newCt));
+            newCt = 0;
+         }
+         pUserSession->setNumConnections(newCt);
+         LOG_DEBUG_MESSAGE("UserSession: " + username + " has: " + std::to_string(newCt) + " socket connections after adding: " + std::to_string(val));
+      }
+   }
+   END_LOCK_MUTEX
+}
+
+
 } // anonymous namespace
 
 bool isCookieRevoked(const std::string& cookie)
 {
+   if (cookie.empty())
+      return true;
+
    bool attemptedConnection = false;
    boost::shared_ptr<IConnection> connection;
    boost::posix_time::ptime now = boost::posix_time::second_clock::universal_time();
 
-   LOCK_MUTEX(s_mutex)
+   RECURSIVE_LOCK_MUTEX(s_mutex)
    {
       bool removeStaleCookies = now > s_lastCookieCheckTime + s_cookieCheckDuration;
 
@@ -240,7 +315,9 @@ bool isCookieRevoked(const std::string& cookie)
       {
          const RevokedCookie& other = *it;
          if (other.cookie == cookie)
+         {
             return true;
+         }
 
          if (removeStaleCookies && other.expiration <= now)
          {
@@ -378,6 +455,150 @@ RevokedCookie::RevokedCookie(const std::string& cookie)
    this->expiration = cookieExpiration(cookie);
 }
 
+boost::shared_ptr<UserSession> UserSession::createUserSession(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = UserSession::lookupUserSession(username);
+      if (pUserSession)
+      {
+         LOG_DEBUG_MESSAGE("Reusing active session for: " + username + " that did not expire and was not logged out");
+         // This session may have been created from the same user with a different browser, but that user never explicitly signed out and the
+         // session itself has not expired. We'll keep the cookies from that session so websockets using them will be closed if the user signs out.
+         //UserSession::invalidateUserSession(username);
+      }
+      else
+      {
+         pUserSession = boost::make_shared<UserSession>(username);
+         s_userSessions[username] = pUserSession;
+
+         LOG_DEBUG_MESSAGE("Created new UserSession for: " + username + " (total: " + std::to_string(s_userSessions.size()) + ")");
+      }
+      return pUserSession;
+   }
+   END_LOCK_MUTEX
+   return boost::shared_ptr<UserSession>();
+}
+
+void UserSession::updateSessionLastActiveTime(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = UserSession::getOrCreateUserSession(username);
+      if (pUserSession)
+      {
+         pUserSession->updateLastActiveTime();
+      }
+   }
+   END_LOCK_MUTEX
+}
+
+void UserSession::updateSocketLastActiveTime(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = UserSession::lookupUserSession(username);
+      if (pUserSession)
+      {
+         pUserSession->updateSocketLastActiveTime();
+      }
+   }
+   END_LOCK_MUTEX
+}
+
+boost::shared_ptr<UserSession> UserSession::lookupUserSession(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      std::map<std::string, boost::shared_ptr<UserSession>>::iterator it = s_userSessions.find(username);
+      if (it == s_userSessions.end())
+         return boost::shared_ptr<UserSession>();
+      return it->second;
+   }
+   END_LOCK_MUTEX
+   return boost::shared_ptr<UserSession>(); // not reached
+}
+
+bool UserSession::userSessionValid(const std::string& username)
+{
+   boost::shared_ptr<UserSession> pUserSession = lookupUserSession(username);
+   return pUserSession != nullptr;
+}
+
+void UserSession::addUserSessionConnection(const std::string& username)
+{
+   LOG_DEBUG_MESSAGE("Adding connection for: " + username);
+   addToUserSessionConnections(username, 1);
+}
+
+void UserSession::removeUserSessionConnection(const std::string& username)
+{
+   LOG_DEBUG_MESSAGE("Removing a connection for: " + username);
+   addToUserSessionConnections(username, -1);
+}
+
+boost::shared_ptr<UserSession> UserSession::getOrCreateUserSession(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = lookupUserSession(username);
+      if (!pUserSession)
+         pUserSession = UserSession::createUserSession(username);
+      return pUserSession;
+   }
+   END_LOCK_MUTEX
+   return boost::shared_ptr<UserSession>(); // not reached
+}
+
+void UserSession::removeUserSession(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      s_userSessions.erase(username);
+   }
+   END_LOCK_MUTEX
+}
+
+bool UserSession::invalidateUserSession(const std::string& username)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> pUserSession = lookupUserSession(username);
+      if (pUserSession)
+      {
+          pUserSession->invalidateSessionCookies();
+          UserSession::removeUserSession(username);
+          return true;
+      }
+   }
+   END_LOCK_MUTEX
+
+   return false;
+}
+
+void UserSession::invalidateSessionCookies()
+{
+   for (std::string cookie : sessionCookies_)
+   {
+      invalidateAuthCookie(cookie);
+   }
+}
+
+void UserSession::updateLastActiveTime()
+{
+   lastActiveTime_ = boost::posix_time::microsec_clock::universal_time();
+}
+
+void UserSession::updateSocketLastActiveTime()
+{
+   lastSocketActiveTime_ = boost::posix_time::microsec_clock::universal_time();
+}
+
+void UserSession::updateLastCookieRefreshTime()
+{
+   lastCookieRefreshTime_ = boost::posix_time::microsec_clock::universal_time();
+}
+
 std::string getUserIdentifier(const core::http::Request& request,
                               bool requireUserListCookie)
 {
@@ -443,9 +664,12 @@ void registerHandler(const Handler& handler)
    // register uri handlers
    uri_handlers::addBlocking(kSignIn, s_handler.signIn);
 
+   // For signout, do not refresh auth cookies right before invalidating them
    uri_handlers::addBlocking(kSignOut,
-                             auth::secureHttpHandler(
-                                boost::bind(s_handler.signOut, _2, _3)));
+          auth::secureHttpHandler(boost::bind(s_handler.signOut, _2, _3),
+                                  false,   /* authenticate */
+                                  true,    /* requireUserListCookie */
+                                  false)); /* refreshAuthCookies */
 
    uri_handlers::add(kRefreshCredentialsAndContinue,
                      s_handler.refreshCredentialsThenContinue);
@@ -482,7 +706,7 @@ void signOut(const http::Request& request, http::Response* pResponse)
 
 bool isUserSignInThrottled(const std::string& user)
 {
-   LOCK_MUTEX(s_mutex)
+   RECURSIVE_LOCK_MUTEX(s_mutex)
    {
       auto it = s_loginTimes.find(user);
 
@@ -493,11 +717,13 @@ bool isUserSignInThrottled(const std::string& user)
          return false;
       }
 
+      int throttlingSeconds = options().authSignInThrottleSeconds();
       if (it->second >
-          now - boost::posix_time::seconds(options().authSignInThrottleSeconds()))
+          now - boost::posix_time::seconds(throttlingSeconds))
       {
          // user is trying to sign back in too quickly
          // prevent the request
+         LOG_WARNING_MESSAGE("Too many attempts within " + safe_convert::numberToString(throttlingSeconds) + " seconds for '" + user + "'");
          return true;
       }
       else
@@ -513,6 +739,22 @@ bool isUserSignInThrottled(const std::string& user)
    return false;
 }
 
+void UserSession::insertSessionCookie(const std::string& userIdentifier, const std::string& cookie)
+{
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      boost::shared_ptr<UserSession> session = UserSession::lookupUserSession(userIdentifier);
+
+      if (session)
+      {
+         LOG_DEBUG_MESSAGE("Adding previous cookie: " + cookie + " for user: " + userIdentifier);
+         session->addSessionCookie(cookie);
+         session->updateLastCookieRefreshTime();
+      }
+   }
+   END_LOCK_MUTEX
+}
+
 void refreshAuthCookies(const std::string& userIdentifier,
                         const http::Request& request,
                         http::Response* pResponse)
@@ -520,14 +762,49 @@ void refreshAuthCookies(const std::string& userIdentifier,
    if (server::options().authTimeoutMinutes() > 0 &&
        !s_handler.refreshAuthCookies.empty())
    {
+      // Allocate new auth cookies periodically, rather than on every request to reduce CPU, and limit the
+      // number of cookies to revoke should the user signout.
+      boost::shared_ptr<UserSession> pUserSession = UserSession::getOrCreateUserSession(userIdentifier);
+      boost::posix_time::ptime now = boost::posix_time::second_clock::universal_time();
+      if (now < pUserSession->lastCookieRefreshTime() + boost::posix_time::seconds(30))
+      {
+         return;
+      }
+
       // clear any existing auth cookies first - this method can be invoked multiple
       // times depending on the handler type (for example, an upload handler)
       pResponse->clearCookies();
       std::string persistCookie = request.cookieValue(kPersistAuthCookie);
       bool persist = persistCookie == "1" ? true : false;
+
+      // We might have long-lasting socket connections using the old cookie, that will need to close
+      // and reconnect when we refresh the auth cookie. For example, if a user signs out with a vscode
+      // or shiny app running in another tab and the auth cookies are refreshed right before the signout,
+      // we only will invalidate the new cookie unless we invalidate this one here.
+      std::string currentCookie = request.cookieValue(kUserIdCookie);
+      if (!currentCookie.empty())
+      {
+         LOG_DEBUG_MESSAGE("Refreshing auth: replacing old cookie: " + currentCookie);
+
+         UserSession::insertSessionCookie(userIdentifier, currentCookie);
+      }
+
       s_handler.refreshAuthCookies(request, userIdentifier, persist, pResponse);
    }
 }
+
+void applyRemoteRevokedCookie(const std::string& cookieValue)
+{
+   insertRevokedCookie(RevokedCookie(cookieValue));
+   std::string username = core::http::secure_cookie::readSecureCookie(cookieValue);
+   if (!username.empty())
+   {
+      // We received a revoked cookie for this user from a remote rserver so we interpret that as signing out cluster-wide
+      if (UserSession::invalidateUserSession(username))
+         LOG_DEBUG_MESSAGE("Invalidated UserSession for: " + username + " from revoked cookie received from remote server");
+   }
+}
+
 
 void insertRevokedCookie(const RevokedCookie& cookie)
 {
@@ -535,7 +812,7 @@ void insertRevokedCookie(const RevokedCookie& cookie)
    if (cookie.expiration <= boost::posix_time::second_clock::universal_time())
       return;
 
-   LOCK_MUTEX(s_mutex)
+   RECURSIVE_LOCK_MUTEX(s_mutex)
    {
       for (auto it = s_revokedCookies.begin(); it != s_revokedCookies.end(); ++it)
       {
@@ -556,6 +833,8 @@ void insertRevokedCookie(const RevokedCookie& cookie)
 void invalidateAuthCookie(const std::string& cookie,
                           ExponentialBackoffPtr backoffPtr)
 {
+   LOG_DEBUG_MESSAGE("invalidateAuthCookie called with: " + cookie);
+
    if (cookie.empty())
       return;
 
@@ -657,6 +936,12 @@ Error initialize()
          if (error)
             LOG_ERROR(error);
       }
+
+      // Periodically cleanup idle/expired UserSessions, used for validating websocket connections
+      scheduler::addCommand(boost::shared_ptr<ScheduledCommand>(
+         new PeriodicCommand(boost::posix_time::seconds(10),
+                             boost::bind(invalidateExpiredSessions),
+                             false)));
 
       return overlay::initialize();
    }

--- a/src/cpp/server/auth/ServerSecureUriHandler.cpp
+++ b/src/cpp/server/auth/ServerSecureUriHandler.cpp
@@ -272,17 +272,18 @@ SecureAsyncUriHandlerFunctionEx makeExtendedAsyncUriHandler(SecureAsyncUriHandle
    
 http::UriHandlerFunction secureHttpHandler(SecureUriHandlerFunction handler,
                                            bool authenticate,
-                                           bool requireUserListCookie)
+                                           bool requireUserListCookie,
+                                           bool refreshAuthCookies)
 {
    if (authenticate)
       return UriHandler(makeExtendedUriHandler(handler),
                         auth::handler::signInThenContinue,
-                        true,
+                        refreshAuthCookies,
                         requireUserListCookie);
    else
       return UriHandler(makeExtendedUriHandler(handler),
                         setHttpError,
-                        true,
+                        refreshAuthCookies,
                         requireUserListCookie);
 }
 

--- a/src/cpp/server/include/server/ServerSessionProxy.hpp
+++ b/src/cpp/server/include/server/ServerSessionProxy.hpp
@@ -111,7 +111,9 @@ void setSessionContextSource(SessionContextSource source);
 
 core::http::Headers getAuthCookies(const core::http::Response& response);
 
-bool sessionCookieValid(const std::string& cookieValue);
+bool checkForValidUserSession(const std::string& username);
+
+void socketConnectionClosed(const std::string& username);
 
 } // namespace session_proxy
 } // namespace server

--- a/src/cpp/server/include/server/auth/ServerAuthCommon.hpp
+++ b/src/cpp/server/include/server/auth/ServerAuthCommon.hpp
@@ -85,6 +85,8 @@ void prepareHandler(handler::Handler& handler,
 
 std::string userIdentifierToLocalUsername(const std::string& userIdentifier);
 
+boost::optional<boost::posix_time::time_duration> getCookieExpiry(bool staySignedIn);
+
 } // namespace common
 } // namespace auth
 } // namespace server

--- a/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
+++ b/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
@@ -82,6 +82,74 @@ struct Handler
                         core::http::Response*)> refreshAuthCookies;
 };
 
+/*
+ * The UserSession class currently is stored one instance per username and represents a valid login to a given
+ * rserver. It's main role now is to allow a websocket socket connection to remain open, even after the user's session
+ * cookie has expired, or more specifically the user's session cookie that was present when the websocket was created.
+ * When auth-timeout-minutes is non-zero, session cookies are allocated with the expiration time of the session and so
+ * need to be refreshed periodically to keep the session alive as long as the user interacts with it. A client such
+ * as a vscode session or shiny app that uses the websocket though, will not see the new session cookie and so won't be
+ * able to reconnect even if they keep that session active. Eventually, we can replace the refreshAuthCookies logic with
+ * a UserSession that is backed by the database. In the meantime, this class tracks information so we can keep active websockets
+ * alive, but consistently close them when the user signs out from another tab.
+ */
+class UserSession
+{
+   public:
+      UserSession(const std::string& username) :
+        username_(username), numConnections_(0)
+      {
+         updateLastActiveTime();
+         lastCookieRefreshTime_ = lastActiveTime();
+         lastSocketActiveTime_ = lastActiveTime();
+      }
+
+      /* Tracks the set of cookies that have been replaced due to refreshAuth, so we can revoke all of them when the user signs out */
+      void addSessionCookie(const std::string& cookie)
+      {
+         sessionCookies_.push_back(cookie);
+      }
+
+      void sessionInvalidated();
+      boost::posix_time::ptime lastActiveTime() { return lastActiveTime_; }
+      boost::posix_time::ptime lastCookieRefreshTime() { return lastCookieRefreshTime_; }
+      boost::posix_time::ptime lastSocketActiveTime() { return lastSocketActiveTime_; }
+      const std::string& username() { return username_; }
+      /* The number of currently open socket connections */
+      const int numConnections() { return numConnections_; }
+      void setNumConnections(const int val) 
+      {
+         numConnections_ = val;
+      }
+
+      static boost::shared_ptr<UserSession> lookupUserSession(const std::string& username);
+      static boost::shared_ptr<UserSession> getOrCreateUserSession(const std::string& username);
+      static boost::shared_ptr<UserSession> createUserSession(const std::string& username);
+      static void removeUserSession(const std::string& username);
+      static bool invalidateUserSession(const std::string& username);
+      static void updateSessionLastActiveTime(const std::string& username);
+      static void updateSocketLastActiveTime(const std::string& username);
+      static void addUserSessionConnection(const std::string& username);
+      static void removeUserSessionConnection(const std::string& username);
+      static bool userSessionValid(const std::string& username);
+      static void insertSessionCookie(const std::string& username, const std::string& cookie);
+
+   private:
+      void invalidateSessionCookies();
+      static void addToUserSessionConnection(const std::string& username, const int val);
+      void updateLastActiveTime();
+      void updateLastCookieRefreshTime();
+      /* Tracks the last time we read data from the client-side of the socket, to detect idle websockets */
+      void updateSocketLastActiveTime();
+
+      std::string username_;
+      boost::posix_time::ptime lastCookieRefreshTime_;
+      boost::posix_time::ptime lastActiveTime_; 
+      boost::posix_time::ptime lastSocketActiveTime_; 
+      std::vector<std::string> sessionCookies_;
+      int numConnections_;
+};
+
 struct RevokedCookie
 {
    RevokedCookie(const std::string& cookie);
@@ -112,6 +180,7 @@ void signOut(const core::http::Request& request,
 bool isUserSignInThrottled(const std::string& user);
 
 void insertRevokedCookie(const RevokedCookie& cookie);
+void applyRemoteRevokedCookie(const std::string& cookie);
 
 // refreshes the auth cookie silently (without user intervention)
 // invoked when the user performs an active action against the system

--- a/src/cpp/server/include/server/auth/ServerSecureUriHandler.hpp
+++ b/src/cpp/server/include/server/auth/ServerSecureUriHandler.hpp
@@ -70,7 +70,8 @@ typedef boost::variant<SecureAsyncUriHandlerFunctionEx,
 core::http::UriHandlerFunction secureHttpHandler(
                                     SecureUriHandlerFunction handler,
                                     bool authenticate = false,
-                                    bool requireUserListCookie = true);
+                                    bool requireUserListCookie = true,
+                                    bool refreshAuthCookies = true);
 
 core::http::UriHandlerFunction secureJsonRpcHandler(
                                     SecureUriHandlerFunction handler);


### PR DESCRIPTION
Keep track of a UserSession to authorize reads from the client-side of a websocket so that signout closes these connections. 

Reviewed in the rstudio-pro PR:

   https://github.com/rstudio/rstudio-pro/pull/3381

