### PR TITLE
open-source merge for rstudio-pro/pull/3450 (fedora 36 builds)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -242,6 +242,9 @@ try {
           [os: 'jammy',      arch: 'amd64',  flavor: 'server',   variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'desktop',  variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Jammy'],
+          [os: 'fedora36',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Fedora 36'],
+          [os: 'fedora36',   arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'Fedora 36'],
+          [os: 'fedora36',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Fedora 36'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'desktop',  variant: '',  package_os: 'RHEL 8']


### PR DESCRIPTION
Open source merge for https://github.com/rstudio/rstudio-pro/pull/3450.