### PR TITLE
normalize R_LIBS_USER before checking library type

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
@@ -30,7 +30,7 @@ public class PackageLibraryUtils
       User,
       System
    }
-
+   
    public static PackageLibraryType typeOfLibrary(Session session, 
                                                   String library)
    {
@@ -42,11 +42,16 @@ public class PackageLibraryUtils
       String rLibsUser = sessionInfo.getRLibsUser();
       boolean hasRLibsUser = !StringUtil.isNullOrEmpty(rLibsUser);
       
-      // On Windows with R 4.2.x, the default value of R_LIBS_USER can
-      // have mixed slashes, but the path comparisons below assume paths
-      // will be using forward slashes. Normalize slashes here.
+      // On Windows with R 4.2.x, the default value of R_LIBS_USER can have
+      // mixed slashes, but the path comparisons below assume paths will be
+      // using forward slashes.
+      // 
+      // Either way, we compute library paths using forward slashes, so it's
+      // prudent for us to normalize slashes before comparison here.
       if (BrowseCap.isWindows() && hasRLibsUser)
+      {
          rLibsUser = rLibsUser.replace('\\', '/');
+      }
       
       // if there's an active project and this package is in its library or
       // the package has no recorded library (i.e. it's not installed), it
@@ -82,5 +87,6 @@ public class PackageLibraryUtils
    {
       return nameOfLibraryType(typeOfLibrary(session, library));
    }
+   
    private static final PackagesConstants constants_ = com.google.gwt.core.client.GWT.create(PackagesConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.packages.model;
 
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -40,6 +41,12 @@ public class PackageLibraryUtils
       
       String rLibsUser = sessionInfo.getRLibsUser();
       boolean hasRLibsUser = !StringUtil.isNullOrEmpty(rLibsUser);
+      
+      // On Windows with R 4.2.x, the default value of R_LIBS_USER can
+      // have mixed slashes, but the path comparisons below assume paths
+      // will be using forward slashes. Normalize slashes here.
+      if (BrowseCap.isWindows() && hasRLibsUser)
+         rLibsUser = rLibsUser.replace('\\', '/');
       
       // if there's an active project and this package is in its library or
       // the package has no recorded library (i.e. it's not installed), it
@@ -71,7 +78,7 @@ public class PackageLibraryUtils
       return constants_.libraryText();
    }
    
-   public static String getLibraryDescription (Session session, String library)
+   public static String getLibraryDescription(Session session, String library)
    {
       return nameOfLibraryType(typeOfLibrary(session, library));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/packages/model/PackageLibraryUtils.java
@@ -48,7 +48,7 @@ public class PackageLibraryUtils
       // 
       // Either way, we compute library paths using forward slashes, so it's
       // prudent for us to normalize slashes before comparison here.
-      if (BrowseCap.isWindows() && hasRLibsUser)
+      if (BrowseCap.isWindowsDesktop() && hasRLibsUser)
       {
          rLibsUser = rLibsUser.replace('\\', '/');
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11847.

### Approach

Normalize slashes in the path provided by `R_LIBS_USER` before comparing the paths.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11847.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
