### PR TITLE
Specify the extension when globbing

### DIFF
--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -71,7 +71,7 @@ if(GWT_BUILD)
    endif()
 
    # depend on Java source files
-   file(GLOB_RECURSE GWT_SOURCE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*")
+   file(GLOB_RECURSE GWT_SOURCE_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/src/*.java")
 
    # generated during GWT build command
    set(GWT_BUILD_TIMESTAMP "${CMAKE_CURRENT_BINARY_DIR}/timestamp")


### PR DESCRIPTION
### Intent

The issue was introduced in #10446. In particular, this glob https://github.com/rstudio/rstudio/blob/203675a9f3e21db36cf224b7dc1c5c056e0b067b/src/gwt/CMakeLists.txt#L74 makes cmake find glob mismatches at install time, and compilation of dependencies starts over.

### Approach

This patch limits the glob to Java files, so mismatches don't happen anymore independently of other files that may have been generated there.

### Automated Tests

No tests added. With this change, compilation runs once during the build stage, and no recompilation occurs during the install stage.

### QA Notes

No issues expected.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests



