### PR TITLE
use ucrtbase.dll with R 4.2.0 or newer

### DIFF
--- a/src/cpp/core/include/core/system/Win32RuntimeLibrary.hpp
+++ b/src/cpp/core/include/core/system/Win32RuntimeLibrary.hpp
@@ -18,8 +18,15 @@
 
 namespace rstudio {
 namespace core {
+class Error;
+} // end namespace core
+} // end namespace rstudio
+
+namespace rstudio {
+namespace core {
 namespace runtime {
 
+core::Error initialize(bool isUcrt);
 int errorNumber();
 
 } // end namespace runtime

--- a/src/cpp/core/system/Win32RuntimeLibrary.cpp
+++ b/src/cpp/core/system/Win32RuntimeLibrary.cpp
@@ -36,6 +36,12 @@ namespace runtime {
 
 namespace {
 
+// forward-declare
+class Library;
+
+// a handle to the runtime library now loaded
+Library* s_pRuntimeLibrary = nullptr;
+
 namespace defaults {
 int s_zero = 0;
 int* _errno() { return &s_zero; }
@@ -46,11 +52,11 @@ class Library : boost::noncopyable
 {
 public:
 
-   Library()
+   Library(const char* libraryName)
       : pLib_(nullptr),
         _errno(defaults::_errno)
    {
-      Error error = core::system::loadLibrary("msvcrt.dll", &pLib_);
+      Error error = core::system::loadLibrary(libraryName, &pLib_);
       if (error)
       {
          LOG_ERROR(error);
@@ -59,8 +65,6 @@ public:
 
       RS_LOAD_SYMBOL(_errno);
    }
-
-   int* (*_errno)(void);
 
    ~Library()
    {
@@ -76,18 +80,23 @@ public:
       CATCH_UNEXPECTED_EXCEPTION
    }
 
-private:
+public:
    void* pLib_;
+   int* (*_errno)(void);
 };
 
 Library& library()
 {
-   static Library instance;
-   return instance;
+   return *s_pRuntimeLibrary;
 }
 
 } // end anonymous namespace
 
+core::Error initialize(bool isUcrt)
+{
+   s_pRuntimeLibrary = new Library(isUcrt ? "ucrtbase.dll" : "msvcrt.dll");
+   return Success();
+}
 
 int errorNumber()
 {

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -501,7 +501,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
          LOG_ERROR(error);
 
       // initialize runtime library
-      rstudio::core::runtime::initialize(crt == "ucrt");
+      error = rstudio::core::runtime::initialize(crt == "ucrt");
+      if (error)
+         LOG_ERROR(error);
    }
 #endif
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -495,13 +495,13 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
 #ifdef _WIN32
    {
       // on Windows, check if we're using UCRT
+      // ignore errors here since older versions of R don't define
+      // the 'crt' memober on R.version
       std::string crt;
-      Error error = rstudio::r::exec::evaluateString("R.version$crt", &crt);
-      if (error)
-         LOG_ERROR(error);
+      rstudio::r::exec::evaluateString("R.version$crt", &crt);
 
       // initialize runtime library
-      error = rstudio::core::runtime::initialize(crt == "ucrt");
+      Error error = rstudio::core::runtime::initialize(crt == "ucrt");
       if (error)
          LOG_ERROR(error);
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11206.

### Approach

Newer versions of R will set errno in ucrtbase.dll, so read it from there instead of msvcrt.dll.

### Automated Tests

N/A

### QA Notes

Given a file with the contents:

```
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
AAAAAAAAAAHHHHHHHHHHHHHHHHHHHH
```

(Screaming is an important part of the test procedure)

- Open a file test.R, and paste these contents in,
- Try to save the file,
- Try File -> Open with Encoding -> UTF-8, and confirm the file contents did not change,
- Try file -> Open with Encoding -> ISO-8859-1, and confirm the file contents did not change.

Run this test with both R 4.2.0 and R 3.6.3, just to confirm we did indeed fix the issue with R 4.2.0, and didn't break anything for R 3.6.3.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

