### PR TITLE
open-source companion to Pro #3394

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,6 +242,8 @@ try {
           [os: 'bionic',     arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Bionic'],
           [os: 'debian9',    arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 9'],
           [os: 'debian9',    arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 9'],
+          [os: 'debian10',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 10'],
+          [os: 'debian10',   arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 10'],
           [os: 'debian10',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Debian 10'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8'],

--- a/NEWS.md
+++ b/NEWS.md
@@ -52,13 +52,17 @@
 - Fixed an intermittent hang when invoking `rstudio-server verify-installation` which caused stale `rserver` processes to exist (rstudio-pro#3041) 
 - (Windows only) Fixed an issue where multiple instances of RStudio launched at the same time could bind to the same session. (#10488)
 - Fixed unintended change of date/time formatting in the VCS commit history (#10810)
+- Add back link to the title of sessions so that users can easily open sessions in new tabs and copy session links (rstudio-pro#3290)
 - (Linux Only) License-manager now works in a installer-less context (rstudio-pro#3150)
 
 ### RStudio Workbench
 
 - Add a -G option to `rsandbox` to allow configuring the effective group of the process (#3214)
+- When resuming a suspended session with the Kubernetes Launcher Plugin, the container image that was previously being used will now be selected by default (#1520)
 - Upgrade the default version of `code-server` to 4.2.0 to resolve issue with the latest Python VS Code extension (Pro #3320)
 
 ### Deprecated / Removed
 
 - The minimum supported R version for the IDE has been increased from R 3.0.1 to R 3.3.0 (rstudio-pro#2887)
+- **BREAKING:** Block port proxy requests at `/proxy/<port>` for Jupyter sessions - previously only available if [Jupyter Server Proxy](https://github.com/jupyterhub/jupyter-server-proxy) was installed (Pro #3339)
+- No longer support Debian 9 ("stretch") for Desktop, Server, and Workbench (#10981)

--- a/docker/jenkins/Dockerfile.debian10-x86_64
+++ b/docker/jenkins/Dockerfile.debian10-x86_64
@@ -2,6 +2,11 @@ FROM debian:buster
 
 ENV OPERATING_SYSTEM=debian_10
 
+# update apt repository to cloudfront's mirror
+RUN set -x \
+    && sed -i "s/deb.debian.org/cloudfront.debian.net/" /etc/apt/sources.list \
+    && sed -i "s/security.debian.org/cloudfront.debian.net/" /etc/apt/sources.list
+
 # update system
 RUN set -x \
     && apt-get update -y
@@ -21,10 +26,8 @@ RUN apt-get update -y && apt-get install -y \
     git \
     gnupg1 \
     libacl1-dev \
-    libacl1-dev \
     libattr1-dev \
     libboost-all-dev \
-    libcap-dev \
     libcap-dev \
     libcurl4-openssl-dev \
     libffi-dev \
@@ -87,6 +90,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common debian10
+
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
 
 # set github login from build argument if defined
 ARG GITHUB_LOGIN


### PR DESCRIPTION
Addresses open-source side of #10981, see https://github.com/rstudio/rstudio-pro/pull/3394 for full change.