### PR TITLE
get dpi from primary display electron

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -790,7 +790,11 @@ export class GwtCallback extends EventEmitter {
     });
 
     ipcMain.handle('desktop_get_display_dpi', () => {
-      return '72';
+      const primaryDisplay = screen.getPrimaryDisplay();
+      // scaling factor of 1 = 96 dpi
+      const dpi = primaryDisplay.scaleFactor * 96;
+      logger().logDebug(`dpi: ${dpi.toString()}`);
+      return dpi.toString();
     });
 
     ipcMain.on('desktop_on_session_quit', () => {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -793,7 +793,6 @@ export class GwtCallback extends EventEmitter {
       const primaryDisplay = screen.getPrimaryDisplay();
       // scaling factor of 1 = 96 dpi
       const dpi = primaryDisplay.scaleFactor * 96;
-      logger().logDebug(`dpi: ${dpi.toString()}`);
       return dpi.toString();
     });
 


### PR DESCRIPTION
### Intent

check for the primary display's dpi, which is used on windows only to determine if display is high dpi

### Approach

using electron primary display's scaling factor * 92. scaling factor of 1 = 92 dpi

### Automated Tests

None

### QA Notes

Needs to be tested on windows with high dpi display, not entirely clear how to test but could literally just check if `windows-highdpi` is added to the CSS (not sure what else to be looking for)
### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


