### PR TITLE
Provide connection address/port, uri, stream file in connection error

### DIFF
--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -297,6 +297,9 @@ protected:
 
    void handleError(const Error& error)
    {
+      Error httpError = error;
+      addErrorProperties(httpError);
+
       // check to see if the socket was closed purposefully
       // if so, we will ignore the error
       LOCK_MUTEX(socketMutex_)
@@ -311,7 +314,7 @@ protected:
 
       // invoke error handler
       if (errorHandler_)
-         errorHandler_(error);
+         errorHandler_(httpError);
 
       // free handlers to ensure they do not keep a strong reference to us
       // this will allow us to properly clean up in that case
@@ -331,6 +334,16 @@ protected:
                                 description,
                                 location);
       handleError(error);
+   }
+
+   virtual void addErrorProperties(Error& error)
+   {
+      std::string host = request_.host();
+      if (!host.empty())
+         error.addProperty("host", host);
+      std::string uri = request_.uri();
+      if (!uri.empty())
+         error.addProperty("uri", uri);
    }
    
 private:

--- a/src/cpp/core/include/core/http/LocalStreamAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/LocalStreamAsyncClient.hpp
@@ -127,6 +127,14 @@ private:
       CATCH_UNEXPECTED_ASYNC_CLIENT_EXCEPTION
    }
 
+   virtual void addErrorProperties(Error& error)
+   {
+      AsyncClient::addErrorProperties(error);
+
+      error.addProperty("path", localStreamPath_);
+      if (validateUid_.is_initialized())
+         error.addProperty("user-id", validateUid_.get());
+   }
 
    const boost::shared_ptr<LocalStreamAsyncClient> sharedFromThis()
    {

--- a/src/cpp/core/include/core/http/SocketUtils.hpp
+++ b/src/cpp/core/include/core/http/SocketUtils.hpp
@@ -18,6 +18,7 @@
 
 #include <boost/asio/error.hpp>
 #include <boost/asio/socket_base.hpp>
+#include <boost/asio/ssl/error.hpp>
 
 #ifdef _WIN32
 #include <boost/system/windows_error.hpp>
@@ -74,6 +75,7 @@ inline bool isConnectionTerminatedError(const core::Error& error)
    bool timedOut = error == boost::asio::error::timed_out;
    bool eof = error == boost::asio::error::eof;
    bool reset = error == boost::asio::error::connection_reset;
+   bool shortRead = error == boost::asio::ssl::error::stream_truncated; // "short read"
    bool badFile = error == boost::asio::error::bad_descriptor;
    bool brokenPipe = error == boost::asio::error::broken_pipe;
    bool noFile = error == systemError(boost::system::errc::no_such_file_or_directory, ErrorLocation());
@@ -85,7 +87,7 @@ inline bool isConnectionTerminatedError(const core::Error& error)
    bool noData = false;
 #endif
    
-   return timedOut || eof || reset || badFile || brokenPipe || noFile || noData;
+   return timedOut || eof || reset || badFile || brokenPipe || noFile || noData || shortRead;
 }
 
 inline bool isConnectionUnavailableError(const Error& error)

--- a/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClient.hpp
@@ -81,6 +81,13 @@ private:
       return address_ + ":" + port_;
    }
 
+   virtual void addErrorProperties(Error& error)
+   {
+      AsyncClient::addErrorProperties(error);
+      error.addProperty("address", address_);
+      error.addProperty("port", port_);
+   }
+
    const boost::shared_ptr<TcpIpAsyncClient> sharedFromThis()
    {
       boost::shared_ptr<AsyncClient<boost::asio::ip::tcp::socket> > ptrShared

--- a/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncClientSsl.hpp
@@ -94,6 +94,13 @@ protected:
    }
 
 
+   virtual void addErrorProperties(Error& error)
+   {
+      AsyncClient::addErrorProperties(error);
+      error.addProperty("address", address_);
+      error.addProperty("port", port_);
+   }
+
 private:
 
    void performHandshake()


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio-pro/issues/3454

Also hides "ssl short read" errors by default, that I've seen a lot in customer logs that are using SSL servers. Those happen when the browser closes the connection mid-stream, as happens pretty regularly in our streaming connections. 

### Approach

Our errors get handled in the abstract base class so I added a method in each subclass to modify the error with details. 

### Automated Tests

Not necessary

### QA Notes

Aside from our existing automation, I don't think this needs additional testing but you can easily see these errors by mis-configuring one of the many ports or addresses in our configuration. For local streams, you should see the stream-path that helps identify the server. For Tcp, you see the address/port of the server in the connection. For both, you see the uri that client is using. 



