### PR TITLE
replace `$$` in snippet only if not preceded by`\`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/snippets/SnippetHelper.java
@@ -15,6 +15,7 @@
 
 package org.rstudio.studio.client.workbench.snippets;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptException;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.core.client.JsArray;
@@ -280,7 +281,7 @@ public class SnippetHelper
          snippet = replaceHeaderGuard(snippet);
       }
 
-      return snippet.replaceAll("\\$\\$", token.substring(snippetName.length()));
+      return snippet.replaceAll("(?<!\\\\)\\$\\$", token.substring(snippetName.length()));
    }
 
    public final native void applySnippetImpl(


### PR DESCRIPTION
### Intent

addresses #11951

### Approach

update `transformMacros()` so that `$$` is only replaced if not preceded by `\` so that `\$$` is legit

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


