### PR TITLE
No indent in C++ mode for `static` and `inline`

### DIFF
--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1066,6 +1066,11 @@ var CppCodeModel = function(session, tokenizer,
             return indent;
          }
 
+         // Don't indent for function modifiers on their own: static, inline
+         if (/\b(static|inline)\b/.test(line)) {
+            return indent;
+         }
+
          // Indent following an opening paren.
          // We prefer inserting two tabs here, reflecting the rules of
          // the Google C++ style guide:

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1066,6 +1066,11 @@ var CppCodeModel = function(session, tokenizer,
             return indent;
          }
 
+         // Don't indent for function modifiers on their own: static, inline
+         if (/\b(static|inline)\b/.test(line)) {
+            return indent;
+         }
+
          // Indent following an opening paren.
          // We prefer inserting two tabs here, reflecting the rules of
          // the Google C++ style guide:
@@ -1444,7 +1449,7 @@ var CppCodeModel = function(session, tokenizer,
                         while (lines[row] != null && /^\s*#/.test(lines[row]))
                            ++row;
                         
-                        return this.$getIndent(lines[row]);
+                        return this.$getIndent(lines[row]) + additionalIndent;
                      }
                   }
 
@@ -1457,6 +1462,7 @@ var CppCodeModel = function(session, tokenizer,
                      if (startValue !== ";") {
                         return this.$getIndent(lines[tokenCursor.$row]) + additionalIndent;
                      }
+                     
                   }
 
                   // We hit a colon ':'...

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1423,6 +1423,7 @@ var CppCodeModel = function(session, tokenizer,
 
                while (true)
                {
+
                   // The token cursor is undefined (we moved past the start of the
                   // document)
                   if (typeof tokenCursor.currentValue() === "undefined") {
@@ -1583,7 +1584,8 @@ var CppCodeModel = function(session, tokenizer,
                      var clone = tokenCursor.cloneCursor();
                      if (clone.bwdToMatchingArrow()) {
                         if (clone.peekBwd().currentValue() === "template") {
-                           return this.$getIndent(lines[clone.$row]);
+                           if (startValue === ">") additionalIndent = "";
+                           return this.$getIndent(lines[clone.$row]) + additionalIndent;
                         }
                      }
                   }

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1066,11 +1066,6 @@ var CppCodeModel = function(session, tokenizer,
             return indent;
          }
 
-         // Don't indent for function modifiers on their own: static, inline
-         if (/\b(static|inline)\b/.test(line)) {
-            return indent;
-         }
-
          // Indent following an opening paren.
          // We prefer inserting two tabs here, reflecting the rules of
          // the Google C++ style guide:
@@ -1449,7 +1444,7 @@ var CppCodeModel = function(session, tokenizer,
                         while (lines[row] != null && /^\s*#/.test(lines[row]))
                            ++row;
                         
-                        return this.$getIndent(lines[row]) + additionalIndent;
+                        return this.$getIndent(lines[row]);
                      }
                   }
 
@@ -1462,7 +1457,6 @@ var CppCodeModel = function(session, tokenizer,
                      if (startValue !== ";") {
                         return this.$getIndent(lines[tokenCursor.$row]) + additionalIndent;
                      }
-                     
                   }
 
                   // We hit a colon ':'...

--- a/src/gwt/acesupport/acemode/cpp_code_model.js
+++ b/src/gwt/acesupport/acemode/cpp_code_model.js
@@ -1423,7 +1423,6 @@ var CppCodeModel = function(session, tokenizer,
 
                while (true)
                {
-
                   // The token cursor is undefined (we moved past the start of the
                   // document)
                   if (typeof tokenCursor.currentValue() === "undefined") {
@@ -1584,8 +1583,7 @@ var CppCodeModel = function(session, tokenizer,
                      var clone = tokenCursor.cloneCursor();
                      if (clone.bwdToMatchingArrow()) {
                         if (clone.peekBwd().currentValue() === "template") {
-                           if (startValue === ">") additionalIndent = "";
-                           return this.$getIndent(lines[clone.$row]) + additionalIndent;
+                           return this.$getIndent(lines[clone.$row]);
                         }
                      }
                   }

--- a/src/gwt/test/autoindent_test_cpp.html
+++ b/src/gwt/test/autoindent_test_cpp.html
@@ -659,6 +659,33 @@ enum Foo
     VALUE_1 = 1,
 </pre></li>
 
+<li><pre data-expected="0">
+using namespace Rcpp;
+static  
+</pre></li>
+
+<li><pre data-expected="0">
+using namespace Rcpp;
+static inline
+</pre></li>
+  
+<li><pre data-expected="0">
+static  
+</pre></li>
+  
+<li><pre data-expected="0">
+static inline
+</pre></li>
+  
+<li><pre data-expected="0">
+__attribute__((noreturn))
+</pre></li>
+  
+<li><pre data-expected="0">
+template &lt;typename ClockDuration&gt;
+cpp11::writable::strings
+</pre></li>
+  
 </ol>
 
 <script type="text/javascript">


### PR DESCRIPTION
### Intent

addresses #8417

### Approach

Tweak the rules so that modifiers on their own line (e.g. `static`) don't cause indent. 

### Automated Tests

Added some tests in `autoindent_test_cpp.html`

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


