### PR TITLE
[poc] embed html widgets in the console

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -186,6 +186,12 @@
   invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
 })
 
+.rs.addApiFunction("consolePrint", function(html, background = "white", height = NULL) {
+   htmltools::html_print(html, background = background, viewer = function(url) {
+      .rs.api.consoleViewer(url, height = height)
+   })
+})
+
 .rs.addApiFunction("savePlotAsImage", function(
                    file,
                    format = c("png", "jpeg", "bmp", "tiff", "emf", "svg", "eps"),

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -172,6 +172,18 @@
   invisible(.Call("rs_viewer", url, height, PACKAGE = "(embedding)"))
 })
 
+.rs.addApiFunction("console_viewer", function(url, height = NULL) {
+   if (!is.character(url) || (length(url) != 1))
+      stop("url must be a single element character vector.")
+
+   if (identical(height, "maximize"))
+      height <- -1
+
+   if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
+      stop("height must be a single element numeric vector or 'maximize'.")
+
+  invisible(.Call("rs_console_viewer", url, height, PACKAGE = "(embedding)"))
+})
 
 .rs.addApiFunction("savePlotAsImage", function(
                    file,

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -182,7 +182,7 @@
    if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
       stop("height must be a single element numeric vector or 'maximize'.")
 
-  invisible(.Call("rs_console_viewer", url, height, PACKAGE = "(embedding)"))
+  invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
 })
 
 .rs.addApiFunction("savePlotAsImage", function(

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -172,7 +172,8 @@
   invisible(.Call("rs_viewer", url, height, PACKAGE = "(embedding)"))
 })
 
-.rs.addApiFunction("console_viewer", function(url, height = NULL) {
+.rs.addApiFunction("consoleViewer", function(url, height = NULL)
+{
    if (!is.character(url) || (length(url) != 1))
       stop("url must be a single element character vector.")
 

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -177,11 +177,11 @@
    if (!is.character(url) || (length(url) != 1))
       stop("url must be a single element character vector.")
 
-   if (identical(height, "maximize"))
+   if (identical(height, "fit"))
       height <- -1
 
    if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
-      stop("height must be a single element numeric vector or 'maximize'.")
+      stop("height must be a single element numeric vector or 'fit'.")
 
   invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
 })

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -40,6 +40,21 @@
    invisible(.Call("rs_viewer", url, height, PACKAGE = "(embedding)"))
 })
 
+# default console_viewer option if not already set
+.rs.setOptionDefault("console_viewer", function(url, height = NULL)
+{
+   if (!is.character(url) || (length(url) != 1))
+      stop("url must be a single element character vector.", call. = FALSE)
+   
+   if (identical(height, "maximize"))
+      height <- -1
+   
+   if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
+      stop("height must be a single element numeric vector or 'maximize'.", call. = FALSE)
+   
+   invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
+})
+
 # default page_viewer option if not already set
 .rs.setOptionDefault("page_viewer", function(url,
                                              title = "RStudio Viewer",

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -46,11 +46,11 @@
    if (!is.character(url) || (length(url) != 1))
       stop("url must be a single element character vector.", call. = FALSE)
    
-   if (identical(height, "maximize"))
+   if (identical(height, "fit"))
       height <- -1
    
    if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
-      stop("height must be a single element numeric vector or 'maximize'.", call. = FALSE)
+      stop("height must be a single element numeric vector or 'fit'.", call. = FALSE)
    
    invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
 })

--- a/src/cpp/r/R/Options.R
+++ b/src/cpp/r/R/Options.R
@@ -41,19 +41,7 @@
 })
 
 # default console_viewer option if not already set
-.rs.setOptionDefault("console_viewer", function(url, height = NULL)
-{
-   if (!is.character(url) || (length(url) != 1))
-      stop("url must be a single element character vector.", call. = FALSE)
-   
-   if (identical(height, "fit"))
-      height <- -1
-   
-   if (!is.null(height) && (!is.numeric(height) || (length(height) != 1)))
-      stop("height must be a single element numeric vector or 'fit'.", call. = FALSE)
-   
-   invisible(.Call("rs_consoleViewer", url, height, PACKAGE = "(embedding)"))
-})
+.rs.setOptionDefault("console_viewer", .rs.api.consoleViewer)
 
 # default page_viewer option if not already set
 .rs.setOptionDefault("page_viewer", function(url,

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -212,6 +212,7 @@ const int kJobsActivate = 194;
 const int kPresentationPreview = 195;
 const int kSuspendBlocked = 196;
 const int kClipboardAction = 197;
+const int kConsoleShowWidget = 198;
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -589,8 +590,10 @@ std::string ClientEvent::typeName() const
          return "presentation_preview";
       case client_events::kSuspendBlocked:
          return "session_suspend_blocked";
-	  case client_events::kClipboardAction:
-		 return "clipboard_action";
+	   case client_events::kClipboardAction:
+		   return "clipboard_action";
+      case client_events::kConsoleShowWidget:
+         return "console_show_widget";
       default:
          LOG_WARNING_MESSAGE("unexpected event type: " + 
                              safe_convert::numberToString(type_));

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -793,6 +793,8 @@ core::json::Value quartoNavigateAsJson(const QuartoNavigate& quartoNav);
 void viewer(const std::string& url,
             int height = 0, // pass 0 for no height change, // pass -1 for maximize
             const QuartoNavigate& quartoNav = QuartoNavigate());
+      
+void console_viewer(const std::string& url, int height = 0);
 
 void clearViewerCurrentUrl();
 std::string viewerCurrentUrl(bool mapped = true);

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -794,7 +794,7 @@ void viewer(const std::string& url,
             int height = 0, // pass 0 for no height change, // pass -1 for maximize
             const QuartoNavigate& quartoNav = QuartoNavigate());
       
-void console_viewer(const std::string& url, int height = 0);
+void consoleViewer(const std::string& url, int height = 0);
 
 void clearViewerCurrentUrl();
 std::string viewerCurrentUrl(bool mapped = true);

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -213,6 +213,7 @@ extern const int kJobsActivate;
 extern const int kPresentationPreview;
 extern const int kSuspendBlocked;
 extern const int kClipboardAction;
+extern const int kConsoleShowWidget;
 }
    
 class ClientEvent

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -521,7 +521,7 @@ void console_viewer(const std::string& url,
          if (isHTMLWidgetPath(filePath))
          {
             // view it
-            consoleShowWidget(path, height);
+            consoleShowWidget(module_context::sessionTempDirUrl(path), height);
          }
       }
    }

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -310,7 +310,7 @@ SEXP rs_viewer(SEXP urlSEXP, SEXP heightSEXP)
    return R_NilValue;
 }
 
-SEXP rs_console_viewer(SEXP urlSEXP, SEXP heightSEXP)
+SEXP rs_consoleViewer(SEXP urlSEXP, SEXP heightSEXP)
 {
    try
    {
@@ -320,7 +320,7 @@ SEXP rs_console_viewer(SEXP urlSEXP, SEXP heightSEXP)
          height = r::sexp::asInteger(heightSEXP);
       std::string url = r::sexp::safeAsString(urlSEXP);
 
-      module_context::console_viewer(url, height);
+      module_context::consoleViewer(url, height);
    }
    CATCH_UNEXPECTED_EXCEPTION
 
@@ -364,7 +364,7 @@ namespace viewer {
 Error initialize()
 {
    RS_REGISTER_CALL_METHOD(rs_viewer);
-   RS_REGISTER_CALL_METHOD(rs_console_viewer);
+   RS_REGISTER_CALL_METHOD(rs_consoleViewer);
 
    // install event handlers
    using namespace module_context;
@@ -490,7 +490,7 @@ void viewer(const std::string& url,
    }
 }
 
-void console_viewer(const std::string& url,
+void consoleViewer(const std::string& url,
                     int height)
 {
    // transform the url to a localhost:<port>/session one if it's

--- a/src/cpp/session/modules/viewer/SessionViewer.cpp
+++ b/src/cpp/session/modules/viewer/SessionViewer.cpp
@@ -510,20 +510,14 @@ void consoleViewer(const std::string& url,
       if (error)
          LOG_ERROR(error);
 
-      // if it's in the temp dir then we can serve it via the help server,
-      // otherwise we need to show it in an external browser
-      if (filePath.isWithin(tempDir))
-      {
-         // calculate the relative path
-         std::string path = filePath.getRelativePath(tempDir);
-         
-         // add to history and treat as a widget if appropriate
-         if (isHTMLWidgetPath(filePath))
-         {
-            // view it
-            consoleShowWidget(module_context::sessionTempDirUrl(path), height);
-         }
-      }
+      // we can only serve from the temp directory via the help server,
+      if (!filePath.isWithin(tempDir))
+         return;
+
+      // calculate the relative path
+      std::string path = filePath.getRelativePath(tempDir);
+      
+      consoleShowWidget(module_context::sessionTempDirUrl(path), height);
    }
 }
 

--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -17,6 +17,7 @@ package org.rstudio.core.client;
 import java.util.List;
 
 import com.google.gwt.aria.client.Roles;
+
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.virtualscroller.VirtualScrollerManager;
 import org.rstudio.core.client.widget.PreWidget;
@@ -25,6 +26,8 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Node;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.user.client.ui.Frame;
+
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 
 /**
@@ -85,6 +88,7 @@ public class ConsoleOutputWriter
     * @param isError Is this an error message?
     * @param ignoreLineCount Output without checking buffer length?
     * @param ariaLiveAnnounce Include in arialive output announcement
+
     * @return was this output below the maximum buffer line count?
     */
    public boolean outputToConsole(String text,
@@ -112,6 +116,16 @@ public class ConsoleOutputWriter
 
       // set the appendTarget to the VirtualConsole bucket if possible
       Element appendTarget = virtualConsole_.getParent();
+
+      if (text.startsWith("\u001b_") && text.endsWith("\u0007"))
+      {
+         Frame frame = new Frame("http://localhost:8787/grid_resource/gridviewer.html?env=package%3Adatasets&obj=mtcars&cache_key=9E14FE8F&max_cols=50");
+         frame.setWidth("100%");
+         frame.setHeight("400px");
+
+         appendTarget.appendChild(frame.getElement());
+         return false;
+      }
 
       // we never want to count lines based on the trailing element so grab its parent, if possible
       // otherwise just grab the outElement

--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -17,7 +17,6 @@ package org.rstudio.core.client;
 import java.util.List;
 
 import com.google.gwt.aria.client.Roles;
-
 import org.rstudio.core.client.dom.DomUtils;
 import org.rstudio.core.client.virtualscroller.VirtualScrollerManager;
 import org.rstudio.core.client.widget.PreWidget;
@@ -156,25 +155,40 @@ public class ConsoleOutputWriter
       RStudioFrame frame = new RStudioFrame("", url);
       frame.setWidth("100%");
       frame.getIFrame().setFrameBorder(0);
-      appendTarget.appendChild(frame.getElement());
-
+      
       if (height > 0) 
       {
          frame.setHeight("" + height + "px");
       } 
       else if (height == -1) // aka "fit"
       {
-         // TODO: this should rather be done after the frame is loaded
-         new Timer()
+         // initialize the frame with height 0 ...
+         frame.setHeight("0px");
+
+         Timer fitTimer = new Timer()
          {
             @Override
             public void run()
             {
-               int bodyHeight = frame.getWindow().getDocument().getBody().getClientHeight() + 20;
-               frame.setHeight("" + bodyHeight + "px");
+               int bodyHeight = frame.getWindow().getDocument().getBody().getClientHeight();
+               if (bodyHeight == 0) 
+               {
+                  // ... so that we can try again if the content was not yet loaded
+                  schedule(50);
+               }
+               else 
+               {
+                  // ... otherwise set the <iframe> height to fit the body height (and then some)
+                  frame.setHeight("" + (bodyHeight + 10 ) + "px");
+               }
+               
             }
-         }.schedule(500);
+         };
+         
+         fitTimer.schedule(50);
       }
+
+      appendTarget.appendChild(frame.getElement());
    }
 
    public boolean trimExcess()

--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -146,7 +146,8 @@ public class ConsoleOutputWriter
       return ignoreLineCount || !trimExcess();
    }
 
-   public void showWidget(String url, int height) {
+   public void showWidget(String url, int height)
+   {
       initVirtualConsole();
 
       // set the appendTarget to the VirtualConsole bucket if possible

--- a/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
+++ b/src/gwt/src/org/rstudio/core/client/ConsoleOutputWriter.java
@@ -162,11 +162,9 @@ public class ConsoleOutputWriter
       {
          frame.setHeight("" + height + "px");
       } 
-      else
+      else if (height == -1) // aka "fit"
       {
          // TODO: this should rather be done after the frame is loaded
-
-         // if height not specified, render then squeeze to body height
          new Timer()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellDisplay.java
@@ -32,6 +32,7 @@ public interface ShellDisplay extends ShellOutputWriter,
                                       HasKeyPressHandlers,
                                       HasKeyUpHandlers
 {
+   void consoleShowWidget(String url, int height);
    void consoleWriteInput(String input, String console);
    void consolePrompt(String prompt, boolean showInput);
    void ensureInputVisible();

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -415,7 +415,8 @@ public class ShellWidget extends Composite implements ShellDisplay,
    }
 
    @Override
-   public void consoleShowWidget(String url, int height) {
+   public void consoleShowWidget(String url, int height)
+   {
       output_.showWidget(url, height);
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -414,6 +414,11 @@ public class ShellWidget extends Composite implements ShellDisplay,
             false /*ignoreLineCount*/, isAnnouncementEnabled(AriaLiveService.CONSOLE_COMMAND));
    }
 
+   @Override
+   public void consoleShowWidget(String url, int height) {
+      output_.showWidget(url, height);
+   }
+
    private void clearPendingInput()
    {
       pendingInput_.setText("");

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -203,7 +203,8 @@ class ClientEvent extends JavaScriptObject
    public static final String PresentationPreview = "presentation_preview";
    public static final String SuspendBlocked = "session_suspend_blocked";
    public static final String ClipboardAction = "clipboard_action";
-   
+   public static final String ConsoleShowWidget = "console_show_widget";
+
    protected ClientEvent()
    {
    }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1126,6 +1126,11 @@ public class ClientEventDispatcher
          {
             ClipboardActionEvent.Data data = event.getData();
             eventBus_.dispatchEvent(new ClipboardActionEvent(data));
+         } 
+         else if (type == ClientEvent.ConsoleShowWidget)
+         {
+            ConsoleShowWidgetEvent.Data data = event.getData();
+            eventBus_.dispatchEvent(new ConsoleShowWidgetEvent(data));
          }
          else
          {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleShowWidgetEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/events/ConsoleShowWidgetEvent.java
@@ -1,0 +1,74 @@
+/*
+ * ConsoleShowWidgetEvent.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.console.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ConsoleShowWidgetEvent extends GwtEvent<ConsoleShowWidgetEvent.Handler>
+{
+    public static final GwtEvent.Type<Handler> TYPE = new GwtEvent.Type<>();
+    
+    public static class Data extends JavaScriptObject
+    {
+        protected Data()
+        {
+        }
+
+        public native final String getURL() /*-{
+            return this.url;
+        }-*/;
+
+        public native final int getHeight() /*-{
+            return this.height;
+        }-*/;
+
+    }
+    
+    public interface Handler extends EventHandler
+    {
+        void onConsoleShowWidget(ConsoleShowWidgetEvent event);
+    }
+    
+    public ConsoleShowWidgetEvent(Data data)
+    {
+        data_ = data;
+    }
+    
+    @Override
+    public Type<Handler> getAssociatedType()
+    {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(Handler handler)
+    {
+        handler.onConsoleShowWidget(this);
+    }
+    
+    public String getURL() 
+    {
+        return data_.getURL();
+    }
+
+    public int getHeight()
+    {
+        return data_.getHeight();
+    }
+
+    private final Data data_;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -295,7 +295,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
 
    @Override
    public void onConsoleShowWidget(ConsoleShowWidgetEvent event) {
-      GWT.log("onConsoleShowWidget:" + event.getURL());
+      view_.consoleShowWidget(event.getURL(), event.getHeight());
    }
 
    public void addKeyDownPreviewHandler(KeyDownPreviewHandler handler)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -91,7 +91,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
                               RunCommandWithDebugEvent.Handler,
                               UnhandledErrorEvent.Handler,
                               SuppressNextShellFocusEvent.Handler,
-                              RestartStatusEvent.Handler
+                              RestartStatusEvent.Handler,
+                              ConsoleShowWidgetEvent.Handler
                               
 {
    static interface Binder extends CommandBinder<Commands, Shell>
@@ -181,6 +182,7 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
       eventBus.addHandler(UnhandledErrorEvent.TYPE, this);
       eventBus.addHandler(SuppressNextShellFocusEvent.TYPE, this);
       eventBus.addHandler(RestartStatusEvent.TYPE, this);
+      eventBus.addHandler(ConsoleShowWidgetEvent.TYPE, this);
 
       final CompletionManager completionManager = new RCompletionManager(
             view_.getInputEditorDisplay(),
@@ -289,6 +291,11 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
          return;
       }
       view_.getConsoleOutputWriter().focusEnd();
+   }
+
+   @Override
+   public void onConsoleShowWidget(ConsoleShowWidgetEvent event) {
+      GWT.log("onConsoleShowWidget:" + event.getURL());
    }
 
    public void addKeyDownPreviewHandler(KeyDownPreviewHandler handler)
@@ -876,4 +883,5 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    private boolean restoreFocus_ = true;
    private boolean debugging_ = false;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/Shell.java
@@ -294,7 +294,8 @@ public class Shell implements ConsoleHistoryAddedEvent.Handler,
    }
 
    @Override
-   public void onConsoleShowWidget(ConsoleShowWidgetEvent event) {
+   public void onConsoleShowWidget(ConsoleShowWidgetEvent event)
+   {
       view_.consoleShowWidget(event.getURL(), event.getHeight());
    }
 


### PR DESCRIPTION
### Intent

display html widgets directly in the console. This may be useful for e.g. error messages, e.g. https://github.com/r-lib/rlang/issues/1440

### Approach

`.rs.api.console_viewer()` similar to `.rs.api.viewer()` (for widgets) but the rsult goes i the console: 

<img width="568" alt="image" src="https://user-images.githubusercontent.com/2625526/192624807-8783d846-5758-4c85-b764-92287c4977ee.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


