### PR TITLE
Upgrade electron to 18.2.4

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -42,7 +42,7 @@
         "chai": "4.3.6",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "6.5.1",
-        "electron": "18.2.3",
+        "electron": "18.2.4",
         "electron-mocha": "11.0.2",
         "eslint": "^7.12.1",
         "eslint-config-prettier": "8.3.0",
@@ -4396,9 +4396,9 @@
       "license": "MIT"
     },
     "node_modules/electron": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.3.tgz",
-      "integrity": "sha512-DJWX03hCRKTscsfXxmW4gmgFuseop+g+m4ml7NfOMfankD8uYyr2Xyi3Ui02inL9qZOlbLMeLVCu6jKCKs8p/w==",
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.4.tgz",
+      "integrity": "sha512-wSjU2N6kBGyGKb2GgBhujpfKtnmNr+gDaZZ6fMmlVMoPJ+GvuW0Zr1ImKPdb5zPXopPYmaURDSvHuAfSd4oHFA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -16369,9 +16369,9 @@
       "dev": true
     },
     "electron": {
-      "version": "18.2.3",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.3.tgz",
-      "integrity": "sha512-DJWX03hCRKTscsfXxmW4gmgFuseop+g+m4ml7NfOMfankD8uYyr2Xyi3Ui02inL9qZOlbLMeLVCu6jKCKs8p/w==",
+      "version": "18.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-18.2.4.tgz",
+      "integrity": "sha512-wSjU2N6kBGyGKb2GgBhujpfKtnmNr+gDaZZ6fMmlVMoPJ+GvuW0Zr1ImKPdb5zPXopPYmaURDSvHuAfSd4oHFA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.13.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -43,7 +43,7 @@
     "chai": "4.3.6",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "6.5.1",
-    "electron": "18.2.3",
+    "electron": "18.2.4",
     "electron-mocha": "11.0.2",
     "eslint": "^7.12.1",
     "eslint-config-prettier": "8.3.0",


### PR DESCRIPTION
### Intent
Upgrade electron to 18.2.4

This includes a fix for Linux that caused a crash at startup.

### Approach
Updated package.json

### Automated Tests
None

### QA Notes
`npm start` on Linux starts up properly and no longer has an error about missing libxkbcommon.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


