### PR TITLE
default to project directory when restoring suspended session

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
   when `Options > Code > Display > [ ] Show color preview` is checked. 
 * Fixes the bug introduced with `rlang` >= 1.03 where Rmd documents show the error message `object 'partition_yaml_front_matter' not found` upon project startup (#11552)
 * Name autocompletion following a `$` now correctly quotes names that start with underscore followed by alphanumeric characters (#11689)
+* Suspended sessions will now default to using the project directory, rather than the user home directory, if the prior working directory is no longer accessible. (#11960)
   
 ### Python
 

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -77,6 +77,8 @@ struct ROptions
          suspendOnIncompleteStatement(false)
    {
    }
+   
+   core::FilePath projectPath;
    core::FilePath userHomePath;
    core::FilePath userScratchPath;
    core::FilePath scopedScratchPath;

--- a/src/cpp/r/include/r/session/RSessionUtils.hpp
+++ b/src/cpp/r/include/r/session/RSessionUtils.hpp
@@ -44,6 +44,9 @@ bool isDefaultPrompt(const std::string& prompt);
 
 bool isServerMode();
 
+// project path
+const core::FilePath& projectPath();
+
 // user home path
 const core::FilePath& userHomePath();
 

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -183,7 +183,7 @@ void restoreSession(const FilePath& suspendedSessionPath,
    // don't show output during deserialization (packages loaded
    // during deserialization sometimes print messages)
    utils::SuppressOutputInScope suppressOutput;
-
+   
    // deserialize session. if any part of this fails then the errors
    // will be logged and error messages will be returned in the passed
    // errorMessages buffer (this mechanism is used because we generally

--- a/src/cpp/r/session/RSession.cpp
+++ b/src/cpp/r/session/RSession.cpp
@@ -320,7 +320,7 @@ Error run(const ROptions& options, const RCallbacks& callbacks)
 
    // set source reloading behavior
    sourceManager().setAutoReload(options.autoReloadSource);
-     
+   
    // initialize suspended session path
    FilePath userScratch = s_options.userScratchPath;
    FilePath oldSuspendedSessionPath = userScratch.completePath("suspended-session");
@@ -534,6 +534,11 @@ bool isDefaultPrompt(const std::string& prompt)
 bool isServerMode()
 {
    return s_options.serverMode;
+}
+
+const FilePath& projectPath()
+{
+   return s_options.projectPath;
 }
 
 const FilePath& userHomePath()

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -222,8 +222,8 @@ Error restoreEnvironmentVars(const FilePath& envFile)
 }
    
 Error restoreWorkingDirectory(const std::string& workingDirectory,
-                              const FilePath& userHomePath, 
-                              const FilePath& projectPath)
+                              const FilePath& projectPath,
+                              const FilePath& userHomePath)
 {
    // resolve working dir
    FilePath workingDirPath = FilePath::resolveAliasedPath(workingDirectory, userHomePath);
@@ -637,8 +637,8 @@ bool restore(const FilePath& statePath,
    std::string workingDir = settings.get(kWorkingDirectory);
    error = restoreWorkingDirectory(
             workingDir,
-            r::session::utils::userHomePath(),
-            r::session::utils::projectPath());
+            r::session::utils::projectPath(),
+            r::session::utils::userHomePath());
    
    if (error)
       reportError(kRestoring, kWorkingDirectory, error, ERROR_LOCATION, er);

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -173,10 +173,13 @@ SerializationCallbackScope::SerializationCallbackScope(int action,
 
 SerializationCallbackScope::~SerializationCallbackScope()
 {
-   try {
-      rCallbacks().serialization(kSerializationActionCompleted,
-                                 FilePath());
-   } catch(...) {}
+   try
+   {
+      rCallbacks().serialization(kSerializationActionCompleted, FilePath());
+   }
+   catch(...)
+   {
+   }
 }
 
 bool suspended()

--- a/src/cpp/r/session/RSuspend.hpp
+++ b/src/cpp/r/session/RSuspend.hpp
@@ -27,11 +27,13 @@ struct RSuspendOptions;
 void setSuspendPaths(const core::FilePath& sessionPath, 
       const core::FilePath& clientStatePath, 
       const core::FilePath& projectClientStatePath);
+
 core::FilePath suspendedSessionPath();
 bool suspend(const RSuspendOptions& options,
              const core::FilePath& suspendedSessionPath,
              bool disableSaveCompression,
              bool force);
+
 bool suspended();
 
 void saveClientState(ClientStateCommitType commitType);

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2298,6 +2298,7 @@ int main(int argc, char * const argv[])
 
       // r options
       rstudio::r::session::ROptions rOptions;
+      rOptions.projectPath = projects::projectContext().hasProject() ? projects::projectContext().directory() : FilePath();
       rOptions.userHomePath = options.userHomePath();
       rOptions.userScratchPath = options.userScratchPath();
       rOptions.scopedScratchPath = module_context::scopedScratchPath();

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -315,7 +315,7 @@ void setSuspendedFromTimeout(bool suspended)
 bool suspendSession(bool force, int status)
 {
    // need to make sure the global environment is loaded before we
-   // attemmpt to save it!
+   // attempt to save it!
    r::session::ensureDeserialized();
 
    // If we're suspending then clear list of blocking ops


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11960.

### Approach

If the working directory associated with a suspended session doesn't exist, prefer using the project directory instead.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/11960.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
