### PR TITLE
Small text tweaks based on feedback

### DIFF
--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1152,7 +1152,7 @@
         "ssh_key_type": {
             "type": "string",
             "enum": ["ed25519", "rsa"],
-            "enumReadable": ["ED25519-encrypted key", "RSA-encrypted key"],
+            "enumReadable": ["ED25519", "RSA"],
             "default": "ed25519",
             "description": "The encryption type to use for the SSH key file."
         },

--- a/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
@@ -1808,11 +1808,11 @@ public interface StudioClientCommonConstants extends com.google.gwt.i18n.client.
     String pathHelpCaption();
 
     /**
-     * Translated "SSH key type".
+     * Translated "SSH key type: ".
      *
-     * @return translated "SSH key type"
+     * @return translated "SSH key type: "
      */
-    @DefaultMessage("SSH key type")
+    @DefaultMessage("SSH key type: ")
     @Key("sshKeyTypeLabel")
     String sshKeyTypeLabel();
 

--- a/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/StudioClientCommonConstants.java
@@ -1817,20 +1817,20 @@ public interface StudioClientCommonConstants extends com.google.gwt.i18n.client.
     String sshKeyTypeLabel();
 
     /**
-     * Translated "RSA-encrypted key"
+     * Translated "RSA"
      *
-     * @return translated "RSA-encrypted key"
+     * @return translated "RSA"
      */
-    @DefaultMessage("RSA-encrypted key")
+    @DefaultMessage("RSA")
     @Key("sshKeyRSAOption")
     String sshKeyRSAOption();
 
     /**
-     * Translated "ED25519-encrypted key"
+     * Translated "ED25519"
      *
-     * @return translated "ED25519-encrypted key"
+     * @return translated "ED25519"
      */
-    @DefaultMessage("ED25519-encrypted key")
+    @DefaultMessage("ED25519")
     @Key("sshKeyEd25519Option")
     String sshKeyEd25519Option();
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1420,9 +1420,9 @@ public interface UserPrefsAccessorConstants extends Constants {
    String sshKeyTypeTitle();
    @DefaultStringValue("The encryption type to use for the SSH key file.")
    String sshKeyTypeDescription();
-   @DefaultStringValue("ED25519-encrypted key")
+   @DefaultStringValue("ED25519")
    String sshKeyTypeEnum_ed25519();
-   @DefaultStringValue("RSA-encrypted key")
+   @DefaultStringValue("RSA")
    String sshKeyTypeEnum_rsa();
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -715,8 +715,8 @@ rsaKeyPathDescription = The path to the SSH key file to use.
 # The encryption type to use for the SSH key file.
 sshKeyTypeTitle = 
 sshKeyTypeDescription = The encryption type to use for the SSH key file.
-sshKeyTypeEnum_ed25519=ED25519-encrypted key
-sshKeyTypeEnum_rsa=RSA-encrypted key
+sshKeyTypeEnum_ed25519=ED25519
+sshKeyTypeEnum_rsa=RSA
 
 # Whether to use the devtools R package.
 useDevtoolsTitle = Use the devtools R package if available

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -128,12 +128,12 @@ public class EditingPreferencesPane extends PreferencesPane
       editingPanel.add(keyboardPanel);
 
       HorizontalPanel projectPrefsPanel = new HorizontalPanel();
+      projectPrefsPanel.getElement().getStyle().setMarginTop(5, Unit.PX);
       Label projectOverride = new Label(constants_.editingProjectOverrideInfoText());
       projectOverride.addStyleName(baseRes.styles().infoLabel());
       projectPrefsPanel.add(projectOverride);
 
       SmallButton editProjectSettings = new SmallButton(constants_.editProjectPreferencesButtonLabel());
-      editProjectSettings.getElement().getStyle().setMarginTop(1, Unit.PX);
       editProjectSettings.getElement().getStyle().setMarginLeft(5, Unit.PX);
       editProjectSettings.addClickHandler(new ClickHandler() {
          @Override


### PR DESCRIPTION
Follow up to #8255 -- small tweaks to text based on feedback.

<img width="402" alt="image" src="https://user-images.githubusercontent.com/7817881/165966016-5b6fa06b-93b8-4d9d-9613-acd66a6e8def.png">


Separate question based on other feedback from the demo session last week:

<img width="456" alt="image" src="https://user-images.githubusercontent.com/7817881/165963146-489fd754-84f9-4494-b415-22ce7d7d663a.png">

There was feedback that it was difficult to visually distinguish the Project Preferences Note in order to realize it was not another setting. Do you think it's okay as is, or would you suggest any other visual changes? Perhaps a tad more padding at the top between Keybindings and the note? We could indent it as well but that would make it look like it was nested under keybindings. We could also put the whole note in parentheses, like the python note is. Or maybe you feel it's still fine as is
