### PR TITLE
Stop building obsolete/unnecessary platforms

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -230,7 +230,6 @@ try {
 
     timestamps {
         def containers = [
-          [os: 'opensuse',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'OpenSUSE'],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'OpenSUSE 15'],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'OpenSUSE 15'],
           [os: 'opensuse15', arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'OpenSUSE 15'],
@@ -243,9 +242,6 @@ try {
           [os: 'jammy',      arch: 'amd64',  flavor: 'server',   variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'desktop',  variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Jammy'],
-          [os: 'debian10',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 10'],
-          [os: 'debian10',   arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 10'],
-          [os: 'debian10',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Debian 10'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'RHEL 8']

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -243,8 +243,6 @@ try {
           [os: 'jammy',      arch: 'amd64',  flavor: 'server',   variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'desktop',  variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Jammy'],
-          [os: 'debian9',    arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 9'],
-          [os: 'debian9',    arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 9'],
           [os: 'debian10',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Debian 10'],
           [os: 'debian10',   arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Debian 10'],
           [os: 'debian10',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Debian 10'],


### PR DESCRIPTION
### Intent

* Spotted-Wakerobin won't support debian9 (it goes out of support at end of June 2022), so stop building it.
* Debian10 build is redundant, the "bionic" build is already intended for use on debian10 (debian9 was a special-case due to libssl issues; why is it always libssl issues?)
* We no longer support opensuse, either, so stop building that

### Approach

Delete lines in Jenkinsfile.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


