### PR TITLE
Gate various Linux-specific system calls with `__linux__`

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -24,7 +24,7 @@
 #include <util.h>
 #include <sys/ttycom.h>
 #include <sys/ioctl.h>
-#else
+#elif defined(__linux__)
 #include <pty.h>
 #include <asm/ioctls.h>
 #include <sys/prctl.h>

--- a/src/cpp/core/system/PosixSched.cpp
+++ b/src/cpp/core/system/PosixSched.cpp
@@ -41,7 +41,7 @@ bool isCpuAffinityEmpty(const CpuAffinity& cpus)
 
 Error getCpuAffinity(CpuAffinity* pCpus)
 {
-#ifndef __APPLE__
+#ifdef __linux__
    cpu_set_t cs;
    CPU_ZERO(&cs);
    if (::sched_getaffinity(0, sizeof(cs), &cs) == -1)
@@ -66,7 +66,7 @@ Error getCpuAffinity(CpuAffinity* pCpus)
 
 Error setCpuAffinity(const CpuAffinity& cpus)
 {
-#ifndef __APPLE__
+#ifdef __linux__
    cpu_set_t cs;
    CPU_ZERO(&cs);
 

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -49,7 +49,7 @@
 #include <gsl/gsl>
 #endif
 
-#ifndef __APPLE__
+#ifdef __linux__
 #include <sys/prctl.h>
 #include <sys/sysinfo.h>
 #include <linux/kernel.h>
@@ -1479,7 +1479,7 @@ Error osResourceLimit(ResourceLimit limit, int* pLimit)
       case CpuLimit:
          *pLimit = RLIMIT_CPU;
          break;
-#ifndef __APPLE__
+#ifdef __linux__
       case NiceLimit:
          *pLimit = RLIMIT_NICE;
          break;
@@ -1552,7 +1552,7 @@ Error systemInformation(SysInfo* pSysInfo)
 {
    pSysInfo->cores = boost::thread::hardware_concurrency();
 
-#ifndef __APPLE__
+#ifdef __linux__
    struct sysinfo info;
    if (::sysinfo(&info) == -1)
       return systemError(errno, ERROR_LOCATION);
@@ -1956,7 +1956,7 @@ Error restrictCoreDumps()
       return error;
 
    // no ptrace core dumps permitted
-#ifndef __APPLE__
+#ifndef __linux__
    int res = ::prctl(PR_SET_DUMPABLE, 0);
    if (res == -1)
       return systemError(errno, ERROR_LOCATION);
@@ -1987,7 +1987,7 @@ void printCoreDumpable(const std::string& context)
    ostr << "  hard limit: " << rLimitHard << std::endl;
 
    // ptrace
-#ifndef __APPLE__
+#ifndef __linux__
    int dumpable = ::prctl(PR_GET_DUMPABLE, nullptr, nullptr, nullptr, nullptr);
    if (dumpable == -1)
       LOG_ERROR(systemError(errno, ERROR_LOCATION));

--- a/src/cpp/shared_core/system/PosixSystem.cpp
+++ b/src/cpp/shared_core/system/PosixSystem.cpp
@@ -29,7 +29,7 @@
 #include <netdb.h>
 #include <pwd.h>
 
-#ifndef __APPLE__
+#ifdef __linux__
 #include <sys/prctl.h>
 #endif
 
@@ -79,7 +79,7 @@ Error restorePrivilegesImpl(uid_t in_uid)
 
 Error enableCoreDumps()
 {
-#ifndef __APPLE__
+#ifdef __linux__
    int res = ::prctl(PR_SET_DUMPABLE, 1);
    if (res == -1)
       return systemError(errno, ERROR_LOCATION);


### PR DESCRIPTION
### Intent

I was looking at the [patches that the FreeBSD port carries](https://cgit.freebsd.org/ports/tree/devel/RStudio/files?id=90225d0c1d8cca043672180d39585462c45558b0) and I noticed that there are several where we assume that "not Apple" means "has Linux-specific system calls", which seems like an easy thing to fix on our end.

### Approach

This PR gates the following Linux-specific system calls and flags behind `__linux__` rather than "not Apple":

* `prctl()`
* `sysinfo()`
* `sched_getaffinity()` and `sched_setaffinity()`
* the `RLIMIT_NICE` flag to `setrlimit()`
* the `pty.h` include for `forkpty()`

This is for two reasons: (1) correctness; and (2) requiring community ports like FreeBSD to carry fewer patches.

We already use `__linux__` in various places, so this does not introduce a new preprocessor directive, either.

### Automated Tests

All of these changes should be adequately tested by "it complies on Linux and macOS", in my understanding.

### QA Notes

Not applicable, as far as I know.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests