### PR TITLE
Rename instances of "RStudio Support" to "Posit Support"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ See our [guide to writing feature requests](https://github.com/rstudio/rstudio/w
 
 ## RStudio Pro
 
-This repo contains the code for the open source version of RStudio and RStudio Server, and its issues page is for issues pertaining specifically to the open source version of the software. To report issues or request new features for the professional version of RStudio, please get in touch with the RStudio support team at <support@rstudio.com>.
+This repo contains the code for the open source version of RStudio and RStudio Server, and its issues page is for issues pertaining specifically to the open source version of the software. To report issues or request new features for the professional version of RStudio, please get in touch with the Posit Support team at <support@rstudio.com>.
 
 ## Contributing Code
 

--- a/docs/user/rstudio/ide/guide/code/console.qmd
+++ b/docs/user/rstudio/ide/guide/code/console.qmd
@@ -10,7 +10,7 @@ Copied from: <https://support.rstudio.com/hc/en-us/articles/200404846-Working-in
 
 ## Code Completion
 
-The RStudio supports the automatic completion of code using the **Tab** key. For example, if you have an object named `pollResults` in your workspace you can type `poll` and then **Tab** and RStudio will automatically complete the full name of the object.
+The RStudio IDE supports the automatic completion of code using the **Tab** key. For example, if you have an object named `pollResults` in your workspace you can type `poll` and then **Tab** and RStudio will automatically complete the full name of the object.
 
 The code completion feature also provides inline help for functions whenever possible. For example, if you typed `med` then pressed **Tab** you would see:
 

--- a/docs/user/rstudio/ide/guide/ui/ui-panes.qmd
+++ b/docs/user/rstudio/ide/guide/ui/ui-panes.qmd
@@ -163,7 +163,7 @@ The package tab allows for viewing currently installed R packages, and has a sea
 
 ### Help
 
-The help tab is used to display package documentation and vignettes. There are arrows for navigating backwards and forwards as additional help pages are viewed. The home icon will return to the general help page, with links to Resources, Manuals, References, and RStudio Support.
+The help tab is used to display package documentation and vignettes. There are arrows for navigating backwards and forwards as additional help pages are viewed. The home icon will return to the general help page, with links to Resources, Manuals, References, and Posit Support.
 
 To get help on a specific R function use the `?functionName` or `help(functionName)` syntax, for example the following code when executed would open the help page for the `paste0()` function:
 

--- a/docs/user/rstudio/index.qmd
+++ b/docs/user/rstudio/index.qmd
@@ -49,4 +49,4 @@ The following documentation helps a user understand the core workflows in RStudi
 ### Additional Resources
 
 - [RStudio Extensions](https://rstudio.github.io/rstudio-extensions/index.html)
-- [RStudio Support tagged IDE](https://support.rstudio.com/hc/en-us/sections/203994097-RStudio-IDE)
+- [Posit Support tagged IDE](https://support.rstudio.com/hc/en-us/sections/203994097-RStudio-IDE)

--- a/src/cpp/session/resources/help_resources/index.htm
+++ b/src/cpp/session/resources/help_resources/index.htm
@@ -76,12 +76,12 @@
             RStudio
             </h3>
             <ul>
-               <li><a href="https://www.rstudio.org/links/rstudio-support">RStudio IDE Support</a></li>
+               <li><a href="https://www.rstudio.org/links/rstudio-support">Posit Support</a></li>
                <li><a href="https://www.rstudio.org/links/community-forum">RStudio Community Forum</a></li>
                <li><a href="https://www.rstudio.org/links/cheat_sheets">RStudio Cheat Sheets</a></li>
                <li><a href="https://twitter.com/rstudiotips">RStudio Tip of the Day</a></li>
                <li><a href="https://www.rstudio.org/links/rstudio-r-packages">RStudio Packages</a></li>
-               <li><a href="https://www.rstudio.org/links/rstudio-products">RStudio Products</a></li>
+               <li><a href="https://www.rstudio.org/links/rstudio-products">Posit Products</a></li>
             </ul>
          </td>
       </tr>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
@@ -3185,7 +3185,7 @@ public interface CmdConstants extends Constants {
     String rstudioCommunityForumMenuLabel();
     
     // rstudioSupport
-    @DefaultStringValue("RStudio _Support") // $NON-NLS-1$
+    @DefaultStringValue("Posit _Support") // $NON-NLS-1$
     String rstudioSupportMenuLabel();
     
     // rstudioLicense

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_en.properties
@@ -2082,7 +2082,7 @@ updateCredentialsMenuLabel = _Update Credentials
 rstudioCommunityForumMenuLabel = RStudio Community _Forum
 
 # rstudioSupport
-rstudioSupportMenuLabel = RStudio _Support
+rstudioSupportMenuLabel = Posit _Support
 
 # rstudioLicense
 rstudioLicenseMenuLabel = RStudio _License

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -3570,7 +3570,7 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
         windowMode="main"/>
 
    <cmd id="rstudioSupport"
-        menuLabel="RStudio _Support"
+        menuLabel="Posit _Support"
         rebindable="false"
         windowMode="main"/>
 


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio-pro/issues/3830
OS PR

I want to wait until we merge OS to pro and then follow up with a pro-pr that will continue with more replacements.

### Intent

Visual references to "RStudio Support" should be replaced with "Posit Support."

### Approach

Find and replace operation with discretion. Some instances of "RStudio" are left as-is in context. I think every instance of "RStudio Support" has been covered.

I have made an effort to preserve the formatting in GWT's menus, so that the quick keys will still work.

### Automated Tests

N / A

### QA Notes

This hits docs and several files within the IDE. @gtritchie our french-speaking friends should also have a look.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


