### PR TITLE
Add 'starting' debug log right after log is initialized

### DIFF
--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1853,6 +1853,32 @@ void afterResume()
    LOG_DEBUG_MESSAGE("Resume complete");
 }
 
+void logStartingEnv()
+{
+#ifdef __linux__
+   LOG_DEBUG_MESSAGE("Starting R session with LD_LIBRARY_PATH: " + core::system::getenv("LD_LIBRARY_PATH"));
+#endif
+#ifdef __APPLE__
+   std::string envVars[] = {"LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH"};
+   bool any = false;
+   for (std::string varName:envVars)
+   {
+      std::string envVal = core::system::getenv(varName);
+      if (!envVal.empty())
+      {
+         LOG_DEBUG_MESSAGE("Starting R session with " + varName + ": " + envVal);
+         any = true;
+         break;
+      }
+   }
+   if (!any)
+      LOG_DEBUG_MESSAGE("Starting R session with default system library path");
+#endif
+#ifdef _WIN32
+   LOG_DEBUG_MESSAGE("Starting R session");
+#endif
+}
+
 } // anonymous namespace
 
 // run session
@@ -1908,6 +1934,8 @@ int main(int argc, char * const argv[])
 #ifndef _WIN32
       ::setpgrp();
 #endif
+
+      logStartingEnv();
 
       rstudio::r::session::setResumeCallbacks(beforeResume, afterResume);
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1853,29 +1853,35 @@ void afterResume()
    LOG_DEBUG_MESSAGE("Resume complete");
 }
 
+std::string getenvForLog(const std::string& envVar)
+{
+   std::string envVal = core::system::getenv("LD_LIBRARY_PATH");
+   if (envVal.empty())
+     return "(empty)";
+   return envVal;
+}
+
 void logStartingEnv()
 {
 #ifdef __linux__
-   LOG_DEBUG_MESSAGE("Starting R session with LD_LIBRARY_PATH: " + core::system::getenv("LD_LIBRARY_PATH"));
+   LOG_DEBUG_MESSAGE("Starting R session with LD_LIBRARY_PATH: " + getenvForLog("LD_LIBRARY_PATH"));
 #endif
 #ifdef __APPLE__
-   std::string envVars[] = {"LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH"};
-   bool any = false;
+   std::string envVars[] = {"DYLD_LIBRARY_PATH", "DYLD_FALLBACK_LIBRARY_PATH", "DYLD_INSERT_LIBRARIES"};
+   std::string msg = "Starting R session with: ";
+   bool first = true;
    for (std::string varName:envVars)
    {
-      std::string envVal = core::system::getenv(varName);
-      if (!envVal.empty())
-      {
-         LOG_DEBUG_MESSAGE("Starting R session with " + varName + ": " + envVal);
-         any = true;
-         break;
-      }
+      if (!first)
+         msg += ", ";
+      else
+         first = false;
+      msg += varName + ": " + getenvForLog(varName);
    }
-   if (!any)
-      LOG_DEBUG_MESSAGE("Starting R session with default system library path");
+   LOG_DEBUG_MESSAGE(msg);
 #endif
 #ifdef _WIN32
-   LOG_DEBUG_MESSAGE("Starting R session");
+   LOG_DEBUG_MESSAGE("Starting R session with PATH: " + getenvForLog("PATH"));
 #endif
 }
 


### PR DESCRIPTION
### Intent

Addresses the remaining aspect of: https://github.com/rstudio/rstudio-pro/issues/2641

Should I log PATH for windows?

### Approach

We already have debug logs beginning the R session, before and after resuming the session, and when
listening. This adds a message right when the session starts (after logging has been initialized), and prints the dyn library path value for linux and mac.

### Automated Tests

None required

### QA Notes

Enable debug logging and hopefully get improved timing info on session start.



