### PR TITLE
Disable quarto on centos 7

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -238,6 +238,10 @@ if(LINUX AND UNAME_M STREQUAL aarch64)
    # disabled on linux aarch64
    message(STATUS "quarto does not yet support aarch64 builds of Linux; disabling quarto")
    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
+elseif(LINUX AND ENV{OPERATING_SYSTEM} STREQUAL centos_7)
+   # disable on Centos 7, use operating system from Jenkins if available
+   message(STATUS "quarto is not supported on Centos7; disabling quarto")
+   set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
 else()
    # enable by default
    set(QUARTO_ENABLED TRUE CACHE INTERNAL "")

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -238,7 +238,7 @@ if(LINUX AND UNAME_M STREQUAL aarch64)
    # disabled on linux aarch64
    message(STATUS "quarto does not yet support aarch64 builds of Linux; disabling quarto")
    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
-elseif(LINUX AND ENV{OPERATING_SYSTEM} STREQUAL centos_7)
+elseif(LINUX AND "$ENV{OPERATING_SYSTEM}" STREQUAL centos_7)
    # disable on Centos 7, use operating system from Jenkins if available
    message(STATUS "quarto is not supported on Centos7; disabling quarto")
    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -233,13 +233,23 @@ endif()
 # pandoc version
 set(PANDOC_VERSION "2.18" CACHE INTERNAL "Pandoc version")
 
+# detect Centos 7, because we don't support Quarto on Centos7
+set(IS_CENTOS7 FALSE)
+if(LINUX AND EXISTS "/etc/centos-release")
+   file(READ "/etc/centos-release" CENTOS_RELEASE)
+   string(FIND "${CENTOS_RELEASE}" "release 7" CENTOS_RELEASE_POS)
+   if(CENTOS_RELEASE_POS GREATER 0)
+     set(IS_CENTOS7 TRUE)
+   endif()
+endif()
+
 # quarto support
 if(LINUX AND UNAME_M STREQUAL aarch64)
    # disabled on linux aarch64
    message(STATUS "quarto does not yet support aarch64 builds of Linux; disabling quarto")
    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
-elseif(LINUX AND "$ENV{OPERATING_SYSTEM}" STREQUAL centos_7)
-   # disable on Centos 7, use operating system from Jenkins if available
+elseif(IS_CENTOS7)
+   # disable quarto on Centos 7
    message(STATUS "quarto is not supported on Centos7; disabling quarto")
    set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
 else()


### PR DESCRIPTION
### Intent

Disable quarto on Centos7 to address https://github.com/rstudio/rstudio-pro/issues/3299

### Approach

Set QUARTO_ENABLED to false in CMake. Will need to make an update in rstudio-ide-automation as well.
May want to make a change to UI so users are aware why Quarto does not appear as an option

### Automated Tests

Need to make an update to rstudio-ide-automation (per Maria's comment on  https://github.com/rstudio/rstudio-pro/issues/3299)

### QA Notes

Test that user running on Centos7 does not have Quarto enabled and cannot create Quarto docs

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


