### PR TITLE
Fix bug with counting sessions

### DIFF
--- a/src/cpp/server/DBActiveSessionsStorage.cpp
+++ b/src/cpp/server/DBActiveSessionsStorage.cpp
@@ -95,6 +95,8 @@ size_t DBActiveSessionsStorage::getSessionCount() const
 
       if(error)
          LOG_ERROR(error);
+
+      return count;
    }
 
    return 0;


### PR DESCRIPTION
### Intent

Fix a bug @astayleraz and I just found while over-viewing the session metadata feature.

### Approach

Actually return the count variable.

### Automated Tests

Our tests will run against the sessions that use this call.

### QA Notes

`.rs.invokeServerRpc` with `operation = "count"` should return a non-zero value.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


