### PR TITLE
avoid conflating minimum-supported libclang version with embedded version

### DIFF
--- a/src/cpp/core/include/core/libclang/LibClang.hpp
+++ b/src/cpp/core/include/core/libclang/LibClang.hpp
@@ -116,7 +116,6 @@ public:
 
    // loading
    bool load(EmbeddedLibrary embedded,
-             LibraryVersion requiredVersion,
              std::string* pDiagnostics = nullptr);
 
    core::Error unload();
@@ -636,8 +635,7 @@ public:
    CXString (*CompileCommand_getArg)(CXCompileCommand, unsigned I);
 
 private:
-   core::Error tryLoad(const std::string& libraryPath,
-                       LibraryVersion requiredVersion);
+   core::Error tryLoad(const std::string& libraryPath);
 
 private:
    void* pLib_;

--- a/src/cpp/core/libclang/LibClang.cpp
+++ b/src/cpp/core/libclang/LibClang.cpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <vector>
 
+#include <fmt/format.h>
+
 #include <boost/regex.hpp>
 
 #include <shared_core/FilePath.hpp>
@@ -27,6 +29,8 @@
 #include <core/RegexUtils.hpp>
 #include <core/system/Environment.hpp>
 #include <core/system/LibraryLoader.hpp>
+
+#define kMinimumSupportedLibclangVersion "5.0.2"
 
 #define LOAD_CLANG_SYMBOL(name)                                                \
    do                                                                          \
@@ -130,8 +134,7 @@ LibClang::~LibClang()
 }
 
 bool LibClang::load(EmbeddedLibrary embedded,
-                         LibraryVersion requiredVersion,
-                         std::string* pDiagnostics)
+                    std::string* pDiagnostics)
 {
    // diagnostics stream
    std::ostringstream ostr;
@@ -161,52 +164,49 @@ bool LibClang::load(EmbeddedLibrary embedded,
    {
       FilePath versionPath(version);
       ostr << versionPath << std::endl;
-      if (versionPath.exists())
-      {
-         Error error = tryLoad(versionPath.getAbsolutePath(), requiredVersion);
-         if (!error)
-         {
-            // if this was the embedded version then record it
-            if (version == embeddedVersion)
-               embedded_ = embedded;
-
-            if (embedded_.empty())
-            {
-               // save the library path
-               s_libraryPath = versionPath;
-
-               // save default compilation arguments
-               s_baseCompileArgs = defaultCompileArgs(this->version());
-            }
-
-            // print diagnostics
-            ostr << "   LOADED: " << this->version().asString()
-                 << std::endl;
-            if (pDiagnostics)
-               *pDiagnostics = ostr.str();
-
-            // return true
-            return true;
-         }
-         else
-         {
-            ostr << "   (" << error.getProperty("dlerror") <<  ")" << std::endl;
-         }
-      }
-      else
+      if (!versionPath.exists())
       {
          ostr << "   (Not Found)" << std::endl;
+         continue;
       }
+      
+      Error error = tryLoad(versionPath.getAbsolutePath());
+      if (error)
+      {
+         ostr << "   (" << error.getProperty("dlerror") <<  ")" << std::endl;
+         continue;
+      }
+         
+      // if this was the embedded version then record it
+      if (version == embeddedVersion)
+         embedded_ = embedded;
+
+      if (embedded_.empty())
+      {
+         // save the library path
+         s_libraryPath = versionPath;
+
+         // save default compilation arguments
+         s_baseCompileArgs = defaultCompileArgs(this->version());
+      }
+
+      // print diagnostics
+      ostr << "   LOADED: " << this->version().asString() << std::endl;
+      if (pDiagnostics)
+         *pDiagnostics = ostr.str();
+
+      // return true
+      return true;
    }
 
    // if we didn't find one by now then we failed
    if (pDiagnostics)
       *pDiagnostics = ostr.str();
+   
    return false;
 }
 
-Error LibClang::tryLoad(const std::string& libraryPath,
-                             LibraryVersion requiredVersion)
+Error LibClang::tryLoad(const std::string& libraryPath)
 {
    // load the library
    Error error = core::system::loadLibrary(libraryPath, &pLib_);
@@ -220,20 +220,24 @@ Error LibClang::tryLoad(const std::string& libraryPath,
 
    // verify that we have the required version
    LibraryVersion libVersion = version();
+   LibraryVersion requiredVersion(Version(kMinimumSupportedLibclangVersion));
+   
    if (libVersion < requiredVersion)
    {
       Error unloadError = unload();
       if (unloadError)
          LOG_ERROR(error);
 
-      Error error = systemError(boost::system::errc::protocol_not_supported,
-                                ERROR_LOCATION);
-      boost::format fmt("Required version %1% not found (library is "
-                        "version %2%)");
-      std::string err = boost::str(fmt %
-                                    requiredVersion.asString() %
-                                    libVersion.asString());
-      error.addProperty("dlerror", err);
+      std::string msg = fmt::format(
+               "Required version {} not found (library is version {})",
+               requiredVersion.asString(),
+               libVersion.asString());
+      
+      Error error = systemError(
+               boost::system::errc::protocol_not_supported,
+               ERROR_LOCATION);
+      
+      error.addProperty("dlerror", msg);
       return error;
    }
 

--- a/src/cpp/session/modules/clang/SessionClang.cpp
+++ b/src/cpp/session/modules/clang/SessionClang.cpp
@@ -63,11 +63,6 @@ std::string embeddedLibClangPath()
    return options().libclangPath().completeChildPath(libclang).getAbsolutePath();
 }
 
-LibraryVersion embeddedLibClangVersion()
-{
-   return LibraryVersion(Version(kEmbeddedLibClangVersion));
-}
-
 std::vector<std::string> embeddedLibClangCompileArgs(const LibraryVersion& version,
                                                      bool isCppFile)
 {
@@ -174,9 +169,7 @@ SEXP rs_isLibClangAvailable()
    else
    {
       LibClang lib;
-      isAvailable = lib.load(embeddedLibClang(),
-                             embeddedLibClangVersion(),
-                             &diagnostics);
+      isAvailable = lib.load(embeddedLibClang(), &diagnostics);
    }
 
    // print diagnostics
@@ -225,7 +218,7 @@ Error initialize()
       return Success();
 
    // attempt to load libclang
-   if (!libclang::clang().load(embeddedLibClang(), embeddedLibClangVersion()))
+   if (!libclang::clang().load(embeddedLibClang()))
       return Success();
 
    // enable crash recovery

--- a/src/cpp/session/modules/clang/SessionClang.hpp
+++ b/src/cpp/session/modules/clang/SessionClang.hpp
@@ -16,8 +16,6 @@
 #ifndef SESSION_MODULES_CLANG_HPP
 #define SESSION_MODULES_CLANG_HPP
 
-#define kEmbeddedLibClangVersion "13.0.1"
-
 #include <shared_core/Error.hpp>
 
 namespace rstudio {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11452.

### Approach

Disentangles the relationship between the embedded version of libclang (relevant only on Windows), and the minimum-supported version of libclang (relevant everywhere).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11452. You might also be able to reproduce this issue on older versions of Ubuntu (where the versions of LLVM / libclang provided by the package manager would be older).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
