### PR TITLE
Live updates for object explorer

### DIFF
--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -17,7 +17,8 @@
 .rs.setVar("explorer.types", list(
    NEW        = "new",
    OPEN_NODE  = "open_node",
-   CLOSE_NODE = "close_node"
+   CLOSE_NODE = "close_node", 
+   REFRESH    = "refresh"
 ))
 
 .rs.setVar("explorer.tags", list(
@@ -406,6 +407,18 @@
       title    = .rs.scalar(title),
       language = .rs.scalar(language)
    )
+})
+
+.rs.addFunction("explorer.refresh", function(id, entry)
+{
+   handle <- list(
+      id       = .rs.scalar(id),
+      name     = .rs.scalar(entry$name),
+      title    = .rs.scalar(entry$title),
+      language = .rs.scalar(entry$language)
+   )
+
+   .rs.explorer.fireEvent(.rs.explorer.types$REFRESH, handle)
 })
 
 # NOTE: synchronize the structure of this object with

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -241,10 +241,6 @@ void onDetectChanges(module_context::ChangeSource source)
       if (envir == R_EmptyEnv)
          continue;
 
-      // TODO: deal with python
-      if (std::string("R") != CHAR(STRING_ELT(language, 0)))
-         continue;
-
       SEXP symbol = Rf_install(CHAR(STRING_ELT(name, 0)));
       SEXP newObject = Rf_findVarInFrame(envir, symbol);
 

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -207,7 +207,7 @@ void onDetectChanges(module_context::ChangeSource source)
 
    Error error;
    r::sexp::Protect rProtect;
-   SEXP envCache;
+   SEXP envCache = R_NilValue;
    error = r::exec::RFunction(".rs.explorer.getCache").call(&envCache, &rProtect);
    if (error)
    {
@@ -227,10 +227,14 @@ void onDetectChanges(module_context::ChangeSource source)
    {
       SEXP s = Rf_install(id.c_str());
       SEXP entry = Rf_findVarInFrame(envCache, s);
+
+      // basic safety check on entry: make sure it's a 
+      // list of 5 elements
+      if (TYPEOF(entry) != VECSXP || Rf_length(entry) != 5)
+         continue;
       
       SEXP object = VECTOR_ELT(entry, 0);
       SEXP name = VECTOR_ELT(entry, 1);
-      // SEXP title = VECTOR_ELT(entry, 2);
       SEXP language = VECTOR_ELT(entry, 3);
       SEXP envir = VECTOR_ELT(entry, 4);
 

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -235,7 +235,6 @@ void onDetectChanges(module_context::ChangeSource source)
       
       SEXP object = VECTOR_ELT(entry, 0);
       SEXP name = VECTOR_ELT(entry, 1);
-      SEXP language = VECTOR_ELT(entry, 3);
       SEXP envir = VECTOR_ELT(entry, 4);
 
       // when envir is the empty env, this indicates

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -234,8 +234,10 @@ void onDetectChanges(module_context::ChangeSource source)
       SEXP language = VECTOR_ELT(entry, 3);
       SEXP envir = VECTOR_ELT(entry, 4);
 
-      // when envir is the empty env, don't try to refresh
-      // TODO: is that correct ?
+      // when envir is the empty env, this indicates
+      // that this was initially a View(<some code>)
+      // i.e. `x` is not a named object from an environment
+      // so don't update it
       if (envir == R_EmptyEnv)
          continue;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -133,6 +133,7 @@ import org.rstudio.studio.client.workbench.views.source.SourceWindowManager.Navi
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.codebrowser.CodeBrowserEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.OpenObjectExplorerEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.RefreshObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.OpenProfileEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfilerContents;
@@ -205,6 +206,7 @@ public class Source implements InsertSourceEvent.Handler,
                                PopoutDocInitiatedEvent.Handler,
                                OpenProfileEvent.Handler,
                                OpenObjectExplorerEvent.Handler,
+                               RefreshObjectExplorerEvent.Handler,
                                ReplaceRangesEvent.Handler,
                                SetSelectionRangesEvent.Handler,
                                GetEditorContextEvent.Handler,
@@ -323,6 +325,7 @@ public class Source implements InsertSourceEvent.Handler,
       events_.addHandler(ShowContentEvent.TYPE, this);
       events_.addHandler(ShowDataEvent.TYPE, this);
       events_.addHandler(OpenObjectExplorerEvent.TYPE, this);
+      events_.addHandler(RefreshObjectExplorerEvent.TYPE, this);
       events_.addHandler(OpenPresentationSourceFileEvent.TYPE, this);
       events_.addHandler(OpenSourceFileEvent.TYPE, this);
       events_.addHandler(CodeBrowserNavigationEvent.TYPE, this);
@@ -785,6 +788,16 @@ public class Source implements InsertSourceEvent.Handler,
          return;
 
       columnManager_.activateObjectExplorer(event.getHandle());
+   }
+
+   @Override
+   public void onRefreshObjectExplorerEvent(RefreshObjectExplorerEvent event)
+   {
+      // ignore if we're a satellite
+      if (!SourceWindowManager.isMainSourceWindow())
+         return;
+
+      columnManager_.refreshObjectExplorer(event.getHandle());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -944,7 +944,7 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             // check for identical titles
             if (handle.getTitle() == target.getTitle())
             {
-               ((ObjectExplorerEditingTarget) target).update(handle);
+               ((ObjectExplorerEditingTarget) target).update(handle, true);
                ensureVisible(false);
                column.selectTab(target.asWidget());
                return;
@@ -965,6 +965,27 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
                getActive().addTab(response, Source.OPEN_INTERACTIVE);
             }
          });
+   }
+
+   public void refreshObjectExplorer(ObjectExplorerHandle handle)
+   {
+      for (SourceColumn column : columnList_)
+      {
+         for (EditingTarget target : column.getEditors())
+         {
+            // bail if this isn't an object explorer filetype
+            FileType fileType = target.getFileType();
+            if (!(fileType instanceof ObjectExplorerFileType))
+               continue;
+
+            // check for identical titles
+            if (handle.getTitle() == target.getTitle())
+            {
+               ((ObjectExplorerEditingTarget) target).update(handle, false);
+               return;
+            }
+         }
+      }
    }
 
    public void showOverflowPopout()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerEditingTarget.java
@@ -156,13 +156,13 @@ public class ObjectExplorerEditingTarget
 
    // Public methods ----
 
-   public void update(ObjectExplorerHandle handle)
+   public void update(ObjectExplorerHandle handle, boolean remove)
    {
-
       final Widget originalWidget = progressPanel_.getWidget();
 
       clearDisplay();
       final String oldHandleId = getHandle().getId();
+      
       HashMap<String, String> props = new HashMap<>();
       handle.fillProperties(props);
 
@@ -174,8 +174,10 @@ public class ObjectExplorerEditingTarget
             @Override
             public void onResponseReceived(Void response)
             {
-               server_.explorerEndInspect(oldHandleId, new ErrorLoggingServerRequestCallback<>());
-
+               // The id does not change when this
+               if (remove)
+                  server_.explorerEndInspect(oldHandleId, new ErrorLoggingServerRequestCallback<>());
+               
                handle.fillProperties(doc_.getProperties());
                reloadDisplay();
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerPresenter.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.explorer;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.ObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.OpenObjectExplorerEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.RefreshObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -43,6 +44,7 @@ public class ObjectExplorerPresenter
       case NEW:        onNew(event.getData());       break;
       case OPEN_NODE:  onOpenNode(event.getData());  break;
       case CLOSE_NODE: onCloseNode(event.getData()); break;
+      case REFRESH:    onRefresh(event.getData());   break;
       case UNKNOWN:    break;
       }
    }
@@ -53,6 +55,13 @@ public class ObjectExplorerPresenter
    {
       ObjectExplorerHandle handle = eventData.getHandle();
       OpenObjectExplorerEvent event = new OpenObjectExplorerEvent(handle);
+      events_.fireEvent(event);
+   }
+
+   private void onRefresh(ObjectExplorerEvent.Data eventData)
+   {
+      ObjectExplorerHandle handle = eventData.getHandle();
+      RefreshObjectExplorerEvent event = new RefreshObjectExplorerEvent(handle);
       events_.fireEvent(event);
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/ObjectExplorerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/ObjectExplorerEvent.java
@@ -37,7 +37,10 @@ public class ObjectExplorerEvent extends GwtEvent<ObjectExplorerEvent.Handler>
       OPEN_NODE,
 
       // close a node
-      CLOSE_NODE
+      CLOSE_NODE, 
+
+      // refresh an explorer tab
+      REFRESH
    }
 
    public static class Data extends JavaScriptObject

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/RefreshObjectExplorerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/RefreshObjectExplorerEvent.java
@@ -1,0 +1,58 @@
+/*
+ * RefreshObjectExplorerEvent.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.source.editors.explorer.events;
+
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class RefreshObjectExplorerEvent extends GwtEvent<RefreshObjectExplorerEvent.Handler>
+{
+   public RefreshObjectExplorerEvent(ObjectExplorerHandle handle)
+   {
+      handle_ = handle;
+   }
+
+   public ObjectExplorerHandle getHandle()
+   {
+      return handle_;
+   }
+
+   private final ObjectExplorerHandle handle_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onRefreshObjectExplorerEvent(RefreshObjectExplorerEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onRefreshObjectExplorerEvent(this);
+   }
+
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/model/ObjectExplorerHandle.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/model/ObjectExplorerHandle.java
@@ -14,7 +14,11 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.explorer.model;
 
+import java.util.HashMap;
+
 import com.google.gwt.core.client.JavaScriptObject;
+
+import org.rstudio.core.client.js.JsObject;
 
 public class ObjectExplorerHandle extends JavaScriptObject
 {
@@ -32,5 +36,21 @@ public class ObjectExplorerHandle extends JavaScriptObject
    public final String getPath()
    {
       return URI_PREFIX + getId();
+   }
+
+   public final void fillProperties(HashMap<String, String> properties)
+   {
+      properties.put("id", getId());
+      properties.put("name", getName());
+      properties.put("title", getTitle());
+      properties.put("language", getLanguage());
+   }
+
+   public final void fillProperties(JsObject properties)
+   {
+      properties.setString("id", getId());
+      properties.setString("name", getName());
+      properties.setString("title", getTitle());
+      properties.setString("language", getLanguage());
    }
 }


### PR DESCRIPTION
### Intent

part of #1994 

### Approach

Make sure a `View(x)` when called a second time updates the view, and removes the entry from `.rs.explorer.cache`. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

In a new session, type: 

```r
f <- function() {
  x <- list(a = runif(1))
  View(x)
}
ls.str(.rs.explorer.cache)
f()
```

`x` is viewed with some number: 

<img width="493" alt="image" src="https://user-images.githubusercontent.com/2625526/185382565-4ee60d39-f236-47b0-9e73-e688fab91034.png">

`.rs.explorer.cache` is empty before the `f()` call: 

<img width="241" alt="image" src="https://user-images.githubusercontent.com/2625526/185382685-2c823880-34d2-4be3-8d88-444f5392ed3e.png">

Then it has one entry after the call to `f()`: 

<img width="348" alt="image" src="https://user-images.githubusercontent.com/2625526/185382886-72fa8d64-042e-47f1-8ea6-f2a6e945573b.png">

Call `f()` a second time, the view is replaced: 

<img width="526" alt="image" src="https://user-images.githubusercontent.com/2625526/185383055-d0deb38c-de4f-4e51-b3b1-318820233ce7.png">

`.rs.explorer.cache` still has only one entry, a new one: 

<img width="357" alt="image" src="https://user-images.githubusercontent.com/2625526/185383378-fa2fe6a8-47a5-4e58-8b5b-eb5cf39ffc59.png">

Without this change, `x` was not updated in the view, and entries were accumulating in `.rs.explorer.cache`, probably retaining the evaluation environment of `f()` forever

<img width="357" alt="image" src="https://user-images.githubusercontent.com/2625526/185383864-95e316f5-7b3a-4fa5-9b53-6af8a032d5c4.png">

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


