### PR TITLE
Reticulate -- revert revert changes to reticulate python fallback without preloading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 * Improved handling of missing arguments for some functions in the diagnostics system.
 * Code editor can show previews of color in strings (R named colors e.g. "tomato3" or of the forms "#rgb", "#rrggbb", "#rrggbbaa")
   when `Options > Code > Display > [ ] Show color preview` is checked. 
+  
+### Python
+
+- RStudio attempts to infer the appropriate version of Python when "Automatically activate project-local Python environments" is checked and the user has not requested a specific version of Python. This Python will be stored in the environment variable "RETICULATE_PYTHON_FALLBACK", available from the R console, the Python REPL, and the RStudio Terminal (#9990)
 
 ### Deprecated / Removed
 

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -275,7 +275,10 @@ void handleClientInit(const boost::function<void()>& initFunction,
    sessionInfo["python_repl_active"] = modules::reticulate::isReplActive();
    
    // propagate RETICULATE_PYTHON if set
-   sessionInfo["reticulate_python"] = core::system::getenv("RETICULATE_PYTHON");
+   std::string reticulate_python = core::system::getenv("RETICULATE_PYTHON");
+   if (reticulate_python.empty())
+      reticulate_python = core::system::getenv("RETICULATE_PYTHON_FALLBACK");
+   sessionInfo["reticulate_python"] = reticulate_python;
    
    // get current console language
    sessionInfo["console_language"] = modules::reticulate::isReplActive() ? "Python" : "R";

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -816,10 +816,11 @@ bool augmentTerminalProcessPython(ConsoleProcessPtr cp)
    if (!prefs::userPrefs().terminalPythonIntegration())
       return false;
    
-   // forward RETICULATE_PYTHON if set
-   std::string reticulatePython = modules::reticulate::reticulatePython();
-   if (!reticulatePython.empty())
-      cp->setenv("RETICULATE_PYTHON", reticulatePython);
+   // forward RETICULATE_PYTHON_FALLBACK if set
+   std::string reticulatePythonFallback = modules::reticulate::reticulatePython();
+
+   if (!reticulatePythonFallback.empty())
+      cp->setenv("RETICULATE_PYTHON_FALLBACK", reticulatePythonFallback);
    
    // forward CONDA_PREFIX if set
    // use custom environment variable name since the user profile
@@ -832,7 +833,7 @@ bool augmentTerminalProcessPython(ConsoleProcessPtr cp)
 
    // return true if we have a configured version of python
    // (indicating that we want terminal hooks to be installed)
-   return !reticulatePython.empty();
+   return !reticulatePythonFallback.empty();
 }
 
 void useTerminalHooks(ConsoleProcessPtr cp)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -16,20 +16,23 @@
 .rs.addJsonRpcHandler("python_active_interpreter", function()
 {
    pythonPath <- Sys.getenv("RETICULATE_PYTHON", unset = NA)
-   
+
+   if (is.na(pythonPath))
+      pythonPath <- Sys.getenv("RETICULATE_PYTHON_FALLBACK", unset = NA)
+
    info <- if (is.na(pythonPath))
    {
       .rs.python.invalidInterpreter(
          path = pythonPath,
          type = NULL,
-         reason = "RETICULATE_PYTHON is unset."
+         reason = "RETICULATE_PYTHON and RETICULATE_PYTHON_FALLBACK are unset."
       )
    }
    else
    {
       .rs.python.getPythonInfo(pythonPath, strict = TRUE)
    }
-   
+
    .rs.scalarListFromList(info)
 })
 
@@ -49,7 +52,7 @@
    historyFile <- file.path(envPath, "conda-meta/history")
    if (!file.exists(historyFile))
       return("")
-   
+
    # read first few lines
    contents <- readLines(historyFile, n = 2L, warn = FALSE)
    if (length(contents) < 2L)
@@ -69,21 +72,26 @@
    condabin <- file.path(dirname(conda), "../condabin", basename(conda))
    if (file.exists(condabin))
       conda <- condabin
-   
+
    # bail if conda wasn't found
    if (!file.exists(conda))
       return("")
-   
+
    .rs.canonicalizePath(conda)
-  
+
 })
 
 .rs.addFunction("python.findWindowsPython", function()
 {
-   # if 'py' is not available, nothing we can do
-   if (!nzchar(Sys.which("py")))
+   # if `py` and `python` are not available, nothing we can do
+   pythonCommands <- c("py", "python3", "python")
+   available <- nzchar(Sys.which(pythonCommands))
+
+   if (!any(available))
       return("")
-   
+   else
+      pythonCommand <- pythonCommands[available][1]
+
    # NOTE: ideally, we would just parse the output of 'py --list-paths',
    # but for whatever reason the '*' indicating the default version of
    # Python is omitted when run from RStudio, so we try to explicitly
@@ -93,17 +101,17 @@
    # influencing how the python session is launched
    pythonPath <- .rs.tryCatch(
       system2(
-         command = "py",
+         command = pythonCommand,
          args    = c("-E"),
          input   = "import sys; print(sys.executable)",
          stdout  = TRUE,
          stderr  = TRUE
       )
    )
-   
+
    if (inherits(pythonPath, "error"))
       return("")
-   
+
    pythonPath
 })
 
@@ -121,16 +129,16 @@
             return(python)
       }
    }
-   
+
    # check some pre-defined environment variables
-   vars <- c("RENV_PYTHON", "RETICULATE_PYTHON")
+   vars <- c("RENV_PYTHON", "RETICULATE_PYTHON", "RETICULATE_PYTHON_FALLBACK")
    for (var in vars)
    {
       value <- Sys.getenv(var, unset = NA)
       if (!is.na(value))
          return(value)
    }
-   
+
    # if this project has a local interpreter, use it
    if (!is.null(projectDir))
    {
@@ -138,15 +146,68 @@
       if (file.exists(projectPython))
          return(projectPython)
    }
-   
+
    # check version of Python configured by user
    prefsPython <- .rs.readUiPref("python_path")
    if (file.exists(prefsPython))
       return(path.expand(prefsPython))
-   
+
+   # on Windows, help users find a default version of Python if possible
+   if (.rs.platform.isWindows)
+   {
+     pythonPath <- .rs.python.findWindowsPython()
+     if (file.exists(pythonPath))
+       return(pythonPath)
+   }
+
+   # look for python + python3 on the PATH
+   if (!.rs.platform.isWindows)
+   {
+     python3 <- Sys.which("python3")
+     if (nzchar(python3) && python3 != "/usr/bin/python3")
+       return(python3)
+
+     python <- Sys.which("python")
+     if (nzchar(python) && python != "/usr/bin/python")
+     {
+       info <- .rs.python.interpreterInfo(python, NULL)
+       version <- numeric_version(info$version, strict = FALSE)
+       if (!is.na(version) && version >= "3.2")
+         return(python)
+     }
+   }
+
+   # if the user has Anaconda installed, then try auto-activating
+   # the base environment of that Anaconda installation
+   conda <- .rs.python.findCondaBinary()
+   if (file.exists(conda))
+   {
+     pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
+     python <- file.path(dirname(conda), pythonPath)
+     if (file.exists(python))
+       return(python)
+   }
+
+   # fall back to versions of python in /usr/bin if available
+   if (!.rs.platform.isWindows)
+   {
+     python3 <- Sys.which("python3")
+     if (nzchar(python3) && python3 == "/usr/bin/python3")
+       return(python3)
+
+     python <- Sys.which("python")
+     if (nzchar(python) && python == "/usr/bin/python")
+     {
+       info <- .rs.python.interpreterInfo(python, NULL)
+       version <- numeric_version(info$version, strict = FALSE)
+       if (!is.na(version) && version >= "3.2")
+         return(python)
+     }
+   }
+
    # no python found; return empty string placeholder
    ""
-   
+
 })
 
 .rs.addFunction("python.projectInterpreterPath", function(projectDir)
@@ -155,15 +216,15 @@
    pythonSuffixes <- if (.rs.platform.isWindows)
       c("Scripts/python.exe", "python.exe")
    else
-      c("bin/python", "bin/python3")
-   
+      c("bin/python3", "bin/python")
+
    # look within all top-level directories for an environment
    envPaths <- list.dirs(
       path = projectDir,
       full.names = TRUE,
       recursive = FALSE
    )
-   
+
    for (envPath in envPaths)
    {
       for (pythonSuffix in pythonSuffixes)
@@ -173,7 +234,7 @@
             return(pythonPath)
       }
    }
-   
+
    ""
 })
 
@@ -183,55 +244,55 @@
    activate <- .rs.readUiPref("python_project_environment_automatic_activate")
    if (!identical(activate, TRUE))
       return()
-   
+
    # find path to python interpreter for this project
    pythonPath <- .rs.python.configuredInterpreterPath(projectDir)
    if (!file.exists(pythonPath))
       return()
-   
+
    # normalize path (avoid following symlinks)
    pythonPath <- file.path(
       normalizePath(dirname(pythonPath), winslash = "/", mustWork = FALSE),
       basename(pythonPath)
    )
- 
+
    # add the Python directory to the PATH
    pythonBin <- dirname(pythonPath)
    .rs.prependToPath(pythonBin)
-   
+
    # if we have a Scripts directory, place that on the PATH as well
    # (primarily for Windows + conda environments)
    scriptsPath <- file.path(pythonBin, "Scripts")
    if (file.exists(scriptsPath))
       .rs.prependToPath(scriptsPath)
-   
+
    pythonInfo <- .rs.python.getPythonInfo(pythonPath, strict = TRUE)
-   
+
    # if this is a virtual environment, set VIRTUAL_ENV
    if (identical(pythonInfo$type, "virtualenv"))
    {
       envPath <- dirname(dirname(pythonPath))
       Sys.setenv(VIRTUAL_ENV = envPath)
    }
-   
+
    # if this is a conda environment, set CONDA_PREFIX
    if (identical(pythonInfo$type, "conda"))
    {
       condaPrefix <- pythonBin
       if (!.rs.platform.isWindows)
          condaPrefix <- dirname(condaPrefix)
-      
+
       Sys.setenv(CONDA_PREFIX = condaPrefix)
-      
+
       # also ensure that conda is placed on the PATH
       condaPath <- .rs.python.findCondaForEnvironment(condaPrefix)
       if (file.exists(condaPath))
          .rs.prependToPath(dirname(condaPath))
    }
-   
-   # also set RETICULATE_PYTHON so this python is used by default
-   Sys.setenv(RETICULATE_PYTHON = pythonPath)
-   
+
+   # also set RETICULATE_PYTHON_FALLBACK so this python is used by default
+   Sys.setenv(RETICULATE_PYTHON_FALLBACK = pythonPath)
+
    # return path to python
    invisible(pythonPath)
 })
@@ -239,17 +300,17 @@
 .rs.addFunction("python.execute", function(python, code)
 {
    python <- normalizePath(python, winslash = "/", mustWork = TRUE)
-   
+
    args <- c("-E", "-c", shQuote(code))
    result <- suppressWarnings(
       system2(python, args, stdout = TRUE, stderr = TRUE)
    )
-   
+
    # propagate failure as error
    status <- .rs.nullCoalesce(attr(result, "status", exact = TRUE), 0L)
    if (!identical(status, 0L))
       .rs.stopf("error retrieving Python version [error code %i]", status)
-   
+
    paste(result, collapse = "\n")
 })
 
@@ -267,26 +328,26 @@
 {
    # default to concluding python binary path == requested path
    pythonPath <- path
-   
+
    # if this is the path to an existing file, use the directory path
    info <- file.info(path, extra_cols = FALSE)
    if (identical(info$isdir, FALSE))
       path <- dirname(path)
-   
+
    # if this is the path to the 'root' of an environment,
    # start from the associated bin / scripts directory
    binExt <- if (.rs.platform.isWindows) "Scripts" else "bin"
    binPath <- file.path(path, binExt)
    if (file.exists(binPath))
       path <- binPath
-      
+
    # now form the python path
    if (!strict)
    {
       exe <- if (.rs.platform.isWindows) "python.exe" else "python"
       pythonPath <- file.path(path, exe)
    }
-   
+
    # if this python doesn't exist, bail
    if (!file.exists(pythonPath))
    {
@@ -295,42 +356,42 @@
          type = NULL,
          reason = "There is no Python interpreter available at this location."
       )
-      
+
       return(info)
    }
-   
+
    # check for conda environment
    # (look for folders normally seen in conda installations)
    condaFiles <- c("../conda-meta", "../condabin")
    condaPaths <- file.path(path, condaFiles)
    if (any(file.exists(condaPaths)))
       return(.rs.python.interpreterInfo(pythonPath, "conda"))
- 
+
    # check for virtual environment
    # (look for files normally seen in virtual envs)
    venvFiles <- c("activate", "pyvenv.cfg", "../pyvenv.cfg")
    venvPaths <- file.path(path, venvFiles)
    if (any(file.exists(venvPaths)))
       return(.rs.python.interpreterInfo(pythonPath, "virtualenv"))
-   
+
    # default to assuming a system interpreter
    .rs.python.interpreterInfo(pythonPath, "system")
-   
+
 })
 
 .rs.addFunction("python.interpreterInfo", function(path, type)
 {
    # prefer UTF-8 path when possible
    path <- enc2utf8(path)
-   
+
    # prefer unix-style slashes
    path <- chartr("\\", "/", path)
-   
+
    # defaults for version, description
    valid <- TRUE
    version <- "[unknown]"
    description <- "[unknown]"
-   
+
    # determine interpreter version
    version <- tryCatch(
       .rs.python.getPythonVersion(path),
@@ -339,7 +400,7 @@
          conditionMessage(e)
       }
    )
-   
+
    # determine interpreter description
    description <- tryCatch(
       .rs.python.getPythonDescription(path),
@@ -348,7 +409,7 @@
          conditionMessage(e)
       }
    )
-   
+
    list(
       path        = .rs.createAliasedPath(path),
       type        = type,
@@ -382,14 +443,14 @@
       .rs.python.findPythonVirtualEnvironments(),
       .rs.python.findPythonCondaEnvironments()
    ))
-   
+
    default <- Sys.getenv("RETICULATE_PYTHON", unset = "")
-   
+
    list(
       python_interpreters = .rs.scalarListFromList(interpreters),
       default_interpreter = .rs.scalar(default)
    )
-   
+
 })
 
 .rs.addFunction("python.findPythonProjectInterpreters", function()
@@ -397,13 +458,13 @@
    projectDir <- .rs.getProjectDirectory()
    if (is.null(projectDir))
       return(list())
-   
+
    candidateDirs <- list.files(
       path = projectDir,
       all.files = TRUE,
       full.names = TRUE
    )
-   
+
    pythonSuffix <- if (.rs.platform.isWindows) "Scripts/python.exe" else "bin/python"
    candidatePaths <- file.path(candidateDirs, pythonSuffix)
    pythonPaths <- Filter(file.exists, candidatePaths)
@@ -413,35 +474,35 @@
 .rs.addFunction("python.findPythonSystemInterpreters", function()
 {
    interpreters <- list()
-   
+
    # look for interpreters on the PATH
    paths <- strsplit(Sys.getenv("PATH"), split = .Platform$path.sep, fixed = TRUE)[[1]]
    paths <- unique(normalizePath(paths, winslash = "/", mustWork = FALSE))
-   
+
    for (path in paths)
    {
-      
+
       # skip fake broken Windows Python interpreters
       skip <-
          .rs.platform.isWindows &&
          grepl("AppData\\Local\\Microsoft\\WindowsApps", path, fixed = TRUE)
-      
+
       if (skip)
          next
-      
+
       # create pattern matching interpreter paths
       pattern <- if (.rs.platform.isWindows)
          "^python[[:digit:].]*exe$"
       else
          "^python[[:digit:].]*$"
-      
+
       # look for python installations
       pythons <- list.files(
          path       = path,
          pattern    = pattern,
          full.names = TRUE
       )
-      
+
       # loop over interpreters and add them
       for (python in pythons)
       {
@@ -454,41 +515,41 @@
             if (grepl(pattern, link))
                next
          }
-         
+
          # add the interpreter
          info <- .rs.python.getPythonInfo(python, strict = TRUE)
          interpreters[[length(interpreters) + 1]] <- info
       }
-      
+
    }
-   
+
    interpreters
-   
+
 })
 
 .rs.addFunction("python.findPythonInterpretersInKnownLocations", function()
 {
    # set of discovered paths
    pythonPaths <- character()
-   
+
    # Python root paths we'll search in
    roots <- if (.rs.platform.isWindows) {
-      
+
       # find path to Windows local app data folder
       localAppData <- local({
-         
+
          path <- Sys.getenv("LOCALAPPDATA", unset = NA)
          if (!is.na(path))
             return(path)
-         
+
          profile <- Sys.getenv("USERPROFILE", unset = NA)
          if (!is.na(profile))
             return(file.path(profile, "AppData\\Local"))
-         
+
          ""
-         
+
       })
-      
+
       # system-installs of Python might be in one of these folders
       drive <- Sys.getenv("SYSTEMDRIVE", unset = "C:")
       suffixes <- c("/", "/Program Files", "/Program Files (x86)")
@@ -497,20 +558,20 @@
          paste0(drive, suffixes),
          file.path(localAppData, "Programs/Python")
       )
-      
+
    } else {
-      
+
       c(
          "/opt/python",
          "/opt/local/python",
          "/usr/local/opt/python"
       )
-      
+
    }
-   
+
    # also include those defined via option
    roots <- c(roots, getOption("rstudio.python.installationPath"))
-      
+
    # check and see if any of these roots point directly
    # to a particular version of Python.
    #
@@ -519,60 +580,60 @@
    suffixes <- if (.rs.platform.isWindows) {
       c("Scripts/python.exe", "python.exe")
    } else {
-      c("bin/python", "bin/python3")
+      c("bin/python3", "bin/python")
    }
-   
+
    paths <- vapply(roots, function(root) {
       paths <- file.path(root, suffixes)
       paths[file.exists(paths)][1]
    }, FUN.VALUE = character(1))
-   
+
    # collect the discovered python paths, if any
    exists <- !is.na(paths)
    pythonPaths <- c(pythonPaths, paths[exists])
    roots <- roots[!exists]
-   
+
    # treat any remaining root directories as versioned roots
    roots <- list.files(roots, full.names = TRUE)
-   
+
    # check and see if any of these roots point directly
    # to a particular version of Python
    paths <- vapply(roots, function(root) {
       paths <- file.path(root, suffixes)
       paths[file.exists(paths)][1]
    }, FUN.VALUE = character(1))
-   
+
    # collect the discovered python paths, if any
    exists <- !is.na(paths)
    pythonPaths <- c(pythonPaths, paths[exists])
-   
+
    # return the discovered paths
    lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
-   
+
 })
 
 .rs.addFunction("python.findPythonPyenvInterpreters", function()
 {
    root <- Sys.getenv("PYENV_ROOT", unset = "~/.pyenv")
-   
+
    # on Windows, Python interpreters are normally part of pyenv-windows
    if (.rs.platform.isWindows)
       root <- file.path(root, "pyenv-win")
-   
+
    # get path to roots of Python installations
    versionsPath <- file.path(root, "versions")
    pythonRoots <- list.files(versionsPath, full.names = TRUE)
-   
+
    # form path to Python binaries
    stem <- if (.rs.platform.isWindows) "python.exe" else "bin/python"
    pythonPaths <- file.path(pythonRoots, stem)
-   
+
    # exclude anything that doesn't exist for some reason
    pythonPaths <- pythonPaths[file.exists(pythonPaths)]
-   
+
    # get interpreter info for each found
    lapply(pythonPaths, .rs.python.getPythonInfo, strict = TRUE)
-   
+
 })
 
 .rs.addFunction("python.findCondaBinary", function()
@@ -585,12 +646,12 @@
       if (nzchar(conda))
          return(conda)
    }
-   
+
    # look on PATH
    conda <- Sys.which("conda")
    if (nzchar(conda))
       return(conda)
-   
+
    # look in some default locations
    if (.rs.platform.isWindows)
    {
@@ -610,19 +671,19 @@
          "/miniconda3"
       )
    }
-   
+
    condaSuffix <- if (.rs.platform.isWindows)
       "condabin/conda.bat"
    else
       "condabin/conda"
-   
+
    condaPaths <- file.path(condaRoots, condaSuffix)
    for (condaPath in condaPaths)
       if (file.exists(condaPath))
          return(path.expand(condaPath))
-   
+
    ""
-   
+
 })
 
 .rs.addFunction("python.findPythonCondaEnvironments", function()
@@ -631,12 +692,12 @@
    conda <- .rs.python.findCondaBinary()
    if (!file.exists(conda))
       return(NULL)
-   
+
    # ask it for environments
    args <- c("env", "list", "--json", "--quiet")
    tmp <- tempfile()
    output <- system2(conda, args, stdout = TRUE, stderr = tmp)
-   
+
    status <- .rs.nullCoalesce(attr(output, "status", exact = TRUE), 0L)
    if (!identical(status, 0L)) {
      errors <- paste(readLines(tmp), collapse = "\n")
@@ -644,26 +705,26 @@
    }
    json <- .rs.fromJSON(paste(output, collapse = "\n"))
    envList <- unlist(json$envs)
-   
+
    # prefer unix separators
    if (.rs.platform.isWindows)
       envList <- chartr("\\", "/", envList)
-   
+
    # ignore certain special environments
    ignorePatterns <- c("/revdep/", "/basilisk/", "/renv/python/condaenvs/")
    pattern <- sprintf("(?:%s)", paste(ignorePatterns, collapse = "|"))
    envList <- grep(pattern, envList, value = TRUE, invert = TRUE)
-   
+
    # get paths to Python in each environment
    pythonSuffix <- if (.rs.platform.isWindows) "python.exe" else "bin/python"
    pythonPaths <- file.path(envList, pythonSuffix)
-   
+
    # only keep existing
    pythonPaths <- Filter(file.exists, pythonPaths)
-   
+
    # drop duplicates, just in case
    pythonPaths <- unique(normalizePath(pythonPaths, winslash = "/"))
-   
+
    # get information for each environment
    lapply(pythonPaths, .rs.python.getCondaEnvironmentInfo)
 })
@@ -690,7 +751,7 @@
       "Scripts/python.exe"
    else
       "bin/python"
-   
+
    # form executable path (ensure it exists)
    exePath <- file.path(envPath, exeSuffix)
    if (!file.exists(exePath))
@@ -703,12 +764,12 @@
          reason = reason
       ))
    }
-   
+
    .rs.python.interpreterInfo(
       path = exePath,
       type = "virtualenv"
    )
-   
+
 })
 
 .rs.addFunction("python.describeInterpreter", function(pythonPath)

--- a/src/cpp/session/modules/SessionPythonEnvironments.R
+++ b/src/cpp/session/modules/SessionPythonEnvironments.R
@@ -157,7 +157,7 @@
    {
      pythonPath <- .rs.python.findWindowsPython()
      if (file.exists(pythonPath))
-       return(pythonPath)
+        return(pythonPath)
    }
 
    # look for python + python3 on the PATH
@@ -165,7 +165,7 @@
    {
      python3 <- Sys.which("python3")
      if (nzchar(python3) && python3 != "/usr/bin/python3")
-       return(python3)
+        return(python3)
 
      python <- Sys.which("python")
      if (nzchar(python) && python != "/usr/bin/python")
@@ -173,7 +173,7 @@
        info <- .rs.python.interpreterInfo(python, NULL)
        version <- numeric_version(info$version, strict = FALSE)
        if (!is.na(version) && version >= "3.2")
-         return(python)
+          return(python)
      }
    }
 
@@ -185,7 +185,7 @@
      pythonPath <- if (.rs.platform.isWindows) "../python.exe" else "../bin/python"
      python <- file.path(dirname(conda), pythonPath)
      if (file.exists(python))
-       return(python)
+        return(python)
    }
 
    # fall back to versions of python in /usr/bin if available
@@ -193,7 +193,7 @@
    {
      python3 <- Sys.which("python3")
      if (nzchar(python3) && python3 == "/usr/bin/python3")
-       return(python3)
+        return(python3)
 
      python <- Sys.which("python")
      if (nzchar(python) && python == "/usr/bin/python")
@@ -201,7 +201,7 @@
        info <- .rs.python.interpreterInfo(python, NULL)
        version <- numeric_version(info$version, strict = FALSE)
        if (!is.na(version) && version >= "3.2")
-         return(python)
+          return(python)
      }
    }
 

--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -181,21 +181,21 @@ public:
 
          if (!reticulatePython.empty())
          {
-            // we found a Python version; forward it
-            core::system::setenv(&env, "RETICULATE_PYTHON", reticulatePython);
+            // we found a Python version; forward it to RETICULATE_PYTHON_FALLBACK
+            core::system::setenv(&env, "RETICULATE_PYTHON_FALLBACK", reticulatePython);
 
             // if showing publishing diagnostics, emit the version of Python
             // we're forwarding (for troubleshooting purposes)
             if (prefs::userPrefs().showPublishDiagnostics())
             {
-               cmd += "cat('Set RETICULATE_PYTHON = \"" +
+               cmd += "cat('Set RETICULATE_PYTHON_FALLBACK = \"" +
                   string_utils::singleQuotedStrEscape(reticulatePython) + "\"\n'); ";
             }
          }
          else if (prefs::userPrefs().showPublishDiagnostics())
          {
             // if we didn't find Python, note as such
-            cmd += "cat('RETICULATE_PYTHON unset (no Python installation found)\n'); ";
+            cmd += "cat('RETICULATE_PYTHON_FALLBACK unset (no Python installation found)\n'); ";
          }
       }
    

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -156,7 +156,7 @@
    
    # write bundle to file
    # (suppress 'may not be available when loading' warnings)
-   suppressWarnings(saveRDS(bundlle, file = "bundle.rds"))
+   suppressWarnings(saveRDS(bundle, file = "bundle.rds"))
    
    # write script to file
    writeLines(deparse(script), con = "script.R")

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -97,6 +97,7 @@
                                                           data = list(),
                                                           workingDir = NULL,
                                                           libPaths = .libPaths(),
+                                                          returnVal = FALSE,
                                                           ...)
 {
    # create and move to directory we'll use to stage our scripts
@@ -124,7 +125,8 @@
    bundle <- list(
       callback   = callback,
       data       = data,
-      workingDir = workingDir
+      workingDir = workingDir,
+      returnVal  = returnVal
    )
    
    # define runner script (will load data and execute user-defined callback)
@@ -144,15 +146,17 @@
       # retrieve callback data
       callback <- bundle[["callback"]]
       data     <- bundle[["data"]]
+      returnVal <- bundle[["returnVal"]]
       
       # execute callback
-      do.call(callback, data)
-      
+      rval <- do.call(callback, data)
+      if (returnVal)
+         saveRDS(object = rval, file = "output.rds")
    })
    
    # write bundle to file
    # (suppress 'may not be available when loading' warnings)
-   suppressWarnings(saveRDS(bundle, file = "bundle.rds"))
+   suppressWarnings(saveRDS(bundlle, file = "bundle.rds"))
    
    # write script to file
    writeLines(deparse(script), con = "script.R")
@@ -166,7 +170,9 @@
    
    # run the script
    system2(r, args, ...)
-   
+   # if callback has a return value, read in the serialized value and return it
+   if (returnVal)
+      return(readRDS("output.rds"))
 })
 
 # NOTE: this uses a bundled YAML library in the IDE as opposed to the R

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -91,6 +91,9 @@
 #' @param libPaths The library paths to be set and used by the child process.
 #'   By default, the parent's library paths are used.
 #'
+#' @param returnVal Whether or not the callback should return a value. By
+#'   default, nothing will be returned.
+#'
 #' @param ... Optional arguments passed to `system2()`.
 #' 
 .rs.addFunction("executeFunctionInChildProcess", function(callback, 

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -2074,12 +2074,17 @@ options(reticulate.repl.teardown = function()
    # if the user has configured RStudio to use a particular version
    # of Python, then use that
    python <- .rs.readUiPref("python_path")
-   if (!is.null(python))
+   if (!is.null(python) && !identical(python, ""))
       return(path.expand(python))
    
    
    # if reticulate is installed, then try to load it in a child process and 
    # ask what version of Python it would choose to bind to.
+   
+   # Use existing RETICULATE_PYTHON_FALLBACK if set
+   python <- Sys.getenv("RETICULATE_PYTHON_FALLBACK", unset = NA)
+   if (!is.na(python))
+     return(python)
    if (.rs.isPackageInstalled("reticulate")) {
       
       # avoid miniconda prompts

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -2084,7 +2084,7 @@ options(reticulate.repl.teardown = function()
    # Use existing RETICULATE_PYTHON_FALLBACK if set
    python <- Sys.getenv("RETICULATE_PYTHON_FALLBACK", unset = NA)
    if (!is.na(python))
-     return(python)
+      return(python)
    if (.rs.isPackageInstalled("reticulate")) {
       
       # avoid miniconda prompts

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -2093,13 +2093,14 @@ options(reticulate.repl.teardown = function()
 
       # Then perform a Python version scan/discovery
       # do this in child process so we don't pollute the namespace
+      # callback must be passed as a func within a func to avoid loading reticulate
       py_config <- NULL
-      tryCatch({
+       tryCatch({
          py_config <- .rs.executeFunctionInChildProcess(
-            callback   = reticulate::py_discover_config,
+            callback   = function() reticulate::py_discover_config(),
             returnVal  = TRUE
          )
-      }, finally = {
+       }, finally = {
          Sys.setenv(RETICULATE_MINICONDA_ENABLED = prev_miniconda)
       })
 

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -2095,10 +2095,9 @@ options(reticulate.repl.teardown = function()
       # do this in child process so we don't pollute the namespace
       # callback must be passed as a func within a func to avoid loading reticulate
       py_config <- NULL
-       tryCatch({
+      tryCatch({
          py_config <- .rs.executeFunctionInChildProcess(
-            callback   = function() reticulate::py_discover_config(),
-            returnVal  = TRUE
+            callback   = function() reticulate::py_discover_config()
          )
        }, finally = {
          Sys.setenv(RETICULATE_MINICONDA_ENABLED = prev_miniconda)

--- a/src/cpp/session/modules/SessionReticulate.cpp
+++ b/src/cpp/session/modules/SessionReticulate.cpp
@@ -56,6 +56,8 @@ void updateReticulatePython(bool forInit)
    s_reticulatePython = core::system::getenv("RETICULATE_PYTHON");
    if (s_reticulatePython.empty())
    {
+      // Will check if RETICULATE_PYTHON_FALLBACK is set,
+      // unless higher priority Python config has already been found
       Error error = r::exec::RFunction(".rs.inferReticulatePython")
             .call(&s_reticulatePython);
 

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -645,7 +645,7 @@ private:
       if (!reticulatePython.empty())
       {
          // we found a Python version; forward it
-         environment.push_back({"RETICULATE_PYTHON", reticulatePython});
+         environment.push_back({"RETICULATE_PYTHON_FALLBACK", reticulatePython});
          
          // also update the PATH so this version of Python is visible
          core::system::addToPath(

--- a/src/cpp/session/resources/terminal/hooks
+++ b/src/cpp/session/resources/terminal/hooks
@@ -59,9 +59,13 @@ if [ -n "${_RS_CONDA_PREFIX}" ]; then
 
 fi
 
-if [ -f "${RETICULATE_PYTHON}" ]; then
+if [ -f "${RETICULATE_PYTHON}" ] || [ -f "${RETICULATE_PYTHON_FALLBACK}" ]; then
 
-	_RS_PYTHON_BIN=$(dirname "${RETICULATE_PYTHON}")
+   if [ -f "${RETICULATE_PYTHON}" ]; then
+      _RS_PYTHON_BIN=$(dirname "${RETICULATE_PYTHON}")
+   else
+      _RS_PYTHON_BIN=$(dirname "${RETICULATE_PYTHON_FALLBACK}")
+   fi
 
 	# munge path for MINGW32 if necessary
 	case "$(uname -s)" in


### PR DESCRIPTION
### Intent

Addresses #9990 by unreverting the original code, and adding additional code to `src/cpp/session/modules/SessionRUtil.R` and `src/cpp/session/modules/SessionReticulate.R` to avoid the issue of reticulate automatically being loaded into the user's namespace at startup, as detailed in #11566

### Approach

- Update the .rs.executeFunctionInChildProcess() function to handle return values
- Use .rs.executeFunctionInChildProcess() in .rs.inferReticulatePython so we can run `reticulate::py_discover_config()` without loading reticulate + friends into the namespace

### Automated Tests

None

### QA Notes

See both #9990 and #11566 for details

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


