### PR TITLE
Ensure that sqlite database RW for user only

### DIFF
--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -146,6 +146,11 @@ Error readOptions(const std::string& databaseConfigFile,
       if (error)
          return error;
 
+      // want to ensure users other than the server can't read the database
+      error = databaseFile.changeFileMode(FileMode::USER_READ_WRITE);
+      if (error)
+         return error;
+
       if (databaseFileUser.has_value())
       {
          // always ensure the database file user is correct, if specified


### PR DESCRIPTION
When the sqlite database is created, it's set to RW for the owning user
only to prevent access from users

addresses rstudio/rstudio-pro#2692
No pro specific PR required

### Intent

close up a security issue by ensuring the sqlite database files are only read/writable by the owning user

### Approach

After the server creates the rstudio.sqlite file, we now manually change the file mode to 600

### Automated Tests

No automated testing added, trivial to manually test and exceptionally low probability of unintentionally breaking in the future.

### QA Notes

From an rstudio session, execute
```
library(connections)
library(RSQLite)
con <- connection_open(SQLite(), "/var/lib/rstudio-server/rstudio-os.sqlite")
```
You'll be greeted by 
```
Error: Could not connect to database:
unable to open database file
```
and no new connection will be added to the connection pane.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


