### PR TITLE
Remove stringsAsFactors default for R-4.2.0 and later when importing data

### DIFF
--- a/src/cpp/session/modules/SessionDataImport.R
+++ b/src/cpp/session/modules/SessionDataImport.R
@@ -122,7 +122,7 @@
         decimal=dec,
         quote=quote,
         comment=comment,
-        defaultStringsAsFactors=default.stringsAsFactors())
+        defaultStringsAsFactors=ifelse(getRversion() >= '4.2.0', FALSE, default.stringsAsFactors()))
 })
 
 .rs.addJsonRpcHandler("get_output_preview", function(path, encoding, header,
@@ -141,5 +141,5 @@
         separator=sep,
         quote=quote,
         comment=comment,
-        defaultStringsAsFactors=default.stringsAsFactors())
+        defaultStringsAsFactors=ifelse(getRversion() >= '4.2.0', FALSE, default.stringsAsFactors()))
 })


### PR DESCRIPTION
Fixes #11510 


### Intent

Fixes #11510, using the hints provided by @kevinushey

### Approach

In R-4.2.0 `default.stringsAsFactors` was deprecated.  When importing data using `read.csv()` from `base`, check for `getRversion() >= '4.2.0' and use an approprate default.

### Automated Tests

None

### QA Notes

To test, use any downloaded CSV file and import data using `read.csv()`

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

