### PR TITLE
ensure new IDE instance is created when opening remote session file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -67,6 +67,7 @@
 - Fixed an issue where R raw strings were not highlighted correctly in R Markdown documents. (#11087)
 - Fixed issue with using RStudio server behind multi-level proxy servers (#11010)
 - Fixed a regression in which the "(Use Default Version)" option was not present in some R version selector drop downs (rstudio-pro#3451)
+- Fix opening a remote session via downloaded rdprsp file in Mac Desktop Pro when it (RDP) is already open (rstudio-pro#3291)
 
 ### RStudio Workbench
 

--- a/src/cpp/desktop/DesktopPosixApplication.cpp
+++ b/src/cpp/desktop/DesktopPosixApplication.cpp
@@ -47,7 +47,7 @@ bool PosixApplication::event(QEvent* pEvent)
          // otherwise we are already running so this is an apple event
          // targeted at opening a file in an existing instance
 
-         // if this is a project then re-post the request back to
+         // if this is a project or remote session then re-post the request back to
          // another instance using the command line (this is to
          // circumvent the fact that the first RStudio application
          // launched on OSX gets all of the apple events). note that
@@ -56,7 +56,8 @@ bool PosixApplication::event(QEvent* pEvent)
          // FileOpen back to existing instances (e.g. via DDE)
 
          FilePath filePath(filename.toUtf8().constData());
-         if (filePath.exists() && filePath.getExtensionLowerCase() == ".rproj")
+         if (filePath.exists() &&
+             (filePath.getExtensionLowerCase() == ".rproj" || filePath.getExtensionLowerCase() == ".rdprsp"))
          {
             std::vector<std::string> args;
             args.push_back(filePath.getAbsolutePath());


### PR DESCRIPTION
### Intent

Addresses [rstudio-pro#3291](https://github.com/rstudio/rstudio-pro/issues/3291) - specifically, if you have Mac Desktop Pro already running and you double-click on a `.rdprsp` file, it should now correctly open the remote session in a new RDP instance instead of just opening the file as a text file in the editor.

The cause: on macOS, if an application is already running and you double-click on a file that is set to open in that application, macOS sends the existing running application an event to open the file. This differs from Windows and Linux where a new instance is started directly when you double-click on a file.

This was reviewed via https://github.com/rstudio/rstudio-pro/pull/3457.

### Approach

Apply the same technique already used for handling this scenario with project files to remote desktop session files.

### Automated Tests

None

### QA Notes

Using RDP on Mac, try opening an .rdprsp file by double-clicking in Finder. Verify that an RStudio window opens and connects to the session, whether you already had RStudio running or not.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


