### PR TITLE
using python3 in unit test

### DIFF
--- a/src/cpp/core/system/ProcessTests.cpp
+++ b/src/cpp/core/system/ProcessTests.cpp
@@ -139,7 +139,7 @@ test_context("ProcessTests")
       callbacks.onStdout = boost::bind(&appendOutput, _2, &output);
 
       // run command
-      std::string command = "bash -c \"python -c $'for i in range(10):\n   print(i)'\"";
+      std::string command = "bash -c \"python3 -c $'for i in range(10):\n   print(i)'\"";
       supervisor.runCommand(command, options, callbacks);
 
       // wait for it to exit


### PR DESCRIPTION
### Intent

Addresses #11351

### Approach

All our build images (dockerfiles) install `python3`, so use that instead of the increasingly obsolete (or absent in the case of latest macOS) `python`.

### Automated Tests

This is to fix automated tests on dev machines.

### QA Notes

No product code changes, just test code.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


