### PR TITLE
Populate default project dir in Version control projects

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/VersionControlPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/VersionControlPage.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.projects.ui.newproject;
 import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.widget.DirectoryChooserTextBox;
 import org.rstudio.core.client.widget.FormLabel;
@@ -31,6 +32,7 @@ import org.rstudio.studio.client.projects.Projects;
 import org.rstudio.studio.client.projects.StudioClientProjectConstants;
 import org.rstudio.studio.client.projects.model.NewProjectInput;
 import org.rstudio.studio.client.projects.model.NewProjectResult;
+import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
 
 import com.google.gwt.core.client.Scheduler;
@@ -55,7 +57,6 @@ public abstract class VersionControlPage extends NewProjectWizardPage
    {
       super(title, subTitle, pageCaption, image, largeImage);  
    }
-   
    
    @Override
    protected boolean acceptNavigation()
@@ -186,8 +187,10 @@ public abstract class VersionControlPage extends NewProjectWizardPage
    protected void initialize(NewProjectInput input)
    {
       super.initialize(input);
-      existingRepoDestDir_.setText(
-                           input.getDefaultNewProjectLocation().getPath());
+      String path = input.getDefaultNewProjectLocation().getPath();
+      if (StringUtil.isNullOrEmpty(path))
+         path = this.getSessionInfo().getDefaultProjectDir();
+      existingRepoDestDir_.setText(path);
    }
 
    @Override
@@ -281,7 +284,7 @@ public abstract class VersionControlPage extends NewProjectWizardPage
    }
    
    protected abstract String guessRepoDir(String url);
-   
+
    private TextBox txtRepoUrl_;
    private TextBox txtUsername_;
    private TextBox txtDirName_;


### PR DESCRIPTION
Addresses #11089

Take same fallback approach we use in NewDirectoryPage.java for non-VCS projects in Version Control projects

### Automated Tests

None

### QA Notes

See issue. There should be no active project, and walk through creating a new project from a Git repo

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


