### PR TITLE
Use old millis-since-epoch time format in properites files

### DIFF
--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -86,8 +86,8 @@ Error ActiveSessions::create(const std::string& project,
          id = candidateId;
    }
 
-   boost::posix_time::ptime time = boost::posix_time::second_clock::universal_time();
-   std::string isoTime = boost::posix_time::to_iso_extended_string(time);
+   double now = date_time::millisecondsSinceEpoch();
+   std::string millisTime = safe_convert::numberToString(now);
 
    //Initial settings
    std::map<std::string, std::string> initialMetadata = {
@@ -95,14 +95,14 @@ Error ActiveSessions::create(const std::string& project,
       {ActiveSession::kWorkingDir, workingDir},
       {ActiveSession::kInitial, initial ? "true" : "false"},
       {ActiveSession::kRunning, "false"},
-      {ActiveSession::kLastUsed, isoTime},
-      {ActiveSession::kCreated, isoTime},
+      {ActiveSession::kLastUsed, millisTime},
+      {ActiveSession::kCreated, millisTime},
       {ActiveSession::kLaunchParameters, ""},
       {ActiveSession::kLabel, project == kProjectNone ? workingDir : project},
       {ActiveSession::kEditor, editor}};
 
    if (editor == kWorkbenchRStudio)
-      initialMetadata[ActiveSession::kLastResumed] = isoTime;
+      initialMetadata[ActiveSession::kLastResumed] = millisTime;
 
    storage_->initSessionProperties(id, initialMetadata);
 


### PR DESCRIPTION
We might later want to fix this to support either format and
create new sessions with the new format.  This might break the database tests until we resolve this discrepancy 

### Intent

Get the daily builds working again

### Approach

Clients expect the lastUsed() method to return a number so if we store in iso time, we need to convert to iso time and support the old format for compatibility 
