### PR TITLE
only allow roxygen completion after a `@`

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
@@ -14,6 +14,9 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
+import com.google.gwt.core.client.GWT;
+
+import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
 
@@ -272,7 +275,24 @@ public class DocumentMode
              isPositionInStanMode(docDisplay, docDisplay.getSelectionEnd());
    }
    
-   
-   
+   public static boolean isCursorInRoxygenExamples(DocDisplay docDisplay)
+   {
+      int i = docDisplay.getCurrentLineNum();
+      while (i > 0) 
+      {
+         String line = docDisplay.getLine(i);
+         if (!PATTERN_ROXYGEN_LINE.test(line))
+            return false;
+            
+         if (PATTERN_ROXYGEN_EXAMPLES_LINE.test(line))
+            return true;
+         
+         i--;
+      }
+      return false;
+   }
 
+   public static Pattern PATTERN_ROXYGEN_LINE = Pattern.create("^\\s*#+'", "");
+   public static Pattern PATTERN_ROXYGEN_CAN_COMPLETE = Pattern.create("^\\s*#+'\\s*@[a-zA-Z]*", "");
+   public static Pattern PATTERN_ROXYGEN_EXAMPLES_LINE = Pattern.create("^\\s*#+'\\s*@examples", "");
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1140,26 +1140,15 @@ public class RCompletionManager implements CompletionManager
                   int cursor = editor.getCursorColumn();
                   
                   int commentSize = DocumentMode.PATTERN_ROXYGEN_LINE.match(firstLine, 0).getValue().length() + 1;
-                  if (cursor < commentSize)
+                  // if just after the ': add one space
+                  String spaces = " ";
+                  if (cursor >= commentSize)
                   {
-                     // #'|<TAB> : just add one space
-                     editor.insertCode(" ");
-                  }
-                  else 
-                  {
-                     // either add a tab or the remainder spaces to the next one
+                     // othewise add a tab or the remainder spaces to the next one
                      int remainder = (cursor - commentSize) % tabSize;
-                     if (remainder == 0)
-                     {
-                        for (int i = 0; i < tabSize; i++)
-                           editor.insertCode(" ");
-                     }
-                     else 
-                     {
-                        for (int i = 0; i < remainder; i++)
-                           editor.insertCode(" ");
-                     }
+                     spaces = StringUtil.repeat(" ", remainder == 0 ? tabSize : remainder);
                   }
+                  editor.insertCode(spaces);
                }
                return true;
             }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -422,11 +422,12 @@ public class RCompletionManager implements CompletionManager
          {
             if (initFilter_ == null || initFilter_.shouldComplete(event))
             {
+               String currentLine = docDisplay_.getCurrentLineUpToCursor();
+
                // If we're in markdown mode, only autocomplete in '```{r',
                // '[](', or '`r |' contexts
                if (DocumentMode.isCursorInMarkdownMode(docDisplay_))
                {
-                  String currentLine = docDisplay_.getCurrentLineUpToCursor();
                   if (!(Pattern.create("^```{[rR]").test(currentLine) ||
                       Pattern.create(".*\\[.*\\]\\(").test(currentLine) ||
                       (Pattern.create(".*`r").test(currentLine) &&
@@ -437,10 +438,18 @@ public class RCompletionManager implements CompletionManager
                // If we're in tex mode, only provide completions in chunks
                if (DocumentMode.isCursorInTexMode(docDisplay_))
                {
-                  String currentLine = docDisplay_.getCurrentLineUpToCursor();
                   if (!Pattern.create("^<<").test(currentLine))
                      return false;
                }
+
+               // only allow roxygen completion after a @
+               if (PATTERN_ROXYGEN_LINE.test(currentLine)) 
+               {
+                  if (!PATTERN_ROXYGEN_CAN_COMPLETE.test(currentLine)) {
+                     return false;
+                  }  
+               }
+               
                return beginSuggest(true, false, true);
             }
          }
@@ -2274,4 +2283,8 @@ public class RCompletionManager implements CompletionManager
    
    private final HandlerRegistrations handlers_;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);
+
+   public static Pattern PATTERN_ROXYGEN_LINE = Pattern.create("^\\s*#'", "");
+   public static Pattern PATTERN_ROXYGEN_CAN_COMPLETE = Pattern.create("^\\s*#'\\s*@[a-zA-Z]*", "");
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1143,8 +1143,7 @@ public class RCompletionManager implements CompletionManager
                   if (cursor < commentSize)
                   {
                      // #'|<TAB> : just add one space
-                     for (; cursor < commentSize; cursor++)
-                        editor.insertCode(" ");
+                     editor.insertCode(" ");
                   }
                   else 
                   {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -442,14 +442,6 @@ public class RCompletionManager implements CompletionManager
                      return false;
                }
 
-               // only allow roxygen completion after a @
-               if (PATTERN_ROXYGEN_LINE.test(currentLine)) 
-               {
-                  if (!PATTERN_ROXYGEN_CAN_COMPLETE.test(currentLine)) {
-                     return false;
-                  }  
-               }
-               
                return beginSuggest(true, false, true);
             }
          }
@@ -1082,8 +1074,7 @@ public class RCompletionManager implements CompletionManager
    
    private boolean isLineInRoxygenComment(String line)
    {
-      Pattern pattern = Pattern.create("^\\s*#+'");
-      return pattern.test(line);
+      return DocumentMode.PATTERN_ROXYGEN_LINE.test(line);
    }
 
    private boolean isLineInPlumberComment(String line)
@@ -1131,6 +1122,22 @@ public class RCompletionManager implements CompletionManager
             !isLineInPlumberComment(firstLine))
          return false;
       
+      if (isLineInRoxygenComment(firstLine)) 
+      {
+         if (!DocumentMode.PATTERN_ROXYGEN_CAN_COMPLETE.test(firstLine))
+         {
+            if (DocumentMode.isCursorInRoxygenExamples(docDisplay_)) 
+            {
+               // GWT.log("insert tab manually");
+               return true;
+            }
+            else 
+            {
+               return false;
+            }
+         }
+      }
+
       // don't autocomplete if the cursor lies within the text of a
       // multi-line string. the logic here isn't perfect (ideally, we'd detect
       // whether we're in the 'qstring' or 'qqstring' state), but this will catch
@@ -2283,8 +2290,4 @@ public class RCompletionManager implements CompletionManager
    
    private final HandlerRegistrations handlers_;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);
-
-   public static Pattern PATTERN_ROXYGEN_LINE = Pattern.create("^\\s*#'", "");
-   public static Pattern PATTERN_ROXYGEN_CAN_COMPLETE = Pattern.create("^\\s*#'\\s*@[a-zA-Z]*", "");
-
 }


### PR DESCRIPTION
### Intent

handles part of #8378

### Approach

handle <TAB> specifically so that we can factor where the code starts (after `#' `) etc ...

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


