### PR TITLE
use Ace built-in methods for converting positions

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintManager.java
@@ -365,7 +365,9 @@ public class LintManager
                finalLint.push(lint.get(i));
       }
       else
+      {
          finalLint = lint;
+      }
 
       if (spellcheck && userPrefs_.realTimeSpellchecking().getValue())
       {
@@ -388,7 +390,9 @@ public class LintManager
          });
       }
       else
+      {
          source_.showLint(finalLint);
+      }
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1275,7 +1275,8 @@ public class AceEditor implements DocDisplay,
       // iterate through rows until we've consumed all the chars
       int row = startPos.getRow();
       int col = startPos.getColumn();
-      while (row < session.getLength()) {
+      while (row < session.getLength())
+      {
 
          // how many chars left in the current column?
          String line = session.getLine(row);
@@ -1303,23 +1304,13 @@ public class AceEditor implements DocDisplay,
    @Override
    public Position positionFromIndex(int index)
    {
-      EditSession session = widget_.getEditor().getSession();
-      return advancePosition(session, Position.create(0,0), index);
+      return widget_.getEditor().getSession().getDocument().indexToPosition(index, 0);
    }
 
    @Override
    public int indexFromPosition(Position position)
    {
-      EditSession session = widget_.getEditor().getSession();
-      int index = 0;
-      int row = 0;
-      while (row < position.getRow())
-      {
-         index += (session.getLine(row).length() + 1); // +1 for newline
-         row++;
-      }
-      index += position.getColumn();
-      return index;
+      return widget_.getEditor().getSession().getDocument().positionToIndex(position, 0);
    }
 
 


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/10967.

### Approach

Use built-in Ace methods for converting between document indexes and positions.

### Automated Tests

Captured by existing tests.

### QA Notes

Does not entirely fix https://github.com/rstudio/rstudio/issues/10967, but should at least make things better.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
