### PR TITLE
Remove the unused libapparmor1 dependency for Debian-based distros

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -87,7 +87,7 @@ if(RSTUDIO_SERVER)
   # automatic dependency resolution use e.g.
   #   sudo apt-get install gdebi-core
   #   sudo gdebi rstudio-server-0.97.151-amd64.deb
-  set(RSTUDIO_DEBIAN_DEPENDS "psmisc, libapparmor1, libedit2, sudo, lsb-release, ${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libsqlite3-0, libpq5, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "psmisc, libedit2, sudo, lsb-release, ${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libsqlite3-0, libpq5, ")
 
 elseif(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON)
 


### PR DESCRIPTION
### Intent

AppArmor functionality was removed in e939585a19e9d98722328a0bac82619b0750aa3b as part of the work to create Launcher (in 2018), but it looks like the Debian package dependency on `libapparmor` was never removed. I noticed this while trying to reconstruct what dependencies the session components have from the main Debian package's metadata.

### Automated Tests

I do not know what existing tests cover packaging-related changes. But since this is a system library dependency, probably "the binary starts on a Debian-based distro" should be sufficient.

### QA Notes

Unknown, please advise.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests