### PR TITLE
Bugfix/filter suspend resets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,7 +66,7 @@
 - (Linux Only) License-manager now works in a installer-less context (rstudio-pro#3150)
 - Fixed an issue where R raw strings were not highlighted correctly in R Markdown documents. (#11087)
 - Fixed issue with using RStudio server behind multi-level proxy servers (#11010)
-- Fixed an issue where other users' actions could prevent a session's auto suspend (rstudio-pro#3362)
+- Fixed an issue with project sharing where other users' actions could prevent a session's auto suspend (rstudio-pro#3362)
 - Fixed a regression in which the "(Use Default Version)" option was not present in some R version selector drop downs (rstudio-pro#3451)
 
 ### RStudio Workbench

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,6 +66,7 @@
 - (Linux Only) License-manager now works in a installer-less context (rstudio-pro#3150)
 - Fixed an issue where R raw strings were not highlighted correctly in R Markdown documents. (#11087)
 - Fixed issue with using RStudio server behind multi-level proxy servers (#11010)
+- Fixed an issue where other users' actions could prevent a session's auto suspend (Pro #3362)
 
 ### RStudio Workbench
 

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -145,6 +145,7 @@ set(SESSION_SOURCE_FILES
    SessionSourceDatabase.cpp
    SessionSourceDatabaseSupervisor.cpp
    SessionSuspend.cpp
+   SessionSuspendFilter.cpp
    SessionUriHandlers.cpp
    SessionUrlPorts.cpp
    SessionWorkerContext.cpp

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -530,7 +530,7 @@ bool waitForMethod(const std::string& method,
          }
 
          // since we got a connection we can reset the timeout time
-         suspend::resetSuspendTimeout();
+         suspend::resetSuspendTimeout(ptrConnection);
 
          // after we've processed at least one waitForMethod it is now safe to
          // initialize the polledEventHandler (which is used to maintain rsession

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -566,6 +566,9 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       // r utils
       (r_utils::initialize)
 
+      // suspend timeout
+      (suspend::initialize)
+
       // modules with c++ implementations
       (modules::spelling::initialize)
       (modules::lists::initialize)

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -131,9 +131,6 @@ void resetSuspendTimeout(boost::shared_ptr<HttpConnection> pConnection)
 {
    if (s_suspendFilters.shouldResetSuspendTimer(pConnection))
    {
-      LOG_DEBUG_MESSAGE(pConnection->request().uri() +
-                        " URI resetting suspend timeout. Request: " +
-                        pConnection->request().body());
       resetSuspendTimeout();
    }
 }

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -572,3 +572,4 @@ core::Error initialize()
 } // namespace suspend
 } // namespace session
 } // namespace rstudio
+

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -57,8 +57,8 @@ enum SuspendTimeoutState
 };
 
 std::unordered_set<std::string> opsBlockingSuspend;
-boost::posix_time::ptime s_suspendTimeoutTime = boost::posix_time::second_clock::universal_time();
-boost::posix_time::ptime s_blockingTimestamp = boost::posix_time::second_clock::universal_time();
+boost::posix_time::ptime s_suspendTimeoutTime(boost::posix_time::max_date_time);
+boost::posix_time::ptime s_blockingTimestamp(boost::posix_time::pos_infin);
 bool s_dirtyBlockingOps = false;
 bool s_initialNotificationSent = false;
 bool s_timeoutLogSent = false;
@@ -544,6 +544,16 @@ void handleUSR2(int unused)
 
    // note that a suspend is being forced
    s_forceSuspend = 1;
+}
+
+core::Error initialize()
+{
+   s_timeoutState = kWaitingForTimeout;
+   resetSuspendTimeout();
+   resetBlockingTimestamp();
+   clearBlockingOps(true);
+
+   return core::Success();
 }
 
 } // namespace suspend

--- a/src/cpp/session/SessionSuspendFilter.cpp
+++ b/src/cpp/session/SessionSuspendFilter.cpp
@@ -1,0 +1,53 @@
+/*
+ * SessionSuspendFilter.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <unordered_set>
+
+#include "core/DistributedEvents.hpp"
+
+#include "session/SessionSuspendFilter.hpp"
+
+namespace rstudio {
+namespace session {
+namespace suspend {
+namespace filter  {
+
+class DistEventFilter : public SessionSuspendFilter
+{
+public:
+   DistEventFilter()
+      : m_uri(kDistributedEventsEndpoint),
+        m_filteredEvents()
+   {
+      m_filteredEvents.insert({
+                                 core::DistEvtUserLeft
+                              });
+   };
+   ~DistEventFilter() {};
+
+   virtual bool shouldResetSuspendTimer(boost::shared_ptr<HttpConnection> pConnection) override
+   {
+      return true;
+   };
+
+private:
+   std::string m_uri;
+   std::unordered_set<core::DistEvtType> m_filteredEvents;
+};
+
+} // namespace filter
+} // namespace suspend
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionSuspendFilter.cpp
+++ b/src/cpp/session/SessionSuspendFilter.cpp
@@ -48,6 +48,45 @@ private:
 };
 
 } // namespace filter
+
+SessionSuspendFilters::SessionSuspendFilters()
+   : m_filters()
+{
+   using namespace rstudio::session::suspend::filter;
+   m_filters.insert(m_filters.end(), {
+                       boost::make_shared<DistEventFilter>()
+                    });
+}
+
+SessionSuspendFilters::~SessionSuspendFilters()
+{
+
+}
+
+/**
+ * Determines if recieving a given HttpConnection should reset the suspend timer for the session.
+ * Assumes that the timer *should* be reset unless a filter explicitly says not to
+ *
+ * @param pConnection The HttpConnection in question
+ *
+ * @return False if any filter determines the timer should not be reset. True otherwise.
+ */
+bool SessionSuspendFilters::shouldResetSuspendTimer(boost::shared_ptr<HttpConnection> pConnection)
+{
+   // Assume we *should* reset unless we have a concrete reason not to
+   if (!pConnection)
+      return true;
+
+   for (auto &e : m_filters)
+   {
+      // bail on first filter that says we shouldn't reset the timer
+      if (!e->shouldResetSuspendTimer(pConnection))
+         return false;
+   }
+
+   return true;
+}
+
 } // namespace suspend
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/SessionSuspendFilter.cpp
+++ b/src/cpp/session/SessionSuspendFilter.cpp
@@ -13,9 +13,9 @@
  *
  */
 
-#include <unordered_set>
-
 #include <session/SessionSuspendFilter.hpp>
+
+#include <unordered_set>
 
 namespace rstudio {
 namespace session {
@@ -78,7 +78,7 @@ SessionSuspendFilters::SessionSuspendFilters()
 SessionSuspendFilters::~SessionSuspendFilters() {}
 
 /**
- * Determines if recieving a given HttpConnection should reset the suspend timer for the session.
+ * Determines if the request should reset the suspend timer for the session.
  * Assumes that the timer *should* be reset unless a filter explicitly says not to
  *
  * @param pConnection The HttpConnection in question

--- a/src/cpp/session/SessionSuspendFilter.cpp
+++ b/src/cpp/session/SessionSuspendFilter.cpp
@@ -15,7 +15,7 @@
 
 #include <unordered_set>
 
-#include "session/SessionSuspendFilter.hpp"
+#include <session/SessionSuspendFilter.hpp>
 
 namespace rstudio {
 namespace session {
@@ -91,10 +91,10 @@ bool SessionSuspendFilters::shouldResetSuspendTimer(boost::shared_ptr<HttpConnec
    if (!pConnection)
       return true;
 
-   for (auto &e : m_filters)
+   for (auto &filter : m_filters)
    {
       // bail on first filter that says we shouldn't reset the timer
-      if (!e->shouldResetSuspendTimer(pConnection))
+      if (!filter->shouldResetSuspendTimer(pConnection))
          return false;
    }
 

--- a/src/cpp/session/SessionSuspendFilterTests.cpp
+++ b/src/cpp/session/SessionSuspendFilterTests.cpp
@@ -77,3 +77,4 @@ test_context("Session Suspend Filters")
 } // namespace suspend
 } // namespace session
 } // namespace rstudio
+

--- a/src/cpp/session/SessionSuspendFilterTests.cpp
+++ b/src/cpp/session/SessionSuspendFilterTests.cpp
@@ -1,0 +1,67 @@
+/*
+ * SessionSuspendFilterTests.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <session/SessionSuspendFilter.hpp>
+
+#include <tests/TestThat.hpp>
+
+namespace rstudio {
+namespace session {
+namespace suspend {
+namespace tests {
+
+class TestConnection : public HttpConnection
+{
+public:
+   TestConnection(std::string uri)
+      : m_request()
+   {
+      m_request.setUri(uri);
+   }
+   virtual const core::http::Request& request() override { return m_request; }
+
+   virtual void sendResponse(const core::http::Response& response) override {}
+   virtual void sendJsonRpcResponse(
+         core::json::JsonRpcResponse& jsonRpcResponse) override {}
+   virtual void close() override {}
+   virtual std::string requestId() const override {return std::string();}
+   virtual void setUploadHandler(const core::http::UriAsyncUploadHandlerFunction& uploadHandler) override {}
+   virtual bool isAsyncRpc() const override {return false;}
+   virtual std::chrono::steady_clock::time_point receivedTime() const override {return std::chrono::steady_clock::now();}
+
+   core::http::Request m_request;
+};
+
+test_context("Session Suspend Filters")
+{
+   SessionSuspendFilters filters = SessionSuspendFilters();
+
+   boost::shared_ptr<HttpConnection> distEvent = boost::make_shared<TestConnection>("/distributed_event");
+   boost::shared_ptr<HttpConnection> notDistEvent = boost::make_shared<TestConnection>("Not a Distributed Event");
+   test_that("Connections with /distributed_event URI should not reset a session's suspend timeout")
+   {
+      expect_false(true);
+      expect_false(filters.shouldResetSuspendTimer(distEvent));
+   }
+   test_that("Connections without /distributed_event URI can reset a session's suspend timeout")
+   {
+      expect_false(filters.shouldResetSuspendTimer(notDistEvent));
+   }
+}
+
+} // namespace tests
+} // namespace suspend
+} // namespace session
+} // namespace rstudio

--- a/src/cpp/session/SessionSuspendFilterTests.cpp
+++ b/src/cpp/session/SessionSuspendFilterTests.cpp
@@ -22,6 +22,9 @@ namespace session {
 namespace suspend {
 namespace tests {
 
+/**
+ * Dummy test implementation for testing HttpConnections with specific URIs
+ */ 
 class TestConnection : public HttpConnection
 {
 public:
@@ -47,17 +50,26 @@ public:
 test_context("Session Suspend Filters")
 {
    SessionSuspendFilters filters = SessionSuspendFilters();
+   boost::shared_ptr<HttpConnection> notYourEvent = boost::make_shared<TestConnection>("This is not the event you are looking for");
 
-   boost::shared_ptr<HttpConnection> distEvent = boost::make_shared<TestConnection>("/distributed_event");
-   boost::shared_ptr<HttpConnection> notDistEvent = boost::make_shared<TestConnection>("Not a Distributed Event");
+   boost::shared_ptr<HttpConnection> distEvent = boost::make_shared<TestConnection>("/distributed_events");
    test_that("Connections with /distributed_event URI should not reset a session's suspend timeout")
    {
-      expect_false(true);
       expect_false(filters.shouldResetSuspendTimer(distEvent));
    }
    test_that("Connections without /distributed_event URI can reset a session's suspend timeout")
    {
-      expect_false(filters.shouldResetSuspendTimer(notDistEvent));
+      expect_true(filters.shouldResetSuspendTimer(notYourEvent));
+   }
+
+   boost::shared_ptr<HttpConnection> currentlyEditing = boost::make_shared<TestConnection>("/rpc/set_currently_editing");
+   test_that("Connections with /rpc/set_currently_editing URI should not reset a session's suspend timeout")
+   {
+      expect_false(filters.shouldResetSuspendTimer(currentlyEditing));
+   }
+   test_that("Connections without /rpc/set_currently_editing URI can reset a session's suspend timeout")
+   {
+      expect_true(filters.shouldResetSuspendTimer(notYourEvent));
    }
 }
 

--- a/src/cpp/session/include/session/SessionSuspend.hpp
+++ b/src/cpp/session/include/session/SessionSuspend.hpp
@@ -18,6 +18,8 @@
 
 #include <boost/function.hpp>
 
+#include "SessionHttpConnection.hpp"
+
 namespace rstudio {
 namespace core {
    class Error;
@@ -42,6 +44,7 @@ core::Error initialize();
 
 bool disallowSuspend();
 void resetSuspendTimeout();
+void resetSuspendTimeout(boost::shared_ptr<HttpConnection> pConnection);
 void addBlockingOp(std::string op);
 void addBlockingOp(std::string method, const boost::function<bool()>& allowSuspend);
 void removeBlockingOp(std::string op);

--- a/src/cpp/session/include/session/SessionSuspend.hpp
+++ b/src/cpp/session/include/session/SessionSuspend.hpp
@@ -19,6 +19,12 @@
 #include <boost/function.hpp>
 
 namespace rstudio {
+namespace core {
+   class Error;
+}
+}
+
+namespace rstudio {
 namespace session {
 namespace suspend {
 
@@ -31,6 +37,8 @@ const char * const kExternalPointer = "Active external data pointer";
 const char * const kActiveJob = "An active job is running";
 const char * const kCommandPrompt = "Incomplete command prompt entered";
 const char * const kGenericMethod = "Waiting for event: ";
+
+core::Error initialize();
 
 bool disallowSuspend();
 void resetSuspendTimeout();

--- a/src/cpp/session/include/session/SessionSuspendFilter.hpp
+++ b/src/cpp/session/include/session/SessionSuspendFilter.hpp
@@ -34,14 +34,17 @@ public:
 
 /**
  * This class holds an expandable list of filter instances that help a session decide
- * whether or not its suspend timeout should be reset, based on the characteristics
- * of a recieved HttpConnection.
+ * whether or not its suspend timeout should be reset, based any characteristics
+ * of a request.
  *
  * By default, accepted HttpConnections will reset a session's suspend timeout. To
- * add a new filter for a specific type of filter, simply
+ * add a new filter for a specific type of request, simply
  * 1. define the filter in SessionSuspendFilter.cpp and implement the
  *    SessionSuspendFilter interface
  * 2. add the new filter instance into this class' constructor
+ * 
+ * Turn on session protocol debug to aid in discovering which requests are triggering
+ * session suspend timeout resets
  */
 class SessionSuspendFilters
 {

--- a/src/cpp/session/include/session/SessionSuspendFilter.hpp
+++ b/src/cpp/session/include/session/SessionSuspendFilter.hpp
@@ -1,0 +1,62 @@
+/*
+ * SessionSuspendFilter.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_SUSPEND_FILTER_HPP
+#define SESSION_SUSPEND_FILTER_HPP
+
+#include "SessionHttpConnection.hpp"
+
+namespace rstudio {
+namespace session {
+namespace suspend {
+
+/**
+ * Interface for filtering out which HttpConnections should reset a session's suspend timeout
+ */
+class SessionSuspendFilter
+{
+public:
+   virtual ~SessionSuspendFilter() {}
+   virtual bool shouldResetSuspendTimer(boost::shared_ptr<HttpConnection> pConnection) = 0;
+};
+
+/**
+ * This class holds an expandable list of filter instances that help a session decide
+ * whether or not its suspend timeout should be reset, based on the characteristics
+ * of a recieved HttpConnection.
+ *
+ * By default, accepted HttpConnections will reset a session's suspend timeout. To
+ * add a new filter for a specific type of filter, simply
+ * 1. define the filter in SessionSuspendFilter.cpp and implementing the
+ *    SessionSuspendFilter interface
+ * 2. add the new filter instance into this class' constructor
+ */
+class SessionSuspendFilters
+{
+public:
+   SessionSuspendFilters();
+   ~SessionSuspendFilters();
+
+   bool shouldResetSuspendTimer(boost::shared_ptr<HttpConnection> pConnection);
+
+protected:
+   std::vector<boost::shared_ptr<SessionSuspendFilter>> m_filters; //!< Expandable list of filters to check connections with
+};
+
+} // namespace suspend
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_SUSPEND_FILTER_HPP

--- a/src/cpp/session/include/session/SessionSuspendFilter.hpp
+++ b/src/cpp/session/include/session/SessionSuspendFilter.hpp
@@ -63,3 +63,4 @@ protected:
 } // namespace rstudio
 
 #endif // SESSION_SUSPEND_FILTER_HPP
+

--- a/src/cpp/session/include/session/SessionSuspendFilter.hpp
+++ b/src/cpp/session/include/session/SessionSuspendFilter.hpp
@@ -39,7 +39,7 @@ public:
  *
  * By default, accepted HttpConnections will reset a session's suspend timeout. To
  * add a new filter for a specific type of filter, simply
- * 1. define the filter in SessionSuspendFilter.cpp and implementing the
+ * 1. define the filter in SessionSuspendFilter.cpp and implement the
  *    SessionSuspendFilter interface
  * 2. add the new filter instance into this class' constructor
  */


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio-pro/issues/3362 where the actions of another user were keeping a session from suspending.

When an `rsession` is waiting for a particular connection to come in (`console_input`, for example), sometimes other, unrelated connections can come in and reset the session suspend timeout without indicating that they've done so. This PR adds a way to 
1. Generate DEBUG messages indicating which `HttpConnection`s are resetting the session's suspend timeout, and
2. filter out incoming connections that should **not** reset that session suspend timeout.

### Approach

I made the implementation a little more verbose than simply iterating through a list of incoming connection `URI`s to ignore for 3 main reasons:

1. Because this was reported by a user, there's a high possibility of similar issues being created going forward. I pulled the implementation into its own file attempt to make it friendlier for a user to contribute their own filter. All they'd need to do is define a new filter class, add it to the list of filters, and make a PR
2. Right now only a couple URIs are filtered. If filtering needs to be more selective (ie filter by URI **and** some aspect of the `HttpConnection` or HTTP request body), this makes it trivial to add that
3. Adding unit tests was trivial for this approach 

### Automated Tests

RSession Unit tests have been added for this fix.

### QA Notes

See the ticket for steps to reproduce in the Pro product. The short of it is that a different user entering/leaving our shared project or following our cursor should not affect when our session suspends from inactivity.

Setting `session-timeout-minutes=1` to `/etc/rstudio/rsession.conf` speeds up testing.


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


