### PR TITLE
fedora-36 specific unit test fix

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -182,6 +182,12 @@ export R_HOME=$(R RHOME)
 export R_DOC_DIR=$(R --vanilla -s -e "cat(paste(R.home('doc'), sep=':'))")
 export R_LIB_DIR=$(R --vanilla -s -e "cat(paste(R.home('lib'), sep=':'))")
 
+# Hack: on Fedora36 (docker), the reported R_DOC_DIR doesn't exist which triggers
+# test failures; create the folder if missing
+if [ ! -e "${R_DOC_DIR}" ]; then
+   sudo mkdir "${R_DOC_DIR}"
+fi
+
 # On macOS, we need to tell the rsession executable where to look for libR.dylib
 if [ "$(uname)" = "Darwin" ]; then
    export DYLD_INSERT_LIBRARIES="${R_LIB_DIR}/libR.dylib"


### PR DESCRIPTION
### Intent

Unit tests failing on fedora36 with:

[2022-05-17T17:31:47.429Z] ==> Running 'rsession' tests
[2022-05-17T17:31:47.685Z] 2022-05-17T17:31:47.612605Z [rsession-] ERROR system error 2 (No such file or directory) [path: /usr/share/doc/R]; OCCURRED AT rstudio::core::Error rstudio::r::session::discoverR(RLocations*) src/cpp/r/session/RDiscovery.cpp:69; LOGGED FROM: int main(int, char* const*) src/cpp/session/SessionMain.cpp:2384

The path reported by:

```R
R.home('doc')
```

in the docker container doesn't exist, and this breaks our tests.

### Approach

We don't need anything to actually be there, just need the folder to exist. So create it if missing.

### Automated Tests

N/A

### QA Notes

Unit test fixes.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


