### PR TITLE
Fix path encoding when opening files on Windows (Electron)

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -391,6 +391,7 @@ export function getDesktopBridge() {
       const webcontents = webContents.getAllWebContents();
 
       if (webcontents.length) {
+        path = path.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n');
         webcontents[0]
           .executeJavaScript(`window.desktopHooks.openFile("${path}")`)
           .catch((error: unknown) => logger().logError(error));

--- a/src/node/desktop/tsconfig.json
+++ b/src/node/desktop/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "incremental": true,
     "module": "commonjs",
-    "target": "es2020",
+    "target": "es2021",
     "sourceMap": true,
     "removeComments": true,
     "baseUrl": ".",
@@ -13,7 +13,7 @@
     "paths": {
       "*": ["node_modules/*"]
     },
-    "lib": ["es2020", "DOM"],
+    "lib": ["es2021", "DOM"],
     "resolveJsonModule": true
   },
   "include": ["src/**/*", "test/**/*"],


### PR DESCRIPTION
### Intent

Files were failing to open from Windows Explorer, giving an error message and leaving the editor region blank.

Addresses #11369. Originally logged as part of #11251 but pulled into a separate (smaller) issue for targeted fix.

### Approach

Reimplement this bit of code from the Qt implementation:

https://github.com/rstudio/rstudio/blob/df26d2643ffecc0b1f4b5c8e99bb6dc1a81d30a8/src/cpp/desktop/DesktopMainWindow.cpp#L570-L572

Uses the JavaScript `replaceAll` method new to ES2021. Electron/Chromium supports it but did need to bump up the target in tsconfig from es2020 to es2021 to avoid warnings.

### Automated Tests

None

### QA Notes

Fix is specific to Windows-formatted paths (backslashes instead of forward slashes).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


