### PR TITLE
bump `RCompilationDatabase :: kCompilationDatabaseVersion` 

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -50,7 +50,7 @@ using namespace rstudio::core;
 using namespace rstudio::core::libclang;
 using namespace boost::placeholders;
 
-#define kCompilationDatabaseVersion 1
+#define kCompilationDatabaseVersion 2
 
 namespace rstudio {
 namespace session {

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -595,26 +595,9 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
       }
    }
 
-   // try to generate an appropriate name for the C++ source file.
-   // if we have Makevars / Makevars.site, they may define OBJECT
-   // targets; if we pick a file name not matching any OBJECT target
-   // then R CMD SHLIB will fail. (technically this implies that we
-   // need OBJECT-specific compilation configs but in practice one
-   // often just enumerates each OBJECT explicitly and re-uses the
-   // same compilation config for each file)
+   // generate an appropriate name for the C++ source file.
    std::string ext = isCpp ? ".cpp" : ".c";
    std::string filename = kCompilationDbPrefix + core::system::generateUuid() + ext;
-
-   std::vector<FilePath> children;
-   srcDir.getChildren(children);
-   for (const FilePath& child : children)
-   {
-      if (child.getExtension() == ext)
-      {
-         filename = child.getFilename();
-         break;
-      }
-   }
 
    // call R CMD SHLIB on a temp file to capture the compilation args
    FilePath tempSrcFile = tempDir.completeChildPath(filename);


### PR DESCRIPTION
### Intent

Follow up to #11864 

### Approach

This bumps `kCompilationDatabaseVersion` to 2 so that we don't restore compilation setting from previous versions. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


