### PR TITLE
Outline uses quarto style labels, `#| label: <name>`

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -800,7 +800,7 @@ var RCodeModel = function(session, tokenizer,
          {
             var value = tok.value;
             
-            var labelRegex = /^#\| *label *: *(.*)$/;
+            var labelRegex = /^#\|\s*label\s*:\s*(.*)$/;
             if (labelRegex.test(value))
                return value.replace(labelRegex, "$1");
             

--- a/src/gwt/acesupport/acemode/r_scope_tree.js
+++ b/src/gwt/acesupport/acemode/r_scope_tree.js
@@ -92,7 +92,6 @@ define('mode/r_scope_tree', ["require", "exports", "module"], function(require, 
       this.isChunk = function() { return this.scopeType == ScopeNode.TYPE_CHUNK; };
       this.isSection = function() { return this.scopeType == ScopeNode.TYPE_SECTION; };
       this.isFunction = function() { return this.isBrace() && !!this.attributes.args; };
-      this.isTest = function() { return this.isBrace() && this.attributes.type == "test"; };
       this.isTest = function() { return this.isBrace() && this.attributes.type === "test"; };
 
       this.equals = function(node) {

--- a/src/gwt/panmirror/src/editor/src/api/rmd.ts
+++ b/src/gwt/panmirror/src/editor/src/api/rmd.ts
@@ -240,7 +240,7 @@ export function rmdChunkEngineAndLabel(text: string) {
       };
     }
 
-    // Finally, look for magic label comments: 
+    // Finally, look for label in #| comments
     // 
     // ```{r}
     // #| label: label

--- a/src/gwt/panmirror/src/editor/src/api/rmd.ts
+++ b/src/gwt/panmirror/src/editor/src/api/rmd.ts
@@ -220,23 +220,43 @@ export function mergeRmdChunks(chunks: EditorRmdChunk[]) {
  * @returns An object with `engine` and `label` properties, or null.
  */
 export function rmdChunkEngineAndLabel(text: string) {
-  // Match the engine and label with a regex
-  const match = text.match(/^\{([a-zA-Z0-9_]+)[\s,]+([a-zA-Z0-9/._='"-]+)/);
+
+  // Match the engine and (maybe the) label with a regex
+  const match = text.match(/^\{([a-zA-Z0-9_]+)[\s,]*([a-zA-Z0-9/._='"-]*)/);
+  
   if (match) {
+    // The first capturing group is the engine
+    const engine = match[1];
+
     // The second capturing group in the regex matches the first string after
-    // the engine. This might be a label (e.g., {r label}), but could also be
-    // a chunk option (e.g., {r echo=FALSE}). If it has an =, presume that it's
-    // an option.
-    if (match[2].indexOf("=") !== -1) {
-      return null;
+    // the engine. This might be: 
+    // - a label (e.g., {r label})
+    // - a chunk option (e.g., {r echo=FALSE}). If it has an =, presume that it's an option.
+    // - empty
+    if (match[2].length && match[2].indexOf("=") == -1) {
+      return {
+        engine: engine,
+        label: match[2],
+      };
     }
-    return {
-      engine: match[1],
-      label: match[2],
-    };
-  } else {
-    return null;
+
+    // Finally, look for magic label comments: 
+    // 
+    // ```{r}
+    // #| label: label
+    // 
+    for (var line of text.split("\n")) {
+      const labelMatch = line.match(/^#\|\s*label:\s+(.*)$/);
+      if (labelMatch) {
+        return {
+          engine: engine,
+          label: labelMatch[1],
+        };
+      }
+    }
   }
+
+  return null;
 }
 
 export function haveTableCellsWithInlineRcode(doc: ProsemirrorNode) {


### PR DESCRIPTION
### Intent

addresses #10473

### Approach

Improve `getChunkLabel()` so that it looks for `#| label:` after the opening of the scope. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Open this quarto document: 

````
---
title: Test Quarto
---

# Test

## heading 2

```{r}
#| label: foo
1 + 1
```

```{r}
#| label: bar
2 + 3
```
````

The chunk labels should be displayed in the source and visual editors: 

<img width="858" alt="image" src="https://user-images.githubusercontent.com/2625526/168235376-986b5524-38a9-4e33-a53f-5af30d5ecf6d.png">

<img width="857" alt="image" src="https://user-images.githubusercontent.com/2625526/168235439-0076b91f-4a36-4c68-ae05-5106b44d87a8.png">


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


