### PR TITLE
upgrade electron from 19.0.6 to 19.0.8

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -42,7 +42,7 @@
         "chai": "4.3.6",
         "copy-webpack-plugin": "^10.2.4",
         "css-loader": "6.5.1",
-        "electron": "19.0.6",
+        "electron": "19.0.8",
         "electron-mocha": "11.0.2",
         "eslint": "^7.12.1",
         "eslint-config-prettier": "8.3.0",
@@ -4443,9 +4443,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
+      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -17570,9 +17570,9 @@
       "dev": true
     },
     "electron": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.6.tgz",
-      "integrity": "sha512-S9Yud32nKhB0iWC0lGl2JXz4FQnCiLCnP5Vehm1/CqyeICcQGmgQaZl2HYpCJ2pesKIsYL9nsgmku/10cxm/gg==",
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-19.0.8.tgz",
+      "integrity": "sha512-OWK3P/NbDFfBUv+wbYv1/OV4jehY5DQPT7n1maQJfN9hsnrWTMktXS/bmS05eSUAjNAzHmKPKfiKH2c1Yr7nGw==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.14.1",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -43,7 +43,7 @@
     "chai": "4.3.6",
     "copy-webpack-plugin": "^10.2.4",
     "css-loader": "6.5.1",
-    "electron": "19.0.6",
+    "electron": "19.0.8",
     "electron-mocha": "11.0.2",
     "eslint": "^7.12.1",
     "eslint-config-prettier": "8.3.0",


### PR DESCRIPTION
Upgrade from Electron 19.0.6 to 19.0.8, release notes:

https://releases.electronjs.org/release/v19.0.7
https://releases.electronjs.org/release/v19.0.8

