### PR TITLE
Update window for no R installation found on Windows Electron

### DIFF
--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -3,7 +3,9 @@
     "buttonOk": "OK",
     "buttonCancel": "Cancel",
     "buttonBrowse": "Browse...",
-    "unknownErrorOccurred": "An unknown error occurred."
+    "unknownErrorOccurred": "An unknown error occurred.",
+    "buttonYes": "Yes",
+    "buttonNo": "No"
   },
   "contextMenu": {
     "saveImageAsDots": "Save image as...",
@@ -83,8 +85,8 @@
     "devModeConfig": "Dev Mode Config",
     "confColon": "conf:",
     "notFoundDotLowercase": "not found.",
-    "errorFindingR": "Error Finding R",
-    "rstudioFailedToFindRInstalationsOnTheSystem": "RStudio failed to find any R installations on the system.",
+    "errorFindingR": "R Not Installed",
+    "rstudioFailedToFindRInstalationsOnTheSystem": "R does not appear to be installed. Please install R before using RStudio.\nYou can download R from the official R Project website. Would you like to go there now?",
     "newRstudioWindow": "New RStudio Window"
   },
   "detectRTs": {

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -86,7 +86,7 @@
     "confColon": "conf:",
     "notFoundDotLowercase": "not found.",
     "errorFindingR": "R Not Installed",
-    "rstudioFailedToFindRInstalationsOnTheSystem": "R does not appear to be installed. Please install R before using RStudio.\nYou can download R from the official R Project website. Would you like to go there now?",
+    "rstudioFailedToFindRInstalationsOnTheSystem": "R does not appear to be installed. Please install R before using RStudio.\n\nYou can download R from the official R Project website.\nWould you like to go there now?",
     "newRstudioWindow": "New RStudio Window"
   },
   "detectRTs": {

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, globalShortcut, Menu, screen, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, globalShortcut, Menu, screen, shell, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -283,13 +283,22 @@ export class Application implements AppState {
     if (process.platform === 'win32') {
       const [path, preflightError] = await promptUserForR();
       if (preflightError) {
-        dialog.showMessageBoxSync({
+
+        await dialog.showMessageBox({
           type: 'error',
           title: i18next.t('applicationTs.errorFindingR'),
           message: i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
-          buttons: [ i18next.t('common.buttonYes', 'common.buttonNo'), ],
-        });
-        logger().logError(preflightError);
+          buttons: [ i18next.t('common.buttonYes'), i18next.t('common.buttonNo') ],
+        }).then(result => {
+          
+          logger().logDebug(`You clicked ${result.response == 0 ? 'Yes' : 'No'}`);
+          if (result.response == 0) {
+            const rProjectUrl = 'https://www.rstudio.org/links/r-project';
+            void shell.openExternal(rProjectUrl);
+          }
+        })
+          .catch((error: unknown) => logger().logError(error));
+        
         return exitFailure();
       }
 

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -283,10 +283,12 @@ export class Application implements AppState {
     if (process.platform === 'win32') {
       const [path, preflightError] = await promptUserForR();
       if (preflightError) {
-        await createStandaloneErrorDialog(
-          i18next.t('applicationTs.errorFindingR'),
-          i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
-        );
+        dialog.showMessageBoxSync({
+          type: 'error',
+          title: i18next.t('applicationTs.errorFindingR'),
+          message: i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
+          buttons: [ i18next.t('common.buttonYes', 'common.buttonNo'), ],
+        });
         logger().logError(preflightError);
         return exitFailure();
       }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -285,7 +285,7 @@ export class Application implements AppState {
       if (preflightError) {
 
         await dialog.showMessageBox({
-          type: 'error',
+          type: 'warning',
           title: i18next.t('applicationTs.errorFindingR'),
           message: i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
           buttons: [ i18next.t('common.buttonYes'), i18next.t('common.buttonNo') ],


### PR DESCRIPTION
### Intent

Addresses #11438 

### Approach

Current window 
<img width="445" alt="image" src="https://user-images.githubusercontent.com/7817881/184214043-321c67de-851e-4780-8b98-caef36ddd724.png">

If you click Yes, a tab opens in your default system browser which points to the R-project website to download/install R
If you click No, the dialog will exit, and RStudio will not start

(see linked issue for [old UI](https://user-images.githubusercontent.com/10569626/173932441-0d1b5f22-d784-4177-8305-7bdbc3448015.png). )

### QA Notes

Test on a Windows machine with no R installation (or put R somewhere sneaky we can't find it)

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


