### PR TITLE
Workaround to Electron second instance hang

### DIFF
--- a/src/node/desktop/forge.config.js
+++ b/src/node/desktop/forge.config.js
@@ -42,6 +42,9 @@ const config = {
             },
           ],
         },
+        // uncoment and change these ports to launch multiple debug instances
+        // port: 3000,
+        // loggerPort: 9000,
       },
     ],
   ],

--- a/src/node/desktop/src/main/application-launch.ts
+++ b/src/node/desktop/src/main/application-launch.ts
@@ -80,7 +80,12 @@ export class ApplicationLaunch {
     }
 
     // run it
-    spawn(process.execPath, argv, { detached: true });
+    const childProcess = spawn(process.execPath, argv,
+      {
+        detached: true,
+        stdio: 'ignore', // don't reuse the stdio from parent
+      });
+    childProcess.unref();
 
     // restore environment variables
     unsetenv(kRStudioInitialProject);

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -81,18 +81,6 @@ export class Application implements AppState {
       return status;
     }
 
-    // check if this is the primary instance
-    // projects always open in a new instance
-    // files prefer to reuse the primary instance
-    const hasInstanceLock = app.requestSingleInstanceLock();
-    const hasProjectToOpen = this.argsManager.getProjectFileArg() ?? getenv('RS_INITIAL_PROJECT');
-    const hasFileToOpen = this.argsManager.getFileArgs().length > 0;
-    logger().logDebug(`instance lock: ${hasInstanceLock}, project: ${hasProjectToOpen}, file: ${hasFileToOpen}`);
-    if (!hasInstanceLock && !(hasProjectToOpen.length > 0) && hasFileToOpen) {
-      logger().logDebug('No instance lock - exiting');
-      return exitSuccess();
-    }
-
     // attempt to remove stale lockfiles, as they can impede application startup
     try {
       removeStaleOptionsLockfile();
@@ -110,12 +98,29 @@ export class Application implements AppState {
 
     initializeSharedSecret();
     this.registerAppEvents();
-    this.initializeInstance();
 
     // allow users to supply extra command-line arguments for Chromium
     augmentCommandLineArguments();
 
+    logger().logDebug('Ready to run');
     return run();
+  }
+
+  private shouldInstanceOpen() {
+    // check if this is the primary instance
+    // projects always open in a new instance
+    // files prefer to reuse the primary instance
+    const hasInstanceLock = app.requestSingleInstanceLock();
+    const hasProjectToOpen = this.argsManager.getProjectFileArg() ?? getenv('RS_INITIAL_PROJECT');
+    const hasFileToOpen = this.argsManager.getFileArgs().length > 0;
+
+    logger().logDebug(`instance lock: ${hasInstanceLock}, project: ${hasProjectToOpen}, file: ${hasFileToOpen}`);
+    if (!hasInstanceLock && !(hasProjectToOpen.length > 0) && hasFileToOpen) {
+      logger().logDebug('No instance lock - exiting');
+      return false;
+    }
+
+    return true;
   }
 
   private initializeInstance() {
@@ -126,6 +131,15 @@ export class Application implements AppState {
     } else {
       this.createMessageClient();
     }
+
+    app.on('second-instance', (_event, argv) => {
+      logger().logDebug(`second-instance event: ARGS ${argv}`);
+
+      // for files, open in the existing instance
+      this.argsManager.setUnswitchedArgs(argv);
+      if (this.argsManager.getProjectFileArg() === undefined)
+        this.argsManager.handleAfterSessionLaunchCommands();
+    });
   }
 
   // listens for messages from the server
@@ -145,11 +159,9 @@ export class Application implements AppState {
       // close out connection to primary instance that just quit
       // another connection will be created to either be the primary or listen to the new primary instance
       this.client?.close()
-        .then(() => {
-          logger().logDebug(`net-ipc: ${process.pid} close client connection`);
-          this.client = undefined;
-        })
-        .catch((error: unknown) => logger().logError(error));
+        .then(() => logger().logDebug(`net-ipc: ${process.pid} close client connection`))
+        .catch((error: unknown) => logger().logError(error))
+        .finally(() => this.client = undefined);
 
       const instanceLock = app.requestSingleInstanceLock();
       if (instanceLock) {
@@ -180,9 +192,7 @@ export class Application implements AppState {
       // closing will send an event to all other instances
       // one of the other instances will take over as primary
       this.server?.close()
-        .then(() => {
-          logger().logDebug(`net-ipc: ${process.pid} is shutting down and releasing the instance lock`);
-        })
+        .then(() => logger().logDebug(`net-ipc: ${process.pid} is shutting down and releasing the instance lock`))
         .catch((error: unknown) => logger().logError(error));
 
       this.client?.close()
@@ -228,15 +238,6 @@ export class Application implements AppState {
         .catch((error: unknown) => logger().logError(error));
     });
 
-    app.on('second-instance', (_event, argv) => {
-      logger().logDebug(`second-instance event: ARGS ${argv}`);
-
-      // for files, open in the existing instance
-      this.argsManager.setUnswitchedArgs(argv);
-      if (this.argsManager.getProjectFileArg() === undefined)
-        this.argsManager.handleAfterSessionLaunchCommands();
-    });
-
     // // Workaround for selecting all text in the input field: https://github.com/rstudio/rstudio/issues/11581
     // if (process.platform === 'darwin') {
     //   app.whenReady()
@@ -253,6 +254,11 @@ export class Application implements AppState {
    * Invoked when Electron app is 'ready'
    */
   async run(): Promise<ProgramStatus> {
+    if (!this.shouldInstanceOpen()) {
+      return exitSuccess();
+    }
+    this.initializeInstance();
+
     // prepare application for launch
     this.appLaunch = ApplicationLaunch.init();
 


### PR DESCRIPTION
### Intent
Address part of #11604 

### Approach
Request instance lock after app is ready to prevent pause until user focuses window. Electron docs show to request before the app is ready but this doesn't seem to make any difference on Linux and Windows. MacOS does briefly show the dock icon since that shows when the app is ready. These seems to be a good compromise to waiting for focus when requesting the instance lock.

I don't know if this addresses the long start up though. It still seems to be long on Windows but that's using an Amazon Workspace, which is already quite slow.

### Automated Tests
None

### QA Notes
This does not necessarily address the long startup for a second window. It does remove the need to focus the second window so that it finishes start up. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


