### PR TITLE
Replace issue type "Question" by a direct link to the RStudio forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,0 @@
----
-name  : Ask a Question
-about : The issue tracker is not for questions -- please ask questions at https://community.rstudio.com/c/rstudio-ide.
----
-
-The issue tracker is not for questions. If you have a question, please feel free to ask it on our community site, at https://community.rstudio.com/c/rstudio-ide.
-


### PR DESCRIPTION
### How to see the result
I consider there is no way to "test" this and see the real results before it is merged to `main`.
Because of that you can look at this project to see how such an "issue link" look like.
https://github.com/Codeberg-AsGithubAlternative-buhtz/spielwiese/issues/new/choose

### Intent
Your third issue type *Ask a question* used a issue template to inform the user to not open an issue in the case of a question. But the issue form is open and some users will create an issue.

### Approach
GitHub offers another technique. The *Ask a question* entry in the `New Issue` page is still there but now points directly to the RStudio forum instead of opening an issue form.

### Contributor Agreement

I assume there is no need for this because I don't contribute to RStudio software itself but to its project infrastructure.
And I don't see the need for such an agreement. Your project is AGPLv3 licences. I don't see what the agreement adds to this licences.