### PR TITLE
use Timer instead of `Scheduler.get().scheduleDeferred()`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
@@ -36,7 +36,8 @@ public class TextEditingTargetThemeHelper
                                        final EventBus eventBus,
                                        final ArrayList<HandlerRegistration> releaseOnDismiss)
    {
-      timer_ = new Timer() {
+      timer_ = new Timer()
+      {
          @Override
          public void run() {
             syncToEditorTheme(editingTarget);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
@@ -39,7 +39,8 @@ public class TextEditingTargetThemeHelper
       timer_ = new Timer()
       {
          @Override
-         public void run() {
+         public void run()
+         {
             syncToEditorTheme(editingTarget);
          }
       };

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetThemeHelper.java
@@ -40,7 +40,7 @@ public class TextEditingTargetThemeHelper
       Timers.singleShot(100, () -> {
 
          // do the sync
-         syncToEditorTheme(editingTarget);
+         syncToEditorThemeImpl(editingTarget);
 
          // register for notification on subsequent changes
          releaseOnDismiss.add(
@@ -73,8 +73,7 @@ public class TextEditingTargetThemeHelper
    {
       // delay execution so that the browser has a chance to apply styles
       // https://github.com/rstudio/rstudio/issues/11868
-      Scheduler.get().scheduleDeferred(() ->
-      {
+      Timers.singleShot(100, () -> {
          syncToEditorThemeImpl(editingTarget);
       });
    }


### PR DESCRIPTION
### Intent

Follow up to #11422 because problem still exist after #11876

### Approach

use a 100ms timer instead of `Scheduler.get().scheduleDeferred` so that there's more time to apply the styles. Presumably `Scheduler.get().scheduleDeferred()` was too early. 

Although I'm not sure because I could not reproduce the problem as in https://github.com/rstudio/rstudio/issues/11422#issuecomment-1242511691

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


