### PR TITLE
use 'webview' for Viewer pane in Electron

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/ScrollUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/ScrollUtil.java
@@ -14,7 +14,7 @@
  */
 package org.rstudio.core.client;
 
-import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
@@ -22,7 +22,7 @@ import com.google.gwt.dom.client.Document;
 
 public class ScrollUtil
 {
-   public static void setScrollPositionOnLoad(final RStudioFrame frame, 
+   public static void setScrollPositionOnLoad(final ViewerPane.Display frame,
                                               final int scrollPosition)
    {
       Scheduler.get().scheduleFixedDelay(new RepeatingCommand() {
@@ -35,14 +35,11 @@ public class ScrollUtil
                return false;
 
             // wait for a document to become available in the frame
-            if (frame.getIFrame() == null)
-               return true;
-            
-            if (frame.getIFrame().getContentDocument() == null)
+            Document doc = frame.getContentDocument();
+            if (doc == null)
                return true;
 
             // wait for the document to finish loading
-            Document doc = frame.getIFrame().getContentDocument();
             String readyState = getDocumentReadyState(doc);
             if (readyState == null)
                return true;

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioFrame.java
@@ -22,10 +22,15 @@ import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.dom.IFrameElementEx;
 import org.rstudio.core.client.dom.WindowEx;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.IFrameElement;
 import com.google.gwt.user.client.ui.Frame;
-import org.rstudio.studio.client.application.Desktop;
+import com.google.gwt.user.client.ui.Widget;
 
-public class RStudioFrame extends Frame
+import org.rstudio.studio.client.application.Desktop;
+import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
+
+public class RStudioFrame extends Frame implements ViewerPane.Display
 {
    public RStudioFrame(String title)
    {
@@ -39,11 +44,12 @@ public class RStudioFrame extends Frame
    
    public RStudioFrame(String title, String url, boolean sandbox, String sandboxAllow)
    {
-      super();
       if (sandbox)
          getElement().setAttribute("sandbox", StringUtil.notNull(sandboxAllow));
+      
       if (url != null)
          setUrl(url);
+      
       setTitle(title);
    }
    
@@ -107,5 +113,35 @@ public class RStudioFrame extends Frame
       {
          super.setUrl(url);
       }
+   }
+
+   @Override
+   public String getCurrentUrl()
+   {
+      return getWindowUrl();
+   }
+
+   @Override
+   public void reload()
+   {
+      getContentWindow().reload();
+   }
+
+   @Override
+   public WindowEx getContentWindow()
+   {
+      return getIFrame().getContentWindow();
+   }
+
+   @Override
+   public Document getContentDocument()
+   {
+      return getIFrame().getContentDocument();
+   }
+
+   @Override
+   public Widget getWidget()
+   {
+      return this;
    }
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioWebview.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioWebview.java
@@ -1,0 +1,90 @@
+/*
+ * RStudioWebview.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.dom.WindowEx;
+import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
+
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.event.dom.client.LoadHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.Widget;
+
+public class RStudioWebview extends Widget implements ViewerPane.Display
+{
+   public RStudioWebview(String title)
+   {
+      view_ = Document.get().createElement("webview").cast();
+      view_.setAttribute("plugins", "");
+      view_.setTitle(title);
+      
+      setElement(view_);
+   }
+   
+   @Override
+   public String getUrl()
+   {
+      return getElement().getAttribute("src");
+   }
+
+   @Override
+   public void setUrl(String url)
+   {
+      getElement().setAttribute("src", url);
+   }
+
+   @Override
+   public String getCurrentUrl()
+   {
+      Debug.breakpoint();
+      return "NYI";
+   }
+
+   @Override
+   public void reload()
+   {
+      Debug.breakpoint();
+   }
+
+   @Override
+   public WindowEx getContentWindow()
+   {
+      Debug.breakpoint();
+      return null;
+   }
+
+   @Override
+   public Document getContentDocument()
+   {
+      Debug.breakpoint();
+      return null;
+   }
+
+   @Override
+   public Widget getWidget()
+   {
+      return this;
+   }
+
+   @Override
+   public HandlerRegistration addLoadHandler(LoadHandler handler)
+   {
+      return this.addLoadHandler(handler);
+   }
+   
+   private final WebviewElement view_;
+   
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/RStudioWebview.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/RStudioWebview.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.core.client.widget;
 
-import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
 
@@ -27,11 +26,9 @@ public class RStudioWebview extends Widget implements ViewerPane.Display
 {
    public RStudioWebview(String title)
    {
-      view_ = Document.get().createElement("webview").cast();
-      view_.setAttribute("plugins", "");
-      view_.setTitle(title);
-      
-      setElement(view_);
+      WebviewElement view = Document.get().createElement("webview").cast();
+      view.setTitle(title);
+      setElement(view);
    }
    
    @Override
@@ -49,28 +46,28 @@ public class RStudioWebview extends Widget implements ViewerPane.Display
    @Override
    public String getCurrentUrl()
    {
-      Debug.breakpoint();
-      return "NYI";
+      WebviewElement view = getElement().cast();
+      return view.getIFrameElement().getCurrentUrl();
    }
 
    @Override
    public void reload()
    {
-      Debug.breakpoint();
+      setUrl(getUrl());
    }
 
    @Override
    public WindowEx getContentWindow()
    {
-      Debug.breakpoint();
-      return null;
+      WebviewElement view = getElement().cast();
+      return view.getIFrameElement().getContentWindow();
    }
 
    @Override
    public Document getContentDocument()
    {
-      Debug.breakpoint();
-      return null;
+      WebviewElement view = getElement().cast();
+      return view.getIFrameElement().getContentDocument();
    }
 
    @Override
@@ -84,7 +81,5 @@ public class RStudioWebview extends Widget implements ViewerPane.Display
    {
       return this.addLoadHandler(handler);
    }
-   
-   private final WebviewElement view_;
    
 }

--- a/src/gwt/src/org/rstudio/core/client/widget/WebviewElement.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WebviewElement.java
@@ -1,0 +1,58 @@
+/*
+ * WebviewElement.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.widget;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Node;
+import com.google.gwt.dom.client.TagName;
+
+@TagName(WebviewElement.TAG)
+public class WebviewElement extends Element
+{
+   protected WebviewElement()
+   {
+   }
+   
+   public static WebviewElement as(Element elem)
+   {
+      assert is(elem);
+      return (WebviewElement) elem;
+   }
+
+   public static boolean is(JavaScriptObject o)
+   {
+      if (Element.is(o)) {
+         return is((Element) o);
+      }
+      return false;
+   }
+
+   public static boolean is(Node node)
+   {
+      if (Element.is(node)) {
+         return is((Element) node);
+      }
+      return false;
+   }
+
+   public static boolean is(Element elem)
+   {
+      return elem != null && elem.hasTagName(TAG);
+   }
+   
+   public static final String TAG = "webview";
+   
+}

--- a/src/gwt/src/org/rstudio/core/client/widget/WebviewElement.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/WebviewElement.java
@@ -14,7 +14,11 @@
  */
 package org.rstudio.core.client.widget;
 
+import org.rstudio.core.client.dom.IFrameElementEx;
+import org.rstudio.core.client.dom.WindowEx;
+
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.TagName;
@@ -52,6 +56,26 @@ public class WebviewElement extends Element
    {
       return elem != null && elem.hasTagName(TAG);
    }
+   
+   public final WindowEx getContentWindow()
+   {
+      return getIFrameElement().getContentWindow();
+   }
+   
+   public final Document getContentDocument()
+   {
+      return getIFrameElement().getContentDocument();
+   }
+   
+   public final native IFrameElementEx getIFrameElement()
+   /*-{
+      var children = this.shadowRoot.childNodes;
+      for (var i = 0; i < children.length; i++) {
+         if (children[i].tagName === "IFRAME") {
+            return chilren[i];
+         }
+      }
+   }-*/;
    
    public static final String TAG = "webview";
    

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputFramePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/ui/RmdOutputFramePane.java
@@ -25,6 +25,7 @@ import org.rstudio.studio.client.rmarkdown.model.RmdPreviewParams;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.shiny.ShinyFrameHelper;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerClearedEvent;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerNavigatedEvent;
 import org.rstudio.studio.client.workbench.views.viewer.events.ViewerPreviewRmdEvent;
@@ -57,7 +58,8 @@ public class RmdOutputFramePane extends RmdOutputFrameBase
    {
       if (frame_ == null)
          return null;
-      return frame_.getWindow();
+      
+      return frame_.getContentWindow();
    }
 
    @Override
@@ -132,7 +134,7 @@ public class RmdOutputFramePane extends RmdOutputFrameBase
          int position = 0;
          try
          {
-            position = frame_.getIFrame().getContentWindow().getScrollTop();
+            position = frame_.getContentWindow().getScrollTop();
          }
          catch(Exception ex)
          {
@@ -157,7 +159,7 @@ public class RmdOutputFramePane extends RmdOutputFrameBase
       {
          try
          {
-            url = frame_.getIFrame().getContentDocument().getURL();
+            url = frame_.getCurrentUrl();
          }
          catch(Exception x)
          {
@@ -172,7 +174,7 @@ public class RmdOutputFramePane extends RmdOutputFrameBase
       return anchorPos > 0 ? url.substring(anchorPos + 1) : "";
    }
    
-   private RStudioFrame frame_;
+   private ViewerPane.Display frame_;
    private ShinyFrameHelper shinyFrame_;
    private boolean isShiny_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/ViewerPane.java
@@ -12,24 +12,31 @@
  */
 package org.rstudio.studio.client.workbench.views.viewer;
 
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.LoadHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
 import org.rstudio.core.client.HtmlMessageListener;
+import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Size;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.URIConstants;
 import org.rstudio.core.client.URIUtils;
+import org.rstudio.core.client.dom.DocumentEx;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.core.client.widget.RStudioWebview;
 import org.rstudio.core.client.widget.Toolbar;
 import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.core.client.widget.ToolbarMenuButton;
@@ -38,6 +45,7 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
+import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.filetypes.FileTypeRegistry;
 import org.rstudio.studio.client.common.icons.StandardIcons;
 import org.rstudio.studio.client.plumber.model.PlumberAPIParams;
@@ -58,6 +66,22 @@ import org.rstudio.studio.client.workbench.views.viewer.quarto.QuartoConnection;
 
 public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
 {
+   public interface Display
+   {
+      String getTitle();
+      String getUrl();
+      void setUrl(String url);
+      String getCurrentUrl();
+      void reload();
+      WindowEx getContentWindow();
+      Document getContentDocument();
+      
+      Element getElement();
+      Widget getWidget();
+      
+      HandlerRegistration addLoadHandler(LoadHandler handler);
+   }
+   
    @Inject
    public ViewerPane(Commands commands,
                      GlobalDisplay globalDisplay,
@@ -181,11 +205,19 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    protected Widget createMainWidget()
    {
-      frame_ = new RStudioFrame(constants_.viewerPaneTitle());
-      frame_.setSize("100%", "100%");
-      frame_.addStyleName("ace_editor_theme");
+      if (BrowseCap.isElectron())
+      {
+         frame_ = new RStudioWebview(constants_.viewerPaneTitle());
+      }
+      else
+      {
+         frame_ = new RStudioFrame(constants_.viewerPaneTitle());
+      }
+      
+      frame_.getWidget().setSize("100%", "100%");
+      frame_.getWidget().addStyleName("ace_editor_theme");
       navigate(URIConstants.ABOUT_BLANK, false);
-      return new AutoGlassPanel(frame_);
+      return new AutoGlassPanel(frame_.getWidget());
    }
 
    @Override
@@ -282,15 +314,15 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
          globalDisplay_.openWindow(quartoConnection_.getUrl());
       }
       else if (frame_ != null &&
-          frame_.getIFrame().getCurrentUrl() != null &&
-          !StringUtil.equals(urlWithoutHash(frame_.getIFrame().getCurrentUrl()), 
+          frame_.getCurrentUrl() != null &&
+          !StringUtil.equals(urlWithoutHash(frame_.getCurrentUrl()), 
                              urlWithoutHash(getUrl())))
       {
          // Typically we navigate to the unmodified URL (i.e. without the
          // viewer_pane=1 query params, etc.) However, if the URL currently
          // loaded in the frame is different, the user probably navigated away
          // from original URL, so load that URL as-is.
-         globalDisplay_.openWindow(frame_.getIFrame().getCurrentUrl());
+         globalDisplay_.openWindow(frame_.getCurrentUrl());
       }
       else if (unmodifiedUrl_ != null)
       {
@@ -303,7 +335,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    {
       try
       {
-         frame_.getWindow().reload();
+         frame_.reload();
       }
       catch (Exception e)
       {
@@ -320,13 +352,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       if (srcFile != null)
       {
          fileTypeRegistry_.editFile(srcFile);
-         new Timer() {
-            @Override
-            public void run()
-            {
-               commands_.activateSource();
-            }
-         }.schedule(200);
+         Timers.singleShot(200, () -> commands_.activateSource());
       }
    }
 
@@ -339,7 +365,9 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
    @Override
    public Size getViewerFrameSize()
    {
-      return new Size(frame_.getOffsetWidth(), frame_.getOffsetHeight());
+      return new Size(
+            frame_.getWidget().getOffsetWidth(),
+            frame_.getWidget().getOffsetHeight());
    }
 
    @Override
@@ -493,7 +521,7 @@ public class ViewerPane extends WorkbenchPane implements ViewerPresenter.Display
       OpenFile
    }
 
-   private RStudioFrame frame_;
+   private Display frame_;
    private String unmodifiedUrl_;
    private RmdPreviewParams rmdPreviewParams_;
    private final Commands commands_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/events/ViewerNavigatedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/viewer/events/ViewerNavigatedEvent.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.viewer.events;
 
 import org.rstudio.core.client.widget.RStudioFrame;
+import org.rstudio.studio.client.workbench.views.viewer.ViewerPane;
 
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
@@ -26,7 +27,7 @@ public class ViewerNavigatedEvent extends GwtEvent<ViewerNavigatedEvent.Handler>
       void onViewerNavigated(ViewerNavigatedEvent event);
    }
 
-   public ViewerNavigatedEvent(String url, RStudioFrame frame)
+   public ViewerNavigatedEvent(String url, ViewerPane.Display frame)
    {
       url_ = url;
       frame_ = frame;
@@ -37,7 +38,7 @@ public class ViewerNavigatedEvent extends GwtEvent<ViewerNavigatedEvent.Handler>
       return url_;
    }
 
-   public RStudioFrame getFrame()
+   public ViewerPane.Display getFrame()
    {
       return frame_;
    }
@@ -55,7 +56,7 @@ public class ViewerNavigatedEvent extends GwtEvent<ViewerNavigatedEvent.Handler>
    }
 
    private final String url_;
-   private final RStudioFrame frame_;
+   private final ViewerPane.Display frame_;
 
    public static final Type<Handler> TYPE = new Type<>();
 }

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -8,6 +8,8 @@
     "buttonNo": "No"
   },
   "contextMenu": {
+    "back": "Back",
+    "forward": "Forward",
     "saveImageAsDots": "Save image as...",
     "saveImageAs": "Save image as",
     "copyImage": "Copy Image",

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -122,6 +122,7 @@ export class DesktopBrowserWindow extends EventEmitter {
           nodeIntegration: false,
           preload: preload,
           sandbox: true,
+          webviewTag: true,
         },
         show: false,
         acceptFirstMouse: true,
@@ -152,7 +153,7 @@ export class DesktopBrowserWindow extends EventEmitter {
 
     // register context menu (right click) handler
     this.window.webContents.on('context-menu', (event, params) => {
-      showContextMenu(event as IpcMainEvent, params);
+      showContextMenu(this.window.webContents, params);
     });
 
     this.window.webContents.on('before-input-event', (event, input) => {
@@ -274,7 +275,7 @@ export class DesktopBrowserWindow extends EventEmitter {
       logger().logDebug(`allowNavigation: disallowed protocol ${url}`);
       return false;
     }
-    
+
     // determine if this is a local request (handle internally only if local)
     const isLocal = isLocalUrl(targetUrl);
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -418,7 +418,10 @@ export class GwtCallback extends EventEmitter {
         if (url === 'chrome://gpu' || url === 'chrome://accessibility') {
           const window = new BrowserWindow({
             autoHideMenuBar: true,
-            webPreferences: { sandbox: true },
+            webPreferences: {
+              sandbox: true,
+              webviewTag: true,
+            },
             acceptFirstMouse: true,
           });
 
@@ -498,7 +501,7 @@ export class GwtCallback extends EventEmitter {
       },
     );
 
-    ipcMain.on('desktop_export_page_region_to_file', 
+    ipcMain.on('desktop_export_page_region_to_file',
       (event, targetPath, format, left, top, width, height) => {
         const rect: Rectangle = { x: left, y: top, width, height };
         targetPath = resolveAliasedPath(targetPath);

--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -20,7 +20,7 @@ import { logger } from '../core/logger';
 import { WaitResult, WaitTimeoutFn, waitWithTimeout } from '../core/wait-utils';
 
 /**
- * 
+ *
  * @param url the URL to check
  * @returns true if is an about: url
  */
@@ -49,23 +49,33 @@ export function isChromeGpuUrl(url: string): boolean {
 
 /**
  * Checks the `url` if it is local
- * 
+ *
  * @param url the URL to check
  * @returns true if it is local
  */
-export function isLocalUrl(url: URL) {
-  const host = url.hostname;
+export function isLocalUrl(url: URL | string) {
 
+  if (typeof url === 'string') {
+    url = new URL(url);
+  }
+
+  const host = url.hostname;
   return host === 'localhost' || host === '127.0.0.1' || host === '[::1]';
+
 }
 
 /**
  * Checks the `url` if it is allowed
- * 
+ *
  * @param url the URL to check
  * @returns true if the protocol is allowed
  */
-export function isAllowedProtocol(url: URL) {
+export function isAllowedProtocol(url: URL | string) {
+
+  if (typeof url === 'string') {
+    url = new URL(url);
+  }
+
   const protocol = url.protocol;
   const allowedProtocols = [
     'http:',
@@ -73,7 +83,9 @@ export function isAllowedProtocol(url: URL) {
     'mailto:',
     'data:',
   ];
+
   return allowedProtocols.includes(protocol);
+
 }
 
 /**

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -154,7 +154,7 @@ export function rsessionExeName(): string {
 }
 
 /**
- * 
+ *
  * @returns Root of the RStudio repo for a dev build, nothing for packaged build
  */
 export function findRepoRoot(): string {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11611.

### Approach

Unfortunately, Electron doesn't expose some of the events events we need in order to control navigation within a sub-frame (e.g. an iframe).

Fortunately, it _does_ in so-called [webviews](https://www.electronjs.org/docs/latest/api/webview-tag). These are effectively enhanced versions of iframes, with a fair amount more isolation + customizability (despite the warnings). These also expose the functionality we require in order to control navigation.

This PR flips a switch for Electron builds, wherein we use a Webview for the Viewer pane rather than an iframe.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11611. In particular, check that various outputs that we render within the Viewer pane are shown correctly, and links within are navigated as expected.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
