### PR TITLE
Put back Qt dependency installer goo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ def s3_upload(type, flavor, os, arch) {
   def renamedTarballFile = ""
   
   // add installer-less tarball if desktop
-  if (flavor == "electron") {
+  if (flavor == "desktop" || flavor == "electron") {
     tarballFile = sh (
       script: "basename `ls ${buildFolder}/_CPack_Packages/Linux/${type}/*.tar.gz`",
       returnStdout: true
@@ -132,7 +132,9 @@ def s3_upload(type, flavor, os, arch) {
     // derive product
     def product="${flavor}"
     if (rstudioVersionSuffix.contains("pro")) {
-        if (product == "electron") {
+        if (product == "desktop") {
+            product = "desktop-pro"
+        } else if (product == "electron") {
             product = "electron-pro"
         } else if (product == "server") {
             product = "workbench"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -1,0 +1,178 @@
+pipeline {
+
+  agent { label 'macos-v1.4-arm64' }
+
+  options {
+    timestamps()
+    disableConcurrentBuilds()
+    buildDiscarder(logRotator(numToKeepStr: '100'))
+  }
+
+  parameters {
+      string(name: 'RSTUDIO_VERSION_MAJOR',  defaultValue: '1', description: 'RStudio Major Version')
+      string(name: 'RSTUDIO_VERSION_MINOR',  defaultValue: '1', description: 'RStudio Minor Version')
+      string(name: 'RSTUDIO_VERSION_PATCH',  defaultValue: '999', description: 'RStudio Patch Version')
+      string(name: 'RSTUDIO_VERSION_SUFFIX', defaultValue: '+9999', description: 'RStudio Pro Suffix Version')
+      string(name: 'GIT_REVISION', defaultValue: 'main', description: 'Git revision to build')
+      string(name: 'BRANCH_NAME', defaultValue: 'origin/main', description: 'Branch name to build')
+      string(name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.')
+  }
+
+  environment {
+    PATH = "$HOME/opt/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+    PACKAGE_OS = 'macOS'
+  }
+
+  stages {
+
+    stage('dependencies') {
+
+      environment {
+        // boost won't compile without the brew version of openssl.
+        // only add it to the dep resolve step though, or the ide build will compile against the wrong openssl
+        PATH = '/usr/local/opt/openssl/bin:/usr/local/opt/openssl/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
+      }
+
+      steps {
+        withCredentials([usernameColonPassword(credentialsId: 'github-rstudio-jenkins', variable: "GITHUB_LOGIN")]) {
+          sh 'cd dependencies/osx && RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN ./install-dependencies-osx && cd ../..'
+        }
+      }
+
+    }
+
+    stage('build') {
+
+      steps {
+        script {
+
+          // unlock keychain to ensure build gets signed.
+          withCredentials([string(credentialsId: 'ide-keychain-passphrase', variable: 'KEYCHAIN_PASSPHRASE')]){
+            sh 'security unlock-keychain -p $KEYCHAIN_PASSPHRASE && security set-keychain-settings' // turn off timeout
+          }
+
+          // set requisite environment variables
+          def env = "RSTUDIO_VERSION_MAJOR=${params.RSTUDIO_VERSION_MAJOR} RSTUDIO_VERSION_MINOR=${params.RSTUDIO_VERSION_MINOR} RSTUDIO_VERSION_PATCH=${params.RSTUDIO_VERSION_PATCH} RSTUDIO_VERSION_SUFFIX=${params.RSTUDIO_VERSION_SUFFIX}"
+
+          // build rstudio
+          sh 'cd package/osx && ${env} ./make-package clean && cd ../..'
+
+        }
+      }
+
+    }
+
+    stage('tests') {
+
+      environment {
+        PATH = "${env.HOME}/opt/bin:${env.PATH}"
+      }
+
+      steps {
+        script {
+          try {
+            // attempt to run cpp unit tests
+            // problems with rsession finding openssl, so those tests
+            // are disabled until we solve it (#6890)
+            sh "cd package/osx/build/src/cpp && arch -x86_64 ./rstudio-tests"
+          } catch(err) {
+             currentBuild.result = "UNSTABLE"
+          }
+        }
+      }
+
+    }
+
+    stage('notarize and upload') {
+
+      environment {
+        PATH = "${env.HOME}/opt/bin:${env.PATH}"
+      }
+      
+      steps {
+        script {
+
+          // extract name of package to publish
+          def packageFile = sh (
+            script: "basename `ls package/osx/build/RStudio-*.dmg`",
+            returnStdout: true
+          ).trim()
+
+          def buildType = sh (
+            script: "cat version/BUILDTYPE",
+            returnStdout: true
+          ).trim().toLowerCase()
+
+          def buildDest =  "s3://rstudio-ide-build/desktop/macos/"
+
+          withCredentials([usernamePassword(credentialsId: 'ide-apple-notarizer', usernameVariable: 'APPLE_ID', passwordVariable: 'APPLE_ID_PASSWORD')]) {
+            sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
+          }
+
+          // this job is going to run on a macOS slave, which cannot use an instance-profile
+          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+            retry(5) {
+              sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"
+            }
+          }
+
+          // upload daily build redirects
+          withCredentials([file(credentialsId: 'www-rstudio-org-pem', variable: 'wwwRstudioOrgPem')]) {
+            sh "docker/jenkins/publish-daily-binary.sh https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/${packageFile} ${wwwRstudioOrgPem}"
+          }
+
+          // upload debug symbols to Sentry
+          withCredentials([string(credentialsId: 'ide-sentry-api-key', variable: 'SENTRY_API_KEY')]){
+            // construct release version
+            def RSTUDIO_RELEASE = "${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
+
+
+            retry(5) {
+               // timeout sentry in 15 minutes
+               timeout(activity: true, time: 15) {
+
+                // create new release on Sentry
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend new ${RSTUDIO_RELEASE}"
+
+                // upload Javascript source maps
+                sh "cd package/osx/build/gwt && sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend files ${RSTUDIO_RELEASE} upload-sourcemaps --ext js --ext symbolMap --rewrite ."
+
+                // associate commits
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend set-commits --auto ${RSTUDIO_RELEASE}"
+
+                // finalize release
+                sh "sentry-cli --auth-token ${SENTRY_API_KEY} releases --org rstudio --project ide-backend finalize ${RSTUDIO_RELEASE}"
+
+                // upload C++ debug information
+                sh "cd package/osx/build/src/cpp && sentry-cli --auth-token ${SENTRY_API_KEY} upload-dif --org rstudio --project ide-backend -t dsym ."
+              }
+            }
+          }
+
+          // publish build to dailies page
+          withCredentials([usernamePassword(credentialsId: 'github-rstudio-jenkins', usernameVariable: 'GITHUB_USERNAME', passwordVariable: 'GITHUB_PAT')]) {
+
+            // derive product
+            def product="desktop"
+            if (params.RSTUDIO_VERSION_SUFFIX.contains("pro")) {
+              product = "desktop-pro"
+            }
+
+            // publish the build
+            sh "docker/jenkins/publish-build.sh --build ${product}/macos --url https://s3.amazonaws.com/rstudio-ide-build/desktop/macos/${packageFile} --pat ${GITHUB_PAT} --file package/osx/build/${packageFile} --version ${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
+          }
+
+        }
+      }
+
+    }
+
+  }
+
+  post {
+    always {
+      deleteDir()
+      sendNotifications slack_channel: SLACK_CHANNEL
+    }
+  }
+}

--- a/dependencies/linux/install-qt-linux
+++ b/dependencies/linux/install-qt-linux
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#
+# install-qt-linux
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+# Install minimal Qt bits needed to build via command-line (e.g. Docker).
+# For developer environments, better to install using Qt's online installer.
+
+set -e
+command -v 7z >/dev/null 2>&1 || { echo >&2 "7z command required to install Qt but not found."; exit 1; }
+
+if [ -z "$QT_VERSION" ]; then
+   echo Error: QT_VERSION must be specified
+   exit 1
+fi
+if [ -z "$QT_SDK_DIR" ]; then
+   QT_SDK_DIR=/opt/RStudio-QtSDK
+fi
+
+mkdir -p "${QT_SDK_DIR}"
+./install-qt.sh --version $QT_VERSION --directory "${QT_SDK_DIR}/Qt$QT_VERSION" \
+    qtbase \
+    qtwebengine \
+    qtwebchannel \
+    qtquick \
+    qtquickcontrols2 \
+    qtdeclarative \
+    qtsensors \
+    qtlocation \
+    qtsvg \
+    qtxmlpatterns \
+    qttools \
+    icu \
+    qttranslations \
+    qtwayland \
+    qtwebsockets \
+    qtimageformats \
+

--- a/dependencies/linux/install-qt-sdk
+++ b/dependencies/linux/install-qt-sdk
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+#
+# install-qt-sdk
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+
+# Used to install legacy Qt version via direct-download and extraction of a 
+# prepared archive.
+
+if [ -z "$QT_VERSION" ]; then
+   echo Error: QT_VERSION must be specified
+   exit 1
+fi
+if [ -z "$QT_SDK_CUSTOM" ]; then
+   echo Error: QT_SDK_CUSTOM must be supplied
+   exit 1
+fi
+if [ -z "$QT_SDK_DIR" ]; then
+   echo Error: QT_SDK_DIR must be specified
+   exit 1
+fi
+
+if [ ! -e "$QT_SDK_DIR" ]
+then
+   QT_SDK_URL=https://s3.amazonaws.com/rstudio-buildtools/$QT_SDK_CUSTOM
+   
+   # download and install
+   wget $QT_SDK_URL -O /tmp/$QT_SDK_CUSTOM
+   cd `dirname $QT_SDK_DIR`
+   tar xzf /tmp/$QT_SDK_CUSTOM
+   rm /tmp/$QT_SDK_CUSTOM
+   
+   if [ ! -e "$QT_SDK_DIR" ]; then
+      echo "Error: Unable to install Qt, run script again or install manually." 
+      exit 1
+   fi
+else
+   echo "Qt $QT_VERSION SDK already installed"
+fi
+

--- a/dependencies/osx/install-qt-macos
+++ b/dependencies/osx/install-qt-macos
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+
+#
+# install-qt-macos
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+# Install minimal Qt bits needed to build via command-line.
+# For developer environments, better to install using Qt's online installer.
+
+set -e
+
+if [ -z "$QT_VERSION" ]; then
+    QT_VERSION=5.12.10
+fi
+if [ -z "$QT_SDK_DIR" ]; then
+
+   # Qt install root if path not supplied
+   QT_SDK_DIR=~/Qt${QT_VERSION}
+
+   # other locations checked for existing installation
+   QT_SDK_DIR2=~/Qt/Qt${QT_VERSION}
+   QT_SDK_DIR3=~/Qt/${QT_VERSION}
+fi
+
+if [ ! -e "$QT_SDK_DIR" ] && [ ! -e "$QT_SDK_DIR2" ] && [ ! -e "$QT_SDK_DIR3" ]
+then
+   command -v 7z >/dev/null 2>&1 || { echo >&2 "7z command required to install Qt but not found (brew install p7zip)."; exit 1; }
+   echo ----------------------------------------------------------------------
+   echo "                            *** Important ***"
+   echo ----------------------------------------------------------------------
+   echo " The minimal Qt installer should only be used on a build machine. For"
+   echo " a developer machine use the Qt online installer from qt.io or"
+   echo " MaintenanceTool.app from existing Qt folder to install $QT_VERSION."
+   echo ----------------------------------------------------------------------
+   echo " Qt is only required if building RStudio Desktop Pro (RDP), not for"
+   echo " building open source desktop (Electron)"
+   echo ----------------------------------------------------------------------
+   echo " Pausing for 15 seconds... (Ctrl+C to interrupt)"
+   echo ----------------------------------------------------------------------
+   sleep 15
+   echo "Installing minimal Qt $QT_VERSION SDK"
+   ../common/install-qt.sh --version $QT_VERSION --directory ${QT_SDK_DIR} \
+      qtbase \
+      qtwebengine \
+      qtwebchannel \
+      qtquick \
+      qtquickcontrols2 \
+      qtdeclarative \
+      qtsensors \
+      qtlocation \
+      qtsvg \
+      qtxmlpatterns \
+      qttools \
+      qttranslations \
+      qtwebsockets
+else
+   echo "Qt $QT_VERSION SDK already installed"
+fi

--- a/docker/jenkins/Dockerfile.bionic-amd64
+++ b/docker/jenkins/Dockerfile.bionic-amd64
@@ -108,6 +108,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto

--- a/docker/jenkins/Dockerfile.centos7-x86_64
+++ b/docker/jenkins/Dockerfile.centos7-x86_64
@@ -105,6 +105,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-common centos7"
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-quarto"

--- a/docker/jenkins/Dockerfile.fedora36-x86_64
+++ b/docker/jenkins/Dockerfile.fedora36-x86_64
@@ -94,6 +94,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common fedora36
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto

--- a/docker/jenkins/Dockerfile.jammy-amd64
+++ b/docker/jenkins/Dockerfile.jammy-amd64
@@ -93,6 +93,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto

--- a/docker/jenkins/Dockerfile.opensuse15-x86_64
+++ b/docker/jenkins/Dockerfile.opensuse15-x86_64
@@ -91,6 +91,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # install GnuPG 1.4 from source (needed for release signing)
 RUN cd /tmp && \
     wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \

--- a/docker/jenkins/Dockerfile.rhel8-x86_64
+++ b/docker/jenkins/Dockerfile.rhel8-x86_64
@@ -93,6 +93,12 @@ COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8
 
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
 # get libuser header files (libuser-devel not currently available on rhel8)
 RUN wget https://pagure.io/libuser/archive/libuser-0.62/libuser-libuser-0.62.tar.gz
 RUN tar zxvf libuser-libuser-0.62.tar.gz

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -48,6 +48,12 @@ RUN $ErrorActionPreference = 'Stop' ;`
 RUN $env:path += ';C:\R\R-3.3.0\bin\i386\' ;`
   [Environment]::SetEnvironmentVariable('Path', $env:path, [System.EnvironmentVariableTarget]::Machine);
 
+# install qt (note that we are using the current directory's context)
+RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48; `
+  (New-Object System.Net.WebClient).DownloadFile('https://s3.amazonaws.com/rstudio-buildtools/Qt/QtSDK-5.12.8-msvc2017_64.7z', 'c:\QtSDK-5.12.8-msvc2017_64.7z'); `
+  7z x c:\QtSDK-5.12.8-msvc2017_64.7z -oc:\ ; `
+  Remove-Item c:\QtSDK-5.12.8-msvc2017_64.7z -Force
+
 # cpack (an alias from chocolatey) and cmake's cpack conflict.
 # Newer choco doesn't have this so don't fail if not found
 RUN if (Test-Path 'C:\ProgramData\chocolatey\bin\cpack.exe') { Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe' }


### PR DESCRIPTION
### Intent

Open-source side of addressing https://github.com/rstudio/rstudio-pro/issues/3701.

### Approach

Puts back installation of Qt SDK on build machines. This is groundwork to re-enable building the Qt flavor of Desktop Pro. There should be no impact on the open-source builds (other than the docker images rebuilding to pull in Qt).

I considered adding conditional logic so open-source docker images would skip installing Qt, but decided that's not worth the complexity.

### Automated Tests

N/A

### QA Notes

Nothing should change as a result of this PR. Once this gets merged into pro repo, then I'll do additional work there to finish the task.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


