### PR TITLE
only add lib if it has the package as an installed package

### DIFF
--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -270,14 +270,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
 })
 
 .rs.addFunction("isDevPackage", function(name) {
-   # use pkgload if available
-   if (.rs.isPackageInstalled("pkgload")) {
-      return(pkgload::is_dev_package(name))
-   }
-
-   # otherwise infer based on the Meta directory
-   path <- attr(as.environment(paste0("package:", name)), "path")
-   !file.exists(file.path(path, "Meta"))
+   "pkgload" %in% loadedNamespaces() && pkgload::is_dev_package(name)
 })
 
 # load a package by name

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -281,7 +281,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # dependencies may live within a separate library path from the package to be
    # loaded; it should suffice to place the requested library at the front of
    # the library paths
-   if (nzchar(lib)) {
+   if (nzchar(lib) && file.exists(file.path(lib, packageName, "Meta"))) {
       libPaths <- .libPaths()
       .libPaths(c(lib, libPaths))
       on.exit(.libPaths(libPaths), add = TRUE)

--- a/src/cpp/r/R/Tools.R
+++ b/src/cpp/r/R/Tools.R
@@ -269,6 +269,17 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
   devToolsPath %in% .libPaths()
 })
 
+.rs.addFunction("isDevPackage", function(name) {
+   # use pkgload if available
+   if (.rs.isPackageInstalled("pkgload")) {
+      return(pkgload::is_dev_package(name))
+   }
+
+   # otherwise infer based on the Meta directory
+   path <- attr(as.environment(paste0("package:", name)), "path")
+   !file.exists(file.path(path, "Meta"))
+})
+
 # load a package by name
 .rs.addFunction( "loadPackage", function(packageName, lib)
 {
@@ -281,7 +292,7 @@ environment(.rs.Env[[".rs.addFunction"]]) <- .rs.Env
    # dependencies may live within a separate library path from the package to be
    # loaded; it should suffice to place the requested library at the front of
    # the library paths
-   if (nzchar(lib) && file.exists(file.path(lib, packageName, "Meta"))) {
+   if (nzchar(lib)) {
       libPaths <- .libPaths()
       .libPaths(c(lib, libPaths))
       on.exit(.libPaths(libPaths), add = TRUE)

--- a/src/cpp/r/session/RSearchPath.cpp
+++ b/src/cpp/r/session/RSearchPath.cpp
@@ -283,6 +283,15 @@ Error save(const FilePath& statePath)
       if (boost::algorithm::starts_with(elementName, "package:"))
       {
          std::string name = elementName.substr(strlen("package:"));
+
+         // skip if this is a dev package, i.e. loaded with load_all()
+         bool isDev = false;
+         Error error = r::exec::RFunction(".rs.isDevPackage").addParam(name).call(&isDev);
+         if (error)
+            return error;
+         if (isDev)
+            continue;
+
          SEXP pathSEXP = Rf_getAttrib(envSEXP, Rf_install("path"));
          if (Rf_isString(pathSEXP) && Rf_length(pathSEXP) == 1)
          {


### PR DESCRIPTION
### Intent

addresses #11527

### Approach

only add the lib (coming from the `path` attribute of the `as.environment()` result) if it has the package as an installed package. 

i.e. not those that have been `load_all()` and are only source packages which will make `library()` fail. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


