### PR TITLE
use Qt 5.12.10 on MacOS

### DIFF
--- a/dependencies/osx/install-qt-macos
+++ b/dependencies/osx/install-qt-macos
@@ -21,7 +21,7 @@
 set -e
 
 if [ -z "$QT_VERSION" ]; then
-    QT_VERSION=5.12.8
+    QT_VERSION=5.12.10
 fi
 if [ -z "$QT_SDK_DIR" ]; then
 


### PR DESCRIPTION
### Intent

We've been using Qt 5.12.10 for our Mac Desktop releases for the past couple of releases. On other platforms we still use 5.12.8.

The dependency-installer script for Mac (only used on dev machines) was still looking for 5.12.8.

### Approach

Bump script to look for 5.12.10.

### Automated Tests

N/A

### QA Notes

Dev machine only thing.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


