### PR TITLE
Fix HTML preview

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.core.client.widget;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.DomUtils;
@@ -89,14 +90,22 @@ public class RStudioFrame extends Frame
    @Override
    public void setUrl(String url)
    {
-      Desktop.getFrame().allowNavigation(DomUtils.makeAbsoluteUrl(url), new CommandWithArg<Boolean>() {
-         @Override
-         public void execute(Boolean arg) {
-            if (arg)
-            {
-               RStudioFrame.super.setUrl(url);
+      if (BrowseCap.isElectron())
+      {
+         // Electron workaround to checking URL for iframe navigation intent
+         Desktop.getFrame().allowNavigation(DomUtils.makeAbsoluteUrl(url), new CommandWithArg<Boolean>() {
+            @Override
+            public void execute(Boolean arg) {
+               if (arg)
+               {
+                  RStudioFrame.super.setUrl(url);
+               }
             }
-         }
-      });
+         });
+      }
+      else
+      {
+         super.setUrl(url);
+      }
    }
 }


### PR DESCRIPTION
### Intent
Fixes previewing HTML files for RStudio server and Qt builds.

### Approach
The `allowNavigation` was only implemented for Electron to get around the lack of a `will-frame-navigate` event.

### Automated Tests
This will fix an automated test

### QA Notes
None 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


