### PR TITLE
handle `missing(repos)` in `install.packages()` shim

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -154,6 +154,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       
       packratMode <- !is.na(Sys.getenv("R_PACKRAT_MODE", unset = NA))
       
+      repos_missing <- missing(repos)
       if (!is.null(repos) && !packratMode && .rs.loadedPackageUpdates(pkgs)) {
 
          # attempt to determine the install command
@@ -186,7 +187,11 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
       })
       
       # call original
-      original(pkgs, lib, repos, ...)
+      if (repos_missing)
+         original(pkgs, lib, ...)   
+      else 
+         original(pkgs, lib, repos, ...)
+      
    })
    
    # whenever a package is removed notify the client (leave attach/detach


### PR DESCRIPTION
### Intent

addresses #12034 

### Approach

`utils::install.packages()` uses whether `repos` was specified: 

```r
if (length(pkgs) == 1L && missing(repos) && missing(contriburl)) {
    if ((type == "source" && any(grepl("[.]tar[.](gz|bz2|xz)$", 
      pkgs))) || (type %in% "win.binary" && endsWith(pkgs, 
      ".zip")) || (startsWith(type, "mac.binary") && endsWith(pkgs, 
      ".tgz"))) {
      repos <- NULL
      message("inferring 'repos = NULL' from 'pkgs'")
    }
```

So making sure the shim don't specify to the original if it had not been given. I think the `repos` promise is resolved by the `if (!is.null(repos) && !packratMode && .rs.loadedPackageUpdates(pkgs)) {` 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


