### PR TITLE
apply ace editor style to vignette code

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 
 ### Fixed
 
+- Fixed an issue where vignette content was illegible when viewed with a dark theme. (#11164)
 - Fixed logging of `HRESULT` error values by logging them as hexadecimal instead of decimal (#10310)
 - Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE (#9436)
 - Fixed plot export to PDF options (#9185)

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -285,6 +285,21 @@ const char * const kJsCallbacks = R"EOF(
    if (window.parent.helpMousedown)
       window.onmousedown = function(e) { window.parent.helpMousedown(e); }
 
+   window.addEventListener("load", function(event) {
+      var els = document.querySelectorAll(".sourceCode span");
+      for (var i = 0, n = els.length; i < n; i++) {
+         var el = els[i];
+         if (el.className === "fu")
+            el.className = "ace_identifier ace_support ace_function";
+         else if (el.className === "at")
+            el.className = "ace_operator ace_keyword";
+         else if (el.className === "cn")
+            el.className = "ace_constant ace_language";
+         else if (el.className === "sc")
+            el.className = "ace_keyword ace_operator ace_infix";
+      }
+   });
+
 </script>
 )EOF";
 

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -286,18 +286,28 @@ const char * const kJsCallbacks = R"EOF(
       window.onmousedown = function(e) { window.parent.helpMousedown(e); }
 
    window.addEventListener("load", function(event) {
+
+      // https://github.com/rstudio/rmarkdown/blob/de02c926371fdadc4d92f08e1ad7b77db069be49/inst/rmarkdown/templates/html_vignette/resources/vignette.css#L187-L201
+      var classMap = {
+         "at": "ace_keyword ace_operator",
+         "ch": "ace_string",
+         "co": "ace_comment",
+         "cf": "ace_keyword",
+         "cn": "ace_constant ace_language",
+         "dt": "ace_identifier",
+         "dv": "ace_constant ace_numeric",
+         "er": "ace_keyword ace_operator",
+         "fu": "ace_identifier",
+         "kw": "ace_keyword",
+         "ot": "ace_keyword ace_operator",
+         "sc": "ace_keyword ace_operator",
+         "st": "ace_string",
+      };
+
       var els = document.querySelectorAll(".sourceCode span");
-      for (var i = 0, n = els.length; i < n; i++) {
-         var el = els[i];
-         if (el.className === "fu")
-            el.className = "ace_identifier ace_support ace_function";
-         else if (el.className === "at")
-            el.className = "ace_operator ace_keyword";
-         else if (el.className === "cn")
-            el.className = "ace_constant ace_language";
-         else if (el.className === "sc")
-            el.className = "ace_keyword ace_operator ace_infix";
-      }
+      for (el of els)
+         el.className = classMap[el.className] || el.className;
+
    });
 
 </script>

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -181,8 +181,22 @@ public class RStudioThemedFrame extends RStudioFrame
    
    private static final native boolean isEligibleForCustomStyles(Document document)
    /*-{
+      // We disable custom styling for most vignettes, as we cannot guarantee
+      // the vignette will remain legible after attempting to re-style with
+      // a dark theme.
+      
+      // If the document contains an 'article', avoid custom styling.
       var articles = document.getElementsByTagName("article");
-      return articles.length === 0;
+      if (articles.length !== 0)
+         return false;
+         
+      // If the document uses hljs, avoid custom styling.
+      // https://github.com/rstudio/rstudio/issues/11022
+      var hljs = document.defaultView.hljs;
+      if (hljs != null)
+         return false;
+         
+      return true;
    }-*/;
    
    // Resources ----

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioThemedFrame.java
@@ -125,7 +125,8 @@ public class RStudioThemedFrame extends RStudioFrame
          style.setInnerHTML(customStyle);
          document.getHead().appendChild(style);
          
-         if (urlStyle != null) {
+         if (urlStyle != null)
+         {
             LinkElement styleLink = document.createLinkElement();
             styleLink.setHref(urlStyle);
             styleLink.setRel("stylesheet");
@@ -137,7 +138,8 @@ public class RStudioThemedFrame extends RStudioFrame
          BodyElement body = document.getBody();
          if (body != null)
          {
-            if (removeBodyStyle) body.removeAttribute("style");
+            if (removeBodyStyle)
+               body.removeAttribute("style");
             
             RStudioThemes.initializeThemes(
                RStudioGinjector.INSTANCE.getUserPrefs(),


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10142.
Addresses https://github.com/rstudio/rstudio/issues/11022.

Examples using `vignette("programming", package = "dplyr")`.

#### Before

<img width="732" alt="Screen Shot 2022-05-09 at 2 58 56 PM" src="https://user-images.githubusercontent.com/1976582/167505588-064f7909-2479-4ca7-b154-fdc4c9995839.png">

#### After

<img width="506" alt="Screen Shot 2022-05-09 at 2 59 16 PM" src="https://user-images.githubusercontent.com/1976582/167505642-d06f6b12-7ff9-4b97-8d55-e84e43441563.png">

And also, from https://github.com/rstudio/rstudio/issues/11022, with no styling applied:

<img width="556" alt="Screen Shot 2022-05-09 at 3 00 29 PM" src="https://user-images.githubusercontent.com/1976582/167505817-51649f8f-5842-4431-97d6-5b0828448853.png">

### Approach

Replace the class names for highlighted source code with the corresponding Ace highlight CSS class.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10142.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
