### PR TITLE
Removed redundant call to invalidateAuthCookie

### DIFF
--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -267,11 +267,9 @@ std::string signOut(const core::http::Request& request,
                               username));
    }
 
-   // invalidate the auth cookie so that it can no longer be used
-   auth::handler::invalidateAuthCookie(request.cookieValue(kUserIdCookie));
-
    clearSignInCookies(request, pResponse);
 
+   // Invalidating the session will revoke all auth cookies allocated
    auth::handler::UserSession::invalidateUserSession(username);
 
    // adjust sign out url point internally


### PR DESCRIPTION
This is now done in invalidateUserSession for all cookies.

For postgres, the extra call causes an error in the logs on signout.

Another part of the fix for: https://github.com/rstudio/rstudio-pro/issues/3287

(This is another small change part of that previous fix so I'm going to merge before the review again...)