### PR TITLE
Fix various typos in `src/cpp/**`

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -767,7 +767,7 @@ OpenSSL License
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
+ * the following conditions are adheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -792,7 +792,7 @@ OpenSSL License
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -810,7 +810,7 @@ OpenSSL License
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publically available version or
+ * The licence and distribution terms for any publicly available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/NOTICE
+++ b/NOTICE
@@ -767,7 +767,7 @@ OpenSSL License
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are adheared to.  The following conditions
+ * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -792,7 +792,7 @@ OpenSSL License
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the routines from the library
+ *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -810,7 +810,7 @@ OpenSSL License
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publicly available version or
+ * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/src/cpp/core/include/core/FileInfo.hpp
+++ b/src/cpp/core/include/core/FileInfo.hpp
@@ -69,7 +69,7 @@ public:
    {
    }
 
-   // COPYING: via compliler (copyable members)
+   // COPYING: via compiler (copyable members)
 
 public:
    bool empty() const { return absolutePath_.empty(); }

--- a/src/cpp/core/include/core/libclang/clang-c/CXCompilationDatabase.h
+++ b/src/cpp/core/include/core/libclang/clang-c/CXCompilationDatabase.h
@@ -7,7 +7,7 @@
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|
-|* This header provides a public inferface to use CompilationDatabase without *|
+|* This header provides a public interface to use CompilationDatabase without *|
 |* the full Clang C++ API.                                                    *|
 |*                                                                            *|
 \*===----------------------------------------------------------------------===*/
@@ -58,7 +58,7 @@ typedef void * CXCompileCommand;
  */
 typedef enum  {
   /*
-   * \brief No error occured
+   * \brief No error occurred
    */
   CXCompilationDatabase_NoError = 0,
 

--- a/src/cpp/core/include/core/libclang/clang-c/Index.h
+++ b/src/cpp/core/include/core/libclang/clang-c/Index.h
@@ -7,7 +7,7 @@
 |*                                                                            *|
 |*===----------------------------------------------------------------------===*|
 |*                                                                            *|
-|* This header provides a public inferface to a Clang library for extracting  *|
+|* This header provides a public interface to a Clang library for extracting  *|
 |* high-level symbol information from source files without exposing the full  *|
 |* Clang C++ API.                                                             *|
 |*                                                                            *|
@@ -1669,7 +1669,7 @@ enum CXCursorKind {
 
   /**
    * \brief An expression that refers to some value declaration, such
-   * as a function, varible, or enumerator.
+   * as a function, variable, or enumerator.
    */
   CXCursor_DeclRefExpr                   = 101,
 
@@ -4485,7 +4485,7 @@ enum CXCompletionChunkKind {
    * for "int x", indicating that the current argument will initialize that
    * parameter. After typing further, to \c add(17, (where the code-completion
    * point is after the ","), the code-completion string will contain a
-   * "current paremeter" chunk to "int y".
+   * "current parameter" chunk to "int y".
    */
   CXCompletionChunk_CurrentParameter,
   /**
@@ -5714,7 +5714,7 @@ typedef enum {
 
   /**
    * \brief Skip a function/method body that was already parsed during an
-   * indexing session assosiated with a \c CXIndexAction object.
+   * indexing session associated with a \c CXIndexAction object.
    * Bodies in system headers are always skipped.
    */
   CXIndexOpt_SkipParsedBodiesInSession = 0x10

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -50,7 +50,7 @@ namespace r_util {
 
    private:
       FilePath scratchPath_;
-      const std::string propertiesDirName_ = "properites";
+      const std::string propertiesDirName_ = "properties";
 
       FilePath getPropertyDir() const;
       FilePath getPropertyFile(const std::string& name) const;

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -50,7 +50,7 @@ namespace r_util {
 
    private:
       FilePath scratchPath_;
-      const std::string propertiesDirName_ = "properties";
+      const std::string propertiesDirName_ = "properites";
 
       FilePath getPropertyDir() const;
       FilePath getPropertyFile(const std::string& name) const;

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -84,7 +84,7 @@ private:
       if (error)
          LOG_ERROR(error);
 
-      propertiesPath_ = scratchPath_.completeChildPath("properites");
+      propertiesPath_ = scratchPath_.completeChildPath("properties");
       error = propertiesPath_.ensureDirectory();
       if (error)
          LOG_ERROR(error);

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -84,7 +84,7 @@ private:
       if (error)
          LOG_ERROR(error);
 
-      propertiesPath_ = scratchPath_.completeChildPath("properties");
+      propertiesPath_ = scratchPath_.completeChildPath("properites");
       error = propertiesPath_.ensureDirectory();
       if (error)
          LOG_ERROR(error);

--- a/src/cpp/core/include/core/rapidxml/rapidxml.hpp
+++ b/src/cpp/core/include/core/rapidxml/rapidxml.hpp
@@ -89,7 +89,7 @@ namespace rapidxml
 
         //! Gets pointer to character data where error happened.
         //! Ch should be the same as char type of xml_document that produced the error.
-        //! \return Pointer to location within the parsed string where error occured.
+        //! \return Pointer to location within the parsed string where error occurred.
         template<class Ch>
         Ch *where() const
         {
@@ -403,7 +403,7 @@ namespace rapidxml
         }
 
         //! Allocates a new node from the pool, and optionally assigns name and value to it. 
-        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param type Type of node to create.
@@ -436,7 +436,7 @@ namespace rapidxml
         }
 
         //! Allocates a new attribute from the pool, and optionally assigns name and value to it.
-        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param name Name to assign to the attribute, or 0 to assign no name.
@@ -467,7 +467,7 @@ namespace rapidxml
         }
 
         //! Allocates a char array of given size from the pool, and optionally copies a given string to it.
-        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param source String to initialize the allocated memory with, or 0 to not initialize it.
@@ -710,7 +710,7 @@ namespace rapidxml
         //! <br><br>
         //! Note that node does not own its name or value, it only stores a pointer to it. 
         //! It will not delete or otherwise free the pointer on destruction.
-        //! It is reponsibility of the user to properly manage lifetime of the string.
+        //! It is the responsibility of the user to properly manage lifetime of the string.
         //! The easiest way to achieve it is to use memory_pool of the document to allocate the string -
         //! on destruction of the document the string will be automatically freed.
         //! <br><br>
@@ -737,7 +737,7 @@ namespace rapidxml
         //! <br><br>
         //! Note that node does not own its name or value, it only stores a pointer to it. 
         //! It will not delete or otherwise free the pointer on destruction.
-        //! It is reponsibility of the user to properly manage lifetime of the string.
+        //! It is the responsibility of the user to properly manage lifetime of the string.
         //! The easiest way to achieve it is to use memory_pool of the document to allocate the string -
         //! on destruction of the document the string will be automatically freed.
         //! <br><br>
@@ -1327,7 +1327,7 @@ namespace rapidxml
     
         // Note that some of the pointers below have UNDEFINED values if certain other pointers are 0.
         // This is required for maximum performance, as it allows the parser to omit initialization of 
-        // unneded/redundant values.
+        // unneeded/redundant values.
         //
         // The rules are as follows:
         // 1. first_node and first_attribute contain valid pointers, or 0 if node has no children/attributes respectively

--- a/src/cpp/core/include/core/rapidxml/rapidxml.hpp
+++ b/src/cpp/core/include/core/rapidxml/rapidxml.hpp
@@ -89,7 +89,7 @@ namespace rapidxml
 
         //! Gets pointer to character data where error happened.
         //! Ch should be the same as char type of xml_document that produced the error.
-        //! \return Pointer to location within the parsed string where error occurred.
+        //! \return Pointer to location within the parsed string where error occured.
         template<class Ch>
         Ch *where() const
         {
@@ -403,7 +403,7 @@ namespace rapidxml
         }
 
         //! Allocates a new node from the pool, and optionally assigns name and value to it. 
-        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param type Type of node to create.
@@ -436,7 +436,7 @@ namespace rapidxml
         }
 
         //! Allocates a new attribute from the pool, and optionally assigns name and value to it.
-        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param name Name to assign to the attribute, or 0 to assign no name.
@@ -467,7 +467,7 @@ namespace rapidxml
         }
 
         //! Allocates a char array of given size from the pool, and optionally copies a given string to it.
-        //! If the allocation request cannot be accommodated, this function will throw <code>std::bad_alloc</code>.
+        //! If the allocation request cannot be accomodated, this function will throw <code>std::bad_alloc</code>.
         //! If exceptions are disabled by defining RAPIDXML_NO_EXCEPTIONS, this function
         //! will call rapidxml::parse_error_handler() function.
         //! \param source String to initialize the allocated memory with, or 0 to not initialize it.
@@ -710,7 +710,7 @@ namespace rapidxml
         //! <br><br>
         //! Note that node does not own its name or value, it only stores a pointer to it. 
         //! It will not delete or otherwise free the pointer on destruction.
-        //! It is the responsibility of the user to properly manage lifetime of the string.
+        //! It is reponsibility of the user to properly manage lifetime of the string.
         //! The easiest way to achieve it is to use memory_pool of the document to allocate the string -
         //! on destruction of the document the string will be automatically freed.
         //! <br><br>
@@ -737,7 +737,7 @@ namespace rapidxml
         //! <br><br>
         //! Note that node does not own its name or value, it only stores a pointer to it. 
         //! It will not delete or otherwise free the pointer on destruction.
-        //! It is the responsibility of the user to properly manage lifetime of the string.
+        //! It is reponsibility of the user to properly manage lifetime of the string.
         //! The easiest way to achieve it is to use memory_pool of the document to allocate the string -
         //! on destruction of the document the string will be automatically freed.
         //! <br><br>
@@ -1327,7 +1327,7 @@ namespace rapidxml
     
         // Note that some of the pointers below have UNDEFINED values if certain other pointers are 0.
         // This is required for maximum performance, as it allows the parser to omit initialization of 
-        // unneeded/redundant values.
+        // unneded/redundant values.
         //
         // The rules are as follows:
         // 1. first_node and first_attribute contain valid pointers, or 0 if node has no children/attributes respectively

--- a/src/cpp/core/markdown/MathJax.cpp
+++ b/src/cpp/core/markdown/MathJax.cpp
@@ -128,7 +128,7 @@ MathJaxFilter::MathJaxFilter(const std::vector<html_utils::ExcludePattern>& excl
                              &displayMathBlocks_);
 
          // latex display equations (latex designator optional, used for
-         // syntactic compatiblity w/ wordpress-style inline equations)
+         // syntactic compatibility w/ wordpress-style inline equations)
          filter(boost::regex("\\${2}(?:latex\\s)?([\\s\\S]+?)\\${2}"),
                              &rangeText,
                              &displayMathBlocks_);

--- a/src/cpp/core/markdown/sundown/buffer.h
+++ b/src/cpp/core/markdown/sundown/buffer.h
@@ -44,7 +44,7 @@ struct buf {
 	size_t unit;	/* reallocation unit size (0 = read-only buffer) */
 };
 
-/* CONST_BUF: global buffer from a string litteral */
+/* CONST_BUF: global buffer from a string literal */
 #define BUF_STATIC(string) \
 	{ (uint8_t *)string, sizeof string -1, sizeof string, 0, 0 }
 
@@ -52,7 +52,7 @@ struct buf {
 #define BUF_VOLATILE(strname) \
 	{ (uint8_t *)strname, strlen(strname), 0, 0, 0 }
 
-/* BUFPUTSL: optimized bufputs of a string litteral */
+/* BUFPUTSL: optimized bufputs of a string literal */
 #define BUFPUTSL(output, literal) \
 	bufput(output, literal, sizeof literal - 1)
 

--- a/src/cpp/core/markdown/sundown/houdini_href_e.c
+++ b/src/cpp/core/markdown/sundown/houdini_href_e.c
@@ -17,7 +17,7 @@
  *	- The characters which are *not* safe to be in
  *	an URL because they are RESERVED characters.
  *
- * We asume (lazily) that any RESERVED char that
+ * We assume (lazily) that any RESERVED char that
  * appears inside an URL is actually meant to
  * have its native function (i.e. as an URL 
  * component/separator) and hence needs no escaping.

--- a/src/cpp/core/markdown/sundown/html.c
+++ b/src/cpp/core/markdown/sundown/html.c
@@ -410,7 +410,7 @@ rndr_raw_html(struct buf *ob, const struct buf *text, void *opaque)
 	struct html_renderopt *options = opaque;
 
 	/* HTML_ESCAPE overrides SKIP_HTML, SKIP_STYLE, SKIP_LINKS and SKIP_IMAGES
-	* It doens't see if there are any valid tags, just escape all of them. */
+	* It doesn't see if there are any valid tags, just escape all of them. */
 	if((options->flags & HTML_ESCAPE) != 0) {
 		escape_html(ob, text->data, text->size);
 		return 1;

--- a/src/cpp/core/markdown/sundown/markdown.c
+++ b/src/cpp/core/markdown/sundown/markdown.c
@@ -581,7 +581,7 @@ tag_length(uint8_t *data, size_t size, enum mkd_autolink *autolink)
 		*autolink = MKDA_NOT_AUTOLINK;
 	}
 
-	/* looking for sometinhg looking like a tag end */
+	/* looking for something looking like a tag end */
 	while (i < size && data[i] != '>') i++;
 	if (i >= size) return 0;
 	return i + 1;

--- a/src/cpp/core/tex/synctex/synctex_parser.c
+++ b/src/cpp/core/tex/synctex/synctex_parser.c
@@ -2857,7 +2857,7 @@ return_on_error:
 	return 3;	/*	Bad parameter.	*/
 }
 
-/*	Opens the ouput file, taking into account the eventual build_directory.
+/*	Opens the output file, taking into account the eventual build_directory.
  *	0 on success, non 0 on error. */
 int _synctex_open(const char * output, const char * build_directory, char ** synctex_name_ref, gzFile * file_ref, synctex_bool_t add_quotes, synctex_io_mode_t * io_mode_ref) {
 #	define synctex_name (*synctex_name_ref)
@@ -2936,7 +2936,7 @@ synctex_scanner_t synctex_scanner_parse(synctex_scanner_t scanner) {
 	scanner->pre_unit = 8192;
 	scanner->pre_x_offset = scanner->pre_y_offset = 578;
 	/*  initialize the offset with a fake unprobable value,
-	 *  If there is a post scriptum section, this value will be overriden by the real life value */
+	 *  If there is a post scriptum section, this value will be overridden by the real life value */
 	scanner->x_offset = scanner->y_offset = 6.027e23f;
 #   define DEFINE_synctex_scanner_class(NAME)\
 	scanner->class[synctex_node_type_##NAME] = synctex_class_##NAME;\
@@ -3561,7 +3561,7 @@ int synctex_display_query(synctex_scanner_t scanner,const char * name,int line,i
 				start_ref = (synctex_node_t *)SYNCTEX_START;
 				end_ref   = (synctex_node_t *)SYNCTEX_START;
 next_end:
-				end_ref += 1; /*  we allways have start_ref<= end_ref*/
+				end_ref += 1; /*  we always have start_ref<= end_ref*/
 				if (end_ref < (synctex_node_t *)SYNCTEX_END) {
 					node = *end_ref;
 					while ((node = SYNCTEX_PARENT(node))) {
@@ -3773,7 +3773,7 @@ int _synctex_point_h_distance(synctex_point_t hitPoint, synctex_node_t node, syn
 		int min,med,max;
 		switch(node->class->type) {
 			/*  The distance between a point and a box is special.
-			 *  It is not the euclidian distance, nor something similar.
+			 *  It is not the euclidean distance, nor something similar.
 			 *  We have to take into account the particular layout,
 			 *  and the box hierarchy.
 			 *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
@@ -3791,7 +3791,7 @@ int _synctex_point_h_distance(synctex_point_t hitPoint, synctex_node_t node, syn
 				/*  getting the box bounds, taking into account negative width, height and depth. */
 				min = visible?SYNCTEX_HORIZ_V(node):SYNCTEX_HORIZ(node);
 				max = min + (visible?SYNCTEX_ABS_WIDTH_V(node):SYNCTEX_ABS_WIDTH(node));
-				/*  We allways have min <= max */
+				/*  We always have min <= max */
 				if (hitPoint.h<min) {
 					return min - hitPoint.h; /*  regions 1+4+7, result is > 0 */
 				} else if (hitPoint.h>max) {
@@ -3807,7 +3807,7 @@ int _synctex_point_h_distance(synctex_point_t hitPoint, synctex_node_t node, syn
 				 *  For these boxes, no visible dimension available */
 				min = SYNCTEX_HORIZ(node);
 				max = min + SYNCTEX_ABS_WIDTH(node);
-				/*  We allways have min <= max */
+				/*  We always have min <= max */
 				if (hitPoint.h<min) {
 					return min - hitPoint.h; /*  regions 1+4+7, result is > 0 */
 				} else if (hitPoint.h>max) {
@@ -3876,7 +3876,7 @@ int _synctex_point_v_distance(synctex_point_t hitPoint, synctex_node_t node,sync
 		int min,max;
 		switch(node->class->type) {
 			/*  The distance between a point and a box is special.
-			 *  It is not the euclidian distance, nor something similar.
+			 *  It is not the euclidean distance, nor something similar.
 			 *  We have to take into account the particular layout,
 			 *  and the box hierarchy.
 			 *  Given a box, there are 9 regions delimited by the lines of the edges of the box.
@@ -3895,7 +3895,7 @@ int _synctex_point_v_distance(synctex_point_t hitPoint, synctex_node_t node,sync
 				min = SYNCTEX_VERT_V(node);
 				max = min + SYNCTEX_ABS_DEPTH_V(node);
 				min -= SYNCTEX_ABS_HEIGHT_V(node);
-				/*  We allways have min <= max */
+				/*  We always have min <= max */
 				if (hitPoint.v<min) {
 					return min - hitPoint.v; /*  regions 1+2+3, result is > 0 */
 				} else if (hitPoint.v>max) {
@@ -3911,7 +3911,7 @@ int _synctex_point_v_distance(synctex_point_t hitPoint, synctex_node_t node,sync
 				min = SYNCTEX_VERT(node);
 				max = min + SYNCTEX_ABS_DEPTH(node);
 				min -= SYNCTEX_ABS_HEIGHT(node);
-				/*  We allways have min <= max */
+				/*  We always have min <= max */
 				if (hitPoint.v<min) {
 					return min - hitPoint.v; /*  regions 1+2+3, result is > 0 */
 				} else if (hitPoint.v>max) {
@@ -3967,7 +3967,7 @@ int _synctex_node_distance_to_point(synctex_point_t hitPoint, synctex_node_t nod
 		int minH,maxH,minV,maxV;
 		switch(node->class->type) {
 			/*  The distance between a point and a box is special.
-			 *  It is not the euclidian distance, nor something similar.
+			 *  It is not the euclidean distance, nor something similar.
 			 *  We have to take into account the particular layout,
 			 *  and the box hierarchy.
 			 *  Given a box, there are 9 regions delimited by the lines of the edges of the box.

--- a/src/cpp/core/tex/synctex/synctex_parser.h
+++ b/src/cpp/core/tex/synctex/synctex_parser.h
@@ -186,7 +186,7 @@ float synctex_scanner_magnification(synctex_scanner_t scanner);
 
 /*  Managing the input file names.
  *  Given a tag, synctex_scanner_get_name will return the corresponding file name.
- *  Conversely, given a file name, synctex_scanner_get_tag will retur, the corresponding tag.
+ *  Conversely, given a file name, synctex_scanner_get_tag will return, the corresponding tag.
  *  The file name must be the very same as understood by TeX.
  *  For example, if you \input myDir/foo.tex, the file name is myDir/foo.tex.
  *  No automatic path expansion is performed.
@@ -283,7 +283,7 @@ int synctex_node_column(synctex_node_t node);
 /*  In order to enhance forward synchronization,
  *  non void horizontal boxes have supplemental cached information.
  *  The mean line is the average of the line numbers of the included nodes.
- *  The child count is the number of chidren.
+ *  The child count is the number of children.
  */
 int synctex_node_mean_line(synctex_node_t node);
 int synctex_node_child_count(synctex_node_t node);

--- a/src/cpp/core/zlib/CMakeLists.txt
+++ b/src/cpp/core/zlib/CMakeLists.txt
@@ -26,7 +26,7 @@ include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
 
-# disable gcc visiblity attribute (not supported by some mingw versinos)
+# disable gcc visibility attribute (not supported by some mingw versinos)
 set(EXTRA_COMPILE_DEFINITIONS "NO_VIZ")
 
 if(MSVC)

--- a/src/cpp/core/zlib/CMakeLists.txt
+++ b/src/cpp/core/zlib/CMakeLists.txt
@@ -26,7 +26,7 @@ include(CheckFunctionExists)
 include(CheckIncludeFile)
 include(CheckCSourceCompiles)
 
-# disable gcc visibility attribute (not supported by some mingw versinos)
+# disable gcc visibility attribute (not supported by some mingw versions)
 set(EXTRA_COMPILE_DEFINITIONS "NO_VIZ")
 
 if(MSVC)

--- a/src/cpp/desktop/synctex/rsinverse/RsInverseMain.cpp
+++ b/src/cpp/desktop/synctex/rsinverse/RsInverseMain.cpp
@@ -105,7 +105,7 @@ int main(int argc, char** argv)
       // we presume that the path is passed to us in the system encoding
       sourceFile = string_utils::systemToUtf8(sourceFile);
 
-      // enocde the source file and line as a query string
+      // encode the source file and line as a query string
       std::string requestBody;
       core::http::Fields args;
       args.push_back(std::make_pair("source-file", sourceFile));

--- a/src/cpp/ext/websocketpp/close.hpp
+++ b/src/cpp/ext/websocketpp/close.hpp
@@ -241,7 +241,7 @@ namespace status {
             case invalid_payload:
                 return "Invalid payload";
             case policy_violation:
-                return "Policy violoation";
+                return "Policy violation";
             case message_too_big:
                 return "Message too big";
             case extension_required:

--- a/src/cpp/ext/websocketpp/config/core.hpp
+++ b/src/cpp/ext/websocketpp/config/core.hpp
@@ -91,7 +91,7 @@ struct core {
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
 
-    /// Controls compile time enabling/disabling of thread syncronization
+    /// Controls compile time enabling/disabling of thread synchronization
     /// code Disabling can provide a minor performance improvement to single
     /// threaded applications
     static bool const enable_multithreading = true;
@@ -103,7 +103,7 @@ struct core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
 
-        /// Controls compile time enabling/disabling of thread syncronization
+        /// Controls compile time enabling/disabling of thread synchronization
         /// code Disabling can provide a minor performance improvement to single
         /// threaded applications
         static bool const enable_multithreading = true;

--- a/src/cpp/ext/websocketpp/config/core_client.hpp
+++ b/src/cpp/ext/websocketpp/config/core_client.hpp
@@ -100,7 +100,7 @@ struct core_client {
     typedef websocketpp::random::random_device::int_generator<uint32_t,
         concurrency_type> rng_type;
 
-    /// Controls compile time enabling/disabling of thread syncronization code
+    /// Controls compile time enabling/disabling of thread synchronization code
     /// Disabling can provide a minor performance improvement to single threaded
     /// applications
     static bool const enable_multithreading = true;
@@ -112,7 +112,7 @@ struct core_client {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
 
-        /// Controls compile time enabling/disabling of thread syncronization
+        /// Controls compile time enabling/disabling of thread synchronization
         /// code Disabling can provide a minor performance improvement to single
         /// threaded applications
         static bool const enable_multithreading = true;

--- a/src/cpp/ext/websocketpp/config/debug.hpp
+++ b/src/cpp/ext/websocketpp/config/debug.hpp
@@ -92,7 +92,7 @@ struct debug_core {
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
 
-    /// Controls compile time enabling/disabling of thread syncronization
+    /// Controls compile time enabling/disabling of thread synchronization
     /// code Disabling can provide a minor performance improvement to single
     /// threaded applications
     static bool const enable_multithreading = true;
@@ -104,7 +104,7 @@ struct debug_core {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
 
-        /// Controls compile time enabling/disabling of thread syncronization
+        /// Controls compile time enabling/disabling of thread synchronization
         /// code Disabling can provide a minor performance improvement to single
         /// threaded applications
         static bool const enable_multithreading = true;

--- a/src/cpp/ext/websocketpp/config/minimal_server.hpp
+++ b/src/cpp/ext/websocketpp/config/minimal_server.hpp
@@ -118,7 +118,7 @@ struct minimal_server {
     /// RNG policies
     typedef websocketpp::random::none::int_generator<uint32_t> rng_type;
 
-    /// Controls compile time enabling/disabling of thread syncronization
+    /// Controls compile time enabling/disabling of thread synchronization
     /// code Disabling can provide a minor performance improvement to single
     /// threaded applications
     static bool const enable_multithreading = true;
@@ -130,7 +130,7 @@ struct minimal_server {
         typedef type::request_type request_type;
         typedef type::response_type response_type;
 
-        /// Controls compile time enabling/disabling of thread syncronization
+        /// Controls compile time enabling/disabling of thread synchronization
         /// code Disabling can provide a minor performance improvement to single
         /// threaded applications
         static bool const enable_multithreading = true;

--- a/src/cpp/ext/websocketpp/connection.hpp
+++ b/src/cpp/ext/websocketpp/connection.hpp
@@ -82,7 +82,7 @@ typedef lib::function<void(connection_hdl)> fail_handler;
 /**
  * The interrupt handler is called when a connection receives an interrupt
  * request from the application. Interrupts allow the application to trigger a
- * handler to be run in the absense of a WebSocket level handler trigger (like
+ * handler to be run in the absence of a WebSocket level handler trigger (like
  * a new message).
  *
  * This is typically used by another application thread to schedule some tasks
@@ -669,9 +669,9 @@ public:
      */
     lib::error_code send(message_ptr msg);
 
-    /// Asyncronously invoke handler::on_inturrupt
+    /// Asynchronously invoke handler::on_inturrupt
     /**
-     * Signals to the connection to asyncronously invoke the on_inturrupt
+     * Signals to the connection to asynchronously invoke the on_inturrupt
      * callback for this connection's handler once it is safe to do so.
      *
      * When the on_inturrupt handler callback is called it will be from
@@ -847,7 +847,7 @@ public:
     // Subprotocol negotiation //
     /////////////////////////////
 
-    /// Gets the negotated subprotocol
+    /// Gets the negotiated subprotocol
     /**
      * Retrieves the subprotocol that was negotiated during the handshake. This
      * method is valid in the open handler and later.
@@ -870,7 +870,7 @@ public:
      * Adds a subprotocol to the list to send with the opening handshake. This
      * may be called multiple times to request more than one. If the server
      * supports one of these, it may choose one. If so, it will return it
-     * in it's handshake reponse and the value will be available via
+     * in it's handshake response and the value will be available via
      * get_subprotocol(). Subprotocol requests should be added in order of
      * preference.
      *
@@ -885,7 +885,7 @@ public:
      * Adds a subprotocol to the list to send with the opening handshake. This
      * may be called multiple times to request more than one. If the server
      * supports one of these, it may choose one. If so, it will return it
-     * in it's handshake reponse and the value will be available via
+     * in it's handshake response and the value will be available via
      * get_subprotocol(). Subprotocol requests should be added in order of
      * preference.
      *
@@ -1272,7 +1272,7 @@ private:
     /**
      * If no arguments are present no close code/reason will be specified.
      *
-     * Note: the close code/reason values provided here may be overrided by
+     * Note: the close code/reason values provided here may be overridden by
      * other settings (such as silent close).
      *
      * @param code The close code to send
@@ -1286,7 +1286,7 @@ private:
     /**
      * If no arguments are present no close code/reason will be specified.
      *
-     * Note: the close code/reason values provided here may be overrided by
+     * Note: the close code/reason values provided here may be overridden by
      * other settings (such as silent close).
      *
      * The ack flag determines what to do in the case of a blank status and
@@ -1456,7 +1456,7 @@ private:
      */
     size_t m_send_buffer_size;
 
-    /// buffer holding the various parts of the current message being writen
+    /// buffer holding the various parts of the current message being written
     /**
      * Lock m_write_lock
      */

--- a/src/cpp/ext/websocketpp/endpoint.hpp
+++ b/src/cpp/ext/websocketpp/endpoint.hpp
@@ -423,7 +423,7 @@ public:
      * can produce one additional type of error, the bad_connection error, that
      * indicates that the conversion from connection_hdl to connection_ptr
      * failed due to the connection not existing anymore. Each method has a
-     * default and an exception free varient.
+     * default and an exception free variant.
      */
 
     void interrupt(connection_hdl hdl, lib::error_code & ec);

--- a/src/cpp/ext/websocketpp/extensions/permessage_deflate/enabled.hpp
+++ b/src/cpp/ext/websocketpp/extensions/permessage_deflate/enabled.hpp
@@ -548,7 +548,7 @@ public:
 private:
     /// Generate negotiation response
     /**
-     * @return Generate extension negotiation reponse string to send to client
+     * @return Generate extension negotiation response string to send to client
      */
     std::string generate_response() {
         std::string ret = "permessage-deflate";

--- a/src/cpp/ext/websocketpp/http/parser.hpp
+++ b/src/cpp/ext/websocketpp/http/parser.hpp
@@ -189,7 +189,7 @@ InputIterator extract_all_lws(InputIterator begin, InputIterator end) {
  * @param [in] end An iterator to the end of the sequence
  * @param [out] attributes A reference to the attributes list to append
  * attribute/value pairs extracted to
- * @return An iterator to the character after the last atribute read
+ * @return An iterator to the character after the last attribute read
  */
 template <typename InputIterator>
 InputIterator extract_attributes(InputIterator begin, InputIterator end,
@@ -286,7 +286,7 @@ InputIterator extract_attributes(InputIterator begin, InputIterator end,
  * @param [in] begin An iterator to the beginning of the sequence
  * @param [in] end An iterator to the end of the sequence
  * @param [out] parameters A reference to the parameters list to append
- * paramter values extracted to
+ * parameter values extracted to
  * @return An iterator to the character after the last parameter read
  */
 template <typename InputIterator>
@@ -445,7 +445,7 @@ public:
      *
      * @todo Make this method case insensitive.
      * @todo Should there be any restrictions on which keys are allowed?
-     * @todo Exception free varient
+     * @todo Exception free variant
      *
      * @see replace_header
      *
@@ -462,7 +462,7 @@ public:
      *
      * @todo Make this method case insensitive.
      * @todo Should there be any restrictions on which keys are allowed?
-     * @todo Exception free varient
+     * @todo Exception free variant
      *
      * @see append_header
      *

--- a/src/cpp/ext/websocketpp/message_buffer/alloc.hpp
+++ b/src/cpp/ext/websocketpp/message_buffer/alloc.hpp
@@ -75,7 +75,7 @@ public:
      *
      * @param msg The message to be recycled.
      *
-     * @return true if the message was successfully recycled, false otherwse.
+     * @return true if the message was successfully recycled, false otherwise.
      */
     bool recycle(message *) {
         return false;

--- a/src/cpp/ext/websocketpp/message_buffer/message.hpp
+++ b/src/cpp/ext/websocketpp/message_buffer/message.hpp
@@ -198,7 +198,7 @@ public:
 
     /// Set the fin bit
     /**
-     * @see get_fin for a more detailed explaination of the fin bit
+     * @see get_fin for a more detailed explanation of the fin bit
      *
      * @param value The value to set the fin bit to.
      */

--- a/src/cpp/ext/websocketpp/message_buffer/pool.hpp
+++ b/src/cpp/ext/websocketpp/message_buffer/pool.hpp
@@ -182,7 +182,7 @@ public:
      *
      * @param msg The message to be recycled.
      *
-     * @return true if the message was successfully recycled, false otherwse.
+     * @return true if the message was successfully recycled, false otherwise.
      */
     bool recycle(message * msg) {
         return false;

--- a/src/cpp/ext/websocketpp/processors/hybi00.hpp
+++ b/src/cpp/ext/websocketpp/processors/hybi00.hpp
@@ -165,7 +165,7 @@ public:
      * always return an error.
      *
      * @param req The original request sent
-     * @param res The reponse to generate
+     * @param res The response to generate
      * @return An error code, 0 on success, non-zero for other errors
      */
     lib::error_code validate_server_handshake_response(request_type const &,

--- a/src/cpp/ext/websocketpp/processors/hybi13.hpp
+++ b/src/cpp/ext/websocketpp/processors/hybi13.hpp
@@ -229,7 +229,7 @@ public:
     /// Validate the server's response to an outgoing handshake request
     /**
      * @param req The original request sent
-     * @param res The reponse to generate
+     * @param res The response to generate
      * @return An error code, 0 on success, non-zero for other errors
      */
     lib::error_code validate_server_handshake_response(request_type const & req,

--- a/src/cpp/ext/websocketpp/processors/processor.hpp
+++ b/src/cpp/ext/websocketpp/processors/processor.hpp
@@ -261,7 +261,7 @@ public:
     /// Validate the server's response to an outgoing handshake request
     /**
      * @param req The original request sent
-     * @param res The reponse to generate
+     * @param res The response to generate
      * @return An error code, 0 on success, non-zero for other errors
      */
     virtual lib::error_code validate_server_handshake_response(request_type
@@ -290,7 +290,7 @@ public:
 
     /// process new websocket connection bytes
     /**
-     * WebSocket connections are a continous stream of bytes that must be
+     * WebSocket connections are a continuous stream of bytes that must be
      * interpreted by a protocol processor into discrete frames.
      *
      * @param buf Buffer from which bytes should be read.

--- a/src/cpp/ext/websocketpp/random/none.hpp
+++ b/src/cpp/ext/websocketpp/random/none.hpp
@@ -37,7 +37,7 @@ namespace none {
 /// Thread safe stub "random" integer generator.
 /**
  * This template class provides a random integer stub. The interface mimics the
- * WebSocket++ RNG generator classes but the generater function always returns
+ * WebSocket++ RNG generator classes but the generator function always returns
  * zero. This can be used to stub out the RNG for unit and performance testing.
  *
  * Call operator() to generate the next number

--- a/src/cpp/ext/websocketpp/transport/asio/connection.hpp
+++ b/src/cpp/ext/websocketpp/transport/asio/connection.hpp
@@ -373,7 +373,7 @@ protected:
         }
 
         // TODO: pre-init timeout. Right now no implemented socket policies
-        // actually have an asyncronous pre-init
+        // actually have an asynchronous pre-init
 
         m_init_handler = callback;
 

--- a/src/cpp/ext/websocketpp/transport/debug/connection.hpp
+++ b/src/cpp/ext/websocketpp/transport/debug/connection.hpp
@@ -258,7 +258,7 @@ protected:
         m_reading = true;
     }
 
-    /// Asyncronous Transport Write
+    /// Asynchronous Transport Write
     /**
      * Write len bytes in buf to the output stream. Call handler to report
      * success or failure. handler may or may not be called during async_write,
@@ -275,7 +275,7 @@ protected:
         m_write_handler = handler;
     }
 
-    /// Asyncronous Transport Write (scatter-gather)
+    /// Asynchronous Transport Write (scatter-gather)
     /**
      * Write a sequence of buffers to the output stream. Call handler to report
      * success or failure. handler may or may not be called during async_write,

--- a/src/cpp/ext/websocketpp/transport/iostream/connection.hpp
+++ b/src/cpp/ext/websocketpp/transport/iostream/connection.hpp
@@ -416,7 +416,7 @@ protected:
         m_reading = true;
     }
 
-    /// Asyncronous Transport Write
+    /// Asynchronous Transport Write
     /**
      * Write len bytes in buf to the output method. Call handler to report
      * success or failure. handler may or may not be called during async_write,
@@ -457,7 +457,7 @@ protected:
         handler(ec);
     }
 
-    /// Asyncronous Transport Write (scatter-gather)
+    /// Asynchronous Transport Write (scatter-gather)
     /**
      * Write a sequence of buffers to the output method. Call handler to report
      * success or failure. handler may or may not be called during async_write,

--- a/src/cpp/ext/websocketpp/transport/stub/connection.hpp
+++ b/src/cpp/ext/websocketpp/transport/stub/connection.hpp
@@ -196,7 +196,7 @@ protected:
         handler(make_error_code(error::not_implemented), 0);
     }
 
-    /// Asyncronous Transport Write
+    /// Asynchronous Transport Write
     /**
      * Write len bytes in buf to the output stream. Call handler to report
      * success or failure. handler may or may not be called during async_write,
@@ -213,7 +213,7 @@ protected:
         handler(make_error_code(error::not_implemented));
     }
 
-    /// Asyncronous Transport Write (scatter-gather)
+    /// Asynchronous Transport Write (scatter-gather)
     /**
      * Write a sequence of buffers to the output stream. Call handler to report
      * success or failure. handler may or may not be called during async_write,

--- a/src/cpp/server/ServerPAMAuthOverlay.hpp
+++ b/src/cpp/server/ServerPAMAuthOverlay.hpp
@@ -23,7 +23,7 @@ namespace server {
 namespace pam_auth {
 namespace overlay {
 
-void intialize();
+void initialize();
 bool canSetSignInCookies();
 void onUserPasswordAvailable(const std::string& username,
                          const std::string& password);

--- a/src/cpp/session/resources/grid/datatables/js/jquery.dataTables.js
+++ b/src/cpp/session/resources/grid/datatables/js/jquery.dataTables.js
@@ -758,7 +758,7 @@
   
   
   /**
-   * Covert the index of a visible column to the index in the data array (take account
+   * Convert the index of a visible column to the index in the data array (take account
    * of hidden columns)
    *  @param {object} oSettings dataTables settings object
    *  @param {int} iMatch Visible column index to lookup
@@ -776,7 +776,7 @@
   
   
   /**
-   * Covert the index of an index in the data array and convert it to the visible
+   * Convert the index of an index in the data array and convert it to the visible
    *   column index (take account of hidden columns)
    *  @param {int} iMatch Column index to lookup
    *  @param {object} oSettings dataTables settings object
@@ -2890,7 +2890,7 @@
    *  @param {int} iColumn column to filter
    *  @param {bool} bRegex treat search string as a regular expression or not
    *  @param {bool} bSmart use smart filtering or not
-   *  @param {bool} bCaseInsensitive Do case insenstive matching or not
+   *  @param {bool} bCaseInsensitive Do case insensitive matching or not
    *  @memberof DataTable#oApi
    */
   function _fnFilterColumn ( settings, searchStr, colIdx, regex, smart, caseInsensitive )
@@ -2920,7 +2920,7 @@
    *  @param {int} force optional - force a research of the master array (1) or not (undefined or 0)
    *  @param {bool} regex treat as a regular expression or not
    *  @param {bool} smart perform smart filtering or not
-   *  @param {bool} caseInsensitive Do case insenstive matching or not
+   *  @param {bool} caseInsensitive Do case insensitive matching or not
    *  @memberof DataTable#oApi
    */
   function _fnFilter( settings, input, force, regex, smart, caseInsensitive )
@@ -13883,7 +13883,7 @@
   
     //
     // Depreciated
-    // The following properties are retained for backwards compatiblity only.
+    // The following properties are retained for backwards compatibility only.
     // The should not be used in new projects and will be removed in a future
     // version
     //

--- a/src/cpp/session/resources/pdfjs/web/l10n.full.js
+++ b/src/cpp/session/resources/pdfjs/web/l10n.full.js
@@ -149,7 +149,7 @@ document.webL10n = (function(window, document, undefined) {
    *    triggered when the l10n resource has been successully parsed.
    *
    * @param {Function} failureCallback
-   *    triggered when the an error has occured.
+   *    triggered when the an error has occurred.
    *
    * @return {void}
    *    uses the following global variables: gL10nData, gTextData, gTextProp.

--- a/src/cpp/session/resources/pdfjs/web/viewer.full.js
+++ b/src/cpp/session/resources/pdfjs/web/viewer.full.js
@@ -2057,8 +2057,8 @@ var PDFHistory = (function () {
         // either:
         // 1. The current zoom value is such that the document does not need to,
         //    or cannot, be scrolled to display the destination.
-        // 2. The previous destination is broken, and doesn't actally point to a
-        //    position within the document.
+        // 2. The previous destination is broken, and doesn't actually point to
+        //    a position within the document.
         //    (This is either due to a bad PDF generator, or the user making a
         //     mistake when entering a destination in the hash parameters.)
         return null;
@@ -4086,7 +4086,7 @@ var PDFPageView = (function PDFPageViewClosure() {
         }, function(error) {
           console.error(error);
           // Tell the printEngine that rendering this canvas/page has failed.
-          // This will make the print proces stop.
+          // This will make the print process stop.
           if ('abort' in obj) {
             obj.abort();
           } else {

--- a/src/cpp/session/resources/presentation/revealjs/css/print/paper.css
+++ b/src/cpp/session/resources/presentation/revealjs/css/print/paper.css
@@ -49,7 +49,7 @@ body, p, td, li, div, a {
 }
 
 /* SECTION 4: Set heading font face, sizes, and color.
-   Diffrentiate your headings from your body text.
+   Differentiate your headings from your body text.
    Perhaps use a large sans-serif for distinction. */
 h1,h2,h3,h4,h5,h6 {
 	color: #000!important;

--- a/src/cpp/session/resources/presentation/revealjs/css/print/pdf.css
+++ b/src/cpp/session/resources/presentation/revealjs/css/print/pdf.css
@@ -55,7 +55,7 @@ body, p, td, li, div {
 }
 
 /* SECTION 4: Set heading font face, sizes, and color.
-   Diffrentiate your headings from your body text.
+   Differentiate your headings from your body text.
    Perhaps use a large sans-serif for distinction. */
 h1,h2,h3,h4,h5,h6 {
 	text-shadow: 0 0 0 #000 !important;

--- a/src/cpp/session/resources/presentation/revealjs/js/reveal.js
+++ b/src/cpp/session/resources/presentation/revealjs/js/reveal.js
@@ -1276,7 +1276,7 @@ var Reveal = (function(){
 				state = state.concat( slideState.split( ' ' ) );
 			}
 
-			// If this slide has a data-autoslide attribtue associated use this as
+			// If this slide has a data-autoslide attribute associated use this as
 			// autoSlide value otherwise use the global configured time
 			var slideAutoSlide = slides[index].getAttribute( 'data-autoslide' );
 			if( slideAutoSlide ) {

--- a/src/cpp/tests/testthat/themes/tmThemes/Amy.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Amy.tmTheme
@@ -506,7 +506,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Invalid - depricated</string>
+			<string>Invalid - deprecated</string>
 			<key>scope</key>
 			<string>invalid.deprecated</string>
 			<key>settings</key>

--- a/src/cpp/tests/testthat/themes/tmThemes/Dreamweaver.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Dreamweaver.tmTheme
@@ -88,7 +88,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>html contstant</string>
+			<string>html constant</string>
 			<key>scope</key>
 			<string>text.html.basic constant.character.entity.html</string>
 			<key>settings</key>
@@ -389,7 +389,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>php varaible</string>
+			<string>php variable</string>
 			<key>scope</key>
 			<string>source.php variable, source.php meta.function.arguments</string>
 			<key>settings</key>
@@ -444,7 +444,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>php varaible global</string>
+			<string>php variable global</string>
 			<key>scope</key>
 			<string>source.php variable.other.global</string>
 			<key>settings</key>

--- a/src/cpp/tests/testthat/themes/tmThemes/Merbivore Soft.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Merbivore Soft.tmTheme
@@ -91,7 +91,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Class inheritence</string>
+			<string>Class inheritance</string>
 			<key>scope</key>
 			<string>entity.other.inherited-class</string>
 			<key>settings</key>

--- a/src/cpp/tests/testthat/themes/tmThemes/Merbivore.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Merbivore.tmTheme
@@ -78,7 +78,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>Class inheritence</string>
+			<string>Class inheritance</string>
 			<key>scope</key>
 			<string>entity.other.inherited-class</string>
 			<key>settings</key>


### PR DESCRIPTION
### Intent

Fixes typos found within the source code which includes comments and documentation. Follow-up to #10868  

### Approach

Found using `codespell -q 3 -S *_fr.properties -L ba,enque,optionel,ot,parm,parms,pres,prevend,pevent,pevents,ptd,texline`
 but then combing through results pruning upstream 3rd party deps etc...

### Automated Tests

This PR fixes typos. No unit tests needed.

### QA Notes

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests


