### PR TITLE
Prevent crashes with malformed regex which match all lines of content

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1034,6 +1034,8 @@ private:
             processContents(&lineInfo.decodedPreview, &lineInfo.decodedContents,
                &matchOn, &matchOff);
 
+            // If we reach here, grep has found a malformed match (usually due to a bad regex)
+            // and processContents was not able to identify the corresponding match string
             if (matchOn.getSize() == 0)
                continue;
 

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -665,6 +665,13 @@ private:
          decodedLine.append(
             Replacer::decode(std::string(inputPos, end), encoding_, firstDecodeError_));
 
+      if (pMatchOn->getSize() == 0)
+      {
+         // If we reach here, grep has found a malformed match
+         pContent = nullptr;
+         pFullLineContent = nullptr;
+         return;
+      }
       *pFullLineContent = decodedLine;
       if (!findResults().replace())
          adjustForPreview(&decodedLine, pMatchOn, pMatchOff);
@@ -1026,6 +1033,9 @@ private:
             json::Array replaceMatchOn, replaceMatchOff;
             processContents(&lineInfo.decodedPreview, &lineInfo.decodedContents,
                &matchOn, &matchOff);
+
+            if (matchOn.getSize() == 0)
+               continue;
 
             if (findResults().replace() &&
                 !(findResults().preview() &&


### PR DESCRIPTION
### Intent

Addresses #11348 part 1 -- prevent RStudio crashes

### Approach

So it turns out that system grep doesn't actually crash when you search for `()` or `[]` or other bad regexes, even though it doesn't really match any content. We give our Find in Files an escape hatch, where if the grep command has completed without error and returns actual output, but the matchOn/matchOff array is empty (this doesn't happen with true no results, where grep stdout is empty) we skip ahead to the next match. 

Essentially this gives us (No results found) when searching for regexes like `()`, but appropriate results when searching for `\(\)`. True no matches (ie searching for `shdjshfdsjgfsjkd`) continue to behave as usual, since the grep onStdOut callback is not triggered when grep finds no matches.

This is because grep doesn't error when you search for `()` -- it actually matches every line, every file, even blank lines.

Separately, we can put in a PR to allow for escaping these characters when in WholeWord mode

### Automated Tests

Existing unit tests pass. We can add a new automated test case in rstudio-ide-automation once this is closed

### QA Notes

Find in files  with regex selected:
Create a file
````
print()

hello()

[1-3]
````
1) `\(\)`
2) `()`
3) `nooooooo`
4) `[]`
5) `\[\]`

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


