### PR TITLE
get_args() rpc extract src from the <pkg>::<fun> notation

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -990,6 +990,16 @@
 
 .rs.addJsonRpcHandler("get_args", function(name, src, helpHandler)
 {
+   if (grepl("::", name) && identical(src, ""))
+   {
+      bits <- strsplit(name, "::")[[1L]]
+      if (length(bits) == 2L)
+      {
+         name <- bits[2L]
+         src <- bits[1L]
+      }
+   }
+
    # call custom help handler if provided
    if (nzchar(helpHandler)) {
 


### PR DESCRIPTION
### Intent

`get_args()` rpc recognize the `<pkg>::<fun>` notation. 

### Approach

This e.g. extracts the right formals when hovering in the editor: 

<img width="296" alt="image" src="https://user-images.githubusercontent.com/2625526/173114345-a3450800-5795-47b3-8cd3-5f53c2f5d0ef.png">

instead of the `(...)` fallback: 

<img width="224" alt="image" src="https://user-images.githubusercontent.com/2625526/173114501-4917a570-3a05-4685-b790-dcd30e4c6d45.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


