### PR TITLE
don't forward to ShortcutManager on Electron

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -234,6 +234,10 @@ public class DataTable
                RStudioGinjector.INSTANCE.getCommands().closeSourceDoc().execute();
             }
          }
+         else
+         {
+            // Intentionally do nothing -- see notes above
+         }
       }
       else
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12029.

### Approach

Because the main menu callbacks are visible to Electron even if a subframe has focus, the DataTable iframe no longer needs to forward keypresses to the ShortcutManager on Electron.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12029.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
