### PR TITLE
hide menu bar on GPU and Accessibility diagnostic windows (Electron)

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -425,11 +425,7 @@ export class GwtCallback extends EventEmitter {
         if (url === 'chrome://gpu' || url === 'chrome://accessibility') {
           const window = new BrowserWindow({
             autoHideMenuBar: true,
-            webPreferences: {
-               contextIsolation: true,
-               nodeIntegration: false,
-               sandbox: true,
-            },
+            webPreferences: { sandbox: true, },
             acceptFirstMouse: true
           });
  

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -423,8 +423,16 @@ export class GwtCallback extends EventEmitter {
       (event: IpcMainEvent, name: string, url: string, width: number, height: number) => {
         // handle some internal chrome urls specially
         if (url === 'chrome://gpu' || url === 'chrome://accessibility') {
-          const window = new BrowserWindow();
-
+          const window = new BrowserWindow({
+            autoHideMenuBar: true,
+            webPreferences: {
+               contextIsolation: true,
+               nodeIntegration: false,
+               sandbox: true,
+            },
+            acceptFirstMouse: true
+          });
+ 
           // ensure window can be closed with Ctrl+W (Cmd+W on macOS)
           window.webContents.on('before-input-event', (event, input) => {
             const ctrlOrMeta = process.platform === 'darwin' ? input.meta : input.control;


### PR DESCRIPTION
### Intent

Addresses #11142

### Approach

Turn off menubar by default when creating window for GPU or Accessibilty diagnostics.

While I was there, also explicitely turn on sandbox and set the acceptFirstMouse to true so clicking on a button (e.g. copy to clipboard) in these windows on Mac will happen even if the window didn't have focus when clicked.

### Automated Tests

None

### QA Notes

Needs to be tested on Windows and/or Linux.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


