### PR TITLE
fuzzy finder showing C(++) macros

### DIFF
--- a/src/cpp/core/include/core/libclang/SourceIndex.hpp
+++ b/src/cpp/core/include/core/libclang/SourceIndex.hpp
@@ -33,6 +33,8 @@ namespace rstudio {
 namespace core {
 namespace libclang {
 
+unsigned parseTranslationUnitOptions();
+
 struct CompilationDatabase
 {
    boost::function<bool(const std::string&)> hasTranslationUnit;

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -300,7 +300,7 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
                          gsl::narrow_cast<int>(argsArray.argCount()),
                          unsavedFiles().unsavedFilesArray(),
                          unsavedFiles().numUnsavedFiles(),
-                         options);
+                         options | CXTranslationUnit_DetailedPreprocessingRecord);
 
 
    // save and return it if we succeeded

--- a/src/cpp/core/libclang/SourceIndex.cpp
+++ b/src/cpp/core/libclang/SourceIndex.cpp
@@ -35,13 +35,16 @@ namespace rstudio {
 namespace core {
 namespace libclang {
 
-namespace {
-
-inline unsigned applyTranslationUnitOptions(unsigned defaultOptions)
+unsigned parseTranslationUnitOptions()
 {
-   // for now just reflect back the defaults
-   return defaultOptions;
+   return (
+      CXTranslationUnit_None |
+      CXTranslationUnit_Incomplete |
+      CXTranslationUnit_DetailedPreprocessingRecord
+   );
 }
+
+namespace {
 
 bool isHeaderExtension(const std::string& ex)
 {
@@ -224,13 +227,11 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
             std::cerr << "  " << reason << std::endl;
          }
 
-         unsigned options = applyTranslationUnitOptions(
-                                    clang().defaultReparseOptions(stored.tu));
          int ret = clang().reparseTranslationUnit(
                                 stored.tu,
                                 unsavedFiles().numUnsavedFiles(),
                                 unsavedFiles().unsavedFilesArray(),
-                                options);
+                                parseTranslationUnitOptions());
 
          if (ret == 0)
          {
@@ -290,9 +291,6 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
    }
    
    // create a new translation unit from the file
-   unsigned options = applyTranslationUnitOptions(
-                           clang().defaultEditingTranslationUnitOptions());
-   
    CXTranslationUnit tu = clang().parseTranslationUnit(
                          index_,
                          filename.c_str(),
@@ -300,7 +298,8 @@ TranslationUnit SourceIndex::getTranslationUnit(const std::string& filename,
                          gsl::narrow_cast<int>(argsArray.argCount()),
                          unsavedFiles().unsavedFilesArray(),
                          unsavedFiles().numUnsavedFiles(),
-                         options | CXTranslationUnit_DetailedPreprocessingRecord);
+                         parseTranslationUnitOptions()
+                         );
 
 
    // save and return it if we succeeded

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1442,7 +1442,8 @@ public:
       Table      = 9,
       Math       = 10,
       Test       = 11, 
-      Roxygen    = 12
+      Roxygen    = 12, 
+      Macro      = 13
    };
 
    SourceItem()
@@ -1578,6 +1579,9 @@ SourceItem fromCppDefinition(const clang::CppDefinition& cppDefinition)
       break;
    case CppMemberFunctionDefinition:
       type = SourceItem::Method;
+      break;
+   case CppMacroDefinition:
+      type = SourceItem::Macro;
       break;
    default:
       type = SourceItem::None;

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -120,7 +120,6 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
          kind = CppTypedefDefinition;
          break;
       case CXCursor_MacroDefinition:
-         
          kind = CppMacroDefinition;
          break;
       default:

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -120,6 +120,7 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
          kind = CppTypedefDefinition;
          break;
       case CXCursor_MacroDefinition:
+         
          kind = CppMacroDefinition;
          break;
       default:
@@ -134,6 +135,18 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
    // build name (strip trailing parens)
    std::string name = cursor.displayName();
    boost::algorithm::replace_last(name, "()", "");
+
+   // skip macros that are header guards
+   if (kind == CppMacroDefinition)
+   {
+      if (boost::algorithm::ends_with(name, "_H") ||
+          boost::algorithm::ends_with(name, "_HPP") ||
+          boost::algorithm::ends_with(name, "_H_") ||
+          boost::algorithm::ends_with(name, "_HPP_"))
+      {
+         return CXChildVisit_Continue;
+      }
+   }
 
    // empty display name for a namespace === anonymous
    if ((kind == CppNamespaceDefinition) && name.empty())

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -66,7 +66,12 @@ bool insertDefinition(const CppDefinition& definition,
    return true;
 }
 
-typedef std::pair<bool, boost::function<bool(const CppDefinition&)>> DefinitionVisitor;
+struct DefinitionVisitor
+{
+   bool hidden;
+   int index;
+   boost::function<bool(const CppDefinition&)> visit;
+};
 
 CXChildVisitResult cursorVisitor(CXCursor cxCursor,
                                  CXCursor,
@@ -135,16 +140,13 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
    std::string name = cursor.displayName();
    boost::algorithm::replace_last(name, "()", "");
 
-   // skip macros that are header guards
-   if (kind == CppMacroDefinition)
+   DefinitionVisitor& visitor = *((DefinitionVisitor*)clientData);
+
+   // skip the first macro if it looks like an header guard
+   if (kind == CppMacroDefinition && visitor.index == 0 && boost::algorithm::iends_with(name, "_h(?pp)?_*$"))
    {
-      if (boost::algorithm::ends_with(name, "_H") ||
-          boost::algorithm::ends_with(name, "_HPP") ||
-          boost::algorithm::ends_with(name, "_H_") ||
-          boost::algorithm::ends_with(name, "_HPP_"))
-      {
-         return CXChildVisit_Continue;
-      }
+      visitor.index++;
+      return CXChildVisit_Continue;
    }
 
    // empty display name for a namespace === anonymous
@@ -161,20 +163,19 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
       parentName = parent.displayName();
    }
 
-   DefinitionVisitor& visitor = *((DefinitionVisitor*)clientData);
-
    // create the definition
    CppDefinition definition(cursor.getUSR(),
                             kind,
                             parentName,
                             name,
-                            visitor.first,
+                            visitor.hidden,
                             cursor.getSourceLocation().getSpellingLocation());
+   visitor.index++;
 
    // yield the definition if it's not a namespace (break if requested)
    if (kind != CppNamespaceDefinition)
    {
-      if (!visitor.second(definition))
+      if (!visitor.visit(definition))
          return CXChildVisit_Break;
    }
 
@@ -248,9 +249,7 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
                                argsArray.args(),
                                gsl::narrow_cast<int>(argsArray.argCount()),
                                nullptr, 0, // no unsaved files
-                               CXTranslationUnit_None |
-                               CXTranslationUnit_Incomplete |
-                               CXTranslationUnit_DetailedPreprocessingRecord);
+                               parseTranslationUnitOptions());
 
 
          // create definitions and wire visitor to it
@@ -260,10 +259,11 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
          definitions.hidden = isGeneratedFile(FilePath(definitions.file));
          s_definitionsByFile[file] = definitions;
 
-         DefinitionVisitor visitor = std::make_pair(
+         DefinitionVisitor visitor = {
             definitions.hidden,
+            0,
             boost::bind(insertDefinition, _1, &s_definitionsByFile[file])
-         );
+         };
          libclang::clang().visitChildren(
               libclang::clang().getTranslationUnitCursor(tu),
               cursorVisitor,
@@ -375,13 +375,13 @@ FileLocation findDefinitionLocation(const FileLocation& location)
       {
          // search for the definition
          CppDefinition def;
-         DefinitionVisitor visitor = std::make_pair(
+         DefinitionVisitor visitor = {
             // hidden: does not matter. This CppDefinition is only used for location
             //         can consider that the definition is not hidden
             false, 
+            0,
             boost::bind(findUSR, USR, _1, &def)
-         );
-
+         };
          // visit the cursors
          libclang::clang().visitChildren(
               libclang::clang().getTranslationUnitCursor(
@@ -634,10 +634,11 @@ void searchDefinitions(const std::string& term,
       bool hidden = isGeneratedFile(FilePath(filename));
       
       // search for matching definitions
-      DefinitionVisitor visitor = std::make_pair(
+      DefinitionVisitor visitor = {
          hidden, 
+         0,
          boost::bind(insertMatching, term, pattern, _1, pDefinitions)
-      );
+      };
 
       // visit the cursors
       libclang::clang().visitChildren(

--- a/src/cpp/session/modules/clang/DefinitionIndex.cpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.cpp
@@ -83,7 +83,8 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
 
    // ensure it's a definition with linkage or a typedef
    if ((!cursor.isDefinition() || !cursor.hasLinkage()) &&
-       cursorKind != CXCursor_TypedefDecl)
+       cursorKind != CXCursor_TypedefDecl &&
+       cursorKind != CXCursor_MacroDefinition)
    {
       return CXChildVisit_Continue;
    }
@@ -117,6 +118,9 @@ CXChildVisitResult cursorVisitor(CXCursor cxCursor,
          break;
       case CXCursor_TypedefDecl:
          kind = CppTypedefDefinition;
+         break;
+      case CXCursor_MacroDefinition:
+         kind = CppMacroDefinition;
          break;
       default:
          kind = CppInvalidDefinition;
@@ -233,7 +237,8 @@ void fileChangeHandler(const core::system::FileChangeEvent& event)
                                gsl::narrow_cast<int>(argsArray.argCount()),
                                nullptr, 0, // no unsaved files
                                CXTranslationUnit_None |
-                               CXTranslationUnit_Incomplete);
+                               CXTranslationUnit_Incomplete |
+                               CXTranslationUnit_DetailedPreprocessingRecord);
 
 
          // create definitions and wire visitor to it
@@ -291,6 +296,9 @@ std::ostream& operator<<(std::ostream& os, const CppDefinition& definition)
          break;
       case CppTypedefDefinition:
          kindStr = "T";
+         break;
+      case CppMacroDefinition:
+         kindStr = "#";
          break;
       default:
          kindStr = " ";

--- a/src/cpp/session/modules/clang/DefinitionIndex.hpp
+++ b/src/cpp/session/modules/clang/DefinitionIndex.hpp
@@ -44,7 +44,8 @@ enum CppDefinitionKind
    CppEnumValue = 5,
    CppFunctionDefinition = 6,
    CppMemberFunctionDefinition = 7,
-   CppTypedefDefinition = 8
+   CppTypedefDefinition = 8, 
+   CppMacroDefinition = 9
 };
 
 // C++ symbol definition

--- a/src/cpp/session/modules/clang/FindReferences.cpp
+++ b/src/cpp/session/modules/clang/FindReferences.cpp
@@ -380,7 +380,8 @@ core::Error findReferences(const core::libclang::FileLocation& location,
                                   gsl::narrow_cast<int>(argsArray.argCount()),
                                   nullptr, 0, // no unsaved files
                                   CXTranslationUnit_None |
-                                  CXTranslationUnit_Incomplete);
+                                  CXTranslationUnit_Incomplete |
+                                  CXTranslationUnit_DetailedPreprocessingRecord);
 
             // find references
             findReferences(USR, tu, pSpelling, pRefs);

--- a/src/cpp/session/modules/clang/FindReferences.cpp
+++ b/src/cpp/session/modules/clang/FindReferences.cpp
@@ -379,9 +379,7 @@ core::Error findReferences(const core::libclang::FileLocation& location,
                                   argsArray.args(),
                                   gsl::narrow_cast<int>(argsArray.argCount()),
                                   nullptr, 0, // no unsaved files
-                                  CXTranslationUnit_None |
-                                  CXTranslationUnit_Incomplete |
-                                  CXTranslationUnit_DetailedPreprocessingRecord);
+                                  parseTranslationUnitOptions());
 
             // find references
             findReferences(USR, tu, pSpelling, pRefs);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
@@ -105,6 +105,9 @@ class CodeSearchSuggestion implements Suggestion
       case SourceItem.ROXYGEN:
          image = new ImageResource2x(CodeIcons.INSTANCE.roxygen2x());
          break;
+      case SourceItem.MACRO:
+         image = new ImageResource2x(CodeIcons.INSTANCE.macro2x());
+         break;
       case SourceItem.NONE:
       default:
          image = new ImageResource2x(CodeIcons.INSTANCE.keyword2x());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
@@ -41,6 +41,7 @@ public class SourceItem extends JavaScriptObject
    public static final int MATH                 = 10;
    public static final int TEST                 = 11;
    public static final int ROXYGEN              = 12;
+   public static final int MACRO                = 13;
 
    public final native int getType() /*-{
       return this.type;


### PR DESCRIPTION
### Intent

addresses #11981

### Approach

use `CXTranslationUnit_DetailedPreprocessingRecord` to get macro definition. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


