### PR TITLE
dial down restrictions in `ide:run:` links

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -46,7 +46,7 @@ public class RunHyperlink extends Hyperlink
     @Override 
     public void onClick()
     {
-        server_.isPackageHyperlinkSafe(package_, new SimpleRequestCallback<Boolean>(){
+        server_.isCodeHyperlinkSafe(code_, new SimpleRequestCallback<Boolean>(){
 
             @Override
             public void onResponseReceived(Boolean response)
@@ -84,6 +84,6 @@ public class RunHyperlink extends Hyperlink
     private static final EventBus events_ = RStudioGinjector.INSTANCE.getEventBus();
     private Server server_;
 
-    // allow code of the form pkg::fn(<args>) where args does not have ;()
-    private static final Pattern HYPERLINK_PATTERN = Pattern.create("^(rstudio|ide):run:(\\w+)::(\\w+)[(][^();]*[)]$", "");
+    // allow code of the form pkg::fn(<args>) where <args> does not have ";"
+    private static final Pattern HYPERLINK_PATTERN = Pattern.create("^(rstudio|ide):run:(\\w+)::(\\w+)[(][^;]*[)]$", "");
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1295,13 +1295,13 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, IS_PACKAGE_LOADED, params, requestCallback);
    }
 
-   public void isPackageHyperlinkSafe(
-                       String packageName,
+   public void isCodeHyperlinkSafe(
+                       String code,
                        ServerRequestCallback<Boolean> requestCallback)
    {
       JSONArray params = new JSONArray();
-      params.set(0, new JSONString(packageName));
-      sendRequest(RPC_SCOPE, IS_PACKAGE_HYPERLINK_SAFE, params, requestCallback);
+      params.set(0, new JSONString(code));
+      sendRequest(RPC_SCOPE, IS_CODE_HYPERLINK_SAFE, params, requestCallback);
    }
 
    public void isPackageInstalled(String packageName,
@@ -6674,7 +6674,7 @@ public class RemoteServer implements Server
    private static final String GET_PACKAGE_NEWS_URL = "get_package_news_url";
    private static final String GET_PACKAGE_INSTALL_CONTEXT = "get_package_install_context";
    private static final String IS_PACKAGE_LOADED = "is_package_loaded";
-   private static final String IS_PACKAGE_HYPERLINK_SAFE = "is_package_hyperlink_safe";
+   private static final String IS_CODE_HYPERLINK_SAFE = "is_code_hyperlink_safe";
    private static final String IS_PACKAGE_INSTALLED = "is_package_installed";
    private static final String SET_CRAN_MIRROR = "set_cran_mirror";
    private static final String GET_CRAN_MIRRORS = "get_cran_mirrors";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackagesServerOperations.java
@@ -37,8 +37,8 @@ public interface PackagesServerOperations extends PackratServerOperations
    void isPackageLoaded(String packageName, String libName,
                         ServerRequestCallback<Boolean> requestCallback);
    
-   void isPackageHyperlinkSafe(String packageName,
-                               ServerRequestCallback<Boolean> requestCallback);
+   void isCodeHyperlinkSafe(String code,
+                            ServerRequestCallback<Boolean> requestCallback);
    
    void isPackageInstalled(String packageName,
                            String version,


### PR DESCRIPTION
### Intent

follow up for #11273

### Approach

Dial down restrictions on `ide:run:`

options: 
 - code not of of form `<pkg>::<fun>(<args>)`, or `<args>` has a `;` : not allowed
 - `<pkg>` not loaded or on the allow list: only get copied, not executed
 - `<args>` has embedded function calls: also only copied, not executed
 - If `<pkg>` is loaded or in the allow list *and*. there are no embedded function calls: safe to execute

For examples: 

```r
# safe to execute
cli::style_hyperlink("show traceback", "ide:run:rlang::last_error()")

# copied
cli::style_hyperlink("show session info", "ide:run:sessioninfo::session_info()")
cli::style_hyperlink("show traceback ...", "ide:run:rlang::last_error(a = rm(list = ls()))")

# denied
cli::style_hyperlink("show traceback ...", "ide:run:rm(list = ls())") # because no <pkg>
cli::style_hyperlink("show traceback ...", "ide:run:rlang::last_error(); rm(list = ls())") # because the ";"
```

I believe this would allow some variation of the examples here https://github.com/rstudio/rstudio/issues/11273#issuecomment-1154249848 to be usable. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


