### PR TITLE
Fix deprecation warnings for RSA sign/verify on OpenSSL 3

### DIFF
--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -145,26 +145,40 @@ Error rsaSign(const std::string& message,
       return systemError(boost::system::errc::not_enough_memory, "RSA sign", ERROR_LOCATION);
 
 
-   std::unique_ptr<RSA, decltype(&RSA_free)> pRsa(PEM_read_bio_RSAPrivateKey(pKeyBuff.get(), nullptr, nullptr, nullptr),
-                                                  RSA_free);
+   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pRsa(PEM_read_bio_PrivateKey(pKeyBuff.get(), nullptr, nullptr, nullptr),
+                                                            EVP_PKEY_free);
    if (!pRsa)
       return systemError(boost::system::errc::not_enough_memory, "RSA private key", ERROR_LOCATION);
 
 
    // sign the message hash
-   std::unique_ptr<unsigned char, decltype(&free)> pSignature((unsigned char*)malloc(RSA_size(pRsa.get())),
-                                                              free);
-   if (!pSignature)
-      return systemError(boost::system::errc::not_enough_memory, "RSA signature", ERROR_LOCATION);
+   std::vector<unsigned char> pSignature(EVP_PKEY_get_size(pRsa.get()));
+   size_t sigLen;
+   std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)> ctx(EVP_PKEY_CTX_new(pRsa.get(), NULL),
+                                                                   EVP_PKEY_CTX_free);
+   if (!ctx)
+   {
+      return systemError(boost::system::errc::not_enough_memory,
+                         "EVP_PKEY_CTX_new()", ERROR_LOCATION);
+   }
 
-   unsigned int sigLen = 0;
-   int ret = RSA_sign(NID_sha256, (const unsigned char*)hash.c_str(),
-                      static_cast<unsigned int>(hash.size()), pSignature.get(), &sigLen, pRsa.get());
-   if (ret != 1)
+   if (!EVP_PKEY_sign_init(ctx.get()) ||
+       !EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_PADDING) ||
+       !EVP_PKEY_CTX_set_signature_md(ctx.get(), EVP_sha256()))
+   {
       return getLastCryptoError(ERROR_LOCATION);
+   }
+
+   if (!EVP_PKEY_sign(ctx.get(), &pSignature[0], &sigLen,
+                      reinterpret_cast<const unsigned char*>(hash.c_str()),
+                      hash.size()))
+   {
+      return getLastCryptoError(ERROR_LOCATION);
+   }
 
    // store signature in output param
-   *pOutSignature = std::string((const char*)pSignature.get(), sigLen);
+   pSignature.resize(sigLen);
+   pOutSignature->assign(pSignature.begin(), pSignature.end());
 
    return Success();
 }
@@ -188,16 +202,35 @@ Error rsaVerify(const std::string& message,
    if (!pKeyBuff)
       return systemError(boost::system::errc::not_enough_memory, "RSA bio public key", ERROR_LOCATION);
 
-   std::unique_ptr<RSA, decltype(&RSA_free)> pRsa(PEM_read_bio_RSA_PUBKEY(pKeyBuff.get(), nullptr, nullptr, nullptr),
-                                                  RSA_free);
+   std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pRsa(PEM_read_bio_PUBKEY(pKeyBuff.get(), nullptr, nullptr, nullptr),
+                                                            EVP_PKEY_free);
    if (!pRsa)
       return systemError(boost::system::errc::not_enough_memory, "RSA pub key", ERROR_LOCATION);
 
    // verify the message hash
-   int ret = RSA_verify(NID_sha256, (const unsigned char*)hash.c_str(), static_cast<unsigned int>(hash.size()),
-                       (const unsigned char*)signature.c_str(), static_cast<unsigned int>(signature.size()), pRsa.get());
-   if (ret != 1)
+   std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)> ctx(EVP_PKEY_CTX_new(pRsa.get(), NULL),
+                                                                   EVP_PKEY_CTX_free);
+   if (!ctx)
+   {
+      return systemError(boost::system::errc::not_enough_memory,
+                         "EVP_PKEY_CTX_new()", ERROR_LOCATION);
+   }
+
+   if (!EVP_PKEY_verify_init(ctx.get()) ||
+       !EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_PADDING) ||
+       !EVP_PKEY_CTX_set_signature_md(ctx.get(), EVP_sha256()))
+   {
       return getLastCryptoError(ERROR_LOCATION);
+   }
+
+   if (!EVP_PKEY_verify(ctx.get(),
+                        reinterpret_cast<const unsigned char*>(signature.c_str()),
+                        signature.size(),
+                        reinterpret_cast<const unsigned char*>(hash.c_str()),
+                        hash.size()))
+   {
+      return getLastCryptoError(ERROR_LOCATION);
+   }
 
    return Success();
 }

--- a/src/cpp/core/system/CryptoTests.cpp
+++ b/src/cpp/core/system/CryptoTests.cpp
@@ -121,6 +121,19 @@ test_context("CryptoTests")
       BIO_free(certBIO);
       BIO_free(keyBIO);
    }
+
+   test_that("Roundtrip RSA signing and verification works")
+   {
+      std::string message = "message from the key holder";
+      std::string pub, priv, sig;
+      REQUIRE_FALSE(core::system::crypto::generateRsaKeyPair(&pub, &priv));
+      REQUIRE_FALSE(core::system::crypto::rsaSign(message, priv, &sig));
+      REQUIRE_FALSE(core::system::crypto::rsaVerify(message, sig, pub));
+      // Sanity checks.
+      REQUIRE(pub.rfind("-----BEGIN PUBLIC KEY-----", 0) == 0);
+      REQUIRE(priv.rfind("-----BEGIN PRIVATE KEY-----", 0) == 0);
+      REQUIRE(sig.size() == 256);
+   }
 }
 
 } // end namespace tests


### PR DESCRIPTION
### Intent

On a system with OpenSSL 3, APIs that use `RSA` pointers directly are all marked as deprecated, resulting in warnings like the following:

<details>
  <summary>Compiler warnings</summary>

    ./rstudio/src/cpp/core/system/Crypto.cpp: In function ‘rstudio::core::Error rstudio::core::system::crypto::rsaSign(const string&, const string&, std::string*)’:
    ./rstudio/src/cpp/core/system/Crypto.cpp:141:35: warning: ‘void RSA_free(RSA*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      141 |    std::unique_ptr<RSA, decltype(&RSA_free)> pRsa(PEM_read_bio_RSAPrivateKey(pKeyBuff.get(), nullptr, nullptr, nullptr),
          |                                   ^~~~~~~~
    In file included from /usr/include/openssl/x509.h:36,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/rsa.h:293:28: note: declared here
      293 | OSSL_DEPRECATEDIN_3_0 void RSA_free(RSA *r);
          |                            ^~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:141:77: warning: ‘RSA* PEM_read_bio_RSAPrivateKey(BIO*, RSA**, int (*)(char*, int, int, void*), void*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      141 | unique_ptr<RSA, decltype(&RSA_free)> pRsa(PEM_read_bio_RSAPrivateKey(pKeyBuff.get(), nullptr, nullptr, nullptr),
          |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    In file included from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/pem.h:447:1: note: declared here
      447 | DECLARE_PEM_rw_cb_attr(OSSL_DEPRECATEDIN_3_0, RSAPrivateKey, RSA)
          | ^~~~~~~~~~~~~~~~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:148:94: warning: ‘int RSA_size(const RSA*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      148 | ed char, decltype(&free)> pSignature((unsigned char*)malloc(RSA_size(pRsa.get())),
          |                                                             ~~~~~~~~^~~~~~~~~~~~

    In file included from /usr/include/openssl/x509.h:36,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/rsa.h:204:27: note: declared here
      204 | OSSL_DEPRECATEDIN_3_0 int RSA_size(const RSA *rsa);
          |                           ^~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:154:22: warning: ‘int RSA_sign(int, const unsigned char*, unsigned int, unsigned char*, unsigned int*, RSA*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      154 |    int ret = RSA_sign(NID_sha256, (const unsigned char*)hash.c_str(),
          |              ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      155 |                       static_cast<unsigned int>(hash.size()), pSignature.get(), &sigLen, pRsa.get());
          |                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from /usr/include/openssl/x509.h:36,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/rsa.h:348:27: note: declared here
      348 | OSSL_DEPRECATEDIN_3_0 int RSA_sign(int type, const unsigned char *m,
          |                           ^~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp: In function ‘rstudio::core::Error rstudio::core::system::crypto::rsaVerify(const string&, const string&, const string&)’:
    ./rstudio/src/cpp/core/system/Crypto.cpp:184:74: warning: ‘RSA* PEM_read_bio_RSA_PUBKEY(BIO*, RSA**, int (*)(char*, int, int, void*), void*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      184 | d::unique_ptr<RSA, decltype(&RSA_free)> pRsa(PEM_read_bio_RSA_PUBKEY(pKeyBuff.get(), nullptr, nullptr, nullptr),
          |                                              ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

    In file included from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/pem.h:449:1: note: declared here
      449 | DECLARE_PEM_rw_attr(OSSL_DEPRECATEDIN_3_0, RSA_PUBKEY, RSA)
          | ^~~~~~~~~~~~~~~~~~~
    ./rstudio/src/cpp/core/system/Crypto.cpp:190:24: warning: ‘int RSA_verify(int, const unsigned char*, unsigned int, const unsigned char*, unsigned int, RSA*)’ is deprecated: Since OpenSSL 3.0 [-Wdeprecated-declarations]
      190 |    int ret = RSA_verify(NID_sha256, (const unsigned char*)hash.c_str(), static_cast<unsigned int>(hash.size()),
          |              ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      191 |                        (const unsigned char*)signature.c_str(), static_cast<unsigned int>(signature.size()), pRsa.get());
          |                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from /usr/include/openssl/x509.h:36,
                     from /usr/include/openssl/pem.h:23,
                     from ./rstudio/src/cpp/core/system/Crypto.cpp:32:
    /usr/include/openssl/rsa.h:351:27: note: declared here
      351 | OSSL_DEPRECATEDIN_3_0 int RSA_verify(int type, const unsigned char *m,
          |                           ^~~~~~~~~~
</details>

### Approach

The OpenSSL project [suggests migrating to the `EVP_PKEY*()` family of functions instead](https://www.openssl.org/docs/man3.0/man3/RSA_verify.html), so that's what this commit does for our RSA sign and verify implementations.

The `EVP_PKEY*()` functions used here have all been present since OpenSSL 1.0.0, and are therefore available on all supported platforms.

### Automated Tests

A small unit test is included for sanity checking and I mixed-and-matched the changes locally to verify them with this test.

### QA Notes

This change touches crypto code, which makes it risky. It also primarily addresses platform compatibility, so it's important to test this against the various OpenSSL configurations we support -- especially on macOS and distributions with very old versions of OpenSSL (e.g. CentOS 7).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->