### PR TITLE
Drop Session ID from interface

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -26,11 +26,11 @@ namespace r_util {
    class IActiveSessionStorage 
    {
    public:
-      Error virtual readProperty(const std::string& id, const std::string& name, std::string* pValue) = 0;
-      Error virtual readProperties(const std::string& id, const std::set<std::string>& names, std::map<std::string, std::string>* pValues) = 0;
-      Error virtual readProperties(const std::string& id, std::map<std::string, std::string>* pValues) = 0;
-      Error virtual writeProperty(const std::string& id, const std::string& name, const std::string& value) = 0;
-      Error virtual writeProperties(const std::string& id, const std::map<std::string, std::string>& properties) = 0;
+      Error virtual readProperty(const std::string& name, std::string* pValue) = 0;
+      Error virtual readProperties(const std::set<std::string>& names, std::map<std::string, std::string>* pValues) = 0;
+      Error virtual readProperties(std::map<std::string, std::string>* pValues) = 0;
+      Error virtual writeProperty(const std::string& name, const std::string& value) = 0;
+      Error virtual writeProperties(const std::map<std::string, std::string>& properties) = 0;
 
    protected:
       virtual ~IActiveSessionStorage() = default;
@@ -42,11 +42,11 @@ namespace r_util {
    public:
       explicit FileActiveSessionStorage(const FilePath& location);
       ~FileActiveSessionStorage() = default;
-      Error readProperty(const std::string& id, const std::string& name, std::string* pValue) override;   
-      Error readProperties(const std::string& id, const std::set<std::string>& names, std::map<std::string, std::string>* pValues) override;
-      Error readProperties(const std::string& id, std::map<std::string, std::string>* pValues) override;
-      Error writeProperty(const std::string& id, const std::string& name, const std::string& value) override;
-      Error writeProperties(const std::string& id, const std::map<std::string, std::string>& properties) override;
+      Error readProperty(const std::string& name, std::string* pValue) override;   
+      Error readProperties(const std::set<std::string>& names, std::map<std::string, std::string>* pValues) override;
+      Error readProperties(std::map<std::string, std::string>* pValues) override;
+      Error writeProperty(const std::string& name, const std::string& value) override;
+      Error writeProperties(const std::map<std::string, std::string>& properties) override;
 
    private:
       FilePath scratchPath_;

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -93,7 +93,7 @@ private:
       std::string value;
       if (!empty())
       {
-         Error error = storage_->readProperty(id_, propertyName, &value);
+         Error error = storage_->readProperty(propertyName, &value);
          if (error)
             LOG_ERROR(error);
       }
@@ -105,7 +105,7 @@ private:
    {
       if (!empty())
       {
-         Error error = storage_->writeProperty(id_, propertyName, value);
+         Error error = storage_->writeProperty(propertyName, value);
          if (error)
             LOG_ERROR(error);
       }

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -61,12 +61,12 @@ namespace
             { "launch_parameters" , "launch-parameters" }
          };
 
-    Error FileActiveSessionStorage::readProperty(const std::string& id, const std::string& name, std::string* pValue)
+    Error FileActiveSessionStorage::readProperty(const std::string& name, std::string* pValue)
     {
         std::map<std::string, std::string> propertyValue{};
         *pValue = "";
 
-        Error error = readProperties(id, { name }, &propertyValue);
+        Error error = readProperties({ name }, &propertyValue);
 
         if (error)
             return error;
@@ -79,7 +79,7 @@ namespace
         return Success();
     }
 
-    Error FileActiveSessionStorage::readProperties(const std::string& id, const std::set<std::string>& names, std::map<std::string, std::string>* pValues)
+    Error FileActiveSessionStorage::readProperties(const std::set<std::string>& names, std::map<std::string, std::string>* pValues)
     {
         std::vector<FilePath> failedFiles{};
         pValues->empty();
@@ -105,7 +105,7 @@ namespace
                 failedFiles, ERROR_LOCATION);
     }
 
-    Error FileActiveSessionStorage::readProperties(const std::string& id, std::map<std::string, std::string>* pValues)
+    Error FileActiveSessionStorage::readProperties(std::map<std::string, std::string>* pValues)
     {
         FilePath propertyDir = getPropertyDir();
         std::vector<FilePath> files{};
@@ -131,13 +131,13 @@ namespace
                 failedFiles, ERROR_LOCATION);
     }
 
-    Error FileActiveSessionStorage::writeProperty(const std::string& id, const std::string& name, const std::string& value)
+    Error FileActiveSessionStorage::writeProperty(const std::string& name, const std::string& value)
     {
         std::map<std::string, std::string> property = {{name, value}};
-        return writeProperties(id, property);
+        return writeProperties(property);
     }
 
-    Error FileActiveSessionStorage::writeProperties(const std::string& id, const std::map<std::string, std::string>& properties)
+    Error FileActiveSessionStorage::writeProperties(const std::map<std::string, std::string>& properties)
     {
         std::vector<FilePath> failedFiles{};
         for (auto&& prop : properties)


### PR DESCRIPTION
It's not needed, in any case, so we drop it.


### Intent

Session ID made it into our storage interface, it's not needed.

### Approach

Dropped the id from the interface

### Automated Tests

None needed

### QA Notes

No further QA testing, compiling will demonstrate the changes work

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


