### PR TITLE
Update the `have_rsa_key` to true property when a ssh key is created

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/CreateKeyDialog.java
@@ -111,6 +111,7 @@ public class CreateKeyDialog extends ModalDialog<CreateKeyOptions>
                                  // set the value of rsa_key_path in computed user prefs layer to newly created file
                                  UserPrefs uiPrefs = RStudioGinjector.INSTANCE.getUserPrefs();
                                  uiPrefs.rsaKeyPath().setValue("computed", input.getPath());
+                                 uiPrefs.haveRsaKey().setValue("computed", true);
 
                                  // update the key path
                                  if (res.getExitStatus() == 0)


### PR DESCRIPTION
### Intent

Follow up to #11182, adresses #8255

### Approach

In #11182 we updated the "rsa_key_path" property, but we also need to update the "have_rsa_key", otherwise it's only set in `UserPrefsComputedLayer::readPrefs()`. 

This PR sets it to `true` 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


