### PR TITLE
Fix toggle developer tools/insert code chunk accelerator conflict

### DIFF
--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -202,7 +202,7 @@ export class MenuCallback extends EventEmitter {
   menuEnd(): void {
     if (this.lastWasDiagnostics) {
       this.lastWasDiagnostics = false;
-      const template: MenuItemConstructorOptions = { role: 'toggleDevTools' };
+      const template: MenuItemConstructorOptions = { role: 'toggleDevTools', accelerator: '' };
       this.addToCurrentMenu(template);
     }
 


### PR DESCRIPTION
### Intent
Addresses #11827  

### Approach
Remove the key accelerator (Opt+Cmd+I or Ctrl+Shift+I) for toggling developer tools

### Automated Tests
None

### QA Notes
I could only reproduce the issue in a non-markdown file like an R code file. It may differ according to platform but the key conflict exists and may prevent the insert code chunk action from working.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


