### PR TITLE
Remove the redundant libedit2 dependency for Debian packages

### DIFF
--- a/package/linux/CMakeLists.txt
+++ b/package/linux/CMakeLists.txt
@@ -87,7 +87,7 @@ if(RSTUDIO_SERVER)
   # automatic dependency resolution use e.g.
   #   sudo apt-get install gdebi-core
   #   sudo gdebi rstudio-server-0.97.151-amd64.deb
-  set(RSTUDIO_DEBIAN_DEPENDS "psmisc, libedit2, sudo, lsb-release, ${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libsqlite3-0, libpq5, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "psmisc, sudo, lsb-release, ${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libsqlite3-0, libpq5, ")
 
 elseif(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON)
 
@@ -119,7 +119,7 @@ elseif(RSTUDIO_DESKTOP OR RSTUDIO_ELECTRON)
   endif()
 
   # deb dependencies
-  set(RSTUDIO_DEBIAN_DEPENDS "libedit2, ${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libxkbcommon-x11-0, libsqlite3-0, libpq5, ")
+  set(RSTUDIO_DEBIAN_DEPENDS "${RSTUDIO_DEBIAN_DEPENDS_SSL}, libclang-dev, libxkbcommon-x11-0, libsqlite3-0, libpq5, ")
 
 endif()
 


### PR DESCRIPTION
### Intent

An explicit dependency on `libedit2` was originally added in 2e7e7ab03c797f39d64097090ca3cc4fe8e710f8 to support the bundled libclang (since libedit is a dependency of LLVM). However, since 543edee3924e843fdad936e2d19e7c2efe088d38 we depend on the system `libclang-dev` on Debian-based distros, which appears to have been part of the move away from using the bundled libclang on Linux (#2892).

Since `libedit2` is a dependency of `libclang-dev` on all supported Debian-based distros, we can safely remove this explicit dependency.

To verify that `libedit2` is a transitive dependency of `libclang-dev`, you can check the following:

    $ apt-cache depends --installed --recurse -i libclang-dev | \
        grep 'Depends: libedit2'

(I also checked this against Debian's online package search for older versions manually.)

### Automated Tests

As with #11468, this is a system library dependency, so probably "the binary starts on a Debian-based distro" should be sufficient.

### QA Notes

Unknown, please advise.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests