### PR TITLE
Build with latest quarto

### DIFF
--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -26,9 +26,14 @@ if [ "$(arch)" = "aarch64" ]; then
 fi
 
 # variables that control download + installation process
-QUARTO_VERSION="0.9.230"
+# update to latest Quarto release
+QUARTO_VERSION=`curl https://api.github.com/repos/quarto-dev/quarto-cli/releases | jq ".[0].tag_name" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
+QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/latest/download"
+
+# specify a version to pin for releases
+#QUARTO_VERSION="0.9.230"
 QUARTO_SUBDIR="quarto"
-QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
+#QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
 
 # move to tools root
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -39,7 +39,13 @@ set PANDOC_VERSION=2.18
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
-set QUARTO_VERSION=0.9.230
+REM set QUARTO_VERSION=0.9.230
+
+REM Get latest Quarto release version
+cd install-quarto
+for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
+cd ..
+
 set QUARTO_FILE=quarto-%QUARTO_VERSION%-win.zip
 
 set LIBCLANG_VERSION=13.0.1
@@ -168,7 +174,8 @@ if not exist pandoc\%PANDOC_VERSION% (
 
 
 
-wget %WGET_ARGS% https://s3.amazonaws.com/rstudio-buildtools/quarto/%QUARTO_VERSION%/%QUARTO_FILE%
+REM wget %WGET_ARGS% https://s3.amazonaws.com/rstudio-buildtools/quarto/%QUARTO_VERSION%/%QUARTO_FILE%
+wget %WGET_ARGS% https://github.com/quarto-dev/quarto-cli/releases/latest/download/%QUARTO_FILE%
 echo Unzipping Quarto %QUARTO_FILE%
 rmdir /s /q quarto
 mkdir quarto

--- a/dependencies/windows/install-quarto/get-quarto-version.ps1
+++ b/dependencies/windows/install-quarto/get-quarto-version.ps1
@@ -1,0 +1,7 @@
+# Retrieve latest Quarto version from GitHub
+
+$response = Invoke-WebRequest -Uri https://api.github.com/repos/quarto-dev/quarto-cli/releases
+$releases = ConvertFrom-Json $response.content
+$tag = $releases.tag_name[0]
+$quartoVersion = $tag | Select-String -Pattern '[0-9]+\.[0-9]+\.[0-9]+'
+$quartoVersion.Matches.Value


### PR DESCRIPTION
### Intent
Address #10920

### Approach
Updates the dependency installer scripts to get Quarto directly from the latest GitHub release instead of AWS S3. This would be temporary until Spotted Wakerobin is ready to pin Quarto to the final release. The old code for retrieving a specific version from S3 remains so that we can upload the final Quarto release and go back to a pinned version.

The latest release version is retrieved from the GH REST API. It fetches the most recent release tag. Then it constructs the download link to the latest release. The version is required since the release assets include the version in the file name.

There is a version check in the source for the required and recommended minimum Quarto version but I don't think that needs to be updated right now.

### Automated Tests
None

### QA Notes
Builds will be bundling a Quarto version greater than the month old v0.9.230

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


