### PR TITLE
recognize (#[0-9]+) as links to issues

### DIFF
--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -202,6 +202,8 @@ for (binding in bindings)
 
    if (grepl("^https://github.com/[-a-zA-Z0-9]+/[-a-zA-Z0-9]+/issues", BugReports)) {
       .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
+   } else if (grepl("^https?://", BugReports)) {
+      .rs.scalar(BugReports)
    } else {
       .rs.scalar("")
    }

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -174,3 +174,12 @@ for (binding in bindings)
 {
    .Call("rs_readLines", path.expand(filePath))
 })
+
+.rs.addJsonRpcHandler("get_issue_url", function(id)
+{
+   project <- .rs.getProjectDirectory()
+   BugReports <- as.character(read.dcf(file.path(.rs.getProjectDirectory(), "DESCRIPTION"), fields = "BugReports"))
+
+   url <- paste0(BugReports, "/", sub("#", "", id))
+   .rs.scalar(url)
+})

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -196,6 +196,13 @@ for (binding in bindings)
       return(.rs.scalar(""))
    }
 
-   url <- paste0(BugReports, "/", sub("#", "", id))
-   .rs.scalar(url)
+   if (!is.character(BugReports) || length(BugReports) != 1L) {
+      return(.rs.scalar(""))
+   }
+
+   if (grepl("^https://github.com/[-a-zA-Z0-9]+/[-a-zA-Z0-9]+/issues", BugReports)) {
+      .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
+   } else {
+      .rs.scalar("")
+   }
 })

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -200,10 +200,9 @@ for (binding in bindings)
       return(.rs.scalar(""))
    }
 
-   if (grepl("^(https://)?(www.)?github.com/[-a-zA-Z0-9.]+/[-a-zA-Z0-9.]+/issues", BugReports)) {
+   # make sure BugReports is a url and append the id to it
+   if (grepl("^(https?://|www.)", BugReports)) {
       .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
-   } else if (grepl("^https?://", BugReports)) {
-      .rs.scalar(BugReports)
    } else {
       .rs.scalar("")
    }

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -200,7 +200,7 @@ for (binding in bindings)
       return(.rs.scalar(""))
    }
 
-   if (grepl("^https://github.com/[-a-zA-Z0-9]+/[-a-zA-Z0-9]+/issues", BugReports)) {
+   if (grepl("^(https://)?(www.)?github.com/[-a-zA-Z0-9.]+/[-a-zA-Z0-9.]+/issues", BugReports)) {
       .rs.scalar(paste0(BugReports, "/", sub("#", "", id)))
    } else if (grepl("^https?://", BugReports)) {
       .rs.scalar(BugReports)

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -178,7 +178,14 @@ for (binding in bindings)
 .rs.addJsonRpcHandler("get_issue_url", function(id)
 {
    project <- .rs.getProjectDirectory()
-   BugReports <- as.character(read.dcf(file.path(.rs.getProjectDirectory(), "DESCRIPTION"), fields = "BugReports"))
+   if (is.null(project)) {
+      return(.rs.scalar(""))
+   }
+   
+   BugReports <- as.character(read.dcf(file.path(project, "DESCRIPTION"), fields = "BugReports"))
+   if (is.na(BugReports)) {
+      return(.rs.scalar(""))
+   }
 
    url <- paste0(BugReports, "/", sub("#", "", id))
    .rs.scalar(url)

--- a/src/cpp/session/modules/SessionFiles.R
+++ b/src/cpp/session/modules/SessionFiles.R
@@ -182,7 +182,16 @@ for (binding in bindings)
       return(.rs.scalar(""))
    }
    
-   BugReports <- as.character(read.dcf(file.path(project, "DESCRIPTION"), fields = "BugReports"))
+   DESCRIPTION <- file.path(project, "DESCRIPTION")
+   if (!file.exists(DESCRIPTION)) {
+      return(.rs.scalar(""))
+   }
+
+   BugReports <- tryCatch(
+      read.dcf(DESCRIPTION, fields = "BugReports"), 
+      error = function(e) NA, 
+      warning = function(w) NA
+   )
    if (is.na(BugReports)) {
       return(.rs.scalar(""))
    }

--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -300,6 +300,11 @@ public abstract class MessageDisplay
       dialog.showModal();
    }
    
+   public void showErrorMessage(String message)
+   {
+      showErrorMessage(constants_.errorCaption(), message);
+   }
+
    public void showErrorMessage(String caption, String message)
    {
       createDialog(MSG_ERROR, caption, message).showModal();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -1764,6 +1764,14 @@ public class RemoteServer implements Server
       sendRequest(RPC_SCOPE, "read_config_json", params, requestCallback);
    }
 
+   public void getIssueUrl(String id, 
+                           ServerRequestCallback<String> requestCallback)
+   {
+      JSONArray params = new JSONArray();
+      params.set(0, new JSONString(id));
+      sendRequest(RPC_SCOPE, GET_ISSUE_URL, params, requestCallback);
+   }
+
    public String getFileExportUrl(String name,
                                   FileSystemItem parentDirectory,
                                   ArrayList<String> filenames)
@@ -6731,6 +6739,7 @@ public class RemoteServer implements Server
    private static final String RENAME_FILE = "rename_file";
    private static final String TOUCH_FILE = "touch_file";
    private static final String COMPLETE_UPLOAD = "complete_upload";
+   private static final String GET_ISSUE_URL = "get_issue_url";
 
    private static final String GET_PLOT_TEMPDIR = "get_plot_tempdir";
    private static final String NEXT_PLOT = "next_plot";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/model/FilesServerOperations.java
@@ -102,6 +102,9 @@ public interface FilesServerOperations
                  boolean logErrorIfNotFound,
                  ServerRequestCallback<JavaScriptObject> requestCallback);
 
+   void getIssueUrl(String id, 
+                    ServerRequestCallback<String> requestCallback);
+
    /**
     * Use VERY sparingly; we generally don't want to expose
     * non-aliased paths to other parts of the client codebase

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants.java
@@ -2710,4 +2710,14 @@ public interface ViewsSourceConstants extends com.google.gwt.i18n.client.Message
     @DefaultMessage("The profiler")
     @Key("theProfilerText")
     String theProfilerText();
+
+    /**
+     * Translated "Could not resolve {0}. Please make sure this is an R package project with a BugReports field set.".
+     *
+     * @return translated "Could not resolve {0}. Please make sure this is an R package project with a BugReports field set."
+     */
+    @DefaultMessage("Could not resolve {0}. Please make sure this is an R package project with a BugReports field set.")
+    @Key("couldNotResolveIssue")
+    String couldNotResolveIssue(String issue);
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_en.properties
@@ -298,3 +298,4 @@ authoringRPresentationsText=Authoring R Presentations
 creatingRPlumberAPIText=Creating R Plumber API
 usingRNotebooksText=Using R Notebooks
 theProfilerText=The profiler
+couldNotResolveIssue=Could not resolve {0}. Please make sure this is an R package project with a BugReports field set.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_fr.properties
@@ -298,3 +298,4 @@ authoringRPresentationsText=Créer des présentations R
 creatingRPlumberAPIText=Création l''API de R Plumber
 usingRNotebooksText=Utilisation des R Notebooks
 theProfilerText=Le profileur
+couldNotResolveIssue==Impossible de résoudre {0}. Merci de vous assurer que le projet est un paquet R avec un champ BugReports renseigné.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/ViewsSourceConstants_fr.properties
@@ -298,4 +298,4 @@ authoringRPresentationsText=Créer des présentations R
 creatingRPlumberAPIText=Création l''API de R Plumber
 usingRNotebooksText=Utilisation des R Notebooks
 theProfilerText=Le profileur
-couldNotResolveIssue==Impossible de résoudre {0}. Merci de vous assurer que le projet est un paquet R avec un champ BugReports renseigné.
+couldNotResolveIssue=Impossible de résoudre {0}. Merci de vous assurer que le projet est un paquet R avec un champ BugReports renseigné.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.css
@@ -7,10 +7,7 @@
    pointer-events: all;
 }
 
-.hover {
-   position: absolute;
-   margin-top: -3px;
-   border-bottom: 1px solid BORDER_COLOR;
+.modified .highlight:hover {
    pointer-events: auto;
    cursor: pointer;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -352,7 +352,7 @@ public class AceEditorBackgroundLinkHighlighter
       if (reSrcRef.test(url))
          return;
 
-      // github issues
+      // github issues for this package (uses BugReports)
       Pattern reIssue = Pattern.create("^#[0-9]+$");
       if (reIssue.test(url))
       {
@@ -364,6 +364,17 @@ public class AceEditorBackgroundLinkHighlighter
                globalDisplay_.openWindow(response);
             }
          });
+
+         return;
+      }
+
+      // explicit github issues
+      Pattern reSpecificGithubIssue = Pattern.create("[-a-zA-Z0-9]+/[-a-zA-Z0-9]+#[0-9]+");
+      if (reSpecificGithubIssue.test(url))
+      {
+         String[] parts = url.split("#");
+         String issueUrl = "https://www.github.com/" + parts[0] + "/issues/" + parts[1];
+         globalDisplay_.openWindow(issueUrl);
 
          return;
       }
@@ -545,7 +556,7 @@ public class AceEditorBackgroundLinkHighlighter
 
    private static Pattern createIssueLinkPattern()
    {
-      return Pattern.create("[(]#([0-9]+)[)]");
+      return Pattern.create("[(]([-a-zA-Z0-9]+/[-a-zA-Z0-9]+)?#([0-9]+)[)]");
    }
 
    private Highlighter markdownLinkHighlighter()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -164,7 +164,7 @@ public class AceEditorBackgroundLinkHighlighter
                      highlighters_.remove(webLinkHighlighter());
                   }
             }});
-            if (fileType.isR())
+            if (fileType != null && fileType.isR())
                highlighters_.add(issueHighlighter());
             if (fileType != null && (fileType.isMarkdown() || fileType.isRmd()))
                highlighters_.add(markdownLinkHighlighter());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -35,6 +35,7 @@ import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.common.filetypes.EditableFileType;
 import org.rstudio.studio.client.common.filetypes.FileType;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
@@ -355,7 +356,16 @@ public class AceEditorBackgroundLinkHighlighter
       Pattern reIssue = Pattern.create("^#[0-9]+$");
       if (reIssue.test(url))
       {
-         // TODO: globalDisplay_.openWindow(BugReports + /url)
+         server_.getIssueUrl(url, new SimpleRequestCallback<String>()
+         {
+            @Override
+            public void onResponseReceived(String response)
+            {
+               globalDisplay_.openWindow(response);
+            }
+         });
+
+         return;
       }
 
       // treat other URLs as paths to files on the server

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -211,6 +211,8 @@ public class AceEditorBackgroundLinkHighlighter
    {
       if (isRequiredClickModifier(modifier))
          editor_.getWidget().getElement().addClassName(RES.styles().modified()); 
+      else 
+         endDetectClickTarget();
    }
 
    private void endDetectClickTarget()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -299,7 +299,7 @@ public class AceEditorBackgroundLinkHighlighter
                   globalDisplay_.openWindow(response); 
                else 
                   RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
-                     "Could not resolve " + finalUrl + ". Please make sure this is an R package project with a BugReports field set.");
+                     constants_.couldNotResolveIssue(finalUrl));
             }
          });
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -52,7 +52,6 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Edit
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CommandClickEvent;
 
 import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.ScheduledCommand;
 import com.google.gwt.dom.client.Element;
@@ -423,13 +422,18 @@ public class AceEditorBackgroundLinkHighlighter
       final String styles = RES.styles().highlight() + " ace_marker " + id;
       AnchoredRange anchoredRange = editor.getSession().createAnchoredRange(start, end, true);
 
+      /*
+      // TODO: leaving this here for now. This was meant to be added as a title= attribute on the marker
+      //       but the previously used hack does not work anymore
+      // 
+      //       maybe instead we could pass an attributes array to addMarker() and use it on the ace side. 
+
       final String title = BrowseCap.isMacintosh()
             ? constants_.openLinkMacCommand()
             : constants_.openLinkNotMacCommand();
-      MarkerRenderer renderer =
-            MarkerRenderer.create(editor.getWidget().getEditor(), styles, title);
-
-      int markerId = editor.getSession().addMarker(anchoredRange, styles, renderer, true);
+      */
+      int markerId = editor.getSession().addMarker(anchoredRange, styles, "text", true);
+      
       registerActiveMarker(row, id, markerId, anchoredRange);
    }
 
@@ -773,34 +777,6 @@ public class AceEditorBackgroundLinkHighlighter
    }
 
    // Private Members ----
-
-   private static class MarkerRenderer extends JavaScriptObject
-   {
-      protected MarkerRenderer() {}
-
-      public static final native MarkerRenderer create(final AceEditorNative editor,
-                                                       final String clazz,
-                                                       final String title)
-      /*-{
-         var markerBack = editor.renderer.$markerBack;
-         return $entry(function(html, range, left, top, config) {
-            // HACK: we take advantage of an implementation detail of
-            // Ace's 'drawTextMarker' implementation. Ace constructs
-            // HTML for the generated markers with code of the form:
-            //
-            //    html = "<div style='..." + extraStyle + "'>"
-            //
-            // We take advantage of this, and inject our 'extraStyle'
-            // to close the style attribute we were intended to be
-            // locked in, and instead inject a 'title' attribute instead.
-            var extra = "' title='" + title;
-            if (range.isMultiLine())
-               return markerBack.drawTextMarker(html, range, clazz, config, extra);
-            else
-               return markerBack.drawSingleLineMarker(html, range, clazz, config, 0, extra);
-         });
-      }-*/;
-   }
 
    private class MarkerRegistration
    {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -153,6 +153,7 @@ public class AceEditorBackgroundLinkHighlighter
          {
             TextFileType fileType = editor_.getFileType();
             highlighters_.clear();
+            highlighters_.add(issueHighlighter());
             pUserPrefs_.get().highlightWebLink().bind(new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {
                   if (arg)
@@ -351,6 +352,13 @@ public class AceEditorBackgroundLinkHighlighter
       if (reSrcRef.test(url))
          return;
 
+      // github issues
+      Pattern reIssue = Pattern.create("^#[0-9]+$");
+      if (reIssue.test(url))
+      {
+         // TODO: globalDisplay_.openWindow(BugReports + /url)
+      }
+
       // treat other URLs as paths to files on the server
       final String finalUrl = url;
       server_.stat(finalUrl, new ServerRequestCallback<FileSystemItem>()
@@ -494,6 +502,36 @@ public class AceEditorBackgroundLinkHighlighter
             reWebLink()
       }, "|");
       return Pattern.create(rePattern);
+   }
+
+   private Highlighter issueHighlighter()
+   {
+      return new Highlighter() {
+         @Override
+         public void highlight(AceEditor editor, String line, int row)
+         {
+            onIssueHighlight(editor, line, row);
+         }
+      };
+   }
+
+   private void onIssueHighlight(AceEditor editor, String line, int row)
+   {
+      Pattern reIssueLink = createIssueLinkPattern();
+      for (Match match = reIssueLink.match(line, 0);
+           match != null;
+           match = match.nextMatch())
+      {
+         int startIdx = match.getIndex() + 1;
+         int endIdx   = match.getIndex() + match.getValue().length() - 1;
+
+         highlight(editor, row, startIdx, endIdx);
+      }
+   }
+
+   private static Pattern createIssueLinkPattern()
+   {
+      return Pattern.create("[(]#([0-9]+)[)]");
    }
 
    private Highlighter markdownLinkHighlighter()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -170,7 +170,7 @@ public class AceEditorBackgroundLinkHighlighter
                highlighters_.add(markdownLinkHighlighter());
 
             nextHighlightStart_ = 0;
-            timer_.schedule(100);
+            timer_.schedule(700);
          }
       });
    }
@@ -667,7 +667,7 @@ public class AceEditorBackgroundLinkHighlighter
       // prepare highlighter
       int row = event.getEvent().getRange().getStart().getRow();
       nextHighlightStart_ = Math.min(nextHighlightStart_, row);
-      timer_.schedule(100);
+      timer_.schedule(700);
 
       // update marker positions (deferred so that anchors update)
       Scheduler.get().scheduleDeferred(new ScheduledCommand()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -139,7 +139,7 @@ public class AceEditorBackgroundLinkHighlighter
       handlers_.add(editor_.addMouseMoveHandler(this));
       handlers_.add(editor_.addMouseUpHandler(this));
 
-      refreshHighlighters(editor_.getModeId());
+      // refreshHighlighters(editor_.getModeId());
    }
 
    private void refreshHighlighters(String mode)
@@ -167,7 +167,7 @@ public class AceEditorBackgroundLinkHighlighter
             if (fileType != null && (fileType.isMarkdown() || fileType.isRmd()))
                highlighters_.add(markdownLinkHighlighter());
             nextHighlightStart_ = 0;
-            timer_.schedule(700);
+            timer_.schedule(100);
          }
       });
    }
@@ -639,7 +639,7 @@ public class AceEditorBackgroundLinkHighlighter
       // prepare highlighter
       int row = event.getEvent().getRange().getStart().getRow();
       nextHighlightStart_ = Math.min(nextHighlightStart_, row);
-      timer_.schedule(700);
+      timer_.schedule(100);
 
       // update marker positions (deferred so that anchors update)
       Scheduler.get().scheduleDeferred(new ScheduledCommand()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -483,7 +483,7 @@ public class AceEditorBackgroundLinkHighlighter
 
    private static Pattern createIssueLinkPattern()
    {
-      return Pattern.create("(?<=test_that.*)[(]((?:[-a-zA-Z0-9]+/[-a-zA-Z0-9]+)?#[0-9]+)[)]");
+      return Pattern.create("(?<=test_that.*)[(]((?:[-a-zA-Z0-9]+/[-a-zA-Z0-9]+)?#[0-9]+|https?://.*)[)]");
    }
 
    private Highlighter markdownLinkHighlighter()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -429,11 +429,6 @@ public class AceEditorBackgroundLinkHighlighter
          int startIdx = match.getIndex();
          int endIdx   = match.getIndex() + match.getValue().length();
 
-         // ensure that the discovered url is not within a string
-         Token token = editor_.getTokenAt(Position.create(row, startIdx));
-         if (token.hasType("string"))
-            continue;
-
          String url = match.getValue();
 
          // trim off enclosing brackets

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -139,7 +139,7 @@ public class AceEditorBackgroundLinkHighlighter
       handlers_.add(editor_.addMouseMoveHandler(this));
       handlers_.add(editor_.addMouseUpHandler(this));
 
-      // refreshHighlighters(editor_.getModeId());
+      refreshHighlighters(editor_.getModeId());
    }
 
    private void refreshHighlighters(String mode)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -352,6 +352,8 @@ public class AceEditorBackgroundLinkHighlighter
       if (reSrcRef.test(url))
          return;
 
+      final String finalUrl = url;
+      
       // github issues for this package (uses BugReports)
       Pattern reIssue = Pattern.create("^#[0-9]+$");
       if (reIssue.test(url))
@@ -361,7 +363,11 @@ public class AceEditorBackgroundLinkHighlighter
             @Override
             public void onResponseReceived(String response)
             {
-               globalDisplay_.openWindow(response);
+               if (response.length() > 0)
+                  globalDisplay_.openWindow(response); 
+               else 
+                  RStudioGinjector.INSTANCE.getGlobalDisplay().showErrorMessage(
+                     "Could not resolve " + finalUrl + ". Please make sure this is an R package project with a BugReports field set.");
             }
          });
 
@@ -380,7 +386,6 @@ public class AceEditorBackgroundLinkHighlighter
       }
 
       // treat other URLs as paths to files on the server
-      final String finalUrl = url;
       server_.stat(finalUrl, new ServerRequestCallback<FileSystemItem>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -170,7 +170,7 @@ public class AceEditorBackgroundLinkHighlighter
                highlighters_.add(markdownLinkHighlighter());
 
             nextHighlightStart_ = 0;
-            timer_.schedule(700);
+            timer_.schedule(100);
          }
       });
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -456,7 +456,7 @@ public class AceEditorBackgroundLinkHighlighter
             : constants_.openLinkNotMacCommand();
       MarkerRenderer renderer =
              MarkerRenderer.create(editor.getWidget().getEditor(), styles, title);
-      int markerId = editor.getSession().addMarker(anchoredRange, styles, renderer, true);
+      int markerId = editor.getSession().addMarker(anchoredRange, styles, renderer, false);
       registerActiveMarker(row, id, markerId, anchoredRange);
    }
 
@@ -809,15 +809,15 @@ public class AceEditorBackgroundLinkHighlighter
                                                       final String clazz,
                                                       final String title)
       /*-{
-         var markerFront = editor.renderer.$markerFront;
+         var markerBack = editor.renderer.$markerBack;
          return $entry(function(html, range, left, top, config) {
-            markerFront.drawSingleLineMarker(html, range, clazz, config, 0);
+            markerBack.drawSingleLineMarker(html, range, clazz, config, 0);
             
-            // HACK: after the marker is drawn, retrieve it based on markerFront.i
+            // HACK: after the marker is drawn, retrieve it based on markerBack.i
             //       and squeeze in a title attribute
             var x;
-            var i = markerFront.i;
-            var markers = markerFront.element.childNodes;
+            var i = markerBack.i;
+            var markers = markerBack.element.childNodes;
             if (i == -1) {
                x = markers[markers.length - 1];
             } else {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorBackgroundLinkHighlighter.java
@@ -153,7 +153,6 @@ public class AceEditorBackgroundLinkHighlighter
          {
             TextFileType fileType = editor_.getFileType();
             highlighters_.clear();
-            highlighters_.add(issueHighlighter());
             pUserPrefs_.get().highlightWebLink().bind(new CommandWithArg<Boolean>() {
                public void execute(Boolean arg) {
                   if (arg)
@@ -165,8 +164,11 @@ public class AceEditorBackgroundLinkHighlighter
                      highlighters_.remove(webLinkHighlighter());
                   }
             }});
+            if (fileType.isR())
+               highlighters_.add(issueHighlighter());
             if (fileType != null && (fileType.isMarkdown() || fileType.isRmd()))
                highlighters_.add(markdownLinkHighlighter());
+
             nextHighlightStart_ = 0;
             timer_.schedule(100);
          }
@@ -561,7 +563,7 @@ public class AceEditorBackgroundLinkHighlighter
 
    private static Pattern createIssueLinkPattern()
    {
-      return Pattern.create("[(]([-a-zA-Z0-9]+/[-a-zA-Z0-9]+)?#([0-9]+)[)]");
+      return Pattern.create("(?<=test_that.*)[(]((?:[-a-zA-Z0-9]+/[-a-zA-Z0-9]+)?#[0-9]+)[)]");
    }
 
    private Highlighter markdownLinkHighlighter()


### PR DESCRIPTION
### Intent

addresses #11840

Treat `(#[0-9]+)` as issue (or pr) links, e.g. 

```r
test_that("can use freshly create variables (#138)", {
  df <- tibble(x = 1:10)
  out <- summarise(df, y = mean(x), z = y + 1)
  expect_equal(out$y, 5.5)
  expect_equal(out$z, 6.5)
})
```

<img width="412" alt="image" src="https://user-images.githubusercontent.com/2625526/177330912-c643f007-c6a1-4d01-aa46-7ee9e20ee718.png">

### Approach

Extend `AceEditorBackgroundLinkHighlighter` to recognize the pattern. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


