### PR TITLE
Check for nulls when testing equality

### DIFF
--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -192,7 +192,7 @@ bool RCntxt::operator==(const RCntxt& other) const
 
    // Also equivalent if they refer to the same call at the same stack position and have the same
    // source references
-   if (!other.isNull() &&
+   if (other.isNull() == isNull() &&
        other.call() == call() &&
        other.evaldepth() == evaldepth() &&
        other.srcref() == srcref())

--- a/src/cpp/r/RCntxt.cpp
+++ b/src/cpp/r/RCntxt.cpp
@@ -192,7 +192,8 @@ bool RCntxt::operator==(const RCntxt& other) const
 
    // Also equivalent if they refer to the same call at the same stack position and have the same
    // source references
-   if (other.call() == call() && 
+   if (!other.isNull() &&
+       other.call() == call() &&
        other.evaldepth() == evaldepth() &&
        other.srcref() == srcref())
       return true;

--- a/version/news/NEWS-2022.02.3-prairie-trillium.md
+++ b/version/news/NEWS-2022.02.3-prairie-trillium.md
@@ -1,5 +1,8 @@
 ## RStudio 2022-02.3 "Prairie Trillium" Release Notes
 
+### R
+* Fixed issue in R debugger that caused RStudio to lose focus out of source code when interacting with the console in certain ways, such as evaluating an expression (#10664)
+
 ### Ubuntu 22.04 ("Jammy") and Fedora 35 Compatibility
 
 * Ubuntu Jammy builds of RStudio using libssl3 to enable installation on Ubuntu Jammy Jellyfish 22.04 LTS (#10902)


### PR DESCRIPTION
### Intent

PRs #9922 and #10238 changed the definition of equality used by the debugger to check the context stack. However, this change introduced a new regression, described in #10664 . This small change fixes the original issues (#9918 and #10045) while also resolving the new regression (10664)

### Approach

Add one more constraint to the equality test -- check if other isNull(). Original equality test was too strict, then it became too liberal, hoping it is now juuuuuust right

Needs PT backport

### Automated Tests

No new tests added. Will ensure that [ide-automation#497](https://github.com/rstudio/rstudio-ide-automation/issues/497) still passes.

### QA Notes

Test the reprexes in all three linked issues:
#9918 
#10045
#10664 


