### PR TITLE
Add arm64 builds of RStudio Server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -240,8 +240,8 @@ try {
           [os: 'bionic',     arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Bionic'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'server',   variant: '',  package_os: 'Ubuntu Jammy'],
           [os: 'jammy',      arch: 'amd64',  flavor: 'electron', variant: '',  package_os: 'Ubuntu Jammy'],
-          [os: 'fedora36',   arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'Fedora 36'],
-          [os: 'fedora36',   arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'Fedora 36'],
+          [os: 'rhel9',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 9'],
+          [os: 'rhel9',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 9'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8']
         ]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -366,7 +366,7 @@ try {
             def index = i
             parallel_containers["${containers[i].os}-${containers[i].arch}-${containers[i].flavor}-${containers[i].variant}"] = {
                 def current_container = containers[index]
-                node('ide') {
+                node(current_container.arch) {
                     def current_image
                     docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:jenkins-aws') {
                         stage('prepare ws/container') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,11 +142,11 @@ def s3_upload(type, flavor, os, arch) {
     }
 
     // publish the build
-    sh "docker/jenkins/publish-build.sh --build ${product}/${os} --url https://s3.amazonaws.com/rstudio-ide-build/${flavor}/${os}/${arch}/${packageFile} --pat ${GITHUB_PAT} --file ${buildFolder}/${packageFile} --version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
+    sh "docker/jenkins/publish-build.sh --build ${product}/${os}-${arch} --url https://s3.amazonaws.com/rstudio-ide-build/${flavor}/${os}/${arch}/${packageFile} --pat ${GITHUB_PAT} --file ${buildFolder}/${packageFile} --version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
 
     // publish the installer-less version of the build if we made one
     if (tarballFile) {
-      sh "docker/jenkins/publish-build.sh --build ${product}/${os}-xcopy --url https://s3.amazonaws.com/rstudio-ide-build/${flavor}/${os}/${arch}/${renamedTarballFile} --pat ${GITHUB_PAT} --file ${buildFolder}/_CPack_Packages/Linux/${type}/${renamedTarballFile} --version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
+      sh "docker/jenkins/publish-build.sh --build ${product}/${os}-${arch}-xcopy --url https://s3.amazonaws.com/rstudio-ide-build/${flavor}/${os}/${arch}/${renamedTarballFile} --pat ${GITHUB_PAT} --file ${buildFolder}/_CPack_Packages/Linux/${type}/${renamedTarballFile} --version ${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
     }
   }
 }

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -97,7 +97,7 @@ BUILD_ARGS="--build-arg ARCH=${CONTAINER_ARCH}"
 
 # get build arg env vars, if any
 if [ ! -z "${DOCKER_GITHUB_LOGIN}" ]; then
-   BUILD_ARGS="${BUILD_ARGS} GITHUB_LOGIN=${DOCKER_GITHUB_LOGIN}"
+   BUILD_ARGS="${BUILD_ARGS} --build-arg GITHUB_LOGIN=${DOCKER_GITHUB_LOGIN}"
 fi
 
 # rebuild the image if necessary

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -165,7 +165,7 @@ if [ "$CMAKE_BUILD_TYPE" = "Debug" ]; then
 fi
 
 # remove previous image if it exists
-CONTAINER_ID="build-$REPO-$IMAGE"
+CONTAINER_ID="build-$REPO-$IMAGE_TAG"
 echo "Cleaning up container $CONTAINER_ID if it exists..."
 docker rm "$CONTAINER_ID" || true
 
@@ -189,7 +189,7 @@ echo "${CMD}"
 docker run                 \
   --name "$CONTAINER_ID"   \
   --volume "$(pwd):/src"   \
-  "$REPO:$IMAGE" bash -c "${CMD}"
+  "$REPO:$IMAGE_TAG" bash -c "${CMD}"
 
 # extract logs to get filename (should be on the last line)
 PKG_FILENAME=$(docker logs --tail 1 "$CONTAINER_ID")

--- a/docker/docker-compile.sh
+++ b/docker/docker-compile.sh
@@ -16,9 +16,9 @@
 #
 # For example:
 # 
-#     docker-compile.sh rhel8-x86_64 desktop 1.2.345
+#     docker-compile.sh rhel8 desktop 1.2.345
 #
-# will produce an RPM of RStudio Desktop from the 64bit RHEL8 container, 
+# will produce an RPM of RStudio Desktop from the RHEL8 container, 
 # with build version 1.2.345, in your package/linux/ directory.
 #
 # For convenience, this script will build the required image if it doesn't
@@ -26,6 +26,11 @@
 # it's already built. If you're iterating on the Dockerfiles themselves, you'll
 # want to use "docker build" directly until you're happy with the
 # configuration, then use this script to test a build under the new config.
+#
+# By default, the script will build packages that match the architecture of the
+# host machine -- i.e. you will get AMD64 builds or ARM64 builds depending on 
+# your processor's architecture. To force a mismatch, set the environment 
+# variable CONTAINER_ARCH to "amd64" or "arm64".
 #
 # To produce a debug build, set the environment variable CMAKE_BUILD_TYPE to
 # "Debug" before invoking the script.
@@ -64,22 +69,40 @@ if [ -z "$IMAGE" ] || [ -z "$FLAVOR" ]; then
     exit 1
 fi
 
-# check to see if there's already a built image
-IMAGEID=$(docker images "$REPO:$IMAGE" --format "{{.ID}}")
-if [ -z "$IMAGEID" ]; then
-    echo "No image found for $REPO:$IMAGE."
+# set container architecture from system architecture (if unspecified)
+SYSTEM_ARCH=$(uname -m)
+if [ -z "$CONTAINER_ARCH" ]; then
+   if [ "$SYSTEM_ARCH" = "aarch64" ] || [ "$SYSTEM_ARCH" = "arm64" ]; then
+      CONTAINER_ARCH="arm64"
+   else
+      CONTAINER_ARCH="amd64"
+   fi
 else
-    echo "Found image $IMAGEID for $REPO:$IMAGE."
+   echo "Building package for ${CONTAINER_ARCH} (system architecture is ${SYSTEM_ARCH})"
 fi
 
+# form image tag from container architecture
+IMAGE_TAG="${IMAGE}-${CONTAINER_ARCH}"
+
+# check to see if there's already a built image
+IMAGEID=$(docker images "$REPO:$IMAGE_TAG" --format "{{.ID}}")
+if [ -z "$IMAGEID" ]; then
+    echo "No image found for $REPO:$IMAGE_TAG."
+else
+    echo "Found image $IMAGEID for $REPO:$IMAGE_TAG."
+fi
+
+# add architecture to build arguments
+BUILD_ARGS="--build-arg ARCH=${CONTAINER_ARCH}"
+
 # get build arg env vars, if any
-if [ -n "${DOCKER_GITHUB_LOGIN}" ]; then
-   BUILD_ARGS="--build-arg GITHUB_LOGIN=${DOCKER_GITHUB_LOGIN}"
+if [ ! -z "${DOCKER_GITHUB_LOGIN}" ]; then
+   BUILD_ARGS="${BUILD_ARGS} GITHUB_LOGIN=${DOCKER_GITHUB_LOGIN}"
 fi
 
 # rebuild the image if necessary
 docker build                                \
-  --tag "$REPO:$IMAGE"                      \
+  --tag "$REPO:$IMAGE_TAG"                  \
   --file "docker/jenkins/Dockerfile.$IMAGE" \
   $BUILD_ARGS                               \
   .

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -13,7 +13,7 @@ RUN set -x \
     && apt-get update \
     && apt-get install -y gnupg1 \
     && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9 \
-    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/' >> /etc/apt/sources.list \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu bionic-cran40/' >> /etc/apt/sources.list \
     && apt-get update
 
 # add ppa repository so we can install java 8 (not in any official repo for bionic)

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -1,63 +1,82 @@
-FROM fedora:36
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH ubuntu:bionic
+ARG ARCH
 
-ENV OPERATING_SYSTEM=fedora_36
+ENV OPERATING_SYSTEM=ubuntu_bionic
 
 ARG AWS_REGION=us-east-1
 
-RUN dnf install -y \
-    R \
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update \
+    && apt-get install -y gnupg1 \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9 \
+    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/' >> /etc/apt/sources.list \
+    && apt-get update
+
+# add ppa repository so we can install java 8 (not in any official repo for bionic)
+RUN apt-get update \
+  && apt-get install -y software-properties-common \
+  && add-apt-repository ppa:openjdk-r/ppa
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y \
     ant \
-    boost-devel \
-    bzip2-devel \
-    clang-devel \
+    build-essential \
+    clang \
     curl \
+    debsigs \
+    dpkg-sig \
     expect \
     fakeroot \
-    fuse-libs \
-    gcc \
-    gcc-c++ \
-    git \
-    gpg1 \
-    gtk3 \
-    java-11-openjdk \
-    java-11-openjdk-devel \
+    git-core \
     jq \
-    libXScrnSaver-devel \
-    libXcursor-devel \
-    libXrandr-devel \
-    libacl-devel \
-    libcap-devel \ 
-    libcurl-devel \
-    libffi \
-    libuser-devel \
-    libuuid-devel \
-    llvm-devel \
+    libattr1-dev \
+    libacl1-dev \
+    libbz2-dev \
+    libcap-dev \
+    libcurl4-openssl-dev \
+    libfuse2 \
+    libgtk-3-0 \
+    libgl1-mesa-dev \
+    libegl1-mesa \
+    libpam-dev \
+    libpango1.0-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libuser1-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
     lsof \
-    make \
-    mesa-libGL-devel \
     ninja-build \
-    openssl-devel \
-    p7zip \
-    p7zip-plugins \
-    pam-devel \
-    pango-devel \
-    patchelf \
-    postgresql-devel \
-    procps \
-    python2 \
-    python3 \
-    rpm-sign \
-    rpmdevtools \
-    sqlite-devel \
+    openjdk-8-jdk \
+    p7zip-full \
+    pkg-config \
+    python \
+    r-base \
     sudo \
+    unzip \
+    uuid-dev \
     valgrind \
     wget \
-    xml-commons-apis \
-    xorg-x11-server-Xvfb \
-    zlib-devel
+    xvfb \
+    zlib1g-dev
 
-# ensure we use the java 11 compiler to build GWT
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
+# ensure we use the java 8 compiler
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+## build patchelf
+RUN cd /tmp \
+    && wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz \
+    && tar xzvf patchelf-0.9.tar.gz \
+    && cd patchelf-0.9 \
+    && ./configure \
+    && make \
+    && make install
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)
 RUN mkdir -p /tools
@@ -73,14 +92,11 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 
 # install cmake
 COPY package/linux/install-dependencies /tmp/
-RUN bash /tmp/install-dependencies
-
-# copy python2 to python so that it can be picked up by Google scripts
-RUN cp /usr/bin/python2 /usr/bin/python
+RUN /bin/bash /tmp/install-dependencies
 
 # install crashpad and its dependencies
 COPY dependencies/common/install-crashpad /tmp/
-RUN bash /tmp/install-crashpad rhel8
+RUN bash /tmp/install-crashpad bionic
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
@@ -92,7 +108,7 @@ COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
 COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common fedora36
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
 
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
@@ -108,14 +124,10 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
-# remove any previous users with conflicting IDs
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999
-COPY docker/jenkins/*.sh /tmp/
-RUN /tmp/clean-uid.sh $JENKINS_UID && \
-    /tmp/clean-gid.sh $JENKINS_GID
-
-# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -67,7 +67,7 @@ RUN apt-get update && \
     zlib1g-dev
 
 # ensure we use the java 8 compiler
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/jre/bin/java
 
 ## build patchelf
 RUN cd /tmp \

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -1,4 +1,6 @@
-FROM centos:7
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH centos:7
+ARG ARCH
 
 ENV OPERATING_SYSTEM=centos_7
 

--- a/docker/jenkins/Dockerfile.fedora36
+++ b/docker/jenkins/Dockerfile.fedora36
@@ -1,60 +1,65 @@
-FROM opensuse/leap:15.1
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH fedora:36
+ARG ARCH
 
-ENV OPERATING_SYSTEM=opensus_leap15
+ENV OPERATING_SYSTEM=fedora_36
 
-# needed to build RPMs
-RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Tumbleweed/systemsmanagement:wbem:deps.repo
+ARG AWS_REGION=us-east-1
 
-# refresh repos and install required packages
-RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
-    zypper --non-interactive install -y \
+RUN dnf install -y \
+    R \
     ant \
     boost-devel \
-    clang \
+    bzip2-devel \
+    clang-devel \
     curl \
     expect \
     fakeroot \
+    fuse-libs \
     gcc \
     gcc-c++ \
-    gdb \
     git \
-    java-1_8_0-openjdk-devel  \
+    gpg1 \
+    gtk3 \
+    java-11-openjdk \
+    java-11-openjdk-devel \
     jq \
-    libacl-devel \
-    libatk-1_0-0 \
-    libatk-bridge-2_0-0 \
-    libattr-devel \
-    libcap-devel \
-    libcups2 \
-    libcurl-devel \
-    libgtk-3-0 \
-    libuser-devel \
-    libuuid-devel \
-    libxml2-devel \
+    libXScrnSaver-devel \
     libXcursor-devel \
     libXrandr-devel \
+    libacl-devel \
+    libcap-devel \ 
+    libcurl-devel \
+    libffi \
+    libuser-devel \
+    libuuid-devel \
+    llvm-devel \
     lsof \
     make \
-    ninja \
+    mesa-libGL-devel \
+    ninja-build \
     openssl-devel \
     p7zip \
+    p7zip-plugins \
     pam-devel \
     pango-devel \
+    patchelf \
     postgresql-devel \
-    python \
-    python-xml \
+    procps \
+    python2 \
     python3 \
-    R \
-    rpm-build \
+    rpm-sign \
+    rpmdevtools \
     sqlite-devel \
     sudo \
-    tar \
-    unzip \
     valgrind \
     wget \
     xml-commons-apis \
-    xvfb-run \
+    xorg-x11-server-Xvfb \
     zlib-devel
+
+# ensure we use the java 11 compiler to build GWT
+ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)
 RUN mkdir -p /tools
@@ -72,12 +77,12 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
+# copy python2 to python so that it can be picked up by Google scripts
+RUN cp /usr/bin/python2 /usr/bin/python
+
 # install crashpad and its dependencies
 COPY dependencies/common/install-crashpad /tmp/
-RUN bash /tmp/install-crashpad opensuse15
-
-# ensure we use the java 8 compiler
-RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
+RUN bash /tmp/install-crashpad rhel8
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
@@ -89,23 +94,13 @@ COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
 COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common fedora36
 
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
-
-# install GnuPG 1.4 from source (needed for release signing)
-RUN cd /tmp && \
-    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
-    bzip2 -d gnupg-1.4.23.tar.bz2 && \
-    tar xvf gnupg-1.4.23.tar && \
-    cd gnupg-1.4.23 && \
-    ./configure && \
-    make && \
-    make install
 
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
@@ -115,13 +110,14 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
-# create nobody user and group, used by unit tests
-RUN groupadd -g 65534 nobody && \
-    useradd -m -d /var/lib/nobody -u 65534 -g nobody nobody
-
-# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+# remove any previous users with conflicting IDs
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999
+COPY docker/jenkins/*.sh /tmp/
+RUN /tmp/clean-uid.sh $JENKINS_UID && \
+    /tmp/clean-gid.sh $JENKINS_GID
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -1,4 +1,6 @@
-FROM ubuntu:jammy
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH ubuntu:jammy
+ARG ARCH
 
 ENV OPERATING_SYSTEM=ubuntu_jammy
 

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -61,7 +61,7 @@ RUN apt-get update && \
     zlib1g-dev
 
 # ensure we use the java 11 compiler
-RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+RUN update-alternatives --set java /usr/lib/jvm/java-11-openjdk-$(dpkg --print-architecture)/bin/java
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)
 RUN mkdir -p /tools

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -1,80 +1,62 @@
-FROM ubuntu:bionic
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH opensuse/leap:15.1
+ARG ARCH
 
-ENV OPERATING_SYSTEM=ubuntu_bionic
+ENV OPERATING_SYSTEM=opensus_leap15
 
-ARG AWS_REGION=us-east-1
+# needed to build RPMs
+RUN zypper --non-interactive addrepo http://download.opensuse.org/repositories/systemsmanagement:wbem:deps/openSUSE_Tumbleweed/systemsmanagement:wbem:deps.repo
 
-# install needed packages. replace httpredir apt source with cloudfront
-RUN set -x \
-    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get update \
-    && apt-get install -y gnupg1 \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 0x51716619e084dab9 \
-    && echo 'deb http://cran.rstudio.com/bin/linux/ubuntu bionic-cran35/' >> /etc/apt/sources.list \
-    && apt-get update
-
-# add ppa repository so we can install java 8 (not in any official repo for bionic)
-RUN apt-get update \
-  && apt-get install -y software-properties-common \
-  && add-apt-repository ppa:openjdk-r/ppa
-
-RUN apt-get update && \
-    export DEBIAN_FRONTEND=noninteractive && \
-    apt-get install -y \
+# refresh repos and install required packages
+RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
+    zypper --non-interactive install -y \
     ant \
-    build-essential \
+    boost-devel \
     clang \
     curl \
-    debsigs \
-    dpkg-sig \
     expect \
     fakeroot \
-    git-core \
+    gcc \
+    gcc-c++ \
+    gdb \
+    git \
+    java-1_8_0-openjdk-devel  \
     jq \
-    libattr1-dev \
-    libacl1-dev \
-    libbz2-dev \
-    libcap-dev \
-    libcurl4-openssl-dev \
-    libfuse2 \
+    libacl-devel \
+    libatk-1_0-0 \
+    libatk-bridge-2_0-0 \
+    libattr-devel \
+    libcap-devel \
+    libcups2 \
+    libcurl-devel \
     libgtk-3-0 \
-    libgl1-mesa-dev \
-    libegl1-mesa \
-    libpam-dev \
-    libpango1.0-dev \
-    libpq-dev \
-    libsqlite3-dev \
-    libuser1-dev \
-    libssl-dev \
-    libxml2-dev \
-    libxslt1-dev \
+    libuser-devel \
+    libuuid-devel \
+    libxml2-devel \
+    libXcursor-devel \
+    libXrandr-devel \
     lsof \
-    ninja-build \
-    openjdk-8-jdk \
-    p7zip-full \
-    pkg-config \
+    make \
+    ninja \
+    openssl-devel \
+    p7zip \
+    pam-devel \
+    pango-devel \
+    postgresql-devel \
     python \
-    r-base \
+    python-xml \
+    python3 \
+    R \
+    rpm-build \
+    sqlite-devel \
     sudo \
+    tar \
     unzip \
-    uuid-dev \
     valgrind \
     wget \
-    xvfb \
-    zlib1g-dev
-
-# ensure we use the java 8 compiler
-RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
-
-## build patchelf
-RUN cd /tmp \
-    && wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz \
-    && tar xzvf patchelf-0.9.tar.gz \
-    && cd patchelf-0.9 \
-    && ./configure \
-    && make \
-    && make install
+    xml-commons-apis \
+    xvfb-run \
+    zlib-devel
 
 # copy RStudio tools (needed so that our other dependency scripts can find it)
 RUN mkdir -p /tools
@@ -90,11 +72,14 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 
 # install cmake
 COPY package/linux/install-dependencies /tmp/
-RUN /bin/bash /tmp/install-dependencies
+RUN bash /tmp/install-dependencies
 
 # install crashpad and its dependencies
 COPY dependencies/common/install-crashpad /tmp/
-RUN bash /tmp/install-crashpad bionic
+RUN bash /tmp/install-crashpad opensuse15
+
+# ensure we use the java 8 compiler
+RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
 
 # copy common dependency installation scripts
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
@@ -106,13 +91,23 @@ COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
 COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15
 
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/
 COPY dependencies/linux/install-qt-linux /tmp/
 RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
+
+# install GnuPG 1.4 from source (needed for release signing)
+RUN cd /tmp && \
+    wget https://gnupg.org/ftp/gcrypt/gnupg/gnupg-1.4.23.tar.bz2 && \
+    bzip2 -d gnupg-1.4.23.tar.bz2 && \
+    tar xvf gnupg-1.4.23.tar && \
+    cd gnupg-1.4.23 && \
+    ./configure && \
+    make && \
+    make install
 
 # cachebust for Quarto release
 ADD https://quarto.org/docs/download/_download.json quarto_releases
@@ -122,10 +117,13 @@ RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
 
+# create nobody user and group, used by unit tests
+RUN groupadd -g 65534 nobody && \
+    useradd -m -d /var/lib/nobody -u 65534 -g nobody nobody
+
 # create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
 ARG JENKINS_GID=999
 ARG JENKINS_UID=999
 RUN groupadd -g $JENKINS_GID jenkins && \
     useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
     echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
-

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -1,4 +1,6 @@
-FROM rockylinux/rockylinux:8
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH rockylinux/rockylinux:8
+ARG ARCH
 
 ENV OPERATING_SYSTEM=rockylinux_8
 

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -1,10 +1,16 @@
 ARG ARCH=amd64
-FROM --platform=linux/$ARCH fedora:36
+FROM --platform=linux/$ARCH rockylinux:9
 ARG ARCH
 
-ENV OPERATING_SYSTEM=fedora_36
+ENV OPERATING_SYSTEM=rockylinux_9
 
 ARG AWS_REGION=us-east-1
+
+RUN set -x \
+      && yum install epel-release -y \
+      && yum install dnf-plugins-core -y \ 
+      && yum config-manager --set-enabled crb \
+      && yum update -y
 
 RUN dnf install -y \
     R \
@@ -46,7 +52,6 @@ RUN dnf install -y \
     patchelf \
     postgresql-devel \
     procps \
-    python2 \
     python3 \
     rpm-sign \
     rpmdevtools \
@@ -77,9 +82,6 @@ RUN bash /tmp/install-boost || bash /tmp/install-boost
 COPY package/linux/install-dependencies /tmp/
 RUN bash /tmp/install-dependencies
 
-# copy python2 to python so that it can be picked up by Google scripts
-RUN cp /usr/bin/python2 /usr/bin/python
-
 # install crashpad and its dependencies
 COPY dependencies/common/install-crashpad /tmp/
 RUN bash /tmp/install-crashpad rhel8
@@ -94,7 +96,7 @@ COPY src/gwt/panmirror/src/editor/yarn.lock /opt/rstudio-tools/panmirror/
 COPY src/gwt/panmirror/src/editor/package.json /opt/rstudio-tools/panmirror/
 
 # install common dependencies
-RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common fedora36
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9
 
 # install Qt SDK
 COPY dependencies/common/install-qt.sh /tmp/

--- a/docker/jenkins/publish-build.ps1
+++ b/docker/jenkins/publish-build.ps1
@@ -71,6 +71,7 @@ type: build
 date: $timestamp
 link: "$url"
 filename: "$filename"
+architecture: x86_64
 sha256: "$sha256"
 channel: "$channel"
 version: "$version"

--- a/docker/jenkins/publish-build.sh
+++ b/docker/jenkins/publish-build.sh
@@ -10,6 +10,8 @@ if [ $# -eq 0 ]; then
     echo "--build   What kind of build is being added, as a path. Example: "
     echo "          desktop-pro/windows"
     echo ""
+    echo "--arch    The CPU architecture supported by the build. Example: arm64"
+    echo ""
     echo "--url     A URL to a location where the build can be downloaded. Example:"
     echo "          https://s3.amazonaws.com/rstudio-ide-build/desktop/windows/RStudio-pro.exe"
     echo ""
@@ -47,6 +49,11 @@ opts=$(getopt \
 # Apply to variables
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        --arch)
+            arch=$2
+            shift 2
+            ;;
+
         --build)
             build=$2
             shift 2
@@ -82,6 +89,11 @@ done
 if [ -z "$build" ]; then
     echo "Build not set; specify a build with --build. Example: --build desktop/windows"
     exit 1
+fi
+
+if [ -z "$arch" ]; then
+    # No architecture set? No problem, just ask uname
+    arch=$(uname -m)
 fi
 
 if [ -z "$url" ]; then
@@ -147,6 +159,7 @@ type: build
 date: $timestamp
 link: \"$url\"
 filename: \"$filename\"
+architecture: \"$arch\"
 sha256: \"$sha256\"
 channel: \"$channel\"
 version: \"$version\"

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -182,7 +182,7 @@ export R_HOME=$(R RHOME)
 export R_DOC_DIR=$(R --vanilla -s -e "cat(paste(R.home('doc'), sep=':'))")
 export R_LIB_DIR=$(R --vanilla -s -e "cat(paste(R.home('lib'), sep=':'))")
 
-# Hack: on Fedora36 (docker), the reported R_DOC_DIR doesn't exist which triggers
+# Hack: on RHEL9 (docker), the reported R_DOC_DIR doesn't exist which triggers
 # test failures; create the folder if missing
 if [ ! -e "${R_DOC_DIR}" ]; then
    sudo mkdir "${R_DOC_DIR}"


### PR DESCRIPTION
### Intent

Adds arm64 builds of RStudio and RStudio Server. Also, replaces Fedora 36 with Rocky Linux 9 since I was in the Dockerfile anyway. 

Addresses https://github.com/rstudio/rstudio/issues/11758
Addresses (most of) https://github.com/rstudio/rstudio/issues/8809

### Approach

- Parameterize all our Dockerfiles with an `ARCH` build argument so that they are switchable between architectures.
- Update dev docker compilation scripts so they can be used to build against either architecture
- Update `Jenkinsfile` to add RStudio and RStudio Server builds for arm64 on the two most modern distributions: Ubuntu 22 (Jammy) and RedHat Linux 9. Tried to extend support further back, but had a rough go of it with dependencies. If demand is high we might consider adding an Ubuntu 20 (Focal) build since Ubuntu 18 (Bionic) seems like a nonstarter.
- Replace Fedora 36 with Rocky Linux 9

### Automated Tests

N/A, not a product change. However, this does cause lots more tests to be run on new platforms (rhel9) and architectures. 

### QA Notes

- Additional work will be required to make these start showing up on the dailies page, since it doesn't currently know about them
- No current plans to release these as stable builds, but we might consider including them as a preview in the 2022.11 release

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


