### PR TITLE
provide script for finding missing translations

### DIFF
--- a/src/gwt/tools/find-missing-translations.R
+++ b/src/gwt/tools/find-missing-translations.R
@@ -1,0 +1,74 @@
+#!/usr/bin/env Rscript
+
+# Find translations defined for one string, but not another, in our
+# translation property files.
+
+readTranslationFile <- function(path) {
+   
+   # read the file
+   contents <- readLines(path, warn = FALSE)
+   eqIndex <- regexpr("=", contents, fixed = TRUE)
+   
+   # drop lines without an '='
+   contents <- contents[eqIndex != -1]
+   eqIndex <- eqIndex[eqIndex != -1]
+   
+   keys <- trimws(substring(contents, 1L, eqIndex - 1L))
+   vals <- trimws(substring(contents, eqIndex + 1L))
+   data.frame(Key = keys, Value = vals)
+   
+}
+
+# look for all of the English property files
+root <- normalizePath("../../..", winslash = "/")
+enFiles <- list.files(
+   path = file.path(root, "src/gwt/src"),
+   pattern = "_en\\.properties$",
+   all.files = TRUE,
+   full.names = TRUE,
+   recursive = TRUE
+)
+
+status <- lapply(enFiles, function(enFile) {
+   
+   # Flag marking if any issues were found.
+   ok <- TRUE
+   
+   # TODO: refactor this for more (non_French) extensions.
+   # TODO: optionally report files without a corresponding translation file
+   frFile <- gsub("_en", "_fr", enFile)
+   if (!file.exists(frFile))
+      return(ok)
+   
+   # Find terms defined in one translation file, but not the other.
+   enData <- readTranslationFile(enFile)
+   frData <- readTranslationFile(frFile)
+   
+   missingEnTerms <- setdiff(enData$Key, frData$Key)
+   if (length(missingEnTerms)) {
+      message(paste("#", enFile))
+      message(paste(missingEnTerms, collapse = " "))
+      ok <- FALSE
+   }
+   
+   missingFrTerms <- setdiff(frData$Key, enData$Key)
+   if (length(missingFrTerms)) {
+      message(paste("#", frFile))
+      message(paste(missingFrTerms, collapse = " "))
+      ok <- FALSE
+   }
+   
+   if (!ok)
+      writeLines("")
+   
+   ok
+   
+})
+
+# For non-interactive usages, return with an exit code depending on whether
+# there were any missing translations.
+if (!interactive()) {
+   allOk <- all(unlist(status))
+   quit(save = "no", status = if (allOk) 0L else 1L)
+}
+

--- a/src/gwt/tools/find-missing-translations.R
+++ b/src/gwt/tools/find-missing-translations.R
@@ -7,6 +7,12 @@ readTranslationFile <- function(path) {
    
    # read the file
    contents <- readLines(path, warn = FALSE)
+   
+   # drop commented lines and empty lines
+   contents <- grep("^\\s*#", contents, perl = TRUE, invert = TRUE, value = TRUE)
+   contents <- contents[nzchar(contents)]
+   
+   # look for lines that look like properties
    eqIndex <- regexpr("=", contents, fixed = TRUE)
    
    # drop lines without an '='


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10595.

### Approach

Provide a small R script that searches for existing translation property files, and reports if the French equivalent exists but does not have the requisite translations for some keys.

### Automated Tests

Not included; intended for interactive use. For posterity, I see the following right now:

```
# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_fr.properties
refreshFindInFilesButtonLabel refreshFindInFilesMenuLabel refreshFindInFilesDesc

# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
useRcppTemplateTitle useRcppTemplateDescription useNativePipeOperatorTitle useNativePipeOperatorDescription
# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
relativeLineNumbersTitle relativeLineNumbersDescription cppTemplateTitle cppTemplateDescription rmdAutoDateTitle rmdAutoDateDescription cleanBeforeInstallTitle cleanBeforeInstallDescription insertNativePipeOperatorTitle insertNativePipeOperatorDescription uiLanguageTitle uiLanguageDescription

# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
quartoBuildEditorToolsTitle quartoBuildEditorToolsDescription
# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_fr.properties
generalTitle generalDescription fontTitle fontDescription viewTitle viewDescription remoteSessionTitle remoteSessionDescription rendererTitle rendererDescription platformTitle platformDescription

# /Users/kevin/rstudio/src/gwt/src/org/rstudio/studio/client/workbench/prefs/PrefsConstants_fr.properties
editingProjectOverrideInfoText editProjectPreferencesButtonLabel
```

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
