### PR TITLE
New RStudio Window Button on Dock for OSX Electron

### DIFF
--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -84,7 +84,8 @@
     "confColon": "conf:",
     "notFoundDotLowercase": "not found.",
     "errorFindingR": "Error Finding R",
-    "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio failed to find any R installations on the system."
+    "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio failed to find any R installations on the system.",
+    "newRstudioWindow": "New RStudio Window"
   },
   "detectRTs": {
     "rNotFound": "R not found",

--- a/src/node/desktop/src/assets/locales/fr.json
+++ b/src/node/desktop/src/assets/locales/fr.json
@@ -84,7 +84,8 @@
     "confColon": "conf :",
     "notFoundDotLowercase": "non trouvé.",
     "errorFindingR": "Erreur de recherche de R",
-    "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio n'a pas réussi à trouver d'installations R sur le système."
+    "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio n'a pas réussi à trouver d'installations R sur le système.",
+    "newRstudioWindow": "Nouvelle fenêtre RStudio"
   },
   "detectRTs": {
     "rNotFound": "R non trouvé",

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, screen, WebContents } from 'electron';
+import { app, BrowserWindow, Menu, screen, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -213,6 +213,8 @@ export class Application implements AppState {
       this.argsManager.handleAfterSessionLaunchCommands();
     });
 
+    this.setDockMenu();
+
     return run();
   }
 
@@ -293,6 +295,19 @@ export class Application implements AppState {
         owner,
         baseUrl,
       );
+    }
+  }
+
+  setDockMenu(){
+    if (process.platform === 'darwin'){
+      const  menuDock = Menu.buildFromTemplate([{
+        label: i18next.t('applicationTs.newRstudioWindow'),
+        click: () => {
+          this.appLaunch?.launchRStudio({});
+        }
+      }]);
+
+      app.dock.setMenu(menuDock);
     }
   }
 }


### PR DESCRIPTION
### Intent

Added the `New RStudio Window` button for when clicking with the right button over the Dock Icon as it used to happen in QT version.

### Approach

Created and added that menu.

### Automated Tests

None

### QA Notes

Refer to #11387

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

Addresses #11387


