### PR TITLE
Fix jsonEscapeString() in SessionCodeTools.R

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1215,7 +1215,7 @@
    chars <- vapply(chars, function(x) {
       if (x %in% c('"', '\\', '/'))
          paste('\\', x, sep = '')
-      else if (charToRaw(x) < 20)
+      else if (length(charToRaw(x)) == 1 && charToRaw(x) < 20)
          paste('\\u', toupper(format(as.hexmode(as.integer(charToRaw(x))),
                                      width = 4)),
                sep = '')

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1215,7 +1215,7 @@
    chars <- vapply(chars, function(x) {
       if (x %in% c('"', '\\', '/'))
          paste('\\', x, sep = '')
-      else if (length(charToRaw(x)) == 1 && charToRaw(x) < 20)
+      else if (length(charToRaw(x)) == 1 && charToRaw(x) < 32)
          paste('\\u', toupper(format(as.hexmode(as.integer(charToRaw(x))),
                                      width = 4)),
                sep = '')


### PR DESCRIPTION
### Intent

If `x` is a multibyte character, `charToRaw(x)` returns a vector longer than 1. Since R 4.2.0 or later, calling if() with a condition of length greater than 1 gives an **error** rather than a warning (https://cran.r-project.org/doc/manuals/r-release/NEWS.html), so the L1218 `else if (charToRaw(x) < 20)`  in `jsonEscapeString()` in SessionCodeTools.R should be corrected.

https://github.com/rstudio/rstudio/blob/438f4c08d77b1424a9b3bb193d16060cdae06aaa/src/cpp/session/modules/SessionCodeTools.R#L1211-L1226

In fact, due to this bug, R 4.2.0 sometimes fails to load R Notebooks (which are probably contain multibyte characters) with an error when opening them.

### Approach

Evaluate whether `charToRaw(x)` is less than 20 only when the length of `x` is equal to 1.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


