### PR TITLE
set the RSTUDIO_SESSION_PID and RSTUDIO_CHILD_PROCESS_PANE for quarto jobs

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -55,6 +55,10 @@ Error QuartoJob::start()
    environment(&env);
    options.environment = env;
 
+   // this runs in the job pane as a child process of this process
+   core::system::setenv(&(options.environment.get()), "RSTUDIO_CHILD_PROCESS_PANE", "job");
+   core::system::setenv(&(options.environment.get()), "RSTUDIO_SESSION_PID", safe_convert::numberToString(::getpid()));
+   
    // callbacks
    core::system::ProcessCallbacks cb;
    cb.onStarted = boost::bind(&QuartoJob::onStarted, QuartoJob::shared_from_this(), _1);


### PR DESCRIPTION
### Intent

Follow up to #11040

### Approach

Also set the environment variables for quarto jobs. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


