### PR TITLE
use `rdoc-` instead of `rd-`

### DIFF
--- a/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/c_cpp_highlight_rules.js
@@ -116,7 +116,7 @@ var c_cppHighlightRules = function() {
             // Roxygen
             token : "comment",
             regex : "\\/\\/'",
-            next : "rd-start"
+            next : "rdoc-start"
          }, {
             // Standard comment
             token : "comment",
@@ -253,21 +253,21 @@ var c_cppHighlightRules = function() {
       rdRules["start"][i].token += ".virtual-comment";
    }
 
-   this.addRules(rdRules, "rd-");
-   this.$rules["rd-start"].unshift({
+   this.addRules(rdRules, "rdoc-");
+   this.$rules["rdoc-start"].unshift({
       token: "text",
       regex: "^",
       next: "start"
    });
-   this.$rules["rd-start"].unshift({
+   this.$rules["rdoc-start"].unshift({
       token : "keyword",
       regex : "@(?!@)[^ ]*"
    });
-   this.$rules["rd-start"].unshift({
+   this.$rules["rdoc-start"].unshift({
       token : "comment",
       regex : "@@"
    });
-   this.$rules["rd-start"].push({
+   this.$rules["rdoc-start"].push({
       token : "comment",
       regex : "[^%\\\\[({\\])}]+"
    });

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -901,7 +901,7 @@ var RCodeModel = function(session, tokenizer,
 
          // Skip roxygen comments.
          var state = Utils.getPrimaryState(this.$session, position.row);
-         if (state === "rd-start") {
+         if (state === "rdoc-start") {
             iterator.moveToEndOfRow();
             continue;
          }

--- a/src/gwt/acesupport/acemode/r_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/r_highlight_rules.js
@@ -60,7 +60,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         token : ["keyword", "comment"],
         regex : "(@(?:export|field|inheritParams|name|param|rdname|slot|template|useDynLib))(\\s+)(?=[a-zA-Z0-9._-])",
         merge : false,
-        next  : "rd-highlight"
+        next  : "rdoc-highlight"
       },
       {
         // generic roxygen tag
@@ -922,13 +922,13 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
         // Begin Roxygen with todo
         token : ["comment", "comment.keyword.operator"],
         regex : "(#+['*]\\s*)(TODO|FIXME)\\b",
-        next  : "rd-start"
+        next  : "rdoc-start"
       },
       {
         // Roxygen
         token : "comment",
         regex : "#+['*]",
-        next  : "rd-start"
+        next  : "rdoc-start"
       },
       {
         // todo in plain comment
@@ -1258,7 +1258,7 @@ define("mode/r_highlight_rules", ["require", "exports", "module"], function(requ
       }
     }
 
-    this.embedRules(rdRules, "rd-", [{
+    this.embedRules(rdRules, "rdoc-", [{
       token : "text",
       regex : "^",
       next  : "start"


### PR DESCRIPTION
### Intent

addresses #12023 

### Approach

Call it "rdoc" instead of "rd" because ace actually ships snippets for `rdoc`: 

```js
define("ace/snippets/rdoc",["require","exports","module"], function(require, exports, module) {
"use strict";

exports.snippetText =undefined;
exports.scope = "rdoc";

});
```

They are empty, but at least they exist. We could create some useful Rd specific snippets, e.g. `\item{}{}`, primarily I suppose to use in roxygen comments. 

Alternatively, we could subsitute `rd` for `rdoc` in `loadSnippetsForMode()` if we wanted to keep using "rd"

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


