### PR TITLE
Set a pipeline timeout for Mac builds

### DIFF
--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -3,6 +3,8 @@ pipeline {
   agent { label 'macos-v1.4-arm64' }
 
   options {
+    // timeout regardless of activity
+    timeout(activity: false, time: 120)
     timestamps()
     disableConcurrentBuilds()
     buildDiscarder(logRotator(numToKeepStr: '100'))


### PR DESCRIPTION
### Intent
Address https://github.com/rstudio/rstudio-pro/issues/3489

Starting with the Mac builds since it was that platform that prompted creating the issue. I'll continue after this PR with the other Jenkinsfile that will cover the other platforms.

### Approach
Sets a 2 hour timeout regardless of activity. The original build referenced in the issue no longer exists so setting `activity=false` would cover whatever the cause of the never-ending build. That build might have stalled with a repeated status update so I wanted to be sure it would be covered.

Builds appear to complete in under an hour. I did see some that approached 1.5 hours but the math seemed incorrect as the build stages added up to ~45 mins.

### Automated Tests
Ran some test builds (2 hour timeout and 12 minute timeout). The 2 hour timeout completed no problem within the hour. The 12 minute ended at 14 minutes with a timeout as the reason.

### QA Notes
N/A 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


