### PR TITLE
Use XDG_CACHE_HOME for secure cookie key in low privilege mode

### DIFF
--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -66,6 +66,13 @@ FilePath userDataDir(const boost::optional<std::string>& user = boost::none,
 // Returns the user-specific logging directory underneath the userDataDir
 FilePath userLogDir();
                      
+// Returns the RStudio XDG user cache directory.
+//
+// On Unix-alikes, this is ~/.cache, or XDG_CACHE_HOME.
+// On Windows, this is 'FOLDERID_InternetCache' (typically 'AppData/Local/Microsoft/Windows/Temporary Files')
+FilePath userCacheDir(const boost::optional<std::string>& user = boost::none,
+                      const boost::optional<FilePath>& homeDir = boost::none);
+
 // This function verifies that the userConfigDir() and userDataDir() exist and are owned by the running user.
 // 
 // It should be invoked once. Any issues with these directories will be emitted to the session log.

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -218,6 +218,21 @@ FilePath userDataDir(
    );
 }
 
+FilePath userCacheDir(
+        const boost::optional<std::string>& user,
+        const boost::optional<FilePath>& homeDir)
+{
+   return resolveXdgDir("RSTUDIO_CACHE_HOME",
+         "XDG_CACHE_HOME",
+#ifdef _WIN32
+         FOLDERID_InternetCache,
+#endif
+         "~/.cache",
+         user,
+         homeDir
+   );
+}
+
 FilePath userLogDir()
 {
    return userDataDir().completePath("log");

--- a/src/cpp/server_core/SecureKeyFile.cpp
+++ b/src/cpp/server_core/SecureKeyFile.cpp
@@ -113,7 +113,7 @@ core::Error readSecureKeyFile(const std::string& filename,
    }
    else
    {
-      secureKeyPath = core::FilePath("/tmp/rstudio-server").completePath(filename);
+      secureKeyPath = core::system::xdg::userCacheDir().completePath(filename);
       if (secureKeyPath.exists())
       {
          LOG_INFO_MESSAGE("Running without privilege; using secure key at " + secureKeyPath.getAbsolutePath());


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11828. 

### Approach

When running in low privilege mode, do not use a hard-coded secure cookie key path in the global folder `/tmp/rstudio-server`. Instead, since we know we are running as a low privilege user, put the secure cookie key in their per-user cache, following the XDG specification for user-level cache data.

### Automated Tests

N/A, automated tests do not currently have the ability to run in low privilege mode AFAIK.

### QA Notes

The secure cookie key is used for login cookies, so testing login/logout in low privilege mode should validate the change. Set the log level to `INFO` or higher to confirm; you should see a message like this:

```
INFO Running without privilege; using secure key at /Users/jmcphers/.cache/rstudio/session-rpc-key
```

See here for more info on low privilege mode: https://docs.rstudio.com/ide/server-pro/access_and_security/server_permissions.html#running-without-permissions

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests


