### PR TITLE
If Quarto has been disabled, then disable the quarto test

### DIFF
--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -51,6 +51,11 @@ test_that("setting UI prefs updates options", {
 })
 
 test_that(".rs.rsconnectDeployList() includes _quarto.yml and _metadata.yml files (#10995 )", {
+   if (!existsFunction(".rs.quartoFileProject")) {
+      # if Quarto is disabled (e.g. on Centos7), skip this test
+      return(TRUE)
+   }
+   
    dir.create(tf <- tempfile()); on.exit(unlink(tf, TRUE, TRUE))
    dir.create(file.path(tf, "sub"))
 


### PR DESCRIPTION
Follow up to changes in 39de73fd61812d and #11201.

If quarto has been disabled (due to OS) we don't want to run this test because it will fail, and doesn't make sense.