### PR TITLE
Viewer pane save as image - Electron

### DIFF
--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -158,10 +158,7 @@ Error getViewerExportContext(const json::JsonRpcRequest& request,
    json::Array formats;
    formats.push_back(plotExportFormat("PNG", kPngFormat));
    formats.push_back(plotExportFormat("JPEG", kJpegFormat));
-   #ifndef __APPLE__
-      formats.push_back(plotExportFormat("BMP", kBmpFormat));
-   #endif // !__APPLE__
-   // TIFF and SVG formats not currently supported in Electron
+   // BMP, TIFF and SVG formats not currently supported in Electron
    contextJson["formats"] = formats;
 
    // get directory path -- if it doesn't exist revert to the current

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -158,11 +158,8 @@ Error getViewerExportContext(const json::JsonRpcRequest& request,
    json::Array formats;
    formats.push_back(plotExportFormat("PNG", kPngFormat));
    formats.push_back(plotExportFormat("JPEG", kJpegFormat));
-#ifdef __APPLE__
-   formats.push_back(plotExportFormat("TIFF", kTiffFormat));
-#else
    formats.push_back(plotExportFormat("BMP", kBmpFormat));
-#endif
+   // TIFF and SVG formats not currently supported in Electron
    contextJson["formats"] = formats;
 
    // get directory path -- if it doesn't exist revert to the current

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -158,7 +158,9 @@ Error getViewerExportContext(const json::JsonRpcRequest& request,
    json::Array formats;
    formats.push_back(plotExportFormat("PNG", kPngFormat));
    formats.push_back(plotExportFormat("JPEG", kJpegFormat));
-   formats.push_back(plotExportFormat("BMP", kBmpFormat));
+   #ifndef __APPLE__
+      formats.push_back(plotExportFormat("BMP", kBmpFormat));
+   #endif // !__APPLE__
    // TIFF and SVG formats not currently supported in Electron
    contextJson["formats"] = formats;
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -501,22 +501,18 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on('desktop_export_page_region_to_file', 
       (event, targetPath, format, left, top, width, height) => {
         const rect: Rectangle = { x: left, y: top, width, height };
-        logger().logDebug(`rect: ${rect.x} ${rect.y} ${rect.width} ${rect.height}`);
         targetPath = resolveAliasedPath(targetPath);
-        logger().logDebug(`targetPath: ${targetPath}`);
         this.mainWindow.window
           .capturePage(rect)
           .then((image) => {
             let buffer: Buffer;
-            if (format == 'BMP') {
+            if (format == 'bmp') {
               buffer = image.toBitmap();
-            } else if (format == 'JPEG') {
+            } else if (format == 'jpeg') {
               buffer = image.toJPEG(100);
             } else {
-              logger().logDebug('creating PNG');
               buffer = image.toPNG();
             }
-            logger().logDebug('writing file');
             writeFileSync(targetPath, buffer);
           })
           .catch((error) => {

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -506,9 +506,7 @@ export class GwtCallback extends EventEmitter {
           .capturePage(rect)
           .then((image) => {
             let buffer: Buffer;
-            if (format == 'bmp') {
-              buffer = image.toBitmap();
-            } else if (format == 'jpeg') {
+            if (format == 'jpeg') {
               buffer = image.toJPEG(100);
             } else {
               buffer = image.toPNG();


### PR DESCRIPTION
Addresses #11392 

follow up to #11705, can be merged first (this PR contains those changes as well)

Change supported file formats for viewer export to remove TIFF export option on Macs, keep BMP option for non Macs
Implement viewer callback in electron native image API