### PR TITLE
Change SchemaVersion Comparison Logic

### DIFF
--- a/NEWS-2021.09.4-ghost-orchid.md
+++ b/NEWS-2021.09.4-ghost-orchid.md
@@ -1,0 +1,9 @@
+## RStudio 2021.09.4 "Ghost Orchid" Release Notes
+
+### RStudio Workbench
+
+### Features
+
+### Bugfixes
+
+* Fix for schema version comparison that breaks db in downgrade -> upgrade scenarios (rstudio-pro#3572)

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -769,8 +769,8 @@ bool SchemaVersion::operator<(const SchemaVersion& other) const
       return false;
 
    const auto& versions = versionMap();
-   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : -1;
-   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : -1;
+   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : INT_MAX;
+   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : INT_MAX;
 
    if (thisFlowerIndex < otherFlowerIndex)
       return true;

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -769,8 +769,8 @@ bool SchemaVersion::operator<(const SchemaVersion& other) const
       return false;
 
    const auto& versions = versionMap();
-   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : INT_MAX;
-   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : INT_MAX;
+   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : versions.size();
+   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : versions.size();
 
    if (thisFlowerIndex < otherFlowerIndex)
       return true;

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -437,6 +437,38 @@ TEST_CASE("Database", "[.database]")
       CHECK(postgresConnection->execute(postgresInsertQuery2));
    }
 
+   test_that("Schema Version comparisons are correct")
+   {
+      std::vector<SchemaVersion> versions {
+         {},
+         {"", "20200226141952248123456_AddRevokedCookie"},
+         {"Ghost Orchid", "20210712182145921760944"},
+         {"Prairie Trillium", "20210916132211194382021"},
+         {"Aphid", "21210916132211194382021"}
+      };
+
+      for(int i=0; i < (int) versions.size(); i++)
+      {
+         //Compare against smaller
+         for(int j=0; j < i; j++){
+            REQUIRE(versions[j] < versions[i]);
+            REQUIRE_FALSE(versions[j] > versions[i]);
+            REQUIRE(versions[j] <= versions[i]);
+         }
+
+         SchemaVersion sameVersion(versions[i]);
+         REQUIRE(sameVersion == versions[i]);
+
+         //Compare against larger
+         for(int j=i+1; j < (int) versions.size(); j++)
+         {
+            REQUIRE(versions[i] < versions[j]);
+            REQUIRE_FALSE(versions[i] > versions[j]);
+            REQUIRE(versions[i] <= versions[j]);
+         }
+      }
+   }
+
    test_that("Can execute str with multiple queries")
    {
       boost::shared_ptr<IConnection> connection;


### PR DESCRIPTION
Now assumes that any unknown flower version is a later rather than prior
version

Add test coverage to ensure the comparisons are correct.

Addresses rstudio/rstudio-pro#3572


### Intent

When a user downgrades the previous version was squashing the db schema, preventing later upgrades from being successful due to a mismatch between the actual schema and the reported schema of the database.

### Approach

Previously unknown flower versions were assumed to be prior versions, unknown flowers are now presumed to be later versions

### Automated Tests

Automated test coverage added to assert the comparisons between the versions, and empty version, unknown version.

### QA Notes

This specifically addresses a scenario in which an installation is downgraded, and then upgraded again.

Previously downgrading would cause the SchemaVersion of the DB to be updated. After upgrading again a duplicate column error when starting the server would prevent the server from starting.

Now doing a PT -> GO -> PT downgrade/upgrade path should result in a working system each step of the way.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


