### PR TITLE
Show Project Name on Dock Icon - Electron

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, Menu, screen, WebContents } from 'electron';
+import { app, BrowserWindow, screen, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -213,8 +213,6 @@ export class Application implements AppState {
       this.argsManager.handleAfterSessionLaunchCommands();
     });
 
-    this.setDockMenu();
-
     return run();
   }
 
@@ -295,19 +293,6 @@ export class Application implements AppState {
         owner,
         baseUrl,
       );
-    }
-  }
-
-  setDockMenu(){
-    if (process.platform === 'darwin'){
-      const  menuDock = Menu.buildFromTemplate([{
-        label: 'New RStudio Window',
-        click: () => {
-          this.appLaunch?.launchRStudio({});
-        }
-      }]);
-
-      app.dock.setMenu(menuDock);
     }
   }
 }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, screen, WebContents } from 'electron';
+import { app, BrowserWindow, Menu, screen, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -213,6 +213,8 @@ export class Application implements AppState {
       this.argsManager.handleAfterSessionLaunchCommands();
     });
 
+    this.setDockMenu();
+
     return run();
   }
 
@@ -294,5 +296,16 @@ export class Application implements AppState {
         baseUrl,
       );
     }
+  }
+
+  setDockMenu(){
+    const  menuDock = Menu.buildFromTemplate([{
+      label: 'New RStudio Window',
+      click: () => {
+        this.appLaunch?.launchRStudio({});
+      }
+    }]);
+
+    app.dock.setMenu(menuDock);
   }
 }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -299,13 +299,15 @@ export class Application implements AppState {
   }
 
   setDockMenu(){
-    const  menuDock = Menu.buildFromTemplate([{
-      label: 'New RStudio Window',
-      click: () => {
-        this.appLaunch?.launchRStudio({});
-      }
-    }]);
+    if (process.platform === 'darwin'){
+      const  menuDock = Menu.buildFromTemplate([{
+        label: 'New RStudio Window',
+        click: () => {
+          this.appLaunch?.launchRStudio({});
+        }
+      }]);
 
-    app.dock.setMenu(menuDock);
+      app.dock.setMenu(menuDock);
+    }
   }
 }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { BrowserWindow, dialog, Menu, session } from 'electron';
+import { app, BrowserWindow, dialog, Menu, session } from 'electron';
 import { ChildProcess } from 'child_process';
 
 import { logger } from '../core/logger';
@@ -217,8 +217,12 @@ export class MainWindow extends GwtWindow {
 
     this.executeJavaScript('window.desktopHooks.getActiveProjectDir()')
       .then((projectDir) => {
+        if (process.platform == 'darwin') app.dock.setBadge('');
+
         if (projectDir.length > 0) {
           this.window.setTitle(`${projectDir} - ${appState().activation().editionName()}`);
+       
+          if (process.platform == 'darwin') app.dock.setBadge(projectDir);
         } else {
           this.window.setTitle(appState().activation().editionName());
         }


### PR DESCRIPTION
### Intent

Show the current project name on the dock icon.

### Approach

Achieved by setting the badge. 

Notes: 
- The background for it is red instead of light blue as in QT. Tried to make it blue but would take too long as it would mess with electron code as it does not currently support fine customizations on it's Dock Badge api

Examples: ( In red, Electron version. In blue, the QT version )

![Screen Shot 2022-06-26 at 23 20 08](https://user-images.githubusercontent.com/36674530/175848520-659311e8-e669-4006-9b7c-a71928bca180.png)
![Screen Shot 2022-06-26 at 23 19 30](https://user-images.githubusercontent.com/36674530/175848526-fa036dbe-f70a-4b9d-a427-4609edd8bf6f.png)



### Automated Tests

None

### QA Notes

Refer to #11386

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11386

