### PR TITLE
Handle non-BMP characters in RMD R chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -75,6 +75,7 @@
 - Fixed several error marker issues in visual mode where they did not display (#10949 #10483)
 - Allow Jupyter and VScode sessions to be renamed from the homepage (rstudio-pro#1686)
 - Fixed a user-facing error and added logging when the a session fails to launch due to a misconfigured launcher (rstudio-pro#1684)
+- Fixed executing incorrect R code chunk in RMD files when non-BMP Unicode characters were used (#10632)
 
 ### RStudio Workbench
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -455,6 +455,16 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       
       return unit;
    }
+
+   /**
+    * Calculate string length based on Unicode code points. This is a low-effort workaround
+    * to calculating length on strings that include non-BMP characters like emojis.
+    * @param text input string
+    * @return the string length based on atomic parts of text
+    */
+   private native int codePointLength(String text) /*-{
+      return Array.from(text).length;
+   }-*/;
    
    private NotebookExecRange getNotebookExecRange(Scope scope, Range range)
    {
@@ -470,13 +480,14 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
            row++)
       {
          String line = docDisplay_.getLine(row);
-         for (int col = 0; col <= line.length(); col++)
+         int lineLength = codePointLength(line);
+         for (int col = 0; col <= lineLength; col++)
          {
             if (startPos.getRow() == row && startPos.getColumn() == col)
             {
                start = pos;
             }
-            else if (endPos.getRow() == row && endPos.getColumn() == col)
+            else if (endPos.getRow() == row && (endPos.getColumn() == col || col == lineLength))
             {
                end = pos;
                break;


### PR DESCRIPTION
### Intent
Address #10632 

### Approach
Javascript doesn't have built-in support for characters outside of the BMP. A quick and dirty workaround is converting the string to a char array to get the line length. This counts positions as is expected when executing the selected lines of code. This handles emojis and even other non-BMP characters that interact differently in the ACE editor. 😎 is selectable as one character, counted as two in ACE, and should be counted as one for execution. ❤️ is selectable as two characters (first character is a heart and the second is a modifier making it red) and is also counted as two in ACE.

Converting to a char array handles these cases as it separates 😎 as one element and ❤️ as two elements, which is correct for the position count for the code range.

### Automated Tests
None

### QA Notes
See rstudio-pro ticket 3292

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


