### PR TITLE
Allow lldb debugging of compiled code in R and R packages

### DIFF
--- a/package/osx/entitlements-electron.plist
+++ b/package/osx/entitlements-electron.plist
@@ -29,5 +29,9 @@
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
 
+  <!--- Allow debugging compiled code in R and R packages -->
+  <key>com.apple.security.get-task-allow</key>
+  <true/>
+
 </dict>
 </plist>

--- a/package/osx/entitlements.plist
+++ b/package/osx/entitlements.plist
@@ -25,5 +25,9 @@
   <key>com.apple.security.automation.apple-events</key>
   <true/>
 
+  <!--- Allow debugging compiled code in R and R packages -->
+  <key>com.apple.security.get-task-allow</key>
+  <true/>
+
 </dict>
 </plist>

--- a/src/node/desktop/resources/electron-entitlements.mac.plist
+++ b/src/node/desktop/resources/electron-entitlements.mac.plist
@@ -25,5 +25,9 @@
   <key>com.apple.security.automation.apple-events</key>
   <true/>
 
+  <!--- Allow debugging compiled code in R and R packages -->
+  <key>com.apple.security.get-task-allow</key>
+  <true/>
+
 </dict>
 </plist>


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

We can't use `lldb` on RStudio's `rsession` process currently, because it does not have the `get-task-allow` entitlement. The original R executable has this entitlement now, since R 4.2.0. More info on that here: https://stat.ethz.ch/pipermail/r-sig-mac/2022-April/014377.html

It would be great to add this entitlement to `rsession` and `rsession-arm64` as well, so we can debug compiled code in RStudio.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Straightforward, mostly. It seems that currently all executables are signed with the same entitlements, and I think `get-task-allow` is only needed for `rsession` and `rsession-arm64`. Since we already have `com.apple.security.cs.disable-library-validation` on all executables, as I understand it is OK to add `get-task-allow` to these as well.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

No tests are included. AFAICT the entitlements are not tested currently.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

Run 

```
codesign -d --entitlements - /Applications/RStudio.app/Contents/MacOS/rsession
codesign -d --entitlements - /Applications/RStudio.app/Contents/MacOS/rsession-arm64
```

and make sure the output has
```
	[Key] com.apple.security.get-task-allow
	[Value]
		[Bool] true
```

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


