### PR TITLE
Electron Mac file associations

### DIFF
--- a/src/node/desktop/.gitignore
+++ b/src/node/desktop/.gitignore
@@ -139,6 +139,9 @@ package/
 # Electron-Forge
 out/
 
+# Generated plist during CMake
+Info.plist
+
 .prettier_and_git_ignores
 
 # End of https://www.toptal.com/developers/gitignore/api/node

--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -117,6 +117,10 @@ endif()
 
 set(ELECTRON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "")
 if (APPLE)
+   # configure Info.plist
+   configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in
+      ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
+
    # copy sources to build directory. note that the build directory cannot
    # be the "true" CMake directory as some files are resolved relative to
    # the desktop project's relative path in the application structure

--- a/src/node/desktop/Info.plist.in
+++ b/src/node/desktop/Info.plist.in
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+      <key>CFBundleDocumentTypes</key>
+      <array>
+      <dict>
+         <key>CFBundleTypeOSTypes</key>
+         <array>
+            <string>fold</string>
+         </array>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+            <string>RData</string>
+            <string>Rdata</string>
+            <string>rdata</string>
+            <string>rda</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RData.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Data File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+         <key>LSTypeIsPackage</key>
+         <false/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+            <string>Rproj</string>
+            <string>RProj</string>
+            <string>rproj</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RProject.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Project</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+         <key>LSTypeIsPackage</key>
+         <false/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+            <string>rdprsp</string>
+         </array>
+         <key>CFBundleTypeMIMETypes</key>
+         <array>
+            <string>application/x-rdp-rsp</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RProject.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>RDP RSP Session</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>R</string>
+             <string>r</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RSource.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Source File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rd</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RDoc.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Doc File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rnw</string>
+             <string>rnw</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RSweave.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Sweave File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rtex</string>
+             <string>rtex</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RSweave.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Sweave File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rmd</string>
+             <string>rmd</string>
+             <string>Rmarkdown</string>
+             <string>rmarkdown</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RMarkdown.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Markdown File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+       <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>qmd</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>QuartoMarkdown.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Quarto Markdown File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rhtml</string>
+             <string>rhtml</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RHTML.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R HTML File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rpres</string>
+             <string>rpres</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RPresentation.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Presentation File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>tex</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RTex.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>TeX File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>md</string>
+             <string>mdtxt</string>
+             <string>markdown</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>Markdown.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Markdown File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+      </dict>
+       <dict>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>htm</string>
+                <string>html</string>
+            </array>
+            <key>CFBundleTypeIconFile</key>
+            <string>HTML.icns</string>
+            <key>CFBundleTypeName</key>
+            <string>HTML File</string>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+         </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>css</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>CSS.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>CSS File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>js</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>JS.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>Javascript File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+      </dict>
+      <dict>
+         <key>CFBundleTypeExtensions</key>
+         <array>
+             <string>Rprofvis</string>
+             <string>rprofvis</string>
+         </array>
+         <key>CFBundleTypeIconFile</key>
+         <string>RSource.icns</string>
+         <key>CFBundleTypeName</key>
+         <string>R Profile File</string>
+         <key>CFBundleTypeRole</key>
+         <string>Editor</string>
+         <key>LSIsAppleDefaultForType</key>
+         <true/>
+      </dict>
+   </array>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>RStudio</string>
+	<key>CFBundleGetInfoString</key>
+	<string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-${CPACK_COPYRIGHT_YEAR} RStudio, PBC</string>
+	<key>CFBundleIconFile</key>
+	<string>RStudio.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.rstudio.RStudio</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${CPACK_PACKAGE_VERSION}</string>
+	<key>CFBundleName</key>
+	<string>RStudio</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${CPACK_PACKAGE_VERSION}</string>
+	<key>CFBundleSignature</key>
+	<string>Rstd</string>
+	<key>CFBundleVersion</key>
+	<string>${CPACK_PACKAGE_VERSION}</string>
+  	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.developer-tools</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>LSRequiresCarbon</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>RStudio ${CPACK_PACKAGE_VERSION}, © 2009-${CPACK_COPYRIGHT_YEAR} RStudio, PBC</string>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+  <key>NSSupportsAutomaticGraphicsSwitching</key>
+  <true/>
+  <key>NSPrincipalClass</key>
+  <string>NSApplication</string>
+  <key>NSAppleScriptEnabled</key>
+  <true/>
+  <key>OSAScriptingDefinition</key>
+  <string>RStudio.sdef</string>
+  <key>NSAppleEventsUsageDescription</key>
+  <string>R wants to run AppleScript.</string>
+  <key>NSBluetoothPeripheralUsageDescription</key>
+  <string>R wants to access bluetooth.</string>
+  <key>NSCalendarsUsageDescription</key>
+  <string>R wants to access calendars.</string>
+  <key>NSCameraUsageDescription</key>
+  <string>R wants to access the camera.</string>
+  <key>NSContactsUsageDescription</key>
+  <string>R wants to access contacts.</string>
+  <key>NSLocationWhenInUseUsageDescription</key>
+  <string>R wants to access location information.</string>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>R wants to access the microphone.</string>
+  <key>NSPhotoLibraryAddUsageDescription</key>
+  <string>R wants write access to the photo library.</string>
+  <key>NSPhotoLibraryUsageDescription</key>
+  <string>R wants to access the photo library.</string>
+  <key>NSRemindersUsageDescription</key>
+  <string>R wants to access the reminders.</string>
+</dict>
+</plist>

--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -46,7 +46,7 @@ const config = {
   packagerConfig: {
     icon: './resources/icons/RStudio',
     appBundleId: 'com.rstudio.desktop',
-    extendInfo: '../../cpp/desktop/Info.plist.in',
+    extendInfo: './Info.plist',
   },
 };
 

--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -46,6 +46,7 @@ const config = {
   packagerConfig: {
     icon: './resources/icons/RStudio',
     appBundleId: 'com.rstudio.desktop',
+    extendInfo: '../../cpp/desktop/Info.plist.in',
   },
 };
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,36 +13,38 @@
  *
  */
 
-import { app, BrowserWindow, WebContents, screen } from 'electron';
-
+import { app, BrowserWindow, screen, WebContents } from 'electron';
+import i18next from 'i18next';
+import path from 'path';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
-import { generateRandomPort } from '../core/system';
 import { logger } from '../core/logger';
-
+import { kRStudioInitialProject } from '../core/r-user-data';
+import { generateRandomPort } from '../core/system';
+import { getDesktopBridge } from '../renderer/desktop-bridge';
+import { DesktopActivation } from './activation-overlay';
+import { AppState } from './app-state';
+import { ApplicationLaunch } from './application-launch';
+import { ArgsManager } from './args-manager';
+import { prepareEnvironment, promptUserForR } from './detect-r';
+import { GwtCallback } from './gwt-callback';
+import { PendingWindow } from './pending-window';
+import { exitFailure, ProgramStatus, run } from './program-status';
+import { SatelliteWindow } from './satellite-window';
+import { SecondaryWindow } from './secondary-window';
+import { SessionLauncher } from './session-launcher';
 import {
-  getAppPath,
+  augmentCommandLineArguments,
   createStandaloneErrorDialog,
   findComponents,
   initializeLang,
   initializeSharedSecret,
   raiseAndActivateWindow,
+  removeStaleOptionsLockfile,
+  resolveAliasedPath
 } from './utils';
-import { augmentCommandLineArguments, removeStaleOptionsLockfile } from './utils';
-import { exitFailure, run, ProgramStatus } from './program-status';
-import { ApplicationLaunch } from './application-launch';
-import { AppState } from './app-state';
-import { SessionLauncher } from './session-launcher';
-import { DesktopActivation } from './activation-overlay';
 import { WindowTracker } from './window-tracker';
-import { GwtCallback } from './gwt-callback';
-import { prepareEnvironment, promptUserForR } from './detect-r';
-import { PendingWindow } from './pending-window';
 import { configureSatelliteWindow, configureSecondaryWindow } from './window-utils';
-import i18next from 'i18next';
-import { ArgsManager } from './args-manager';
-import { SatelliteWindow } from './satellite-window';
-import { SecondaryWindow } from './secondary-window';
 
 /**
  * The RStudio application
@@ -92,11 +94,45 @@ export class Application implements AppState {
     }
 
     initializeSharedSecret();
+    this.registerAppEvents();
 
     // allow users to supply extra command-line arguments for Chromium
     augmentCommandLineArguments();
 
     return run();
+  }
+
+  private registerAppEvents() {
+    app.on('open-file', (event: Event, filepath: string) => {
+      const resolvedPath = resolveAliasedPath(filepath);
+      event.preventDefault();
+
+      const ext = path.extname(filepath).toLowerCase();
+
+      // first startup - open the project by setting the initial project env var
+      // otherwise it would open in the last state then open the project
+      if (ext === '.rproj') {
+        if (app.isReady()) {
+          this.appLaunch?.launchRStudio({projectFilePath: filepath});
+        } else {
+          setenv(kRStudioInitialProject, filepath);
+        }
+        return;
+      }
+
+      app.whenReady()
+        .then(() => {
+          // app may be ready but GWT may not be ready
+          if (this.gwtCallback?.initialized) {
+            getDesktopBridge().openFile(resolvedPath);
+          } else {
+            this.gwtCallback?.once(GwtCallback.WORKBENCH_INITIALIZED, () => {
+              getDesktopBridge().openFile(resolvedPath);
+            });
+          }
+        })
+        .catch((error: unknown) => logger().logError(error));
+    });
   }
 
   /**
@@ -174,6 +210,10 @@ export class Application implements AppState {
     // launch a local session
     this.sessionLauncher = new SessionLauncher(this.sessionPath, confPath, new FilePath(), this.appLaunch);
     this.sessionLauncher.launchFirstSession();
+
+    this.gwtCallback?.once(GwtCallback.WORKBENCH_INITIALIZED, () => {
+      this.argsManager.handleAfterSessionLaunchCommands();
+    });
 
     return run();
   }

--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -14,9 +14,18 @@
  */
 
 import { app } from 'electron';
+import path from 'path';
+import { setenv } from '../core/environment';
+import { FilePath } from '../core/file-path';
+import {
+  enableDiagnosticsOutput,
+  logger,
+  parseCommandLineLogLevel,
+  setLogger
+} from '../core/logger';
+import { kRStudioInitialProject } from '../core/r-user-data';
 import { WinstonLogger } from '../core/winston-logger';
-
-import { enableDiagnosticsOutput, parseCommandLineLogLevel, setLogger } from '../core/logger';
+import { getDesktopBridge } from '../renderer/desktop-bridge';
 import { Application } from './application';
 import { exitSuccess, ProgramStatus, run } from './program-status';
 import { getComponentVersions, userLogPath } from './utils';
@@ -37,6 +46,7 @@ export const kHelp = '--help';
 
 // !IMPORTANT: If some args should early exit the application, add them to `webpack.plugins.js`
 export class ArgsManager {
+  unswitchedArgs: string[] = [];
 
   initCommandLine(application: Application, argv: string[] = process.argv): ProgramStatus {
 
@@ -71,7 +81,28 @@ export class ArgsManager {
       enableDiagnosticsOutput();
     }
 
+    // filter out the process path and . (occurs in dev mode)
+    this.unswitchedArgs = process.argv.filter(
+      (value) => !value.startsWith('--') && value !== process.execPath && value !== '.'
+    );
+
     return run();
+  }
+
+  handleAfterSessionLaunchCommands() {
+    if (this.unswitchedArgs.length) {
+      this.unswitchedArgs.forEach((arg) => {
+        if (FilePath.existsSync(arg)) {
+          app.whenReady()
+            .then(() => {
+              getDesktopBridge().openFile(arg);
+            })
+            .catch((error: unknown) => {
+              logger().logError(error);
+            });
+        }
+      });
+    }
   }
 
   handleAppReadyCommands(application: Application) {
@@ -84,6 +115,21 @@ export class ArgsManager {
     // (will happen after session start delay above, if also specified)
     if (app.commandLine.hasSwitch(kSessionExit)) {
       application.sessionEarlyExitCode = 1;
+    }
+
+    if (this.unswitchedArgs.length) {
+      this.unswitchedArgs = this.unswitchedArgs.filter((arg) => {
+        if (FilePath.existsSync(arg)) {
+          const ext = path.extname(arg).toLowerCase();
+
+          if (ext === '.rproj') {
+            setenv(kRStudioInitialProject, arg);
+            return false;
+          }
+        }
+
+        return true;
+      });
     }
   }
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -94,6 +94,7 @@ export class GwtCallback extends EventEmitter {
   static WORKBENCH_INITIALIZED = 'gwt-callback-workbench_initialized';
   static SESSION_QUIT = 'gwt-callback-session_quit';
 
+  initialized = false;
   pendingQuit: number = PendingQuit.PendingQuitNone;
   private owners = new Set<GwtWindow>();
 
@@ -336,6 +337,7 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_on_workbench_initialized', (event, scratchPath: string) => {
+      this.initialized = true;
       this.emit(GwtCallback.WORKBENCH_INITIALIZED);
       appState().setScratchTempDir(new FilePath(scratchPath));
     });

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -110,6 +110,7 @@ function launchProcess(absPath: FilePath, argList: string[]): ChildProcess {
 
   logger().logDebug(`Launching rsession: ${absPath.getAbsolutePath()} ${argList.join(' ')}`);
   logger().logDebug(`R_HOME: ${getenv('R_HOME')}`);
+  logger().logDebug(`RS_INITIAL_PROJECT: ${getenv('RS_INITIAL_PROJECT')}`);
 
   if (!appState().runDiagnostics) {
     return spawn(absPath.getAbsolutePath(), argList, { env: env });

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -13,7 +13,8 @@
  *
  */
 
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, webContents } from 'electron';
+import { logger } from '../core/logger';
 
 interface VoidCallback<Type> {
   (result: Type): void;
@@ -370,6 +371,20 @@ export function getDesktopBridge() {
         .invoke('desktop_set_pending_quit', pendingQuit)
         .then((response) => callback(response))
         .catch((error) => reportIpcError('setPendingQuit', error));
+    },
+
+    openFile: (path: string) => {
+      if (!path) {
+        return;
+      }
+      const webcontents = webContents
+        .getAllWebContents();
+
+      if (webcontents.length) {
+        webcontents[0]
+          .executeJavaScript(`window.desktopHooks.openFile("${path}")`)
+          .catch((error: unknown) => logger().logError(error));
+      }
     },
 
     openProjectInNewWindow: (projectFilePath: string) => {


### PR DESCRIPTION
### Intent
Addresses #10893

Allows opening associated files, dragging files on to the app icon, and command-line arguments

### Approach
Feeds in the `Info.plist.in` template when building the app. This associates the files with MacOS.

Listens to the `open-file` event which triggers for associated file open events and dragging files on to the app icon. For project files, this sets the env var before the session is created so that the project is opened.

For command-line arguments, they are searched for unswitched options, checks if it's a valid file, and opens it.

An `initialized` property was added to the GWT callback so it can track when GWT has initialized the workbench. Responding to the app open event needs to know if the workbench is ready to call the open file action.

### Automated Tests
None

### QA Notes
Main cases to test:
* dragging files on to the app icon (in Finder or the dock)
* double-clicking files in Finder
* opening from the command-line (`open RStudio.app --args /path/to/file`)
* opening a second project should open a new instance of RStudio

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


