### PR TITLE
Skip quarto tests when quarto disabled

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -277,6 +277,7 @@ if has-scope "r"; then
    export RS_CRASH_HANDLER_PATH="@CMAKE_CURRENT_BINARY_DIR@/server/crash-handler-proxy/crash-handler-proxy"
    export RS_CRASHPAD_HANDLER_PATH="@RSTUDIO_TOOLS_ROOT@/crashpad/crashpad/out/Default/crashpad_handler"
 
+   export QUARTO_ENABLED="@QUARTO_ENABLED@"
    runWatchdogProcess 5m false                                                   \
       "@CMAKE_CURRENT_BINARY_DIR@/session/${RSTUDIO_SESSION_BIN}"                \
       --run-script "\"source('${TESTTHAT_TESTS_DIR}/run-tests.R'); runTests()\"" \

--- a/src/cpp/tests/testthat/test-rsconnect.R
+++ b/src/cpp/tests/testthat/test-rsconnect.R
@@ -51,6 +51,10 @@ test_that("setting UI prefs updates options", {
 })
 
 test_that(".rs.rsconnectDeployList() includes _quarto.yml and _metadata.yml files (#10995 )", {
+   if (Sys.getenv("QUARTO_ENABLED") == "FALSE") {
+      skip('Not run when Quarto disabled')
+   }
+
    dir.create(tf <- tempfile()); on.exit(unlink(tf, TRUE, TRUE))
    dir.create(file.path(tf, "sub"))
 


### PR DESCRIPTION
### Intent

Fix unit test failures in CentOS7 environments
See: https://build.rstudioservices.com/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/1285/pipeline

### Approach

Have `cmake` pass `$QUARTO_ENABLED` in the `rstudio-tests` script. Then use this variable to skip unit tests that depend on quarto. 

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


