### PR TITLE
fix styles for hyperlink help preview popup

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/hyperlinkStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/hyperlinkStyles.css
@@ -93,3 +93,17 @@
     margin-top: 4px;
     margin-bottom: 4px; 
 }
+
+.helpPreviewDescription a {
+    pointer-events: none;
+    text-decoration: none;
+    color: #000023;
+}
+
+.rstudio-themes-dark-menus .helpPreviewDescription a {
+    color: #FFF;
+}
+
+.rstudio-themes-dark-menus .helpPreviewDescription span {
+    color: #bfbfbf !important;
+}


### PR DESCRIPTION
### Intent

making the link inside the popup for `ide:(help|run)` links unclickable and same style as the rest of the text. 

<img width="509" alt="image" src="https://user-images.githubusercontent.com/2625526/174141243-a452ed51-d982-4e7d-887e-9120c09a69d6.png">

<img width="508" alt="image" src="https://user-images.githubusercontent.com/2625526/174141397-972dd838-0cff-43ba-a8c6-3d983fe51f3e.png">

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


