### PR TITLE
Always show .lintr files

### DIFF
--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -14,7 +14,7 @@
  */
 
 #define RSTUDIO_DEBUG_LABEL "codesearch"
-#define RSTUDIO_ENABLE_DEBUG_MACROS
+// #define RSTUDIO_ENABLE_DEBUG_MACROS
 
 #include "SessionCodeSearch.hpp"
 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -14,7 +14,7 @@
  */
 
 #define RSTUDIO_DEBUG_LABEL "codesearch"
-// #define RSTUDIO_ENABLE_DEBUG_MACROS
+#define RSTUDIO_ENABLE_DEBUG_MACROS
 
 #include "SessionCodeSearch.hpp"
 
@@ -213,7 +213,7 @@ void print_tree(tree<Entry> const& tr)
       int depth = tr.depth(it);
       for (int i = 0; i < depth; i++)
          std::cerr << "--";
-      std::cerr << (*it).fileInfo.getAbsolutePath() << "\n";
+      std::cerr << (*it).fileInfo.absolutePath() << "\n";
    }
 #endif
 }
@@ -269,7 +269,7 @@ public:
       //     --> foo/bar
       //                  --> foo/bar/baz
       iterator parent = begin();
-      DEBUG("First parent: '" << (*parent).fileInfo.getAbsolutePath() << "'");
+      DEBUG("First parent: '" << (*parent).fileInfo.absolutePath() << "'");
 
       std::string::size_type matchIndex = absolutePath.find('/');
       
@@ -281,7 +281,7 @@ public:
                   true);
          
          Entry entry(path);
-         DEBUG("Entry: '" << entry.fileInfo.getAbsolutePath() << "'");
+         DEBUG("Entry: '" << entry.fileInfo.absolutePath() << "'");
 
          if (isSamePath(*parent, entry))
          {
@@ -290,7 +290,7 @@ public:
 
          else if (number_of_children(parent) == 0)
          {
-            DEBUG("- Inserting new node as first child of '" << (*parent).fileInfo.getAbsolutePath() << "'");
+            DEBUG("- Inserting new node as first child of '" << (*parent).fileInfo.absolutePath() << "'");
 
             iterator newItr = append_child(parent, entry);
             DEBUG("- Parent now has " << number_of_children(parent) << " children.");
@@ -305,7 +305,7 @@ public:
 
             for (; it != end; ++it)
             {
-               DEBUG("-- Current node: '" << (*it).fileInfo.getAbsolutePath() << "'");
+               DEBUG("-- Current node: '" << (*it).fileInfo.absolutePath() << "'");
                if (isSamePath(*it, entry))
                {
                   DEBUG("-- Found it!");
@@ -315,12 +315,12 @@ public:
 
             if (it == end)
             {
-               DEBUG("- Adding another child to parent '" << (*parent).fileInfo.getAbsolutePath() << "'");
+               DEBUG("- Adding another child to parent '" << (*parent).fileInfo.absolutePath() << "'");
                parent = append_child(parent, entry);
             }
             else
             {
-               DEBUG("- Node already exists; setting parent to child (" << (*parent).fileInfo.getAbsolutePath() << ")");
+               DEBUG("- Node already exists; setting parent to child (" << (*parent).fileInfo.absolutePath() << ")");
                parent = it;
             }
          }
@@ -330,8 +330,8 @@ public:
       DEBUG("Exiting directory node insertion phase");
       
       // Now, we have the filename. We append that to the parent.
-      DEBUG("Parent: '" << (*parent).fileInfo.getAbsolutePath() << "'");
-      DEBUG("Entry: '" << entry.fileInfo.getAbsolutePath() << "'");
+      DEBUG("Parent: '" << (*parent).fileInfo.absolutePath() << "'");
+      DEBUG("Entry: '" << entry.fileInfo.absolutePath() << "'");
       if (parent.number_of_children() == 0)
       {
          DEBUG("- No children at parent node; adding child");
@@ -357,8 +357,8 @@ public:
          sibling_iterator end = parent.end();
          for (; it != end; ++it)
          {
-            DEBUG("-- Current node: '" << (*it).fileInfo.getAbsolutePath() << "'");
-            DEBUG("-- Entry       : '" << entry.fileInfo.getAbsolutePath() << "'");
+            DEBUG("-- Current node: '" << (*it).fileInfo.absolutePath() << "'");
+            DEBUG("-- Entry       : '" << entry.fileInfo.absolutePath() << "'");
             
             if (isSamePath(*it, entry))
             {
@@ -423,7 +423,7 @@ private:
       sibling_iterator end = parent.end();
       for (; it != end; ++it)
       {
-         DEBUG("- Current branch: '" << (*it).fileInfo.getAbsolutePath() << "'");
+         DEBUG("- Current branch: '" << (*it).fileInfo.absolutePath() << "'");
          if (isSamePath(*it, entry))
          {
             *pResult = it;
@@ -621,7 +621,7 @@ public:
       EntryTree::iterator parent = pEntries_->find(parentEntry);
       if (parent != pEntries_->end())
       {
-         DEBUG("Found node: '" + (*parent).fileInfo.getAbsolutePath() + "'");
+         DEBUG("Found node: '" + (*parent).fileInfo.absolutePath() + "'");
          DEBUG("Node has: '" << pEntries_->number_of_children(parent) << "' children.");
          DEBUG("Node has: '" << pEntries_->number_of_siblings(parent) << "' siblings.");
 
@@ -639,7 +639,7 @@ public:
       {
          const Entry& entry = *it;
          
-         DEBUG("Node: '" << (*it).fileInfo.getAbsolutePath() << "'");
+         DEBUG("Node: '" << (*it).fileInfo.absolutePath() << "'");
          
          // skip if it's not a source file
          if (sourceFilesOnly && !isSourceFile(entry.fileInfo))
@@ -900,7 +900,7 @@ private:
          pEntries_->erase(it);
       else
       {
-         DEBUG("Failed to remove index entry for file: '" << fileInfo.getAbsolutePath() << "'");
+         DEBUG("Failed to remove index entry for file: '" << fileInfo.absolutePath() << "'");
          print_tree(*pEntries_);
       }
    }

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -976,6 +976,7 @@
                 ".github",
                 ".gitignore",
                 ".httr-oauth",
+                ".lintr",
                 ".r",
                 ".rbuildignore",
                 ".rdata"   ,

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -137,6 +137,7 @@ MimeType s_mimeTypes[] =
       { "txt",          "text/plain" },
       { "mml",          "text/mathml" },
       { "log",          "text/plain" },
+      { "lintr",        "text/plain" },
       { "out",          "text/plain" },
       { "csl",          "text/x-csl" },
       { "R",            "text/x-r-source" },

--- a/src/cpp/tests/testthat/test-files.R
+++ b/src/cpp/tests/testthat/test-files.R
@@ -74,9 +74,6 @@ test_that("file listings are correct", {
 })
 
 test_that("our list.files, list.dirs hooks function as expected", {
-   
-   library(testthat)
-   
    # use native R routines
    .rs.files.restoreBindings()
    on.exit(.rs.files.replaceBindings(), add = TRUE)

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -327,6 +327,7 @@ public class FileTypeRegistry
       register("README", TEXT, new ImageResource2x(icons.iconText2x()));
       register(".gitignore", TEXT, new ImageResource2x(icons.iconText2x()));
       register(".Rbuildignore", TEXT, new ImageResource2x(icons.iconText2x()));
+      register(".lintr", TEXT, new ImageResource2x(icons.iconText2x()));
       register("packrat.lock", DCF, new ImageResource2x(icons.iconDCF2x()));
       register("*.r", R, new ImageResource2x(icons.iconRdoc2x()));
       register("*.q", R, new ImageResource2x(icons.iconRdoc2x()));

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2036,7 +2036,7 @@ public class UserPrefsAccessor extends Prefs
          "always_shown_extensions",
          _constants.alwaysShownExtensionsTitle(), 
          _constants.alwaysShownExtensionsDescription(), 
-         JsArrayUtil.createStringArray(".circleci", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
+         JsArrayUtil.createStringArray(".circleci", ".gitattributes", ".github", ".gitignore", ".httr-oauth", ".lintr", ".r", ".rbuildignore", ".rdata", ".renvignore", ".renviron", ".rhistory", ".rprofile", ".ruserdata"));
    }
 
    /**

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -198,7 +198,7 @@ public class UserStateAccessor extends Prefs
       protected Platform() {} 
 
       public final native JavaScriptObject getWindows() /*-{
-         return this && this.windows || {"rBinDir":"","preferR64":true,"rstudioPath":""};
+         return this && this.windows || {"rBinDir":"","preferR64":true,"rExecutablePath":""};
       }-*/;
 
    }


### PR DESCRIPTION
### Intent

addresses #11269

### Approach

Add the `.lintr` extension to those that are always visible, mark `*.lintr` files as text files. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


