### PR TITLE
switch from data viewer and object  explorer viewer if object type changes

### DIFF
--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -42,6 +42,8 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_ERROR(error) rstudio::core::log::logError(error, \
                                                       ERROR_LOCATION)
 
+#define LOG_AND_RETURN_IF_ERROR(error) do { if (error) { LOG_ERROR(error); return; } } while(false)
+
 #define LOG_ERROR_NAMED(logSection, error) rstudio::core::log::logError(logSection, \
                                                                         error, \
                                                                         ERROR_LOCATION)

--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -42,8 +42,6 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_ERROR(error) rstudio::core::log::logError(error, \
                                                       ERROR_LOCATION)
 
-#define LOG_AND_RETURN_IF_ERROR(error) do { if (error) { LOG_ERROR(error); return; } } while(false)
-
 #define LOG_ERROR_NAMED(logSection, error) rstudio::core::log::logError(logSection, \
                                                                         error, \
                                                                         ERROR_LOCATION)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -746,6 +746,9 @@
 
 .rs.addFunction("dataViewer.shouldUseObjectExplorer", function(object)
 {
+   if (inherits(object, c("function", "vignette")))
+      return(FALSE)
+
    # prefer data viewer for pandas DataFrames
    if (inherits(object, "pandas.core.frame.DataFrame"))
       return(FALSE)

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -653,7 +653,6 @@
    name <- ""
    env <- emptyenv()
    
-   
    if (.rs.isViewOverride()) 
    {
       # if the View() invoked wasn't our own, we have no way of knowing what's

--- a/src/cpp/session/modules/SessionObjectExplorer.R
+++ b/src/cpp/session/modules/SessionObjectExplorer.R
@@ -421,6 +421,18 @@
    .rs.explorer.fireEvent(.rs.explorer.types$REFRESH, handle)
 })
 
+.rs.addFunction("explorer.close", function(id, entry)
+{
+   handle <- list(
+      id       = .rs.scalar(id),
+      name     = .rs.scalar(entry$name),
+      title    = .rs.scalar(entry$title),
+      language = .rs.scalar(entry$language)
+   )
+
+   .rs.explorer.fireEvent(.rs.explorer.types$CLOSE_NODE, handle)
+})
+
 # NOTE: synchronize the structure of this object with
 # the JSO defined in 'ObjectExplorerInspectionResult.java'
 .rs.addFunction("explorer.createInspectionResult", function(object,

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -58,7 +58,6 @@ void removeOrphanedCacheItems()
    // list source documents
    std::vector<FilePath> docPaths;
    error = source_database::list(&docPaths);
-   LOG_AND_RETURN_IF_ERROR(error);
    if (error)
    {
       LOG_ERROR(error);
@@ -273,7 +272,11 @@ void onDetectChanges(module_context::ChangeSource source)
             .addUtf8Param(id)
             .addParam(entry)
             .call();
-         LOG_AND_RETURN_IF_ERROR(error);
+         if (error)
+         {
+            LOG_ERROR(error);
+            return;
+         }
       }
       else 
       {
@@ -283,14 +286,22 @@ void onDetectChanges(module_context::ChangeSource source)
             .addUtf8Param(id)
             .addParam(entry)
             .call();
-         LOG_AND_RETURN_IF_ERROR(error);
+         if (error)
+         {
+            LOG_ERROR(error);
+            return;
+         }
 
          // then just let View() show it
          error = r::exec::RFunction("View")
             .addParam(symbol)
             .addParam(title)
             .call(envir, true);
-         LOG_AND_RETURN_IF_ERROR(error);
+         if (error)
+         {
+            LOG_ERROR(error);
+            return;
+         }
       }
       
    }

--- a/src/cpp/session/modules/SessionObjectExplorer.cpp
+++ b/src/cpp/session/modules/SessionObjectExplorer.cpp
@@ -256,18 +256,36 @@ void onDetectChanges(module_context::ChangeSource source)
          continue;
 
       // update the object
-      SET_VECTOR_ELT(entry, 0, newObject);
+         SET_VECTOR_ELT(entry, 0, newObject);
 
-      error = r::exec::RFunction(".rs.explorer.refresh")
-         .addUtf8Param(id)
-         .addParam(entry)
-         .call();
-
-      if (error)
+      if (Rf_inherits(newObject, "data.frame")) 
       {
-         LOG_ERROR(error);
-         return;
+         // close it
+         error = r::exec::RFunction(".rs.explorer.close")
+            .addUtf8Param(id)
+            .addParam(entry)
+            .call();
+
+         if (error)
+         {
+            LOG_ERROR(error);
+            return;
+         }
       }
+      else 
+      {
+         error = r::exec::RFunction(".rs.explorer.refresh")
+            .addUtf8Param(id)
+            .addParam(entry)
+            .call();
+
+         if (error)
+         {
+            LOG_ERROR(error);
+            return;
+         }
+      }
+      
    }
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -134,6 +134,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.codebrowser.CodeBrowserEditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.OpenObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.RefreshObjectExplorerEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.CloseObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.OpenProfileEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfilerContents;
@@ -207,6 +208,7 @@ public class Source implements InsertSourceEvent.Handler,
                                OpenProfileEvent.Handler,
                                OpenObjectExplorerEvent.Handler,
                                RefreshObjectExplorerEvent.Handler,
+                               CloseObjectExplorerEvent.Handler,
                                ReplaceRangesEvent.Handler,
                                SetSelectionRangesEvent.Handler,
                                GetEditorContextEvent.Handler,
@@ -326,6 +328,7 @@ public class Source implements InsertSourceEvent.Handler,
       events_.addHandler(ShowDataEvent.TYPE, this);
       events_.addHandler(OpenObjectExplorerEvent.TYPE, this);
       events_.addHandler(RefreshObjectExplorerEvent.TYPE, this);
+      events_.addHandler(CloseObjectExplorerEvent.TYPE, this);
       events_.addHandler(OpenPresentationSourceFileEvent.TYPE, this);
       events_.addHandler(OpenSourceFileEvent.TYPE, this);
       events_.addHandler(CodeBrowserNavigationEvent.TYPE, this);
@@ -798,6 +801,16 @@ public class Source implements InsertSourceEvent.Handler,
          return;
 
       columnManager_.refreshObjectExplorer(event.getHandle());
+   }
+
+   @Override
+   public void onCloseObjectExplorerEvent(CloseObjectExplorerEvent event)
+   {
+      // ignore if we're a satellite
+      if (!SourceWindowManager.isMainSourceWindow())
+         return;
+
+      columnManager_.closeObjectExplorer(event.getHandle());
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -170,6 +170,7 @@ import org.rstudio.studio.client.workbench.views.source.events.PopoutDocEvent;
 import org.rstudio.studio.client.workbench.views.source.events.PopoutDocInitiatedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowContentEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowDataEvent;
+import org.rstudio.studio.client.workbench.views.source.events.CloseDataEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceFileSavedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourcePathChangedEvent;
@@ -197,6 +198,7 @@ public class Source implements InsertSourceEvent.Handler,
                                FileEditEvent.Handler,
                                ShowContentEvent.Handler,
                                ShowDataEvent.Handler,
+                               CloseDataEvent.Handler,
                                CodeBrowserNavigationEvent.Handler,
                                CodeBrowserFinishedEvent.Handler,
                                CodeBrowserHighlightEvent.Handler,
@@ -326,6 +328,8 @@ public class Source implements InsertSourceEvent.Handler,
       events_.addHandler(InsertSourceEvent.TYPE, this);
       events_.addHandler(ShowContentEvent.TYPE, this);
       events_.addHandler(ShowDataEvent.TYPE, this);
+      events_.addHandler(CloseDataEvent.TYPE, this);
+      events_.addHandler(CloseDataEvent.TYPE, this);
       events_.addHandler(OpenObjectExplorerEvent.TYPE, this);
       events_.addHandler(RefreshObjectExplorerEvent.TYPE, this);
       events_.addHandler(CloseObjectExplorerEvent.TYPE, this);
@@ -821,6 +825,16 @@ public class Source implements InsertSourceEvent.Handler,
          return;
 
       columnManager_.showDataItem(event.getData());
+   }
+
+   @Override
+   public void onCloseData(CloseDataEvent event)
+   {
+      // ignore if we're a satellite
+      if (!SourceWindowManager.isMainSourceWindow())
+         return;
+
+      columnManager_.closeDataItem(event.getData());
    }
 
    public void onShowProfiler(OpenProfileEvent event)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -1049,6 +1049,22 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
          });
    }
 
+   public void closeDataItem(DataItem data)
+   {
+      for (SourceColumn column : columnList_)
+      {
+         for (EditingTarget target : column.getEditors())
+         {
+            String path = target.getPath();
+            if (path != null && path.equals(data.getURI()))
+            {
+               column.closeTab(target.asWidget(), false);
+               return;
+            }
+         }
+      }
+   }
+
    public void showUnsavedChangesDialog(
       String title,
       ArrayList<UnsavedChangesTarget> dirtyTargets,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/SourceColumnManager.java
@@ -981,7 +981,29 @@ public class SourceColumnManager implements CommandPaletteEntrySource,
             // check for identical titles
             if (handle.getTitle() == target.getTitle())
             {
+               
                ((ObjectExplorerEditingTarget) target).update(handle, false);
+               return;
+            }
+         }
+      }
+   }
+
+   public void closeObjectExplorer(ObjectExplorerHandle handle)
+   {
+      for (SourceColumn column : columnList_)
+      {
+         for (EditingTarget target : column.getEditors())
+         {
+            // bail if this isn't an object explorer filetype
+            FileType fileType = target.getFileType();
+            if (!(fileType instanceof ObjectExplorerFileType))
+               continue;
+
+            // check for identical titles
+            if (handle.getTitle() == target.getTitle())
+            {
+               column.closeTab(target.asWidget(), false);
                return;
             }
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -31,6 +31,7 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.views.source.ViewsSourceConstants;
 import org.rstudio.studio.client.workbench.views.source.editors.urlcontent.UrlContentEditingTarget;
+import org.rstudio.studio.client.workbench.views.source.events.CloseDataEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DataViewChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.PopoutDocEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DataItem;
@@ -89,8 +90,16 @@ public class DataEditingTarget extends UrlContentEditingTarget
    @Override
    public void onDataViewChanged(DataViewChangedEvent event)
    {
-      if (event.getData().getCacheKey().equals(getDataItem().getCacheKey()))
+      DataViewChangedEvent.Data eventData = event.getData();
+      if (eventData.getCacheKey().equals(getDataItem().getCacheKey()))
       {
+         // when this is no longer a data frame, close it
+         if (eventData.typeChanged())
+         {
+            events_.fireEvent(new CloseDataEvent(getDataItem()));
+            return;
+         }
+
          queuedRefresh_ = QueuedRefreshType.StructureRefresh;
          // perform the refresh immediately if the tab is active; otherwise,
          // leave it in the queue and it'll be run when the tab is activated

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/ObjectExplorerPresenter.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.explorer;
 
 import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.CloseObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.ObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.OpenObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.RefreshObjectExplorerEvent;
@@ -30,7 +31,6 @@ public class ObjectExplorerPresenter
    public ObjectExplorerPresenter(EventBus events)
    {
       events_ = events;
-      
       events_.addHandler(ObjectExplorerEvent.TYPE, this);
    }
    
@@ -69,8 +69,9 @@ public class ObjectExplorerPresenter
    {
    }
    
-   private void onCloseNode(ObjectExplorerEvent.Data data)
+   private void onCloseNode(ObjectExplorerEvent.Data eventData)
    {
+      events_.fireEvent(new CloseObjectExplorerEvent(eventData.getHandle()));
    }
    
    // Private members ----

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/CloseObjectExplorerEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/explorer/events/CloseObjectExplorerEvent.java
@@ -1,0 +1,58 @@
+/*
+ * CloseObjectExplorerEvent.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.workbench.views.source.editors.explorer.events;
+
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class CloseObjectExplorerEvent extends GwtEvent<CloseObjectExplorerEvent.Handler>
+{
+   public CloseObjectExplorerEvent(ObjectExplorerHandle handle)
+   {
+      handle_ = handle;
+   }
+
+   public ObjectExplorerHandle getHandle()
+   {
+      return handle_;
+   }
+
+   private final ObjectExplorerHandle handle_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onCloseObjectExplorerEvent(CloseObjectExplorerEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCloseObjectExplorerEvent(this);
+   }
+
+
+   public static final Type<Handler> TYPE = new Type<>();
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CloseDataEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/CloseDataEvent.java
@@ -1,0 +1,54 @@
+/*
+ * CloseDataEvent.java
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.events;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+import org.rstudio.studio.client.workbench.views.source.model.DataItem;
+
+public class CloseDataEvent extends GwtEvent<CloseDataEvent.Handler>
+{
+   public static final Type<Handler> TYPE = new Type<>();
+
+   public interface Handler extends EventHandler
+   {
+      void onCloseData(CloseDataEvent event);
+   }
+
+   public CloseDataEvent(DataItem data)
+   {
+      data_ = data;
+   }
+
+   public DataItem getData()
+   {
+      return data_;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCloseData(this);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   private final DataItem data_;
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
@@ -31,6 +31,10 @@ public class DataViewChangedEvent extends GwtEvent<DataViewChangedEvent.Handler>
       public final native boolean structureChanged() /*-{
          return this.structure_changed;
       }-*/;
+
+      public final native boolean typeChanged() /*-{
+         return this.type_changed;
+      }-*/;
    }
 
    public static final GwtEvent.Type<DataViewChangedEvent.Handler> TYPE = new GwtEvent.Type<>();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
@@ -29,11 +29,11 @@ public class DataViewChangedEvent extends GwtEvent<DataViewChangedEvent.Handler>
       }-*/;
 
       public final native boolean structureChanged() /*-{
-         return this.structure_changed;
+         return this.structure_changed || false;
       }-*/;
 
       public final native boolean typeChanged() /*-{
-         return this.type_changed;
+         return this.type_changed || false;
       }-*/;
    }
 


### PR DESCRIPTION
### Intent

Addresses #1994 (follow up after comment https://github.com/rstudio/rstudio/issues/1994#issuecomment-1234386524)

### Approach

The refresh code for both explorer and data viewer makes sure these are still the best way to `View()` the objects, if not then their tab is closed and `View()` is called again. 

For example (needs to be executed line by line): 

```r
x <- list(a = 1)
View(x)             # object explorer view
x <- cars           # after this the `x` View uses data viewer
x <- rnorm        # then function viewer
```

The data frame view is replaced by an object explorer view: 

<img width="337" alt="image" src="https://user-images.githubusercontent.com/2625526/188915072-d2eabfe9-318a-4380-878d-7a8d724b8a92.png">

then the function viewer: 

<img width="374" alt="image" src="https://user-images.githubusercontent.com/2625526/189064540-f3360a38-70eb-43f7-b4bd-78e20feaaf4d.png">

Similarly, the data view gets replaced by an explorer view here:

```r
y <- cars
View(y)             # data view
y <- list(a = 2)  # object explorer view
y <- rnorm        # function view
```

<img width="556" alt="image" src="https://user-images.githubusercontent.com/2625526/189064638-70f757d8-9469-4986-a61a-b505dad88cfd.png">

<img width="366" alt="image" src="https://user-images.githubusercontent.com/2625526/189064694-f3b17dee-dc61-4d70-bfa1-d9b74c235bbd.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


