### PR TITLE
don't remove empty lines of code -- we need them for the source code markers

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2243,7 +2243,7 @@
       return(NULL)
    # If Quarto and no R code chunks, don't parse further
    # Rmd may have yaml front matter to parse even if no R chunks
-   if (identical(code, .rs.scalar("")) && identical(extension, ".qmd"))
+   if (identical(gsub("\n", "", code), .rs.scalar("")) && identical(extension, ".qmd"))
       return(NULL)
 
    # attempt to parse extracted R code

--- a/src/cpp/session/modules/SessionDiagnostics.R
+++ b/src/cpp/session/modules/SessionDiagnostics.R
@@ -149,7 +149,6 @@
 
       new[(start + 1):(end - 1)] <- splat[(start + 1):(end - 1)]
    }
-   new <- new[new != ""]
    .rs.scalar(paste(new, collapse = "\n"))
 })
 


### PR DESCRIPTION
### Intent

I made a whoopsie! When I made [this change ](https://github.com/rstudio/rstudio/pull/10864), I filtered out empty lines because they were empty, so we don't need to check whether or not they contain R code. That was a mistake, because we DO need them in order to make sure the diagnostic source code markers in the gutter actually line up with the appropriate code line, which means they need to include the blank spaces. We should filter them out only later, when we are checking for the existence of R code, rather than in SessionDiagnostics.R

### Approach

Remove 1 silly line of code so we don't filter out blanks. Filter out the newline characters later instead

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Test that diagnostic code markers show up on the correct line. Also retest the issue from the original PR [pro#3310](https://github.com/rstudio/rstudio-pro/issues/3310) but this is probably unnecessary

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


