### PR TITLE
Fix issue when selecting a R Executable from a Network Path - Electron

### DIFF
--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -42,7 +42,7 @@ const homePathLeafAlias = '~';
  * @return {*} 
  */
 function normalizeSeparators(path: string, separator = '/') {
-  return path.replace(/[\\/]+/g, separator);
+  return path.replace(/[\\]/g, separator);
 }
 
 /**

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -35,7 +35,7 @@ const homePathAlias = '~/';
 const homePathLeafAlias = '~';
 
 /**
- * Removes duplicate separators from a path, given a separator for search.
+ * Normalize separators of a given path.
  *
  * @param {string} path
  * @param {string} [separator='/']
@@ -46,7 +46,7 @@ function normalizeSeparators(path: string, separator = '/') {
 }
 
 /**
- * Removes duplicated separators from a path based on platform.
+ * Normalizes separatos of a given path based on the current platform.
  *
  * @export
  * @param {string} path

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -42,7 +42,7 @@ const homePathLeafAlias = '~';
  * @return {*} 
  */
 function normalizeSeparators(path: string, separator = '/') {
-  return path.replace(/[\\]/g, separator);
+  return path.replace(/[\\/]/g, separator);
 }
 
 /**

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -46,7 +46,7 @@ function normalizeSeparators(path: string, separator = '/') {
 }
 
 /**
- * Normalizes separatos of a given path based on the current platform.
+ * Normalizes separators of a given path based on the current platform.
  *
  * @export
  * @param {string} path

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -603,12 +603,14 @@ describe('FilePath', () => {
       assert.strictEqual(cPath.completeChildPath('../bar'), cPath);
       assert.strictEqual(cPath.completeChildPath('/path/to/quux'), cPath);
     });
-    it('Paths only contain forward slashes with no duplicates', () => {
+    it('Paths contain correct slashes based on OS', () => {
       const paths = [
         'c:\\www\\app\\my/folder/file.r',
         'C:\\R\\4.1.2/bin/R.exe',
-        'c:\\\\www\\\\app\\my/folder/file.r',
+        'c:\\www\\\\app\\my/folder/file.r',
         'T:\\R-3.6.3\\bin\\x64\\R.exe',
+        '\\\\TOWER\\downloads\\R-3.6.3\\bin\\x64\\R.exe',
+        'C:\\R\\4.1.2/bin/R.exe'
       ];
     
       const correctSeparator = process.platform === 'win32' ? '\\' : '/';


### PR DESCRIPTION
### Intent

Fix an issue that would occur when trying to select a R Executable that was located on an unmounted Network Drive.

### Approach

Previously, we were not enabling paths with duplicated slashes. By removing that and enabling users to have double slashes ( Ex: `\\TOWER\downloads\R-3.6.3\bin\x64\R.exe`), this issue was solved.

### Automated Tests

Added a few other tests case scenarios for normalizing paths.

### QA Notes

Refer to #11247 

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11247


