### PR TITLE
Nextflow filetype support

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -112,6 +112,8 @@ MimeType s_mimeTypes[] =
       { "ts",           "text/x-typescript"},
       { "ojs",          "text/javascript" },
       { "lua",          "text/x-lua"},
+      { "groovy",       "text/x-groovy"},
+      { "nf",           "text/x-groovy"},
 
       // other types we are likely to serve
       { "xml",          "text/xml" },

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -377,6 +377,8 @@ public class FileSystemItem extends JavaScriptObject
       MIME_TYPES.put( "sql",       "text/x-sql" );
       MIME_TYPES.put( "stan",      "text/x-stan" );
       MIME_TYPES.put( "clj",       "text/x-clojure");
+      MIME_TYPES.put( "groovy",    "text/x-groovy");
+      MIME_TYPES.put( "nf",        "text/x-groovy");
 
       // other types we are likely to serve
       MIME_TYPES.put( "xml",   "text/xml" );

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/FileTypeRegistry.java
@@ -445,6 +445,7 @@ public class FileTypeRegistry
       register("*.el", LISP, new ImageResource2x(icons.iconLisp2x()));
       register("*.lua", LUA, new ImageResource2x(icons.iconLua2x()));
       register("*.m", MATLAB, new ImageResource2x(icons.iconMatlab2x()));
+      register("*.nf", GROOVY, new ImageResource2x(icons.iconGroovy2x()));
       register("*.pl", PERL, new ImageResource2x(icons.iconPerl2x()));
       register("*.rb", RUBY, new ImageResource2x(icons.iconRuby2x()));
       register("*.rs", RUST, new ImageResource2x(icons.iconRust2x()));


### PR DESCRIPTION
### Intent

Add basic support for nextflow language (*.nf) files. Partially adresses https://github.com/rstudio/rstudio/issues/11677

### Approach
Based on https://github.com/rstudio/rstudio/commit/59cab5bba624acd1574b144ab828d14728b70561
Nextflow is a DSL in groovy, so adding groovy syntax highligting is appropriate. THis will not include nextflow specific syntax highlighing (e.g. `process`, `workflow` etc)

### Automated Tests
Not done.

### QA Notes

### Checklist
Singed contributors agreement


