### PR TITLE
Fix showing a minimized main window

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -537,7 +537,7 @@ export class GwtCallback extends EventEmitter {
 
       // bring main window under active window by focusing main window then back to active
       if (activeWindow && mainWindow !== activeWindow) {
-        mainWindow.focus();
+        mainWindow.show();
         activeWindow.focus();
       }
     });


### PR DESCRIPTION
### Intent
There was an issue showing a minimized window when Jon tested this initially. #11407 

### Approach
`show()` will raise and focus the window. The secondary window is then focused to bring it back to the top. I tried `showInactive()` which seems to imply that it will raise but not focus the window but it always focused the window for me on Mac.

### Automated Tests
None

### QA Notes
None

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


