### PR TITLE
stop building unused urlopener for Electron

### DIFF
--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -696,6 +696,5 @@ elseif(WIN32 AND NOT RSTUDIO_SESSION_WIN32)
       ${TESTS_INCLUDE_DIR}
    )
 
-   add_subdirectory(urlopener)
    add_subdirectory(synctex/rsinverse)
 endif()


### PR DESCRIPTION
### Intent

Addresses #11439

### Approach

The Windows-only urlopener.exe is not used by Electron desktop, so stop building it.

### Automated Tests

N/A

### QA Notes

This executable wasn't being used for anything in Electron desktop (see issue for gory details of why it existed for Qt desktop), so other than checking that urlopener.exe is no longer present when you install rstudio electron on Windows, nothing to test here.

I suppose you could also check that urlopener.exe DOES still get installed by Qt desktop.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


