### PR TITLE
tweaks for parsing rs-theme-is-dark field for themes

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -318,6 +318,7 @@ target_link_libraries(rstudio-core
    ${SOCI_LIBRARIES}
    ${CORE_SYSTEM_LIBRARIES}
    ${YAML_CPP_LIBRARIES}
+   fmt::fmt
 )
 
 # define executable (for running unit tests)

--- a/src/cpp/core/StringUtils.cpp
+++ b/src/cpp/core/StringUtils.cpp
@@ -47,6 +47,24 @@ namespace rstudio {
 namespace core {
 namespace string_utils {
 
+bool hasTruthyValue(const std::string& string)
+{
+   for (const char* value : { "TRUE", "True", "true", "YES", "Yes", "yes", "1" })
+      if (string == value)
+         return true;
+   
+   return false;
+}
+
+bool hasFalsyValue(const std::string& string)
+{
+   for (const char* value : { "FALSE", "False", "false", "NO", "No", "no", "0" })
+      if (string == value)
+         return true;
+   
+   return false;
+}
+
 bool isTruthy(const std::string& string,
               bool valueIfEmpty)
 {

--- a/src/cpp/core/include/core/StringUtils.hpp
+++ b/src/cpp/core/include/core/StringUtils.hpp
@@ -52,6 +52,9 @@ private:
    std::string needle_;
 };
 
+bool hasTruthyValue(const std::string& string);
+bool hasFalsyValue(const std::string& string);
+
 bool isTruthy(const std::string& string,
               bool valueIfEmpty = false);
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1924,7 +1924,7 @@ int main(int argc, char * const argv[])
       // (some users on Windows report these having trailing
       // slashes, which confuses a number of RStudio routines)
       boost::regex reTrailing("[/\\\\]+$");
-      for (const std::string& envvar : {"HOME", "R_USER"})
+      for (const char* envvar : {"HOME", "R_USER"})
       {
          std::string oldVal = core::system::getenv(envvar);
          if (!oldVal.empty())

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -43,6 +43,8 @@ namespace session {
 namespace modules { 
 namespace path {
 
+#ifdef __APPLE__
+
 namespace {
 
 bool containsPathEntry(
@@ -198,8 +200,10 @@ std::string homePath(const std::string& suffix)
          .getAbsolutePath();
 }
 
+
 } // anonymous namespace
 
+#endif
 
 Error initialize()
 {

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -160,47 +160,49 @@ void getThemesInLocation(
                continue;
             }
 
-            boost::smatch matches;
-            bool found = boost::regex_search(
-               themeContents,
-               matches,
-               boost::regex("rs-theme-name\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"));
+            boost::regex reThemeName("rs-theme-name\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)");
+            boost::smatch mThemeName;
+            bool themeNameFound = boost::regex_search(themeContents, mThemeName, reThemeName);
 
             // If there's no name specified,use the name of the file
             std::string name;
-            if (!found || (matches.size() < 2) || (matches[1] == ""))
+            if (!themeNameFound || (mThemeName.size() < 2) || (mThemeName[1] == ""))
             {
                name = themeFile.getStem();
             }
             else
             {
                // If there's at least one name specified, get the first one.
-               name = matches[1];
+               name = mThemeName[1];
             }
+            
+            WLOGF("Reading theme: '{}'", name);
 
             // Find out if the theme is dark or not.
-            found = boost::regex_search(
-                     themeContents,
-                     matches,
-                     boost::regex("rs-theme-is-dark\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)"));
-
+            boost::regex reThemeIsDark("rs-theme-is-dark\\s*:\\s*([^\\*]+?)\\s*(?:\\*|$)");
+            boost::smatch mThemeIsDark;
+            bool themeIsDarkFound = boost::regex_search(themeContents, mThemeIsDark, reThemeIsDark);
+            
             bool isDark = false;
-            if (found && (matches.size() >= 2))
+            if (themeIsDarkFound && (mThemeIsDark.size() >= 2))
             {
                try
                {
-                  isDark = convertToBool(matches[1].str());
+                  isDark = convertToBool(mThemeIsDark[1].str());
                }
                catch (boost::bad_lexical_cast&)
                {
-                  LOG_WARNING_MESSAGE("rs-theme-is-dark value is not a valid boolean string "
-                        " for theme \"" + name + "\" (" + themeFile.getAbsolutePath() + ")");
+                  WLOGF("rs-theme-is-dark value ('{}') is not a valid boolean string for theme \"{}\" ({})",
+                        mThemeIsDark[1].str(),
+                        name,
+                        themeFile.getAbsolutePath());
                }
             }
             else
             {
-               LOG_WARNING_MESSAGE("rs-theme-is-dark is not set for theme \"" + name + "\" (" +
-                     themeFile.getAbsolutePath() + ")");
+               WLOGF("rs-theme-is-dark not set for theme \"{}\" ({})",
+                     name,
+                     themeFile.getAbsolutePath());
             }
 
             (*themeMap)[boost::algorithm::to_lower_copy(name)] = std::make_tuple(

--- a/src/cpp/shared_core/CMakeLists.txt
+++ b/src/cpp/shared_core/CMakeLists.txt
@@ -89,8 +89,7 @@ define_source_file_names(rstudio-shared-core)
 
 target_link_libraries(rstudio-shared-core
    ${Boost_LIBRARIES}
-   ${SHARED_CORE_SYSTEM_LIBS}
-   fmt::fmt)
+   ${SHARED_CORE_SYSTEM_LIBS})
 
 # Define executable for running unit tests
 if (RSTUDIO_UNIT_TESTS_ENABLED)

--- a/src/cpp/shared_core/CMakeLists.txt
+++ b/src/cpp/shared_core/CMakeLists.txt
@@ -89,7 +89,8 @@ define_source_file_names(rstudio-shared-core)
 
 target_link_libraries(rstudio-shared-core
    ${Boost_LIBRARIES}
-   ${SHARED_CORE_SYSTEM_LIBS})
+   ${SHARED_CORE_SYSTEM_LIBS}
+   fmt::fmt)
 
 # Define executable for running unit tests
 if (RSTUDIO_UNIT_TESTS_ENABLED)


### PR DESCRIPTION
### Intent

Speculatively addresses https://github.com/rstudio/rstudio/issues/11176. Unfortunately, I don't know the cause of the issue, but my guess is that the issue lies either in how we're lexically casting the associated string to a boolean, or in how regex matching is being done.

### Approach

- Avoid using `boost::lexical_cast<>`; instead, check the possible set of valid values directly (via newly-added helpers).
- Avoid using temporary `boost::regex` objects. It's not clear this is actually an issue, but almost all examples I've seen online ensure the `boost::regex` pattern is constructed before it is used for searches / matches. (For example; https://github.com/boostorg/regex/tree/develop/example/snippets)

### Automated Tests

N/A; speculative fix.

### QA Notes

Will need to rely on user testing.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
