### PR TITLE
Add null guards for Quarto capabilities

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewQuartoProjectPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/newproject/NewQuartoProjectPage.java
@@ -181,7 +181,8 @@ public class NewQuartoProjectPage extends NewDirectoryPage
       
       // popuplate kernel list from caps
       quartoCaps_ = input.getContext().getQuartoCapabilities();
-      JsArray<QuartoJupyterKernel> kernels = quartoCaps_.jupyterKernels();
+      JsArray<QuartoJupyterKernel> kernels = quartoCaps_ == null ?
+              JsArray.createArray().cast() : quartoCaps_.jupyterKernels();
       
       String[] kernelNames = new String[kernels.length()];
       String[] kernelDisplayNames = new String[kernels.length()];

--- a/src/gwt/src/org/rstudio/studio/client/quarto/ui/NewQuartoDocumentDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/quarto/ui/NewQuartoDocumentDialog.java
@@ -188,7 +188,8 @@ public class NewQuartoDocumentDialog extends ModalDialog<NewQuartoDocumentDialog
       setListBoxValue(engineSelect_, lastResult_.getEngine());
             
       Label kernelLabel = createLabel(constants_.kernelLabelCaption());
-      JsArray<QuartoJupyterKernel> kernels = caps.jupyterKernels();
+      JsArray<QuartoJupyterKernel> kernels = caps == null ?
+              JsArray.createArray().cast() : caps.jupyterKernels();
       
       String[] kernelNames = new String[kernels.length()];
       String[] kernelDisplayNames = new String[kernels.length()];
@@ -293,7 +294,7 @@ public class NewQuartoDocumentDialog extends ModalDialog<NewQuartoDocumentDialog
       {
          language = "r";
       }
-      else
+      else if (caps_ != null)
       {
          JsArray<QuartoJupyterKernel> kernels = caps_.jupyterKernels();
          for (int i=0; i<kernels.length(); i++)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11769.

### Approach

We don't have an exact repro for this bug, but it has been reported a number of times on the community forum and in support tickets. In each case, the problem is that creating a new project fails with a JavaScript error referring to `python`. 

Analyzing the code reveals that the problem is almost certainly related to Quarto capabilities. These can be `NULL` when Quarto is disabled (for any reason), but one of the pages in the New Project wizard reads the `.python` member without a null guard (while fetching the set of Jupyter kernels). 

The fix is speculative; it just adds null guards to places where we were presuming the capability set to be non-null. 

### Automated Tests

N/A; we don't have a real repro for this.

### QA Notes

Test project creation in environments where Quarto is disabled, such as CentOS 7. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


