### PR TITLE
Fix backend yaml chunk evaluation of options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 - Added support for using the AGG renderer (as provided by the ragg package) as a graphics backend for inline plot execution; also added support for using the backend graphics device requested by the knitr `dev` chunk option (#9931)
 - rstudioapi functions are now always evaluated in a clean environment, and will not be masked by objects in the global environment (#8031)
 - Removed support for versions of R earlier than R 3.3.0. (rstudio-pro#2887)
+- Chunk options in the body of a code chunk, prefaced by `#|` will be respected during inline code execution, and will take precedence over conflicting chunk options in the chunk header (#10645). Both YAML `tag: value` syntax and valid R expressions will be parsed.
 
 #### Python
 

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -627,16 +627,16 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
         opts <- .rs.fromYAML(opt)
         # parse truthy and falsy style yaml options
         opts <- lapply(opts, function(value)
-                             {
-                               if (!is.character(value))
-                                 return(value)
-                               if (tolower(value) %in% c("y", "yes", "on"))
-                                 return(TRUE)
-                               if (tolower(value) %in% c("n", "no", "off"))
-                                 return(FALSE)
-                               else
-                                 return(value)
-                             })
+           {
+             if (!is.character(value))
+               return(value)
+             if (tolower(value) %in% c("y", "yes", "on"))
+               return(TRUE)
+             if (tolower(value) %in% c("n", "no", "off"))
+               return(FALSE)
+             else
+               return(value)
+           })
     }
     return(opts)
 })
@@ -659,7 +659,15 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
         break
     yamlChunkOpts <- c(yamlChunkOpts, match)
   }
-  opts <- .rs.parseYamlOpt(yamlChunkOpts)
+  
+  if (length(yamlChunkOpts) > 0)
+  {
+     opts <- tryCatch(
+     .rs.parseYamlOpt(yamlChunkOpts),
+     error = function(e) {
+        warning("Failed to parse chunk options in body:\n", e)
+     })
+  }
 
   # strip chunk indicators if present
   matches <- unlist(regmatches(rmdChunkOpts, regexec(.rs.reRmdChunkBegin(), rmdChunkOpts)))

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -687,7 +687,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
     # the body should override the header option
     opts <- opts[unique(names(opts))]
     
-    # convert T, F (knitr chunk style) or "true", "false" (yaml chunk style) to TRUE, FALSE as appropriate
+    # convert T, F for R code chunk options to TRUE, FALSE as appropriate
     opts <- lapply(opts, function(opt) {
       if (identical(opt, as.name("T")))
         TRUE

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -617,8 +617,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 .rs.addFunction("parseYamlOpt", function(opt)
 {
     opt <- sub("^#\\|\\s*", "", opt)
-    if (grepl(".+=.+", opt)) # R-style chunk options
-        opts <- knitr:::parse_params(opt)
+    if (any(grepl(".+=.+", opt))) # R-style chunk options
+    {
+        opts <- paste(opt, collapse=" ")
+        opts <- knitr:::parse_params(opts)
+    }
     else
     {
         opts <- .rs.fromYAML(opt)
@@ -647,15 +650,16 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
   # the next several lines may or may not contain YAML-style chunk options
   code <- unlist(strsplit(code, "\n", fixed = TRUE))
   rmdChunkOpts <- code[[1]]
-  yamlChunkOpts <- code[-1]
+  yamlChunkOpts <- c()
 
-  for (line in yamlChunkOpts) {
-    matches <- unlist(regmatches(line, regexec(.rs.reYamlOptChunkBegin(), line)))
+  for (line in code[-1]) {
+    match <- unlist(regmatches(line, regexec(.rs.reYamlOptChunkBegin(), line)))
     # there may be variable number of yaml chunk opts, but they should all be at the top of the chunk
-    if (length(matches) == 0)
+    if (length(match) == 0)
         break
-    opts <- append(opts, .rs.parseYamlOpt(matches))
+    yamlChunkOpts <- c(yamlChunkOpts, match)
   }
+  opts <- .rs.parseYamlOpt(yamlChunkOpts)
 
   # strip chunk indicators if present
   matches <- unlist(regmatches(rmdChunkOpts, regexec(.rs.reRmdChunkBegin(), rmdChunkOpts)))

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -619,7 +619,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
     opt <- sub("^#\\|\\s*", "", opt)
     if (any(grepl(".+=.+", opt))) # R-style chunk options
     {
-        opts <- paste(opt, collapse=" ")
+        opts <- paste(opt, collapse = " ")
         opts <- knitr:::parse_params(opts)
     }
     else

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -620,7 +620,21 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
     if (grepl(".+=.+", opt)) # R-style chunk options
         opts <- knitr:::parse_params(opt)
     else
+    {
         opts <- .rs.fromYAML(opt)
+        # parse truthy and falsy style yaml options
+        opts <- lapply(opts, function(value)
+                             {
+                               if (!is.character(value))
+                                 return(value)
+                               if (tolower(value) %in% c("y", "yes", "on"))
+                                 return(TRUE)
+                               if (tolower(value) %in% c("n", "no", "off"))
+                                 return(FALSE)
+                               else
+                                 return(value)
+                             })
+    }
     return(opts)
 })
 


### PR DESCRIPTION
### Intent

Addresses #10645 so that YAML style chunk options are evaluating when executing a chunk

### Approach

This PR includes only backend changes so the YAML chunk options are respected and combined with the standard chunk options when executing a chunk inline. This does not affect the UI of the ChunkOptionsPopupPanel -- however, upon investigation that would require a lot more lift for seemingly minimal benefit, and there is no clear way forward, as the LineWidget really only ever parses the first line of a chunk on the frontend. Given this, and given that only a very small set of chunk options are even considered in the PopupPanel (see below), I'm not sure the frontend changes are worth doing at this time. We can always revisit if this becomes important to users

<img width="291" alt="image" src="https://user-images.githubusercontent.com/7817881/165788132-2d248ec4-9aca-45f4-81e9-c53404b8c550.png">


### Automated Tests
None

### QA Notes

Run chunks with both YAML and standard style chunk options, and compare behavior.

```
```{r}
#| eval: false
  
# doesn't runs with "Run all chunks above", correct behaviour
1 + 1
```

```{r eval = FALSE}
  
# doesn't run with "Run all chunks above", correct behaviour
2 + 2
```

```{r}
#| warning: false
#| message: false
# doesn't output warnings or messages, correct behaviour

library(ggplot2)
ggplot(airquality, aes(Temp, Ozone)) + 
        geom_point() + 
        geom_smooth(method = "loess", se = FALSE)
```


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

