### PR TITLE
Do not use "inset" -- too recent of a css property for QT

### DIFF
--- a/src/gwt/www/rstudio.css
+++ b/src/gwt/www/rstudio.css
@@ -26,7 +26,10 @@ html, body {
   background-color: var(--bg-col);
   color: var(--fg-col);
   position: fixed;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   height: 100vh;
   margin: 0;
 }


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio-pro/issues/3846
OS-PR, but when this merges to Pro it will fix Pro / RDP.

### Intent

Fix the login page not being centered in RDP, which is caused by an unsupported CSS shorthand.

### Approach

Instead of `inset`, use `top`-`right`-`bottom`-`left` for absolute positioning. `inset` is a shorthand introduced in 2020 which is _after_ we stopped updating the QT versions.

### Automated Tests

This does not require automated tests. It's a layout-specific issue that only requires a one-time fix.

### QA Notes

I verified that this was working in actual RDP.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


