### PR TITLE
Fix build time quarto version check

### DIFF
--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -27,7 +27,7 @@ fi
 
 # variables that control download + installation process
 # update to latest Quarto release
-QUARTO_VERSION=`curl https://api.github.com/repos/quarto-dev/quarto-cli/releases | jq ".[0].tag_name" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
+QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/latest/download"
 
 # specify a version to pin for releases

--- a/dependencies/windows/install-quarto/get-quarto-version.ps1
+++ b/dependencies/windows/install-quarto/get-quarto-version.ps1
@@ -1,7 +1,7 @@
 # Retrieve latest Quarto version from GitHub
 
-$response = Invoke-WebRequest -UseBasicParsing -Uri https://api.github.com/repos/quarto-dev/quarto-cli/releases
+$response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_download.json
 $releases = ConvertFrom-Json $response.content
-$tag = $releases.tag_name[0]
-$quartoVersion = $tag | Select-String -Pattern '[0-9]+\.[0-9]+\.[0-9]+'
+$version = $releases.version
+$quartoVersion = $version | Select-String -Pattern '[0-9]+\.[0-9]+\.[0-9]+'
 $quartoVersion.Matches.Value

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -115,7 +115,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -112,7 +112,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-quarto"
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.fedora36-x86_64
+++ b/docker/jenkins/Dockerfile.fedora36-x86_64
@@ -101,7 +101,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.jammy-amd64
+++ b/docker/jenkins/Dockerfile.jammy-amd64
@@ -100,7 +100,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -108,7 +108,7 @@ RUN cd /tmp && \
     make install
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.rhel8-x86_64
+++ b/docker/jenkins/Dockerfile.rhel8-x86_64
@@ -113,7 +113,7 @@ RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1 
 
 # cachebust for Quarto release
-ADD https://api.github.com/repos/quarto-dev/quarto-cli/releases quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined


### PR DESCRIPTION
### Intent
Too many builds run concurrently for all the platforms which causes the build agents to exceed the GitHub API limit. This fixes the issue in case too many builds start within an hour.

### Approach
Uses the download metadata from quarto.org instead of GitHub to check which release to use for the build. This changes the Dockerfiles for Linux and the installer scripts for Linux/Mac/Windows. Mac and Windows always run the dependency install.

### Automated Tests
None

### QA Notes
None 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


