### PR TITLE
ignore 'did-fail-load' events from subframes

### DIFF
--- a/src/node/desktop/src/core/winston-logger.ts
+++ b/src/node/desktop/src/core/winston-logger.ts
@@ -82,8 +82,8 @@ export class WinstonLogger implements Logger {
     if (!app.isPackaged && this.logger.isLevelEnabled(level)) {
       const ts = new Date().toISOString();
       const tlevel = level.toUpperCase();
-      const tmessage = message.replace(/\n/g, '|||') + '\n';
-      process.stderr.write(`${ts} ${tlevel} ${tmessage}`);
+      const tmessage = message.replace(/\n/g, '|||');
+      console.log(`${ts} ${tlevel} ${tmessage}`);
     }
   }
 

--- a/src/node/desktop/src/main/url-utils.ts
+++ b/src/node/desktop/src/main/url-utils.ts
@@ -14,13 +14,12 @@
  */
 
 import http from 'http';
-import { URL } from 'url';
 import { Err } from '../core/err';
 import { logger } from '../core/logger';
 import { WaitResult, WaitTimeoutFn, waitWithTimeout } from '../core/wait-utils';
 
 /**
- * 
+ *
  * @param url the URL to check
  * @returns true if is an about: url
  */
@@ -49,7 +48,7 @@ export function isChromeGpuUrl(url: string): boolean {
 
 /**
  * Checks the `url` if it is local
- * 
+ *
  * @param url the URL to check
  * @returns true if it is local
  */
@@ -61,7 +60,7 @@ export function isLocalUrl(url: URL) {
 
 /**
  * Checks the `url` if it is allowed
- * 
+ *
  * @param url the URL to check
  * @returns true if the protocol is allowed
  */

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -154,7 +154,7 @@ export function rsessionExeName(): string {
 }
 
 /**
- * 
+ *
  * @returns Root of the RStudio repo for a dev build, nothing for packaged build
  */
 export function findRepoRoot(): string {
@@ -493,3 +493,106 @@ export const handleLocaleCookies = async (window: BrowserWindow, isMainWindow = 
     }
   });
 };
+
+export function registerWebContentsDebugHandlers(webContents: WebContents) {
+
+  // add debug handlers for all of the various navigation and load events
+  const events = [
+    'before-input-event',
+    'blur',
+    'certificate-error',
+    'console-message',
+    'context-menu',
+    'crashed',
+    'cursor-changed',
+    'destroyed',
+    'devtools-closed',
+    'devtools-focused',
+    'devtools-opened',
+    'devtools-reload-page',
+    'did-attach-webview',
+    'did-change-theme-color',
+    'did-create-window',
+    'did-fail-load',
+    'did-fail-provisional-load',
+    'did-finish-load',
+    'did-frame-finish-load',
+    'did-frame-navigate',
+    'did-navigate',
+    'did-navigate-in-page',
+    'did-redirect-navigation',
+    'did-start-loading',
+    'did-start-navigation',
+    'did-stop-loading',
+    'dom-ready',
+    'enter-html-full-screen',
+    'focus',
+    'found-in-page',
+    'frame-created',
+    'ipc-message',
+    'ipc-message-sync',
+    'leave-html-full-screen',
+    'login',
+    'media-paused',
+    'media-started-playing',
+    'new-window',
+    'page-favicon-updated',
+    'page-title-updated',
+    'paint',
+    'plugin-crashed',
+    'preferred-size-changed',
+    'preload-error',
+    'render-process-gone',
+    'responsive',
+    'select-bluetooth-device',
+    'select-client-certificate',
+    'unresponsive',
+    'update-target-url',
+    'will-attach-webview',
+    'will-navigate',
+    'will-prevent-unload',
+    'will-redirect',
+    'zoom-changed',
+  ] as const;
+
+  for (const event of events) {
+    try {
+      registerWebContentsDebugHandlerImpl(webContents, event);
+    } catch (error: unknown) {
+      logger().logDebug(`Error adding debug handler for event '${event}': ${error}`);
+    }
+  }
+
+}
+
+function registerWebContentsDebugHandlerImpl(webContents: WebContents, event: string) {
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  webContents.on(event as any, (...args) => {
+
+    const json = args.map((arg) => {
+
+      // check for an Electron Event and handle it specially here
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const electronEvent = arg as any;
+      if (typeof electronEvent.preventDefault !== 'undefined') {
+        return '<event>';
+      }
+
+      // try to stringify other arguments
+      try {
+        if (typeof arg === 'object') {
+          return '<object>';
+        } else {
+          return JSON.stringify(arg);
+        }
+      } catch (e: unknown) {
+        return '<unknown>';
+      }
+    });
+
+    logger().logDebug(`'${event}': [${json.join(', ')}]`);
+
+  });
+
+}

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -17,7 +17,7 @@ import fs, { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { sep } from 'path';
-import { app, BrowserWindow, dialog, FileFilter, MessageBoxOptions, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, FileFilter, MessageBoxOptions, WebContents, WebRequest } from 'electron';
 
 import { Xdg } from '../core/xdg';
 import { getenv, setenv } from '../core/environment';
@@ -529,8 +529,11 @@ export function registerWebContentsDebugHandlers(webContents: WebContents) {
     'focus',
     'found-in-page',
     'frame-created',
-    'ipc-message',
-    'ipc-message-sync',
+
+    // TODO: These are pretty noisy.
+    // 'ipc-message',
+    // 'ipc-message-sync',
+
     'leave-html-full-screen',
     'login',
     'media-paused',

--- a/src/node/desktop/test/unit/main/browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/browser-window.test.ts
@@ -1,0 +1,66 @@
+/*
+ * build-info.test.ts
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { describe } from 'mocha';
+import { assert } from 'chai';
+
+import { BrowserWindow } from 'electron';
+import { execSync, spawn } from 'child_process';
+
+describe('BrowserWindow', () => {
+
+  it('fires events in the expected order', async () => {
+
+    const pythonVersion = execSync(
+      'python -c "import sys; print(sys.version_info[0])"',
+      { encoding: 'utf-8' }
+    );
+
+    let args : string[] = [];
+    if (pythonVersion.trim() === '2') {
+      args = ['-m', 'SimpleHTTPServer', '9876'];
+    } else {
+      args = ['-m', 'http.server', '9876'];
+    }
+
+    const server = spawn('python', args, {});
+
+    const win = new BrowserWindow({ show: false });
+    const eventHistory: string[] = [];
+
+    const events = [
+      'did-start-loading',
+      'did-start-navigation',
+      'did-frame-navigate',
+      'did-frame-finish-load',
+    ];
+
+    for (const event of events) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      win.webContents.on(event as any, () => {
+        eventHistory.push(event);
+      });
+    }
+
+    await win.loadURL('http://localhost:9876');
+    server.kill();
+
+    assert.deepEqual(eventHistory, events);
+
+
+  });
+
+});
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11611.

### Approach

Ensure that `did-fail-load` events from sub-frames don't force the main frame to attempt to reload the main page.

In addition, try to make sure that attempts to navigate to external URLs from within the iframe open externally. (Implementation is sub-optimal; we need 'will-frame-navigate' to get it right.)

### Automated Tests

Not included.

### QA Notes

Test that navigating a link as in https://github.com/rstudio/rstudio/issues/11611 merely fails in the Viewer pane, but nothing bad happens to the IDE.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
