### PR TITLE
Implement set presentation url

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -769,6 +769,10 @@ export class GwtCallback extends EventEmitter {
       this.getSender('desktop_set_viewer_url', event.processId, event.frameId).setViewerUrl(url);
     });
 
+    ipcMain.on('desktop_set_presentation_url', (event, url) => {
+      this.getSender('desktop_set_presentation_url', event.processId, event.frameId).setPresentationUrl(url);
+    });
+
     ipcMain.on('desktop_reload_viewer_zoom_window', (_event, url) => {
       const browser = appState().windowTracker.getWindow('_rstudio_viewer_zoom');
       if (browser) {

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -537,6 +537,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_viewer_url', url);
     },
 
+    setPresentationUrl: (url: string) => {
+      ipcRenderer.send('desktop_set_presentation_url', url);
+    },
+
     reloadViewerZoomWindow: (url: string) => {
       ipcRenderer.send('desktop_reload_viewer_zoom_window', url);
     },


### PR DESCRIPTION
### Intent
More work for #11252 

### Approach
Implement the `setPresentationUrl` call in the desktop bridge. This allows navigation to the presentation url when rendering to the Presentation Pane.

### Automated Tests
None

### QA Notes
Render preview to pane will work now. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


