### PR TITLE
Fix showing nested R chunks in document outline

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,3 +11,7 @@
 ### Deprecated / Removed
 
 - Removed the Tools / Shell command (#11253)
+
+### Fixed
+
+- Fixed visual mode outline missing nested R code chunks (#11410)

--- a/src/gwt/panmirror/src/editor/src/api/node.ts
+++ b/src/gwt/panmirror/src/editor/src/api/node.ts
@@ -79,7 +79,7 @@ export type NodeTraversalFn = (
 export function findTopLevelBodyNodes(doc: ProsemirrorNode, predicate: (node: ProsemirrorNode) => boolean) {
   const body = findChildrenByType(doc, doc.type.schema.nodes.body, false)[0];
   const offset = body.pos + 1;
-  const nodes = findChildren(body.node, predicate, false);
+  const nodes = findChildren(body.node, predicate, true);
   return nodes.map(value => ({ ...value, pos: value.pos + offset }));
 }
 


### PR DESCRIPTION
### Intent
Address #11410

### Approach
Sets the option to descend into child nodes to find R chunks.

### Automated Tests
None

### QA Notes
This only occurs in visual mode. The code chunk can be named or unnamed.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


