### PR TITLE
Fix pro desktop build

### DIFF
--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -603,6 +603,16 @@ void Options::resolveRsclangPath(const FilePath& resourcePath,
    resolvePath(resourcePath, pPath);
 }
 #endif
+
+// This is defined in the overlay for RSERVER configs but that's not included in all desktop configs
+#ifndef RSTUDIO_SERVER
+
+bool Options::supportsProjectSharing() const
+{
+   return false;
+}
+
+#endif
    
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/SessionOptionsOverlay.cpp
+++ b/src/cpp/session/SessionOptionsOverlay.cpp
@@ -44,10 +44,14 @@ bool Options::supportsDriversLicensing() const
    return !allowOverlay();
 }
 
+#ifdef RSTUDIO_SERVER
+
 bool Options::supportsProjectSharing() const
 {
    return false;
 }
+
+#endif
 
 } // namespace session
 } // namespace rstudio


### PR DESCRIPTION
SessionOptionsOverlay.cpp isn't included in the pro-desktop build, I assume for a good reason. Need to resort to the #ifdef approach for this one. I'm going to merge this to get the build working but happy to fix it another way later. 