### PR TITLE
Update add Quarto to PATH

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -219,7 +219,7 @@ void detectQuartoInstallation()
          s_quartoPath = s_userInstalledPath;
          const std::string quartoPath = string_utils::utf8ToSystem(s_quartoPath.getParent().getAbsolutePath());
 
-         if (sysPath.find(quartoPath) == std::string::npos)
+         if (sysPath.find(quartoPath) != std::string::npos)
             return;
 
          // prepend to path only if RSTUDIO_QUARTO is defined
@@ -255,7 +255,7 @@ void detectQuartoInstallation()
       s_quartoVersion = embeddedVersion;
       const std::string quartoPath = string_utils::utf8ToSystem(s_quartoPath.getParent().getAbsolutePath());
 
-      if (sysPath.find(quartoPath) == std::string::npos)
+      if (sysPath.find(quartoPath) != std::string::npos)
          return;
 
       // append to path


### PR DESCRIPTION
Quarto is not being correctly added to the PATH on Windows platforms, which means that Shiny Quarto apps cannot be rendered, and also the R quarto package will not work. 

Addresses #11291 

Call `Sys.setenv` in R to set the PATH variable instead of `core::system::setenv` in C++. 

Tested in Windows (Server 2019) and bundled Quarto is now correctly added to path, and Shiny Quarto docs can be rendered.

QA: For test plan, see details in #11291. Test with both bundled Quarto installation as well as separately installed Quarto CLI installed from quarto.org

