### PR TITLE
Honor Quarto execution directory setting

### DIFF
--- a/src/cpp/session/include/session/SessionQuarto.hpp
+++ b/src/cpp/session/include/session/SessionQuarto.hpp
@@ -102,6 +102,8 @@ void readQuartoProjectConfig(const core::FilePath& configFile,
 
 core::json::Value quartoXRefIndex();
 
+core::FilePath getQuartoExecutionDir(const std::string& docPath);
+
 } // namespace quarto
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/include/session/SessionQuarto.hpp
+++ b/src/cpp/session/include/session/SessionQuarto.hpp
@@ -37,6 +37,8 @@ extern const char* const kQuartoProjectDefault;
 extern const char* const kQuartoProjectWebsite;
 extern const char* const kQuartoProjectSite;
 extern const char* const kQuartoProjectBook;
+extern const char* const kQuartoExecuteDirProject;
+extern const char* const kQuartoExecuteDirFile;
 
 struct QuartoConfig
 {

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2297,18 +2297,19 @@ assign(x = ".rs.acCompletionTypes",
       # NOTE: For Markdown link completions, we overload the meaning of the
       # function call string here, and use it as a signal to generate paths
       # relative to the R markdown path.
-      isRmd <- .rs.endsWith(tolower(filePath), ".rmd")
+      isNotebook <- .rs.endsWith(tolower(filePath), ".rmd") ||
+                    .rs.endsWith(tolower(filePath), ".qmd")
       
       path <- NULL
       
       # if in an Rmd file, ask it for its desired working dir (can be changed
       # with the knitr root.dir option)
-      if (isRmd)
+      if (isNotebook)
       {
-         path <- .Call("rs_getRmdWorkingDir", filePath, documentId)
+         path <- .Call("rs_getNotebookWorkingDir", filePath, documentId)
       }
       
-      if (is.null(path) && isRmd)
+      if (is.null(path) && isNotebook)
       {
          # for R Markdown documents without an explicit working dir,
          # use preferences instead

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -1216,47 +1216,47 @@ void readQuartoProjectConfig(const FilePath& configFile,
 // Returns an empty FilePath if no directory is specified.
 FilePath getQuartoExecutionDir(const std::string& docPath)
 {
-    // Ensure we have a path to work with (an empty string will resolve to the home directory below)
-    if (docPath.empty())
+   // Ensure we have a path to work with (an empty string will resolve to the home directory below)
+   if (docPath.empty())
+   {
+      return FilePath();
+   }
+
+   // Resolve path, and ensure the document is a Quarto file
+   FilePath qmdPath = module_context::resolveAliasedPath(docPath);
+   if (!qmdPath.hasExtensionLowerCase(".qmd"))
+   {
+      return FilePath();
+   }
+
+   // Find the Quarto configuration file associated with this document
+   FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
+   if (quartoConfig.isEmpty())
+   {
+      return FilePath();
+   }
+
+   // Read the Quarto configuration file
+   std::string executeDir;
+   quarto::readQuartoProjectConfig(quartoConfig,
+            nullptr, // type
+            nullptr, // output dir
+            &executeDir);
+
+    if (executeDir == quarto::kQuartoExecuteDirProject)
     {
-        return FilePath();
+       // If the execution dir is set to 'project', infer the project root from the location
+       // of the Quarto config file and use it as the directory for execution
+       return quartoConfig.getParent();
+    }
+    else if (executeDir == quarto::kQuartoExecuteDirFile)
+    {
+       // If the execution dir is set to 'file', use the directory of the document
+       return qmdPath.getParent();
     }
 
-    // Resolve path, and ensure the document is a Quarto file
-    FilePath qmdPath = module_context::resolveAliasedPath(docPath);
-    if (!qmdPath.hasExtensionLowerCase(".qmd"))
-    {
-        return FilePath();
-    }
-
-    // Find the Quarto configuration file associated with this document
-    FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
-    if (quartoConfig.isEmpty())
-    {
-        return FilePath();
-    }
-
-    // Read the Quarto configuration file
-    std::string executeDir;
-    quarto::readQuartoProjectConfig(quartoConfig,
-             nullptr, // type
-             nullptr, // output dir
-             &executeDir);
-
-     if (executeDir == quarto::kQuartoExecuteDirProject)
-     {
-         // If the execution dir is set to 'project', infer the project root from the location
-         // of the Quarto config file and use it as the directory for execution
-         return quartoConfig.getParent();
-     }
-     else if (executeDir == quarto::kQuartoExecuteDirFile)
-     {
-         // If the execution dir is set to 'file', use the directory of the document
-         return qmdPath.getParent();
-     }
-
-     // In all other cases, treat the execution directory as unspecified
-     return FilePath();
+    // In all other cases, treat the execution directory as unspecified
+    return FilePath();
 }
 
 } // namespace quarto

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -1210,9 +1210,56 @@ void readQuartoProjectConfig(const FilePath& configFile,
    }
 }
 
+// Given the (aliased) path to a file, return the file path to the working directory where code
+// should be executed in the file, based on the settings in _quarto.yml.
+//
+// Returns an empty FilePath if no directory is specified.
+FilePath getQuartoExecutionDir(const std::string& docPath)
+{
+    // Ensure we have a path to work with (an empty string will resolve to the home directory below)
+    if (docPath.empty())
+    {
+        return FilePath();
+    }
 
+    // Resolve path, and ensure the document is a Quarto file
+    FilePath qmdPath = module_context::resolveAliasedPath(docPath);
+    if (!qmdPath.hasExtensionLowerCase(".qmd"))
+    {
+        return FilePath();
+    }
 
-} // namesace quarto
+    // Find the Quarto configuration file associated with this document
+    FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
+    if (quartoConfig.isEmpty())
+    {
+        return FilePath();
+    }
+
+    // Read the Quarto configuration file
+    std::string executeDir;
+    quarto::readQuartoProjectConfig(quartoConfig,
+             nullptr, // type
+             nullptr, // output dir
+             &executeDir);
+
+     if (executeDir == quarto::kQuartoExecuteDirProject)
+     {
+         // If the execution dir is set to 'project', infer the project root from the location
+         // of the Quarto config file and use it as the directory for execution
+         return quartoConfig.getParent();
+     }
+     else if (executeDir == quarto::kQuartoExecuteDirFile)
+     {
+         // If the execution dir is set to 'file', use the directory of the document
+         return qmdPath.getParent();
+     }
+
+     // In all other cases, treat the execution directory as unspecified
+     return FilePath();
+}
+
+} // namespace quarto
 
 namespace module_context  {
 

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -904,6 +904,9 @@ const char* const kQuartoProjectWebsite = "website";
 const char* const kQuartoProjectSite = "site"; // 'website' used to be 'site'
 const char* const kQuartoProjectBook = "book";
 
+// possible values for the execute-dir project option
+const char* const kQuartoExecuteDirProject = "project";
+const char* const kQuartoExecuteDirFile = "file";
 
 QuartoConfig quartoConfig(bool refresh)
 {

--- a/src/cpp/session/modules/rmarkdown/NotebookChunkDefs.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookChunkDefs.cpp
@@ -27,6 +27,7 @@
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSourceDatabase.hpp>
+#include <session/SessionQuarto.hpp>
 
 using namespace rstudio::core;
 
@@ -37,13 +38,15 @@ namespace rmarkdown {
 namespace notebook {
 namespace {
 
-SEXP rs_getRmdWorkingDir(SEXP rmdFileSEXP, SEXP docIdSEXP)
+// Get the desired working directory of a notebook-like document
+// (R Markdown or Quarto).
+SEXP rs_getNotebookWorkingDir(SEXP notebookFileSEXP, SEXP docIdSEXP)
 {
    r::sexp::Protect protect;
    FilePath dir;
 
    // extract the document's path and ID
-   std::string docPath = r::sexp::safeAsString(rmdFileSEXP, "");
+   std::string docPath = r::sexp::safeAsString(notebookFileSEXP, "");
    if (docPath.empty()) 
       return R_NilValue;
    std::string docId = r::sexp::safeAsString(docIdSEXP, "");
@@ -54,7 +57,16 @@ SEXP rs_getRmdWorkingDir(SEXP rmdFileSEXP, SEXP docIdSEXP)
    std::string workingDir;
    getChunkValue(docPath, docId, kChunkWorkingDir, &workingDir);
    if (!workingDir.empty())
+   {
       dir = module_context::resolveAliasedPath(workingDir);
+   }
+   else
+   {
+      // if this is a Quarto document, attempt to look up its desired
+      // working directory that way (returns an empty FilePath if not
+      // a Quarto doc or no explicit working directory is set)
+      dir = quarto::getQuartoExecutionDir(docPath);
+   }
 
    // if we found a valid working directory, return it
    if (dir.exists())
@@ -225,7 +237,7 @@ void extractChunkIds(const json::Array& chunkOutputs,
 
 core::Error initChunkDefs()
 {
-   RS_REGISTER_CALL_METHOD(rs_getRmdWorkingDir, 2);
+   RS_REGISTER_CALL_METHOD(rs_getNotebookWorkingDir, 2);
    return Success();
 }
 

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
@@ -74,34 +74,12 @@ NotebookDocQueue::NotebookDocQueue(const std::string& docId,
       // precedence
       setWorkingDir(docWorkingDir, SetupChunkDir);
    }
-   else if (!docPath_.empty())
+   else
    {
-      // if this is a Quarto document, check to see if the associated project configuration file (if
-      // present) specifies a working directory for computations
-      FilePath qmdPath = module_context::resolveAliasedPath(docPath_);
-      if (qmdPath.hasExtensionLowerCase(".qmd"))
+      FilePath qmdExecutionPath = quarto::getQuartoExecutionDir(docPath_);
+      if (!qmdExecutionPath.isEmpty())
       {
-         FilePath quartoConfig = quarto::quartoProjectConfigFile(qmdPath);
-         if (!quartoConfig.isEmpty())
-         {
-             std::string executeDir;
-             quarto::readQuartoProjectConfig(quartoConfig,
-                   nullptr, // type
-                   nullptr, // output dir
-                   &executeDir);
-
-             if (executeDir == quarto::kQuartoExecuteDirProject)
-             {
-                // if the execution dir is set to 'project', infer the project root from the location
-                // of the Quarto config file and use it as the directory for execution
-                setWorkingDir(quartoConfig.getParent().getAbsolutePath(), QuartoProjectDir);
-             }
-             else if (executeDir == quarto::kQuartoExecuteDirFile)
-             {
-                // if the execution dir is set to 'file', use the directory of the document
-                setWorkingDir(qmdPath.getParent().getAbsolutePath(), QuartoProjectDir);
-             }
-         }
+         setWorkingDir(qmdExecutionPath.getAbsolutePath(), QuartoProjectDir);
       }
    }
 

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.cpp
@@ -90,11 +90,16 @@ NotebookDocQueue::NotebookDocQueue(const std::string& docId,
                    nullptr, // output dir
                    &executeDir);
 
-             // if the execution dir is set to 'project', infer the project root from the location
-             // of the Quarto config file and use it as the directory for execution
              if (executeDir == quarto::kQuartoExecuteDirProject)
              {
+                // if the execution dir is set to 'project', infer the project root from the location
+                // of the Quarto config file and use it as the directory for execution
                 setWorkingDir(quartoConfig.getParent().getAbsolutePath(), QuartoProjectDir);
+             }
+             else if (executeDir == quarto::kQuartoExecuteDirFile)
+             {
+                // if the execution dir is set to 'file', use the directory of the document
+                setWorkingDir(qmdPath.getParent().getAbsolutePath(), QuartoProjectDir);
              }
          }
       }

--- a/src/cpp/session/modules/rmarkdown/NotebookDocQueue.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookDocQueue.hpp
@@ -36,12 +36,14 @@ namespace modules {
 namespace rmarkdown {
 namespace notebook {
 
-// possible sources for specifying the working directory in a notebook execution queue
+// possible sources for specifying the working directory in a notebook execution queue, in
+// increasing order of precedence/specificity
 enum WorkingDirSource
 {
-   DefaultDir    = 0,    // working directory was unspecified (default)
-   GlobalDir     = 1,    // working dir was specified by the IDE (globally)
-   SetupChunkDir = 2     // working dir was specified by the doc's setup chunk
+   DefaultDir       = 0,    // working directory was unspecified (default)
+   GlobalDir        = 1,    // working dir was specified by the IDE (globally)
+   QuartoProjectDir = 2,    // working dir was specified in Quarto project config (project level)
+   SetupChunkDir    = 3     // working dir was specified by the doc's setup chunk (doc level)
 };
 
 class NotebookDocQueue : boost::noncopyable


### PR DESCRIPTION
### Intent

Honor the `execute-dir` setting in `_quarto.yml` when executing chunks interactively, and when performing file-based completions inside chunks. 

Addresses https://github.com/rstudio/rstudio/issues/11361. 

### Approach

Pretty straightforward: add a method that checks `execute-dir` for Quarto docs, and use it to resolve working directories when creating notebook execution queues and resolving completions.

### Automated Tests
N/A; neither Quarto nor Notebook code has unit test hooks, and refactoring it to add them isn't appropriate due to proximity to release. 

### QA Notes

- The `execute-dir` setting can conflict with the RStudio setting that governs where code chunks are executed. In the case where they differ, `execute-dir` wins because it is more specific (it's a project setting rather than a global one). If `execute-dir` isn't set, RStudio should fall back on the existing global settings. 
- The issue writeup in #11361 suggests that we only read the `project` value, but I've chosen here to respect `file` as well so that it is possible to override global preferences.
- The `project` value will use the Quarto project directory of the open file, not necessarily the Quarto project directory (if any) currently open in the IDE. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

