### PR TITLE
Add rhel8-arm64 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -254,7 +254,9 @@ try {
           [os: 'rhel9',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 9'],
           [os: 'rhel9',      arch: 'arm64',  flavor: 'electron', variant: '',  package_os: 'RHEL 9'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
+          [os: 'rhel8',      arch: 'arm64',  flavor: 'server',   variant: '',  package_os: 'RHEL 8'],
           [os: 'rhel8',      arch: 'x86_64', flavor: 'electron', variant: '',  package_os: 'RHEL 8']
+          [os: 'rhel8',      arch: 'arm64',  flavor: 'electron', variant: '',  package_os: 'RHEL 8']
         ]
         containers = limit_builds(containers)
 


### PR DESCRIPTION
### Intent

Adds `aarch64` builds for RedHat 8 based Linux distributions such as Oracle Linux 8. See one example of a request for this on the community forum:

> I checked the arm version from your link but it doesn't have RedHat 8 version which I think I'm running on (Mine is Oracle Linux 8 which appears to be a modified version of RedHat 8).

https://community.rstudio.com/t/rstudio-server-compile-error-on-arm64-machine/148190/

### Approach

Add builds to the matrix. I have confirmed with a local Docker build.

### Automated Tests

N/A, build script change only.

### QA Notes

Note that we will only add arm64 for rhel8 to our open source releases. Our licensing system does not have rhel8-arm64 compatible binaries, so we can't make a viable Workbench build for this platform.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

