### PR TITLE
run mac unit tests in x64 terminal

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -74,7 +74,7 @@ pipeline {
             // attempt to run cpp unit tests
             // problems with rsession finding openssl, so those tests
             // are disabled until we solve it (#6890)
-            sh "cd package/osx/build/src/cpp && ./rstudio-tests"
+            sh "cd package/osx/build/src/cpp && arch -x86_64 ./rstudio-tests"
           } catch(err) {
              currentBuild.result = "UNSTABLE"
           }

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -74,7 +74,7 @@ pipeline {
             // attempt to run cpp unit tests
             // problems with rsession finding openssl, so those tests
             // are disabled until we solve it (#6890)
-            sh "cd package/osx/build/src/cpp && ./rstudio-tests"
+            sh "cd package/osx/build/src/cpp && arch -x86_64 ./rstudio-tests"
             
             // electron tests not working in CI environment, under investigation
             // sh "cd ../../../../../src/node/desktop/ && $HOME/.yarn/bin/yarn && $HOME/.yarn/bin/yarn test"


### PR DESCRIPTION
### Intent

Mac Unit tests have been failing with messages like these:

```
[2022-06-03T16:36:06.111Z] ==> Running 'core' tests
[2022-06-03T16:36:06.111Z] dyld[79930]: terminating because inserted dylib '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' could not be loaded: tried: '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/libR.dylib' (no such file), '/usr/lib/libR.dylib' (no such file)
[2022-06-03T16:36:06.111Z] dyld[79930]: tried: '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/libR.dylib' (no such file), '/usr/lib/libR.dylib' (no such file)
```

It appears that the terminal running our tests has switched from Intel to M1, and that causes this bit of the `rstudio-tests` script to break attempts to run commands, including `uname`.

https://github.com/rstudio/rstudio/blob/c4dda48c467ec7643e2d01371c61781e50acfc48/src/cpp/rstudio-tests.in#L191-L194

For example, this stripped-down version of `rstudio-tests` exhibits the problem when run on the build machine:

```bash
#!/usr/bin/env bash

if [ "$(uname)" = "Darwin" ]; then
   echo "Yes, this is Darwin."
   PATH="${HOME}/homebrew/x86_64/bin:${PATH}"
else
   echo "NOT Darwin?"
fi

export R_HOME=$(R RHOME)
export R_DOC_DIR=$(R --vanilla -s -e "cat(paste(R.home('doc'), sep=':'))")
export R_LIB_DIR=$(R --vanilla -s -e "cat(paste(R.home('lib'), sep=':'))")
echo "R_LIB_DIR=${R_LIB_DIR}"

if [ "$(uname)" = "Darwin" ]; then
   export DYLD_INSERT_LIBRARIES="${R_LIB_DIR}/libR.dylib"
fi

if [ "$(uname)" = "Darwin" ]; then
   echo "Still Darwin"
else
   echo "Identity crisis"
fi
```

```
% ./gary
Yes, this is Darwin.
R_LIB_DIR=/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib
dyld[23216]: terminating because inserted dylib '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' could not be loaded: tried: '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/libR.dylib' (no such file), '/usr/lib/libR.dylib' (no such file)
dyld[23216]: tried: '/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib/libR.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/libR.dylib' (no such file), '/usr/lib/libR.dylib' (no such file)
Identity crisis
```

```
% arch -x86_64 ./gary
Yes, this is Darwin.
R_LIB_DIR=/Users/user193109/homebrew/x86_64/Cellar/r/4.1.0/lib/R/lib
Still Darwin
```

### Approach

Use the `arch` command to ensure the shell running tests is Intel.

After this has made a trip through the open-source pipeline (assuming it works), I'll make the same change in the desktop-pro dockerfile for Electron Mac.

### Automated Tests

Hopefully

### QA Notes

Move along, nothing to see here.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


