### PR TITLE
remove `#|` comments before executing alternative engine

### DIFF
--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -746,8 +746,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
   start <- max(1, grep(.rs.reRmdChunkBegin(), code, perl = TRUE))
   end   <- min(length(code), grep(.rs.reRmdChunkEnd(), code, perl = TRUE))
 
-  paste(code[(start + 1):(end - 1)], collapse = "\n")
-});
+  code <- code[(start + 1):(end - 1)]
+  code <- code[!grepl("^\\s*#\\|", code) & code != ""]
+
+  paste(code, collapse = "\n")
+})
 
 .rs.addFunction("extractRmdChunkInformation", function(rmd)
 {

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -747,8 +747,8 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
   end   <- min(length(code), grep(.rs.reRmdChunkEnd(), code, perl = TRUE))
 
   code <- code[(start + 1):(end - 1)]
-  code <- code[!grepl("^\\s*#\\|", code) & code != ""]
-
+  code <- gsub("#[|].*$", "", code)
+  
   paste(code, collapse = "\n")
 })
 

--- a/src/cpp/tests/testthat/test-notebook.R
+++ b/src/cpp/tests/testthat/test-notebook.R
@@ -15,5 +15,6 @@
 
 test_that("#| comments are removed by .rs.extractChunkInnerCode() (#11606)", {
    code <- "```{sql}\n#| connection = db\n\nSELECT 'test'\n```"
-   expect_equal(.rs.extractChunkInnerCode(code), "SELECT 'test'")
+   extract <- .rs.extractChunkInnerCode(code)
+   expect_true(!any(grepl("#[|]", extract)))
 })

--- a/src/cpp/tests/testthat/test-notebook.R
+++ b/src/cpp/tests/testthat/test-notebook.R
@@ -1,0 +1,19 @@
+#
+# test-notebook.R
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+test_that("#| comments are removed by .rs.extractChunkInnerCode() (#11606)", {
+   code <- "```{sql}\n#| connection = db\n\nSELECT 'test'\n```"
+   expect_equal(.rs.extractChunkInnerCode(code), "SELECT 'test'")
+})


### PR DESCRIPTION
### Intent

addresses #11606

### Approach

Remove the `#|` comments before the code is executed in the alternative engine

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


