### PR TITLE
Fix rhel9 builds

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -108,6 +108,23 @@ RUN export QT_VERSION=5.12.8 && \
 ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
+# work around bug in Rocky Linux 9 in which file(1) fails on WASM files with 
+# this error:
+#
+#  ERROR: Bad magic format `version %#x (MVP)' (bad format char: #)
+# 
+# create a /usr/local/bin script that wraps file but always assumes files
+# ending in *.wasm are WASM modules, without invoking file(1) on them
+#
+RUN printf '\
+#!/usr/bin/env bash \n\
+if [[ $1 == *.wasm ]]; then \n\
+    echo "$1: WebAssembly (wasm) binary module version 0x1 (MVP)" \n\
+else \n\
+    /usr/bin/file "$@" \n\
+fi \n' > /usr/local/bin/file
+RUN chmod 755 /usr/local/bin/file
+
 # set github login from build argument if defined
 ARG GITHUB_LOGIN
 ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN


### PR DESCRIPTION
### Intent

rhel9 builds are currently failing due to a bug in Rocky Linux 9's `file` utility. 

### Approach

Work around the bug by creating a wrapper script in `/usr/local/bin` that wraps `file` in most cases, but assumes all `.wasm` files to be WebAssembly. 

### Automated Tests

N/A, build fix

### QA Notes

N/A, build fix

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
