### PR TITLE
Fix carriage return colour interaction

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -277,7 +277,7 @@ public class VirtualConsole
     * @param range
     */
    private void insertText(ClassRange range)
-   {      
+   {
       int start = range.start;
       int end = start + range.length;
       
@@ -288,11 +288,16 @@ public class VirtualConsole
       // overlaps
       SortedMap<Integer, ClassRange> view = null;
       
-      if (left != null && right != null) {
+      if (left != null && right != null) 
+      {
          view = class_.subMap(left.getKey(), true, right.getKey(), true);
-      } else if (left == null && right != null) {
+      } 
+      else if (left == null && right != null) 
+      {
          view = class_.tailMap(right.getKey(), true);
-      } else if (left != null) {
+      } 
+      else if (left != null) 
+      {
          view = class_.headMap(left.getKey(), true);
       }
       
@@ -441,7 +446,7 @@ public class VirtualConsole
 
       for (Integer key: moves.keySet())
       {
-         ClassRange moved = class_.get(key);     
+         ClassRange moved = class_.get(key);
          class_.remove(key);
          class_.put(moves.get(key), moved);
       }

--- a/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
+++ b/src/gwt/src/org/rstudio/core/client/VirtualConsole.java
@@ -280,23 +280,22 @@ public class VirtualConsole
    {      
       int start = range.start;
       int end = start + range.length;
-
+      
       Entry<Integer, ClassRange> left = class_.floorEntry(start);
-      Entry<Integer, ClassRange> right = class_.lowerEntry(end);
-
+      Entry<Integer, ClassRange> right = class_.floorEntry(end);
+      
       // create a view into the map representing the ranges that this class
       // overlaps
       SortedMap<Integer, ClassRange> view = null;
       
       if (left != null && right != null) {
-         view = class_.subMap(left.getKey(), true, right.getKey(), left.equals(right));
+         view = class_.subMap(left.getKey(), true, right.getKey(), true);
       } else if (left == null && right != null) {
          view = class_.tailMap(right.getKey(), true);
       } else if (left != null) {
          view = class_.headMap(left.getKey(), true);
       }
-         
-
+      
       // if no overlapping ranges exist, we can just create a new one
       if (view == null)
       {
@@ -378,12 +377,15 @@ public class VirtualConsole
                // reduce the original range and add ours
                overlap.trimLeft(delta);
 
+               // move the shortened range to its new start position
+               // unless it's empty
+               if (overlap.length > 0) {
+                  moves.put(l, overlap.start);
+               }
+
                if (!range.text().isEmpty())
                   insertions.add(range);
-
-               // move the shortened range to its new start position
-               moves.put(l, overlap.start);
-
+               
                if (parent_ != null && !range.text().isEmpty())
                   overlap.element.getParentElement().insertBefore(range.element, overlap.element);
 
@@ -439,7 +441,7 @@ public class VirtualConsole
 
       for (Integer key: moves.keySet())
       {
-         ClassRange moved = class_.get(key);
+         ClassRange moved = class_.get(key);     
          class_.remove(key);
          class_.put(moves.get(key), moved);
       }

--- a/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
+++ b/src/gwt/test/org/rstudio/core/client/VirtualConsoleTests.java
@@ -1262,4 +1262,12 @@ public class VirtualConsoleTests extends GWTTestCase
       String expected = "<a class=\"xtermHyperlink\" title=\"http://www.example.com\">text</a>";
       Assert.assertEquals(expected, ele.getInnerHTML());
    }
+
+   public void testIssue9846()
+   {
+      PreElement ele = Document.get().createPreElement();
+      VirtualConsole vc = getVC(ele);
+      vc.submit("i Some intermediate step with a \033[32mfield\033[39m-----------------------\r+++++++++++++++++++++++++++++++++++++\r\033[33m!\033[39m An alert message which is long enough\ni Some intermediate step with a \033[32mfield\033[39m\n");
+      Assert.assertEquals("<span class=\"xtermColor3\">!</span><span> An alert message which is long enough</span><span>---------------------\ni Some intermediate step with a </span><span class=\"xtermColor2\">field</span><span>\n</span>", ele.getInnerHTML());
+   }
 }


### PR DESCRIPTION
### Intent

adresses #9846

### Approach

handle special case of right side (full) overlapping

### Automated Tests

Added a unit test inspired from the text of #9846. This could probably be simplified 🤷 

```java
   public void testIssue9846()
   {
      PreElement ele = Document.get().createPreElement();
      VirtualConsole vc = getVC(ele);
      vc.submit("i Some intermediate step with a \033[32mfield\033[39m-----------------------\r+++++++++++++++++++++++++++++++++++++\r\033[33m!\033[39m An alert message which is long enough\ni Some intermediate step with a \033[32mfield\033[39m\n");
      Assert.assertEquals("<span class=\"xtermColor3\">!</span><span> An alert message which is long enough</span><span>---------------------\ni Some intermediate step with a </span><span class=\"xtermColor2\">field</span><span>\n</span>", ele.getInnerHTML());
   }
```

### QA Notes

This code: 

```r
msg <- c( 
  "ℹ Some intermediate step with a \033[32mfield\033[39m-----------------------\r+++++++++++++++++++++++++++++++++++++\r\033[33m!\033[39m An alert message which is long enough\n", 
  "ℹ Some intermediate step with a \033[32mfield\033[39m\n"
)
cat(msg, sep = "")
```

now gives this: 

<img width="459" alt="image" src="https://user-images.githubusercontent.com/2625526/165818543-175ca297-be3e-4032-8a11-0684ae27e7b3.png">

where it gives this without the fix: 

<img width="570" alt="image" src="https://user-images.githubusercontent.com/2625526/165818633-66e5d2b9-60ef-4bef-b514-51895418542f.png">

(different font here on my desktop version). The relevant bit is that "field" should be right after "a". 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


