### PR TITLE
add windows metadata to Electron installation

### DIFF
--- a/package/win32/CMakeLists.txt
+++ b/package/win32/CMakeLists.txt
@@ -49,8 +49,8 @@ if(RSTUDIO_ELECTRON)
       WriteRegStr HKCR 'Applications\\\\rstudio.exe' 'FriendlyAppName' 'RStudio'
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\shell\\\\open\\\\command' '' '$INSTDIR\\\\rstudio.exe \\\"%1\\\"'
 
-      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\RStudio.exe.ApplicationCompnay' 'RStudio, PBC'
-      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\RStudio.exe.FriendlyAppName' 'RStudio'
+      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\rstudio.exe.ApplicationCompany' 'RStudio, PBC'
+      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\rstudio.exe.FriendlyAppName' 'RStudio'
 
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.R' ''
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.RData' ''

--- a/package/win32/CMakeLists.txt
+++ b/package/win32/CMakeLists.txt
@@ -46,11 +46,7 @@ if(RSTUDIO_ELECTRON)
    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
       WriteRegStr HKLM 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\App Paths\\\\rstudio.exe' '' '$INSTDIR\\\\rstudio.exe'
 
-      WriteRegStr HKCR 'Applications\\\\rstudio.exe' 'FriendlyAppName' 'RStudio'
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\shell\\\\open\\\\command' '' '$INSTDIR\\\\rstudio.exe \\\"%1\\\"'
-
-      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\rstudio.exe.ApplicationCompany' 'RStudio, PBC'
-      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\rstudio.exe.FriendlyAppName' 'RStudio'
 
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.R' ''
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.RData' ''

--- a/package/win32/CMakeLists.txt
+++ b/package/win32/CMakeLists.txt
@@ -46,7 +46,11 @@ if(RSTUDIO_ELECTRON)
    set(CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
       WriteRegStr HKLM 'Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\App Paths\\\\rstudio.exe' '' '$INSTDIR\\\\rstudio.exe'
 
+      WriteRegStr HKCR 'Applications\\\\rstudio.exe' 'FriendlyAppName' 'RStudio'
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\shell\\\\open\\\\command' '' '$INSTDIR\\\\rstudio.exe \\\"%1\\\"'
+
+      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\RStudio.exe.ApplicationCompnay' 'RStudio, PBC'
+      WriteRegStr HKCR 'Local Settings\\\\Software\\\\Microsoft\\\\Windows\\\\Shell\\\\MuiCache' '$INSTDIR\\\\RStudio.exe.FriendlyAppName' 'RStudio'
 
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.R' ''
       WriteRegStr HKCR 'Applications\\\\rstudio.exe\\\\SupportedTypes' '.RData' ''

--- a/package/win32/make-install-win32.bat
+++ b/package/win32/make-install-win32.bat
@@ -19,7 +19,6 @@ if defined CLEANBUILD (
 REM perform 32-bit build
 if not exist %WIN32_BUILD_PATH% mkdir %WIN32_BUILD_PATH%
 cd %WIN32_BUILD_PATH%
-if exist CMakeCache.txt del CMakeCache.txt
 
 REM Build the project
 set VS_TOOLS="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\BuildTools\Common7\Tools"

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -15,6 +15,7 @@ set PACKAGE_VERSION_SET=
 
 if "%1" == "--help" goto :showhelp
 if "%1" == "-h" goto :showhelp
+if "%1" == "help" goto :showhelp
 if "%1" == "/?" goto :showhelp
 
 for %%A in (%*) do (
@@ -92,7 +93,7 @@ if not defined RSTUDIO_VERSION_SUFFIX set RSTUDIO_VERSION_SUFFIX=-dev+999
 set RSTUDIO_VERSION_FULL=%RSTUDIO_VERSION_MAJOR%.%RSTUDIO_VERSION_MINOR%.%RSTUDIO_VERSION_PATCH%%RSTUDIO_VERSION_SUFFIX%
 
 REM put version and product name into package.json
-call :set-version %RSTUDIO_VERSION_FULL% rstudio
+call :set-version %RSTUDIO_VERSION_FULL% RStudio
 
 REM Establish build dir
 set BUILD_DIR=build

--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -43,9 +43,18 @@ const config = {
     ],
   ],
 
+  // https://electron.github.io/electron-packager/main/interfaces/electronpackager.options.html 
   packagerConfig: {
     icon: './resources/icons/RStudio',
     appBundleId: 'com.rstudio.desktop',
+    appCopyright: 'Copyright (C) 2022 by RStudio, PBC',
+    name: 'RStudio',
+    win32metadata: {
+      CompanyName: "RStudio, PBC",
+      FileDescription: "RStudio",
+      InternalName: "RStudio",
+      ProductName: "RStudio",
+    }
   },
 };
 

--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -49,6 +49,7 @@ const config = {
     appBundleId: 'com.rstudio.desktop',
     appCopyright: 'Copyright (C) 2022 by RStudio, PBC',
     name: 'RStudio',
+    executableName: 'rstudio',
     win32metadata: {
       CompanyName: "RStudio, PBC",
       FileDescription: "RStudio",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11035.

### Approach

Some NSIS hacks to make sure that the application "friendly name" + copyright are set. (I couldn't find out where exactly Electron was choosing to use "rstudio" rather than "RStudio" here.)

### Automated Tests

N/A

### QA Notes

- Check that the application copyright is properly set
- Check that the application name is presented as "RStudio" in right click open menus

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
