### PR TITLE
only get word from token that are not folded

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -1646,6 +1646,12 @@ public class AceEditor implements DocDisplay,
       ArrayList<org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor>
         anchors = new ArrayList<>();
 
+      TokenPredicate spellCheckPredicate = fileType_.getSpellCheckTokenPredicate();
+      TokenPredicate filteredTokenPredicate = (token, row, column) ->
+      {
+         return getSession().getFoldAt(row, column) == null  && spellCheckPredicate.test(token, row, column);
+      };
+
       return new SpellingDoc() {
 
 
@@ -1659,7 +1665,7 @@ public class AceEditor implements DocDisplay,
                {
                   // get underlying iterator
                   Iterator<Range> ranges = AceEditor.this.getWords(
-                        fileType_.getSpellCheckTokenPredicate(),
+                        filteredTokenPredicate,
                         fileType_.getCharPredicate(),
                         positionFromIndex(start),
                         end != -1 ? positionFromIndex(end) : null).iterator();


### PR DESCRIPTION
### Intent

addresses #10967

### Approach

Only present the tokens that are non folded. 

```java
      TokenPredicate spellCheckPredicate = fileType_.getSpellCheckTokenPredicate();
      TokenPredicate filteredTokenPredicate = (token, row, column) ->
      {
         return getSession().getFoldAt(row, column) == null  && spellCheckPredicate.test(token, row, column);
      }; 
```

I don't know if we can do something better than do `getSession().getFoldAt(row, column)` many many times.  

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


