### PR TITLE
Fix select all in text input fields

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, Menu, screen, WebContents } from 'electron';
+import { app, BrowserWindow, globalShortcut, Menu, screen, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -44,7 +44,7 @@ import {
   resolveAliasedPath
 } from './utils';
 import { WindowTracker } from './window-tracker';
-import { configureSatelliteWindow, configureSecondaryWindow } from './window-utils';
+import { configureSatelliteWindow, configureSecondaryWindow, focusedWebContents } from './window-utils';
 
 /**
  * The RStudio application
@@ -133,6 +133,17 @@ export class Application implements AppState {
         })
         .catch((error: unknown) => logger().logError(error));
     });
+
+    // Workaround for selecting all text in the input field: https://github.com/rstudio/rstudio/issues/11581
+    if (process.platform === 'darwin') {
+      app.whenReady()
+        .then(() => {
+          globalShortcut.register('Cmd+A', () => {
+            focusedWebContents()?.selectAll();
+          });
+        })
+        .catch((error: unknown) => logger().logError(error));
+    }
   }
 
   /**

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -23,7 +23,6 @@ import {
   Rectangle,
   screen,
   shell,
-  webContents,
   webFrameMain
 } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
@@ -49,7 +48,7 @@ import {
   filterFromQFileDialogFilter, findRepoRoot,
   getAppPath, handleLocaleCookies, resolveAliasedPath
 } from './utils';
-import { activateWindow } from './window-utils';
+import { activateWindow, focusedWebContents } from './window-utils';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -71,20 +70,6 @@ function formatSelectedVersionForUi(rBinDir: string) {
   } else {
     return rHome;
   }
-}
-
-// The documentation for getFocusedWebContents() has:
-//
-// /**
-//  * The web contents that is focused in this application, otherwise returns `null`.
-//  */
-//
-//  static getFocusedWebContents(): WebContents;
-//
-// and so the documentation appears to state that the return value may be 'null',
-// but the type definition doesn't propagate that reality. Hence, this wrapper function.
-function focusedWebContents(): Electron.WebContents | null {
-  return webContents.getFocusedWebContents();
 }
 
 /**

--- a/src/node/desktop/src/main/window-utils.ts
+++ b/src/node/desktop/src/main/window-utils.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { BrowserWindow, WebContents } from 'electron';
+import { BrowserWindow, webContents, WebContents } from 'electron';
 import { appState } from './app-state';
 import { PendingSatelliteWindow, PendingSecondaryWindow } from './pending-window';
 import { SatelliteWindow } from './satellite-window';
@@ -105,4 +105,18 @@ export function activateWindow(name: string): void {
       return;
     }
   }
+}
+
+// The documentation for getFocusedWebContents() has:
+//
+// /**
+//  * The web contents that is focused in this application, otherwise returns `null`.
+//  */
+//
+//  static getFocusedWebContents(): WebContents;
+//
+// and so the documentation appears to state that the return value may be 'null',
+// but the type definition doesn't propagate that reality. Hence, this wrapper function.
+export function focusedWebContents(): Electron.WebContents | null {
+  return webContents.getFocusedWebContents();
 }


### PR DESCRIPTION
### Intent
Address #11581

### Approach
Implements a workaround to call Electron's `selectAll()` on the focused web view. I'm not sure what is overriding the Cmd+A but it eats the keyboard event. This seems to get around that and results in the same behaviour as Qt (even down to pressing Tab to focus on a button and it selects UI text). We could refine this behaviour by executing Javascript and querying the `document.activeElement` for the active element but this seems cleaner and easier to understand.

I've refactored the wrapper method on `getFocusedWebContents()` since it could be useful in other places.

### Automated Tests
None

### QA Notes
Any text input field would have been affected by this bug. It should also work on editors that have been popped out to its own window.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->