### PR TITLE
delete unused devicePixelRatio gwt callback

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -418,11 +418,6 @@ export class GwtCallback extends EventEmitter {
       return formatSelectedVersionForUi(rBinDir);
     });
 
-    ipcMain.handle('desktop_device_pixel_ratio', () => {
-      GwtCallback.unimpl('desktop_device_pixel_ratio');
-      return 1.0;
-    });
-
     ipcMain.on(
       'desktop_open_minimal_window',
       (event: IpcMainEvent, name: string, url: string, width: number, height: number) => {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -246,13 +246,6 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('chooseRVersion', error));
     },
 
-    devicePixelRatio: (callback: VoidCallback<number>) => {
-      ipcRenderer
-        .invoke('desktop_device_pixel_ratio')
-        .then((ratio) => callback(ratio))
-        .catch((error) => reportIpcError('devicePixelRatio', error));
-    },
-
     openMinimalWindow: (name: string, url: string, width: number, height: number) => {
       ipcRenderer.send('desktop_open_minimal_window', name, url, width, height);
     },


### PR DESCRIPTION
### Issue

The `devicePixelRatio()` gwt callback is never used. It isn't even exposed on the GWT side.

Presumably a remnant of ye olde days; the code now uses the `devicePixelRatio` property from the window object here:

https://github.com/rstudio/rstudio/blob/8272ed629be0d542352c3308e4f6f5ed8e21448a/src/gwt/src/org/rstudio/core/client/BrowseCap.java#L197-L210

### Approach

Deleted the partially implemented Electron callback. I didn't bother deleting the Qt implementation, though it is also unused.

For historical purposes, the Qt implementation returned 1.0 for Windows and Linux, and for Mac did this:

```
   NSWindow* pWindow = nsWindowForMainWindow(pMainWindow);

   if ([pWindow respondsToSelector:@selector(backingScaleFactor)])
   {
      return [pWindow backingScaleFactor];
   }
 ```

### Automated Tests

N/A

### QA Notes

Dead code removal, nothing to specifically test.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


