### PR TITLE
Allows background commands to surface the main window under the active one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,4 +16,4 @@
 
 - Fixed visual mode outline missing nested R code chunks (#11410)
 - Fixed an issue where chunks containing multibyte characters was not executed correctly (#10632)
-
+- Fixed bringing main window under active secondary window when executing background command (#11407)

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -534,7 +534,14 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_bring_main_frame_behind_active', () => {
-      GwtCallback.unimpl('desktop_bring_main_frame_behind_active');
+      const mainWindow = this.mainWindow.window;
+      const activeWindow = BrowserWindow.getFocusedWindow();
+
+      // bring main window under active window by focusing main window then back to active
+      if (activeWindow && mainWindow !== activeWindow) {
+        mainWindow.focus();
+        activeWindow.focus();
+      }
     });
 
     ipcMain.handle('desktop_rendering_engine', () => {


### PR DESCRIPTION
### Intent
Addresses #11407

### Approach
Originally, this was implemented for Windows only as it could set the window order. Electron doesn't have any kind of window ordering mechanism. So the workaround is focusing the main window and then back to the active one. This may cause a slight flicker on some platforms. I only noticed this on Windows and it didn't occur if the main window was already directly underneath the secondary window. Other Linux distros may differ depending on window managers but Ubuntu 22 seemed good.

### Automated Tests
None

### QA Notes
This is new to Linux and Mac but existed before on Windows. It can be triggered by a few different commands:

* Test Package
* Check Package
* Build package documentation
* Run Shiny Application in New Pane
* Run Shiny Application in RStudio Viewer
* Run Shiny Application in Web Browser
* Run Plumber API in New Pane
* Run Plumber API in RStudio Viewer
* Run Plumber API in Web Browser

Any of those commands will trigger a check on the window and make sure the main window is displayed directly underneath the secondary window.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


