### PR TITLE
avoid using empty class names in image previewer

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -260,7 +260,8 @@ public class ImagePreviewer
             imgEl.setId(parsedAttributes.getIdentifier());
 
          for (String className : parsedAttributes.getClasses())
-            imgEl.addClassName(className);
+            if (!className.isEmpty())
+               imgEl.addClassName(className);
       }
       
       // add load handlers to image
@@ -372,7 +373,8 @@ public class ImagePreviewer
                   imgEl.setId(parsedAttributes.getIdentifier());
                
                for (String className : parsedAttributes.getClasses())
-                  imgEl.addClassName(className);
+                  if (!className.isEmpty())
+                     imgEl.addClassName(className);
             }
          };
          


### PR DESCRIPTION
### Intent

Potentially addresses https://github.com/rstudio/rstudio/issues/11619; it seemed to resolve the issue in a local package build.

### Approach

Avoid attempting to add empty class name to image elements on preview.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11619.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
