### PR TITLE
Fix deprecation warnings for `SHA256_*` functions under OpenSSL 3

### DIFF
--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -108,19 +108,12 @@ Error HMAC_SHA2(const std::string& data,
 Error sha256(const std::string& message,
              std::string* pHash)
 {
-   SHA256_CTX shaCtx;
-   int ret = SHA256_Init(&shaCtx);
-   if (ret != 1)
-      return getLastCryptoError(ERROR_LOCATION);
-
-   ret = SHA256_Update(&shaCtx, message.c_str(), message.size());
-   if (ret != 1)
-      return getLastCryptoError(ERROR_LOCATION);
-
    unsigned char hash[SHA256_DIGEST_LENGTH];
-   ret = SHA256_Final(hash, &shaCtx);
-   if (ret != 1)
+   if (SHA256(reinterpret_cast<const unsigned char*>(message.c_str()),
+              message.size(), hash) == nullptr)
+   {
       return getLastCryptoError(ERROR_LOCATION);
+   }
 
    *pHash = std::string((const char*)hash, SHA256_DIGEST_LENGTH);
    return Success();

--- a/src/cpp/core/system/CryptoTests.cpp
+++ b/src/cpp/core/system/CryptoTests.cpp
@@ -121,6 +121,22 @@ test_context("CryptoTests")
       BIO_free(certBIO);
       BIO_free(keyBIO);
    }
+
+   test_that("SHA-256 hashing works correctly")
+   {
+      // Generated with openssl sha256 -hex.
+      std::string message = "secret message";
+      std::vector<unsigned char> raw = {
+         0xbb, 0x0b, 0x57, 0x00, 0x5f, 0x01, 0x01, 0x8b, 0x19, 0xc2, 0x78, 0xc5,
+         0x52, 0x73, 0xa6, 0x01, 0x18, 0xff, 0xdd, 0x3e, 0x57, 0x90, 0xcc, 0xc8,
+         0xa4, 0x8c, 0xad, 0x03, 0x90, 0x7f, 0xa5, 0x21
+      };
+      std::string expected(raw.begin(), raw.end());
+      std::string hash;
+      REQUIRE_FALSE(core::system::crypto::sha256(message, &hash));
+      REQUIRE(hash.size() == 32);
+      REQUIRE(hash == expected);
+   }
 }
 
 } // end namespace tests


### PR DESCRIPTION
### Intent

On a system with OpenSSL 3, we see the following build warnings:

    ./rstudio/src/cpp/core/system/Crypto.cpp: In function ‘rstudio::core::Error rstudio::core::system::crypto::sha256(const string&, std::string*)’:
    ./rstudio/src/cpp/core/system/Crypto.cpp:120:25: warning: ‘int SHA256_Init(SHA256_CTX*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      120 |    int ret = SHA256_Init(&shaCtx);
          |              ~~~~~~~~~~~^~~~~~~~~
    In file included from /usr/include/openssl/x509.h:41,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/sha.h:73:27: note: declared here
       73 | OSSL_DEPRECATEDIN_3_0 int SHA256_Init(SHA256_CTX *c);
          |                           ^~~~~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:124:23: warning: ‘int SHA256_Update(SHA256_CTX*, const void*, size_t)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      124 |    ret = SHA256_Update(&shaCtx, message.c_str(), message.size());
          |          ~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from /usr/include/openssl/x509.h:41,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/sha.h:74:27: note: declared here
       74 | OSSL_DEPRECATEDIN_3_0 int SHA256_Update(SHA256_CTX *c,
          |                           ^~~~~~~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:129:22: warning: ‘int SHA256_Final(unsigned char*, SHA256_CTX*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      129 |    ret = SHA256_Final(hash, &shaCtx);
          |          ~~~~~~~~~~~~^~~~~~~~~~~~~~~
    In file included from /usr/include/openssl/x509.h:41,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/sha.h:76:27: note: declared here
       76 | OSSL_DEPRECATEDIN_3_0 int SHA256_Final(unsigned char *md, SHA256_CTX *c);
          |                           ^~~~~~~~~~~~

This PR is an attempt to eliminate these warnings in a backward compatible way.

### Approach

The OpenSSL project [suggests migrating to the `EVP_Digest*()` family of functions instead](https://www.openssl.org/docs/man1.0.2/man3/SHA256.html), but in practice we actually use the digest in a simple "one-shot" fashion, so we can use the provided `SHA256()` function.

`SHA256()` has the benefit of being (a) not deprecated under OpenSSL 3 and (b) present since OpenSSL 1.0.0, and therefore available on all supported platforms -- as far as I understand it.

### Automated Tests

A small unit test is included to catch obvious regressions.

### QA Notes

This change touches crypto code, which makes it risky. It also primarily addresses platform compatibility, so it's important to test this against the various OpenSSL configurations we support -- especially on macOS and distributions with very old versions of OpenSSL (e.g. CentOS 7).

However, in my current understanding bugs should be caught by compilation or unit test failures without requiring more careful checks.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->