### PR TITLE
add option to use web dialogs on Electron desktop

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -404,6 +404,7 @@ namespace prefs {
 #define kUiLanguage "ui_language"
 #define kUiLanguageEn "en"
 #define kUiLanguageFr "fr"
+#define kNativeFileDialogs "native_file_dialogs"
 
 class UserPrefValues: public Preferences
 {
@@ -1812,6 +1813,12 @@ public:
     */
    std::string uiLanguage();
    core::Error setUiLanguage(std::string val);
+
+   /**
+    * Whether RStudio Desktop will use operating system File and Message dialog boxes.
+    */
+   bool nativeFileDialogs();
+   core::Error setNativeFileDialogs(bool val);
 
 };
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3065,6 +3065,19 @@ core::Error UserPrefValues::setUiLanguage(std::string val)
    return writePref("ui_language", val);
 }
 
+/**
+ * Whether RStudio Desktop will use operating system File and Message dialog boxes.
+ */
+bool UserPrefValues::nativeFileDialogs()
+{
+   return readPref<bool>("native_file_dialogs");
+}
+
+core::Error UserPrefValues::setNativeFileDialogs(bool val)
+{
+   return writePref("native_file_dialogs", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3302,6 +3315,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kPythonProjectEnvironmentAutomaticActivate,
       kCheckNullExternalPointers,
       kUiLanguage,
+      kNativeFileDialogs,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1596,6 +1596,12 @@
             "default": "en",
             "title": "User Interface Language",
             "description": "The IDE's user-interface language."
+        },
+        "native_file_dialogs": {
+            "description": "Whether RStudio Desktop will use operating system File and Message dialog boxes.",
+            "title": "Use operating system File and Message dialog boxes",
+            "type": "boolean",
+            "default": true
         }
     }
 }

--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -47,6 +47,24 @@
       return window.navigator.userAgent.indexOf("Electron") > 0 ? "true" : "false";
    ]]></property-provider>
 
+   <!-- Detect option to stop use of native OS file dialogs on Electron Desktop -->
+   <define-property name="rstudio.nativedialogs" values="true,false"/>
+   <property-provider name="rstudio.nativedialogs"><![CDATA[
+      try {
+         if (window.navigator.userAgent.indexOf("Electron") > 0) {
+            var cookieArr = window.document.cookie.split(";");
+            for( var i = 0; i < cookieArr.length; i++) {
+               var cookiePair = cookieArr[i].split("=");
+               if ('WEBDIALOG' === cookiePair[0].trim().toUpperCase()) {
+                  return "false";
+               }
+            }
+         }
+      } catch (e) {
+         console.error(e);
+      }
+      return "true";
+   ]]></property-provider>
 
    <!-- Set the user agent. Note that we no longer support older IE. -->
    <!-- Note that 'safari' here is effectively an alias for modern browsers. -->
@@ -77,6 +95,7 @@
       <when-type-is class="org.rstudio.studio.client.common.FileDialogs" />
       <all>
          <when-property-is name="rstudio.desktop" value="true"/>
+         <when-property-is name="rstudio.nativedialogs" value="true"/>
          <when-property-is name="rstudio.remoteDesktop" value="false"/>
       </all>
    </replace-with>
@@ -96,6 +115,7 @@
       <when-type-is class="org.rstudio.studio.client.workbench.views.packages.CRANChooser"/>
       <all>
          <when-property-is name="rstudio.desktop" value="true"/>
+         <when-property-is name="rstudio.nativedialogs" value="true"/>
          <when-property-is name="rstudio.remoteDesktop" value="false"/>
       </all>
    </replace-with>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3349,6 +3349,18 @@ public class UserPrefsAccessor extends Prefs
    public final static String UI_LANGUAGE_EN = "en";
    public final static String UI_LANGUAGE_FR = "fr";
 
+   /**
+    * Whether RStudio Desktop will use operating system File and Message dialog boxes.
+    */
+   public PrefValue<Boolean> nativeFileDialogs()
+   {
+      return bool(
+         "native_file_dialogs",
+         _constants.nativeFileDialogsTitle(), 
+         _constants.nativeFileDialogsDescription(), 
+         true);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -3819,6 +3831,8 @@ public class UserPrefsAccessor extends Prefs
          checkNullExternalPointers().setValue(layer, source.getBool("check_null_external_pointers"));
       if (source.hasKey("ui_language"))
          uiLanguage().setValue(layer, source.getString("ui_language"));
+      if (source.hasKey("native_file_dialogs"))
+         nativeFileDialogs().setValue(layer, source.getBool("native_file_dialogs"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -4057,6 +4071,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(pythonProjectEnvironmentAutomaticActivate());
       prefs.add(checkNullExternalPointers());
       prefs.add(uiLanguage());
+      prefs.add(nativeFileDialogs());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1943,6 +1943,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    @DefaultStringValue("The IDE's user-interface language.")
    String uiLanguageDescription();
 
+   /**
+    * Whether RStudio Desktop will use operating system File and Message dialog boxes.
+    */
+   @DefaultStringValue("Use operating system File and Message dialog boxes")
+   String nativeFileDialogsTitle();
+   @DefaultStringValue("Whether RStudio Desktop will use operating system File and Message dialog boxes.")
+   String nativeFileDialogsDescription();
+
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -977,4 +977,8 @@ checkNullExternalPointersDescription = When enabled, RStudio will detect R objec
 uiLanguageTitle = User Interface Language
 uiLanguageDescription = The IDE's user-interface language.
 
+# Whether RStudio Desktop will use operating system File and Message dialog boxes.
+nativeFileDialogsTitle = Use operating system File and Message dialog boxes
+nativeFileDialogsDescription = Whether RStudio Desktop will use operating system File and Message dialog boxes.
+
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/WebDialogCookie.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/WebDialogCookie.java
@@ -1,0 +1,51 @@
+/*
+ * WebDialogCookie.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.prefs.model;
+
+import com.google.gwt.user.client.Cookies;
+import org.rstudio.core.client.StringUtil;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Manage cookie used to tell GWT to use web-based dialogs for picking files and folders, and showing messages, 
+ * on Desktop (instead of the default operating-system native dialogs).
+ */
+public class WebDialogCookie
+{
+   /**
+    * @return Whether cookie requesting use of web-based dialog boxes is set
+    */
+   public static boolean getUseWebDialogs()
+   {
+      return !StringUtil.isNullOrEmpty(Cookies.getCookie(WEB_DIALOG_COOKIE));
+   }
+
+   /**
+    * Set/unset the cookie requesting use of web-based dialog boxes
+    * @param useWebDialogs
+    */
+   @SuppressWarnings("deprecation") // Date is deprecated but the replacement isn't available in GWT
+   public static void setUseWebDialogs(boolean useWebDialogs)
+   {
+      if (useWebDialogs)
+         Cookies.setCookie(WEB_DIALOG_COOKIE, "1", new Date(5000, Calendar.DECEMBER, 31, 18, 0));
+      else
+         Cookies.removeCookie(WEB_DIALOG_COOKIE);
+   }
+
+   private static final String WEB_DIALOG_COOKIE = "WEBDIALOG";
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -57,6 +57,7 @@ import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Label;
 import com.google.inject.Inject;
+import org.rstudio.studio.client.workbench.prefs.model.WebDialogCookie;
 
 public class GeneralPreferencesPane extends PreferencesPane
 {
@@ -339,6 +340,11 @@ public class GeneralPreferencesPane extends PreferencesPane
 
          fullPathInTitle_ = new CheckBox(constants_.fullProjectPathInWindowTitleLabel());
          advanced.add(lessSpaced(fullPathInTitle_));
+         if (BrowseCap.isElectron())
+         {
+            nativeFileDialogs_ = checkboxPref(prefs_.nativeFileDialogs());
+            advanced.add(nativeFileDialogs_);
+         }
       }
 
       Label otherLabel = headerLabel(constants_.otherLabel());
@@ -487,8 +493,8 @@ public class GeneralPreferencesPane extends PreferencesPane
       graphicsAntialias_.setValue(prefs.graphicsAntialiasing().getValue());
 
       initialUiLanguage_ = prefs_.uiLanguage().getValue();
+      initialNativeFileDialogs_ = prefs_.nativeFileDialogs().getValue();
    }
-
 
    @Override
    public ImageResource getIcon()
@@ -580,6 +586,23 @@ public class GeneralPreferencesPane extends PreferencesPane
       {
          LocaleCookie.setUiLanguage(uiLanguagePrefValue);
          restartRequirement.setUiReloadRequired(true);
+      }
+
+      if (BrowseCap.isElectron())
+      {
+         boolean useNativeDialogsPrefValue = nativeFileDialogs_.getValue();
+         if (useNativeDialogsPrefValue != initialNativeFileDialogs_)
+         {
+            restartRequirement.setUiReloadRequired(true);
+         }
+
+         // The uiLanguage preference is mirrored in a cookie telling GWT which language to display.
+         // Ensure consistency here and force a page reload if necessary.
+         if (WebDialogCookie.getUseWebDialogs() != useNativeDialogsPrefValue)
+         {
+            WebDialogCookie.setUseWebDialogs(useNativeDialogsPrefValue);
+            restartRequirement.setUiReloadRequired(true);
+         }
       }
 
       // Pro specific
@@ -680,6 +703,7 @@ public class GeneralPreferencesPane extends PreferencesPane
    private SelectWidget uiLanguage_;
    private CheckBox clipboardMonitoring_ = null;
    private CheckBox fullPathInTitle_ = null;
+   private CheckBox nativeFileDialogs_ = null;
    private CheckBox useGpuExclusions_ = null;
    private CheckBox useGpuDriverBugWorkarounds_ = null;
    private SelectWidget renderingEngineWidget_ = null;
@@ -702,4 +726,5 @@ public class GeneralPreferencesPane extends PreferencesPane
    private final UserPrefs prefs_;
    private final Session session_;
    private String initialUiLanguage_;
+   private boolean initialNativeFileDialogs_;
 }


### PR DESCRIPTION
### Intent

Addresses #11184

This is intended both to provide a workaround for an Electron bug with File dialogs on Linux, and as a way to leverage more of our existing Selenium automation for Electron.

### Approach

On Electron desktop, added new user preference to the General / Advanced / OS Integration settings (the default is "on", matching current behaviour):

![Screen Shot 2022-05-11 at 4 42 48 PM](https://user-images.githubusercontent.com/10569626/167959401-515aaee4-ec8c-4245-82d5-7c0e6cf75d02.png)

When unchecked, a cookie is set and the page is refreshed, and GWT detects this cookie and changes to use the web-based dialogs instead of the native ones.

This isn't actually breaking (much) new ground, as we already do this in Desktop Pro when connected to a server.

For example, here's Mac Electron IDE showing result of File / Open when this option was unchecked.

![Screen Shot 2022-05-11 at 4 45 13 PM](https://user-images.githubusercontent.com/10569626/167959584-2931b84c-3cee-4bce-9d87-650a239e0fb7.png)

Versus the normal default behaviour:

![Screen Shot 2022-05-11 at 4 45 39 PM](https://user-images.githubusercontent.com/10569626/167959603-b00ee826-0e69-4a3c-b128-6f24b1b7b4a0.png)

### Automated Tests

N/A

### QA Notes

Check that with Electron Desktop that operations such as File / Open File, File / Open Project, and any other entrypoints that bring up filesystem browsing dialogs obey this setting.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


