### PR TITLE
Fix handling of Live-update objects in object explorer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -932,7 +932,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
 
    public void activateObjectExplorer(ObjectExplorerHandle handle)
    {
-      columnList_.forEach((column) -> {
+      for (SourceColumn column : columnList_)
+      {
          for (EditingTarget target : column.getEditors())
          {
             // bail if this isn't an object explorer filetype
@@ -949,8 +950,8 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                return;
             }
          }
-      });
-
+      }
+      
       ensureVisible(true);
       server_.newDocument(
          FileTypeRegistry.OBJECT_EXPLORER.getTypeId(),


### PR DESCRIPTION
### Intent

addresses #1994

### Approach

use a regular loop so that `return;` gets out of the function, with the `forEach()` loop, it used to only get out of the lambda, and so the object was modified, but then was open again. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


