### PR TITLE
More hyperlink tweaks

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
@@ -37,7 +37,7 @@ public abstract class Hyperlink
 
         anchor_ = Document.get().createAnchorElement();
         styles_ = RES.hyperlinkStyles();
-        popup_ = new HyperlinkPopupPanel();
+        popup_ = new HyperlinkPopupPanel(this);
     }
 
     public Element getElement()
@@ -52,31 +52,16 @@ public abstract class Hyperlink
         {
             if (event.getTypeInt() == Event.ONMOUSEOVER)
             {   
-                visible_ = true;
                 getPopupContent((content) -> {
-                    if (visible_)
-                    {
-                        if (content != null)
-                        {
-                            popup_.setContent(content);
+                    popup_.setContent(content);
 
-                            Rectangle bounds = new Rectangle(anchor_.getAbsoluteLeft(), anchor_.getAbsoluteBottom(), anchor_.getClientWidth(), anchor_.getClientHeight());
-                            HyperlinkPopupPositioner positioner = new HyperlinkPopupPositioner(bounds, popup_);
-                            popup_.setPopupPositionAndShow(positioner);
-                        }
-                        
-                    }
-                    
+                    Rectangle bounds = new Rectangle(anchor_.getAbsoluteLeft(), anchor_.getAbsoluteBottom(), anchor_.getClientWidth(), anchor_.getClientHeight());
+                    HyperlinkPopupPositioner positioner = new HyperlinkPopupPositioner(bounds, popup_);
+                    popup_.setPopupPositionAndShow(positioner);
                 });
             } 
-            else if (event.getTypeInt() == Event.ONMOUSEOUT)
-            {
-                visible_ = false;
-                popup_.hide();
-            }
             else if (event.getTypeInt() == Event.ONCLICK) 
             {
-                visible_ = false;
                 popup_.hide();
                 onClick();
             }
@@ -92,10 +77,8 @@ public abstract class Hyperlink
 
     public abstract void onClick();
     
-    public void getPopupContent(CommandWithArg<Widget> onReady)
-    {
-        onReady.execute(null);
-    }
+    public void getPopupContent(CommandWithArg<Widget> onReady){}
+    public void showHelp(){}
 
     public static Hyperlink create(String url, String paramsTxt, String text, String clazz)
     {
@@ -141,7 +124,6 @@ public abstract class Hyperlink
     public String text;
     public String clazz;
     public Map<String, String> params;
-    private boolean visible_;
     protected AnchorElement anchor_;
     
     protected final HyperlinkResources.HyperlinkStyles styles_;

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/HyperlinkPopupPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/HyperlinkPopupPanel.java
@@ -98,12 +98,18 @@ public class HyperlinkPopupPanel extends ThemedPopupPanel implements HyperlinkPo
 
     public void setContent(Widget content)
     {
+        if (current_ != null)
+        {
+            current_.hide();
+            current_ = null;
+        }
         container_ = new VerticalPanel();
         container_.addStyleName(HyperlinkResources.INSTANCE.hyperlinkStyles().hyperlinkPopup());
         setWidget(container_);
         container_.add(content);
 
         registerNativeHandler(handler_);
+        current_ = this;
     }
 
     @Override
@@ -137,4 +143,5 @@ public class HyperlinkPopupPanel extends ThemedPopupPanel implements HyperlinkPo
     private HandlerRegistration handlerRegistration_;
     private Hyperlink hyperlink_;
    
+    private static HyperlinkPopupPanel current_;
 }

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -25,6 +25,7 @@ import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
+import org.rstudio.studio.client.common.codetools.RCompletionType;
 import org.rstudio.studio.client.server.Server;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
@@ -71,6 +72,10 @@ public class RunHyperlink extends Hyperlink
     public static boolean handles(String url)
     {
         return HYPERLINK_PATTERN.test(url);
+    }
+
+    public void showHelp(){
+        server_.showHelpTopic(fun_, package_, RCompletionType.FUNCTION);
     }
 
     private String code_;    


### PR DESCRIPTION
### Intent

Follow up for #11273

### Approach

Instead of having the popup disappear on mouse out, hide it on: 
 - mouse down anywhere else
 - escape
But making sure there is only one hyperlink popup showing at a time. 

In addition, pressing F1 on `:run:` hyperlink will show the help page. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


