### PR TITLE
handle C projects using rlang-rcc.cpp

### DIFF
--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -255,7 +255,25 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    // add verbose output if requested
    if (verbose_ >= 2)
      args.push_back("-v");
-
+   
+   // fix up '-std=' arguments; in particular, we only pass the C++
+   // '-std' flags when compiling C++ sources, and the C '-std' flags
+   // whe compiling C sources
+   if (FilePath(filename).hasExtensionLowerCase(".c"))
+   {
+      core::algorithm::expel_if(args, [](const std::string& arg)
+      {
+         return arg.find("-std") == 0 && arg.find("++") != 0;
+      });
+   }
+   else
+   {
+      core::algorithm::expel_if(args, [](const std::string& arg)
+      {
+         return arg.find("-std") == 0 && arg.find("++") == 0;
+      });
+   }
+   
    // report to user if requested
    if (verbose_ > 1)
    {

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -454,7 +454,7 @@ bool packageIsCpp(const std::string& linkingTo, const FilePath& srcDir)
 
    for (const FilePath& srcFile : allSrcFiles)
    {
-      // some projects that are other pure C might depend on some
+      // some projects that are otherwise pure C might depend on some
       // C++ extensions from rlang; ignore those if they exist
       std::string name = srcFile.getFilename();
       if (name == "rlang-rcc.cpp")


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11852.

### Approach

- Try to fix up `-std` flags before compiling translation units, just in case.
- Ignore that `rlang-rcc.cpp` file when deciding if a project is primarily C or C++.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11852.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
