### PR TITLE
Get Cran URL for Rtools 42 windows installer

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -297,8 +297,8 @@ std::string RToolsInfo::url(const std::string& repos) const
 
    if (name() == "4.2")
    {
-      // TODO: replace with CRAN URL once available
-      url = "https://rstudio.org/links/rtools42";
+      std::string suffix = "bin/windows/Rtools/rtools42/rtools.html";
+      url = core::http::URL::complete(repos, suffix);
    }
    else if (name() == "4.0")
    {

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -105,10 +105,14 @@ Error installRtools()
                .call();
 
          std::string rToolsHome = file_utils::readFile(tmpFile);
-         boost::regex reLinkPattern("<a\\shref=\"(.*\\.exe)\">\\s*Rtools42 installer<\\/a>", boost::regex::icase);
-         boost::cmatch matches;
-         if (regex_utils::match(rToolsHome.c_str(), matches, reLinkPattern))
+
+         boost::regex reLinkPattern("<a\\shref=\"(.*rtools.*\\.exe)\">\\s*.+<\\/a>", boost::regex::icase);
+         boost::smatch matches;
+         if (regex_utils::match(rToolsHome, matches, reLinkPattern))
             url = matches[1];
+         else
+            // Use RStudio's hosted copy as a fallback if no match is found
+            url = "https://rstudio.org/links/rtools42";
       }
       catch (std::exception& e)
       {


### PR DESCRIPTION
Addresses #10361 

Since we are not expecting a stable CRAN url, one option is to extract the installer url from the Rtools 42 landing page. 

We can do this in `SessionInstallRtools` using a regex to parse the HTML