### PR TITLE
set `RSTUDIO_SESSION_PID` once, don't restore it

### DIFF
--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -171,6 +171,10 @@ void setEnvVar(const std::string& name, const std::string& value)
    if (name == "RSTUDIO_VERSION" && !core::system::getenv(name).empty())
       return;
 
+   // don't restore the pid of this session (should be set by main session initialization)
+   if (name == "RSTUDIO_SESSION_PID" && !core::system::getenv(name).empty())
+      return;
+
    // don't restore socket path environment variables (should be set by main session initialization)
    if (name == "RS_SERVER_RPC_SOCKET_PATH" && !core::system::getenv(name).empty())
       return;

--- a/src/cpp/session/SessionAsyncRProcess.cpp
+++ b/src/cpp/session/SessionAsyncRProcess.cpp
@@ -174,9 +174,6 @@ void AsyncRProcess::start(const char* rCommand,
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_RESPONSE_FILE", ipcResponse_.getAbsolutePath());
    core::system::setenv(&childEnv, "RSTUDIOAPI_IPC_SHARED_SECRET", sharedSecret_);
    
-   // PID of this R session, to match against parent pid of child process
-   core::system::setenv(&childEnv, "RSTUDIO_SESSION_PID", core::safe_convert::numberToString(::getpid()));
-   
    // update environment used for child process
    options.environment = childEnv;
    

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -261,7 +261,6 @@ void ConsoleProcess::commonInit()
    
    // this runs in the terminal pane as a child process of this process
    core::system::setenv(&(options_.environment.get()), "RSTUDIO_CHILD_PROCESS_PANE", "terminal");
-   core::system::setenv(&(options_.environment.get()), "RSTUDIO_SESSION_PID", safe_convert::numberToString(::getpid()));
    
    // When we retrieve from outputBuffer, we only want complete lines. Add a
    // dummy \n so we can tell the first line is a complete line.

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2025,6 +2025,9 @@ int main(int argc, char * const argv[])
       // whether rstudio is running
       core::system::setenv("RSTUDIO", "1");
 
+      // The pid of the session process
+      core::system::setenv("RSTUDIO_SESSION_PID", core::safe_convert::numberToString(::getpid()));
+
       // Mirror the R getOptions("width") value in an environment variable
       core::system::setenv("RSTUDIO_CONSOLE_WIDTH",
                safe_convert::numberToString(rstudio::r::options::kDefaultWidth));

--- a/src/cpp/session/modules/build/SessionBuild.cpp
+++ b/src/cpp/session/modules/build/SessionBuild.cpp
@@ -321,7 +321,6 @@ private:
 
       // this runs in the build pane as a child process of this process
       core::system::setenv(&environment, "RSTUDIO_CHILD_PROCESS_PANE", "build");
-      core::system::setenv(&environment, "RSTUDIO_SESSION_PID", safe_convert::numberToString(::getpid()));
       
       FilePath buildTargetPath = projects::projectContext().buildTargetPath();
       const core::r_util::RProjectConfig& config = projectConfig();


### PR DESCRIPTION
### Intent

Follow up to #11040, addresses #11276 

### Approach

This sets `RSTUDIO_SESSION_PID` once, and makes sure it's not restored. This way we have a match in the console between `RSTUDIO_SESSION_PID` and `Sys.getpid()`. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


