### PR TITLE
Fix Electron renderer crash on macOS during Quarto editing

### DIFF
--- a/package/osx/cmake/codesign-package-electron.cmake
+++ b/package/osx/cmake/codesign-package-electron.cmake
@@ -24,7 +24,7 @@ endfunction()
 set(CODESIGN_FLAGS
    --options runtime
    --timestamp
-   --entitlements "@CMAKE_CURRENT_SOURCE_DIR@/entitlements.plist"
+   --entitlements "@CMAKE_CURRENT_SOURCE_DIR@/entitlements-electron.plist"
    --force
    --deep)
 

--- a/package/osx/entitlements-electron.plist
+++ b/package/osx/entitlements-electron.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  
+  <!-- Required by R packages which want to access the camera. -->
+  <key>com.apple.security.device.camera</key>
+  <true/>
+
+  <!-- Required by R packages which want to access the microphone. -->
+  <key>com.apple.security.device.audio-input</key>
+  <true/>
+
+  <!-- Required by Qt / Chromium. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.disable-executable-page-protection</key>
+  <true/>
+
+  <!-- We use DYLD_INSERT_LIBRARIES to load the libR.dylib dynamically. -->
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+
+  <!-- Required to knit to Word -->
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
+
+  <!-- Required for Electron WebAssembly compilation -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+
+</dict>
+</plist>


### PR DESCRIPTION
### Intent

Addresses #11309

Quarto uses WebAssembly for which Electron requires an entitlement that we were removing when we did package builds.

### Approach

Copied the existing `entitlements.plist` to `entitlements-electron.plist`, added `com.apple.security.cs.allow-jit entitlement`, and tweaked script to use it for Electron build. I didn't want to mess with Qt entitlements.

### Automated Tests

None

### QA Notes

This is Mac / M1 specific. See issue for repro steps.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


