### PR TITLE
eliminate warnings from Electron unit tests

### DIFF
--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -407,7 +407,7 @@ describe('FilePath', () => {
       assert(isSuccessful(result));
       const newPath = path.join(target, extraFolder);
       assert.isTrue(fs.existsSync(newPath));
-      fs.rmdirSync(path.join(os.tmpdir(), firstLevel), { recursive: true });
+      fs.rmSync(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
     it('createDirectorySync should fail when it cannot create the directory', () => {
       const fp = new FilePath(cannotCreatePath);
@@ -502,7 +502,7 @@ describe('FilePath', () => {
       assert(isSuccessful(result));
       const newPath = path.join(target, extraFolder);
       assert.isTrue(await FilePath.existsAsync(newPath));
-      await fsPromises.rmdir(path.join(os.tmpdir(), firstLevel), { recursive: true });
+      await fsPromises.rm(path.join(os.tmpdir(), firstLevel), { recursive: true });
     });
     it('createDirectory should fail when it cannot create the directory', async () => {
       const fp = new FilePath(cannotCreatePath);

--- a/src/node/desktop/test/unit/core/xdg.test.ts
+++ b/src/node/desktop/test/unit/core/xdg.test.ts
@@ -157,7 +157,7 @@ describe('Xdg', () => {
       const result = Xdg.systemConfigDir();
       assert.isTrue(result.getAbsolutePath().startsWith(fullDir));
       assert.isTrue(hasExpectedEnding(result));
-      fs.rmdirSync(fullDir, { recursive: true });
+      fs.rmSync(fullDir, { recursive: true });
       assert.isFalse(fs.existsSync(fullDir));
     });
     it('systemConfigFile returns default location if requested file not found', () => {

--- a/src/node/desktop/test/unit/main/menu-callback.test.ts
+++ b/src/node/desktop/test/unit/main/menu-callback.test.ts
@@ -14,13 +14,22 @@
  */
 
 import { assert } from 'chai';
-import { MenuItemConstructorOptions } from 'electron';
+import { ipcMain, MenuItemConstructorOptions } from 'electron';
 import { describe } from 'mocha';
 import { MenuCallback } from '../../../src/main/menu-callback';
 
 const separatorTemplate: MenuItemConstructorOptions = { type: 'separator' };
 
 describe('MenuCallback', () => {
+
+  afterEach(() => {
+    // MenuCallback is really intended to be a singleton, but we create a new one for 
+    // each unit test. This causes listeners to accumulate on the underlying ipcMain
+    // which eventually triggers a warning about potential leaks. We could up the limit,
+    // but opting to cleanup after each test, instead.
+    ipcMain.removeAllListeners();
+  });
+
   it('can be constructed', () => {
     const callback = new MenuCallback();
     const menuCount = process.platform === 'darwin' ? 1 : 0; // adjust for MacOS app menu


### PR DESCRIPTION
### Intent

Addresses #10946 (and also some other warnings not mentioned in an issue):

(node:22538) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead

### Approach

Release listeners attached by construction of MenuCallback after each test, and eliminate deprecation warnings by stopping use of the to-be-deprecated functions.

### Automated Tests

Same tests, less noisy warnings.

### QA Notes

Nothing to test here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


