### PR TITLE
Hide blank quarto doc when quarto disabled

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FileCommandToolbar.java
@@ -20,6 +20,7 @@ import com.google.inject.Inject;
 import com.google.gwt.event.logical.shared.ResizeEvent;
 import com.google.gwt.event.logical.shared.ResizeHandler;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.command.AppCommand;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeStyles;
 import org.rstudio.core.client.widget.Toolbar;
@@ -27,7 +28,9 @@ import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarMenuButton;
 import org.rstudio.core.client.widget.ToolbarPopupMenu;
 import org.rstudio.core.client.widget.UserPrefMenuItem;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.icons.StandardIcons;
+import org.rstudio.studio.client.quarto.model.QuartoConfig;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.files.FilesConstants;
@@ -49,7 +52,11 @@ public class FileCommandToolbar extends Toolbar
       newFileMenu.addItem(commands.touchSourceDoc().createMenuItem(false));
       newFileMenu.addSeparator();
       newFileMenu.addItem(commands.touchRMarkdownDoc().createMenuItem(false));
-      newFileMenu.addItem(commands.touchQuartoDoc().createMenuItem(false));
+      // if quarto is disabled, remove Quarto file from the new blank file dropdown
+      AppCommand touchQuarto = commands.touchQuartoDoc();
+      QuartoConfig quartoConfig = RStudioGinjector.INSTANCE.getSession().getSessionInfo().getQuartoConfig();
+      touchQuarto.setVisible(quartoConfig.enabled);
+      newFileMenu.addItem(touchQuarto.createMenuItem(false));
       newFileMenu.addSeparator();
       // these two commands will automatically set up files and folders, so they do not need touch commands
       newFileMenu.addItem(commands.newRShinyApp().createMenuItem(false));


### PR DESCRIPTION
### Intent

QA discovered that when Quarto is disabled, Quarto doc shows up in the Files pane under New blank file...

### Approach

Check session Info to see if quarto is configured, and if not set the Quarto doc item to invisible

<img width="251" alt="image" src="https://user-images.githubusercontent.com/7817881/169353277-5f7b6237-fa76-4bd6-bf36-9415cdd02e23.png">

Also removes quarto file from the Command Palette

<img width="754" alt="image" src="https://user-images.githubusercontent.com/7817881/169368436-c259a80a-6c0d-4786-856e-134f7d83bad4.png">


### Automated Tests

None

### QA Notes

Will repeat QA testing on Centos 7 from https://github.com/rstudio/rstudio-pro/issues/3299

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


