### PR TITLE
Added Window Menu on OSX for Electron

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -339,7 +339,7 @@ export class MenuCallback extends EventEmitter {
      * @returns the final template list after removing unnecessary separators and hidden items
      */
     const recursiveCopy = (menuItemTemplates: MenuItemConstructorOptions[]) => {
-      const newMenuTemplate = new Array<MenuItemConstructorOptions>();
+      let newMenuTemplate = new Array<MenuItemConstructorOptions>();
 
       for (const menuItemTemplate of menuItemTemplates) {
         let referenceMenuItemTemplate;
@@ -369,7 +369,7 @@ export class MenuCallback extends EventEmitter {
         newMenuTemplate.push(newMenuItemTemplate);
       }
 
-      return newMenuTemplate.filter((item, idx, arr) => {
+      newMenuTemplate = newMenuTemplate.filter((item, idx, arr) => {
         if (item.type !== 'separator') {
           return removeItemsWithEmptySubmenuList(item);
         }
@@ -377,6 +377,25 @@ export class MenuCallback extends EventEmitter {
         const prevItem = arr[idx - 1];
         return idx !== 0 && prevItem.type !== 'separator' && idx != arr.length - 1;
       });
+
+      if (process.platform === 'darwin') {
+        newMenuTemplate = newMenuTemplate.reduce((menuTemplateList: MenuItemConstructorOptions[], menuItem) => {
+          if (menuItem.id === 'Help') {
+            const windowMenuItem: MenuItemConstructorOptions = {
+              id: 'Window',
+              visible: true,
+              role: 'windowMenu',
+              label: 'Window',
+            };
+
+            menuTemplateList.push(windowMenuItem);
+          }
+          menuTemplateList.push(menuItem);
+          return menuTemplateList;
+        }, []);
+      }
+
+      return newMenuTemplate;
     };
 
     const newMainMenuTemplate = recursiveCopy(this.mainMenuTemplate);


### PR DESCRIPTION
### Intent

Add Window Menu on OSX for Electron

### Approach

Added Electron native Window Menu before the Help menu

### Automated Tests

None

### QA Notes

Refer to #11238

### QT Window Menu:
![Screen Shot 2022-06-02 at 01 37 27](https://user-images.githubusercontent.com/36674530/171673940-d6cb2960-bde4-4483-82fb-e058863c3857.png)

### Electron Window Menu:
![Screen Shot 2022-06-02 at 12 54 49](https://user-images.githubusercontent.com/36674530/171673964-3c208d8d-ce37-4f0f-b416-5b0f873e04a5.png)


### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11238

