### PR TITLE
sneak '--always-make' into R CMD SHLIB invocation

### DIFF
--- a/dependencies/common/.gitignore
+++ b/dependencies/common/.gitignore
@@ -1,6 +1,7 @@
 *.tar.bz
 *.tar.bz2
 *.tar.gz
+index.html
 CEF/
 dictionaries/
 libclang/

--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -47,7 +47,7 @@ public:
    std::string url(const std::string& repos) const;
    const std::string& versionPredicate() const { return versionPredicate_; }
    const FilePath& installPath() const { return installPath_; }
-   const std::vector<std::string> clangArgs() const { return clangArgs_; }
+   const std::vector<std::string> clangArgs(bool isCpp) const { return isCpp ? cppClangArgs_ : cClangArgs_; }
    const std::vector<FilePath>& pathEntries() const { return pathEntries_; }
    const std::vector<core::system::Option> environmentVars() const
    {
@@ -57,7 +57,8 @@ public:
 private:
    std::string name_;
    FilePath installPath_;
-   std::vector<std::string> clangArgs_;
+   std::vector<std::string> cClangArgs_;
+   std::vector<std::string> cppClangArgs_;
    std::string versionPredicate_;
    std::vector<FilePath> pathEntries_;
    std::vector<core::system::Option> environmentVars_;

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -253,7 +253,7 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    removeTranslationUnit(filename);
 
    // add verbose output if requested
-   if (verbose_ >= 2)
+   if (verbose_ >= 3)
      args.push_back("-v");
    
    // fix up '-std=' arguments; in particular, we only pass the C++

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -526,6 +526,11 @@ void RCompilationDatabase::updateForCurrentPackage()
 
    if (isCurrent && !s_rebuildCompilationDatabase)
       return;
+   
+   if (verbose(2))
+   {
+      std::cerr << "[!] The compilation database is out-of-date and will be rebuilt." << std::endl << std::endl;
+   }
 
    // we're about to rebuild the database, so unset flag now
    s_rebuildCompilationDatabase = false;

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -616,7 +616,7 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
    // call R CMD shlib on that file
    std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, targetSrcFile);
 
-   // clena up
+   // clean up
    if (removeOnExit)
    {
       targetSrcFile.removeIfExists();

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -595,32 +595,17 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
          break;
       }
    }
-
-   // if we couldn't find a source file, create and use a tempfile
-   // (presumedly this could happen in a brand new project?)
-   // (or should we be waiting for the user to create a file?)
-   bool removeOnExit = false;
-   if (targetSrcFile.isEmpty())
+   
+   // if we couldn't find a source file for some reason, just try to rebuild
+   // the compilation database again next time
+   if (!targetSrcFile.exists())
    {
-      removeOnExit = true;
-      std::string name = kCompilationDbPrefix + core::system::generateShortenedUuid() + (isCpp ? ".cpp" : ".c");
-      targetSrcFile = srcDir.completeChildPath(name);
-      Error error = core::writeStringToFile(targetSrcFile, "void test() {}\n");
-      if (error)
-      {
-         LOG_ERROR(error);
-         return {};
-      }
+      s_rebuildCompilationDatabase = true;
+      return {};
    }
    
    // call R CMD shlib on that file
    std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, targetSrcFile);
-
-   // clean up
-   if (removeOnExit)
-   {
-      targetSrcFile.removeIfExists();
-   }
 
    // diagnostics
    if (verbose(3))

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -1183,7 +1183,7 @@ std::vector<std::string> RCompilationDatabase::baseCompilationArgs(bool isCpp) c
 
    // add Rtools arguments
    auto rtInfo = rToolsInfo();
-   auto rtArgs = rtInfo.clangArgs();
+   auto rtArgs = rtInfo.clangArgs(isCpp);
    args.insert(args.end(), rtArgs.begin(), rtArgs.end());
 
    // re-generate compiler definitions
@@ -1224,9 +1224,6 @@ std::vector<std::string> RCompilationDatabase::packageCompilationArgs(
       core::r_util::RPackageInfo* pPkgInfo,
       bool* pIsCpp)
 {
-   // start with base args
-   std::vector<std::string> args = baseCompilationArgs(true);
-
    // read the package description file
    using namespace projects;
    FilePath pkgPath = projectContext().buildTargetPath();
@@ -1237,6 +1234,13 @@ std::vector<std::string> RCompilationDatabase::packageCompilationArgs(
       LOG_ERROR(error);
       return {};
    }
+
+   // determine if package is cpp
+   FilePath srcDir = pkgPath.completeChildPath("src");
+   bool isCpp = packageIsCpp(pkgInfo.linkingTo(), srcDir);
+
+   // start with base args
+   std::vector<std::string> args = baseCompilationArgs(isCpp);
 
    // Discover all of the LinkingTo relationships and add -I
    // arguments for them
@@ -1270,8 +1274,6 @@ std::vector<std::string> RCompilationDatabase::packageCompilationArgs(
    }
 
    // Run R CMD SHLIB
-   FilePath srcDir = pkgPath.completeChildPath("src");
-   bool isCpp = packageIsCpp(pkgInfo.linkingTo(), srcDir);
    std::vector<std::string> compileArgs = compileArgsForPackage(env, srcDir, isCpp);
 
    // perform path substitution

--- a/src/cpp/session/modules/clang/RCompilationDatabase.cpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.cpp
@@ -50,7 +50,7 @@ using namespace rstudio::core;
 using namespace rstudio::core::libclang;
 using namespace boost::placeholders;
 
-#define kCompilationDatabaseVersion 3
+#define kCompilationDatabaseVersion 2
 
 namespace rstudio {
 namespace session {
@@ -518,7 +518,7 @@ void RCompilationDatabase::updateForCurrentPackage()
          packageBuildFileHash == packageBuildFileHash_ &&
          compilerHash == compilerHash_ &&
          module_context::rVersion() == rVersion_;
-   
+
    if (isCurrent && !s_rebuildCompilationDatabase)
       return;
 
@@ -555,9 +555,58 @@ std::vector<std::string> RCompilationDatabase::compileArgsForPackage(
       const FilePath& srcDir,
       bool isCpp)
 {
-   
-   // R CMD SHLIB dry run to capture the compilation args
-   std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, srcDir);
+   // create a temp dir to call R CMD SHLIB within
+   FilePath tempDir = module_context::tempFile(kCompilationDbPrefix, "dir");
+   Error error = tempDir.ensureDirectory();
+   if (error)
+   {
+      LOG_ERROR(error);
+      return {};
+   }
+
+   static const boost::regex objectsRegex("^OBJECTS *=");
+
+   // copy Makevars to tempdir if it exists
+   FilePath makevarsPath = srcDir.completeChildPath("Makevars");
+   if (makevarsPath.exists())
+   {
+      std::string Makevars = file_utils::readFile(makevarsPath);
+      Makevars = boost::regex_replace(Makevars, objectsRegex, "zzzOBJECTS =");
+      
+      error = file_utils::writeFile(tempDir.completeChildPath("Makevars"), Makevars);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return {};
+      }
+   }
+
+   FilePath makevarsWinPath = srcDir.completeChildPath("Makevars.win");
+   if (makevarsWinPath.exists())
+   {
+      std::string MakevarsWin = file_utils::readFile(makevarsWinPath);
+      MakevarsWin = boost::regex_replace(MakevarsWin, objectsRegex, "zzzOBJECTS =");
+      
+      error = file_utils::writeFile(tempDir.completeChildPath("Makevars.win"), MakevarsWin);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return {};
+      }
+   }
+
+   // generate an appropriate name for the C++ source file.
+   std::string ext = isCpp ? ".cpp" : ".c";
+   std::string filename = kCompilationDbPrefix + core::system::generateUuid() + ext;
+
+   // call R CMD SHLIB on a temp file to capture the compilation args
+   FilePath tempSrcFile = tempDir.completeChildPath(filename);
+   std::vector<std::string> compileArgs = argsForRCmdSHLIB(env, tempSrcFile);
+
+   // remove the tempDir
+   error = tempDir.remove();
+   if (error)
+      LOG_ERROR(error);
 
    // diagnostics
    if (verbose(3))
@@ -790,7 +839,7 @@ Error RCompilationDatabase::executeSourceCpp(
 
 core::Error RCompilationDatabase::executeRCmdSHLIB(
                                  core::system::Options env,
-                                 const core::FilePath& srcDir,
+                                 const core::FilePath& srcPath,
                                  core::system::ProcessResult* pResult)
 {
    // get R bin directory
@@ -799,17 +848,15 @@ core::Error RCompilationDatabase::executeRCmdSHLIB(
    if (error)
       return error;
 
-   std::string output = std::string("--output=") + kCompilationDbPrefix + core::system::generateUuid() + ".so";
-   
    // compile the file as dry-run
    module_context::RCommand rCmd(rBinDir);
    rCmd << "SHLIB";
    rCmd << "--dry-run";
-   rCmd << output;
+   rCmd << srcPath.getFilename();
 
    // set options and run
    core::system::ProcessOptions options;
-   options.workingDir = srcDir;
+   options.workingDir = srcPath.getParent();
    options.environment = env;
    Error result = core::system::runCommand(
             rCmd.shellCommand(),
@@ -1061,11 +1108,23 @@ RCompilationDatabase::CompilationConfig
 
 std::vector<std::string> RCompilationDatabase::argsForRCmdSHLIB(
                                           core::system::Options env,
-                                          const FilePath& srcDir)
+                                          FilePath tempSrcFile)
 {
+   Error error = core::writeStringToFile(tempSrcFile, "void foo() {}\n");
+   if (error)
+   {
+      LOG_ERROR(error);
+      return {};
+   }
+
    // execute R CMD SHLIB
    core::system::ProcessResult result;
-   Error error = executeRCmdSHLIB(env, srcDir, &result);
+   error = executeRCmdSHLIB(env, tempSrcFile, &result);
+
+   // remove the temporary source file
+   Error removeError = tempSrcFile.remove();
+   if (removeError)
+      LOG_ERROR(removeError);
 
    // process results of R CMD SHLIB
    if (error)
@@ -1083,32 +1142,7 @@ std::vector<std::string> RCompilationDatabase::argsForRCmdSHLIB(
       // parse the compilation results
       if (verbose(3))
       {
-         std::cerr << "# COMPILATION OUTPUT for R CMD SHLIB --dry-run ----" << std::endl;
-         std::cerr << result.stdOut << std::endl;
-      }
-
-      std::vector<std::string> lines;
-      boost::algorithm::split(lines, result.stdOut, boost::algorithm::is_any_of("\r\n"));
-      std::string makeCmd = lines[1] + " --dry-run --always-make";
-
-      result.stdOut = "";
-      result.stdErr = "";
-      core::system::ProcessOptions options;
-      options.workingDir = srcDir;
-      options.environment = env;
-      error = core::system::runCommand(
-               makeCmd,
-               options,
-               &result);
-      if (error)
-      {
-         LOG_ERROR(error);
-         return {};
-      }
-
-      if (verbose(3))
-      {
-         std::cerr << "# COMPILATION OUTPUT for make --dry-run --always-run ----" << std::endl;
+         std::cerr << "# PARSING COMPILATION OUTPUT ----" << std::endl;
          std::cerr << result.stdOut << std::endl;
       }
 

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -69,7 +69,7 @@ private:
                                 core::system::ProcessResult* pResult);
 
    core::Error executeRCmdSHLIB(core::system::Options env,
-                                const core::FilePath& srcDir,
+                                const core::FilePath& srcPath,
                                 core::system::ProcessResult* pResult);
 
    void updateForCurrentPackage();
@@ -96,7 +96,7 @@ private:
                                         core::FilePath srcFile);
 
    std::vector<std::string> argsForRCmdSHLIB(core::system::Options env,
-                                             const core::FilePath& srcDir);
+                                             core::FilePath tempSrcFile);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
    std::vector<std::string> packageCompilationArgs(

--- a/src/cpp/session/modules/clang/RCompilationDatabase.hpp
+++ b/src/cpp/session/modules/clang/RCompilationDatabase.hpp
@@ -76,7 +76,7 @@ private:
    void updateForSourceCpp(const core::FilePath& cppPath);
    std::vector<std::string> compileArgsForPackage(
                                      const core::system::Options& env,
-                                     const core::FilePath& pkgPath,
+                                     const core::FilePath& srcDir,
                                      bool isCpp);
 
 
@@ -96,7 +96,7 @@ private:
                                         core::FilePath srcFile);
 
    std::vector<std::string> argsForRCmdSHLIB(core::system::Options env,
-                                             core::FilePath tempSrcFile);
+                                             core::FilePath srcFile);
 
    std::vector<std::string> baseCompilationArgs(bool isCppFile) const;
    std::vector<std::string> packageCompilationArgs(


### PR DESCRIPTION
### Intent

Addresses #6384.

### Approach

- Ensure `R CMD SHLIB` runs in the package `src/` directory directly.
- Sneak in the `--always-make` argument into the `R CMD SHLIB` invocation.

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
