### PR TITLE
Fixed 2 compile errors and one warning on Mac OS build

### DIFF
--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -208,13 +208,13 @@ size_t RpcActiveSessionsStorage::getSessionCount() const
       return 0;
    }
 
-   size_t count = 0;
+   uint64_t count = 0;
    error = json::readObject(response.result().getObject(), kSessionStorageCountField, count);
 
    if (error)
       LOG_ERROR(error);
    
-   return count;
+   return (size_t) count;
 }
 
 std::shared_ptr<core::r_util::IActiveSessionStorage> RpcActiveSessionsStorage::getSessionStorage(const std::string& id) const 

--- a/src/cpp/r/RJson.cpp
+++ b/src/cpp/r/RJson.cpp
@@ -162,7 +162,7 @@ Error jsonValueFromVectorElement(SEXP vectorSEXP,
                }
                case UINT32:
                {
-                  if ((value >= 0) && (value <= UINT32_MAX))
+                  if (value >= 0)
                   {
                      *pValue = static_cast<uint32_t>(value);
                      break;

--- a/src/cpp/server/session/ServerSessionMetadataRpc.cpp
+++ b/src/cpp/server/session/ServerSessionMetadataRpc.cpp
@@ -447,7 +447,7 @@ void handleMetadataRpcImpl(const std::string& username, boost::shared_ptr<core::
       else
       {
          json::Object countObj;
-         countObj[kSessionStorageCountField] = count;
+         countObj[kSessionStorageCountField] = (uint64_t) count;
          response.setResult(countObj);
       }
    }


### PR DESCRIPTION
 - size_t != uint64_t (it seems?) so add some explicit cases
 - warning for comparing int against uint (remove the "max test" because a sized int can never be larger than umax int)
 - don't use readObject directly with size_t as it leads to an undefined method
