### PR TITLE
only ignore quarto output dir if it's set

### DIFF
--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -22,14 +22,16 @@
 #include <boost/format.hpp>
 #include <boost/numeric/conversion/cast.hpp>
 
-#include <core/BoostSignals.hpp>
-#include <core/BoostThread.hpp>
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
+#include <shared_core/Hash.hpp>
+
+#include <core/BoostSignals.hpp>
+#include <core/BoostThread.hpp>
+#include <core/Debug.hpp>
 #include <core/FileInfo.hpp>
 #include <core/Log.hpp>
 #include <core/Base64.hpp>
-#include <shared_core/Hash.hpp>
 #include <core/Settings.hpp>
 #include <core/DateTime.hpp>
 #include <core/FileSerializer.hpp>
@@ -2912,16 +2914,25 @@ void checkXcodeLicense()
 std::vector<FilePath> ignoreContentDirs()
 {
    std::vector<FilePath> ignoreDirs;
-   if (projects::projectContext().hasProject()) {
+   
+   if (projects::projectContext().hasProject())
+   {
       // python virtual environments
       ignoreDirs = projects::projectContext().pythonEnvs();
       quarto::QuartoConfig quartoConf = quarto::quartoConfig();
+      
       // quarto site output dir
-      if (quartoConf.is_project) {
+      if (quartoConf.is_project)
+      {
          FilePath quartoProjDir = module_context::resolveAliasedPath(quartoConf.project_dir);
-         ignoreDirs.push_back(quartoProjDir.completeChildPath(quartoConf.project_output_dir));
+         
+         std::string quartoOutputDir = quartoConf.project_output_dir;
+         if (!quartoOutputDir.empty())
+            ignoreDirs.push_back(quartoProjDir.completeChildPath(quartoOutputDir));
+         
          ignoreDirs.push_back(quartoProjDir.completeChildPath("_freeze"));
       }
+      
       // rmarkdown site output dir
       if (module_context::isWebsiteProject())
       {
@@ -2930,8 +2941,8 @@ std::vector<FilePath> ignoreContentDirs()
          if (!outputDir.empty())
             ignoreDirs.push_back(buildTargetPath.completeChildPath(outputDir));
       }
-
    }
+   
    return ignoreDirs;
 }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11522.

### Approach

Validate that `project_output_dir` is set and non-empty, before trying to use it to add to the ignore list.

### Automated Tests

N/A

### QA Notes

https://github.com/rstudio/rstudio/issues/11522

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
