### PR TITLE
fix issue when previewing plot after session restart

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@
 ### Fixed
 
 - Fixed an issue where vignette content was illegible when viewed with a dark theme. (#11164)
+- Fixed an issue where previewing a plot as PDF could fail after a session restart. (#1905)
 - Fixed logging of `HRESULT` error values by logging them as hexadecimal instead of decimal (#10310)
 - Fixed notebook execution handling of knitr `message=FALSE` chunk option to suppress messages if the option is set to FALSE (#9436)
 - Fixed plot export to PDF options (#9185)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -1316,7 +1316,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 {
    # collect information about the running version of R / RStudio
    rstudioInfo <- .rs.api.versionInfo()
-   rstudioVersion <- format(rstudioInfo$version)
+   rstudioVersion <- format(rstudioInfo$long_version)
    
    rstudioEdition <- sprintf(
       "%s [%s]",

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -237,13 +237,6 @@ void handleClientInit(const boost::function<void()>& initFunction,
       sessionInfo["scratch_dir"] = options.userScratchPath().getAbsolutePath();
    }
 
-   // temp dir
-   FilePath tempDir = rstudio::r::session::utils::tempDir();
-   Error error = tempDir.ensureDirectory();
-   if (error)
-      LOG_ERROR(error);
-   sessionInfo["temp_dir"] = tempDir.getAbsolutePath();
-
    // R_LIBS_USER
    sessionInfo["r_libs_user"] = module_context::rLibsUser();
    
@@ -263,7 +256,7 @@ void handleClientInit(const boost::function<void()>& initFunction,
    
    // source documents
    json::Array jsonDocs;
-   error = modules::source::clientInitDocuments(&jsonDocs);
+   Error error = modules::source::clientInitDocuments(&jsonDocs);
    if (error)
       LOG_ERROR(error);
    sessionInfo["source_documents"] = jsonDocs;

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -37,6 +37,8 @@
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
 #include <r/RRoutines.hpp>
+
+#include <r/session/RSessionUtils.hpp>
 #include <r/session/RGraphics.hpp>
 
 #include <session/SessionModuleContext.hpp>
@@ -55,7 +57,19 @@ namespace {
 
 // locations
 #define kGraphics "/graphics"
+
+Error getPlotTempdir(const json::JsonRpcRequest& request, 
+                     json::JsonRpcResponse* pResponse)
+{
+   std::string tempdir;
+   Error error = r::exec::RFunction("tempdir").callUtf8(&tempdir);
+   if (error)
+      LOG_ERROR(error);
    
+   pResponse->setResult(tempdir);
+   return Success();
+}
+
 Error nextPlot(const json::JsonRpcRequest& request, 
                json::JsonRpcResponse* pResponse)
 {   
@@ -903,6 +917,7 @@ Error initialize()
    using namespace module_context;
    ExecBlock initBlock;
    initBlock.addFunctions()
+      (bind(registerRpcMethod, "get_plot_tempdir", getPlotTempdir))
       (bind(registerRpcMethod, "next_plot", nextPlot))
       (bind(registerRpcMethod, "previous_plot", previousPlot))
       (bind(registerRpcMethod, "remove_plot", removePlot))

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1763,6 +1763,11 @@ public class RemoteServer implements Server
 
       return previewURL;
    }
+   
+   public void getPlotTempdir(ServerRequestCallback<String> requestCallback)
+   {
+      sendRequest(RPC_SCOPE, GET_PLOT_TEMPDIR, requestCallback);
+   }
 
    public void nextPlot(ServerRequestCallback<Void> requestCallback)
    {
@@ -6664,6 +6669,7 @@ public class RemoteServer implements Server
    private static final String TOUCH_FILE = "touch_file";
    private static final String COMPLETE_UPLOAD = "complete_upload";
 
+   private static final String GET_PLOT_TEMPDIR = "get_plot_tempdir";
    private static final String NEXT_PLOT = "next_plot";
    private static final String PREVIOUS_PLOT = "previous_plot";
    private static final String REMOVE_PLOT = "remove_plot";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -115,10 +115,6 @@ public class SessionInfo extends JavaScriptObject
       return this.scratch_dir;
    }-*/;
 
-   public final native String getTempDir() /*-{
-      return this.temp_dir;
-   }-*/;
-
    public final native JsArray<PrefLayer> getPrefs() /*-{
       if (!this.user_prefs)
          this.user_prefs = [ {} ];

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/model/PlotsServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/model/PlotsServerOperations.java
@@ -34,6 +34,8 @@ public interface PlotsServerOperations
                            int height, 
                            boolean attachment);
    
+   void getPlotTempdir(ServerRequestCallback<String> requestCallback);
+   
    void nextPlot(ServerRequestCallback<Void> requestCallback);
    void previousPlot(ServerRequestCallback<Void> requestCallback);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/SavePlotAsPdfDialog.java
@@ -35,7 +35,9 @@ import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.server.Bool;
+import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotResources;
 import org.rstudio.studio.client.workbench.exportplot.ExportPlotUtils;
@@ -120,16 +122,24 @@ public class SavePlotAsPdfDialog extends ModalDialogBase
                                                      new ClickHandler() {
          @Override
          public void onClick(ClickEvent event)
-         {  
-            // get temp file for preview
-            FileSystemItem tempDir = 
-                  FileSystemItem.createDir(sessionInfo.getTempDir());
-            FileSystemItem previewPath = 
-                  FileSystemItem.createFile(tempDir.completePath("preview.pdf"));
-                
-            // invoke handler
-            SavePlotAsHandler handler = createSavePlotAsHandler();
-            handler.attemptSave(previewPath, true, true, null);
+         {
+            server_.getPlotTempdir(new SimpleRequestCallback<String>()
+            {
+               @Override
+               public void onResponseReceived(String response)
+               {
+                  FileSystemItem tempDir = 
+                        FileSystemItem.createDir(response);
+
+                  // get temp file for preview
+                  FileSystemItem previewPath = 
+                        FileSystemItem.createFile(tempDir.completePath("preview.pdf"));
+                  
+                  // invoke handler
+                  SavePlotAsHandler handler = createSavePlotAsHandler();
+                  handler.attemptSave(previewPath, true, true, null);
+               }
+            });
          }
       });
       addLeftButton(previewButton, ElementIds.PREVIEW_BUTTON);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/1905.

### Approach

Rather than reading and caching the R temporary directory when the client connects, use an RPC to read the current temporary directory value (as that could change over the lifetime of the session).

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/1905.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
