### PR TITLE
tweaks for building on jammy

### DIFF
--- a/dependencies/common/install-boost
+++ b/dependencies/common/install-boost
@@ -114,12 +114,18 @@ if [ "$PLATFORM" = "Darwin" ]; then
 
 else
 
+   # set up cxxflags
+   cxxflags="-fPIC -std=c++11"
+   if grep -siq jammy /etc/os-release; then
+      cxxflags="${cxxflags} -DTHREAD_STACK_MIN=$(getconf PTHREAD_STACK_MIN)"
+   fi
+
    # plain old build for other platforms
-   ./bjam                         \
-      "${BOOST_BJAM_FLAGS}"       \
-      --prefix="$BOOST_DIR"       \
-      variant=release             \
-      cxxflags="-fPIC -std=c++11" \
+   ./bjam                    \
+      "${BOOST_BJAM_FLAGS}"  \
+      --prefix="$BOOST_DIR"  \
+      variant=release        \
+      cxxflags="${cxxflags}" \
       install
 
 fi

--- a/src/cpp/tests/cpp/tests/vendor/catch.hpp
+++ b/src/cpp/tests/cpp/tests/vendor/catch.hpp
@@ -10824,7 +10824,7 @@ namespace Catch {
 
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
-    static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
+    static constexpr std::size_t sigStackSize = 32768;
 
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
Some minimal changes to get RStudio building on Ubuntu Jammy. Note: still need to ensure `-DPTHREAD_STACK_MIN=131072` is added to CMake CXX flags.