### PR TITLE
avoid getClientLeft() / getClientTop()

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/ElementEx.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/ElementEx.java
@@ -46,35 +46,38 @@ public class ElementEx extends Element
       return (result == null) ? '' : result + '';
    }-*/;
 
-   public final int getClientLeft()
+   // NOTE: We intentionally avoid calling this method 'getClientLeft()',
+   // as it seems to collide with other GWT definitions and causes GWT to
+   // fail to see the function definition.
+   public final int clientLeft()
    {
       int left = getAbsoluteLeft();
       ElementEx iFrame = getOwningIFrame();
       if (iFrame != null)
-         left += iFrame.getClientLeft();
+         left += iFrame.clientLeft();
       return left;
    }
 
-   public final int getClientTop()
+   // NOTE: We intentionally avoid calling this method 'getClientTop()',
+   // as it seems to collide with other GWT definitions and causes GWT to
+   // fail to see the function definition.
+   public final int clientTop()
    {
       int top = getAbsoluteTop();
       ElementEx iFrame = getOwningIFrame();
       if (iFrame != null)
-         top += iFrame.getClientTop();
+         top += iFrame.clientTop();
       return top;
    }
 
-   // NOTE: these static methods are provided only because
-   // GWT seems unable to find the instance methods of the
-   // same name in some contexts in devmode
-   public static final int getClientLeft(Element el)
+   public static final int clientLeft(Element el)
    {
-      return ((ElementEx) el).getClientLeft();
+      return ((ElementEx) el).clientLeft();
    }
 
-   public static final int getClientTop(Element el)
+   public static final int clientTop(Element el)
    {
-      return ((ElementEx) el).getClientTop();
+      return ((ElementEx) el).clientTop();
    }
 
    public static final DOMRect getBoundingClientRect(Element el)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
@@ -93,8 +93,8 @@ public class CopyPlotToClipboardDesktopDialog
                // NOTE: we use a one-pixel fudge factor here to avoid copying
                // bits of the border; see https://github.com/rstudio/rstudio/issues/4864
                frame.copyPageRegionToClipboard(
-                     ElementEx.getClientLeft(img) + 1,
-                     ElementEx.getClientTop(img) + 1,
+                     ElementEx.clientLeft(img) + 1,
+                     ElementEx.clientTop(img) + 1,
                      img.getClientWidth(),
                      img.getClientHeight(),
                      completed);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/PlotsPanePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/export/PlotsPanePreviewer.java
@@ -82,8 +82,8 @@ public class PlotsPanePreviewer implements ExportPlotPreviewer
       if (images.getLength() > 0)
       {
          ElementEx img = images.getItem(0).cast();
-         return new Rectangle(img.getClientLeft(),
-                              img.getClientTop(),
+         return new Rectangle(img.clientLeft(),
+                              img.clientTop(),
                               img.getClientWidth(),
                               img.getClientHeight());
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/export/DesktopExport.java
@@ -54,11 +54,12 @@ public class DesktopExport
          }
 
          private void performExport(double zoomLevel) {
+            
             // get the preview iframe rect
             ElementEx iframe = sizeEditor.getPreviewIFrame().<ElementEx>cast();
             final Rectangle viewerRect = new Rectangle(
-                   (int) Math.ceil(zoomLevel * iframe.getClientLeft()),
-                   (int) Math.ceil(zoomLevel * iframe.getClientTop()),
+                   (int) Math.ceil(zoomLevel * ElementEx.clientLeft(iframe)),
+                   (int) Math.ceil(zoomLevel * ElementEx.clientTop(iframe)),
                    (int) Math.ceil(zoomLevel * iframe.getClientWidth()),
                    (int) Math.ceil(zoomLevel * iframe.getClientHeight())).inflate(-1);
 


### PR DESCRIPTION
### Intent

Fixes an issue where calls to `getClientLeft()` and `getClientTop()` would seemingly fail to resolve when using GWT devmode.

### Approach

Rename the methods to `clientLeft()` / `clientTop()`.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
