### PR TITLE
Reflow not adding superfluous new lines  after wrapping

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/WordWrap.java
+++ b/src/gwt/src/org/rstudio/core/client/WordWrap.java
@@ -141,11 +141,14 @@ public class WordWrap
          line = trimmed;
       }
 
-      // Now just append the rest of the line
-      int lastInsertionRow = row_;
-      int lastInsertionPoint = lineLength_;
-      appendRawWithIndent(line);
-      onChunkWritten(line, lastInsertionRow, lastInsertionPoint, origStringPos);
+      // Now just append the rest of the line if needed
+      if (line.length() > 0)
+      {
+         int lastInsertionRow = row_;
+         int lastInsertionPoint = lineLength_;
+         appendRawWithIndent(line);
+         onChunkWritten(line, lastInsertionRow, lastInsertionPoint, origStringPos);
+      }
    }
 
    protected void onChunkWritten(String chunk,
@@ -180,12 +183,9 @@ public class WordWrap
    private void appendRawWithIndent(String value)
    {
       assert value.indexOf('\n') < 0;
-      if (value.length() > 0)
-      {
-         if (lineLength_ == 0 && indent_ != null)
-            appendRaw(indent_);
-         appendRaw(value);
-      }
+      if (lineLength_ == 0 && indent_ != null)
+         appendRaw(indent_);
+      appendRaw(value);
    }
 
    private void appendRaw(String value)

--- a/src/gwt/src/org/rstudio/core/client/WordWrap.java
+++ b/src/gwt/src/org/rstudio/core/client/WordWrap.java
@@ -180,9 +180,12 @@ public class WordWrap
    private void appendRawWithIndent(String value)
    {
       assert value.indexOf('\n') < 0;
-      if (lineLength_ == 0 && indent_ != null)
-         appendRaw(indent_);
-      appendRaw(value);
+      if (value.length() > 0)
+      {
+         if (lineLength_ == 0 && indent_ != null)
+            appendRaw(indent_);
+         appendRaw(value);
+      }
    }
 
    private void appendRaw(String value)


### PR DESCRIPTION
### Intent

addresses #5886

### Approach

after wrapping a long line with `processLine()`, finish with `appendRawWithIndent()` only if there is more content to append. Otherwise this leaves a superfluous empty line with the indent string. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


