### PR TITLE
open pdf in system viewer, synctex not yet implemented on electron

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -366,7 +366,12 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.on('desktop_show_pdf', (event, path: string, pdfPage: string) => {
-      GwtCallback.unimpl('desktop_show_pdf');
+      // TODO: when desktop_external_synctex_view is implemented, use synctex viewer as appropriate
+      // pdfPage is only relevant for synctex
+      shell.openPath(resolveAliasedPath(normalizeSeparatorsNative(path))).catch((value) => {
+        console.log('error:', value);
+        logger().logErrorMessage(value);
+      });
     });
 
     ipcMain.on('desktop_prepare_show_word_doc', () => {


### PR DESCRIPTION
### Intent

Addresses #11388

### Approach

Use default system pdf viewer. Synctex is not yet implemented -- added a note on the backlog ticket so this method can be updated when synctex viewer is implemented in Electron

### QA Notes

See issue

### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


