### PR TITLE
Indicate if R is running in the build pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,9 +20,10 @@
 - Read only R and C++ files (marked by "do not edit by hand") are ignored by the fuzzy file finder (#10912)
 - Linux: For compatibility with newer versions of glibc (>= 2.34), the seccomp filter sandbox is disabled. See https://chromium.googlesource.com/chromium/src/+/0e94f26e8/docs/linux_sandboxing.md#the-sandbox-1 for more details.
 - Changed "Jobs" tab in IDE to "Local Jobs"
-- The fuzzy finder shows `test_that()` calls when the search term starts with "t ".  
+- The fuzzy finder shows `test_that()` calls when the search term starts with "t "
 - Calls to test_that() appear in the source file outline (#11082)
 - Windows: Update embedded libclang to 13.0.1 (#11186)
+- The `RSTUDIO_SESSION_PID` and `RSTUDIO_CHILD_PROCESS_PANE` are set when child processes are made. `RSTUDIO_CHILD_PROCESS_PANE` takes terminal/build/job/render. 
 
 #### Find in Files
 

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -173,6 +173,7 @@ void AsyncRProcess::start(const char* rCommand,
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_REQUESTS_FILE", ipcRequests_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
+   core::system::setenv(&childEnv, "RSTUDIO_PANE", "job");
    
    // update environment used for child process
    options.environment = childEnv;

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -175,7 +175,6 @@ void AsyncRProcess::start(const char* rCommand,
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
    
    // this runs in the job pane as a child process of this process
-   core::system::setenv(&childEnv, "RSTUDIO_CHILD_PROCESS_PANE", "job");
    core::system::setenv(&childEnv, "RSTUDIO_SESSION_PID", core::safe_convert::numberToString(::getpid()));
    
    // update environment used for child process

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -176,7 +176,7 @@ void AsyncRProcess::start(const char* rCommand,
    
    // this runs in the job pane as a child process of this process
    core::system::setenv(&childEnv, "RSTUDIO_CHILD_PROCESS_PANE", "job");
-   core::system::setenv(&childEnv, "RSTUDIO_CHILD_PROCESS_PARENT_PID", core::safe_convert::numberToString(::getpid()));
+   core::system::setenv(&childEnv, "RSTUDIO_SESSION_PID", core::safe_convert::numberToString(::getpid()));
    
    // update environment used for child process
    options.environment = childEnv;

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -173,7 +173,10 @@ void AsyncRProcess::start(const char* rCommand,
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_REQUESTS_FILE", ipcRequests_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
-   core::system::setenv(&childEnv, "RSTUDIO_PANE", "job");
+   
+   // this runs in the job pane as a child process of this process
+   core::system::setenv(&childEnv, "RSTUDIO_CHILD_PROCESS_PANE", "job");
+   core::system::setenv(&childEnv, "RSTUDIO_CHILD_PROCESS_PARENT_PID", core::safe_convert::numberToString(::getpid()));
    
    // update environment used for child process
    options.environment = childEnv;

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -174,7 +174,7 @@ void AsyncRProcess::start(const char* rCommand,
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
    
-   // this runs in the job pane as a child process of this process
+   // PID of this R session, to match against parent pid of child process
    core::system::setenv(&childEnv, "RSTUDIO_SESSION_PID", core::safe_convert::numberToString(::getpid()));
    
    // update environment used for child process

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -269,7 +269,7 @@ void ConsoleProcess::commonInit()
    
    // this runs in the terminal pane as a child process of this process
    core::system::setenv(&(options_.environment.get()), "RSTUDIO_CHILD_PROCESS_PANE", "terminal");
-   core::system::setenv(&(options_.environment.get()), "RSTUDIO_CHILD_PROCESS_PARENT_PID", safe_convert::numberToString(::getpid()));
+   core::system::setenv(&(options_.environment.get()), "RSTUDIO_SESSION_PID", safe_convert::numberToString(::getpid()));
    
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -267,6 +267,8 @@ void ConsoleProcess::commonInit()
 #endif
    }
    
+   core::system::setenv(&(options_.environment.get()), "RSTUDIO_PANE", "terminal");
+
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
    if (!options_.smartTerminal)

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -267,8 +267,10 @@ void ConsoleProcess::commonInit()
 #endif
    }
    
-   core::system::setenv(&(options_.environment.get()), "RSTUDIO_PANE", "terminal");
-
+   // this runs in the terminal pane as a child process of this process
+   core::system::setenv(&(options_.environment.get()), "RSTUDIO_CHILD_PROCESS_PANE", "terminal");
+   core::system::setenv(&(options_.environment.get()), "RSTUDIO_CHILD_PROCESS_PARENT_PID", safe_convert::numberToString(::getpid()));
+   
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.
    if (!options_.smartTerminal)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2025,10 +2025,6 @@ int main(int argc, char * const argv[])
       // whether rstudio is running
       core::system::setenv("RSTUDIO", "1");
 
-      // Keep the pid of this process so that it can be disambiguated
-      core::system::setenv("RSTUDIO_PID", safe_convert::numberToString(::getpid()));
-      core::system::setenv("RSTUDIO_PANE", "console");
-
       // Mirror the R getOptions("width") value in an environment variable
       core::system::setenv("RSTUDIO_CONSOLE_WIDTH",
                safe_convert::numberToString(rstudio::r::options::kDefaultWidth));

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2025,6 +2025,10 @@ int main(int argc, char * const argv[])
       // whether rstudio is running
       core::system::setenv("RSTUDIO", "1");
 
+      // Keep the pid of this process so that it can be disambiguated
+      core::system::setenv("RSTUDIO_PID", safe_convert::numberToString(::getpid()));
+      core::system::setenv("RSTUDIO_PANE", "console");
+
       // Mirror the R getOptions("width") value in an environment variable
       core::system::setenv("RSTUDIO_CONSOLE_WIDTH",
                safe_convert::numberToString(rstudio::r::options::kDefaultWidth));

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -319,8 +319,9 @@ private:
       else
          core::system::unsetenv(&environment, "RSTUDIO_CONSOLE_WIDTH");
 
-      core::system::setenv(&environment, "RSTUDIO_BUILD_PANE", "1");
-
+      // this runs in the build pane
+      core::system::setenv(&environment, "RSTUDIO_PANE", "build");
+      
       FilePath buildTargetPath = projects::projectContext().buildTargetPath();
       const core::r_util::RProjectConfig& config = projectConfig();
       if (type == kTestFile)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -319,6 +319,8 @@ private:
       else
          core::system::unsetenv(&environment, "RSTUDIO_CONSOLE_WIDTH");
 
+      core::system::setenv(&environment, "RSTUDIO_BUILD_PANE", "1");
+
       FilePath buildTargetPath = projects::projectContext().buildTargetPath();
       const core::r_util::RProjectConfig& config = projectConfig();
       if (type == kTestFile)

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -321,7 +321,7 @@ private:
 
       // this runs in the build pane as a child process of this process
       core::system::setenv(&environment, "RSTUDIO_CHILD_PROCESS_PANE", "build");
-      core::system::setenv(&environment, "RSTUDIO_CHILD_PROCESS_PARENT_PID", safe_convert::numberToString(::getpid()));
+      core::system::setenv(&environment, "RSTUDIO_SESSION_PID", safe_convert::numberToString(::getpid()));
       
       FilePath buildTargetPath = projects::projectContext().buildTargetPath();
       const core::r_util::RProjectConfig& config = projectConfig();

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -319,8 +319,9 @@ private:
       else
          core::system::unsetenv(&environment, "RSTUDIO_CONSOLE_WIDTH");
 
-      // this runs in the build pane
-      core::system::setenv(&environment, "RSTUDIO_PANE", "build");
+      // this runs in the build pane as a child process of this process
+      core::system::setenv(&environment, "RSTUDIO_CHILD_PROCESS_PANE", "build");
+      core::system::setenv(&environment, "RSTUDIO_CHILD_PROCESS_PARENT_PID", safe_convert::numberToString(::getpid()));
       
       FilePath buildTargetPath = projects::projectContext().buildTargetPath();
       const core::r_util::RProjectConfig& config = projectConfig();

--- a/src/cpp/session/modules/jobs/ScriptJob.cpp
+++ b/src/cpp/session/modules/jobs/ScriptJob.cpp
@@ -155,6 +155,7 @@ void ScriptJob::start()
       "exportRdata = " + exportRdata + ");";
      
    core::system::Options environment;
+   environment.push_back(std::make_pair("RSTUDIO_CHILD_PROCESS_PANE", "job"));
 
    // build options for async R process; default to no rdata unless we have other options (most
    // common is a vanilla R process)

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -626,6 +626,9 @@ private:
       environment.push_back(std::make_pair("RSTUDIO_VERSION", parsableRStudioVersion()));
       environment.push_back(std::make_pair("RSTUDIO_LONG_VERSION", RSTUDIO_VERSION));
 
+      // inform that this runs in the Render pane
+      environment.push_back(std::make_pair("RSTUDIO_CHILD_PROCESS_PANE", "render"));
+      
       // set the not cran env var
       environment.push_back(std::make_pair("NOT_CRAN", "true"));
 

--- a/src/cpp/session/modules/shiny/ShinyAsyncJob.cpp
+++ b/src/cpp/session/modules/shiny/ShinyAsyncJob.cpp
@@ -57,6 +57,8 @@ void ShinyAsyncJob::start()
 
    // start the R process
    core::system::Options environment;
+   environment.push_back(std::make_pair("RSTUDIO_CHILD_PROCESS_PANE", "job"));
+   
    async_r::AsyncRProcess::start(cmd.c_str(), environment, path_.getParent(), 
          async_r::AsyncRProcessOptions::R_PROCESS_NO_RDATA);
 


### PR DESCRIPTION
### Intent

addresses #11024 

### Approach

Define the `RSTUDIO_BUILD_PANE` environment variable in `Build::executeBuild()` which I believe is only called from `Build::start()` which sets the callbacks so that standard output goes through `Build::onStandardOutput()`, eventually picked up by the ui side by `void onBuildOutput(BuildOutputEvent event)` 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


