### PR TITLE
Fix SW bugs in Find in Files path and find in files replacements

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -986,7 +986,7 @@ private:
             // (git grep doesn't prepend a '.' so we need to be careful here)
             if (boost::algorithm::starts_with(file, "./"))
             {
-               file = workingDir_ + file.substr(2);
+               file = workingDir_ + file.substr(1);
             }
             else if (findResults().gitFlag())
             {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4498,6 +4498,8 @@ public class RemoteServer implements Server
                               boolean searchIgnoreCase,
                               FileSystemItem directory,
                               JsArrayString includeFilePatterns,
+                              boolean useGitGrep,
+                              boolean excludeGitIgnore,
                               JsArrayString excludeFilePatterns,
                               String replaceString,
                               ServerRequestCallback<String> requestCallback)
@@ -4509,8 +4511,10 @@ public class RemoteServer implements Server
       params.set(3, new JSONString(directory == null ? ""
                                                      : directory.getPath()));
       params.set(4, new JSONArray(includeFilePatterns));
-      params.set(5, new JSONArray(excludeFilePatterns));
-      params.set(6, new JSONString(replaceString));
+      params.set(5, JSONBoolean.getInstance(useGitGrep));
+      params.set(6, JSONBoolean.getInstance(excludeGitIgnore));
+      params.set(7, new JSONArray(excludeFilePatterns));
+      params.set(8, new JSONString(replaceString));
 
       sendRequest(RPC_SCOPE, PREVIEW_REPLACE, params, requestCallback);
    }
@@ -4521,6 +4525,8 @@ public class RemoteServer implements Server
                                boolean searchIgnoreCase,
                                FileSystemItem directory,
                                JsArrayString includeFilePatterns,
+                               boolean useGitGrep,
+                               boolean excludeGitIgnore,
                                JsArrayString excludeFilePatterns,
                                int searchResults,
                                String replaceString,
@@ -4533,9 +4539,11 @@ public class RemoteServer implements Server
       params.set(3, new JSONString(directory == null ? ""
                                                      : directory.getPath()));
       params.set(4, new JSONArray(includeFilePatterns));
-      params.set(5, new JSONArray(excludeFilePatterns));
-      params.set(6, new JSONNumber(searchResults));
-      params.set(7, new JSONString(replaceString));
+      params.set(5, JSONBoolean.getInstance(useGitGrep));
+      params.set(6, JSONBoolean.getInstance(excludeGitIgnore));
+      params.set(7, new JSONArray(excludeFilePatterns));
+      params.set(8, new JSONNumber(searchResults));
+      params.set(9, new JSONString(replaceString));
 
       sendRequest(RPC_SCOPE, COMPLETE_REPLACE, params, requestCallback);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -231,6 +231,8 @@ public class FindOutputPresenter extends BasePresenter
                                    !dialogState_.isCaseSensitive(),
                                    searchPath,
                                    includeFilePatterns,
+                                   dialogState_.getUseGitGrep(),
+                                   dialogState_.getExcludeGitIgnore(),
                                    excludeFilePatterns,
                                    view_.getReplaceText(),
                                    new SimpleRequestCallback<String>()
@@ -320,6 +322,8 @@ public class FindOutputPresenter extends BasePresenter
                                                 !dialogState_.isCaseSensitive(),
                                                 searchPath,
                                                 includeFilePatterns,
+                                                dialogState_.getUseGitGrep(),
+                                                dialogState_.getExcludeGitIgnore(),
                                                 excludeFilePatterns,
                                                 dialogState_.getResultsCount(),
                                                 view_.getReplaceText(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
@@ -41,6 +41,8 @@ public interface FindInFilesServerOperations
                        boolean searchIgnoreCase,
                        FileSystemItem dictionary,
                        JsArrayString includeFilePatterns,
+                       boolean useGitGrep,
+                       boolean excludeGitIgnore,
                        JsArrayString excludeFilePatterns,
                        String replaceString,
                        ServerRequestCallback<String> requestCallback);
@@ -50,6 +52,8 @@ public interface FindInFilesServerOperations
                         boolean searchIgnoreCase,
                         FileSystemItem dictionary,
                         JsArrayString includeFilePatterns,
+                        boolean useGitGrep,
+                        boolean excludeGitIgnore,
                         JsArrayString excludeFilePatterns,
                         int searchResults,
                         String replaceString,


### PR DESCRIPTION
### Intent

Fix bugs described in #11041 and #11125

### Approach

1. We previously added two new git grep related params to the begin Find RPC calls, but not to the preview Replace and complete Replace calls, leading to parameter mismatch errors when attempting to do replacements with regex selected (the replace methods are actually only called when regex is True)
2. We previously stripped off the leading `./` from non git grep search result paths, when instead we should have stripped only the `.`, which resulted in a missing separator `/` between the search directory and the result path

### Automated Tests

Will check existing tests

### QA Notes

Find in Files search and replace with regex selected

