### PR TITLE
only set DYLD_INSERT_LIBRARIES if running rsession directly

### DIFF
--- a/src/cpp/desktop/DesktopSessionLauncher.cpp
+++ b/src/cpp/desktop/DesktopSessionLauncher.cpp
@@ -97,19 +97,27 @@ void launchProcess(const std::string& absPath,
 #ifdef Q_OS_DARWIN
    
    QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
-   
+
    // on macOS with the hardened runtime, we can no longer rely on dyld
    // to lazy-load symbols from libR.dylib; to resolve this, we use
-   // DYLD_INSERT_LIBRARIES to inject the library we wish to use on
-   // launch 
-   FilePath rHome = FilePath(core::system::getenv("R_HOME"));
-   FilePath rLib = rHome.completeChildPath("lib/libR.dylib");
-   if (rLib.exists())
+   // DYLD_INSERT_LIBRARIES to inject the library we wish to use.
+   //
+   // only do this if we're running rsession directly; if we're running through
+   // arch then it's arch's responsibility to forward DYLD_INSERT_LIBRARIES
+   //
+   // otherwise we risk inserting the library directly into /usr/bin/arch,
+   // and that could fail!
+   if (absPath != "/usr/bin/arch")
    {
-      environment.insert(
-               QStringLiteral("DYLD_INSERT_LIBRARIES"),
-               QString::fromStdString(rLib.getAbsolutePathNative()));
-      
+      FilePath rHome = FilePath(core::system::getenv("R_HOME"));
+      FilePath rLib = rHome.completeChildPath("lib/libR.dylib");
+      if (rLib.exists())
+      {
+         environment.insert(
+            QStringLiteral("DYLD_INSERT_LIBRARIES"),
+            QString::fromStdString(rLib.getAbsolutePathNative()));
+
+      }
    }
    
    // create fallback library path (use TMPDIR so it's user-specific)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9543.

### Approach

Don't set `DYLD_INSERT_LIBRARIES` if we're running `rsession` through `/usr/bin/arch`, as doing so tries to force macOS to load the R library into _the /usr/bin/arch process_, rather than the `rsession` process! I still don't quite understand why this only fails sometimes, but I'm pretty confident this is the underlying issue (as I was finally able to reproduce locally).

### Automated Tests

N/A

### QA Notes

Test that RStudio can run with both x86_64 and arm64 R installations on M1 macOS machines.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
