### PR TITLE
Avoid error when calling socket.cancel() method if the socket is not open

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
@@ -109,10 +109,16 @@ private:
             if (isConnected_ || hasFailed_)
                return;
 
+            LOG_DEBUG_MESSAGE("In onConnectionTimeout - cancelling socket connection");
+
             // timer has elapsed and the socket is still not connected
             // cancel any outstanding async operations
             resolver_.cancel();
-            pSocket_->cancel();
+            // avoid throwing an exception by checking for an open socket first
+            if (pSocket_->is_open())
+               pSocket_->cancel();
+            else
+               LOG_ERROR_MESSAGE("Socket is already closed in onConnectionTimeout");
 
             // invoke error handler since the connection has failed
             handleError(systemError(boost::system::errc::timed_out, ERROR_LOCATION));


### PR DESCRIPTION
Using a call to is_open() before calling cancel.  This allows us to finish the cleanup in that method and call the error handler for the connection.  This is a speculative fix we'd like to get into a build for a customer to try. I think it's pretty safe because the only place that code is used is the connection timeout error handler and it's a simple change. 

### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/3812

### Automated Tests

I don't think we have a way to test connection timeouts currently but we might want to investigate a "network fuzzer" or something so we can run load tests with flaky connectivity in a load balancing scenario. 

