### PR TITLE
Don't reload rmarkdown/yaml if already loading

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Improved handling of missing arguments for some functions in the diagnostics system.
 * Code editor can show previews of color in strings (R named colors e.g. "tomato3" or of the forms "#rgb", "#rrggbb", "#rrggbbaa")
   when `Options > Code > Display > [ ] Show color preview` is checked. 
+* Fixes the bug introduced with `rlang` >= 1.03 where Rmd documents show the error message `object 'partition_yaml_front_matter' not found` upon project startup (#11552)
   
 ### Python
 

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2287,6 +2287,7 @@
    # for R Markdown docs, scan the YAML header (requires the rmarkdown package and the yaml package,
    # a dependency of rmarkdown)
    if (identical(extension, ".Rmd") &&
+       is.null(dynGet("__NameSpacesLoading__", NULL)) &&
        requireNamespace("rmarkdown", quietly = TRUE) &&
        requireNamespace("yaml", quietly = TRUE))
    {


### PR DESCRIPTION
### Intent

Addresses #11552 

### Approach

Before calling `requireNamespace()` which loads the package, we check that packages are not already loading. Not sure if we want to specifically check that rmarkdown/yaml aren't already loading? But this appears to fix the error message, and the appropriate packages (e.g. rmarkdown, yaml, rlang) all get loaded into the namespace

### Automated Tests

None
### QA Notes

R version shouldn't matter. rlang version for testing must be >= 1.03, as the issue only exists in very recent rlang releases. Must have at least 2 Rmd files open. Check that rmarkdown, yaml, and any packages references in the open Rmd files end up in `loadedNamespaces()` at project startup.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


