### PR TITLE
Ignore registry entries for Rtools

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -309,10 +309,8 @@ function scanForRPosix(): Expected<string> {
 
 function queryRegistry(cmd: string, rInstallations: Set<string>): Set<string> {
   const [output, error] = executeCommand(cmd);
-    if (error) {
-      logger().logError(error);
-      return rInstallations;
-    }
+  if (error)      
+    return rInstallations;
 
   // parse the actual path from the output
   const lines = output.split(EOL);
@@ -339,7 +337,12 @@ export function findRInstallationsWin32(): string[] {
       'HKEY_LOCAL_MACHINE',
       'HKEY_CURRENT_USER',
     ];
-    const regQueryCommands = keyNames.map(key => `reg query ${key}\\SOFTWARE\\R-Core /s /v InstallPath ${view}`);  
+
+    // look specifically for R or R64, ignore Rtools directory
+    const rBinaryNames = ['R', 'R64'];
+
+    const regQueryCommands = keyNames.flatMap(key => rBinaryNames.map(
+      rBin => `reg query ${key}\\SOFTWARE\\R-Core\\${rBin} /s /v InstallPath ${view}`));  
     regQueryCommands.map(cmd => queryRegistry(cmd, rInstallations));
   }
 


### PR DESCRIPTION
Addresses edge case in #11438 (when Rtools is installed)

The current way we check the registry for anything from R-Core means it will detect RTools installation as well as R itself. While it's highly unlikely a user would have Rtools installed, but R not installed, it could happen if they uninstalled R and forgot to reinstall, and this came up in QA. Also we don't want to log errors relating to not finding a particular entry in the registry; these are expected and already handled.