### PR TITLE
Fix path normalization when saving file

### DIFF
--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { ipcRenderer, webContents } from 'electron';
+import { ipcRenderer, SaveDialogReturnValue, webContents } from 'electron';
 import { logger } from '../core/logger';
 import { normalizeSeparators } from '../ui/utils';
 
@@ -69,7 +69,7 @@ export function getDesktopBridge() {
     ) => {
       ipcRenderer
         .invoke('desktop_get_save_file_name', caption, label, dir, defaultExtension, forceDefaultExtension, focusOwner)
-        .then((result) => {
+        .then((result: SaveDialogReturnValue) => {
           // if the result was canceled, bail early
           if (result.canceled as boolean) {
             return callback('');
@@ -93,12 +93,14 @@ export function getDesktopBridge() {
             filePath = normalizeSeparators(filePath, '/');
           }
 
-          const expandedHomePath = normalizeSeparators(process.env.HOME as string, '/');
+          const expandedHomePath = normalizeSeparators(process.env.HOME ?? '', '/');
           const homePath = '~';
 
-          /* this makes sure the file path and HOME path 
+          /* this makes sure the file path and HOME path
           only contains forward slashes as separators for correct comparison */
-          filePath = homePath + filePath.substring(expandedHomePath.length);
+          if (expandedHomePath.length && filePath.startsWith(expandedHomePath)) {
+            filePath = homePath + filePath.substring(expandedHomePath.length);
+          }
 
           // invoke callback
           return callback(filePath);


### PR DESCRIPTION
### Intent
Address #11515 - File cannot be saved on Windows

### Approach
In dev, `process.env.HOME` returns the user's home path. In a build, it returns `undefined`. The error is caused by normalizing the home path.

There was another bug uncovered as well where we are assuming the save path is somewhere in the user's home. So this only performs the home alias replacement if the save path starts with the home path. It is a similar check as the CPP code.

### Automated Tests
None

### QA Notes
This only affected Windows but would be good to test the change on Linux or Mac (tested in dev on Mac and Windows). A network path is likely the use case where a user would save outside of their home directory.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


