### PR TITLE
Duplicated files on Recent Files fix - Electron

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -90,10 +90,12 @@ export function getDesktopBridge() {
           }
 
           if (process.platform === 'win32') {
-            filePath = normalizeSeparatorsNative(filePath);
+            filePath = normalizeSeparatorsNative(filePath, '/');
           }
-          
-          filePath = filePath.replace(normalizeSeparatorsNative(process.env.HOME as string), '~');
+
+          /* this makes sure the file path and HOME path 
+          only contains forward slashes as separators for correct comparison */
+          filePath = filePath.replace(normalizeSeparatorsNative(process.env.HOME as string, '/'), '~');
 
           // invoke callback
           return callback(filePath);

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -69,7 +69,6 @@ export function getDesktopBridge() {
       ipcRenderer
         .invoke('desktop_get_save_file_name', caption, label, dir, defaultExtension, forceDefaultExtension, focusOwner)
         .then((result) => {
-
           // if the result was canceled, bail early
           if (result.canceled as boolean) {
             return callback('');
@@ -91,8 +90,10 @@ export function getDesktopBridge() {
 
           if (process.platform === 'win32') {
             filePath = filePath.replace(/\\/g, '/');
+          } else {
+            filePath = filePath.replace(process.env.HOME as string, '~');
           }
-          
+
           // invoke callback
           return callback(filePath);
         })
@@ -378,11 +379,11 @@ export function getDesktopBridge() {
     },
 
     openFile: (path: string) => {
+      console.log('open file: ');
       if (!path) {
         return;
       }
-      const webcontents = webContents
-        .getAllWebContents();
+      const webcontents = webContents.getAllWebContents();
 
       if (webcontents.length) {
         webcontents[0]

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -93,9 +93,12 @@ export function getDesktopBridge() {
             filePath = normalizeSeparators(filePath, '/');
           }
 
+          const expandedHomePath = normalizeSeparators(process.env.HOME as string, '/');
+          const homePath = '~';
+
           /* this makes sure the file path and HOME path 
           only contains forward slashes as separators for correct comparison */
-          filePath = filePath.replace(normalizeSeparators(process.env.HOME as string, '/'), '~');
+          filePath = homePath + filePath.substring(expandedHomePath.length);
 
           // invoke callback
           return callback(filePath);

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -15,7 +15,7 @@
 
 import { ipcRenderer, webContents } from 'electron';
 import { logger } from '../core/logger';
-import { normalizeSeparatorsNative } from '../ui/utils';
+import { normalizeSeparators } from '../ui/utils';
 
 interface VoidCallback<Type> {
   (result: Type): void;
@@ -90,12 +90,12 @@ export function getDesktopBridge() {
           }
 
           if (process.platform === 'win32') {
-            filePath = normalizeSeparatorsNative(filePath, '/');
+            filePath = normalizeSeparators(filePath, '/');
           }
 
           /* this makes sure the file path and HOME path 
           only contains forward slashes as separators for correct comparison */
-          filePath = filePath.replace(normalizeSeparatorsNative(process.env.HOME as string, '/'), '~');
+          filePath = filePath.replace(normalizeSeparators(process.env.HOME as string, '/'), '~');
 
           // invoke callback
           return callback(filePath);
@@ -382,7 +382,6 @@ export function getDesktopBridge() {
     },
 
     openFile: (path: string) => {
-      console.log('open file: ');
       if (!path) {
         return;
       }

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -60,8 +60,13 @@ function normalizeSeparators(path: string, separator = '/') {
  * @param {string} path
  * @return {*} 
  */
-export function normalizeSeparatorsNative(path: string) {
+export function normalizeSeparatorsNative(path: string, forcedSeparator = '') {
   /* using conditional to set the separator based on platform as `path` is not available here */
-  const separator = process.platform === 'win32' ? '\\' : '/';
+  let separator = process.platform === 'win32' ? '\\' : '/';
+
+  if (forcedSeparator !== '') {
+    separator = forcedSeparator;
+  }
+
   return normalizeSeparators(path, separator);
 }

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -49,7 +49,7 @@ export const checkForNewLanguage = () => {
  * @param {string} [separator='/']
  * @return {*} 
  */
-function normalizeSeparators(path: string, separator = '/') {
+export function normalizeSeparators(path: string, separator = '/') {
   return path.replace(/[\\/]+/g, separator);
 }
 

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -60,13 +60,8 @@ export function normalizeSeparators(path: string, separator = '/') {
  * @param {string} path
  * @return {*} 
  */
-export function normalizeSeparatorsNative(path: string, forcedSeparator = '') {
+export function normalizeSeparatorsNative(path: string) {
   /* using conditional to set the separator based on platform as `path` is not available here */
-  let separator = process.platform === 'win32' ? '\\' : '/';
-
-  if (forcedSeparator !== '') {
-    separator = forcedSeparator;
-  }
-
+  const separator = process.platform === 'win32' ? '\\' : '/';
   return normalizeSeparators(path, separator);
 }


### PR DESCRIPTION
### Intent

Fix an issue that would make duplicated files to appear on `Recent Files` submenu.

### Approach

Replaced `home` path with `~`.

### Automated Tests

None.

### QA Notes

Refer to #11150

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11150

