### PR TITLE
Build timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,7 +152,7 @@ def sentry_upload(type, flavor) {
     retry(5) {
       // timeout sentry in 15 minutes
       timeout(activity: true, time: 15) {
-	sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ../../../../../docker/jenkins/sentry-upload.sh ${SENTRY_API_KEY}"
+    sh "cd package/linux/build-${flavor.capitalize()}-${type}/src/cpp && ../../../../../docker/jenkins/sentry-upload.sh ${SENTRY_API_KEY}"
       }
     }
   }
@@ -389,123 +389,123 @@ try {
 
         // build each windows variant in parallel
         for (int i = 0; i < windows_containers.size(); i++) {
-          def index = i
-          parallel_containers["${windows_containers[i].os}-${windows_containers[i].flavor}"] = {
-            def current_container = windows_containers[index]
-            retry(2) {
-              node('windows') {
-                stage('prepare container') {
-                  checkout scm
-                  docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:jenkins-aws') {
-                    def image_tag = "${current_container.os}-${rstudioReleaseBranch}"
-                    windows_image = docker.image("jenkins/ide:" + image_tag)
-                      windows_image.pull()
-                      image_name = windows_image.imageName()
-                  }
-                }
-                docker.image(image_name).inside() {
-                    timeout(time: 180, units: 'MINUTES', activity: false) {
-                        stage('dependencies') {
-                            withCredentials([usernameColonPassword(credentialsId: 'github-rstudio-jenkins', variable: "GITHUB_LOGIN")]) {
-                                bat 'cd dependencies/windows && set RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN && set RSTUDIO_SKIP_QT=1 && install-dependencies.cmd && cd ../..'
+            def index = i
+            parallel_containers["${windows_containers[i].os}-${windows_containers[i].flavor}"] = {
+                def current_container = windows_containers[index]
+                retry(2) {
+                    node('windows') {
+                        stage('prepare container') {
+                            checkout scm
+                            docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:jenkins-aws') {
+                                def image_tag = "${current_container.os}-${rstudioReleaseBranch}"
+                                windows_image = docker.image("jenkins/ide:" + image_tag)
+                                windows_image.pull()
+                                image_name = windows_image.imageName()
                             }
                         }
-                        stage('build'){
-                            def env = "set \"RSTUDIO_VERSION_MAJOR=${rstudioVersionMajor}\" && set \"RSTUDIO_VERSION_MINOR=${rstudioVersionMinor}\" && set \"RSTUDIO_VERSION_PATCH=${rstudioVersionPatch}\" && set \"RSTUDIO_VERSION_SUFFIX=${rstudioVersionSuffix}\""
-                            bat "cd package/win32 && ${env} && set \"PACKAGE_OS=Windows\" && make-package.bat clean ${current_container.flavor} && cd ../.."
-                        }
-                        stage('tests'){
-                            try {
-                            bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'
-                            }
-                            catch(err){
-                            currentBuild.result = "UNSTABLE"
-                            }
-                        }
-                        if (current_container.flavor == "electron") {
-                            stage('electron tests'){
-                            try {
-                                bat 'cd src/node/desktop && scripts\\run-unit-tests.cmd'
-                            }
-                            catch(err){
-                                currentBuild.result = "UNSTABLE"
-                            }
-                            }
-                        }
-                        stage('sign') {
-                            def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
-                            packageVersion = packageVersion.replace('+', '-')
+                        docker.image(image_name).inside() {
+                            timeout(time: 180, units: 'MINUTES', activity: false) {
+                                stage('dependencies') {
+                                    withCredentials([usernameColonPassword(credentialsId: 'github-rstudio-jenkins', variable: "GITHUB_LOGIN")]) {
+                                        bat 'cd dependencies/windows && set RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN && set RSTUDIO_SKIP_QT=1 && install-dependencies.cmd && cd ../..'
+                                    }
+                                }
+                                stage('build'){
+                                    def env = "set \"RSTUDIO_VERSION_MAJOR=${rstudioVersionMajor}\" && set \"RSTUDIO_VERSION_MINOR=${rstudioVersionMinor}\" && set \"RSTUDIO_VERSION_PATCH=${rstudioVersionPatch}\" && set \"RSTUDIO_VERSION_SUFFIX=${rstudioVersionSuffix}\""
+                                    bat "cd package/win32 && ${env} && set \"PACKAGE_OS=Windows\" && make-package.bat clean ${current_container.flavor} && cd ../.."
+                                }
+                                stage('tests'){
+                                    try {
+                                        bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'
+                                    }
+                                    catch(err){
+                                        currentBuild.result = "UNSTABLE"
+                                    }
+                                }
+                                if (current_container.flavor == "electron") {
+                                    stage('electron tests'){
+                                        try {
+                                            bat 'cd src/node/desktop && scripts\\run-unit-tests.cmd'
+                                        }
+                                        catch(err){
+                                            currentBuild.result = "UNSTABLE"
+                                        }
+                                    }
+                                }
+                                stage('sign') {
+                                    def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
+                                    packageVersion = packageVersion.replace('+', '-')
 
-                            def packageName = "RStudio-${packageVersion}-RelWithDebInfo"
+                                    def packageName = "RStudio-${packageVersion}-RelWithDebInfo"
 
-                            withCredentials([file(credentialsId: 'ide-windows-signing-pfx', variable: 'pfx-file'), string(credentialsId: 'ide-pfx-passphrase', variable: 'pfx-passphrase')]) {
-                            bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" sign /f %pfx-file% /p %pfx-passphrase% /v /debug /n \"RStudio PBC\" /t http://timestamp.digicert.com  package\\win32\\build\\${packageName}.exe"
+                                    withCredentials([file(credentialsId: 'ide-windows-signing-pfx', variable: 'pfx-file'), string(credentialsId: 'ide-pfx-passphrase', variable: 'pfx-passphrase')]) {
+                                        bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" sign /f %pfx-file% /p %pfx-passphrase% /v /debug /n \"RStudio PBC\" /t http://timestamp.digicert.com  package\\win32\\build\\${packageName}.exe"
 
-                            bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${packageName}.exe"
-                            }
-                        }
-                        stage('upload') {
-                            def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
-                            packageVersion = packageVersion.replace('+', '-')
+                                        bat "\"C:\\Program Files (x86)\\Windows Kits\\10\\bin\\10.0.19041.0\\x86\\signtool\" verify /v /pa package\\win32\\build\\${packageName}.exe"
+                                    }
+                                }
+                                stage('upload') {
+                                    def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
+                                    packageVersion = packageVersion.replace('+', '-')
 
-                            def buildDest = "s3://rstudio-ide-build/${current_container.flavor}/windows"
-                            def packageName = "RStudio-${packageVersion}"
+                                    def buildDest = "s3://rstudio-ide-build/${current_container.flavor}/windows"
+                                    def packageName = "RStudio-${packageVersion}"
 
-                            // strip unhelpful suffixes from filenames
-                            bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.exe package\\win32\\build\\${packageName}.exe"
-                            bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.zip package\\win32\\build\\${packageName}.zip"
+                                    // strip unhelpful suffixes from filenames
+                                    bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.exe package\\win32\\build\\${packageName}.exe"
+                                    bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.zip package\\win32\\build\\${packageName}.zip"
 
-                            // windows docker container cannot reach instance-metadata endpoint. supply credentials at upload.
+                                    // windows docker container cannot reach instance-metadata endpoint. supply credentials at upload.
 
-                            withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
-                            retry(5) {
-                                bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"
-                                bat "aws s3 cp package\\win32\\build\\${packageName}.zip ${buildDest}/${packageName}.zip"
-                            }
-                            }
+                                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+                                        retry(5) {
+                                            bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"
+                                            bat "aws s3 cp package\\win32\\build\\${packageName}.zip ${buildDest}/${packageName}.zip"
+                                        }
+                                    }
 
-                        }
-                        stage ('publish') {
-                            def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
-                            packageVersion = packageVersion.replace('+', '-')
+                                }
+                                    stage ('publish') {
+                                    def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
+                                    packageVersion = packageVersion.replace('+', '-')
 
-                            def packageName = "RStudio-${packageVersion}"
-                            withCredentials([usernamePassword(credentialsId: 'github-rstudio-jenkins', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
+                                    def packageName = "RStudio-${packageVersion}"
+                                    withCredentials([usernamePassword(credentialsId: 'github-rstudio-jenkins', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
 
-                            // derive product
-                            def product = "${current_container.flavor}"
-                            if (rstudioVersionSuffix.contains("pro")) {
-                                product = "${current_container.flavor}-pro"
-                            }
+                                        // derive product
+                                        def product = "${current_container.flavor}"
+                                        if (rstudioVersionSuffix.contains("pro")) {
+                                            product = "${current_container.flavor}-pro"
+                                        }
 
-                            // publish the build (self installing exe)
-                            def stdout = powershell(returnStdout: true, script: ".\\docker\\jenkins\\publish-build.ps1 -build ${product}/windows -url https://s3.amazonaws.com/rstudio-ide-build/${current_container.flavor}/windows/${packageName}.exe -pat ${GITHUB_PAT} -file package\\win32\\build\\${packageName}.exe -version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}")
-                            println stdout
+                                        // publish the build (self installing exe)
+                                        def stdout = powershell(returnStdout: true, script: ".\\docker\\jenkins\\publish-build.ps1 -build ${product}/windows -url https://s3.amazonaws.com/rstudio-ide-build/${current_container.flavor}/windows/${packageName}.exe -pat ${GITHUB_PAT} -file package\\win32\\build\\${packageName}.exe -version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}")
+                                        println stdout
 
-                            // publish the build (installer-less zip)
-                            stdout = powershell(returnStdout: true, script: ".\\docker\\jenkins\\publish-build.ps1 -build ${product}/windows-xcopy -url https://s3.amazonaws.com/rstudio-ide-build/${current_container.flavor}/windows/${packageName}.zip -pat ${GITHUB_PAT} -file package\\win32\\build\\${packageName}.zip -version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}")
-                            println stdout
-                            }
-                        }
-                        if (current_container.flavor == "desktop") {
-                            stage('upload debug symbols') {
-                            // convert the PDB symbols to breakpad format (PDB not supported by Sentry)
-                            bat '''
-                            cd package\\win32\\build
-                                FOR /F %%G IN ('dir /s /b *.pdb') DO (..\\..\\..\\dependencies\\windows\\breakpad-tools-windows\\dump_syms %%G > %%G.sym)
-                            '''
+                                        // publish the build (installer-less zip)
+                                        stdout = powershell(returnStdout: true, script: ".\\docker\\jenkins\\publish-build.ps1 -build ${product}/windows-xcopy -url https://s3.amazonaws.com/rstudio-ide-build/${current_container.flavor}/windows/${packageName}.zip -pat ${GITHUB_PAT} -file package\\win32\\build\\${packageName}.zip -version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}")
+                                        println stdout
+                                    }
+                                }
+                                if (current_container.flavor == "desktop") {
+                                    stage('upload debug symbols') {
+                                        // convert the PDB symbols to breakpad format (PDB not supported by Sentry)
+                                        bat '''
+                                        cd package\\win32\\build
+                                        FOR /F %%G IN ('dir /s /b *.pdb') DO (..\\..\\..\\dependencies\\windows\\breakpad-tools-windows\\dump_syms %%G > %%G.sym)
+                                        '''
 
-                            // upload the breakpad symbols
-                            withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]){
-                                bat "cd package\\win32\\build\\src\\cpp && ..\\..\\..\\..\\..\\dependencies\\windows\\sentry-cli.exe --auth-token %SENTRY_API_KEY% upload-dif --log-level=debug --org rstudio --project ide-backend -t breakpad ."
-                            }
+                                        // upload the breakpad symbols
+                                        withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]) {
+                                            bat "cd package\\win32\\build\\src\\cpp && ..\\..\\..\\..\\..\\dependencies\\windows\\sentry-cli.exe --auth-token %SENTRY_API_KEY% upload-dif --log-level=debug --org rstudio --project ide-backend -t breakpad ."
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
                 }
-              }
             }
-          }
         }
 
         // trigger macos build if we're in open-source repo


### PR DESCRIPTION
### Intent
https://github.com/rstudio/rstudio-pro/issues/3489

### Approach
Applies to a timeout to each platform's build (dependencies, compile, and tests).

I've also re-indented some of the lines because it was really confusing adding another timeout to enclose the stages. So turn off whitespace changes to see the real change.

Changes have already been made to the Mac builds. After this is merged, I'll follow-up and monitor the pro builds.

### Automated Tests
None

### QA Notes
I've run this in a branch build on Jenkins with a lower timeout and it does expire the build for each platform.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


