### PR TITLE
Electron instance handling with file open events

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -68,6 +68,7 @@ used by these components are included below):
 - properties-reader (npm)
 - json-schema-to-typescript (npm)
 - lodash.debounce (npm)
+- net-ipc (npm)
 
 Windows builds of RStudio also include a binary copy of libclang. This
 component is licensed to you under the Apache License v2.0 with LLVM
@@ -4621,3 +4622,27 @@ Files located in the node_modules and vendor directories are externally
 maintained libraries used by this software which have their own
 licenses; we recommend you read them, as their terms may differ from the
 terms above.
+
+net-ipc
+----------------------------------------------------------------------
+MIT License
+
+Copyright (c) 2020 timotejroiko
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -16,6 +16,7 @@
         "i18next": "21.8.13",
         "line-reader": "0.4.0",
         "lodash.debounce": "4.0.8",
+        "net-ipc": "2.0.1",
         "node-addon-api": "5.0.0",
         "node-system-fonts": "1.0.1",
         "properties-reader": "2.2.0",
@@ -1282,6 +1283,78 @@
       "engines": {
         "node": ">= 12.13.0"
       }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha512-FMX5i7a+ojIguHpWbzh5MCsCouJkwf4z4ejdUY/fsgB9Vkdak4ZnoIEskOyOUMMB4lctiZFGszFQJXUeFL8tRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-DznYtF3lHuZDSRaIOYeif4JgO0NtO2Xf8DsngAugMx/bUdTFbg86jDTmkVJBNmV+cxszz6OjGvinnS8AbJ342g==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.0.2.tgz",
+      "integrity": "sha512-Gy9+c3Wj+rUlD3YvCZTi92gs+cRX7ZQogtwq0IhRenloTTlsbpezNgk6OCkt59V4ATEWSic9rbU92H/l7XsRvA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.0.2.tgz",
+      "integrity": "sha512-b0jMEo566YdM2K+BurSed7bswjo3a6bcdw5ETqoIfSuxKuRLPfAiOjVbZyZBgx3J/TAM/QrvEQ/VN89A0ZAxSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.0.2.tgz",
+      "integrity": "sha512-zrBHaePwcv4cQXxzYgNj0+A8I1uVN97E7/3LmkRocYZ+rMwUsnPpp4RuTAHSRoKlTQV3nSdCQW4Qdt4MXw/iHw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.0.2.tgz",
+      "integrity": "sha512-fpnI00dt+yO1cKx9qBXelKhPBdEgvc8ZPav1+0r09j0woYQU2N79w/jcGawSY5UGlgQ3vjaJsFHnGbGvvqdLzg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6065,6 +6138,16 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "node_modules/fast-zlib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-zlib/-/fast-zlib-2.0.1.tgz",
+      "integrity": "sha512-DCoYgNagM2Bt1VIpXpdGnRx4LzqJeYG0oh6Nf/7cWo6elTXkFGMw9CrRCYYUIapYNrozYMoyDRflx9mgT3Awyw==",
+      "optional": true,
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/timotejroiko"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -9257,6 +9340,33 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/msgpackr": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.1.tgz",
+      "integrity": "sha512-Je+xBEfdjtvA4bKaOv8iRhjC8qX2oJwpYH4f7JrG4uMVJVmnmkAT4pjKdbztKprGj3iwjcxPzb5umVZ02Qq3tA==",
+      "optional": true,
+      "optionalDependencies": {
+        "msgpackr-extract": "^2.0.2"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.0.2.tgz",
+      "integrity": "sha512-coskCeJG2KDny23zWeu+6tNy7BLnAiOGgiwzlgdm4oeSsTpqEJJPguHIuKZcCdB7tzhZbXNYSg6jZAXkZErkJA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.2"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.0.2"
+      }
+    },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -9324,6 +9434,19 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/net-ipc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/net-ipc/-/net-ipc-2.0.1.tgz",
+      "integrity": "sha512-4HLjZ/Xorj4kxA7WUajF2EAXlS+OR+XliDLkqQA53Wm7eIr/hWLjdXt4zzB6q4Ii8BB+HbuRbM9yLov3+ttRUw==",
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/timotejroiko"
+      },
+      "optionalDependencies": {
+        "fast-zlib": "^2.0.1",
+        "msgpackr": "^1.3.2"
+      }
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
@@ -9462,6 +9585,17 @@
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.2.tgz",
+      "integrity": "sha512-PiN4NWmlQPqvbEFcH/omQsswWQbe5Z9YK/zdB23irp5j2XibaA2IrGvpSWmVVG4qMZdmPdwPctSy4a86rOMn6g==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-test": "build-test.js"
       }
     },
@@ -14793,6 +14927,42 @@
         "cross-spawn": "^7.0.1"
       }
     },
+    "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-2.0.2.tgz",
+      "integrity": "sha512-FMX5i7a+ojIguHpWbzh5MCsCouJkwf4z4ejdUY/fsgB9Vkdak4ZnoIEskOyOUMMB4lctiZFGszFQJXUeFL8tRg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-2.0.2.tgz",
+      "integrity": "sha512-DznYtF3lHuZDSRaIOYeif4JgO0NtO2Xf8DsngAugMx/bUdTFbg86jDTmkVJBNmV+cxszz6OjGvinnS8AbJ342g==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-2.0.2.tgz",
+      "integrity": "sha512-Gy9+c3Wj+rUlD3YvCZTi92gs+cRX7ZQogtwq0IhRenloTTlsbpezNgk6OCkt59V4ATEWSic9rbU92H/l7XsRvA==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-2.0.2.tgz",
+      "integrity": "sha512-b0jMEo566YdM2K+BurSed7bswjo3a6bcdw5ETqoIfSuxKuRLPfAiOjVbZyZBgx3J/TAM/QrvEQ/VN89A0ZAxSg==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-2.0.2.tgz",
+      "integrity": "sha512-zrBHaePwcv4cQXxzYgNj0+A8I1uVN97E7/3LmkRocYZ+rMwUsnPpp4RuTAHSRoKlTQV3nSdCQW4Qdt4MXw/iHw==",
+      "optional": true
+    },
+    "@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-2.0.2.tgz",
+      "integrity": "sha512-fpnI00dt+yO1cKx9qBXelKhPBdEgvc8ZPav1+0r09j0woYQU2N79w/jcGawSY5UGlgQ3vjaJsFHnGbGvvqdLzg==",
+      "optional": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18556,6 +18726,12 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "fast-zlib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-zlib/-/fast-zlib-2.0.1.tgz",
+      "integrity": "sha512-DCoYgNagM2Bt1VIpXpdGnRx4LzqJeYG0oh6Nf/7cWo6elTXkFGMw9CrRCYYUIapYNrozYMoyDRflx9mgT3Awyw==",
+      "optional": true
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -20969,6 +21145,30 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msgpackr": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.6.1.tgz",
+      "integrity": "sha512-Je+xBEfdjtvA4bKaOv8iRhjC8qX2oJwpYH4f7JrG4uMVJVmnmkAT4pjKdbztKprGj3iwjcxPzb5umVZ02Qq3tA==",
+      "optional": true,
+      "requires": {
+        "msgpackr-extract": "^2.0.2"
+      }
+    },
+    "msgpackr-extract": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-2.0.2.tgz",
+      "integrity": "sha512-coskCeJG2KDny23zWeu+6tNy7BLnAiOGgiwzlgdm4oeSsTpqEJJPguHIuKZcCdB7tzhZbXNYSg6jZAXkZErkJA==",
+      "optional": true,
+      "requires": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "2.0.2",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "2.0.2",
+        "node-gyp-build-optional-packages": "5.0.2"
+      }
+    },
     "multicast-dns": {
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
@@ -21024,6 +21224,15 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "net-ipc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/net-ipc/-/net-ipc-2.0.1.tgz",
+      "integrity": "sha512-4HLjZ/Xorj4kxA7WUajF2EAXlS+OR+XliDLkqQA53Wm7eIr/hWLjdXt4zzB6q4Ii8BB+HbuRbM9yLov3+ttRUw==",
+      "requires": {
+        "fast-zlib": "^2.0.1",
+        "msgpackr": "^1.3.2"
+      }
     },
     "next-tick": {
       "version": "1.1.0",
@@ -21138,6 +21347,12 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true
+    },
+    "node-gyp-build-optional-packages": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.2.tgz",
+      "integrity": "sha512-PiN4NWmlQPqvbEFcH/omQsswWQbe5Z9YK/zdB23irp5j2XibaA2IrGvpSWmVVG4qMZdmPdwPctSy4a86rOMn6g==",
+      "optional": true
     },
     "node-loader": {
       "version": "2.0.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -71,6 +71,7 @@
     "i18next": "21.8.13",
     "line-reader": "0.4.0",
     "lodash.debounce": "4.0.8",
+    "net-ipc": "2.0.1",
     "node-addon-api": "5.0.0",
     "node-system-fonts": "1.0.1",
     "properties-reader": "2.2.0",

--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -14,6 +14,7 @@
  */
 
 import { BrowserWindow, WebContents } from 'electron';
+import { Client, Server } from 'net-ipc';
 import { FilePath } from '../core/file-path';
 
 import { DesktopActivation } from './activation-overlay';
@@ -43,6 +44,8 @@ export interface AppState {
     | { action: 'deny' }
     | { action: 'allow'; overrideBrowserWindowOptions?: Electron.BrowserWindowConstructorOptions | undefined };
   windowCreated(newWindow: BrowserWindow, owner: WebContents, baseUrl?: string): void;
+  server?: Server;
+  client?: Client;
 }
 
 let rstudio: AppState | null = null;


### PR DESCRIPTION
### Intent
Implement single instance logic when opening a file at startup.
Addresses part of #11251 

### Approach
Before attempting to open a file at startup, request the instance lock. If obtained, the instance is the primary instance and should open the file. If not, it exits and the request would send an event to the primary instance that will open the file.

This brings in `net-ipc` to communicate locally among the instances using a Unix/Windows socket. This notifies other instances when the primary instance exits and allows one of the other instances to request the lock. It will then take over opening files that come from `Open With`.

If we do need more IPC events, this will provide everything that's necessary to communicate with the primary instance.

This may or may not fix it on Linux but I would expect it to work.

### Automated Tests
None

### QA Notes
* `rstudio.exe --log-level=DEBUG <some_path_to_a_file_to_open>` should open the file and activate an existing instance.
* if the file is a project then it will always open a new instance
* debug messages have been added to confirm the primary instance handover so check `~/AppData/Local/RStudio/log` (desktop log files are rotated by day)
   * the `net-ipc` messages are the instance handling messages
   * almost all of the `net-ipc` messages include the process id
   * it should log the process id that is the primary instance
   * secondary instances should log the process id and that it connected to the primary instance
   * closing the primary instance should show logs that the other instances disconnected and one of them took over as primary
   * NOTE: sometimes the logs for secondary instances don't flush to file because the logger we use doesn't really handle that very well

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


