### PR TITLE
delay sync of document outline styles

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -958,7 +958,6 @@ public class DomUtils
       return parent;
    }
 
-   // NOTE: Not supported in IE8
    public static final native Style getComputedStyles(Element el)
    /*-{
       return $wnd.getComputedStyle(el);
@@ -1329,8 +1328,7 @@ public class DomUtils
    /*-{
       return el.getBoundingClientRect();
    }-*/;
-
-
+   
    public static final int ESTIMATED_SCROLLBAR_WIDTH = 19;
    private static int SCROLLBAR_WIDTH = -1;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeStyleChangedEvent;
 
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.event.shared.HandlerManager;
@@ -70,11 +71,22 @@ public class TextEditingTargetThemeHelper
  
    private void syncToEditorTheme(TextEditingTarget editingTarget)
    {
+      // delay execution so that the browser has a chance to apply styles
+      // https://github.com/rstudio/rstudio/issues/11868
+      Scheduler.get().scheduleDeferred(() ->
+      {
+         syncToEditorThemeImpl(editingTarget);
+      });
+   }
+   
+   private void syncToEditorThemeImpl(TextEditingTarget editingTarget)
+   {
       // ensure we're passed a real widget
       Widget editingWidget = editingTarget.asWidget();
       if (editingWidget == null)
          return;
       
+      // get the element containing the editor
       Element editorContainer = editingWidget.getElement();
       Element[] aceContentElements =
             DomUtils.getElementsByClassName(editorContainer, "ace_scroller");


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11868.
Addresses https://github.com/rstudio/rstudio/issues/11422.

### Approach

Delay synchronization of CSS styles with editor theme, so that the browser has a chance to render these themes first.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11868 (perhaps an update to Chrome is causing this to be more easily triggered?)

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
