### PR TITLE
Add Timer class and ITimer interface to core library.

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -54,6 +54,7 @@ set(CORE_SOURCE_FILES
    StringUtils.cpp
    ColorUtils.cpp
    Thread.cpp
+   Timer.cpp
    Trace.cpp
    WaitUtils.cpp
    YamlUtil.cpp

--- a/src/cpp/core/Timer.cpp
+++ b/src/cpp/core/Timer.cpp
@@ -1,0 +1,42 @@
+/*
+ * Timer.cpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <core/Timer.hpp>
+
+namespace rstudio {
+namespace core {
+
+Timer::Timer(boost::asio::io_service& ioService) :
+   timer_(ioService)
+{
+}
+
+void Timer::setExpiration(const boost::posix_time::time_duration& timeDuration)
+{
+   timer_.expires_from_now(timeDuration);
+}
+
+void Timer::cancel()
+{
+   timer_.cancel();
+}
+
+void Timer::wait(const std::function<void(const boost::system::error_code& ec)>& callback)
+{
+   timer_.async_wait(callback);
+}
+
+} // namespace core
+} // namespace rstudio

--- a/src/cpp/core/include/core/Timer.hpp
+++ b/src/cpp/core/include/core/Timer.hpp
@@ -1,0 +1,58 @@
+/*
+ * Timer.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef CORE_TIMER_HPP
+#define CORE_TIMER_HPP
+
+#include <functional>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/deadline_timer.hpp>
+
+namespace rstudio {
+namespace core {
+
+using TimerCallback = std::function<void(const boost::system::error_code& ec)>;
+
+class ITimer
+{
+public:
+   virtual void cancel() = 0;
+   virtual void setExpiration(const boost::posix_time::time_duration& timeDuration) = 0;
+   virtual void wait(const TimerCallback& callback) = 0;
+
+   virtual ~ITimer() {}
+};
+
+class Timer : public ITimer
+{
+public:
+   Timer(boost::asio::io_service& ioService);
+   virtual ~Timer() {}
+
+   virtual void cancel() override;
+   virtual void setExpiration(const boost::posix_time::time_duration& timeDuration) override;
+   virtual void wait(const std::function<void(const boost::system::error_code& ec)>& callback) override;
+
+private:
+   boost::asio::deadline_timer timer_;
+};
+
+using TimerPtr = boost::shared_ptr<ITimer>;
+
+} // namespace core
+} // namespace rstudio
+
+#endif // CORE_TIMER_HPP
+


### PR DESCRIPTION
This allows code that needs to test timeout functionality the ability to mock the timer to allow you to have control over when the timer is actually invoked, making this very useful for unit testing.

This has already been proven out in the Launcher codebase.