### PR TITLE
change OBJECTS = to zzzOBJECTS = in Makevars and Makevars.win

### DIFF
--- a/src/cpp/core/FileUtils.cpp
+++ b/src/cpp/core/FileUtils.cpp
@@ -128,6 +128,22 @@ std::string readFile(const FilePath& filePath)
    return content;
 }
 
+Error writeFile(const FilePath& filePath, const std::string& content)
+{
+   std::shared_ptr<std::ostream> stream;
+   Error error = filePath.openForWrite(stream);
+   if (error)
+   {
+      return error;
+   }
+   *stream << content;
+
+   stream->flush();
+   stream.reset(); 
+
+   return Success();
+}
+
 #ifdef _WIN32
 // test a filename to see if it corresponds to a reserved device name on
 // Windows

--- a/src/cpp/core/include/core/FileUtils.hpp
+++ b/src/cpp/core/include/core/FileUtils.hpp
@@ -31,6 +31,7 @@ FilePath uniqueFilePath(const core::FilePath& parent,
                         const std::string& extension = "");
 
 std::string readFile(const core::FilePath& filePath);
+Error writeFile(const FilePath& filePath, const std::string& content);
 
 #ifdef _WIN32
 bool isWindowsReservedName(const std::string& name);

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -559,11 +559,16 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
       return {};
    }
 
+   static const boost::regex objectsRegex("^OBJECTS *=");
+
    // copy Makevars to tempdir if it exists
    FilePath makevarsPath = srcDir.completeChildPath("Makevars");
    if (makevarsPath.exists())
    {
-      Error error = makevarsPath.copy(tempDir.completeChildPath("Makevars"));
+      std::string Makevars = file_utils::readFile(makevarsPath);
+      Makevars = boost::regex_replace(Makevars, objectsRegex, "zzzOBJECTS =");
+      
+      error = file_utils::writeFile(tempDir.completeChildPath("Makevars"), Makevars);
       if (error)
       {
          LOG_ERROR(error);
@@ -574,7 +579,10 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
    FilePath makevarsWinPath = srcDir.completeChildPath("Makevars.win");
    if (makevarsWinPath.exists())
    {
-      Error error = makevarsWinPath.copy(tempDir.completeChildPath("Makevars.win"));
+      std::string MakevarsWin = file_utils::readFile(makevarsWinPath);
+      MakevarsWin = boost::regex_replace(MakevarsWin, objectsRegex, "zzzOBJECTS =");
+      
+      error = file_utils::writeFile(tempDir.completeChildPath("Makevars.win"), MakevarsWin);
       if (error)
       {
          LOG_ERROR(error);


### PR DESCRIPTION
### Intent

addresses #6384

### Approach

hack the files `Makevars` and `Makeovers.win` before they get copied to temp directory so that the line `OBJECTS = ` has no effect. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


