### PR TITLE
`uiLanguage*` properties in fr

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -974,7 +974,7 @@ checkNullExternalPointersTitle = Check values in the Environment pane for null e
 checkNullExternalPointersDescription = When enabled, RStudio will detect R objects containing null external pointers when building the Environment pane, and avoid introspecting their contents further.
 
 # The IDE's user-interface language.
-uiLanguageTitle = User Interface Language
+uiLanguageTitle = User Interface Language: 
 uiLanguageDescription = The IDE's user-interface language.
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -959,5 +959,5 @@ quartoEnabledTitle= Activer les fonctionnalités de Quarto
 quartoEnabledDescription= Active les fonctionnalités de l''IDE pour le système de publication Quarto.
 
 # The IDE's user-interface language.
-uiLanguageTitle= Langage de l'interface utilisateur·rice
-uiLanguageDescription= Le langage de l'interface utilisateur·rice de l'IDE
+uiLanguageTitle= Langage de l'interface utilisateur·rice:
+uiLanguageDescription= Le langage de l'interface utilisateur·rice de l'IDE.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -957,3 +957,7 @@ checkNullExternalPointersDescription= Lorsque cette option est activée, RStudio
 # Enable IDE features for the Quarto publishing system.
 quartoEnabledTitle= Activer les fonctionnalités de Quarto
 quartoEnabledDescription= Active les fonctionnalités de l''IDE pour le système de publication Quarto.
+
+# The IDE's user-interface language.
+uiLanguageTitle= Langage de l'interface utilisateur·rice
+uiLanguageDescription= Le langage de l'interface utilisateur·rice de l'IDE


### PR DESCRIPTION

<img width="602" alt="image" src="https://user-images.githubusercontent.com/2625526/166682365-41240b5b-4a27-4996-9791-645214ac914a.png">


Questions: 
 - (technical) I see that sometimes double single quotes are used, e.g. `terminalPythonIntegrationTitle= Activer l''intégration Python du terminal` and so I tried `uiLanguageTitle= Langage de l''interface utilisateur·rice` but it showed up as two single quotes instead of one as expected. Is there anything I'm missing ?

 - (cultural): Je suis parti sur de l'écriture inclusive avec point médian (interface utilisateur·rice). Qu'en pense d'autres francophones ? @cderv @maelle @ColinFay ... 