### PR TITLE
Companion commit for server side of activity state changes

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -36,6 +36,34 @@ namespace rstudio {
 namespace core {
 namespace r_util {
 
+// Transitional states - set in the activeSession metadata when rpc requests are made to change the state
+//   These will override the job launcher state.
+static const std::string kActivityStateResuming = "resuming";
+static const std::string kActivityStateSuspending = "suspending";
+static const std::string kActivityStateShuttingDown = "shutting_down";
+static const std::string kActivityStateQuitting = "quitting";
+
+// Running states: launching -> pending -> running
+// launch request received, new session url allocated
+static const std::string kActivityStateLaunching = "launching";
+// job status returned as Pending
+static const std::string kActivityStatePending = "pending";
+// job status is Running when Launching/Pending, before rsession reports running
+static const std::string kActivityStateStarting = "starting";
+// job status returned as Running or for R sessions, beginSession called by rsession
+static const std::string kActivityStateRunning = "running";
+// Session completes the suspend
+static const std::string kActivityStateSaved = "saved";
+// Session marks itself finished
+static const std::string kActivityStateEnded = "ended";
+
+// Exited states - job/process is not running
+static const std::string kActivityStateSuspended = "suspended";
+static const std::string kActivityStateFailed = "failed";
+static const std::string kActivityStateCanceled = "canceled";
+static const std::string kActivityStateFinished = "finished";
+static const std::string kActivityStateKilled = "killed";
+
 class ActiveSession : boost::noncopyable
 {
 private:
@@ -76,11 +104,32 @@ private:
    const std::string kRVersionHome = "r_version_home";
    const std::string kRVersionLabel = "r_version_label";
    const std::string kWorkingDir = "working_directory";
+   const std::string kActivityState = "activity_state";
+   const std::string kLastStateUpdated = "last_state_updated";
+   const std::string kEditor = "editor";
    const std::string kLastResumed = "last_resumed";
    const std::string kSuspendTimestamp = "suspend_timestamp";
    const std::string kBlockingSuspend = "blocking_suspend";
 
  public:
+
+   // The rsession process has exited with an exit code
+   static bool isExitedState(const std::string& state)
+   {
+      return state == kActivityStateFailed || state == kActivityStateCanceled ||
+             state == kActivityStateFinished || state == kActivityStateSuspended || state == kActivityStateKilled;
+   }
+
+   // The rsession has marked itself as saved/ended or the process is exited
+   static bool isSessionEndedState(const std::string& state)
+   {
+      return isExitedState(state) || state == kActivityStateEnded || state == kActivityStateSaved;
+   }
+
+   static bool isTransitionState(const std::string& state)
+   {
+      return state == kActivityStateSuspending || state == kActivityStateShuttingDown || state == kActivityStateQuitting || state == kActivityStateResuming;
+   }
 
    bool empty() const { return scratchPath_.isEmpty(); }
 
@@ -101,7 +150,7 @@ private:
       return value;
    }
 
-   void writeProperty(const std::string& propertyName, const std::string& value)
+   void writeProperty(const std::string& propertyName, const std::string& value) const
    {
       if (!empty())
       {
@@ -129,6 +178,31 @@ private:
    void setWorkingDir(const std::string& workingDir)
    {
       writeProperty(kWorkingDir, workingDir);
+   }
+
+   std::string activityState() const
+   {
+      return readProperty(kActivityState);
+   }
+
+   void setActivityState(const std::string& activityState, bool isTransition)
+   {
+      writeProperty(kActivityState, activityState);
+      if (isTransition)
+         setLastStateUpdated();
+   }
+
+   std::string editor() const
+   {
+      std::string res = readProperty(kEditor);
+      if (res == "") // If resuming a session saved before this field was added
+         res = kWorkbenchRStudio;
+      return res;
+   }
+
+   void setEditor(const std::string& editor)
+   {
+      writeProperty(kEditor, editor);
    }
 
    bool initial() const
@@ -193,6 +267,31 @@ private:
    void setLastUsed()
    {
       setTimestampProperty(kLastUsed);
+   }
+
+   double lastStateUpdated() const
+   {
+      return timestampProperty(kLastStateUpdated);
+   }
+
+   void setLastStateUpdated()
+   {
+      setTimestampProperty(kLastStateUpdated);
+   }
+
+   double created() const
+   {
+      return timestampProperty("created");
+   }
+
+   boost::posix_time::ptime createdTime() const
+   {
+      return ptimeTimestampProperty("created");
+   }
+
+   void setCreated()
+   {
+      setTimestampProperty("created");
    }
 
    bool executing() const
@@ -281,6 +380,7 @@ private:
       setLastUsed();
       setRunning(true);
       setRVersion(rVersion, rVersionHome, rVersionLabel);
+      setActivityState(kActivityStateRunning, true);
    }
 
    void endSession()
@@ -288,6 +388,14 @@ private:
       setLastUsed();
       setRunning(false);
       setExecuting(false);
+      std::string curState = activityState();
+      if (!isSessionEndedState(curState))
+      {
+         LOG_DEBUG_MESSAGE("Ending session: " + id() + " changing activityState to ended from: " + curState);
+         setActivityState(kActivityStateEnded, true);
+      }
+      else
+         LOG_DEBUG_MESSAGE("Ending session: " + id() + " with previous activityState: " + curState);
    }
 
    uintmax_t suspendSize()
@@ -302,7 +410,10 @@ private:
    core::Error destroy()
    {
       if (!empty())
+      {
+         LOG_DEBUG_MESSAGE("Removing session directory: " + scratchPath_.getAbsolutePath());
          return scratchPath_.removeIfExists();
+      }
       else
          return Success();
    }
@@ -311,32 +422,58 @@ private:
                  bool projectSharingEnabled) const
    {
       // ensure the scratch path and properties paths exist
-      if (!scratchPath_.exists() || !propertiesPath_.exists())
-         return false;
-
-      // ensure the properties are there
-      if (project().empty() || workingDir().empty() || (lastUsed() == 0))
-          return false;
-
-      // for projects validate that the base directory still exists
-      std::string theProject = project();
-      if (theProject != kProjectNone)
+      if (!scratchPath_.exists())
       {
-         FilePath projectDir = FilePath::resolveAliasedPath(theProject,
-                                                            userHomePath);
-         if (!projectDir.exists())
-            return false;
+         LOG_DEBUG_MESSAGE("ActiveSession validation failed: " + scratchPath_.getAbsolutePath() + " not accessible to the session user");
+         return false;
+      }
 
-        // check for project file
-        FilePath projectPath = r_util::projectFromDirectory(projectDir);
-        if (!projectPath.exists())
-           return false;
+      if (!propertiesPath_.exists())
+      {
+         LOG_DEBUG_MESSAGE("ActiveSession validation failed: " + propertiesPath_.getAbsolutePath() + " not accessible to the session user");
+         return false;
+      }
 
-        // if we got this far the scope is valid, do one final check for
-        // trying to open a shared project if sharing is disabled
-        if (!projectSharingEnabled &&
-            r_util::isSharedPath(projectPath.getAbsolutePath(), userHomePath))
-           return false;
+      bool isRSession = editor() == kWorkbenchRStudio || editor().empty();
+
+      if (isRSession)
+      {
+         // ensure the properties are there
+         if (project().empty() || workingDir().empty() || (lastUsed() == 0))
+         {
+            LOG_DEBUG_MESSAGE("ActiveSession validation failed: project info missing");
+             return false;
+         }
+
+         // for projects validate that the base directory still exists
+         std::string theProject = project();
+         if (theProject != kProjectNone)
+         {
+            FilePath projectDir = FilePath::resolveAliasedPath(theProject,
+                                                               userHomePath);
+            if (!projectDir.exists())
+            {
+               LOG_DEBUG_MESSAGE("ActiveSession validation failed: project directory: " + projectDir.getAbsolutePath() + " not accessible to the session user");
+               return false;
+            }
+
+           // check for project file
+           FilePath projectPath = r_util::projectFromDirectory(projectDir);
+           if (!projectPath.exists())
+           {
+              LOG_DEBUG_MESSAGE("ActiveSession validation failed: project path: " + projectPath.getAbsolutePath() + " not accessible to the session user");
+              return false;
+           }
+
+           // if we got this far the scope is valid, do one final check for
+           // trying to open a shared project if sharing is disabled
+           if (!projectSharingEnabled &&
+               r_util::isSharedPath(projectPath.getAbsolutePath(), userHomePath))
+           {
+              LOG_DEBUG_MESSAGE("ActiveSession validation failed. Project is shared but system has disabled project sharing for project: " + projectPath.getAbsolutePath());
+              return false;
+           }
+         }
       }
 
       // validated!
@@ -446,6 +583,7 @@ private:
          writeProperty(kRunning, value);
    }
 
+private:
    std::shared_ptr<IActiveSessionStorage> storage_;
    std::string id_;
    FilePath scratchPath_;
@@ -473,12 +611,13 @@ public:
                       const std::string& working,
                       std::string* pId) const
    {
-      return create(project, working, true, pId);
+      return create(project, working, true, kWorkbenchRStudio, pId);
    }
 
    core::Error create(const std::string& project,
                       const std::string& working,
                       bool initial,
+                      const std::string& editor,
                       std::string* pId) const;
 
    std::vector<boost::shared_ptr<ActiveSession> > list(

--- a/src/cpp/core/include/core/r_util/RSessionContext.hpp
+++ b/src/cpp/core/include/core/r_util/RSessionContext.hpp
@@ -157,6 +157,8 @@ public:
 
    static SessionScope vscodeSession(const std::string& id);
 
+   static SessionScope fromSessionId(const std::string &id, const std::string& editor);
+
    SessionScope()
    {
    }

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -115,6 +115,18 @@ SessionScope SessionScope::vscodeSession(const std::string& id)
    return SessionScope(ProjectId(kVSCodeId), id);
 }
 
+SessionScope SessionScope::fromSessionId(const std::string& id, const std::string& editor)
+{
+   if (editor == kWorkbenchJupyterLab)
+      return jupyterLabSession(id);
+   else if (editor == kWorkbenchJupyterNotebook)
+      return jupyterNotebookSession(id);
+   else if (editor == kWorkbenchVSCode)
+      return vscodeSession(id);
+   else
+      return projectNone(id);
+}
+
 bool SessionScope::isProjectNone() const
 {
    return project_.id() == kProjectNoneId;

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -266,6 +266,8 @@ bool browserContextActive();
 // quit
 void quit(bool saveWorkspace, int status = EXIT_SUCCESS);
 
+void setResumeCallbacks(boost::function<void()> before, boost::function<void()> after);
+
 } // namespace session
 } // namespace r
 } // namespace rstudio


### PR DESCRIPTION
 - editor, lastStateUpdated, and activityState properties to session metadata
 - suspend/resume callbacks so the session can update the activity state at the right time

Reviewed in workbench PR: https://github.com/rstudio/rstudio-pro/pull/3408