### PR TITLE
Use rockylinux base image, was rockylinux/rockylinux

### DIFF
--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -1,5 +1,5 @@
 ARG ARCH=amd64
-FROM --platform=linux/$ARCH rockylinux/rockylinux:8
+FROM --platform=linux/$ARCH rockylinux:8
 ARG ARCH
 
 ENV OPERATING_SYSTEM=rockylinux_8


### PR DESCRIPTION
The official RockyLinux docker image is `rockylinux`

### Intent

The `rockylinux/rockylinux` image is not the official docker image.

### Approach

Changed base image to use official `rockylinux` image

### Automated Tests

This will update the image used in Jenkins

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
