### PR TITLE
install same cmake for debian10 used by other Linux builds

### DIFF
--- a/docker/jenkins/Dockerfile.debian10-x86_64
+++ b/docker/jenkins/Dockerfile.debian10-x86_64
@@ -16,7 +16,6 @@ RUN apt-get update -y && apt-get install -y \
     ant \
     bzip2 \
     clang \
-    cmake \
     curl \
     debsigs \
     dpkg-sig \
@@ -71,6 +70,10 @@ COPY dependencies/tools/rstudio-tools.sh /opt/rstudio-tools/dependencies/tools/r
 # https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
 COPY dependencies/common/install-boost /tmp/
 RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN bash /tmp/install-dependencies
 
 # add clang to system path
 ENV PATH=/usr/lib/llvm-7/bin:$PATH


### PR DESCRIPTION
### Intent

When I made the debian10 dockerfile I decided to install cmake using `apt` instead of building a specific version from source like we do on other platforms.

For consistency (and especially now that we're building a relatively new version of cmake) switch debian10 to same technique.

I will do the same for the monitor dockerfile (Pro) via separate PR.

### Approach

Same approach as other dockerfiles.

### Automated Tests

None

### QA Notes

Build mechanics, nothing to test.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


