### PR TITLE
Fix to support a chain of proxy servers in front of RStudio server. 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,7 @@
 - Add back link to the title of sessions so that users can easily open sessions in new tabs and copy session links (rstudio-pro#3290)
 - (Linux Only) License-manager now works in a installer-less context (rstudio-pro#3150)
 - Fixed an issue where R raw strings were not highlighted correctly in R Markdown documents. (#11087)
+- Fixed issue with using RStudio server behind multi-level proxy servers (#11010)
 
 ### RStudio Workbench
 

--- a/src/cpp/core/http/Request.cpp
+++ b/src/cpp/core/http/Request.cpp
@@ -93,6 +93,19 @@ std::string Request::rootPath() const
    return rootPathHeader;
 }
 
+std::string firstInList(const std::string& input)
+{
+   std::string res;
+
+   // Take the first if there's a list
+   std::size_t pos = input.find(',');
+   if (pos != std::string::npos)
+      res = input.substr(0, pos);
+   else
+      res = input;
+   return res;
+}
+
 std::string Request::proxiedUri() const
 {
    // if using the product-specific header use it
@@ -139,15 +152,24 @@ std::string Request::proxiedUri() const
    {
       protocol = "http";
    }
+   else
+   {
+      protocol = firstInList(protocol);
+   }
+
 
    // might be using the legacy X-Forwarded headers
    std::string forwardedHost = headerValue("X-Forwarded-Host");
    if (!forwardedHost.empty())
    {
+      forwardedHost = firstInList(forwardedHost);
+
       // get the port that may be specified in the request
       std::string port = headerValue("X-Forwarded-Port");
       if (!port.empty())
       {
+         port = firstInList(port);
+
          std::size_t pos = forwardedHost.find(':');
          if (pos == std::string::npos)
          {


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio/issues/11010

### Approach

The first one in the comma separated list will be the first proxy in the chain, i.e. the
one that matches the browser's URL and the one we should use for redirects. 

### Automated Tests

This is a fairly easy fix and not that common so I propose we skip automation.

### QA Notes

### Checklist

- [x ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


