### PR TITLE
Change from bionic to jammy deps

### DIFF
--- a/docker/jenkins/Dockerfile.jammy-amd64
+++ b/docker/jenkins/Dockerfile.jammy-amd64
@@ -90,7 +90,7 @@ COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
 COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy
 
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/


### PR DESCRIPTION
### Intent

Install the correct version of Launcher

Needs to be merged into main.

### Approach

Pass `jammy` instead of `bionic` to the script that will eventually install launcher

### Automated Tests

Any tests using launcher against ubuntu 22 (probably not for this branch)

### QA Notes

Any tests using launcher against ubuntu 22 (probably not for this branch)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


