### PR TITLE
only have `PackageCleanBeforeInstall` in `.Rproj` if it's "No"

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1119,11 +1119,7 @@ Error writeProjectFile(const FilePath& projectFilePath,
                build.append("PackageUseDevtools: Yes\n");
             }
 
-            if (config.packageCleanBeforeInstall)
-            {
-               build.append("PackageCleanBeforeInstall: Yes\n");
-            }
-            else
+            if (!config.packageCleanBeforeInstall)
             {
                build.append("PackageCleanBeforeInstall: No\n");
             }


### PR DESCRIPTION
### Intent

follow up on #10432

### Approach

the `PackageCleanBeforeInstall` only get added to the Rproj file if it's "No". This way when we open old project, the setting is silently set to "Yes" and the file is not modified. 

cc @hadley 

Tested with `multidplyr`. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


