### PR TITLE
Check for group_member() and execinfo.h via CMake

### DIFF
--- a/src/cpp/core/Backtrace.cpp
+++ b/src/cpp/core/Backtrace.cpp
@@ -16,7 +16,9 @@
 #include <core/Backtrace.hpp>
 #include <core/RegexUtils.hpp>
 
-#ifndef _WIN32
+#include "config.h"
+
+#ifdef HAVE_EXECINFO
 # include <core/Algorithm.hpp>
 # include <iostream>
 # include <boost/regex.hpp>
@@ -46,7 +48,7 @@ std::string demangle(const std::string& name)
 
 void printBacktrace(std::ostream& os)
 {
-#ifndef _WIN32
+#ifdef HAVE_EXECINFO
    
    os << "Backtrace (most recent calls first):" << std::endl << std::endl;
    

--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -167,6 +167,20 @@ if (UNIX)
       set(HAVE_PROCSELF TRUE)
    endif()
 
+   # missing on non-glibc platforms like macOS, musl-based Linux distros, and
+   # the BSDs
+   check_function_exists(group_member HAVE_GROUP_MEMBER)
+
+   # missing on musl-based Linux distros and some BSDs
+   CHECK_CXX_SOURCE_COMPILES (
+   "#include <execinfo.h>
+   int main (int, char **)
+   {
+      return 0;
+   }
+   "
+   HAVE_EXECINFO)
+
    # find packages and libraries
    find_library(PTHREAD_LIBRARIES pthread)
    if(NOT APPLE)

--- a/src/cpp/core/config.h.in
+++ b/src/cpp/core/config.h.in
@@ -27,5 +27,7 @@
 #cmakedefine HAVE_PROCSELF
 #cmakedefine HAVE_SETRESUID
 #cmakedefine HAVE_SCANDIR_POSIX
+#cmakedefine HAVE_GROUP_MEMBER
+#cmakedefine HAVE_EXECINFO
 #cmakedefine RSTUDIO_SERVER
 #cmakedefine RSTUDIO_PRO_BUILD


### PR DESCRIPTION
### Intent

Folks trying to build RStudio on FreeBSD and Musl-based distributions like Alpine or Void Linux both encounter two assumptions that we make:

1. `group_member()` is available on non-macOS platforms. But `group_member()` is a Glibc extension, so this is not actually true.

2. `backtrace()` and `backtrace_symbols()` from `execinfo.h` are always provided by the system's libc. But they *happen* to be provided by Glibc and macOS's libc; on FreeBSD these are in a separate library, and Musl doesn't implement them at all.

### Approach

Both of these can be fixed by adding more careful checks for these features in our CMake configuration. I've also found numerous other major projects that have near-identical CMake checks for these two features; it's clearly a common problem.

This commit also adds a fallback implementation of `group_member()` rather than simply skipping the check (as currently happens on macOS) because this should improve correctness. However, this has an important consequence that this check will now happen on macOS, where previously it did not. I'm happy to remove this fallback if it is not regarded as necessary for correct behaviour.

Note that this PR *might* fully address the Alpine build errors discussed in #3650.

Also note that the community-based [FreeBSD](https://cgit.freebsd.org/ports/tree/devel/RStudio/files?id=90225d0c1d8cca043672180d39585462c45558b0) and [Void Linux ports](https://github.com/void-linux/void-packages/tree/master/srcpkgs/rstudio/patches) currently carry patches similar to (though less complete than) this one; hopefully this change will require them to carry fewer patches in the future.

### Automated Tests

All of these changes should be adequately tested by "it still complies on Linux and macOS", in my understanding.

### QA Notes

Please advise.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


