### PR TITLE
add null checks to cache_ when reading pref values

### DIFF
--- a/src/cpp/session/prefs/PrefLayer.cpp
+++ b/src/cpp/session/prefs/PrefLayer.cpp
@@ -265,6 +265,12 @@ boost::optional<core::json::Value> PrefLayer::readValue(const std::string& name)
 {
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
+      if (!cache_)
+      {
+         WLOGF("Attempt to look up preference '{}' in layer '{}' before it was initialized", name, layerName());
+         return boost::none;
+      }
+      
       const auto it = cache_->find(name);
       if (it == cache_->end())
       {
@@ -282,6 +288,12 @@ Error PrefLayer::clearValue(const std::string& name)
 {
    RECURSIVE_LOCK_MUTEX(mutex_)
    {
+      if (!cache_)
+      {
+         WLOGF("Attempt to clear preference '{}' in layer '{}' before it was initialized", name, layerName());
+         return Success();
+      }
+      
       auto it = cache_->find(name);
       if (it == cache_->end())
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11802.

### Approach

Copies the existing formula for checking for unset preference layers here:

https://github.com/rstudio/rstudio/blob/11579f2d472ea9a6f677efafcce33c6a26e9dcd9/src/cpp/session/include/session/prefs/PrefLayer.hpp#L54-L59

### Automated Tests

Not included as this is mostly a speculative fix.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
