### PR TITLE
Sync cpp lib launcher

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -64,6 +64,8 @@ else()
    set(RSTUDIO_PRO_BUILD 0)
 endif()
 
+set(RSTUDIO_DEFAULT_LOG_PATH "/var/log/rstudio/rstudio-server")
+
 # detect architecture
 if(UNIX)
 

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -64,7 +64,9 @@ else()
    set(RSTUDIO_PRO_BUILD 0)
 endif()
 
-set(RSTUDIO_DEFAULT_LOG_PATH "/var/log/rstudio/rstudio-server")
+if (NOT DEFINED RSTUDIO_DEFAULT_LOG_PATH)
+   set(RSTUDIO_DEFAULT_LOG_PATH "/var/log/rstudio/rstudio-server")
+endif()
 
 # detect architecture
 if(UNIX)

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -500,6 +500,7 @@ if (SOCI_LIB_COUNT EQUAL 0)
 endif()
 
 message(STATUS "SOCI libraries found under ${SOCI_LIBRARY_DIR}")
+set(RSTUDIO_HAS_SOCI 1)
 
 if(UNIX)
 

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -35,7 +35,6 @@ set(CORE_SOURCE_FILES
    ConfigProfile.cpp
    ConfigUtils.cpp
    CrashHandler.cpp
-   Database.cpp
    DateTime.cpp
    ExponentialBackoff.cpp
    Exec.cpp
@@ -131,6 +130,10 @@ set(CORE_SOURCE_FILES
    text/TermBufferParser.cpp
    zlib/zlib.cpp
 )
+
+if (RSTUDIO_HAS_SOCI)
+   list(APPEND CORE_SOURCE_FILES Database.cpp)
+endif()
 
 # UNIX specific
 if (UNIX)
@@ -320,6 +323,9 @@ target_link_libraries(rstudio-core
 if (RSTUDIO_UNIT_TESTS_ENABLED)
 
    file(GLOB_RECURSE CORE_TEST_FILES "*Tests.cpp")
+   if (NOT RSTUDIO_HAS_SOCI)
+      list(REMOVE_ITEM CORE_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/DatabaseTests.cpp")
+   endif()
 
    add_executable(rstudio-core-tests
       TestMain.cpp

--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -74,14 +74,14 @@ FilePath defaultLogPathImpl()
 {
 #ifdef RSTUDIO_SERVER
 #ifdef RSTUDIO_PRO_BUILD
-   return FilePath("/var/log/rstudio/rstudio-server");
+   return FilePath(RSTUDIO_DEFAULT_LOG_PATH);
 #else
    // For open-source Server, support logging even if RStudio Server is run
    // as a non-root user.
    if (core::system::effectiveUserIsRoot())
    {
       // server: root uses default documented logging directory
-      return FilePath("/var/log/rstudio/rstudio-server");
+      return FilePath(RSTUDIO_DEFAULT_LOG_PATH);
    }
    else
    {

--- a/src/cpp/server_core/CMakeLists.txt
+++ b/src/cpp/server_core/CMakeLists.txt
@@ -23,12 +23,15 @@ set (SERVER_CORE_SOURCE_FILES
    http/SecureCookie.cpp
    RVersionsScanner.cpp
    SecureKeyFile.cpp
-   ServerDatabase.cpp
    ServerLicense.cpp
    sessions/SessionSignature.cpp
    system/Pam.cpp
    UrlPorts.cpp
 )
+
+if (RSTUDIO_HAS_SOCI)
+   list(APPEND SERVER_CORE_SOURCE_FILES ServerDatabase.cpp)
+endif()
 
 # define server core include dir
 set(SERVER_CORE_INCLUDE_DIRS ${SERVER_CORE_INCLUDE_DIRS} include)

--- a/src/cpp/shared_core/CMakeLists.txt
+++ b/src/cpp/shared_core/CMakeLists.txt
@@ -75,9 +75,13 @@ else()
 
 endif()
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
+               ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+
 include_directories(
    ${SHARED_INCLUDE_DIRS}
    ${TESTS_INCLUDE_DIR}
+   ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 add_library(rstudio-shared-core STATIC ${SHARED_CORE_HEADER_FILES} ${SHARED_CORE_SOURCE_FILES})

--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -38,6 +38,8 @@
 #include <shared_core/system/SyslogDestination.hpp>
 #endif
 
+#include "config.h"
+
 namespace rstudio {
 namespace core {
 namespace log {
@@ -229,12 +231,12 @@ struct FileLogDestination::Impl
             }
          }
       }
-      else if (LogOptions.getDirectory().getAbsolutePath() == "/var/log/rstudio/rstudio-server")
+      else if (LogOptions.getDirectory().getAbsolutePath() == RSTUDIO_DEFAULT_LOG_PATH)
       {
          // fix-up legacy log directory permissions
          // the original release of standardized file-logging caused logging dirs
          // to be created with 0777 permissions which is too permissive
-         FilePath paths[2] = {FilePath("/var/log/rstudio"), FilePath("/var/log/rstudio/rstudio-server")};
+         FilePath paths[2] = {FilePath("/var/log/rstudio"), FilePath(RSTUDIO_DEFAULT_LOG_PATH)};
          for (const FilePath& path : paths)
          {
             FileMode mode;

--- a/src/cpp/shared_core/config.h.in
+++ b/src/cpp/shared_core/config.h.in
@@ -13,19 +13,4 @@
  *
  */
 
-#ifndef RSTUDIO_VERSION
-#define RSTUDIO_VERSION "${CPACK_PACKAGE_VERSION}"
-#endif
-
-#define RSTUDIO_RELEASE_NAME     "${RSTUDIO_RELEASE_NAME}"
 #define RSTUDIO_DEFAULT_LOG_PATH "${RSTUDIO_DEFAULT_LOG_PATH}"
-
-#cmakedefine HAVE_SA_NOCLDWAIT
-#cmakedefine HAVE_INOTIFY_INIT1
-#cmakedefine HAVE_SO_PEERCRED
-#cmakedefine HAVE_GETPEEREID
-#cmakedefine HAVE_PROCSELF
-#cmakedefine HAVE_SETRESUID
-#cmakedefine HAVE_SCANDIR_POSIX
-#cmakedefine RSTUDIO_SERVER
-#cmakedefine RSTUDIO_PRO_BUILD


### PR DESCRIPTION
### Intent

Sync the C++ libraries between the rstudio and Launcher repos.

### Approach

On our side, we will use some merge strategies to rewrite the histories of the rstudio-pro repo to extract out just the library code changes, and then pull them into the Launcher code base regularly (see https://github.com/rstudio/launcher/blob/6e2227de2e1e0939317740aee1ef503ecf17c230/sync-repo.sh). The changes made here sync up the two codebases to ensure that when a sync is done, nothing is overwritten in the Launcher repo.

Changes had to be made to unify things, such as the log location (which differed between the codebases). This is unified via a CMake variable which is set in files that are not shared within the libraries themselves.

Similarly, we do not support any database functionality as of yet, so we conditionally skip compilation in the Launcher case by not setting the required CMake variable.

The change to options parsing was made to make it obvious when a user has specified a problematic option on the command line, instead of in a config file. This was introduced here, which I failed to upstream: https://github.com/rstudio/launcher/commit/98505fdf8202b489f04695664aa57da0ec2cac76

### Automated Tests

N/A

### QA Notes

N/A - development/build only.



