### PR TITLE
install cmake 3.19.8 on builders

### DIFF
--- a/package/linux/install-dependencies
+++ b/package/linux/install-dependencies
@@ -10,16 +10,16 @@ else
    cmake_version=$(cmake --version | grep -oP "cmake version \K[\w.]+")
    version_array=(${cmake_version//./ })
    if ((${version_array[0]} < 3)) || 
-      ( ((${version_array[0]} == 3)) && ((${version_array[1]} < 4)) ) ||
-      ( ((${version_array[0]} == 3)) && ((${version_array[1]} == 4)) && ((${version_array[2]} < 3)) ); then
+      ( ((${version_array[0]} == 3)) && ((${version_array[1]} < 19)) ) ||
+      ( ((${version_array[0]} == 3)) && ((${version_array[1]} == 19)) && ((${version_array[2]} < 8)) ); then
       install_cmake=true
    fi
 fi
 
 if $install_cmake ; then
- 	CMAKE_VERSION=cmake-3.4.3
+ 	CMAKE_VERSION=cmake-3.19.8
 	CMAKE_TARBALL=$CMAKE_VERSION.tar.gz
-	wget http://www.cmake.org/files/v3.4/$CMAKE_TARBALL
+	wget http://www.cmake.org/files/v3.19/$CMAKE_TARBALL
 	tar xf $CMAKE_TARBALL
 	cd $CMAKE_VERSION
 	./bootstrap 


### PR DESCRIPTION
### Intent

Addresses #10916

### Approach

Picked 3.19.x because it isn't bleeding edge, but matches the highest minimum version we require (on osx, which doesn't use this script for installing cmake, but picked that just for consistency):

https://github.com/rstudio/rstudio/blob/ba0b1462a760b9bdde7d2250011ab50c86bbbac1/package/osx/cmake/codesign-package-electron.cmake#L16

My understanding is we have such an old version currently because some of the ancient distros we used to build on couldn't handle building anything much newer, but that was MANY years ago.

It's possible I'll discover that's still the case in which case I'll have to rinse and repeat with a lower version.

### Automated Tests

Build-time change only.

### QA Notes

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


