### PR TITLE
Make project settings button visible only when a project is active

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -50,7 +50,6 @@ import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
-import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -49,6 +49,8 @@ import org.rstudio.studio.client.common.DiagnosticsHelpLink;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
 import org.rstudio.studio.client.workbench.prefs.model.Prefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
@@ -63,7 +65,8 @@ public class EditingPreferencesPane extends PreferencesPane
    public EditingPreferencesPane(UserPrefs prefs,
                                  SourceServerOperations server,
                                  PreferencesDialogResources res,
-                                 Commands commands)
+                                 Commands commands,
+                                 Session session)
    {
       prefs_ = prefs;
       server_ = server;
@@ -144,6 +147,10 @@ public class EditingPreferencesPane extends PreferencesPane
       });
       projectPrefsPanel.add(editProjectSettings);
       editingPanel.add(projectPrefsPanel);
+
+      String activeProjectFile = session.getSessionInfo().getActiveProjectFile();
+      boolean hasProject = activeProjectFile != null;
+      projectPrefsPanel.setVisible(hasProject);
 
       Label executionLabel = headerLabel(constants_.editingExecutionLabel());
       editingPanel.add(executionLabel);


### PR DESCRIPTION
Follow-up to #10814. 

### Intent

Text and button on Global Preferences pane (Code tab) is only visible when a project is active

### Approach

No active project: 
<img width="594" alt="image" src="https://user-images.githubusercontent.com/7817881/164314526-533e30c9-fa54-435b-accc-4276676fc795.png">

Active project:
<img width="591" alt="image" src="https://user-images.githubusercontent.com/7817881/164314638-52b7f8a3-8efc-4865-bbd4-331481bde6ef.png">

### Automated Tests

N/A

### QA Notes

Check Tools > Global Options > Code pane with and without a project active

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


