### PR TITLE
use UTF-8 byte offsets for code execution

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,3 +15,5 @@
 ### Fixed
 
 - Fixed visual mode outline missing nested R code chunks (#11410)
+- Fixed an issue where chunks containing multibyte characters was not executed correctly (#10632)
+

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -441,9 +441,8 @@ private:
             if (label != "setup")
                workingDir = docQueue->workingDir();
 
-            std::string codeString = string_utils::wideToUtf8(unit->code());
             execContext_ = boost::make_shared<ChunkExecContext>(
-               unit->docId(), unit->chunkId(), codeString, label, ctx, engine,
+               unit->docId(), unit->chunkId(), unit->code(), label, ctx, engine,
                unit->execScope(), workingDir, options,
                docQueue->pixelWidth(), docQueue->charWidth());
             execContext_->connect();

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
@@ -76,7 +76,7 @@ public:
    std::string chunkId() const;
    ExecMode execMode() const;
    ExecScope execScope() const;
-   std::wstring code() const;
+   std::string code() const;
    std::string executingCode() const;
 
 private:
@@ -84,7 +84,7 @@ private:
    std::string chunkId_;
    ExecMode execMode_;
    ExecScope execScope_;
-   std::wstring code_;
+   std::string code_;
    std::list<ExecRange> completed_;
    std::list<ExecRange> pending_;
    ExecRange executing_;

--- a/src/gwt/src/org/rstudio/core/client/JsVector.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVector.java
@@ -75,10 +75,12 @@ public class JsVector<T> extends JavaScriptObject
 
    public final native int indexOf(T value)
    /*-{
-      for (var i = 0, n = this.length; i < n; i++)
-         if (this[i] === value)
-           return i;
-      return -1;
+      return this.indexOf(value);
+   }-*/;
+   
+   public final native int indexOf(T value, int offset)
+   /*-{
+      return this.indexOf(value, offset);
    }-*/;
 
    public final native boolean isEmpty()

--- a/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorBoolean.java
@@ -75,10 +75,12 @@ public class JsVectorBoolean extends JavaScriptObject
 
    public final native int indexOf(boolean value)
    /*-{
-      for (var i = 0, n = this.length; i < n; i++)
-         if (this[i] === value)
-           return i;
-      return -1;
+      return this.indexOf(value);
+   }-*/;
+   
+   public final native int indexOf(boolean value, int offset)
+   /*-{
+      return this.indexOf(value, offset);
    }-*/;
 
    public final native boolean isEmpty()

--- a/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorInteger.java
@@ -75,10 +75,12 @@ public class JsVectorInteger extends JavaScriptObject
 
    public final native int indexOf(int value)
    /*-{
-      for (var i = 0, n = this.length; i < n; i++)
-         if (this[i] === value)
-           return i;
-      return -1;
+      return this.indexOf(value);
+   }-*/;
+   
+   public final native int indexOf(int value, int offset)
+   /*-{
+      return this.indexOf(value, offset);
    }-*/;
 
    public final native boolean isEmpty()

--- a/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorNumber.java
@@ -75,10 +75,12 @@ public class JsVectorNumber extends JavaScriptObject
 
    public final native int indexOf(double value)
    /*-{
-      for (var i = 0, n = this.length; i < n; i++)
-         if (this[i] === value)
-           return i;
-      return -1;
+      return this.indexOf(value);
+   }-*/;
+   
+   public final native int indexOf(double value, int offset)
+   /*-{
+      return this.indexOf(value, offset);
    }-*/;
 
    public final native boolean isEmpty()

--- a/src/gwt/src/org/rstudio/core/client/JsVectorString.java
+++ b/src/gwt/src/org/rstudio/core/client/JsVectorString.java
@@ -75,10 +75,12 @@ public class JsVectorString extends JavaScriptObject
 
    public final native int indexOf(String value)
    /*-{
-      for (var i = 0, n = this.length; i < n; i++)
-         if (this[i] === value)
-           return i;
-      return -1;
+      return this.indexOf(value);
+   }-*/;
+   
+   public final native int indexOf(String value, int offset)
+   /*-{
+      return this.indexOf(value, offset);
    }-*/;
 
    public final native boolean isEmpty()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10632.

### Approach

Use UTF-8 strings on the server side, and compute execution ranges are UTF-8 byte offsets on the client side. Use the `TextEncoder` helper class to convert text in the editor document to a UTF-8 byte array, and compute offsets from that array size.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10632.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

