### PR TITLE
read rest of stdout / stderr on process exit

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 - Support for v2 format of Quarto crossref index
 
 ### Posit Workbench
+
 - Adds `-l` (long) option to `rserver-url`. When `/usr/lib/rstudio-server/bin/rserver-url -l <port number>` is executed within a VS Code or Jupyter session, the full URL where a user can view a server proxied at that port is displayed (rstudio-pro#3620)
 - Sets the `UVICORN_ROOT_PATH` environment variable to the proxied port URL for port 8000 in VS Code and Jupyter sessions, allowing FastAPI applications to run without additional configuration. (rstudio-pro#2660)
 
@@ -40,6 +41,7 @@
 
 ### Fixed
 
+- Fixed an issue where Find in Files could omit matches in some cases on Windows (#11736)
 - Fixed an issue where the Git History window inverted the display of merge diffs (#10150)
 - Fixed an issue where Find in Files could fail to find results with certain versions of git (#11822)
 - Fixed visual mode outline missing nested R code chunks (#11410)

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -779,8 +779,29 @@ void AsyncChildProcess::poll()
          LOG_ERROR(error);
       }
 
+      // check stdout, stderr once more
+      std::string stdOut;
+      error = WinPty::readFromPty(pImpl_->hStdOutRead, &stdOut);
+      if (error)
+         reportError(error);
+
+      if (!stdOut.empty() && callbacks_.onStdout)
+         callbacks_.onStdout(*this, stdOut);
+
+      // check stderr
+      if (pImpl_->hStdErrRead)
+      {
+         std::string stdErr;
+         error = WinPty::readFromPty(pImpl_->hStdErrRead, &stdErr);
+         if (error)
+            reportError(error);
+
+         if (!stdErr.empty() && callbacks_.onStderr)
+            callbacks_.onStderr(*this, stdErr);
+      }
+
       // close the process handle
-      Error error = closeHandle(&pImpl_->hProcess, ERROR_LOCATION);
+      error = closeHandle(&pImpl_->hProcess, ERROR_LOCATION);
       if (error)
          LOG_ERROR(error);
 

--- a/src/cpp/core/system/Win32ChildProcess.cpp
+++ b/src/cpp/core/system/Win32ChildProcess.cpp
@@ -797,7 +797,10 @@ void AsyncChildProcess::poll()
             reportError(error);
 
          if (!stdErr.empty() && callbacks_.onStderr)
+         {
+            hasRecentOutput = true;
             callbacks_.onStderr(*this, stdErr);
+         }
       }
 
       // close the process handle


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/11736.

### Approach

When a process exits, we need to check stdout + stderr once more in case any more output was produced in the interval between our last poll and when the exit happened.

Deserves a sanity check because if this is really the issue it's stunning that this is the first time we're encountering it!

Also, if so, then arguably we should be doing the same thing in PosixChildProcess.cpp:

https://github.com/rstudio/rstudio/blob/main/src/cpp/core/system/PosixChildProcess.cpp#L1126-L1165

### Automated Tests

N/A

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

