### PR TITLE
test that error parser compatible with hyperlinks

### DIFF
--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -34,6 +34,7 @@
 #include <session/projects/SessionProjects.hpp>
 
 #define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
+#define kAnsiUrlRegex "(?:\u001B]8;[^\u0007]*\u0007)*"
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -291,11 +292,13 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   kAnsiEscapeRegex // color
                   "\\s+"           // separating space
                   "\\("            // opening paren
+                  kAnsiUrlRegex    // opening hyperlink
                   "([^:\\n]+)"     // file name           (2)
                   ":"              // colon separator
                   "([0-9]+)"       // file line           (3)
                   ":"              // colon separator
                   "([0-9]+)"       // file column         (4)
+                  kAnsiUrlRegex    // closing hyperlink
                   "\\)"            // closing paren
                   ":"              // colon separator
                   "\\s+"           // separating space


### PR DESCRIPTION
### Intent

addresses #11026

### Approach

Improve the regex used by test that error parser so that it can remove the hyperlink escape codes syntax. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

On a package that has at least one failed expectation, e.g. 

```r
test_that("2+2", {
  expect_identical(2+2, 5)
})
```

Running the tests should make the `Output | Issues` button couple visible: 

![image](https://user-images.githubusercontent.com/2625526/164457040-9a7becfd-9862-4671-854c-ac9b7cf76883.png)

<img width="461" alt="image" src="https://user-images.githubusercontent.com/2625526/164457068-bc7f1925-3094-4334-9dec-414e005b426a.png">

This needs dev `cli` and `testthat`

```r
pak::pak("r-lib/cli")
pak::pak("r-lib/testthat")
```

This should work with hyperlinks enabled (default) or disabled: 

```r
Sys.setenv("RSTUDIO_CLI_HYPERLINKS" = "false")
```
  
### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


