### PR TITLE
let session create its own job object

### DIFF
--- a/src/cpp/core/system/Win32System.cpp
+++ b/src/cpp/core/system/Win32System.cpp
@@ -88,8 +88,11 @@ Error initJobObject(bool* detachFromJob)
    }
 
    JOBOBJECT_EXTENDED_LIMIT_INFORMATION jeli = { 0 };
-   jeli.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
-                                           JOB_OBJECT_LIMIT_BREAKAWAY_OK;
+   jeli.BasicLimitInformation.LimitFlags =
+         JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE |
+         JOB_OBJECT_LIMIT_BREAKAWAY_OK |
+         JOB_OBJECT_LIMIT_DIE_ON_UNHANDLED_EXCEPTION;
+
    ::SetInformationJobObject(hJob,
                              JobObjectExtendedLimitInformation,
                              &jeli,

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1885,6 +1885,18 @@ int main(int argc, char * const argv[])
 {
    try
    {
+      // create and use a job object -- this is necessary on Electron as node
+      // creates processes with JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK, and we want
+      // to make sure child processes for the rsession are terminated if the rsession
+      // process itself is shut down.
+      //
+      // the downside here is that the desktop front-end and the session will no
+      // longer be part of the same job, but because rsession is not detached from
+      // the desktop frontend, it will still be closed if the frontend is closed
+#ifdef _WIN32
+      core::system::initHook();
+#endif
+
       // save fallback library path
       s_fallbackLibraryPath = core::system::getenv("RSTUDIO_FALLBACK_LIBRARY_PATH");
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11487.

### Approach

On Windows, we use job objects to ensure that child processes are cleaned up when a parent process exits. However, node creates processes with `JOB_OBJECT_LIMIT_SILENT_BREAKAWAY_OK`, which effectively prevents new processes from being added to an existing job object.

This PR resolves the issue by allowing the R session to create its own job object, so that the lifetime of child processes created by the session is limited by the lifetime of the session itself.

Some open questions...

- Is there a way for us to pass the desktop's job object handle down to the session, when it is initialized? Is this worth doing?
- Can we convince ourselves that node will appropriately kill the session process if the desktop process dies in this case?

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11487.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

