### PR TITLE
Fix markdown preview setting the pane url as a path

### DIFF
--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -33,8 +33,14 @@ export function getAuthority(url: string): string {
     return url;
   }
 
-  const targetUrl = new URL(url);
-  return `${targetUrl.protocol}//${targetUrl.host}`;
+  try {
+    // uses 127.0.0.1 for host if url is just a path
+    const targetUrl = new URL(url, 'http://127.0.0.1');
+    return `${targetUrl.protocol}//${targetUrl.host}`;
+  } catch (error: unknown) {
+    logger().logError(error);
+    return '';
+  }
 }
 
 export function isChromeGpuUrl(url: string): boolean {

--- a/src/node/desktop/test/unit/main/url-utils.test.ts
+++ b/src/node/desktop/test/unit/main/url-utils.test.ts
@@ -86,4 +86,16 @@ describe('URL Utils', () => {
     assert.equal(getAuthority(url), 'http://localhost:123');
     assert.equal(getAuthority(`${url}?param_one=test`), 'http://localhost:123');
   });
+
+  it('gets authority for localhost paths', () => {
+    assert.equal(getAuthority('rmd_output/0'), 'http://127.0.0.1');
+  });
+  
+  it('gets authority for external URLs', () => {
+    assert.equal(getAuthority('http://www.rstudio.com/download'), 'http://www.rstudio.com');
+  });
+
+  it('handles invalid url', () => {
+    assert.equal(getAuthority('http://bad^url'), '');
+  });
 });


### PR DESCRIPTION
### Intent
Knitting a markdown file would show an error message after the preview displays in the pane.

### Approach
Added a try/catch to `getAuthority` since it can throw when constructing a bad url. The default base url is set to localhost to handle the preview setting the URL as `rmd_output/0`. What we really want to do with the authority is to make sure that the host and port match our list of URL's that a pane might be set to. If the URL is completely invalid, an empty string is used.

### Automated Tests
Unit test added to check a bad url or a path.

### QA Notes
Knitting a markdown file will not show an error message. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


