### PR TITLE
Put all session cookies in the UserSession

### DIFF
--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -104,10 +104,6 @@ void signIn(const core::http::Request& request,
       }
       LOG_DEBUG_MESSAGE("Signed in user: " + username + " redirecting to: " + appUri);
 
-      // Create this on signin to set the initial lastActiveTime and lastCookieRefreshTime. It's also created if it does not exist
-      // the first time we try to update the session's last activity in a user-initiated RPC request.
-      boost::shared_ptr<auth::handler::UserSession> pUserSession = auth::handler::UserSession::createUserSession(username);
-
       pResponse->setMovedTemporarily(request, appUri);
       return;
    }
@@ -373,7 +369,7 @@ void setSignInCookies(const core::http::Request& request,
    core::http::Cookie::SameSite sameSite = server::options().wwwSameSite();
 
    // set the secure user id cookie
-   core::http::secure_cookie::set(kUserIdCookie,
+   http::Cookie cookie = core::http::secure_cookie::set(kUserIdCookie,
                                   userIdentifier,
                                   request,
                                   validity,
@@ -382,6 +378,8 @@ void setSignInCookies(const core::http::Request& request,
                                   pResponse,
                                   secureCookie,
                                   sameSite);
+
+   auth::handler::UserSession::insertSessionCookie(userIdentifier, cookie.value());
 
    // set a cookie that is tied to the specific user list we have written
    // if the user list ever has conflicting changes (e.g. a user is locked),

--- a/src/cpp/server/auth/ServerAuthHandler.cpp
+++ b/src/cpp/server/auth/ServerAuthHandler.cpp
@@ -743,11 +743,11 @@ void UserSession::insertSessionCookie(const std::string& userIdentifier, const s
 {
    RECURSIVE_LOCK_MUTEX(s_mutex)
    {
-      boost::shared_ptr<UserSession> session = UserSession::lookupUserSession(userIdentifier);
+      boost::shared_ptr<UserSession> session = UserSession::getOrCreateUserSession(userIdentifier);
 
       if (session)
       {
-         LOG_DEBUG_MESSAGE("Adding previous cookie: " + cookie + " for user: " + userIdentifier);
+         LOG_DEBUG_MESSAGE("Adding session cookie: " + cookie + " for user: " + userIdentifier);
          session->addSessionCookie(cookie);
          session->updateLastCookieRefreshTime();
       }
@@ -785,8 +785,6 @@ void refreshAuthCookies(const std::string& userIdentifier,
       if (!currentCookie.empty())
       {
          LOG_DEBUG_MESSAGE("Refreshing auth: replacing old cookie: " + currentCookie);
-
-         UserSession::insertSessionCookie(userIdentifier, currentCookie);
       }
 
       s_handler.refreshAuthCookies(request, userIdentifier, persist, pResponse);
@@ -833,7 +831,7 @@ void insertRevokedCookie(const RevokedCookie& cookie)
 void invalidateAuthCookie(const std::string& cookie,
                           ExponentialBackoffPtr backoffPtr)
 {
-   LOG_DEBUG_MESSAGE("invalidateAuthCookie called with: " + cookie);
+   LOG_DEBUG_MESSAGE("Invalidated auth cookie: " + cookie);
 
    if (cookie.empty())
       return;

--- a/src/cpp/server_core/http/SecureCookie.cpp
+++ b/src/cpp/server_core/http/SecureCookie.cpp
@@ -204,7 +204,7 @@ std::string readSecureCookie(const std::string& signedCookieValue)
    return value;
 }
 
-void set(const std::string& name,
+http::Cookie set(const std::string& name,
          const std::string& value,
          const http::Request& request,
          const boost::posix_time::time_duration& validDuration,
@@ -229,6 +229,8 @@ void set(const std::string& name,
 
    // add to response
    pResponse->addCookie(cookie);
+
+   return cookie;
 }
 
 void remove(const http::Request& request,
@@ -265,6 +267,7 @@ const std::string& getKey()
 {
    return s_secureCookieKey;
 }
+
 const std::string& getKeyFileUsed()
 {
    return s_secureCookieKeyPath;

--- a/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
+++ b/src/cpp/server_core/include/server_core/http/SecureCookie.hpp
@@ -53,7 +53,7 @@ std::string readSecureCookie(const std::string& signedCookieValue);
 
 core::Error hashWithSecureKey(const std::string& value, std::string* pHMAC);
 
-void set(const std::string& name,
+http::Cookie set(const std::string& name,
          const std::string& value,
          const http::Request& request,
          const boost::posix_time::time_duration& validDuration,


### PR DESCRIPTION
Before this change, the current cookie was not in the
UserSession, which meant that if two tabs were directly addressing
different servers in the cluster, using different server:port
(and thus different cookie domains), the most recent cookie in one cluster
would not get revoked if the other session was signed out.

It's safer to make sure all cookies used by a UserSession for one member in the
cluster get revoked when another server revokes a cookie (i.e. the user signs out from there)

Part of the fix for: https://github.com/rstudio/rstudio-pro/pull/3381

(BTW, I'm going to merge this before the review  to get the builds going). 