### PR TITLE
Fix RSA signature buffer initialisation for old versions of OpenSSL

### DIFF
--- a/src/cpp/core/system/Crypto.cpp
+++ b/src/cpp/core/system/Crypto.cpp
@@ -146,7 +146,7 @@ Error rsaSign(const std::string& message,
 
    // sign the message hash
    std::vector<unsigned char> pSignature(EVP_PKEY_size(pRsa.get()));
-   size_t sigLen;
+   size_t sigLen = pSignature.size();
    std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)> ctx(EVP_PKEY_CTX_new(pRsa.get(), NULL),
                                                                    EVP_PKEY_CTX_free);
    if (!ctx)


### PR DESCRIPTION
### Intent

This commit initialises the `siglen` parameter as required by [the OpenSSL docs for `EVP_PKEY_sign()`](https://www.openssl.org/docs/manmaster/man3/EVP_PKEY_sign.html#DESCRIPTION):

> If sig is not NULL then before the call the siglen parameter should contain the length of the sig buffer, if the call is successful the signature is written to sig and the amount of data written to siglen.

The previous code worked against the OpenSSL 3 library I QA'd it against and in unit tests (which have small payloads), but @colearendt [reported that it failed in real-world usage](https://rstudio.slack.com/archives/C7HT9GDB9/p1661873074996499) on a Ubuntu 18.04 environment:

    2022-08-30T15:23:32.112970Z [rserver] ERROR system error 74 (Bad message) [description: error:0608C09B:digital envelope routines:EVP_PKEY_sign:buffer too small, description: Error signing Launcher session request, request-uri: /events/get_events]; OCCURRED AT rstudio::core::Error rstudio::core::system::crypto::rsaSign(const string&, const string&, std::__cxx11::string*) src/cpp/core/system/Crypto.cpp:169; LOGGED FROM: void rstudio::server::session_proxy::{anonymous}::logIfNotConnectionTerminated(const rstudio::core::Error&, const rstudio::core::http::Request&) src/cpp/server/session/ServerSessionProxy.cpp:503

I have not precisely identified the root cause, but I notice that OpenSSL [changed how this parameter is handled internally in 2021](https://github.com/openssl/openssl/commit/43da9a14f0e73f42f28ae34219929b44df5d1a11). That OpenSSL commit in question describes the fix as requring an "application bug" to hit the problem and cites no CVE issued -- so it's likely that not all distros will backport the patch and we should expect different behaviour among them.

### Approach

Since the previous code was, according to the documentation, an "application bug", it seems likely that this change will resolve the issue for everyone.

### Automated Tests

This change is covered by unit tests but the old code was only flagged as problematic in practical usage.

### QA Notes

We should check that daily builds with this change resolve the issues in the environement @colearendt observed them in.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests