### PR TITLE
tweak handling for potentially null response values

### DIFF
--- a/src/cpp/session/SessionRpc.cpp
+++ b/src/cpp/session/SessionRpc.cpp
@@ -255,19 +255,20 @@ void endHandleRpcRequestIndirect(
         const core::Error& executeError,
         json::JsonRpcResponse* pJsonRpcResponse)
 {
-   json::JsonRpcResponse temp;
-   json::JsonRpcResponse& jsonRpcResponse =
-           pJsonRpcResponse ? *pJsonRpcResponse : temp;
+   // pJsonRpcResponse may be a nullptr, so handle that safely
+   json::JsonRpcResponse emptyResponse;
+   if (pJsonRpcResponse == nullptr)
+      pJsonRpcResponse = &emptyResponse;
 
    if (executeError)
-      jsonRpcResponse.setError(executeError);
+      pJsonRpcResponse->setError(executeError);
    
-   if (!jsonRpcResponse.hasField(kEventsPending))
-      jsonRpcResponse.setField(kEventsPending, "false");
+   if (!pJsonRpcResponse->hasField(kEventsPending))
+      pJsonRpcResponse->setField(kEventsPending, "false");
    
    json::Object value;
    value["handle"] = asyncHandle;
-   value["response"] = jsonRpcResponse.getRawResponse();
+   value["response"] = pJsonRpcResponse->getRawResponse();
    ClientEvent evt(client_events::kAsyncCompletion, value);
    module_context::enqueClientEvent(evt);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11841.

### Approach

In handling a potentially null pointer, rather than defining a separate "safe" reference variable, just set the pointer binding to a valid reference.

### Automated Tests

Not sure how to test (theoretically, would be covered by existing tests?)

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
