### PR TITLE
Open docx files rendered by rstudio -- electron

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -358,7 +358,10 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_show_word_doc', (event, wordDoc: string) => {
-      GwtCallback.unimpl('desktop_show_word_doc');
+      shell.openPath(resolveAliasedPath(normalizeSeparatorsNative(wordDoc))).catch((value) => {
+        console.log('error:', value);
+        logger().logErrorMessage(value);
+      });
     });
 
     ipcMain.on('desktop_show_ppt_presentation', (event, pptDoc: string) => {
@@ -370,7 +373,8 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_prepare_show_word_doc', () => {
-      GwtCallback.unimpl('desktop_prepare_show_word_doc');
+      // if possible, close most recently rendered docx item
+      return '';
     });
 
     ipcMain.on('desktop_prepare_show_ppt_presentation', () => {


### PR DESCRIPTION
### Intent

Addresses #10897 

### Approach

Open the file using the default application for .docx files (Word/Pages/LibreOffice whatever)
Does not close the most recently rendered file, so if rendering multiple times, user will get multiple windows and have to manage the windows themselves

### Automated Tests

None

### QA Notes

See issue
### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


