### PR TITLE
Fixes a few db/rpc session problems found in testing

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -562,7 +562,9 @@ Error Connection::executeStr(const std::string& queryStr)
    }
    catch (soci::soci_error& error)
    {
-      return DatabaseError(error);
+      Error res = DatabaseError(error);
+      res.addProperty("query", queryStr);
+      return res;
    }
 }
 
@@ -946,6 +948,7 @@ Error SchemaUpdater::getSchemaTableColumnCount(int* pColumnCount)
    }
 
    *pColumnCount = columnCount;
+
    return Success();
 }
 
@@ -1223,6 +1226,43 @@ Error createConnectionPool(size_t poolSize,
    }
 
    return Success();
+}
+
+Error execAndProcessQuery(boost::shared_ptr<database::IConnection> pConnection,
+                          const std::string& sql,
+                          const boost::function<void(const database::Row&)>& rowHandler)
+{
+   Rowset rows;
+   Query query = pConnection->query(sql);
+   Error error = pConnection->execute(query, rows);
+   if (error)
+      return error;
+
+   LOG_DEBUG_MESSAGE("SQL Executed: " + sql);
+   if (!rowHandler.empty())
+   {
+      std::size_t rowCount = 0;
+      for (RowsetIterator it = rows.begin(); it != rows.end(); ++it)
+      {
+         const Row& row = *it;
+         rowHandler(row);
+         rowCount++;
+      }
+      LOG_DEBUG_MESSAGE("SQL Processed: " + std::to_string(rowCount) + " rows");
+   }
+
+   return Success();
+}
+
+std::string getRowStringValue(const Row& row, const std::string& column)
+{
+   soci::indicator indicator = row.get_indicator(column);
+   if (indicator == soci::i_ok)
+   {
+      return row.get<std::string>(column);
+   }
+   LOG_WARNING_MESSAGE("Could not retrieve " + column + " value from database row.");
+   return std::string();
 }
 
 } // namespace database

--- a/src/cpp/core/include/core/Database.hpp
+++ b/src/cpp/core/include/core/Database.hpp
@@ -107,6 +107,11 @@ public:
       return *this;
    }
 
+   int getAffectedRows()
+   {
+      return statement_.get_affected_rows();
+   }
+
 private:
    friend class Connection;
    friend class Rowset;
@@ -123,7 +128,7 @@ class Rowset
 public:
    RowsetIterator begin();
    RowsetIterator end();
-   
+
    size_t columnCount() const;
 
 private:
@@ -355,6 +360,15 @@ Error connect(const ConnectionOptions& options,
 Error createConnectionPool(size_t poolSize,
                            const ConnectionOptions& options,
                            boost::shared_ptr<ConnectionPool>* pPool);
+
+// execute a provided query and pass each row to the rowHandler
+Error execAndProcessQuery(boost::shared_ptr<database::IConnection> pConnection,
+                          const std::string& sql,
+                          const boost::function<void(const database::Row&)>& rowHandler =
+                             boost::function<void(const database::Row&)>());
+
+// uses soci::indicator to safely parse a string value from a row
+std::string getRowStringValue(const Row& row, const std::string& column);
 
 } // namespace database
 } // namespace core

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -107,9 +107,6 @@ private:
       const FilePath& scratchPath,
       std::shared_ptr<IActiveSessionStorage> storage) : id_(id), scratchPath_(scratchPath), storage_(storage)
    {
-      core::Error error = scratchPath_.ensureDirectory();
-      if (error)
-         LOG_ERROR(error);
    }
 
 public:
@@ -499,13 +496,6 @@ public:
    bool validate(const FilePath& userHomePath,
                  bool projectSharingEnabled) const
    {
-      // ensure the scratch path and properties paths exist
-      if (!scratchPath_.exists())
-      {
-         LOG_DEBUG_MESSAGE("ActiveSession validation failed: " + scratchPath_.getAbsolutePath() + " not accessible to the session user");
-         return false;
-      }
-
       if (empty())
       {
          LOG_DEBUG_MESSAGE("ActiveSession validation failed on empty session");

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -60,9 +60,6 @@ ActiveSessions::ActiveSessions(std::shared_ptr<IActiveSessionsStorage> storage, 
    storage_(storage)
 {
    storagePath_ = storagePath(rootStoragePath);
-   Error error = storagePath_.ensureDirectory();
-   if (error)
-      LOG_ERROR(error);
 }
 
 Error ActiveSessions::create(const std::string& project,


### PR DESCRIPTION
No pressure to review this weekend :)   I may merge this myself in a bit so I can flush out build problems, and do more testing on the official build. 

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/3566

### Approach

 - don't ensureDirectory for scratch path in ActiveSession since that code runs on the server scratchPath is not accessible. This is already done by the File storage implementation when it's required and so is not necessary here.
 - Similarly don't check for scratchPath existing in ActiveSession::validate since that check is in file storage.isValid called by empty()
 - Similarly for ActiveSessions and rootStoragePath
 - fixes for editor/workbench renaming, consistently map and unmap columnName/propertyName for each property in the list
 - diagnostics for destroySession when row does not exist
 - don't suppress errors for "session doesn't exist" in read-property RPC
 - treat "session not found" as a special error in read property. This is only a partial fix to the fact that readProperty() will return a default value if either the session does not exist, the rpc fails, or some other error. That's not a great development pattern so I'll file an issue to fix this and improve the performance by batching 'read property' calls and caching them on the client. Not really a problem for rsession but causes a ton of extra rpc calls in rsession and poor error checking (i.e. might return a default property value when the rpc fails in a ton of code paths).
 - add some missing apis for db queries (that were made in pro only but seem to compile in OS so why not?)

### QA Notes

Same testing as for original feature.



