### PR TITLE
Fix problems with list() method and single-session mode resume

### DIFF
--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -707,7 +707,7 @@ public:
                       const std::string& editor,
                       std::string* pId) const;
 
-   std::vector<boost::shared_ptr<ActiveSession> > list(FilePath userHomePath, bool projectSharingEnabled) const;
+   std::vector<boost::shared_ptr<ActiveSession> > list(FilePath userHomePath, bool projectSharingEnabled, bool validate) const;
 
    size_t count(const FilePath& userHomePath,
                 bool projectSharingEnabled) const;

--- a/src/cpp/server/session/ServerSessionMetadataRpc.cpp
+++ b/src/cpp/server/session/ServerSessionMetadataRpc.cpp
@@ -114,8 +114,9 @@ Error handleReadAll(
       std::unique_ptr<ActiveSessions> activeSessions = getActiveSessions(user.get());
       std::vector<boost::shared_ptr<ActiveSession> > sessions = 
          activeSessions->list(
-            userDataDir(user.get()),
-            options().getOverlayOption("server-project-sharing") == "1");
+            user->getHomePath(),
+            options().getOverlayOption("server-project-sharing") == "1",
+            false); // don't validate sessions as there's no access to the project dir from the server
 
       std::string field;
       if (fields.size() == 1)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1892,8 +1892,8 @@ r_util::ActiveSession& activeSession()
                activeSessions().list(userHomePath(), options().projectSharingEnabled(), true);
          if (sessions.size() > 0)
          {
-            // there is only one session, so this must be singleton session mode
-            // reopen that session
+            // there is more than one session but no session id was passed in. This is OS server or pro with server-multiple-sessions=0
+            // so we must be referring to the most recent session.
             pSession = sessions.front();
 
             if (sessions.size() == 1)

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -1868,6 +1868,7 @@ r_util::ActiveSession& activeSession()
    if (!pSession)
    {
       std::string id = options().sessionScope().id();
+
       if (!id.empty())
          pSession = activeSessions().get(id);
       else if (options().programMode() == kSessionProgramModeDesktop)
@@ -1888,15 +1889,21 @@ r_util::ActiveSession& activeSession()
          // if no scope was specified, we are in singleton session mode
          // check to see if there is an existing active session, and use that
          std::vector<boost::shared_ptr<r_util::ActiveSession> > sessions =
-               activeSessions().list(userHomePath(), options().projectSharingEnabled());
-         if (sessions.size() == 1)
+               activeSessions().list(userHomePath(), options().projectSharingEnabled(), true);
+         if (sessions.size() > 0)
          {
             // there is only one session, so this must be singleton session mode
             // reopen that session
             pSession = sessions.front();
+
+            if (sessions.size() == 1)
+               LOG_DEBUG_MESSAGE("Reusing singleton session: " + pSession->id());
+            else
+               LOG_DEBUG_MESSAGE("Reusing most recent session: " + pSession->id() + " out of: " + std::to_string(sessions.size()));
          }
          else
          {
+
             // create a new session entry
             // this should not really run because in single session mode there will
             // only be one session but we'll create one here just in case for safety
@@ -1907,6 +1914,8 @@ r_util::ActiveSession& activeSession()
             // the actual user preference or session default directory that it should be
             activeSessions().create(options().sessionScope().project(), "~", &sessionId);
             pSession = activeSessions().get(sessionId);
+
+            LOG_DEBUG_MESSAGE("Creating new session in singleton session mode: " + sessionId);
          }
       }
    }


### PR DESCRIPTION
** Note - requires a companion commit in pro to add the new validate
parameter to list() in a few places. Let me do the merge so I can coordinate.

### Intent

Addresses: https://github.com/rstudio/rstudio/issues/11446

### Approach

Add a new 'validate' param to list that is passed as 'false' in `rserver` so it doesn't try to remove the session if it can't validate it. Also should be passing homePath, not userDataDir to list in that case so fixed the code but it won't matter since we don't use that parameter when validate=false.  These are the safe parts of the fix.

I also changed the code so that when initializing an rsession without a specific session id (i.e. non-multiple sessions case in the pro or OS), if there is more than one active session, use the most recent one
rather than creating a new one each time. If an extra session gets left over,
that will never resolve itself until all sessions are cleared. Users who switch back and forth between OS and pro will sometimes see this situation, or maybe a session fails to get removed?  I can't see a downside to that change but let me know if I missed an important use case!

### QA Notes

This affects OS and server-multiple-sessions=0 in workbench when you are suspending and resuming. For OS, I'm not sure how you do that without "ant devmode". 


