### PR TITLE
Fix python chunk execution with blank lines

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -170,9 +170,9 @@ void fixupPendingConsoleInput()
       return;
    
    // if this has no newlines, then nothing to do
-   auto index = input.text.find('\n');
-   if (index == std::string::npos)
-      return;
+   //auto index = input.text.find('\n');
+   //if (index == std::string::npos)
+   //   return;
    
    // if we're about to send code to the Python REPL, then
    // we need to fix whitespace in the code before sending
@@ -353,7 +353,7 @@ bool rConsoleRead(const std::string& prompt,
       }
       else
       {
-         popConsoleInput(pConsoleInput);
+            popConsoleInput(pConsoleInput);
       }
    }
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -353,7 +353,7 @@ bool rConsoleRead(const std::string& prompt,
       }
       else
       {
-            popConsoleInput(pConsoleInput);
+         popConsoleInput(pConsoleInput);
       }
    }
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -170,9 +170,9 @@ void fixupPendingConsoleInput()
       return;
    
    // if this has no newlines, then nothing to do
-   //auto index = input.text.find('\n');
-   //if (index == std::string::npos)
-   //   return;
+   auto index = input.text.find('\n');
+   if (index == std::string::npos)
+      return;
    
    // if we're about to send code to the Python REPL, then
    // we need to fix whitespace in the code before sending

--- a/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueue.cpp
@@ -283,7 +283,7 @@ private:
          execContext_->onExprComplete();
          
       ExecRange range;
-      std::string code = execUnit_->popExecRange(&range, mode);
+      std::string code = execUnit_->popExecRange(&range, mode, execContext_->engine());
       if (code.empty())
       {
          // no code to evaluate--skip this unit

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -240,7 +240,8 @@ json::Object NotebookQueueUnit::toJson() const
 }
 
 std::string NotebookQueueUnit::popExecRange(ExecRange* pRange, 
-                                            ExpressionMode mode)
+                                            ExpressionMode mode,
+                                            const std::string& engine)
 {
    // do we have any unevaluated code in this execution unit?
    if (pending_.empty())
@@ -258,9 +259,16 @@ std::string NotebookQueueUnit::popExecRange(ExecRange* pRange,
    int start = range.start;
    int stop = range.stop;
 
-   // use the first line of the range if it's multi-line
+   // for python chunks, use the entire range, even when it's multi-line
+   // otherwise, use the first line of the range if it's multi-line
    size_t idx = code_.find('\n', start + 1);
-   if (idx != std::string::npos && gsl::narrow_cast<int>(idx) < (stop - 1))
+   if (engine == "python")
+   {
+      code_ = code_ + "\n"; // add a newline to terminate the multiline chunk
+      stop = stop + 1;
+      pending_.pop_front();
+   }
+   else if (idx != std::string::npos && gsl::narrow_cast<int>(idx) < (stop - 1))
    {
       stop = gsl::narrow_cast<int>(idx);
 

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
@@ -64,7 +64,7 @@ public:
    core::json::Object toJson() const;
 
    core::Error parseOptions(core::json::Object* pOptions);
-   std::string popExecRange(ExecRange* pRange, ExpressionMode mode);
+   std::string popExecRange(ExecRange* pRange, ExpressionMode mode, const std::string& engine);
    bool complete() const;
    core::Error innerCode(std::string* pCode);
    void updateFrom(const NotebookQueueUnit& other);


### PR DESCRIPTION
### Intent

Addresses #11665. 

### Approach

Instead of sending python chunks to the executor one line at a time, as we do with R chunks, send all lines at once. This will ensure the preprocessing that already happens for non markdown python code gets applied to python code in chunks, instead of applying the preprocessing one line at a time

<img width="516" alt="image" src="https://user-images.githubusercontent.com/7817881/183518463-ada6ebf8-bc72-4b81-b6a1-cb7475a76e28.png">

Sends full function body to the console, and adds a newline to terminate the function definition

### Automated Tests

None

### QA Notes

See issue 
### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [X] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


