### PR TITLE
use short path name when running quarto

### DIFF
--- a/src/cpp/core/FileUtils.cpp
+++ b/src/cpp/core/FileUtils.cpp
@@ -65,6 +65,29 @@ bool copySourceFile(const FilePath& sourceDir,
 
 } // anonymous namespace
 
+// NOTE: Assumes that the path string is UTF-8 encoded.
+std::string shortPathName(const std::string& path)
+{
+#ifdef _WIN32
+
+   std::wstring widePath = string_utils::utf8ToWide(path);
+   DWORD length = ::GetShortPathNameW(widePath.c_str(), nullptr, 0);
+   if (length == 0)
+      return path;
+
+   std::vector<WCHAR> buffer(length, 0);
+   DWORD result = ::GetShortPathNameW(widePath.c_str(), &buffer[0], length);
+   if (result == 0)
+      return path;
+
+   return string_utils::wideToUtf8(std::wstring(&buffer[0]));
+
+#else
+   return string;
+#endif
+
+}
+
 FilePath uniqueFilePath(const FilePath& parent, const std::string& prefix, const std::string& extension)
 {
    // try up to 100 times then fallback to a uuid

--- a/src/cpp/core/include/core/FileUtils.hpp
+++ b/src/cpp/core/include/core/FileUtils.hpp
@@ -24,6 +24,8 @@ namespace rstudio {
 namespace core {
 namespace file_utils {
 
+std::string shortPathName(const std::string& string);
+
 FilePath uniqueFilePath(const core::FilePath& parent,
                         const std::string& prefix = "",
                         const std::string& extension = "");

--- a/src/cpp/session/include/session/SessionQuarto.hpp
+++ b/src/cpp/session/include/session/SessionQuarto.hpp
@@ -86,7 +86,12 @@ std::string quartoDefaultFormat(const core::FilePath& sourceFile);
 bool isFileInSessionQuartoProject(const core::FilePath& file);
 std::string urlPathForQuartoProjectOutputFile(const core::FilePath& outputFile);
 
+// NOTE: Prefer using 'quartoExecutablePath()' when running quarto
+// as a program / command, as this will use a Windows-safe short
+// path and so avoid issues with paths containing spaces in some contexts
+// https://github.com/rstudio/rstudio/issues/11779
 core::FilePath quartoBinary();
+std::string quartoExecutablePath();
 
 bool projectIsQuarto();
 

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -384,7 +384,7 @@ Error runQuarto(const std::vector<std::string>& args,
       options.workingDir = workingDir;
 
    return core::system::runProgram(
-      string_utils::utf8ToSystem(s_quartoPath.getAbsolutePath()),
+      string_utils::utf8ToSystem(quartoExecutablePath()),
       args,
       "",
       options,
@@ -790,7 +790,7 @@ Error quartoCreateProject(const json::JsonRpcRequest& request,
          boost::make_shared<ConsoleProcessInfo>("Creating project...",
                                                 console_process::InteractionNever);
    boost::shared_ptr<console_process::ConsoleProcess> pCP = ConsoleProcess::create(
-     string_utils::utf8ToSystem(s_quartoPath.getAbsolutePath()),
+     string_utils::utf8ToSystem(quartoExecutablePath()),
       args,
       options,
       pCPI);
@@ -1066,7 +1066,12 @@ json::Object quartoConfigJSON(bool refresh)
 
 FilePath quartoBinary()
 {
-    return s_quartoPath;
+   return s_quartoPath;
+}
+
+std::string quartoExecutablePath()
+{
+   return file_utils::shortPathName(s_quartoPath.getAbsolutePath());
 }
 
 bool projectIsQuarto()

--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -71,10 +71,11 @@ Error QuartoJob::start()
    cb.onExit =  boost::bind(&QuartoJob::onCompleted,
                              QuartoJob::shared_from_this(), _1);
 
-   Error error = processSupervisor().runProgram(string_utils::utf8ToSystem(quartoBinary().getAbsolutePath()),
-                                  args(),
-                                  options,
-                                  cb);
+   Error error = processSupervisor().runProgram(
+            string_utils::utf8ToSystem(quartoExecutablePath()),
+            args(),
+            options,
+            cb);
 
    if (error)
       return error;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11779.

### Approach

Use a short path name when trying to run Quarto.

### Automated Tests

N/A (Windows only)

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11779.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

