### PR TITLE
Fix typos in various subdirs within src/

### DIFF
--- a/src/cpp/core/include/core/rapidxml/rapidxml.hpp
+++ b/src/cpp/core/include/core/rapidxml/rapidxml.hpp
@@ -89,7 +89,7 @@ namespace rapidxml
 
         //! Gets pointer to character data where error happened.
         //! Ch should be the same as char type of xml_document that produced the error.
-        //! \return Pointer to location within the parsed string where error occured.
+        //! \return Pointer to location within the parsed string where error occurred.
         template<class Ch>
         Ch *where() const
         {

--- a/src/cpp/core/markdown/sundown/markdown.h
+++ b/src/cpp/core/markdown/sundown/markdown.h
@@ -37,9 +37,9 @@ extern "C" {
 
 /* mkd_autolink - type of autolink */
 enum mkd_autolink {
-	MKDA_NOT_AUTOLINK,	/* used internally when it is not an autolink*/
+	MKDA_NOT_AUTOLINK,	/* used internally when it is not an autolink */
 	MKDA_NORMAL,		/* normal http/http/ftp/mailto/etc link */
-	MKDA_EMAIL			/* e-mail link without explit mailto: */
+	MKDA_EMAIL			/* e-mail link without explicit mailto: */
 };
 
 enum mkd_tableflags {

--- a/src/cpp/core/r_util/RActiveSessionStorage.cpp
+++ b/src/cpp/core/r_util/RActiveSessionStorage.cpp
@@ -420,7 +420,7 @@ Error RpcActiveSessionStorage::destroy()
 
    error = Error(json::errc::ExecutionError, ERROR_LOCATION);
    error.addProperty(
-      "descritpion",
+      "description",
       "Server was unable to destroy the session " + id_ + ".");
       
    LOG_ERROR(error);

--- a/src/cpp/server/DBActiveSessionStorageTests.cpp
+++ b/src/cpp/server/DBActiveSessionStorageTests.cpp
@@ -276,7 +276,7 @@ TEST_CASE("Database Session Storage, Sqlite","[database][integration][session][s
    runTests(storage);
 }
 
-TEST_CASE("Databse Session Storage, Postgres","[database][integration][session][.postgres]")
+TEST_CASE("Database Session Storage, Postgres","[database][integration][session][.postgres]")
 {
    system::User currUser;
    Error error = system::User::getCurrentUser(currUser);

--- a/src/cpp/server/DBActiveSessionsStorage.cpp
+++ b/src/cpp/server/DBActiveSessionsStorage.cpp
@@ -66,7 +66,7 @@ std::vector< std::string > DBActiveSessionsStorage::listSessionIds() const
    }
    else
    {
-      Error logError("DatabaseException", errc::DBError, "Exception occured while ", error, ERROR_LOCATION);
+      Error logError("DatabaseException", errc::DBError, "Exception occurred while ", error, ERROR_LOCATION);
       LOG_ERROR(logError);
    }
    return sessions;

--- a/src/cpp/server/ServerDatabaseMigrationTests.cpp
+++ b/src/cpp/server/ServerDatabaseMigrationTests.cpp
@@ -75,7 +75,7 @@ std::string typeToString(DatasetType type)
         case Postgres:
             return "Postgres";
         default:
-            return "UKNOWN";
+            return "UNKNOWN";
     }
 }
 

--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -334,7 +334,7 @@ boost::optional<boost::posix_time::time_duration> getCookieExpiry(bool staySigne
       // legacy auth expiration - users do not idle
       // and stay signed in for multiple days
       // not very secure, but maintained for those users that want this
-      // optional persistance beyond the browser session
+      // optional persistence beyond the browser session
       boost::optional<boost::posix_time::time_duration> expiry;
       if (staySignedIn)
          expiry = boost::posix_time::hours(24 * staySignedInDays);

--- a/src/cpp/server/auth/ServerSecureUriHandler.cpp
+++ b/src/cpp/server/auth/ServerSecureUriHandler.cpp
@@ -290,7 +290,7 @@ http::UriHandlerFunction secureHttpHandler(SecureUriHandlerFunction handler,
 http::UriHandlerFunction secureJsonRpcHandler(
                                        SecureUriHandlerFunction handler)
 {
-   // automatic auth refresh is dependant on the actual RPC being invoked
+   // automatic auth refresh is dependent on the actual RPC being invoked
    // (since many of them are invoked automatically on timers)
    // therefore, auth refresh is handled in the session proxy, before the request
    // is forwarded to the actual session

--- a/src/cpp/server/db/CreateTables.postgresql
+++ b/src/cpp/server/db/CreateTables.postgresql
@@ -115,7 +115,7 @@ CREATE TABLE active_session_metadata(
    /* Things which are blocking the suspension of the session, if any */
    blocking_suspend TEXT,
 
-   /* Time at which the session suspeneded */
+   /* Time at which the session suspended */
    suspend_timestamp TEXT,
 
    PRIMARY KEY (session_id),

--- a/src/cpp/server/db/CreateTables.sqlite
+++ b/src/cpp/server/db/CreateTables.sqlite
@@ -109,7 +109,7 @@ CREATE TABLE active_session_metadata(
    /* Things which are blocking the suspension of the session, if any */
    blocking_suspend TEXT,
 
-   /* Time at which the session suspeneded */
+   /* Time at which the session suspended */
    suspend_timestamp TEXT,
 
    PRIMARY KEY (session_id),

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -1524,7 +1524,7 @@ void handleIdentifier(RTokenCursor& cursor,
           isParentRightAssign(cursor.previousSignificantToken()))
       {
          
-         // A parent assignment eithers modifes a binding in a parent scope,
+         // A parent assignment eithers modifies a binding in a parent scope,
          // or adds a binding at the top level. Check and see if this symbol
          // has already been defined; if not, add a top-level definition.
          auto symbolName = token_utils::getSymbolName(cursor);

--- a/src/cpp/shared_core/json/JsonTests.cpp
+++ b/src/cpp/shared_core/json/JsonTests.cpp
@@ -767,7 +767,7 @@ TEST_CASE("Json")
       CHECK(obj1 == obj2);
    }
 
-   SECTION("Object deep comparsion - insertion order doesn't matter")
+   SECTION("Object deep comparison - insertion order doesn't matter")
    {
       json::Object obj1;
       obj1.insert("member1", json::Value(1));

--- a/src/cpp/tests/testthat/themes/tmThemes/Brilliance Black.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Brilliance Black.tmTheme
@@ -1865,7 +1865,7 @@ source.css meta.scope.property-list meta.property-value punctuation.separator.ar
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>◊ Source Embeded Source</string>
+			<string>◊ Source Embedded Source</string>
 			<key>scope</key>
 			<string>source source, source.java.embedded</string>
 			<key>settings</key>

--- a/src/cpp/tests/testthat/themes/tmThemes/Brilliance Dull.tmTheme
+++ b/src/cpp/tests/testthat/themes/tmThemes/Brilliance Dull.tmTheme
@@ -1624,7 +1624,7 @@
 		</dict>
 		<dict>
 			<key>name</key>
-			<string>◊ Source Embeded Source</string>
+			<string>◊ Source Embedded Source</string>
 			<key>scope</key>
 			<string>source.java.embedded</string>
 			<key>settings</key>

--- a/src/node/desktop/src/main/i18n-manager.ts
+++ b/src/node/desktop/src/main/i18n-manager.ts
@@ -49,7 +49,7 @@ const changeLanguage = async (language = 'en') => {
  * translated equivalent (if any).
  *
  * @param document The document, whose elements will be translated.
- * @param scope The scope in which translations are defiend.
+ * @param scope The scope in which translations are defined.
  */
 function localize(document: Document, scope: string): void {
   try {

--- a/src/node/desktop/src/main/preferences/mac-preferences.ts
+++ b/src/node/desktop/src/main/preferences/mac-preferences.ts
@@ -21,7 +21,7 @@ import DesktopOptions from './desktop-options';
 /**
  * MacOS specific implementation
  *
- * The preferences are stored in defauls, which is MacOS specific.
+ * The preferences are stored in defaults, which is MacOS specific.
  */
 class MacPreferences extends DesktopOptions {
   constructor() {


### PR DESCRIPTION
### Intent


### Approach

Fixes various typos found via `codespell -q 3 -S *_fr.properties,./src/gwt -L ba,enque,optionel,ot,parm,parms,pres,prevend,pevent,pevents,ptd,texline`

### Automated Tests

n/a

### QA Notes

n/a

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests