### PR TITLE
Restore option allow-overlay pattern

### DIFF
--- a/src/cpp/generate-options.R
+++ b/src/cpp/generate-options.R
@@ -317,6 +317,8 @@ generateProgramOptions <- function (optionsJson, overlayOptionsJson) {
             # handle any implicit conversions that we should support
             if (identical(type, "core::FilePath")) {
                accessorCode <- sprintf("return core::FilePath(%s);", memberName)
+            } else if (identical(category, "allow")) {
+               accessorCode <- sprintf("return %s || allowOverlay();", memberName)
             } else {
                accessorCode <- sprintf("return %s;", memberName)
             }
@@ -516,6 +518,7 @@ generateProgramOptions <- function (optionsJson, overlayOptionsJson) {
    classContents <- paste(classContents, buildOptions, sep="\n\n")
    classContents <- paste(classContents, accessors, sep="\n\n")
    classContents <- paste(classContents, members, sep="\n\n")
+   classContents <- paste(classContents, "  virtual bool allowOverlay() const { return false; };\n")
    
    # finally, close out the class
    classContents <- paste0(classContents, "};")

--- a/src/cpp/server/include/server/ServerOptions.gen.hpp
+++ b/src/cpp/server/include/server/ServerOptions.gen.hpp
@@ -334,6 +334,7 @@ protected:
    std::string authRevocationListDir_;
    bool authCookiesForceSecure_;
    int monitorIntervalSeconds_;
+   virtual bool allowOverlay() const { return false; };
 };
 
 } // namespace server

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -424,6 +424,54 @@ core::ProgramStatus Options::read(int argc, char * const argv[], std::ostream& o
    FilePath reposFile(rCRANReposFile());
    rCRANMultipleRepos_ = parseReposConfig(reposFile);
 
+   // if the allow overlay is enabled, emit warnings for any overlay option it masks
+   if (allowOverlay())
+   {
+      // it'd be nicer to iterate over the `allow` options_description object, but the
+      // variable-to-value mapping is not accessible here since it's only available
+      // during the parse phase
+      std::vector<std::string> violations;
+      if (!allowVcsExecutableEdit_)
+         violations.push_back("allow-vcs-executable-edit");
+      if (!allowCRANReposEdit_)
+         violations.push_back("allow-r-cran-repos-edit");
+      if (!allowVcs_)
+         violations.push_back("allow-vcs");
+      if (!allowPackageInstallation_)
+         violations.push_back("allow-package-installation");
+      if (!allowShell_)
+         violations.push_back("allow-shell");
+      if (!allowTerminalWebsockets_)
+         violations.push_back("allow-terminal-websockets");
+      if (!allowFileDownloads_)
+         violations.push_back("allow-file-downloads");
+      if (!allowFileUploads_)
+         violations.push_back("allow-file-uploads");
+      if (!allowRemovePublicFolder_)
+         violations.push_back("allow-remove-public-folder");
+      if (!allowRpubsPublish_)
+         violations.push_back("allow-rpubs-publish");
+      if (!allowExternalPublish_)
+         violations.push_back("allow-external-publish");
+      if (!allowFullUI_)
+         violations.push_back("allow-full-ui");
+      if (!allowLauncherJobs_)
+         violations.push_back("allow-launcher-jobs");
+
+      if (violations.size() == 1)
+      {
+         LOG_WARNING_MESSAGE("The option '" +
+                             violations[0] +
+                             "' was set, but it is not supported in this edition of RStudio and will be ignored");
+      }
+      else if (violations.size() > 1)
+      {
+         LOG_WARNING_MESSAGE("The following options were set, but are not supported in this edition of RStudio "
+                             "and will be ignored: " +
+                             boost::algorithm::join(violations, ", "));
+      }
+   }
+
    // return status
    return status;
 }

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -456,21 +456,21 @@ public:
    bool handleOfflineEnabled() const { return handleOfflineEnabled_; }
    int handleOfflineTimeoutMs() const { return handleOfflineTimeoutMs_; }
    bool sessionUseFileStorage() const { return sessionUseFileStorage_; }
-   bool allowVcsExecutableEdit() const { return allowVcsExecutableEdit_; }
-   bool allowCRANReposEdit() const { return allowCRANReposEdit_; }
-   bool allowVcs() const { return allowVcs_; }
-   bool allowPackageInstallation() const { return allowPackageInstallation_; }
-   bool allowShell() const { return allowShell_; }
-   bool allowTerminalWebsockets() const { return allowTerminalWebsockets_; }
-   bool allowFileDownloads() const { return allowFileDownloads_; }
-   bool allowFileUploads() const { return allowFileUploads_; }
-   bool allowRemovePublicFolder() const { return allowRemovePublicFolder_; }
-   bool allowRpubsPublish() const { return allowRpubsPublish_; }
-   bool allowExternalPublish() const { return allowExternalPublish_; }
-   bool allowPublish() const { return allowPublish_; }
-   bool allowPresentationCommands() const { return allowPresentationCommands_; }
-   bool allowFullUI() const { return allowFullUI_; }
-   bool allowLauncherJobs() const { return allowLauncherJobs_; }
+   bool allowVcsExecutableEdit() const { return allowVcsExecutableEdit_ || allowOverlay(); }
+   bool allowCRANReposEdit() const { return allowCRANReposEdit_ || allowOverlay(); }
+   bool allowVcs() const { return allowVcs_ || allowOverlay(); }
+   bool allowPackageInstallation() const { return allowPackageInstallation_ || allowOverlay(); }
+   bool allowShell() const { return allowShell_ || allowOverlay(); }
+   bool allowTerminalWebsockets() const { return allowTerminalWebsockets_ || allowOverlay(); }
+   bool allowFileDownloads() const { return allowFileDownloads_ || allowOverlay(); }
+   bool allowFileUploads() const { return allowFileUploads_ || allowOverlay(); }
+   bool allowRemovePublicFolder() const { return allowRemovePublicFolder_ || allowOverlay(); }
+   bool allowRpubsPublish() const { return allowRpubsPublish_ || allowOverlay(); }
+   bool allowExternalPublish() const { return allowExternalPublish_ || allowOverlay(); }
+   bool allowPublish() const { return allowPublish_ || allowOverlay(); }
+   bool allowPresentationCommands() const { return allowPresentationCommands_ || allowOverlay(); }
+   bool allowFullUI() const { return allowFullUI_ || allowOverlay(); }
+   bool allowLauncherJobs() const { return allowLauncherJobs_ || allowOverlay(); }
    core::FilePath coreRSourcePath() const { return core::FilePath(coreRSourcePath_); }
    core::FilePath modulesRSourcePath() const { return core::FilePath(modulesRSourcePath_); }
    core::FilePath sessionLibraryPath() const { return core::FilePath(sessionLibraryPath_); }
@@ -613,6 +613,7 @@ protected:
    std::string projectId_;
    std::string scopeId_;
    std::string launcherToken_;
+   virtual bool allowOverlay() const { return false; };
 };
 
 } // namespace session

--- a/src/cpp/session/include/session/SessionOptions.hpp
+++ b/src/cpp/session/include/session/SessionOptions.hpp
@@ -291,7 +291,7 @@ private:
    void resolveRsclangPath(const core::FilePath& resourcePath, std::string* pPath);
 
    void resolveOverlayOptions();
-   bool allowOverlay() const;
+   bool allowOverlay() const override;
 };
   
 } // namespace session


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3509.

### Approach

Restores the options overlay pattern originally introduced in https://github.com/rstudio/rstudio/commit/707d5c29680970f1b0259ea9ae15a69f0a8ddc65, but inadvertently removed in https://github.com/rstudio/rstudio/commit/a9bb34c8c75302ad7a378129ce8dab27ee92a5cd. 

Also adds some explicit warnings at startup when the overlay changes option values; in previous versions these changes occurred silently. 

### Automated Tests

N/A, except for logging improvements this only touches a code generator (and resultant output)

### QA Notes

- Test both open source and Pro versions with this change; i.e. that these options are both correctly ignored (with a warning) in open source, and correctly respected in Pro
- A comprehensive list of affected options can be found in the associated Pro issue

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


