### PR TITLE
Migrate file sessions to DB

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -214,7 +214,9 @@ public:
                kEditor,
                kLastResumed,
                kSuspendTimestamp,
-               kBlockingSuspend
+               kBlockingSuspend,
+               kCreated,
+               kLaunchParameters
              };
 
             return storage_->readProperties(allProperties, pValues);

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -37,6 +37,8 @@ namespace rstudio {
 namespace core {
 namespace r_util {
 
+class RpcActiveSessionsStorage;
+
 // Constants for RPCs related to session metadata ===========================
 // RPC endpoint
 constexpr const char * kSessionStorageRpc = "/storage/session_metadata";
@@ -94,6 +96,7 @@ class ActiveSession : boost::noncopyable
 {
 private:
    friend class ActiveSessions;
+   friend class RpcActiveSessionsStorage;
 
    explicit ActiveSession(const std::string& id) : id_(id) 
    {

--- a/src/cpp/core/include/core/r_util/RActiveSessionsStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionsStorage.hpp
@@ -67,6 +67,8 @@ namespace r_util {
       core::Error hasSessionId(const std::string& sessionId, bool* pHasSessionId)  const override;
 
    private:
+      void migrateSessions() const;
+
       const core::system::User user_;
       FilePath storagePath_;
       const InvokeRpc invokeRpcFunc_;

--- a/src/cpp/core/r_util/RActiveSessionsStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionsStorage.cpp
@@ -117,7 +117,7 @@ std::shared_ptr<IActiveSessionStorage> FileActiveSessionsStorage::getSessionStor
 
 RpcActiveSessionsStorage::RpcActiveSessionsStorage(const core::system::User& user, const FilePath& rootStoragePath, InvokeRpc invokeRpcFunc) :
    user_(user),
-   storagePath_(rootStoragePath),
+   storagePath_(ActiveSessions::storagePath(rootStoragePath)),
    invokeRpcFunc_(std::move(invokeRpcFunc))
 {
 }
@@ -314,6 +314,12 @@ void RpcActiveSessionsStorage::migrateSessions() const
                {
                   error.addProperty("operation", "Attempting to migrate old sessions for user " + user_.getUsername());
                   LOG_ERROR(error);
+                  continue;
+               }
+
+               // Skip workspaces
+               if (sessionId == kWorkspacesId)
+               {
                   continue;
                }
 

--- a/src/cpp/server/DBActiveSessionsStorage.cpp
+++ b/src/cpp/server/DBActiveSessionsStorage.cpp
@@ -28,8 +28,8 @@ namespace server {
 namespace storage {
 
 
-DBActiveSessionsStorage::DBActiveSessionsStorage(const system::User& user)
-   : user_(user)
+DBActiveSessionsStorage::DBActiveSessionsStorage(const system::User& user) :
+   user_(user)
 {
 }
 

--- a/src/cpp/server/include/server/DBActiveSessionsStorage.hpp
+++ b/src/cpp/server/include/server/DBActiveSessionsStorage.hpp
@@ -38,7 +38,7 @@ public:
    std::shared_ptr<core::r_util::IActiveSessionStorage> getSessionStorage(const std::string& id) const override;
    core::Error hasSessionId(const std::string& sessionId, bool* pHasSessionId) const override;
 private:
-   core::system::User user_;
+   const core::system::User user_;
 };
 
 } // namespace storage


### PR DESCRIPTION
### Intent

The last part of [Pro #3094](https://github.com/rstudio/rstudio-pro/issues/3094) - migrating file based session to the database.
 
### Approach

When we list sessions, migrate if we haven't already. Best effort only, don't do it twice.

### Automated Tests

There are none at the moment, this would be difficult to automate due to the config change requirement.

### QA Notes

We should start some session in the old way and then set `session-use-file-storage=0` and see that there are no errors in the logs and things still work (in pro as especially).

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


