### PR TITLE
Moved verifyRequestSignature call into authenticate

### DIFF
--- a/src/cpp/session/http/SessionLocalStreamHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionLocalStreamHttpConnectionListener.hpp
@@ -127,7 +127,9 @@ protected:
 
    virtual bool authenticate(boost::shared_ptr<HttpConnection> ptrConnection)
    {
-      return connection::authenticate(ptrConnection, secret_);
+      if (!connection::authenticate(ptrConnection, secret_))
+         return false;
+      return HttpConnectionListenerImpl::authenticate(ptrConnection);
    }
 
 private:

--- a/src/cpp/session/http/SessionTcpIpHttpConnectionListener.hpp
+++ b/src/cpp/session/http/SessionTcpIpHttpConnectionListener.hpp
@@ -65,7 +65,10 @@ protected:
 
    bool authenticate(boost::shared_ptr<HttpConnection> ptrConnection)
    {
-      return connection::authenticate(ptrConnection, secret_);
+      bool res = connection::authenticate(ptrConnection, secret_);
+      if (!res)
+         return false;
+      return HttpConnectionListenerImpl::authenticate(ptrConnection);
    }
 
 private:


### PR DESCRIPTION
### Intent

Follow on fix for: http://github.com/rstudio/rstudio-pro/issues/3674 

### Approach

Use the existing authenticate() hook for the verifyRequestSignature. We could remove all of the other calls to verifyRequestSignature as they are now redundant but am thinking to leave them in for this patch.

### QA

See the original PR for testing. 

