### PR TITLE
Add Finder handling for Mac setting initial working directory

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -208,9 +208,7 @@ export class Application implements AppState {
       }
       else {
         // for non-Rproj files, we want to set the initial working directory, before opening the file
-        if (app.isReady()) {
-          this.appLaunch?.launchRStudio({workingDirectory: path.dirname(filepath)});
-        } else {
+        if (!app.isReady()) {
           setenv(kRStudioInitialWorkingDir, path.dirname(filepath));
         }
       }

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -19,7 +19,7 @@ import path from 'path';
 import { getenv, setenv } from '../core/environment';
 import { FilePath } from '../core/file-path';
 import { logger } from '../core/logger';
-import { kRStudioInitialProject } from '../core/r-user-data';
+import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-user-data';
 import { generateRandomPort } from '../core/system';
 import { getDesktopBridge } from '../renderer/desktop-bridge';
 import { DesktopActivation } from './activation-overlay';
@@ -205,6 +205,14 @@ export class Application implements AppState {
           setenv(kRStudioInitialProject, filepath);
         }
         return;
+      }
+      else {
+        // for non-Rproj files, we want to set the initial working directory, before opening the file
+        if (app.isReady()) {
+          this.appLaunch?.launchRStudio({workingDirectory: path.dirname(filepath)});
+        } else {
+          setenv(kRStudioInitialWorkingDir, path.dirname(filepath));
+        }
       }
 
       app.whenReady()

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -208,6 +208,7 @@ export class Application implements AppState {
       }
       else {
         // for non-Rproj files, we want to set the initial working directory, before opening the file
+        // if a session does not already exist (otherwise, just open the file)
         if (!app.isReady()) {
           setenv(kRStudioInitialWorkingDir, path.dirname(filepath));
         }


### PR DESCRIPTION
### Intent
Second part of [#11778](https://github.com/rstudio/rstudio/issues/11778) for Macs

### Approach

set the initial working directory in the `open-file` event used when double clicking file from the Finder window.
