### PR TITLE
change def of isExecutableChunk to recognize `#| eval: false`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6181,6 +6181,28 @@ public class TextEditingTarget implements
       if (reEvalFalse.test(headerText))
          return false;
 
+      // Also check for YAML style chunk option with eval false
+      Pattern reYamlOpt = Pattern.create("^#\\| .*");
+      Pattern reYamlEvalFalse = Pattern.create("eval\\s*:\\s*false");
+      int start = chunk.getBodyStart().getRow();
+      int end = chunk.getEnd().getRow();
+      ArrayList<String> chunkBody = JsArrayUtil.fromJsArrayString(docDisplay_.getLines(start, end));
+      for (String line : chunkBody)
+      {
+         if (reYamlOpt.test(line))
+         {
+            // both #| eval: false and #| eval = FALSE style comments are permitted
+            if (reYamlEvalFalse.test(line) || reEvalFalse.test(line))
+               return false;
+         }
+         else
+         {
+            // all yaml chunk options should be at the beginning of the chunk, so we can stop early once we get to a
+            // line that does not start with #|
+            break;
+         }
+      }
+
       return true;
    }
 


### PR DESCRIPTION

### Intent

Addresses edge case of #10645 found by @hadley where the YAML chunk options only work in inline chunk execution ("notebook mode"), not when chunks are executed in the console.

### Approach

Ultimately, we need to revamp our definition of notebook mode a bit -- it seems too expansive, in that chunk execution is handled differently in many ways depending on whether chunk execution is set to inline or console. However, the immediate concern here is that when `#| eval: false` is provided as a chunk option, the chunk erroneously executes when in console mode. It correctly does not execute when in inline mode. We previously changed behavior on the backend to parse these new format chunk options. Here, we additionally update the frontend method `isExecutableChunk` so that it not only returns `false` when the chunk starts with `{r eval = FALSE}` but also when it contains `#| eval: false`.

It feels a little unsatisfying to me to have separate frontend and backend methods for parsing these new chunk options, and ultimately a long-term solution should address the issue in #10677 as well, but I think this is good as a stopgap for now to address the immediate issue. 

### Automated Tests

None

### QA Notes

Create and save the following Rmd file:

~~~~
---
output: html_document
editor_options: 
  chunk_output_type: console
---

```{r}
print("I should run")
```

```{r}
#| eval: false
stop("I shouldn't run")
```
~~~~

Using the gearbox next to the Knit button,  "Chunk Output in Console" should be selected.
<img width="401" alt="image" src="https://user-images.githubusercontent.com/7817881/169154307-902d0b82-effb-4121-a85e-afc4592c0536.png">

Select "Run all" (option + cmd + R)

Ensure that `stop("I shouldn't run")` does not run and does not get output to the console


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


