### PR TITLE
Fix opening multiple satellite windows causing an error dialog

### DIFF
--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -78,6 +78,7 @@ export class SatelliteWindow extends GwtWindow {
           if (readyToClose) {
             this.closeStage = 'CloseStageAccepted';
             this.window.close();
+            appState().gwtCallback?.unregisterOwner(this);
           } else {
             // not ready to close, revert close stage and take care of business
             this.closeStage = 'CloseStageOpen';
@@ -88,6 +89,7 @@ export class SatelliteWindow extends GwtWindow {
     } else {
       // not a  source window, just close it
       this.closeSatellite(event);
+      appState().gwtCallback?.unregisterOwner(this);
     }
   }
 


### PR DESCRIPTION
### Intent
Address #11719

### Approach
Anything that tries to call `gwt-callback#getSender` fails if a satellite window was previously registered. The error occurs when searching the `owners` list for the sender.

Unregister the owner when the satellite window closes.

### Automated Tests
None.

### QA Notes
Anything that opens a satellite window should allow it a second time without error. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


