### PR TITLE
Fix Translation on Choose R Popup from Global Options

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -46,7 +46,7 @@ import { GwtWindow } from './gwt-window';
 import { MainWindow } from './main-window';
 import { openMinimalWindow } from './minimal-window';
 import { defaultFonts, ElectronDesktopOptions } from './preferences/electron-desktop-options';
-import { findRepoRoot, getAppPath, filterFromQFileDialogFilter, resolveAliasedPath } from './utils';
+import { findRepoRoot, getAppPath, filterFromQFileDialogFilter, resolveAliasedPath, handleLocaleCookies } from './utils';
 import { activateWindow } from './window-utils';
 
 export enum PendingQuit {
@@ -387,6 +387,9 @@ export class GwtCallback extends EventEmitter {
 
       // ask the user what version of R they'd like to use
       const chooseRDialog = new ChooseRModalWindow(rInstalls);
+     
+      void handleLocaleCookies(chooseRDialog);
+
       const [data, error] = await chooseRDialog.showModal();
       if (error) {
         logger().logError(error);


### PR DESCRIPTION
### Intent

Fix an issue that would make the `Choose R` popup on Windows not to display the correct language when opened from Global Options Window.

### Approach

That popup now also handles the correct locale.

### Automated Tests

None

### QA Notes

Info on #11079

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11079 

