### PR TITLE
Fix $ autocompletion of underscores followed by a number

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 * Code editor can show previews of color in strings (R named colors e.g. "tomato3" or of the forms "#rgb", "#rrggbb", "#rrggbbaa")
   when `Options > Code > Display > [ ] Show color preview` is checked. 
 * Fixes the bug introduced with `rlang` >= 1.03 where Rmd documents show the error message `object 'partition_yaml_front_matter' not found` upon project startup (#11552)
+* $ completion now correctly quotes names that start with underscore followed by a number.
   
 ### Python
 

--- a/src/gwt/src/org/rstudio/core/client/RegexUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/RegexUtil.java
@@ -33,7 +33,7 @@ public class RegexUtil
    {
       String regex =
             "^" +
-            "(?![0-9])" +
+            "(?!_*[0-9])" +
             "[" + WORD_CHARACTER + ".]" +
             "[" + WORD_CHARACTER +  "._]*" +
             "$";


### PR DESCRIPTION
### Intent

> Fix the issue I raised regarding autocompletion (#11689).

### Approach

> Fix up the regex that determines if backticks should be used or not.

### Automated Tests

> N/A

### QA Notes

> I don't believe anything could go wrong but I don't really know how everything fits together.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->



----

### My initial PR message
Sorry I am new to this and got rid of your boiler plate text initially. But I think this is more informative than the above.


#### Preamble

I don't know much about Java or pull requests or very much at all for that matter (I am but a humble R user) but one thing I do know is that RStudio auto-complete has a slight bug in it, so I thought I'd have a crack at fixing it.

#### The issue

In $ autocompletion, if I was to create the following list, say:
```r
x <- list("_0" = NA)
```
and then attempt to autocomplete with `x$`, I obtain this:
```
x$_0
#> Error: unexpected input in "x$_"
```

when I should be getting:
```
x$`_0`
#> [1] NA
```

#### The solution

After trawling through code  I barely understood (starting with where the code uses the  `utils::.DollarNames` R function and then finding myself in the uncharted territory of Java code), I discovered a regex which I beleive to be the driving force behind which names are *backticked*. I don't beleive this would have any unintended flow on effects but I am pretty sure it will fix the problem (based on my quick and dirty R code):
```
paste0("^",
  "(?![0-9])",
  "[\\w.]",
  "[\\w._]*",
  "$") -> regex_original
paste0("^",
  "(?!_*[0-9])",
  "[\\w.]",
  "[\\w._]*",
  "$") -> regex_fixed

string <- c("___adsadasd", "_9sdasd", "asdsadas", "9sdasdasd", "___9sdasdasd")

stringr::str_detect(string, regex_original)
#> [1]  TRUE  TRUE  TRUE FALSE  TRUE
stringr::str_detect(string, regex_fixed)
#> [1]  TRUE FALSE  TRUE FALSE FALSE
```
