### PR TITLE
VisualMode only react to change in DOC_OUTLINE_VISIBLE if activated

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -162,9 +162,11 @@ public class VisualMode implements VisualModeEditorSync,
       
       // sync to outline visible prop
       releaseOnDismiss.add(onDocPropChanged(TextEditingTarget.DOC_OUTLINE_VISIBLE, (value) -> {
-         withPanmirror(() -> {
-            panmirror_.showOutline(getOutlineVisible(), getOutlineWidth(), true);
-         });
+         if(isVisualEditorActive()) {
+            withPanmirror(() -> {
+               panmirror_.showOutline(getOutlineVisible(), getOutlineWidth(), true);
+            });
+         }
       }));
    } 
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -162,7 +162,8 @@ public class VisualMode implements VisualModeEditorSync,
       
       // sync to outline visible prop
       releaseOnDismiss.add(onDocPropChanged(TextEditingTarget.DOC_OUTLINE_VISIBLE, (value) -> {
-         if(isVisualEditorActive()) {
+         if(isVisualEditorActive()) 
+         {
             withPanmirror(() -> {
                panmirror_.showOutline(getOutlineVisible(), getOutlineWidth(), true);
             });

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -162,7 +162,7 @@ public class VisualMode implements VisualModeEditorSync,
       
       // sync to outline visible prop
       releaseOnDismiss.add(onDocPropChanged(TextEditingTarget.DOC_OUTLINE_VISIBLE, (value) -> {
-         if(isVisualEditorActive()) 
+         if (isVisualEditorActive()) 
          {
             withPanmirror(() -> {
                panmirror_.showOutline(getOutlineVisible(), getOutlineWidth(), true);


### PR DESCRIPTION
### Intent

addresses #10987 

### Approach

Not quite sure about this; but the bug described in #10987 was happening with the `target_.setPreferredOutlineWidgetVisibility(destination != 0);` code in: 

```java
toggleDocOutlineButton_ = new LatchingToolbarButton(
            ToolbarButton.NoText,
            ToolbarButton.NoTitle,
            false, /* textIndicatesState */
            new ImageResource2x(StandardIcons.INSTANCE.outline2x()),
            event -> {
               final double initialSize = editorPanel_.getWidgetSize(docOutlineWidget_);

               // Clicking the icon toggles the outline widget's visibility. The
               // 'destination' below is the width we would like to set -- we
               // animate to that position for a slightly nicer visual treatment.
               final double destination = docOutlineWidget_.getOffsetWidth() > 5
                     ? 0
                     : Math.min(editorPanel_.getOffsetWidth(), target_.getPreferredOutlineWidgetSize());

               // Update tooltip ('Show'/'Hide' depending on current visibility)
               String title = toggleDocOutlineButton_.getTitle();
               if (destination != 0)
                  title = title.replace(constants_.show(), constants_.hide());
               else
                  title = title.replace(constants_.hide(), constants_.show());
               toggleDocOutlineButton_.setTitle(title);

               setDocOutlineLatchState(destination != 0);

               int duration = (userPrefs_.reducedMotion().getValue() ? 0 : 400);
               new Animation()
               {
                  @Override
                  protected void onUpdate(double progress)
                  {
                     progress = interpolate(progress);
                     double size =
                           destination * progress +
                           initialSize * (1 - progress);
                     editorPanel_.setWidgetSize(docOutlineWidget_, size);
                     editor_.onResize();
                  }

                  @Override
                  protected void onComplete()
                  {
                     editorPanel_.setWidgetSize(docOutlineWidget_, destination);
                     target_.setPreferredOutlineWidgetVisibility(destination != 0);
                     editor_.onResize();
                  }
               }.run(duration);
            });
```

and then this is: 

```java
   public void setPreferredOutlineWidgetVisibility(boolean visible)
   {
      docUpdateSentinel_.setProperty(DOC_OUTLINE_VISIBLE, visible ? "1" : "0");
   }
```

And the `DOC_OUTLINE_VISIBLE` property is used by both visual and source modes. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


