### PR TITLE
Full Path on Tab Title When Saving New File on Windows

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -89,7 +89,7 @@ export function getDesktopBridge() {
             filePath = name + defaultExtension;
           }
 
-          if (process.platform == 'win32') {
+          if (process.platform === 'win32') {
             filePath = filePath.replace(/\\/g, '/');
           }
           

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -89,6 +89,10 @@ export function getDesktopBridge() {
             filePath = name + defaultExtension;
           }
 
+          if (process.platform == 'win32') {
+            filePath = filePath.replace(/\\/g, '/');
+          }
+          
           // invoke callback
           return callback(filePath);
         })


### PR DESCRIPTION
### Intent

Fix an issue that would make the Tab Title show  the full path instead of filename only on windows

### Approach

Removed double slashes for when saving files on Windows.

### Automated Tests

None

### QA Notes

Instructions on #11046

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses ##11046
