### PR TITLE
add title label to help info popup

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -20,12 +20,22 @@
    margin-bottom: 4px;
 }
 
+.helpBodyText a {
+   pointer-events: none;
+   text-decoration: none;
+}
+
 .rstudio-themes-dark-menus .helpBodyText a {
    color: #FFF;
 }
 
 .rstudio-themes-dark-menus .helpBodyText span {
    color: #bfbfbf !important;
+}
+
+.helpTitleText {
+   font-weight: bold;
+   margin-bottom: 4px;
 }
 
 .snippetText {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -23,6 +23,7 @@
 .helpBodyText a {
    pointer-events: none;
    text-decoration: none;
+   color: #000023 !important; 
 }
 
 .rstudio-themes-dark-menus .helpBodyText a {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
@@ -80,6 +80,10 @@ public class HelpInfoPopupPanel extends PopupPanel
       }
       vpanel_.add(lblSig);
       
+      Label lblTitle = new Label(help.getTitle());
+      lblTitle.setStylePrimaryName(RES.styles().helpTitleText());
+      vpanel_.add(lblTitle);
+
       HTML htmlDesc = new HTML(help.getDescription());
       htmlDesc.setStylePrimaryName(RES.styles().helpBodyText());
       vpanel_.add(htmlDesc);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanelResources.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanelResources.java
@@ -24,6 +24,7 @@ public interface HelpInfoPopupPanelResources extends ClientBundle
    public static interface Styles extends CssResource
    {
       String helpPopup();
+      String helpTitleText();
       String helpBodyText();
       String snippetText();
    }
@@ -35,5 +36,4 @@ public interface HelpInfoPopupPanelResources extends ClientBundle
    public static HelpInfoPopupPanelResources INSTANCE = 
       (HelpInfoPopupPanelResources)GWT.create(HelpInfoPopupPanelResources.class);
    
-  
 }


### PR DESCRIPTION
### Intent

addresses #7839

### Approach

add a Label for the title, in bold: 

<img width="663" alt="image" src="https://user-images.githubusercontent.com/2625526/174139616-d94f7598-2d6a-4cfa-a952-87b98f955003.png">

<img width="677" alt="image" src="https://user-images.githubusercontent.com/2625526/174139852-513da2ed-8db4-432c-9801-dfb8b1e582c6.png">

Also rendered the links unclickable and same color as the rest, because they were not linking to the correct location anyway. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


