### PR TITLE
hide Code / Editing / General (options) section title when project is open

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -70,10 +70,18 @@ public class EditingPreferencesPane extends PreferencesPane
       prefs_ = prefs;
       server_ = server;
       commands_ = commands;
+
+      boolean hasProject = session.getSessionInfo().getActiveProjectFile() != null;
+
       PreferencesDialogBaseResources baseRes = PreferencesDialogBaseResources.INSTANCE;
 
       VerticalTabPanel editingPanel = new VerticalTabPanel(ElementIds.EDIT_EDITING_PREFS);
-      editingPanel.add(headerLabel(constants_.generalHeaderLabel()));
+      
+      // Extra UI shown when a project is open makes the pane overflow on some
+      // browsers, so don't display initial "General" section title to regain
+      // some vertical space.
+      if (!hasProject)
+         editingPanel.add(headerLabel(constants_.generalHeaderLabel()));
 
       editingPanel.add(tight(spacesForTab_ = checkboxPref(prefs_.useSpacesForTab(),false /*defaultSpace*/)));
       editingPanel.add(indent(tabWidth_ = numericPref(constants_.editingTabWidthLabel(), 1, UserPrefs.MAX_TAB_WIDTH,
@@ -147,8 +155,6 @@ public class EditingPreferencesPane extends PreferencesPane
       projectPrefsPanel.add(editProjectSettings);
       editingPanel.add(projectPrefsPanel);
 
-      String activeProjectFile = session.getSessionInfo().getActiveProjectFile();
-      boolean hasProject = activeProjectFile != null;
       projectPrefsPanel.setVisible(hasProject);
 
       Label executionLabel = headerLabel(constants_.editingExecutionLabel());


### PR DESCRIPTION
### Intent

Addresses #11272 - additional message/button shown in Global Options / Code / Editing when there is a project open is making the pane contents too tall for some browsers.

### Approach

When a project is open, hide the "General" section title to regain some vertical space and reduce likelyhood of the pane not fitting in the available space. The "General" title will still be shown when there is no project.

Original:
 
![before](https://user-images.githubusercontent.com/10569626/170376700-2780e9d6-6019-4d30-8db6-2dd05234f40c.png)

With this change:

![after](https://user-images.githubusercontent.com/10569626/170376833-d5db6f9f-55fd-44f2-8f6f-01798f46e7db.png)

When there is no project open:

![no-project](https://user-images.githubusercontent.com/10569626/170377649-bccc0b0e-d939-4020-9b1e-f6be79d8f9a7.png)

### Automated Tests

N/A

### QA Notes

Verify that when a project is open, the General title gets hidden as seen in screenshots above.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


