### PR TITLE
Bugfix/followup native pipe default

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -74,8 +74,7 @@ struct ROptions
          rProfileOnResume(false),
          restoreEnvironmentOnResume(true),
          packratEnabled(false),
-         suspendOnIncompleteStatement(false),
-         useNativePipeOperator(false)
+         suspendOnIncompleteStatement(false)
    {
    }
    core::FilePath userHomePath;
@@ -105,7 +104,6 @@ struct ROptions
    core::r_util::SessionScope sessionScope;
    bool packratEnabled;
    bool suspendOnIncompleteStatement;
-   bool useNativePipeOperator;
 };
       
 struct RInitInfo

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -88,8 +88,6 @@ bool alwaysSaveHistory();
 
 bool restoreEnvironmentOnResume();
 
-bool useNativePipeOperator();
-
 // suppress output in scope
 class SuppressOutputInScope
 {

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -616,11 +616,6 @@ bool restoreEnvironmentOnResume()
    return s_options.restoreEnvironmentOnResume;
 }
 
-bool useNativePipeOperator()
-{
-   return s_options.useNativePipeOperator;
-}
-
 FilePath tempFile(const std::string& prefix, const std::string& extension)
 {
    std::string filename;

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -767,24 +767,6 @@ void ProjectContext::updatePackageInfo()
    }
 }
 
-bool useNativePipeOption(int useNativePipeOperator)
-{
-   // allow project override
-   switch(useNativePipeOperator)
-   {
-      case r_util::YesValue:
-         return true;
-      case r_util::NoValue:
-         return false;
-      default:
-         // fall through
-         break;
-   }
-
-   // no project override
-   return prefs::userPrefs().insertNativePipeOperator();
-}
-
 json::Object ProjectContext::uiPrefs() const
 {
    using namespace r_util;
@@ -792,7 +774,11 @@ json::Object ProjectContext::uiPrefs() const
    json::Object uiPrefs;
    uiPrefs[kUseSpacesForTab] = config_.useSpacesForTab;
    uiPrefs[kNumSpacesForTab] = config_.numSpacesForTab;
-   uiPrefs[kInsertNativePipeOperator] = useNativePipeOption(config_.useNativePipeOperator);
+   // only set project value if explicitly set to Yes or No
+   if (config_.useNativePipeOperator == r_util::YesValue)
+      uiPrefs[kInsertNativePipeOperator] = true;
+   if (config_.useNativePipeOperator == r_util::NoValue)
+      uiPrefs[kInsertNativePipeOperator] = false;
    uiPrefs[kAutoAppendNewline] = config_.autoAppendNewline;
    uiPrefs[kStripTrailingWhitespace] = config_.stripTrailingWhitespace;
    uiPrefs[kDefaultEncoding] = defaultEncoding();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -635,16 +635,15 @@ public class AceEditor implements DocDisplay,
    public void insertAssignmentOperator()
    {
       if (DocumentMode.isCursorInRMode(this))
-         insertAssignmentOperatorImpl("<-");
+         insertOperatorWithSpacing("<-");
       else
-         insertAssignmentOperatorImpl("=");
+         insertOperatorWithSpacing("=");
    }
 
-   @SuppressWarnings("deprecation")
-   private void insertAssignmentOperatorImpl(String op)
+   private void insertOperatorWithSpacing(String op)
    {
       boolean hasWhitespaceBefore =
-            Character.isSpace(getCharacterBeforeCursor()) ||
+            Character.isWhitespace(getCharacterBeforeCursor()) ||
             (!hasSelection() && getCursorPosition().getColumn() == 0);
 
       String insertion = hasWhitespaceBefore
@@ -654,20 +653,12 @@ public class AceEditor implements DocDisplay,
       insertCode(insertion, false);
    }
 
-   @SuppressWarnings("deprecation")
-   public void insertPipeOperator()
+   private void insertPipeOperator()
    {
-      boolean hasWhitespaceBefore =
-            Character.isSpace(getCharacterBeforeCursor()) ||
-            (!hasSelection() && getCursorPosition().getColumn() == 0);
-
       // Use magrittr style pipes if the user has not opted into new native pipe syntax
-      String pipe = userPrefs_.insertNativePipeOperator().getValue() ? NATIVE_R_PIPE : MAGRITTR_PIPE;
-
-      if (hasWhitespaceBefore)
-         insertCode(pipe + " ", false);
-      else
-         insertCode(" " + pipe + " ", false);
+      boolean nativePipePreferred = RStudioGinjector.INSTANCE.getUserPrefs().insertNativePipeOperator().getValue();
+      String pipe =  nativePipePreferred ? NATIVE_R_PIPE : MAGRITTR_PIPE;
+      insertOperatorWithSpacing(pipe);
    }
 
    private boolean shouldIndentOnPaste()


### PR DESCRIPTION
Follow up to #9409 (PR #10814). 

During QA it was found that there were some issues around how it handled changing the global default for the `insert_native_pipe_operator` preference when a project was active and the project setting was set to (Default).

Fixed that here by not writing anything to the project prefs layer when the project setting is Default, instead of previous behavior which wrote the global user preference to the project layer. Initial testing shows the issue seems to be resolved, but will rely on initial QA plan and point of failure from #9409 . 

Also removed some unnecessary code and did some minor refactoring when I was trying to figure out what was going on here.