### PR TITLE
For non-launcher sessions, need to pass the server rpc key

### DIFF
--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -202,8 +202,9 @@ core::system::ProcessConfig sessionProcessConfig(
    environment.push_back(
          std::make_pair(kSessionTmpDirEnvVar, sessionTmpDir().getAbsolutePath()));
 
-   // Set RPC socket path
+   // Set RPC socket path and secret
    environment.push_back({kServerRpcSocketPathEnvVar, serverRpcSocketPath().getAbsolutePath()});
+   environment.push_back({kServerRpcSecretEnvVar, core::socket_rpc::secret()});
 
    // build the config object and return it
    core::system::ProcessConfig config;

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1969,6 +1969,9 @@ int main(int argc, char * const argv[])
          }
       }
 
+      // Initialize rpc to rserver before options. Rpc validates session scope with db session storage
+      error = socket_rpc::initialize();
+
       // read program options
       std::ostringstream osWarnings;
       Options& options = rsession::options();
@@ -2050,8 +2053,6 @@ int main(int argc, char * const argv[])
          }
       }
 
-      // Initialize rpc methods
-      error = socket_rpc::initialize();
       if (error)
          return sessionExitFailure(error, ERROR_LOCATION);
 


### PR DESCRIPTION
Initialize the socket rpc before the session scope is initialized
in the options so the initial "validate" works.

We pass the server's rpc secret key to the session already for OS/Server but we don't for non-launcher sessions. 
