### PR TITLE
Add correct path for rpostback mac electron (no need to hoist) 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,3 +32,4 @@
 - Fixed an issue where chunks containing multibyte characters was not executed correctly (#10632)
 - Fixed bringing main window under active secondary window when executing background command (#11407)
 - Fix for schema version comparison that breaks db in downgrade -> upgrade scenarios (rstudio-pro#3572)
+- Fixed an issue in the Electron build of the IDE on Macs where users could not clone a git repository via password-protected SSH or HTTPS (#11693)

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2157,9 +2157,15 @@ int main(int argc, char * const argv[])
          core::thread::safeLaunchThread(detectParentTermination);
 
       // set the rpostback absolute path
-      FilePath rpostback = options.rpostbackPath()
-                                  .getParent().getParent()
-                                  .completeChildPath("rpostback");
+      FilePath rpostback = options.rpostbackPath();
+   #ifndef __APPLE__
+      // package builds on Linux and Windows hoist the binary one level higher in the directory structure
+      if (rpostback.getAbsolutePath().find("session/postback") == std::string::npos) {
+         rpostback = rpostback.getParent().getParent();
+         rpostback = rpostback.completeChildPath("rpostback");
+      }
+   #endif
+
       core::system::setenv(
             "RS_RPOSTBACK_PATH",
             string_utils::utf8ToSystem(rpostback.getAbsolutePath()));

--- a/src/cpp/session/SessionOptions.cpp
+++ b/src/cpp/session/SessionOptions.cpp
@@ -566,7 +566,6 @@ FilePath macBinaryPath(const FilePath& resourcePath,
 
    FilePath electronPath =
          resourcePath.completePath("bin").completePath(stem);
-   
    if (electronPath.exists())
       return electronPath;
 


### PR DESCRIPTION
and fix path for development builds on all platforms

### Intent

Addresses #11693 
### Approach
support correct pathing to rpostback binary on Mac/Windows/Linux and Qt/Electron as well as development builds

Correct bundled paths:
~/rstudio/src/build/session/postback/postback/rpostback  development build - Mac
/Volumes/RStudio-99.9.9/RStudio.app/Contents/Resources/app/bin/rpostback Electron - package build - Mac
/Volumes/RStudio-99.9.9 1/RStudio.app/Contents/MacOS/rpostback Qt - package build - Mac

~/rstudio/src/build/session/postback/postback/rpostback development build - Windows
C:/Program Files/RStudio/resources/app/bin/rpostback Electron - package build - Windows
C:/Program Files/RStudio/bin/rpostback Qt - package build - Windows

/usr/lib/rstudio/resources/app/bin/rpostback Electron - package build - Ubuntu
/usr/lib/rstudio/bin/rpostback Qt - package build - Ubuntu

### QA Notes

Test on all platforms

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


