### PR TITLE
remove unused gwt class replacements

### DIFF
--- a/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
+++ b/src/gwt/src/org/rstudio/studio/RStudio.gwt.xml
@@ -108,25 +108,6 @@
       <when-property-is name="rstudio.desktop" value="true"/>
    </replace-with>
 
-   <replace-with class="org.rstudio.studio.client.workbench.views.packages.impl.WebCRANChooser">
-      <when-type-is class="org.rstudio.studio.client.workbench.views.packages.CRANChooser"/>
-   </replace-with>
-   <replace-with class="org.rstudio.studio.client.workbench.views.packages.impl.DesktopCRANChooser">
-      <when-type-is class="org.rstudio.studio.client.workbench.views.packages.CRANChooser"/>
-      <all>
-         <when-property-is name="rstudio.desktop" value="true"/>
-         <when-property-is name="rstudio.remoteDesktop" value="false"/>
-      </all>
-   </replace-with>
-
-   <replace-with class="org.rstudio.studio.client.workbench.views.plots.ui.impl.WebActionsWidget">
-      <when-type-is class="org.rstudio.studio.client.workbench.views.plots.ui.ActionsWidget"/>
-   </replace-with>
-   <replace-with class="org.rstudio.studio.client.workbench.views.plots.ui.impl.DesktopActionsWidget">
-      <when-type-is class="org.rstudio.studio.client.workbench.views.plots.ui.ActionsWidget"/>
-      <when-property-is name="rstudio.desktop" value="true"/>
-   </replace-with>
-
     <replace-with class="org.rstudio.studio.client.workbench.views.plots.ui.export.impl.ExportPlotWeb">
        <when-type-is class="org.rstudio.studio.client.workbench.views.plots.ui.export.ExportPlot"/>
     </replace-with>


### PR DESCRIPTION
### Intent

Cleanup unused class replacements in RStudio.gwt.xml.

### Approach

Confirmed the GWT codebase (including pro/workbench) doesn't include any of `WebCRANChooser`, `CRANChooser`, `DesktopCRANChooser `, `ActionsWidget `, `DesktopActionsWidget`, or `WebActionsWidget ` and removed from RStudio.gwt.xml.
 
### Automated Tests

N/A

### QA Notes

Nothing to test here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


