### PR TITLE
properly handle R rawstring state in multimode docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -57,6 +57,7 @@
 - Fixed an issue where code of the form '1:2:3' was diagnosed incorrectly. (#10979)
 - Add back link to the title of sessions so that users can easily open sessions in new tabs and copy session links (rstudio-pro#3290)
 - (Linux Only) License-manager now works in a installer-less context (rstudio-pro#3150)
+- Fixed an issue where R raw strings were not highlighted correctly in R Markdown documents. (#11087)
 
 ### RStudio Workbench
 

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -274,6 +274,10 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
           // save current state in stack
           stack[0] = state;
 
+          // save the name of the next state
+          // (needed because state names can be mutated in multi-mode documents)
+          stack[1] = this.next;
+
           // save the expected suffix for exit
           stack[2] =
             $complements[value[value.length - 1]] +
@@ -480,7 +484,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         token : "string",
         regex : "[\\]})][-]*['\"]",
         onMatch: function(value, state, stack, line) {
-          this.next = (value === stack[2]) ? stack[0] : "rawstring";
+          this.next = (value === stack[2]) ? stack[0] : stack[1];
           return this.token;
         }
       },

--- a/src/gwt/acesupport/acemode/rainbow_paren_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/rainbow_paren_highlight_rules.js
@@ -44,19 +44,30 @@ define("mode/rainbow_paren_highlight_rules", ["require", "exports", "module"], f
           return this.token;
         }
 
+        // NOTE: The 'stack' object here (which is really just an array) is
+        // shared by different highlight rules, and is a general way to set and
+        // persist state in the tokenizer. However, because it's visible to
+        // each matching highlight rule, and each individual highlight rule
+        // might want to manipulate that stack, we need to choose the index
+        // carefully to avoid stomping on state declared from other highlight
+        // rules. 15 is chosen as a "large enough" number to avoid stepping
+        // other rules, which normally would be manipulating the first few
+        // slots of the 'stack' array.
+        //
+        // https://github.com/rstudio/rstudio/issues/11087
         stack = stack || [];
         stack[0] = state;
-        stack[1] = stack[1] || 0;
+        stack[15] = stack[15] || 0;
 
         switch(val) {
 
         case "[": case "{": case "(":
-          this.token = "paren.paren_color_" + (stack[1] % $numParenColors);
-          stack[1] = stack[1] + 1;
+          this.token = "paren.paren_color_" + (stack[15] % $numParenColors);
+          stack[15] = stack[15] + 1;
           break;
         case "]": case "}": case ")":
-          stack[1] = Math.max(0, stack[1] - 1);
-          this.token = "paren.paren_color_" + (stack[1] % $numParenColors);
+          stack[15] = Math.max(0, stack[15] - 1);
+          this.token = "paren.paren_color_" + (stack[15] % $numParenColors);
           break;
         }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11087.

### Approach

Multi-mode documents embed the highlight rules of other languages by prepending the associated state names with a language-specific prefix. For example, R highlight rules are embedded for R Markdown documents here:

https://github.com/rstudio/rstudio/blob/0a4befe8ef2003ea69b554f1ae2280141f6f6aaa/src/gwt/acesupport/acemode/rmarkdown_highlight_rules.js#L58-L66

Importantly, this is done by giving each "state" name from that highlight group a unique prefix, so that the highlight definitions from one language don't collide with those from another. However, this implies that highlight rules in those languages need to be careful, since the "raw" state names might be transformed in such cases.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11087.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
