### PR TITLE
Fixes with multi line statement in `Cmd` + `Enter`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -4022,7 +4022,7 @@ public class AceEditor implements DocDisplay,
       // discover end of current statement -- we search from the inferred statement
       // start, so that we can perform counting of matching pairs of brackets
       endRow = startRow;
-
+      
       // NOTE: '[[' is not tokenized as a single token in our Ace tokenizer,
       // so it is not included here (this shouldn't cause issues in practice
       // since balanced pairs of '[' and '[[' would still imply a correct count
@@ -4033,15 +4033,6 @@ public class AceEditor implements DocDisplay,
 
       while (endRow <= endRowLimit)
       {
-         // continue search if we're in a multi-line string
-         // (forego updating our bracket counts)
-         String state = getSession().getState(endRow);
-         if (state == "qstring" || state == "qqstring" || state == "rawstring")
-         {
-            endRow++;
-            continue;
-         }
-
          // update bracket token counts
          JsArray<Token> tokens = getTokens(endRow);
          for (Token token : JsUtil.asIterable(tokens))
@@ -4067,6 +4058,14 @@ public class AceEditor implements DocDisplay,
 
          // continue search if we have unbalanced brackets
          if (parenCount > 0 || braceCount > 0 || bracketCount > 0)
+         {
+            endRow++;
+            continue;
+         }
+
+         // continue search if end of row is in a multiline string
+         String state = getSession().getState(endRow);
+         if (state == "qstring" || state == "qqstring" || state == "rawstring")
          {
             endRow++;
             continue;
@@ -4110,11 +4109,11 @@ public class AceEditor implements DocDisplay,
          if (fn != null)
             return Range.fromPoints(fn.getPreamble(), fn.getEnd());
       }
-
+ 
       // construct range
       int endColumn = getSession().getLine(endRow).length();
       Range range = Range.create(startRow, 0, endRow, endColumn);
-
+      
       // return empty range if nothing to execute
       if (getTextForRange(range).trim().isEmpty())
          range = Range.fromPoints(pos, pos);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -3904,7 +3904,7 @@ public class AceEditor implements DocDisplay,
 
       }
       while (false);
-
+      
       // check for lines of the form:
       //
       //     ) foo +
@@ -4009,7 +4009,7 @@ public class AceEditor implements DocDisplay,
 
          // keep going if we're in a multiline string
          String state = getSession().getState(prevRow);
-         if (state == "qstring" || state == "qqstring")
+         if (state == "qstring" || state == "qqstring" || state == "rawstring")
          {
             startRow--;
             continue;
@@ -4036,7 +4036,7 @@ public class AceEditor implements DocDisplay,
          // continue search if we're in a multi-line string
          // (forego updating our bracket counts)
          String state = getSession().getState(endRow);
-         if (state == "qstring" || state == "qqstring")
+         if (state == "qstring" || state == "qqstring" || state == "rawstring")
          {
             endRow++;
             continue;
@@ -4075,7 +4075,7 @@ public class AceEditor implements DocDisplay,
          // we had balanced brackets and no trailing binary operator; bail
          break;
       }
-
+      
       // if we're unbalanced at this point, that means we tried to
       // expand in an unclosed expression -- just execute the current
       // line rather than potentially executing unintended code


### PR DESCRIPTION
### Intent

adresses #11123, #10077, #11124

### Approach

 - add `rawstring` in `if (state == "qstring" || state == "qqstring" || state == "rawstring")`
 - better handle the situation where end of row is a multiline string, but there is something else before

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


