### PR TITLE
use knitr 'root.dir' for completions as fallback

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,8 @@
 
 * Whether pending console input is discarded on error can now be controlled via a preference in the Console pane. (#10391)
 * Improved handling of diagnostics within pipeline expressions. (#11780)
-* Improved handling of diagnostics within glue() expressions. 
+* Improved handling of diagnostics within glue() expressions.
+* Completions within R Markdown documents now respect the `knitr` `root.dir` chunk option if set. (#12047)
 * RStudio now provides autocompletion results for packages used but not loaded within a project.
 * Improved handling of missing arguments for some functions in the diagnostics system.
 * Code editor can show previews of color in strings (R named colors e.g. "tomato3" or of the forms "#rgb", "#rrggbb", "#rrggbbaa")

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -41,7 +41,7 @@
       # the path to the project hosting the document
       # (just in case the user is editing a document that
       # belongs to an alternate project)
-      path <-  substring(props$path, 1L, nchar(props$path) - nchar(props$project_path) - 1L)
+      path <- substring(props$path, 1L, nchar(props$path) - nchar(props$project_path) - 1L)
       return(path)
    }
    

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -41,12 +41,7 @@
       # the path to the project hosting the document
       # (just in case the user is editing a document that
       # belongs to an alternate project)
-      path <-  substring(
-         props$path,
-         1L,
-         nchar(props$path) - nchar(props$project_path) - 1L
-      )
-      
+      path <-  substring(props$path, 1L, nchar(props$path) - nchar(props$project_path) - 1L)
       return(path)
    }
    

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -41,16 +41,32 @@
       # the path to the project hosting the document
       # (just in case the user is editing a document that
       # belongs to an alternate project)
-      substring(props$path, 1L, nchar(props$path) - nchar(props$project_path) - 1L)
+      path <-  substring(
+         props$path,
+         1L,
+         nchar(props$path) - nchar(props$project_path) - 1L
+      )
+      
+      return(path)
    }
-   else if (identical(workingDirProp, "current"))
+   
+   # if we're configured to use the working directory, use it
+   if (identical(workingDirProp, "current"))
    {
-      getwd()
+      return(getwd())
    }
-   else
+   
+   # if the 'root.dir' knitr option is set, use that
+   if ("knitr" %in% loadedNamespaces())
    {
-      dirname(path)
+      rootDir <- knitr::opts_knit$get("root.dir")
+      if (is.character(rootDir))
+         return(rootDir)
    }
+   
+   # all else fails, use the parent directory of the document
+   dirname(path)
+   
 })
 
 .rs.addFunction("markdown.getCompletionsHref", function(data)


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio/issues/9184.

### Approach

Check and see if the `knitr` root.dir knit option is set; if so, use it.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9184#issuecomment-1258873085.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
