### PR TITLE
Force install quarto from latest

### DIFF
--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -114,6 +114,10 @@ COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -111,6 +111,10 @@ COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-quarto"
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.fedora36-x86_64
+++ b/docker/jenkins/Dockerfile.fedora36-x86_64
@@ -100,6 +100,10 @@ COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.jammy-amd64
+++ b/docker/jenkins/Dockerfile.jammy-amd64
@@ -99,6 +99,10 @@ COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -107,6 +107,10 @@ RUN cd /tmp && \
     make && \
     make install
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN

--- a/docker/jenkins/Dockerfile.rhel8-x86_64
+++ b/docker/jenkins/Dockerfile.rhel8-x86_64
@@ -112,6 +112,10 @@ RUN tar xvf gnupg-1.4.23.tar.bz2
 RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1 
 
+# cachebust for Quarto release
+ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN


### PR DESCRIPTION
### Intent
Address #10920  for linux platforms

### Approach
Cache bust the docker layer by checking the Quarto release. The layer never changes because the install script doesn't change. This queries the GH API to get the Quarto release list and adds it as a file to the docker image. If the file contents has changed then there has been a new Quarto release. The file changing invalidates future layers and will run the Quarto install script.

This will likely be temporary until the final Quarto release. Then it will go back to the old way with specifying a specific version. At that time, it's probably best to add an argument to the Dockerfile and specify the Quarto version there.

### Automated Tests
None

### QA Notes
Tested locally with a test Dockerfile. The `ADD` is cached if the release list hasn't changed. When it changes, the subsequent layers are rebuilt. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


