### PR TITLE
ignore `/.git/` instead of `/.git`

### DIFF
--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -514,7 +514,8 @@ std::vector<std::string> fileMonitorIgnoredComponents()
       "/.quarto",
 
       // ignore things within a .git folder
-      "/.git",
+      // ... but allow e.g. .github
+      "/.git/",
 
       // ignore some directories within the revdep folder
       "/revdep/checks",


### PR DESCRIPTION
### Intent

addresses #11284 

### Approach

Adding `/` at the end of ignored `/.git/` so that `/.github` is not ignored by file monitor. 

e.g. in dplyr: 

<img width="459" alt="image" src="https://user-images.githubusercontent.com/2625526/170271201-9d5e3d81-b2a5-410d-b880-140b7e541804.png">

<img width="452" alt="image" src="https://user-images.githubusercontent.com/2625526/170271264-24cd7f39-2281-4ba0-8439-cc9456156ac2.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


