### PR TITLE
Fix load screen overwriting base URL

### DIFF
--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -271,7 +271,7 @@ export class MainWindow extends GwtWindow {
   //   quitConfirmed_ = true;
   // }
 
-  async loadUrl(url: string): Promise<void> {
+  async loadUrl(url: string, updateBaseUrl = true): Promise<void> {
     // pass along the shared secret with every request
     const filter = {
       urls: [`${url}/*`],
@@ -281,8 +281,10 @@ export class MainWindow extends GwtWindow {
       callback({ requestHeaders: details.requestHeaders });
     });
 
-    logger().logDebug(`Setting base URL: ${url}`);
-    this.options.baseUrl = url;
+    if (updateBaseUrl) {
+      logger().logDebug(`Setting base URL: ${url}`);
+      this.options.baseUrl = url;
+    }
 
     this.window.loadURL(url).catch((reason) => {
       logger().logErrorMessage(`Failed to load ${url}: ${reason}`);
@@ -437,7 +439,7 @@ export class MainWindow extends GwtWindow {
         // the load failed, but we haven't yet received word that the
         // session has failed to load. let the user know that the R
         // session is still initializing, and then reload the page.
-        this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY).catch(logger().logError);
+        this.loadUrl(LOADING_WINDOW_WEBPACK_ENTRY, false).catch(logger().logError);
         waitForUrlWithTimeout(this.options.baseUrl ?? '', reloadWaitDuration, reloadWaitDuration, 10)
           .then((error: Err) => {
             if (error) {


### PR DESCRIPTION
### Intent
Addresses #11915

Fixes the wait until UI is ready not transitioning from the load screen

### Approach
Don't overwrite the base URL when showing the load screen.

### Automated Tests
None

### QA Notes
Launching with the `--session-delay` option will cause the load screen to show for 5s.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


