### PR TITLE
Fix windows home path ~ implementation

### DIFF
--- a/src/node/desktop/src/core/user.ts
+++ b/src/node/desktop/src/core/user.ts
@@ -14,17 +14,26 @@
  */
 
 import os from 'os';
-import { getenv } from './environment';
 
+import { getenv } from './environment';
+import desktop from '../native/desktop.node';
 import { FilePath } from './file-path';
 
 export function userHomePath(): FilePath {
   const user = getenv('R_USER');
-  if (user !== '') 
+  if (checkPath(user)) 
     return new FilePath(user);
   const home = getenv('HOME');
-  if (home !== '')
+  if (checkPath(home))
     return new FilePath(home);
+  if (process.platform === 'win32') {
+    const currentHome = desktop.currentCSIDLPersonalHomePath();
+    if (checkPath(currentHome))
+      return new FilePath(currentHome);
+    const defaultHome = desktop.defaultCSIDLPersonalHomePath();
+    if (checkPath(defaultHome))
+      return new FilePath(defaultHome);
+  }
   return new FilePath(os.homedir());
 }
 
@@ -34,4 +43,11 @@ export function username(): string {
   } catch (err: unknown) {
     return '';
   }
+}
+
+function checkPath(path: string): boolean {
+  if (path === '')
+    return false;
+  const fp = new FilePath(path);
+  return fp.existsSync();
 }

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -15,3 +15,17 @@ export declare function cleanClipboard(stripHtml: boolean): void;
  * Detect if the CTRL key is currently being held down.
  */
 export declare function isCtrlKeyDown(): boolean;
+
+/**
+ * (Windows only)
+ *
+ * Return the path for the current user's My Documents directory.
+ */
+ export declare function currentCSIDLPersonalHomePath(): string;
+
+ /**
+ * (Windows only)
+ *
+ * Return the path for the default My Documents directory and force creation if needed.
+ */
+  export declare function defaultCSIDLPersonalHomePath(): string;

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -212,8 +212,8 @@ wchar_t* currentCSIDLPersonalHomePathImpl()
                                    nullptr,
                                    SHGFP_TYPE_CURRENT,
                                    homePath);
-   if (SUCCEEDED(hr))
-      return homePath;
+   #else
+   wchar_t homePath[1024] = {};
    #endif
    return homePath;
 }
@@ -232,6 +232,7 @@ namespace {
 
 wchar_t* defaultCSIDLPersonalHomePathImpl()
 {
+   
    #ifdef _WIN32
    // query for default and force creation (works around situations
    // where redirected path is not available)
@@ -242,8 +243,8 @@ wchar_t* defaultCSIDLPersonalHomePathImpl()
                                    nullptr,
                                    SHGFP_TYPE_DEFAULT,
                                    homePath);
-   if (SUCCEEDED(hr))
-      return homePath;
+   #else
+   wchar_t homePath[1024] = {};
    #endif
    return homePath;
 }

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -222,9 +222,9 @@ wchar_t* currentCSIDLPersonalHomePathImpl()
 Napi::Value currentCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
    wchar_t* value = currentCSIDLPersonalHomePathImpl();
-   // wide to UTF-8
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
-    std::string u8str = conv1.to_bytes(value);
+   // convert wide to UTF-8
+   std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
+   std::string u8str = conv1.to_bytes(value);
    return Napi::String::New(info.Env(), u8str);
 }
 
@@ -253,9 +253,9 @@ wchar_t* defaultCSIDLPersonalHomePathImpl()
 Napi::Value defaultCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
    wchar_t* value = defaultCSIDLPersonalHomePathImpl();
-      // wide to UTF-8
-    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
-    std::string u8str = conv1.to_bytes(value);
+   // convert wide to UTF-8
+   std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
+   std::string u8str = conv1.to_bytes(value);
    return Napi::String::New(info.Env(), u8str);
 }
 

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -201,7 +201,7 @@ Napi::Value isCtrlKeyDown(const Napi::CallbackInfo& info)
 
 namespace {
 
-std::string currentCSIDLPersonalHomePathImpl()
+wchar_t* currentCSIDLPersonalHomePathImpl()
 {
    #ifdef _WIN32
    // query for My Documents directory
@@ -215,19 +215,22 @@ std::string currentCSIDLPersonalHomePathImpl()
    if (SUCCEEDED(hr))
       return homePath;
    #endif
-   return "";
+   return homePath;
 }
 } // end anonymous namespace
 
 Napi::Value currentCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
-   std::string value = currentCSIDLPersonalHomePathImpl();
-   return Napi::String::New(info.Env(), value);
+   wchar_t* value = currentCSIDLPersonalHomePathImpl();
+   // wide to UTF-8
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
+    std::string u8str = conv1.to_bytes(value);
+   return Napi::String::New(info.Env(), u8str);
 }
 
 namespace {
 
-std::string defaultCSIDLPersonalHomePathImpl()
+wchar_t* defaultCSIDLPersonalHomePathImpl()
 {
    #ifdef _WIN32
    // query for default and force creation (works around situations
@@ -242,14 +245,17 @@ std::string defaultCSIDLPersonalHomePathImpl()
    if (SUCCEEDED(hr))
       return homePath;
    #endif
-   return "";
+   return homePath;
 }
 } // end anonymous namespace
 
 Napi::Value defaultCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
-   std::string value = defaultCSIDLPersonalHomePathImpl();
-   return Napi::String::New(info.Env(), value);
+   wchar_t* value = defaultCSIDLPersonalHomePathImpl();
+      // wide to UTF-8
+    std::wstring_convert<std::codecvt_utf8<wchar_t>> conv1;
+    std::string u8str = conv1.to_bytes(value);
+   return Napi::String::New(info.Env(), u8str);
 }
 
 } // end namespace desktop

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -200,10 +200,10 @@ Napi::Value isCtrlKeyDown(const Napi::CallbackInfo& info)
 
 
 namespace {
-#ifdef _WIN32
 
-std::string currentCSIDLPersonalHomePath()
+std::string currentCSIDLPersonalHomePathImpl()
 {
+   #ifdef _WIN32
    // query for My Documents directory
    const DWORD SHGFP_TYPE_CURRENT = 0;
    wchar_t homePath[MAX_PATH];
@@ -214,23 +214,22 @@ std::string currentCSIDLPersonalHomePath()
                                    homePath);
    if (SUCCEEDED(hr))
       return homePath;
-   else
-      return "";
+   #endif
+   return "";
 }
-#endif // _WIN32
 } // end anonymous namespace
 
 Napi::Value currentCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
-   String value = currentCSIDLPersonalHomePath();
-   return Napi::String::From(info.Env(), value);
+   std::string value = currentCSIDLPersonalHomePathImpl();
+   return Napi::String::New(info.Env(), value);
 }
 
 namespace {
-#ifdef _WIN32
 
-std::string defaultCSIDLPersonalHomePath()
+std::string defaultCSIDLPersonalHomePathImpl()
 {
+   #ifdef _WIN32
    // query for default and force creation (works around situations
    // where redirected path is not available)
    const DWORD SHGFP_TYPE_DEFAULT = 1;
@@ -242,16 +241,15 @@ std::string defaultCSIDLPersonalHomePath()
                                    homePath);
    if (SUCCEEDED(hr))
       return homePath;
-   else
-      return "";
+   #endif
+   return "";
 }
-#endif // _WIN32
 } // end anonymous namespace
 
 Napi::Value defaultCSIDLPersonalHomePath(const Napi::CallbackInfo& info)
 {
-   String value = defaultCSIDLPersonalHomePath();
-   return Napi::String::From(info.Env(), value);
+   std::string value = defaultCSIDLPersonalHomePathImpl();
+   return Napi::String::New(info.Env(), value);
 }
 
 } // end namespace desktop


### PR DESCRIPTION
### Intent

Address implementation of `~` on Windows in #11635 and #11712

### Approach

Port over `currentCSIDLPersonalHomePath` and `defaultCSIDLPersonalHomePath` as native modules and use those when both R_USER and HOME are unset and platform is Windows

### Automated Tests

None

