### PR TITLE
use `--always-make` in addition to `--dry-run`

### DIFF
--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -556,13 +556,8 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
       bool isCpp)
 {
    
-   // generate an appropriate name for the C++ source file.
-   std::string ext = isCpp ? ".cpp" : ".c";
-   std::string filename = kCompilationDbPrefix + core::system::generateUuid() + ext;
-   
-   // call R CMD SHLIB on a temp file to capture the compilation args
-   FilePath srcFile = srcDir.completeChildPath(filename);
-   std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, srcFile);
+   // R CMD SHLIB dry run to capture the compilation args
+   std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, srcDir);
 
    // diagnostics
    if (verbose(3))
@@ -795,7 +790,7 @@ Error RCompilationDatabase::executeSourceCpp(
 
 core::Error RCompilationDatabase::executeRCmdSHLIB(
                                  core::system::Options env,
-                                 const core::FilePath& srcPath,
+                                 const core::FilePath& srcDir,
                                  core::system::ProcessResult* pResult)
 {
    // get R bin directory
@@ -804,20 +799,17 @@ core::Error RCompilationDatabase::executeRCmdSHLIB(
    if (error)
       return error;
 
+   std::string output = std::string("--output=") + kCompilationDbPrefix + core::system::generateUuid() + ".so";
+   
    // compile the file as dry-run
    module_context::RCommand rCmd(rBinDir);
    rCmd << "SHLIB";
    rCmd << "--dry-run";
-
-   // non existing output
-   std::string output = std::string("--output=") + kCompilationDbPrefix + core::system::generateUuid() + ".so";
    rCmd << output;
-   
-   rCmd << srcPath.getFilename();
 
    // set options and run
    core::system::ProcessOptions options;
-   options.workingDir = srcPath.getParent();
+   options.workingDir = srcDir;
    options.environment = env;
    Error result = core::system::runCommand(
             rCmd.shellCommand(),
@@ -1069,23 +1061,11 @@ RCompilationDatabase::CompilationConfig
 
 std::vector<std::string> RCompilationDatabase::argsForRCmdSHLIB(
                                           core::system::Options env,
-                                          FilePath tempSrcFile)
+                                          const FilePath& srcDir)
 {
-   Error error = core::writeStringToFile(tempSrcFile, "void foo() {}\n");
-   if (error)
-   {
-      LOG_ERROR(error);
-      return {};
-   }
-
    // execute R CMD SHLIB
    core::system::ProcessResult result;
-   error = executeRCmdSHLIB(env, tempSrcFile, &result);
-
-   // remove the temporary source file
-   Error removeError = tempSrcFile.remove();
-   if (removeError)
-      LOG_ERROR(removeError);
+   Error error = executeRCmdSHLIB(env, srcDir, &result);
 
    // process results of R CMD SHLIB
    if (error)
@@ -1103,7 +1083,32 @@ std::vector<std::string> RCompilationDatabase::argsForRCmdSHLIB(
       // parse the compilation results
       if (verbose(3))
       {
-         std::cerr << "# PARSING COMPILATION OUTPUT ----" << std::endl;
+         std::cerr << "# COMPILATION OUTPUT for R CMD SHLIB --dry-run ----" << std::endl;
+         std::cerr << result.stdOut << std::endl;
+      }
+
+      std::vector<std::string> lines;
+      boost::algorithm::split(lines, result.stdOut, boost::algorithm::is_any_of("\r\n"));
+      std::string makeCmd = lines[1] + " --dry-run --always-make";
+
+      result.stdOut = "";
+      result.stdErr = "";
+      core::system::ProcessOptions options;
+      options.workingDir = srcDir;
+      options.environment = env;
+      error = core::system::runCommand(
+               makeCmd,
+               options,
+               &result);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return {};
+      }
+
+      if (verbose(3))
+      {
+         std::cerr << "# COMPILATION OUTPUT for make --dry-run --always-run ----" << std::endl;
          std::cerr << result.stdOut << std::endl;
       }
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -69,7 +69,7 @@ private:
                                 core::system::ProcessResult* pResult);
 
    core::Error executeRCmdSHLIB(core::system::Options env,
-                                const core::FilePath& srcPath,
+                                const core::FilePath& srcDir,
                                 core::system::ProcessResult* pResult);
 
    void updateForCurrentPackage();
@@ -96,7 +96,7 @@ private:
                                         core::FilePath srcFile);
 
    std::vector<std::string> argsForRCmdSHLIB(core::system::Options env,
-                                             core::FilePath tempSrcFile);
+                                             const core::FilePath& srcDir);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
    std::vector<std::string> packageCompilationArgs(


### PR DESCRIPTION
### Intent

Another followup on #6384 

### Approach

`--dry-run` on the same directory, using `--output=<non existing so>` and `--always-make`

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


