### PR TITLE
tweak how compiler definitions are passed along to libclang

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -243,6 +243,9 @@ RToolsInfo::RToolsInfo(const std::string& name,
       environmentVars.push_back({"RTOOLS42_HOME", rtoolsPath});
 
       // undefine _MSC_VER, so that we can "pretend" to be gcc
+      // this is important for C++ libraries which might try to use
+      // MSVC-specific tools when _MSC_VER is defined (e.g. Eigen), which might
+      // not actually be defined or available in Rtools
       clangArgs.push_back("-U_MSC_VER");
 
       // set GNUC levels

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -242,6 +242,9 @@ RToolsInfo::RToolsInfo(const std::string& name,
       std::replace(rtoolsPath.begin(), rtoolsPath.end(), '/', '\\');
       environmentVars.push_back({"RTOOLS42_HOME", rtoolsPath});
 
+      // undefine _MSC_VER, so that we can "pretend" to be gcc
+      clangArgs.push_back("-U_MSC_VER");
+
       // set GNUC levels
       // (required for _mingw.h, which otherwise tries to use incompatible MSVC defines)
       clangArgs.push_back("-D__GNUC__=9");

--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -48,7 +48,7 @@
 .rs.addFunction("packagePCH", function(linkingTo)
 {
    linkingTo <- .rs.parseLinkingTo(linkingTo)
-   packages <- c("RcppArmadillo", "RcppEigen", "Rcpp11", "Rcpp")
+   packages <- c("RcppArmadillo", "RcppEigen", "Rcpp11", "Rcpp", "cpp11")
    for (package in packages)
       if (package %in% linkingTo)
          return(package)

--- a/src/cpp/session/modules/SessionClang.R
+++ b/src/cpp/session/modules/SessionClang.R
@@ -61,16 +61,38 @@
    
    linkingTo <- .rs.parseLinkingTo(linkingTo)
    for (pkg in linkingTo) {
-      includeDir <- system.file("include", package = pkg)
+      
+      includeDir <- if (identical(pkg, "R"))
+         R.home("include")
+      else
+         system.file("include", package = pkg)
+      
       if (file.exists(includeDir)) {
          includes <- c(
             includes,
             paste("-I", .rs.asBuildPath(includeDir), sep = "")
          )
       }
+      
    }
    
    includes
+})
+
+.rs.addFunction("includesForPackage", function(package)
+{
+   # find the package path
+   pkgPath <- find.package(package, quiet = TRUE)
+   if (!file.exists(pkgPath))
+      return(.rs.includesForLinkingTo(package))
+   
+   # read the description file
+   desc <- .rs.readPackageDescription(pkgPath)
+   if (is.null(desc$LinkingTo))
+      return(.rs.includesForLinkingTo(package))
+   
+   linkingTo <- paste(package, desc$LinkingTo, "R", sep = ", ")
+   .rs.includesForLinkingTo(linkingTo)
 })
 
 .rs.addFunction("asBuildPath", function(path)

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -162,8 +162,8 @@ std::string guessRcppPackage(const std::string& contents)
    if (regex_utils::search(contents, reRcpp11))
       return "Rcpp11";
 
-   // we need to pre-compiled RcppArmadillo if used as Rcpp will
-   // complain if we try to include Rcpp before RcppArmadillo
+   // we need to use pre-compiled RcppArmadillo headers instead
+   // of Rcpp as otherwise Rcpp will complain about include order
    boost::regex reRcppArmadillo("#include\\s+<RcppArmadillo");
    if (regex_utils::search(contents, reRcppArmadillo))
       return "RcppArmadillo";
@@ -424,7 +424,7 @@ std::string packagePCH(const std::string& linkingTo)
 
    if (verbose(1))
    {
-      std::cerr << "PACKAGE PCH: " << pch << std::endl;
+      std::cerr << "PACKAGE PCH: " << (pch.empty() ? "(none)" : pch) << std::endl;
    }
 
    return pch;

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -102,6 +102,8 @@ FilePath compilationConfigFilePath()
    return compilerDatabaseDir().completeChildPath("config.json");
 }
 
+#ifdef _WIN32
+
 FilePath compilerDefinitionsPath(bool isCpp)
 {
    std::string name = isCpp ? "cpp-definitions.h" : "c-definitions.h";
@@ -120,7 +122,6 @@ void generateCompilerDefinitions(FilePath defnPath, bool isCpp)
 
 void generateCompilerDefinitions()
 {
-#ifdef _WIN32
    // update C definitions
    FilePath cDefnPath = compilerDefinitionsPath(false);
    if (s_regenerateCompilerDefinitions || !cDefnPath.exists())
@@ -133,8 +134,9 @@ void generateCompilerDefinitions()
 
    // we've re-generated our definitions, so unset flag
    s_regenerateCompilerDefinitions = false;
-#endif
 }
+
+#endif
 
 FilePath precompiledHeaderDir(const std::string& pkgName)
 {

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -1459,7 +1459,7 @@ std::vector<std::string> RCompilationDatabase::precompiledHeaderArgs(
       // create args array
       if (rSourceIndex().verbose() > 0)
       {
-         std::cerr << "# GENERATING PRECOMPILED HEADERS ----" << std::endl;
+         std::cerr << "# GENERATING PRECOMPILED HEADERS (" << pkgName << ") ----" << std::endl;
          core::debug::print(args);
          std::cerr << std::endl;
       }

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -1147,7 +1147,7 @@ std::vector<std::string> RCompilationDatabase::argsForRCmdSHLIB(
 std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp) const
 {
    std::vector<std::string> args;
-
+   
 #ifdef _WIN32
    // add built-in clang compiler headers
    // built-in headers are not required with Rtools40 or newer
@@ -1156,13 +1156,7 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp) c
       auto clArgs = clang().compileArgs(isCpp);
       args.insert(args.end(), clArgs.begin(), clArgs.end());
    }
-#else
-   // add built-in clang compiler headers
-   auto clArgs = clang().compileArgs(isCpp);
-   args.insert(args.end(), clArgs.begin(), clArgs.end());
-#endif
-
-#ifdef _WIN32
+   
    // disable inclusion of default system headers
    // otherwise, libclang will discover and use headers as provided with
    // an installation of Visual Studio (if available), and those headers
@@ -1178,15 +1172,6 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp) c
    auto rtArgs = rtInfo.clangArgs();
    args.insert(args.end(), rtArgs.begin(), rtArgs.end());
 
-#else
-   // add system include headers as reported by compiler
-   std::vector<std::string> includes;
-   discoverSystemIncludePaths(&includes);
-   for (auto include : includes)
-      args.push_back("-I" + include);
-#endif
-
-#ifdef _WIN32
    // re-generate compiler definitions
    generateCompilerDefinitions();
 
@@ -1198,6 +1183,17 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp) c
       args.push_back("-include");
       args.push_back(defnPath.getAbsolutePath());
    }
+   
+#else
+   // add built-in clang compiler headers
+   auto clArgs = clang().compileArgs(isCpp);
+   args.insert(args.end(), clArgs.begin(), clArgs.end());
+   
+   // add system include headers as reported by compiler
+   std::vector<std::string> includes;
+   discoverSystemIncludePaths(&includes);
+   for (auto&& include : includes)
+      args.push_back("-I" + include);
 #endif
 
    if (verbose(3))

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -126,6 +126,7 @@ private:
    std::string packageBuildFileHash_;
    std::string compilerHash_;
    std::string rVersion_;
+   int databaseVersion_;
    CompilationConfig packageCompilationConfig_;
    bool usePrecompiledHeaders_;
    bool forceRebuildPrecompiledHeaders_;

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -36,6 +36,7 @@ namespace rstudio {
 namespace core {
 namespace r_util {
 class RPackageInfo;
+class RToolsInfo;
 } // namespace r_util
 } // namespace core
 } // namespace rstudio
@@ -102,7 +103,10 @@ private:
          core::r_util::RPackageInfo* pPkgInfo = nullptr,
          bool* pIsCpp = nullptr);
 
-   std::vector<std::string> rToolsArgs() const;
+#ifdef _WIN32
+   core::r_util::RToolsInfo& rToolsInfo() const;
+#endif
+
    core::system::Options compilationEnvironment() const;
    std::vector<std::string> precompiledHeaderArgs(const CompilationConfig& config);
 
@@ -110,16 +114,13 @@ private:
 
 private:
 
-   // Rtools arguments (cache once we successfully get them)
-   mutable std::vector<std::string> rToolsArgs_;
-
    // track the sourceCpp hash values used to derive args (don't re-run
    // detection if hash hasn't changed)
-   typedef std::map<std::string,std::string> SourceCppHashes;
+   typedef std::map<std::string, std::string> SourceCppHashes;
    SourceCppHashes sourceCppHashes_;
 
    // source file compilation settings
-   typedef std::map<std::string,CompilationConfig> ConfigMap;
+   typedef std::map<std::string, CompilationConfig> ConfigMap;
    ConfigMap sourceCppConfigMap_;
 
    // package compliation settings (track file modification times on build

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -63,7 +63,7 @@ public:
 private:
 
    core::Error executeSourceCpp(core::system::Options env,
-                                const std::string& rcppPkg,
+                                const std::string& cppPkg,
                                 const core::FilePath& srcPath,
                                 core::system::ProcessResult* pResult);
 
@@ -90,7 +90,8 @@ private:
       std::string PCH;
       bool isCpp;
    };
-   CompilationConfig configForSourceCpp(const std::string& rcppPkg,
+
+   CompilationConfig configForSourceCpp(const std::string& cppPkg,
                                         core::FilePath srcFile);
 
    std::vector<std::string> argsForRCmdSHLIB(core::system::Options env,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/7554#issuecomment-1126513442.

### Approach

The previous implementation tried to write the compiler definitions header to the R temporary directory. However, this path cannot be used for the base compilation arguments, as those get persisted as part of the compilation database, and so we end up persisting a transient path.

Instead, we use a stable scoped scratch path. We also ensure that the compiler definitions are re-generated if we need to re-generate the rest of the compilation database.

### Automated Tests

N/A

### QA Notes

https://github.com/rstudio/rstudio/issues/7554#issuecomment-1126513442

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

