### PR TITLE
Make sure session has been restored before running requests offline

### DIFF
--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -218,6 +218,9 @@ core::Error run(const ROptions& options, const RCallbacks& callbacks);
    
 // deferred deserialization of the session
 void ensureDeserialized();
+
+// returns false if there is a pending deferred deserialization of session data
+bool isSessionRestored();
       
 // set client metrics 
 void setClientMetrics(const RClientMetrics& metrics);

--- a/src/cpp/r/session/RInit.cpp
+++ b/src/cpp/r/session/RInit.cpp
@@ -392,6 +392,13 @@ void ensureDeserialized()
       s_deferredDeserializationAction.clear();
    }
 }
+
+bool isSessionRestored()
+{
+   if (s_deferredDeserializationAction)
+      return false;
+   return true;
+}
    
 FilePath rHistoryFilePath()
 {

--- a/src/cpp/session/SessionInit.cpp
+++ b/src/cpp/session/SessionInit.cpp
@@ -53,6 +53,11 @@ bool isSessionInitialized()
    return s_sessionInitialized;
 }
 
+bool isSessionInitializedAndRestored()
+{
+   return isSessionInitialized() && rstudio::r::session::isSessionRestored();
+}
+
 } // namespace init
 } // namespace session
 } // namespace rstudio

--- a/src/cpp/session/SessionInit.hpp
+++ b/src/cpp/session/SessionInit.hpp
@@ -27,6 +27,7 @@ namespace init {
 
 void ensureSessionInitialized();
 bool isSessionInitialized();
+bool isSessionInitializedAndRestored();
 
 } // namespace init
 } // namespace session

--- a/src/cpp/session/SessionOfflineService.cpp
+++ b/src/cpp/session/SessionOfflineService.cpp
@@ -232,7 +232,7 @@ void OfflineService::run()
             std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
 
 	    // Make sure session is initialized before doing any processing in the offline thread to avoid the call to lazily init it
-            if (handleOfflineMillis > 0 && init::isSessionInitialized())
+            if (handleOfflineMillis > 0 && init::isSessionInitializedAndRestored())
             {
                boost::shared_ptr<HttpConnection> ptrConnection;
                do

--- a/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
+++ b/src/cpp/session/http/SessionHttpConnectionListenerImpl.hpp
@@ -354,7 +354,7 @@ private:
             eventsActive_ = false;
          }
          if (options().handleOfflineEnabled() && options().handleOfflineTimeoutMs() == 0 &&
-             rpc::isOfflineableRequest(ptrHttpConnection) && init::isSessionInitialized())
+             rpc::isOfflineableRequest(ptrHttpConnection) && init::isSessionInitializedAndRestored())
          {
             // TODO: handleOffline - should these be put into a separate queue and run in a dedicated thread?
             if (http_methods::protocolDebugEnabled())


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/3870

### Approach

Added a new method used by the two places we handle requests in the offline thread to be sure there's not a pending deferred session deserialization. Otherwise, we can end up running that R code off the main thread. 

### Automated Tests

See the issue for a test case that I found attached to this issue fixed a couple of years ago: https://github.com/rstudio/rstudio/issues/4178

Given that it's reproduced two bugs, it would be a good one for our regression suite.



