### PR TITLE
 don't re-encode to utf8

### DIFF
--- a/src/cpp/core/CrashHandler.cpp
+++ b/src/cpp/core/CrashHandler.cpp
@@ -163,8 +163,7 @@ void readOptions()
 base::FilePath googleFilePath(const std::string& str)
 {
 #ifdef _WIN32
-   std::string utf8Str = core::string_utils::systemToUtf8(str);
-   std::wstring wideStr = core::string_utils::utf8ToWide(utf8Str);
+   std::wstring wideStr = core::string_utils::utf8ToWide(str);
    return base::FilePath(wideStr);
 #else
    return base::FilePath(str);


### PR DESCRIPTION
### Intent

Addresses #11717, followup to #11788 
### Approach

#11788  makes it so an error in the crash handler doesn't bring down the r session. This PR addresses the actual error so it doesn't get thrown in the first place. 

### Automated Tests

None yet

### QA Notes

- Use Windows, R 3.6.3
- Create a user with an accented character (e.g. umlaut) in the user name
- Install daily as usual, ensure RStudio starts without crashing


