### PR TITLE
fix some issues with Mac main menu in French (Qt)

### DIFF
--- a/src/cpp/desktop/DesktopMenuCallback.cpp
+++ b/src/cpp/desktop/DesktopMenuCallback.cpp
@@ -57,7 +57,12 @@ void MenuCallback::beginMainMenu()
 void MenuCallback::beginMenu(QString label)
 {
 #ifdef Q_OS_MAC
-   if (label == QString::fromUtf8("&Help"))
+
+   if (label == QString::fromUtf8("&Fichier"))
+      this->isEnglish = false;
+
+   if (label == QString::fromUtf8("&Help") ||
+       label == QString::fromUtf8("Aide"))
    {
       pMainMenu_->addMenu(new WindowMenu(pMainMenu_));
    }
@@ -87,7 +92,7 @@ QAction* MenuCallback::addCustomAction(QString commandId,
 #ifdef Q_OS_MAC
    // On Mac, certain commands will be automatically moved to Application Menu by Qt. If we want them to also
    // appear in RStudio menus, check for them here and return nullptr.
-   if (duplicateAppMenuAction(QString::fromUtf8("showAboutDialog"),
+   if (this->isEnglish && duplicateAppMenuAction(QString::fromUtf8("showAboutDialog"),
                               commandId, label, tooltip, keySequence, checkable, isRadio))
    {
       return nullptr;
@@ -97,6 +102,13 @@ QAction* MenuCallback::addCustomAction(QString commandId,
    {
       return nullptr;
    }
+   else if (!this->isEnglish &&
+            duplicateAppMenuAction(QString::fromUtf8("showOptions"),
+                              commandId, label, tooltip, keySequence, checkable, isRadio))
+   {
+      return nullptr;
+   }
+
 
    // If we want a command to not be automatically moved to Application Menu, include it here and return the
    // created action.
@@ -104,6 +116,14 @@ QAction* MenuCallback::addCustomAction(QString commandId,
                                     commandId, label, tooltip, keySequence, checkable, isRadio);
    if (pAction)
       return pAction;
+
+   if (!this->isEnglish)
+   {
+      pAction = duplicateAppMenuAction(QString::fromUtf8("projectOptions"),
+                                    commandId, label, tooltip, keySequence, checkable, isRadio);
+      if (pAction)
+         return pAction;
+   }
 
 #endif // Q_OS_MAC
 

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -94,6 +94,15 @@ private:
     QStack<SubMenu*> menuStack_;
     QMap<QString, QVector<QPointer<QAction>>> actions_;
     QMap<QString, QVector<QPointer<MenuActionBinder>>> binders_;
+
+#ifdef Q_OS_MAC
+    // This terrible hack is to around some Main Menu quirks when the UI is being
+    // displayed in French. We aren't going to ever make the Qt desktop fully
+    // support UI language switching, but want to at least make the initial experimental
+    // release work reasonably well.
+    // https://github.com/rstudio/rstudio/issues/11189
+    bool isEnglish = true;
+#endif
 };
 
 /* Previously, in desktop mode, many keyboard shortcuts were handled by Qt,

--- a/src/cpp/desktop/DesktopMenuCallback.hpp
+++ b/src/cpp/desktop/DesktopMenuCallback.hpp
@@ -96,7 +96,7 @@ private:
     QMap<QString, QVector<QPointer<MenuActionBinder>>> binders_;
 
 #ifdef Q_OS_MAC
-    // This terrible hack is to around some Main Menu quirks when the UI is being
+    // This terrible hack is to work around some Main Menu quirks when the UI is being
     // displayed in French. We aren't going to ever make the Qt desktop fully
     // support UI language switching, but want to at least make the initial experimental
     // release work reasonably well.


### PR DESCRIPTION
### Intent

Addresses: #11189

### Approach

The underlying issue is Qt's internal heuristics which move some menu items to the Mac Application menu based on the labels of the menu items. We do additional work to try and prevent this in some cases. All of this behaves badly when the UI strings aren't in English.

Given we are not officially supporting non-English UI in the upcoming release (it is labeled as "experimental"), and are retiring the Qt-based desktop after this release, I've made some horrible hacks to improve the situation in French, and not impact English in any way.

With this change, the main menu should not be any different than before in English. In French, I fixed the following:

* There is now a Windows menu between Tools and Help (this was missing because our code was looking specifically for "&Help"; for this short-term hack I also now look for "Aide"); this menu and its contents are not localized (and never will be in the Qt desktop)
* The "Apropos de RStudio" menu item is no longer duplicated under the Aide menu
* Global Options and Project Options (in French...) now displaying on the Tools/Outils menu in French

Not fixed (and I don't think we'll ever fix these for Qt desktop):

* About RStudio not displayed on RStudio menu in French (it's available on Help/Aide menu and via command-palette so I don't think this is a major problem)
* The "Editer" menu still has a "Prefeferences..." item at the end that isn't there in English; not a huge problem

### Automated Tests

No automation for French UI or Qt desktop in general.

### QA Notes

These changes are Mac-only, Qt-desktop only.

Main thing to check is that main menu, on Mac, in English, isn't changed in any way as a result of this.

In French, verify that the things I've mentioned fixing are now fixed and the things I didn't fix... aren't fixed.

With Qt desktop, there is a known issue that when running in French, the app will always do a UI reload at startup (it briefly displays in English, then switches to French). This isn't a problem with Electron, and is another thing we'll never bother fixing for Qt desktop.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


