### PR TITLE
Disable interaction with window behind Choose R Modal

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -386,7 +386,7 @@ export class GwtCallback extends EventEmitter {
       }
 
       // ask the user what version of R they'd like to use
-      const chooseRDialog = new ChooseRModalWindow(rInstalls);
+      const chooseRDialog = new ChooseRModalWindow(rInstalls, mainWindow.window);
 
       void handleLocaleCookies(chooseRDialog);
 

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -13,19 +13,18 @@
  *
  */
 
-import { BrowserWindow, ipcMain } from 'electron';
+import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain } from 'electron';
 import { err, Expected, ok } from '../core/expected';
 import { safeError } from '../core/err';
 
 export abstract class ModalDialog<T> extends BrowserWindow {
-
   abstract onShowModal(): Promise<T>;
 
-  private readonly _widgetUrl : string;
-  private _ipcMainChannels : string[];
+  private readonly _widgetUrl: string;
+  private _ipcMainChannels: string[];
 
-  constructor(url: string, preload: string) {
-    super({
+  constructor(url: string, preload: string, parentWindow: BrowserWindow | null = null) {
+    let options: BrowserWindowConstructorOptions = {
       minWidth: 400,
       minHeight: 400,
       width: 400,
@@ -34,7 +33,13 @@ export abstract class ModalDialog<T> extends BrowserWindow {
       webPreferences: {
         preload: preload,
       },
-    });
+    };
+
+    if (parentWindow !== null) {
+      options = { ...options, parent: parentWindow, modal: true };
+    }
+
+    super(options);
 
     // initialize instance variables
     this._widgetUrl = url;
@@ -72,7 +77,6 @@ export abstract class ModalDialog<T> extends BrowserWindow {
   }
 
   async showModalImpl(): Promise<T> {
-
     // load the associated HTML
     await this.loadURL(this._widgetUrl);
 
@@ -81,6 +85,5 @@ export abstract class ModalDialog<T> extends BrowserWindow {
 
     // invoke derived class's callback and return the response
     return this.onShowModal();
-
   }
 }

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { dialog } from 'electron';
+import { BrowserWindow, dialog } from 'electron';
 import { detectREnvironment, findDefault32Bit, findDefault64Bit, isValidInstallation } from '../../main/detect-r';
 import { logger } from '../../core/logger';
 import { ModalDialog } from '../modal-dialog';
@@ -27,14 +27,12 @@ declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
 
 function checkValid(data: CallbackData) {
-
   // get path to R
   const rBinaryPath = data.binaryPath as string;
 
   // try to run it
   const [rEnvironment, err] = detectREnvironment(rBinaryPath);
   if (err) {
-    
     // something went wrong; let the user know they can't use
     // this version of R with RStudio
     dialog.showMessageBoxSync({
@@ -45,42 +43,34 @@ function checkValid(data: CallbackData) {
     });
 
     return false;
-
   }
 
   logger().logDebug(`Validated R: ${rEnvironment.rScriptPath}`);
   logger().logDebug(JSON.stringify(rEnvironment));
   return true;
-
 }
 
 export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
-  
   private rInstalls: string[];
 
-  constructor(rInstalls: string[]) {
-
-    super(CHOOSE_R_WEBPACK_ENTRY, CHOOSE_R_PRELOAD_WEBPACK_ENTRY);
+  constructor(rInstalls: string[], parentWindow: BrowserWindow | null = null) {
+    super(CHOOSE_R_WEBPACK_ENTRY, CHOOSE_R_PRELOAD_WEBPACK_ENTRY, parentWindow);
 
     this.rInstalls = rInstalls;
 
     initI18n();
-
   }
 
   async maybeResolve(resolve: (data: CallbackData) => void, data: CallbackData) {
-
     if (checkValid(data)) {
       resolve(data);
       return true;
     } else {
       return false;
     }
-
   }
 
   async onShowModal(): Promise<CallbackData | null> {
-    
     const r32 = findDefault32Bit();
     const r64 = findDefault64Bit();
     const initData = {
@@ -95,7 +85,6 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
     // listen for messages from the window
     return new Promise((resolve) => {
-
       this.addIpcHandler('use-default-32bit', async (event, data: CallbackData) => {
         const installPath = initData.default32bitPath;
         data.binaryPath = `${installPath}/bin/i386/R.exe`;
@@ -116,14 +105,12 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
       });
 
       this.addIpcHandler('browse-r-exe', async (event, data: CallbackData) => {
-
         const response = dialog.showOpenDialogSync(this, {
           title: i18next.t('uiFolder.chooseRExecutable'),
           properties: ['openFile'],
           filters: [{ name: i18next.t('uiFolder.rExecutable'), extensions: ['exe'] }],
         });
 
-        
         if (response) {
           data.binaryPath = response[0];
           logger().logDebug(`Using user-selected version of R (${data.binaryPath})`);
@@ -131,7 +118,6 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
         }
 
         return false;
-
       });
 
       this.addIpcHandler('cancel', () => {
@@ -141,7 +127,6 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
       this.on('closed', () => {
         return resolve(null);
       });
-
     });
   }
 }


### PR DESCRIPTION
### Intent

Disable interaction with window behind Choose R Modal

### Approach

Setting the main window as Choose R Modal parent Window.

### Automated Tests

None

### QA Notes

Refer to #11097 

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11097


