### PR TITLE
keep user home / rhome as UTF-8 with R 4.2.x

### DIFF
--- a/dependencies/windows/tools.R
+++ b/dependencies/windows/tools.R
@@ -113,7 +113,7 @@ exec <- function(command,
          logmsg <- paste0(logmsg, paste(readLines(output), collapse = "\n"), "\n")
          msg <- paste(msg, logmsg, sep = "\n")
       }
-      fatal(msg)
+      fatal("%s\n", msg)
    }
    
    invisible(TRUE)

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -316,7 +316,7 @@ void runEmbeddedR(const core::FilePath& rHome,
    std::string* pRHome;
    std::string* pUserHome;
 
-   // With R 4.2.x, using UCRT, we avoid converting to the system encoding
+   // With R 4.2.x, using UCRT, we avoid converting to the native encoding
    // and retain the UTF-8 encoding here
    if (core::Version(getDLLVersion()) >= core::Version("4.2.0"))
    {

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -35,9 +35,11 @@
 #include <boost/date_time/posix_time/posix_time_duration.hpp>
 
 #include <shared_core/FilePath.hpp>
+
 #include <core/Exec.hpp>
 #include <core/StringUtils.hpp>
 #include <core/Version.hpp>
+#include <core/system/Environment.hpp>
 #include <core/system/LibraryLoader.hpp>
 
 #include <r/RInterface.hpp>
@@ -311,10 +313,23 @@ void runEmbeddedR(const core::FilePath& rHome,
    initializeParams(pRP);
 
    // set paths (copy to new string so we can provide char*)
-   std::string* pRHome = new std::string(
-            core::string_utils::utf8ToSystem(rHome.getAbsolutePath()));
-   std::string* pUserHome = new std::string(
-            core::string_utils::utf8ToSystem(userHome.getAbsolutePath()));
+   std::string* pRHome;
+   std::string* pUserHome;
+
+   // With R 4.2.x, using UCRT, we avoid converting to the system encoding
+   // and retain the UTF-8 encoding here
+   if (core::Version(getDLLVersion()) >= core::Version("4.2.0"))
+   {
+      pRHome = new std::string(rHome.getAbsolutePath());
+      pUserHome = new std::string(userHome.getAbsolutePath());
+   }
+   else
+   {
+      using string_utils::utf8ToSystem;
+      pRHome = new std::string(utf8ToSystem(rHome.getAbsolutePath()));
+      pUserHome = new std::string(utf8ToSystem(userHome.getAbsolutePath()));
+   }
+
    pRP->rhome = const_cast<char*>(pRHome->c_str());
    pRP->home = const_cast<char*>(pUserHome->c_str());
 

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -182,3 +182,13 @@
    yamlCode <- paste(yamlCode, collapse = "\n")
    .Call("rs_fromYAML", yamlCode, PACKAGE = "(embedding)")
 })
+
+.rs.addFunction("systemToUtf8", function(text)
+{
+   .Call("rs_systemToUtf8", as.character(text), PACKAGE = "(embedding)")
+})
+
+.rs.addFunction("utf8ToSystem", function(text)
+{
+   .Call("rs_utf8ToSystem", as.character(text), PACKAGE = "(embedding)")
+})

--- a/src/cpp/session/modules/SessionRUtil.cpp
+++ b/src/cpp/session/modules/SessionRUtil.cpp
@@ -322,6 +322,24 @@ SEXP rs_runAsyncRProcess(SEXP codeSEXP,
    return r::sexp::create(true, &protect);
 }
 
+SEXP rs_systemToUtf8(SEXP stringSEXP)
+{
+   std::string text = r::sexp::asString(stringSEXP);
+   std::string asUtf8 = core::string_utils::systemToUtf8(text);
+
+   r::sexp::Protect protect;
+   return r::sexp::createUtf8(asUtf8, &protect);
+}
+
+SEXP rs_utf8ToSystem(SEXP stringSEXP)
+{
+   std::string text = r::sexp::asUtf8String(stringSEXP);
+   std::string asNative = core::string_utils::utf8ToSystem(text);
+
+   r::sexp::Protect protect;
+   return r::sexp::create(asNative, &protect);
+}
+
 } // anonymous namespace
 
 Error initialize()
@@ -333,6 +351,8 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_readIniFile);
    RS_REGISTER_CALL_METHOD(rs_rResourcesPath);
    RS_REGISTER_CALL_METHOD(rs_runAsyncRProcess);
+   RS_REGISTER_CALL_METHOD(rs_systemToUtf8);
+   RS_REGISTER_CALL_METHOD(rs_utf8ToSystem);
    
    using boost::bind;
    using namespace module_context;

--- a/src/cpp/shared_core/system/Win32User.cpp
+++ b/src/cpp/shared_core/system/Win32User.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/bind/bind.hpp>
+#include <boost/format.hpp>
 
 #include <shared_core/FilePath.hpp>
 #include <shared_core/Logger.hpp>
@@ -46,8 +47,10 @@ FilePath environmentHomePath(std::string envVariables)
            it != split_iterator<std::string::iterator>();
            ++it)
       {
+         // NOTE: returns a UTF-8 value
          std::string envHomePath =
             detail::getenv(boost::copy_range<std::string>(*it));
+
          if (!envHomePath.empty())
          {
             FilePath userHomePath(envHomePath);
@@ -192,6 +195,12 @@ FilePath User::getUserHomePath(const std::string& in_envOverride)
                path[0] = toupper(path[0]);
                homePath = FilePath(path);
             }
+
+            std::string message = boost::format("Using home directory %1% (from %2%)")
+                  .bind_arg(1, path)
+                  .bind_arg(2, source.first)
+                  .str();
+            log::logDebugMessage(message);
 
             return homePath;
          }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11721.
May also address https://github.com/rstudio/rstudio/issues/11717.

### Approach

When using the UCRT runtime, environment variables are expected to be encoded as UTF-8, so don't try to convert from UTF-8 to the system encoding here.

### Automated Tests

N/A

### QA Notes

Test that, when using RStudio + R 4.2.x on Windows, no warnings are printed to the console on startup.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

