### PR TITLE
close editors when satellite window closed (Electron)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java
@@ -199,6 +199,9 @@ public class Satellite implements HasCloseHandlers<Satellite>
       $wnd.opener.registerAsRStudioSatellite(name, $wnd);
    }-*/;
 
+   public native void notifyRStudioSatelliteClosed() /*-{
+      $wnd.opener.notifyRStudioSatelliteClosed($wnd.RStudioSatelliteName);
+   }-*/;
 
    // check whether the current window is a satellite
    public static native boolean isCurrentWindowSatellite() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceWindow.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.ApplicationCommandManager;
@@ -324,6 +325,15 @@ public class SourceWindow implements LastSourceDocClosedEvent.Handler,
                public void onReadyToQuit(boolean saveChanges)
                {
                   markReadyToClose();
+                  if (BrowseCap.isElectron())
+                  {
+                     // Fix: https://github.com/rstudio/rstudio/issues/10906
+                     // On Electron, the 'unload' event isn't being received when we close
+                     // the satellite window via WindowEx.get().close() below; we rely on 
+                     // Satellite.java invoking `opener.notifyRStudioSatelliteClosed` in response 
+                     // to that event so invoke it directly here.
+                     satellite_.notifyRStudioSatelliteClosed();
+                  }
 
                   // we may be in the middle of closing the window already, so
                   // defer the closure request


### PR DESCRIPTION
### Intent

Addresses #10906

On Electron, when we close the satellite window the `unload` event isn't received, and we were relying on this to close the editor(s) in a satellite window when it closed. MDN does say the unload event is unreliable and recommends against using it and that appears to be a valid warning for Electron.

### Approach

On Electron, directly invoke `notifyRStudioSatelliteClosed()` instead of doing it in response to the unload event.

### Automated Tests

None

### QA Notes

In addition to the basic scenario outlined in the issue, also spot-check that that if you try to close a window containing modified (unsaved) buffers, you get prompted to save, etc.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


