### PR TITLE
ensure 'output.rds' written to expected location

### DIFF
--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -133,6 +133,9 @@
    # define runner script (will load data and execute user-defined callback)
    script <- quote({
       
+      # save the original working directory
+      originalWorkingDir <- getwd()
+      
       # read side-car data file
       bundle <- readRDS("bundle.rds")
       
@@ -149,8 +152,12 @@
       data     <- bundle[["data"]]
       
       # execute callback
-      rval <- do.call(callback, data)
-      saveRDS(object = rval, file = "output.rds")
+      result <- do.call(callback, data)
+      
+      # return to original directory
+      setwd(originalWorkingDir)
+      saveRDS(object = result, file = "output.rds")
+      
    })
    
    # write bundle to file
@@ -169,8 +176,10 @@
    
    # run the script
    system2(r, args, ...)
+   
    # read in the serialized return value of the callback and return it
-   readRDS("output.rds")
+   if (file.exists("output.rds"))
+      readRDS("output.rds")
 })
 
 # NOTE: this uses a bundled YAML library in the IDE as opposed to the R


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11766.

### Approach

When running code within an R sub-process, ensure that any output is written to `output.rds` at the expected location.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11766. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

