### PR TITLE
Don't deref storage_ for empty sessions since it's not set

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -127,7 +127,8 @@ public:
    bool empty() const
    { 
       bool empty = true;
-      storage_->isEmpty(&empty);
+      if (storage_)
+         storage_->isEmpty(&empty);
       return empty;
    }
 
@@ -427,6 +428,12 @@ public:
       if (!scratchPath_.exists())
       {
          LOG_DEBUG_MESSAGE("ActiveSession validation failed: " + scratchPath_.getAbsolutePath() + " not accessible to the session user");
+         return false;
+      }
+
+      if (empty())
+      {
+         LOG_DEBUG_MESSAGE("ActiveSession validation failed on empty session");
          return false;
       }
 


### PR DESCRIPTION
Fixes crash on Desktop and rworkspaces - both of which attempt to
get properties from an empty session, expecting to return nothing back.

I don't think the empty() test in validate() is strictly necessary as the only places we call it we already have called empty() but maybe this will save us from another confusing crash in the future :) 