### PR TITLE
Addresses handling of native pipe args with no placeholder

### DIFF
--- a/src/cpp/core/include/core/r_util/RTokenizer.hpp
+++ b/src/cpp/core/include/core/r_util/RTokenizer.hpp
@@ -562,7 +562,9 @@ inline bool canFollowBinaryOperator(const RToken& rToken)
 
 inline bool isPipeOperator(const RToken& rToken)
 {
-   static const boost::wregex rePipe(L"^%[^>]*>+[^>]*%$");
+   // We're intentionally liberal here about what constitutes a pipe operator as we allow an arbitrary
+   // user-defined binary operator containing any symbols between the two % % (must contain at least one >)
+   static const boost::wregex rePipe(L"^(%[^>]*>+[^>]*%)|([|]>)$");
    return regex_utils::match(rToken.begin(), rToken.end(), rePipe);
 }
 

--- a/src/cpp/core/r_util/RTokenCursorTests.cpp
+++ b/src/cpp/core/r_util/RTokenCursorTests.cpp
@@ -24,7 +24,7 @@ using namespace core::r_util::token_cursor;
 
 bool isPipeOperator(const std::wstring& string)
 {
-   static const boost::wregex rePipe(L"^%[^>]*>+[^>]*%$");
+   static const boost::wregex rePipe(L"^(%[^>]*>+[^>]*%)|([|]>)$");
    return regex_utils::match(string.begin(), string.end(), rePipe);
 }
 
@@ -77,6 +77,8 @@ test_context("RTokenCursor")
       expect_true(isPipeOperator(L"%>%"));
       expect_true(isPipeOperator(L"%>>%"));
       expect_true(isPipeOperator(L"%T>%"));
+      expect_true(isPipeOperator(L"|>"));
+      expect_false(isPipeOperator(L"%!%"));
       
       RTokens rTokens(L"mtcars %>% first_level() %>% second_level(1");
       RTokenCursor cursor(rTokens);


### PR DESCRIPTION
### Intent

Addresses #10124

### Approach

Do the same thing we do with the magrittr pipe, i.e. 1) update isPipeOperator to recognize `|>` as a valid pipe, 2) add to the list of unnamed arguments only if magrittr pipe is used without `.` or native pipe is used without `_`

### Automated Tests

Small tweaks to automated tests for isPipeOperator regex.

### QA Notes

With diagnostics turned on for "Check arguments to R function calls"

```
c(1,2,3) %% length()            # EXPECTED: warning (missing arg, because not a pipe)
c(1,2,3) %>% length()          # EXPECTED: no warning
c(1,2,3) %>% length(.)         # EXPECTED: no warning
c(1,2,3) |> length(_)              # EXPECTED: no warning
c(1,2,3) |> length()                # EXPECTED: no warning
c(1,2,3) |> cor(y = c(1,2,3))  # EXPECTED: no warning
cor(y = c(1,2,3))                    # EXPECTED: warning (missing arg)
length()                                  # EXPECTED: warning (missing arg)
c(1,2,3) |> length(.)               # EXPECTED: error (too many args, incompatible placeholder)
```

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


