### PR TITLE
Open Source side changes for https://github.com/rstudio/rstudio-pro/p…

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -71,6 +71,7 @@
 - Fixed a regression in which the "(Use Default Version)" option was not present in some R version selector drop downs (rstudio-pro#3451)
 - Fix opening a remote session via downloaded rdprsp file in Mac Desktop Pro when it (RDP) is already open (rstudio-pro#3291)
 - Fixed several error marker issues in visual mode where they did not display (#10949 #10483)
+- Allow Jupyter and VScode sessions to be renamed from the homepage (rstudio-pro#1686)
 
 ### RStudio Workbench
 

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -75,6 +75,7 @@ Error ActiveSessions::create(const std::string& project,
    activeSession.setCreated();
    activeSession.setActivityState(kActivityStateLaunching, true);
    activeSession.setEditor(editor);
+   activeSession.setLabel(project == kProjectNone ? workingDir : project);
    if (editor == kWorkbenchRStudio)
       activeSession.setLastResumed();
 


### PR DESCRIPTION
…ull/3472

Moves 2 parts of https://github.com/rstudio/rstudio-pro/pull/3472 into OS side. Setting the label on OS session creation has little effect as it's not really used.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


