### PR TITLE
Companion to session ssl load-balancing bug fix

### DIFF
--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -552,6 +552,17 @@ bool isSslShutdownError(const boost::system::error_code& ec)
 }
 #endif
 
+#ifndef _WIN32
+
+bool isSslCertificateVerifyFailedError(const core::Error& error)
+{
+   return error.getName() == boost::asio::error::get_ssl_category().name() &&
+              ERR_GET_LIB(error.getCode()) == ERR_LIB_SSL &&
+              ERR_GET_REASON(error.getCode()) == SSL_R_CERTIFICATE_VERIFY_FAILED;
+}
+
+#endif
+
 std::string addQueryParam(const std::string& uri,
                           const std::string& queryParam)
 {

--- a/src/cpp/core/include/core/http/Util.hpp
+++ b/src/cpp/core/include/core/http/Util.hpp
@@ -180,6 +180,12 @@ bool isWSUpgradeRequest(const Request& request);
 // does the given error represent SSL truncation/shutdown?
 bool isSslShutdownError(const boost::system::error_code& code);
 
+#ifndef _WIN32
+
+bool isSslCertificateVerifyFailedError(const rstudio::core::Error& error);
+
+#endif
+
 std::string addQueryParam(const std::string& uri,
                           const std::string& queryParam);
 


### PR DESCRIPTION
Add a new util function to identify certificate verify ssl errors for linux

Reviewed in: https://github.com/rstudio/rstudio-pro/pull/3778