### PR TITLE
Added ESC and Enter key recognition for Choose R window - Electron

### DIFF
--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -98,7 +98,7 @@ window.addEventListener('load', () => {
       switch (event.key) {
         case 'Enter':
           if (document.activeElement !== buttonBrowse) {
-            void okButton();
+            void accept();
           }
           break;
         case 'Escape':
@@ -127,7 +127,7 @@ function closeWindow() {
   window.close();
 }
 
-async function okButton() {
+async function accept() {
   const useDefault32Radio = document.getElementById('use-default-32') as HTMLInputElement;
   if (useDefault32Radio.checked) {
     const shouldCloseWindow = await window.callbacks.useDefault32bit(callbackData());

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -79,11 +79,16 @@ buttonBrowse.addEventListener('click', async () => {
     }
   } catch (err) {
     logger().logDebug(`Error occurred when trying to browse for R: ${err}`);
+  } finally {
+    /** 
+    * Without this timeout, the Choose R Modal will also be closed together with the Browse Dialog.
+    * As the modal keeps focused while interacting with the Browse Dialog,
+    * as soon as the dialog is closed, the `Esc` keypress event will also be triggered in the modal.
+    */
+    setTimeout(() => {
+      isBrowseDialogOpen = false;
+    }, 150);
   }
-
-  setTimeout(() => {
-    isBrowseDialogOpen = false;
-  }, 150);
 });
 
 window.addEventListener('load', () => {


### PR DESCRIPTION
### Intent

Added ESC and Enter key recognition for Choose R window

### Approach

Detected those key presses for that window.

### Automated Tests

None

### QA Notes

Refer to #11098. Also, on QT RStudio, when the user presses `enter` when having the `Browse` button highlighted, the browse dialog would open instead of using the current selection. Also, when pressing `ESC` with the browse dialog open, the `Choose R Window` would not close, only the browse dialog.

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11098

