### PR TITLE
Nit: standardize arg names to lowercase in Socket.hpp

### DIFF
--- a/src/cpp/core/include/core/http/Socket.hpp
+++ b/src/cpp/core/include/core/http/Socket.hpp
@@ -39,11 +39,11 @@ public:
 
    virtual void asyncWrite(
                      const boost::asio::const_buffers_1& buffer,
-                     Handler Handler) = 0;
+                     Handler handler) = 0;
 
    virtual void asyncWrite(
                      const std::vector<boost::asio::const_buffer>& buffers,
-                     Handler Handler) = 0;
+                     Handler handler) = 0;
 
    virtual void close() = 0;
 };


### PR DESCRIPTION
### Intent
Updates `src/cpp/include/core/http/socket.hpp` with a small casing fix. Any parameter variables should not be title case by default, and we refer to similar variables as the lowercase `handler` as well.

### Automated Tests
This should be a no-op, nowhere do we ever name this argument when making calls to `asyncWrite()`.
If we introduced any bugs our compiler should catch them, given we're just renaming a couple variables.

### Checklist
- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ x If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


