### PR TITLE
Allow fallback unknown text file types to open in Desktop

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -607,12 +607,9 @@ public class FileTypeRegistry
    public FileType getTypeForFile(FileSystemItem file)
    {
       // last ditch default type -- see if this either a known text file type
-      // or (for server mode) NOT a known binary type. the result of this is
+      // or NOT a known binary type. the result of this is
       // that unknown files types are treated as text and opened in the editor
-      // (we don't do this on desktop because  in that case users have the
-      // recourse of using a local editor)
-      String defaultType = Desktop.isDesktop() ? "application/octet-stream" :
-                                                 "text/plain";
+      String defaultType = "text/plain";
       return getTypeForFile(file, defaultType);
    }
 


### PR DESCRIPTION
We already allow users to open these files from the File pane. We also already allow users to open these files from the Find in Files results pane in RStudio Server. We just haven't allowed users to open these from Find in Files results in RStudio Desktop. This seems to be overly strict.

### Intent

Addresses #10741

### Approach

Remove the Desktop/Server distinction and allow for normal opening of unknown text file types as plain text.

### Automated Tests

None

### QA Notes

See #10741

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


