### PR TITLE
Ignore duplicate key errors for postgres and sqlite for revoked cookies

### DIFF
--- a/src/cpp/server/auth/ServerAuthHandler.cpp
+++ b/src/cpp/server/auth/ServerAuthHandler.cpp
@@ -172,7 +172,9 @@ Error writeRevokedCookieToDatabase(const RevokedCookie& cookie,
          .withInput(cookie.cookie);
 
    Error error = connection->execute(query);
-   if (error)
+   // Ignore duplicate key errors for postgres and sqlite in case another cluster member has already processed this revoke cookie request
+   if (error && !boost::algorithm::contains(error.getMessage(), "duplicate key") &&
+                !boost::algorithm::contains(error.getMessage(), "UNIQUE constraint"))
    {
       error.addProperty("description", "Could not insert revoked cookie into the database");
       return error;


### PR DESCRIPTION
In a load balancing scenario, the UserSession from more than one server
may end up storing the session same session cookie. This is particularly
true when one rserver routes the request to another for load balancing...
in that case, both rservers will get the same auth cookie to represent
that session.

Now that we invalidate all auth cookies when a user signs out, on all
servers in the cluster, that means some of them will try to insert a
record into the DB that's already there. We just need to ignore those
specific errors.

Part of the fix for: https://github.com/rstudio/rstudio-pro/issues/3287