### PR TITLE
Don't create user-d.ctx file unless project sharing is enabled

### DIFF
--- a/src/cpp/session/SessionOptionsOverlay.cpp
+++ b/src/cpp/session/SessionOptionsOverlay.cpp
@@ -44,5 +44,10 @@ bool Options::supportsDriversLicensing() const
    return !allowOverlay();
 }
 
+bool Options::supportsProjectSharing() const
+{
+   return false;
+}
+
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -173,10 +173,14 @@ public:
       return core::string_utils::LineEndingPosix;
    }
 
+   // Returns false if project sharing has been explicitly disabled for the session
    bool projectSharingEnabled() const
    {
       return projectSharingEnabled_;
    }
+
+   // Unlike projectSharingEnabled(), this only returns true for versions that support the project sharing feature (i.e. Workbench)
+   bool supportsProjectSharing() const;
 
    std::string monitorSharedSecret() const
    {

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -978,7 +978,11 @@ void startup(const std::string& firstProjectPath)
 
    core::FilePath sessionTmpDir(core::system::getenv(kSessionTmpDirEnvVar));
    core::FilePath ctxFile = sessionTmpDir.completeChildPath(system::username() + "-d.ctx");
-   ctxFile.removeIfExists();
+
+   bool needsCtxFile = options().supportsProjectSharing();
+   if (needsCtxFile)
+      ctxFile.removeIfExists();
+
    if (options().sessionScope().empty())
    {
       // This is single-session mode where the project is discovered from last-project-path and other places
@@ -992,7 +996,7 @@ void startup(const std::string& firstProjectPath)
       s_projectId = projectId;
 
 #ifndef _WIN32
-      if (options().projectSharingEnabled())
+      if (needsCtxFile)
       {
          std::string sessionId = session.id();
          std::string sessionCtxStr = projectId.userId() + projectId.id() + ":" + sessionId;


### PR DESCRIPTION
### Intent

Currently desktop users are getting files username-d.ctx created due to this file being added for project sharing when there's no sessionScope(). 

Requires a companion commit to implement supportsProjectSharing() that will look like:

```
bool Options::supportsProjectSharing() const
{
   return projectSharingEnabled() && programMode() == kSessionProgramModeServer;
}```

### Approach

Although we have options().projectSharingEnabled() it's used all over
the place and is true even for desktop/server so I'm reluctant to change it
to return false for OS.

Instead I'm adding a new supportProjectSharing() that will only be true
when projectSharingEnabled() is true and the environment supports sharing.

### Automated Tests

None required.  

### QA Notes

Just need to verify that the username-d.ctx file is only created in /var/run/rstudio-server/rstudio-rsession/ if project-sharing-enabled=1 and server-multiple-sessions=0.  It should not be created when using the job launcher, server/OS, or when server-multiple-sessions=1.  




