### PR TITLE
don't set '-r' in git grep invocation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+- Fixed an issue where Find in Files could fail to find results with certain versions of git (#11822)
 - Fixed visual mode outline missing nested R code chunks (#11410)
 - Fixed an issue where chunks containing multibyte characters was not executed correctly (#10632)
 - Fixed bringing main window under active secondary window when executing background command (#11407)

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1474,7 +1474,7 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...
       cmd << (grepOptions.excludeGitIgnore() ? "--exclude-standard" : "--no-exclude-standard");
-      cmd << "-rHn";
+      cmd << "-Hn";
       cmd << "--color=always";
       if (grepOptions.ignoreCase())
          cmd << "-i";


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11822.

### Approach

`git grep` is recursive by default, and some version of `git` don't support the `--recursive` (`-r`) flag. So, don't set it. See: https://git-scm.com/docs/git-grep#Documentation/git-grep.txt--r

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11822.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
