### PR TITLE
Bug/3572 main downgrade upgrade issue

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,3 +24,4 @@
 - Fixed visual mode outline missing nested R code chunks (#11410)
 - Fixed an issue where chunks containing multibyte characters was not executed correctly (#10632)
 - Fixed bringing main window under active secondary window when executing background command (#11407)
+- Fix for schema version comparison that breaks db in downgrade -> upgrade scenarios (rstudio-pro#3572)

--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -771,8 +771,8 @@ bool SchemaVersion::operator<(const SchemaVersion& other) const
       return false;
 
    const auto& versions = versionMap();
-   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : -1;
-   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : -1;
+   int thisFlowerIndex = (versions.find(Flower) != versions.end()) ? versions.at(Flower) : versions.size();
+   int otherFlowerIndex = (versions.find(other.Flower) != versions.end()) ? versions.at(other.Flower) : versions.size();
 
    if (thisFlowerIndex < otherFlowerIndex)
       return true;

--- a/src/cpp/core/DatabaseTests.cpp
+++ b/src/cpp/core/DatabaseTests.cpp
@@ -448,6 +448,38 @@ TEST_CASE("Database", "[.database]")
       CHECK(postgresConnection->execute(postgresInsertQuery2));
    }
 
+   test_that("Schema Version comparisons are correct")
+   {
+      std::vector<SchemaVersion> versions {
+         {},
+         {"", "20200226141952248123456_AddRevokedCookie"},
+         {"Ghost Orchid", "20210712182145921760944"},
+         {"Prairie Trillium", "20210916132211194382021"},
+         {"Aphid", "21210916132211194382021"}
+      };
+
+      for(int i=0; i < (int) versions.size(); i++)
+      {
+         //Compare against smaller
+         for(int j=0; j < i; j++){
+            REQUIRE(versions[j] < versions[i]);
+            REQUIRE_FALSE(versions[j] > versions[i]);
+            REQUIRE(versions[j] <= versions[i]);
+         }
+
+         SchemaVersion sameVersion(versions[i]);
+         REQUIRE(sameVersion == versions[i]);
+
+         //Compare against larger
+         for(int j=i+1; j < (int) versions.size(); j++)
+         {
+            REQUIRE(versions[i] < versions[j]);
+            REQUIRE_FALSE(versions[i] > versions[j]);
+            REQUIRE(versions[i] <= versions[j]);
+         }
+      }
+   }
+
    test_that("Can execute str with multiple queries")
    {
       boost::shared_ptr<IConnection> connection;


### PR DESCRIPTION
### Intent

Prevent previous versions from overwriting the database version in a rollback scenario. Preventing clean upgrades from that database.

Addresses: rstudio/rstudio-pro#3572

### Approach

Inverting the logic surrounding unknown versions, assuming they must be from later versions rather than previous versions.

### Automated Tests

Unit testing to ensure these version comparisons are correct.

### QA Notes

Performing an install of a later version, downgrading to this version and upgrading again will no longer leave the database in a broken state.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->