### PR TITLE
Discard duplicate RmdChunk entries from visual editor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualMode.java
@@ -1866,11 +1866,22 @@ public class VisualMode implements VisualModeEditorSync,
       
       // Get all of the chunks from the outline emitted by visual mode
       ArrayList<PanmirrorEditingOutlineLocationItem> chunkItems = new ArrayList<>();
+      PanmirrorEditingOutlineLocationItem lastChunkItem = null;
       for (int j = 0; j < location.items.length; j++)
       {
-         if (StringUtil.equals(location.items[j].type, PanmirrorOutlineItemType.RmdChunk))
+         PanmirrorEditingOutlineLocationItem nextChunkItem = location.items[j];
+         if (StringUtil.equals(nextChunkItem.type, PanmirrorOutlineItemType.RmdChunk))
          {
-            chunkItems.add(location.items[j]);
+            // It is possible for the visual editor to contain two representations of the
+            // same RmdChunk when the chunk is indented. Since the items are sorted by
+            // position, we discard consecutive chunks with identical positions; they
+            // represent the same underlying scope entry.
+            if (lastChunkItem != null && lastChunkItem.position == nextChunkItem.position)
+            {
+               continue;
+            }
+            lastChunkItem = nextChunkItem;
+            chunkItems.add(nextChunkItem);
          }
       }
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12021. 

This issue is caused by behavior in the visual editor that causes code chunks (`RmdChunk`) to appear multiple times in the internal outline when they are indented. Because there are multiple representations of the same code chunk, the algorithm that synchronizes the code chunks between visual mode and source mode cannot run properly.

### Approach

When receiving the list of chunk locations from the visual editor, discard adjacent duplicates.

It might also be worth investigating why we are getting multiple `RmdChunk` entries; this is possibly new or buggy behavior, and likely the source of the regression. However, changing the code upstream is much higher risk, and this change is correct either way.

### Automated Tests

N/A; unfortunately unit tests cannot currently be written against the visual editor. 

### QA Notes

The affected code runs any time you execute code in the visual editor; spot check with/without indented chunks. 

### Checklist

Note: No NEWS entry for this one since it's a regression in 2022.11 (worked in 2022.07 as per bug notes)


- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

