### PR TITLE
Fix bug with single-session mode and project sharing

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -992,7 +992,7 @@ void startup(const std::string& firstProjectPath)
       core::r_util::ProjectId projectId = session::projectToProjectId(
                options().userScratchPath(),
                FilePath(options().getOverlayOption(kSessionSharedStoragePath)),
-               session.project());
+               module_context::createAliasedPath(projectFilePath.getParent()));
       s_projectId = projectId;
 
 #ifndef _WIN32


### PR DESCRIPTION
### Intent

Fixes a bug the cloud team found with `server-multiple-sessions=0` and project sharing (a feature just added in this release)

### Approach

* Need to create the project id with the path chosen above as the active session's project (session.project() is not set until later)

* Need to use createAliasedPath() so that ~/ is managed consistently
or you can have two different project ids for the same path


