### PR TITLE
Make newly created SSH key the preferred key

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
@@ -108,6 +108,10 @@ public class CreateKeyDialog extends ModalDialog<CreateKeyOptions>
                                  // close the dialog
                                  indicator.onCompleted();
 
+                                 // set the value of rsa_key_path in computed user prefs layer to newly created file
+                                 UserPrefs uiPrefs = RStudioGinjector.INSTANCE.getUserPrefs();
+                                 uiPrefs.rsaKeyPath().setValue("computed", input.getPath());
+
                                  // update the key path
                                  if (res.getExitStatus() == 0)
                                     onCompleted.execute(input.getPath());


### PR DESCRIPTION
### Intent

Follow up to #8255. Address issue that @romainfrancois raised during testing. There was previously no connection between the SSH key you just created, and the SSH key that would be chosen (based on the computed user preference) when you re-open the Global options pane. Update so that the key you just created takes precedence, no session restart necessary.

### Approach

On successful response to RPC call creating the SSH key, reset the computed user preference to point to the new key.

### Automated Tests

None

### QA Notes

Can follow Romain's test plan in the #8255 [comments](https://github.com/rstudio/rstudio/issues/8255#issuecomment-1117141856). 
Create new SSH key. Close and re-open Global options pane, check that SSH key path and View public key file point to the newly created key, and not the old one you had before.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


