### PR TITLE
Copy behavior from Qt desktop for Mac -- check fallback list of R

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -263,7 +263,9 @@ export function detectREnvironment(rPath?: string): Expected<REnvironment> {
 
 function scanForR(): Expected<string> {
   // if the RSTUDIO_WHICH_R environment variable is set, use that
+  // note that this does not pick up variables set in a user's bash profile, for example
   const rstudioWhichR = getenv('RSTUDIO_WHICH_R');
+
   if (rstudioWhichR) {
     logger().logDebug(`Using ${rstudioWhichR} (found by RSTUDIO_WHICH_R environment variable)`);
     return ok(rstudioWhichR);
@@ -278,6 +280,8 @@ function scanForR(): Expected<string> {
 }
 
 function scanForRPosix(): Expected<string> {
+  const defaultLocations = ['/usr/bin/R', '/usr/local/bin/R', '/opt/local/bin/R'];
+
   if (process.platform == 'darwin') {
     // For Mac, we want to first look in a list of hard-coded locations
     // also check framework directory and then homebrew ARM locations for macOS
@@ -288,7 +292,6 @@ function scanForRPosix(): Expected<string> {
     // should we launch the default shell to pick up the user modifications to the path?
     const [rLocation, error] = executeCommand('/usr/bin/which R');
     if (!error && rLocation) {
-      logger().logDebug(`PATH: ${getenv("PATH")}`);
       logger().logDebug(`Using ${rLocation} (found by /usr/bin/which/R)`);
       return ok(rLocation);
     } 


### PR DESCRIPTION
### Intent

Addresses #11567 to at least mimic the old Qt desktop behavior for Macs

### Approach

Qt desktop code took [1 approach for Mac](https://github.com/rstudio/rstudio/blob/8df7e8c7c6b7727779786613a9089ba14e0c4a68/src/cpp/core/r_util/REnvironmentPosix.cpp#L106-L147) and a[ different approach for Linux](https://github.com/rstudio/rstudio/blob/8df7e8c7c6b7727779786613a9089ba14e0c4a68/src/cpp/core/r_util/REnvironmentPosix.cpp#L203-L244) in terms of finding the right R executable. Electron code was essentially applying the Linux logic to both platforms, and then falling back to the Mac logic, leading to funny behavior on Mac. 

Overall, it would probably be ideal to launch a terminal process in the user's default shell to pick up any profile modifications to the RSTUDIO_WHICH_R and/or PATH variables, since we check those variables as part of detecting the right R. But for now, we don't pick up any user modifications to those variables, so if they are set in bash/zsh profile, changes will be ignored. 

This change doesn't fix that issue, just brings back in line with the former Qt behavior

### Automated Tests 

### QA Notes

See #11567 for details -- probably need to test on Mac with brew installed R on the system
### Checklist

- [X] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


