### PR TITLE
remove unused closeNamedWindow GWT callback

### DIFF
--- a/src/cpp/desktop/DesktopGwtCallback.cpp
+++ b/src/cpp/desktop/DesktopGwtCallback.cpp
@@ -654,11 +654,6 @@ QString GwtCallback::chooseRVersion()
 #endif
 }
 
-double GwtCallback::devicePixelRatio()
-{
-   return desktop::devicePixelRatio(pMainWindow_);
-}
-
 void GwtCallback::openMinimalWindow(QString name,
                                     QString url,
                                     int width,
@@ -732,16 +727,6 @@ void GwtCallback::prepareForNamedWindow(QString name,
 {
    pOwner_->webPage()->prepareForWindow(
                 PendingWindow(name, allowExternalNavigate, showDesktopToolbar));
-}
-
-void GwtCallback::closeNamedWindow(QString name)
-{
-   // close the requested window
-   pOwner_->webPage()->closeWindow(name);
-
-   // bring the main window to the front (so we don't lose RStudio context
-   // entirely)
-   desktop::raiseAndActivateWindow(pMainWindow_);
 }
 
 void GwtCallback::activateSatelliteWindow(QString name)

--- a/src/cpp/desktop/DesktopGwtCallback.hpp
+++ b/src/cpp/desktop/DesktopGwtCallback.hpp
@@ -124,8 +124,6 @@ public Q_SLOTS:
    QString getRVersion();
    QString chooseRVersion();
 
-   double devicePixelRatio();
-
    void openMinimalWindow(QString name, QString url, int width, int height);
    void activateMinimalWindow(QString name);
    void activateSatelliteWindow(QString name);
@@ -133,7 +131,6 @@ public Q_SLOTS:
                                   int height);
    void prepareForNamedWindow(QString name, bool allowExternalNavigate,
                               bool showToolbar);
-   void closeNamedWindow(QString name);
 
    // coordinates are relative to entire containing web page
    void copyPageRegionToClipboard(int left, int top, int width, int height);

--- a/src/cpp/desktop/DesktopUtils.hpp
+++ b/src/cpp/desktop/DesktopUtils.hpp
@@ -40,8 +40,6 @@ void reattachConsoleIfNecessary();
 rstudio::core::FilePath userLogPath();
 rstudio::core::FilePath userWebCachePath();
 
-double devicePixelRatio(QMainWindow* pMainWindow);
-
 bool isWindows();
 bool isMacOS();
 bool isCentOS();

--- a/src/cpp/desktop/DesktopUtilsMac.mm
+++ b/src/cpp/desktop/DesktopUtilsMac.mm
@@ -65,20 +65,6 @@ void initializeSystemPrefs()
 
 } // anonymous namespace
 
-double devicePixelRatio(QMainWindow* pMainWindow)
-{
-   NSWindow* pWindow = nsWindowForMainWindow(pMainWindow);
-
-   if ([pWindow respondsToSelector:@selector(backingScaleFactor)])
-   {
-      return [pWindow backingScaleFactor];
-   }
-   else
-   {
-      return 1.0;
-   }
-}
-
 bool isMacOS()
 {
    return true;

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -88,7 +88,6 @@ public interface DesktopFrame extends JavaScriptPassthrough
                                   int height, Command onPrepared);
    void prepareForNamedWindow(String name, boolean allowExternalNavigation,
          boolean showDesktopToolbar, Command onPrepared);
-   void closeNamedWindow(String name);
    
    void copyPageRegionToClipboard(int left, int top, int width, int height,
                                   Command onCopied);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -489,10 +489,6 @@ export class GwtCallback extends EventEmitter {
       },
     );
 
-    ipcMain.on('desktop_close_named_window', (event, name: string) => {
-      GwtCallback.unimpl('desktop_close_named_window');
-    });
-
     ipcMain.handle(
       'desktop_copy_page_region_to_clipboard',
       (_event, x: number, y: number, width: number, height: number) => {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -284,10 +284,6 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('prepareForNamedWindow', error));
     },
 
-    closeNamedWindow: (name: string) => {
-      ipcRenderer.send('desktop_close_named_window', name);
-    },
-
     copyPageRegionToClipboard: (x: number, y: number, width: number, height: number, callback: () => void) => {
       ipcRenderer
         .invoke('desktop_copy_page_region_to_clipboard', x, y, width, height)


### PR DESCRIPTION
- removed from Qt and Electron
- also removed underpinnings of the unused devicePixelRatio callback
