### PR TITLE
Electron - open file in working directory when launching RStudio with a file arg

### DIFF
--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -17,6 +17,7 @@ import path from 'path';
 import { spawn } from 'child_process';
 import { existsSync, readdirSync } from 'fs';
 import { setenv, unsetenv } from '../core/environment';
+import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
 import { MainWindow } from './main-window';
 import { app } from 'electron';
 
@@ -70,19 +71,18 @@ export class ApplicationLaunch {
 
     // resolve working directory
     const workingDir = options.workingDirectory ?? path.dirname(options.projectFilePath || '');
-    setenv('RS_INITIAL_WD', workingDir);
+    setenv(kRStudioInitialWorkingDir, workingDir);
 
     // resolve project file, if any
     const projectFile = options.projectFilePath ?? resolveProjectFile(workingDir);
     if (existsSync(projectFile)) {
-      setenv('RS_INITIAL_PROJECT', projectFile);
+      setenv(kRStudioInitialProject, projectFile);
     }
 
     // run it
     spawn(process.execPath, argv, { detached: true });
 
     // restore environment variables
-    unsetenv('RS_INSTALL_WD');
-    unsetenv('RS_INITIAL_PROJECT');
+    unsetenv(kRStudioInitialProject);
   }
 }

--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -15,7 +15,7 @@
 
 import { app, webContents } from 'electron';
 import path from 'path';
-import { setenv } from '../core/environment';
+import { setenv, getenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 import {
   enableDiagnosticsOutput,
@@ -23,7 +23,7 @@ import {
   parseCommandLineLogLevel,
   setLogger
 } from '../core/logger';
-import { kRStudioInitialProject } from '../core/r-user-data';
+import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
 import { WinstonLogger } from '../core/winston-logger';
 import { getDesktopBridge } from '../renderer/desktop-bridge';
 import { Application } from './application';
@@ -122,6 +122,7 @@ export class ArgsManager {
             });
         }
       });
+      logger().logDebug(`RS_INITIAL_WD: ${getenv(kRStudioInitialWorkingDir)}`); 
     }
   }
 
@@ -139,6 +140,7 @@ export class ArgsManager {
 
     if (this.unswitchedArgs.length) {
       this.unswitchedArgs = this.unswitchedArgs.filter((arg) => {
+        logger().logDebug(`arg: ${arg}`);
         if (FilePath.existsSync(arg)) {
           const ext = path.extname(arg).toLowerCase();
 
@@ -146,8 +148,11 @@ export class ArgsManager {
             setenv(kRStudioInitialProject, arg);
             return false;
           }
+          else {
+            setenv(kRStudioInitialWorkingDir, arg);
+          }
         }
-
+        logger().logDebug(`RS_INITIAL_WD: ${getenv(kRStudioInitialWorkingDir)}`);
         return true;
       });
     }

--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -122,7 +122,6 @@ export class ArgsManager {
             });
         }
       });
-      logger().logDebug(`RS_INITIAL_WD: ${getenv(kRStudioInitialWorkingDir)}`); 
     }
   }
 
@@ -140,7 +139,6 @@ export class ArgsManager {
 
     if (this.unswitchedArgs.length) {
       this.unswitchedArgs = this.unswitchedArgs.filter((arg) => {
-        logger().logDebug(`arg: ${arg}`);
         if (FilePath.existsSync(arg)) {
           const ext = path.extname(arg).toLowerCase();
 
@@ -149,7 +147,8 @@ export class ArgsManager {
             return false;
           }
           else {
-            setenv(kRStudioInitialWorkingDir, arg);
+            const workingDir = path.dirname(arg);
+            setenv(kRStudioInitialWorkingDir, workingDir);
           }
         }
         logger().logDebug(`RS_INITIAL_WD: ${getenv(kRStudioInitialWorkingDir)}`);


### PR DESCRIPTION
### Intent

Address #[#11778](https://github.com/rstudio/rstudio/issues/11778), at least on Windows and Linux. May need some additional handling for Mac to process double-click on Finder events, but will leave to subsequent PR.

### Approach

Set the RS_INITIAL_WD environment variable, used by the C++ session code, in pre-launch Electron code

### Automated Tests
None

### QA Notes
Will need to be tested on at least Windows and Mac -- see notes in issue.
