### PR TITLE
PyShiny Run App support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 ### Python
 
 - RStudio attempts to infer the appropriate version of Python when "Automatically activate project-local Python environments" is checked and the user has not requested a specific version of Python. This Python will be stored in the environment variable "RETICULATE_PYTHON_FALLBACK", available from the R console, the Python REPL, and the RStudio Terminal (#9990)
+- Shiny for Python apps now display a "Run App" button on the Source editor toolbar. (Requires `shiny` Python package v0.2.7 or later.)
 
 ### Quarto
 

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -713,6 +713,7 @@ else()
       # add server subprojects if we aren't building in desktop only mode
       if(RSTUDIO_SERVER)
          add_subdirectory(server)
+         add_subdirectory(server/url-ports)
          configure_file(rserver-dev.in ${CMAKE_CURRENT_BINARY_DIR}/rserver-dev)
          configure_file(conf/rserver-dev.conf ${CMAKE_CURRENT_BINARY_DIR}/conf/rserver-dev.conf)
          configure_file(conf/rsession-dev.conf ${CMAKE_CURRENT_BINARY_DIR}/conf/rsession-dev.conf)

--- a/src/cpp/core/include/core/http/AsyncConnection.hpp
+++ b/src/cpp/core/include/core/http/AsyncConnection.hpp
@@ -57,12 +57,14 @@ public:
 
    // populate or set response then call writeResponse when done
    virtual http::Response& response() = 0;
-   virtual void writeResponse(bool close = true) = 0;
+   virtual void writeResponse(bool close = true,
+                              Socket::Handler handler = Socket::NullHandler) = 0;
 
    // simple wrappers for writing an existing response or error
    virtual void writeResponse(const http::Response& response,
                               bool close = true,
-                              const http::Headers& extraHeaders = http::Headers()) = 0;
+                              const http::Headers& extraHeaders = http::Headers(),
+                              Socket::Handler handler = Socket::NullHandler) = 0;
 
    // writes only the headers and not any body data
    // useful for chunked encoding (streaming)

--- a/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
+++ b/src/cpp/core/include/core/http/AsyncConnectionImpl.hpp
@@ -194,7 +194,7 @@ public:
       return response_;
    }
 
-   virtual void writeResponse(bool close = true)
+   virtual void writeResponse(bool close = true, Socket::Handler handler = Socket::NullHandler)
    {
       // add extra response headers
       if (!response_.containsHeader("Date"))
@@ -214,9 +214,13 @@ public:
                      socket(), // using socket(), not *socket in case of SSL connection
                      response_,
                      boost::bind(&AsyncConnectionImpl<SocketType>::onStreamComplete,
-                                 AsyncConnectionImpl<SocketType>::shared_from_this()),
+                                 AsyncConnectionImpl<SocketType>::shared_from_this(),
+                                 close,
+                                 handler),
                      boost::bind(&AsyncConnectionImpl<SocketType>::handleStreamError,
                                  AsyncConnectionImpl<SocketType>::shared_from_this(),
+                                 close,
+                                 handler,
                                  _1)));
 
          pWriter->write();
@@ -235,23 +239,32 @@ public:
              response_.setContentLength(0);
          }
 
+         // After asyncWrite completes, we want to first do our cleanup
+         // (this->handleWrite()) and then call the caller's handler
+         Socket::Handler handlers = boost::bind(
+            &Socket::joinHandlers,
+            static_cast<Socket::Handler>(boost::bind(
+               &AsyncConnectionImpl<SocketType>::handleWrite,
+               AsyncConnectionImpl<SocketType>::shared_from_this(),
+               boost::asio::placeholders::error,
+               close)),
+            handler,
+            _1,
+            _2
+         );
+
          // write
-         socketOperations_->asyncWrite(
-             response_.toBuffers(),
-             boost::bind(
-                  &AsyncConnectionImpl<SocketType>::handleWrite,
-                  AsyncConnectionImpl<SocketType>::shared_from_this(),
-                  boost::asio::placeholders::error,
-                  close));
+         socketOperations_->asyncWrite(response_.toBuffers(), handlers);
       }
    }
 
    virtual void writeResponse(const http::Response& response,
                               bool close = true,
-                              const Headers& additionalHeaders = Headers())
+                              const Headers& additionalHeaders = Headers(),
+                              Socket::Handler handler = Socket::NullHandler)
    {
       response_.assign(response, additionalHeaders);
-      writeResponse(close);
+      writeResponse(close, handler);
    }
 
    virtual void writeResponseHeaders(Socket::Handler handler)
@@ -529,8 +542,8 @@ private:
             }
          }
          
-         // close the socket
-         if (closeSocket)
+         // close the socket, if requested or if error
+         if (e || closeSocket)
          {
             close();
          }
@@ -567,17 +580,26 @@ private:
       readSome();
    }
 
-   void onStreamComplete()
+   void onStreamComplete(bool close, Socket::Handler handler)
    {
-      close();
+      if (close)
+         this->close();
+      // -1 isn't the correct number of bytes written, but we don't have access
+      // to that information at this point.
+      handler(boost::system::error_code(), -1);
    }
 
-   void handleStreamError(const Error& error)
+   void handleStreamError(bool close, Socket::Handler handler, const Error& error)
    {
       if (!core::http::isConnectionTerminatedError(error))
          LOG_ERROR(error);
-
-      close();
+      if (close)
+         this->close();
+      // jcheng: boost::system::generic_category() isn't correct, but I don't
+      // know how to get an error_code category out of an Error object.
+      // -1 isn't the correct number of bytes written, but we don't have access
+      // to that information at this point.
+      handler(boost::system::error_code(error.getCode(), boost::system::generic_category()), -1);
    }
 
 private:

--- a/src/cpp/core/include/core/http/Socket.hpp
+++ b/src/cpp/core/include/core/http/Socket.hpp
@@ -33,7 +33,7 @@ public:
    typedef boost::function<void(const boost::system::error_code&, std::size_t)>
                                                          Handler;
 
-   // An implementatino of Handler that does nothing.   
+   // An implementation of Handler that does nothing.   
    static void NullHandler(const boost::system::error_code& ec, std::size_t bytes_transferred)
    {   
    }

--- a/src/cpp/core/include/core/http/Socket.hpp
+++ b/src/cpp/core/include/core/http/Socket.hpp
@@ -33,6 +33,19 @@ public:
    typedef boost::function<void(const boost::system::error_code&, std::size_t)>
                                                          Handler;
 
+   // An implementatino of Handler that does nothing.   
+   static void NullHandler(const boost::system::error_code& ec, std::size_t bytes_transferred)
+   {   
+   }
+
+   // boost::bind two handlers to the first two arguments, and you've got
+   // yourself a Handler that invokes each of those handler arguments in turn.
+   static void joinHandlers(Handler a, Handler b, const boost::system::error_code& ec, std::size_t bytes_transferred)
+   {
+      a(ec, bytes_transferred);
+      b(ec, bytes_transferred);
+   }
+
 public:
    virtual void asyncReadSome(boost::asio::mutable_buffers_1 buffers,
                               Handler handler) = 0;

--- a/src/cpp/core/r_util/RSessionContext.cpp
+++ b/src/cpp/core/r_util/RSessionContext.cpp
@@ -321,6 +321,12 @@ std::string urlPathForSessionScope(const SessionScope& scope)
    std::string project = http::util::urlEncode(scope.projectId().asString());
    boost::algorithm::replace_all(project, "%2F", "/");
 
+   // This seems to be the case when running under rserver-dev
+   if (project == "" && scope.id() == "")
+   {
+      return "/";
+   }
+
    // create url
    boost::format fmt("/s/%1%%2%/");
    return boost::str(fmt % project % scope.id());

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -455,7 +455,7 @@ void handleLocalhostResponse(
          {         
             sendSparkUIResponse(response, ptrConnection);
          }
-         else if (response.headerValue(core::http::kTransferEncoding) == core:http::kChunkedTransferEncoding)
+         else if (response.headerValue(core::http::kTransferEncoding) == core::http::kChunkedTransferEncoding)
          {
             // Even if the response from upstream is "Transfer-Encoding: chunked",
             // our response to the client is no longer chunked; the AsyncClient

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -431,7 +431,16 @@ void handleLocalhostResponse(
          }
          else if (response.headerValue("Transfer-Encoding") == "chunked")
          {
-            // Even if the response from upstream is "Transfer-Encoding: chunked", 
+            // Even if the response from upstream is "Transfer-Encoding: chunked",
+            // our response to the client is no longer chunked; the AsyncClient
+            // parses and consumes the chunk lengths. Therefore, remove the
+            // Transfer-Encoding header and set the content length, to reflect
+            // that the body will come all at once.
+            //
+            // TODO: Determine what happens when the Transfer-Encoding is both
+            // chunked and something else ("gzip, chunked" or "chunked, gzip").
+            // TODO: What other hop-by-hop response headers are we not removing
+            // but should?
             http::Response response1;
             response1.assign(response);
             response1.removeHeader("Transfer-Encoding");

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -455,7 +455,7 @@ void handleLocalhostResponse(
          {         
             sendSparkUIResponse(response, ptrConnection);
          }
-         else if (response.headerValue("Transfer-Encoding") == "chunked")
+         else if (response.headerValue(core::http::kTransferEncoding) == core:http::kChunkedTransferEncoding)
          {
             // Even if the response from upstream is "Transfer-Encoding: chunked",
             // our response to the client is no longer chunked; the AsyncClient

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -1121,8 +1121,6 @@ void proxyLocalhostRequest(
 
    std::string port = safe_convert::numberToString(portNum);
 
-   LOG_DEBUG_MESSAGE("Localhost proxying is over port " + port);
-
    // strip the port part of the uri
    using namespace boost::algorithm;
    std::string portPath = match[0];

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -429,6 +429,15 @@ void handleLocalhostResponse(
          {         
             sendSparkUIResponse(response, ptrConnection);
          }
+         else if (response.headerValue("Transfer-Encoding") == "chunked")
+         {
+            // Even if the response from upstream is "Transfer-Encoding: chunked", 
+            http::Response response1;
+            response1.assign(response);
+            response1.removeHeader("Transfer-Encoding");
+            response1.setContentLength(response.body().size());
+            ptrConnection->writeResponse(response1);
+         }
          else
          {
             ptrConnection->writeResponse(response);
@@ -1102,6 +1111,8 @@ void proxyLocalhostRequest(
    }
 
    std::string port = safe_convert::numberToString(portNum);
+
+   LOG_DEBUG_MESSAGE("Localhost proxying is over port " + port);
 
    // strip the port part of the uri
    using namespace boost::algorithm;

--- a/src/cpp/server/url-ports/CMakeLists.txt
+++ b/src/cpp/server/url-ports/CMakeLists.txt
@@ -1,0 +1,63 @@
+#
+# CMakeLists.txt
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+project (RSERVER_URLS)
+
+# include files
+#file(GLOB_RECURSE URL_HEADER_FILES "*.h*")
+
+# source files
+set(URL_SOURCE_FILES
+    UrlPortsMain.cpp
+)
+
+# set include directories
+include_directories(
+   include
+   ${Boost_INCLUDE_DIRS}
+   ${SERVER_SYSTEM_INCLUDE_DIRS}
+   ${CORE_INCLUDE_DIRS}
+   ${SERVER_CORE_SOURCE_DIR}/include
+   ${SHARED_CORE_SOURCE_DIR}/include
+   ${CORE_SOURCE_DIR}/include
+   ${TESTS_INCLUDE_DIR}
+)
+
+# define executable
+add_stripped_executable(rserver-url ${URL_SOURCE_FILES})
+
+# set link dependencies
+target_link_libraries(rserver-url
+   rstudio-server-core
+)
+
+# installation rules
+install(TARGETS rserver-url DESTINATION ${RSTUDIO_INSTALL_BIN})
+
+# test files
+if (RSTUDIO_UNIT_TESTS_ENABLED)
+
+   set(URL_TEST_FILES
+       UrlPortsMainTests.cpp)
+
+   add_executable(rserver-url-tests
+      TestMain.cpp
+      ${URL_TEST_FILES}
+   )
+
+   target_link_libraries(rserver-url-tests
+      rstudio-server-core
+   )
+endif()

--- a/src/cpp/server/url-ports/TestMain.cpp
+++ b/src/cpp/server/url-ports/TestMain.cpp
@@ -1,0 +1,16 @@
+/*
+ * Main.cpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <tests/TestMain.hpp>

--- a/src/cpp/server/url-ports/UrlPortsMain.cpp
+++ b/src/cpp/server/url-ports/UrlPortsMain.cpp
@@ -1,0 +1,72 @@
+/*
+ * UrlPortsMain.cpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include <iostream> 
+#include <cstdlib>
+
+#include <core/Log.hpp>
+#include <core/system/System.hpp>
+#include <shared_core/Error.hpp>
+#include <server_core/UrlPorts.hpp>
+#include <url-ports/UrlPorts.hpp>
+
+using namespace rstudio;
+using namespace rstudio::core;
+
+/**
+ * This executable is used by programs such as quarto, that need to launch a server on behalf of a given session user. This program takes the port number and a secure token and returns an obfuscated URL that rserver will accept in order to proxy traffic to the specific port for the session user.  
+ * 
+ * Parameters are provided as command line arguments.
+ * @param $1 The port number to be transformed
+ * @param $2 (optional) The token to use to transform the port. If no port is provided,
+ * the token will be read from RS_PORT_TOKEN
+ * 
+ * @return The obfuscated port value
+ */
+
+int main(int argc, char * const argv[])
+{
+   int port;
+   bool longOutput = false;
+   std::string portToken;
+   if (!parseArguments(argc, argv, longOutput, &port, &portToken))
+   {
+      std::cerr << "\nrserver-url: invalid options\n\n"
+         "Usage: rserver-url -<OPTIONAL FLAGS> <PORT> <TOKEN>\n"
+         "TOKEN is optional when the environment variable RS_PORT_TOKEN is set.\n\n" 
+         "Optional flags:\n"
+         "   l: long - displays the complete URL.\n\n";
+
+      return EXIT_FAILURE;
+   }
+
+   std::string transformedPort = server_core::transformPort(portToken, port);
+   if (!longOutput)
+   {
+      std::cout << transformedPort;
+   }
+   else
+   {
+      char* pSessionPath = std::getenv("RS_SESSION_URL");
+      std::string sessionPath = pSessionPath != NULL ? std::string(pSessionPath) : std::string();
+
+      char* pServerPath = std::getenv("RS_SERVER_URL");
+      std::string serverPath = pServerPath != NULL ? std::string(pServerPath) : std::string();
+
+      std::cout << serverPath + sessionPath + "p/" + transformedPort + "/" << std::endl;
+   }
+   return EXIT_SUCCESS;
+}
+

--- a/src/cpp/server/url-ports/UrlPortsMainTests.cpp
+++ b/src/cpp/server/url-ports/UrlPortsMainTests.cpp
@@ -1,0 +1,112 @@
+#include <stdlib.h> 
+#include <url-ports/UrlPorts.hpp>
+#include <tests/TestThat.hpp>
+
+namespace {
+
+char* getPort()
+{
+   return (char*) "8050";
+}
+
+char* getPortTokenEnvVarSetter()
+{
+   return (char*) "RS_PORT_TOKEN=91c63048efb0";
+}
+
+char* getPortTokenEnvVar()
+{
+   return (char*) "91c63048efb0";
+}
+
+} // anonymous namespace
+
+TEST_CASE("Url Ports Main")
+{
+
+   SECTION("Provide port")
+   {
+      int argc = 2;
+      char *args[] = {
+         (char*)"",
+         getPort(),
+         NULL
+      };
+      putenv(getPortTokenEnvVarSetter());
+
+      bool longOutput = false;
+      int port;
+      std::string portToken;
+      bool pass = parseArguments(argc, args, longOutput, &port, &portToken);
+
+      CHECK(pass == true);
+      CHECK(longOutput == false);
+      CHECK(std::to_string(port) == getPort());
+      CHECK(portToken == getPortTokenEnvVar());
+   }
+
+   SECTION("Provide port, long ouput");
+   {
+      int argc = 3;
+      char *args[] = {
+         (char*)"",
+         (char*)"-l",
+         getPort(),
+         NULL
+      };
+      putenv(getPortTokenEnvVarSetter());
+
+      bool longOutput = false;
+      int port;
+      std::string portToken;
+      bool pass = parseArguments(argc, args, longOutput, &port, &portToken);
+
+      CHECK(pass == true);
+      CHECK(longOutput == true);
+      CHECK(std::to_string(port) == getPort());
+      CHECK(portToken == getPortTokenEnvVar());
+   }
+
+   SECTION("Provide port and token")
+   {
+      int argc = 3;
+      char *args[] = {
+         (char*)"",
+         getPort(),
+         getPortTokenEnvVar(),
+         NULL
+      };
+
+      bool longOutput = false;
+      int port;
+      std::string portToken;
+
+      bool pass = parseArguments(argc, args, longOutput, &port, &portToken);
+      CHECK(pass == true);
+      CHECK(longOutput == false);
+      CHECK(std::to_string(port) == getPort());
+      CHECK(portToken == getPortTokenEnvVar());
+   }
+
+   SECTION("Provide port and token, long output")
+   {
+      int argc = 4;
+      char *args[] = {
+         (char*)"",
+         (char*)"-l",
+         getPort(),
+         getPortTokenEnvVar(),
+         NULL
+      };
+
+      bool longOutput = false;
+      int port;
+      std::string portToken;
+
+      bool pass = parseArguments(argc, args, longOutput, &port, &portToken);
+      CHECK(pass == true);
+      CHECK(longOutput == true);
+      CHECK(std::to_string(port) == getPort());
+      CHECK(portToken == getPortTokenEnvVar());
+   }
+}

--- a/src/cpp/server/url-ports/include/url-ports/UrlPorts.hpp
+++ b/src/cpp/server/url-ports/include/url-ports/UrlPorts.hpp
@@ -1,0 +1,70 @@
+/*
+ * UrlPorts.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef URL_PORTS_URL_PORTS_HPP
+#define URL_PORTS_URL_PORTS_HPP
+
+#include <iostream> 
+#include <cstdlib>
+
+#include <shared_core/Error.hpp>
+
+using namespace rstudio;
+using namespace rstudio::core;
+
+bool parseArguments(const int argc, char * const argv[], bool& longOutput, int* pPort, std::string* pPortToken)
+{
+   if (argc < 2)
+   {
+      return false;
+   }
+
+   longOutput = false;
+   int portIndex = 1;
+   int tokenIndex = 2;
+
+   *pPortToken = std::getenv("RS_PORT_TOKEN");
+
+   if (std::string(argv[1]).at(0) == '-')
+   {
+      if (std::string(argv[1]).at(1) != 'l')
+      {
+         return false;
+      }
+
+      longOutput = true;
+      portIndex = 2;
+      tokenIndex = 3;
+   }
+   int minCount = portIndex + 1;
+   int maxCount = tokenIndex + 1;
+   if (argc < minCount || argc > maxCount || ((argc == minCount) && pPortToken->empty()))
+   {
+      return false;
+   }
+
+   if (argc > minCount)
+      *pPortToken = argv[tokenIndex];
+   
+   try
+   {
+      *pPort = std::stoi(argv[portIndex]);
+      return true;
+   }
+   CATCH_UNEXPECTED_EXCEPTION
+   return false;
+}
+
+#endif

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -308,6 +308,7 @@ set(SESSION_SOURCE_FILES
    modules/quarto/SessionQuartoServe.cpp
    modules/quarto/SessionQuartoXRefs.cpp
    modules/shiny/SessionShiny.cpp
+   modules/shiny/SessionPyShiny.cpp
    modules/shiny/ShinyAsyncJob.cpp
    modules/sql/SessionSql.cpp
    modules/stan/SessionStan.cpp

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -116,7 +116,7 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
    if (error)
       return error;
 
-      // save the base URL to persistent state (for forming absolute URLs)
+   // save the base URL to persistent state (for forming absolute URLs)
    persistentState().setActiveClientUrl(baseURL);
 
    // generate a new port token

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -116,11 +116,18 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
    if (error)
       return error;
 
-   // save the base URL to persistent state (for forming absolute URLs)
+      // save the base URL to persistent state (for forming absolute URLs)
    persistentState().setActiveClientUrl(baseURL);
 
    // generate a new port token
    persistentState().setPortToken(server_core::generateNewPortToken());
+
+   // Set environment variables RS_SERVER_URL, RS_SESSION_URL, and RS_PORT_TOKEN,
+   // needed for subprocesses to use the rserver-url binary with the -l option.
+   core::system::setenv(kPortTokenEnvVar, persistentState().portToken());
+   core::system::setenv(kServerUrlEnvVar, baseURL);
+   core::system::setenv(kSessionUrlEnvVar,
+                        core::r_util::urlPathForSessionScope(options().sessionScope()));
 
    std::string path = ptrConnection->request().rootPath();
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -191,6 +191,7 @@
 #include "modules/rmarkdown/SessionBookdown.hpp"
 #include "modules/quarto/SessionQuarto.hpp"
 #include "modules/shiny/SessionShiny.hpp"
+#include "modules/shiny/SessionPyShiny.hpp"
 #include "modules/sql/SessionSql.hpp"
 #include "modules/stan/SessionStan.hpp"
 #include "modules/viewer/SessionViewer.hpp"
@@ -600,6 +601,7 @@ Error rInit(const rstudio::r::session::RInitInfo& rInitInfo)
       (modules::rmarkdown::templates::initialize)
       (modules::rmarkdown::bookdown::initialize)
       (modules::rpubs::initialize)
+      (modules::pyshiny::initialize)
       (modules::shiny::initialize)
       (modules::sql::initialize)
       (modules::stan::initialize)

--- a/src/cpp/session/SessionUrlPorts.cpp
+++ b/src/cpp/session/SessionUrlPorts.cpp
@@ -66,12 +66,20 @@ std::string translateLocalUrl(const std::string& localUrl, bool absolute)
       return localUrl;
    }
 
+   auto prefix = persistentState().activeClientUrl();
+   if (!prefix.empty() && localUrl.rfind(prefix, 0) == 0)
+   {
+      // Transformation is not necessary because it's not a hidden port.
+      // e.g.: rstudioapi::translateLocalUrl(rstudioapi::translateLocalUrl("http://127.0.0.1:9000", TRUE), TRUE)
+      // should NOT return a URL with TWO portmaps
+      return localUrl;
+   }
+
    // The URL was transformed. mapUrlPorts takes an absolute URL and returns a relative URL like
    // "p/08afc455", so make it absolute again if requested by prefixing it with the URL of the
    // connected client.
    if (absolute)
    {
-      auto prefix = persistentState().activeClientUrl();
       if (!prefix.empty())
       {
          // Ensure trailing slash before we stick the strings, since mapUrlPorts doesn't return one

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -43,6 +43,10 @@
 
 #define kRStudioUserHomePage              "RSTUDIO_USER_HOME_PAGE"
 
+#define kSessionUrlEnvVar                 "RS_SESSION_URL"
+#define kServerUrlEnvVar                  "RS_SERVER_URL"
+#define kPortTokenEnvVar                  "RS_PORT_TOKEN"
+
 #define kSessionSslCertEnvVar             "RS_SESSION_SSL_CERT"
 #define kSessionSslCertKeyEnvVar          "RS_SESSION_SSL_CERT_KEY"
 #define kSessionSslCertPathEnvVar         "RS_SESSION_SSL_CERT_PATH"

--- a/src/cpp/session/include/session/SessionUrlPorts.hpp
+++ b/src/cpp/session/include/session/SessionUrlPorts.hpp
@@ -29,6 +29,8 @@ namespace rstudio {
 namespace session {
 namespace url_ports {
 
+// localUrl is a full URL that may or may not be local.
+// If absolute, return a full URL, not just the portion of the path following the workbench URL.
 std::string translateLocalUrl(const std::string& localUrl, bool absolute = true);
 
 std::string mapUrlPorts(const std::string& url);

--- a/src/cpp/session/include/session/SessionUrlPorts.hpp
+++ b/src/cpp/session/include/session/SessionUrlPorts.hpp
@@ -29,6 +29,8 @@ namespace rstudio {
 namespace session {
 namespace url_ports {
 
+std::string translateLocalUrl(const std::string& localUrl, bool absolute = true);
+
 std::string mapUrlPorts(const std::string& url);
 
 core::Error initialize();

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -50,6 +50,8 @@
 #include <session/RVersionSettings.hpp>
 #include <session/SessionTerminalShell.hpp>
 
+#include <session/SessionUrlPorts.hpp>
+
 #include "SessionSpelling.hpp"
 #include "SessionReticulate.hpp"
 
@@ -419,6 +421,18 @@ void viewPdfPostback(const std::string& pdfPath,
    cont(EXIT_SUCCESS, "");
 }
 
+// $BROWSER
+void browserPostback(const std::string& url,
+                     const module_context::PostbackHandlerContinuation& cont)
+{
+   // TODO: Translate local URL and enqueue event
+   LOG_DEBUG_MESSAGE("browser postback called with url " + url);
+   auto transformedUrl = session::url_ports::translateLocalUrl(url);
+   auto event = browseUrlEvent(transformedUrl);
+   module_context::enqueClientEvent(event);
+   cont(EXIT_SUCCESS, "");
+}
+
 
 void handleFileShow(const http::Request& request, http::Response* pResponse)
 {
@@ -513,6 +527,14 @@ Error initialize()
       // register edit_completed waitForMethod handler
       s_waitForEditCompleted = module_context::registerWaitForMethod(
                                                          "edit_completed");
+
+      std::string browserCommand;
+      error = module_context::registerPostbackHandler("browser",
+                                                      browserPostback,
+                                                      &browserCommand);
+      if (error)
+         return error;
+      core::system::setenv("BROWSER", browserCommand);
    }
    
    // register waitForMethod for active document context

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -425,7 +425,7 @@ void viewPdfPostback(const std::string& pdfPath,
 void browserPostback(const std::string& url,
                      const module_context::PostbackHandlerContinuation& cont)
 {
-   auto transformedUrl = session::url_ports::translateLocalUrl(url);
+   auto transformedUrl = session::url_ports::translateLocalUrl(url, true);
    auto event = browseUrlEvent(transformedUrl);
    module_context::enqueClientEvent(event);
    cont(EXIT_SUCCESS, "");

--- a/src/cpp/session/modules/SessionWorkbench.cpp
+++ b/src/cpp/session/modules/SessionWorkbench.cpp
@@ -425,8 +425,6 @@ void viewPdfPostback(const std::string& pdfPath,
 void browserPostback(const std::string& url,
                      const module_context::PostbackHandlerContinuation& cont)
 {
-   // TODO: Translate local URL and enqueue event
-   LOG_DEBUG_MESSAGE("browser postback called with url " + url);
    auto transformedUrl = session::url_ports::translateLocalUrl(url);
    auto event = browseUrlEvent(transformedUrl);
    module_context::enqueClientEvent(event);

--- a/src/cpp/session/modules/shiny/SessionPyShiny.cpp
+++ b/src/cpp/session/modules/shiny/SessionPyShiny.cpp
@@ -1,0 +1,77 @@
+/*
+ * SessionPyShiny.cpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#include "SessionPyShiny.hpp"
+
+#include <boost/algorithm/string/predicate.hpp>
+
+#include <core/Algorithm.hpp>
+#include <core/Exec.hpp>
+#include <core/FileSerializer.hpp>
+#include <core/YamlUtil.hpp>
+
+#include <r/RExec.hpp>
+#include <r/RRoutines.hpp>
+
+#include <session/SessionRUtil.hpp>
+#include <session/SessionOptions.hpp>
+#include <session/SessionModuleContext.hpp>
+#include <session/SessionUrlPorts.hpp>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+
+#define kPyShinyXt           "pyshiny-app"
+
+using namespace rstudio::core;
+
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace pyshiny {
+
+namespace {
+
+std::string onDetectPyShinySourceType(
+      boost::shared_ptr<source_database::SourceDocument> pDoc)
+{
+   if (!pDoc->path().empty() && pDoc->type().size() != 0 && pDoc->type() == kSourceDocumentTypePython)
+   {
+      FilePath filePath = module_context::resolveAliasedPath(pDoc->path());
+      // ShinyFileType type = getShinyFileType(filePath, pDoc->contents());
+      return kPyShinyXt;
+   }
+
+   return std::string();
+}
+
+} // anonymous namespace
+
+Error initialize()
+{
+   using namespace module_context;
+   using boost::bind;
+
+   events().onDetectSourceExtendedType.connect(onDetectPyShinySourceType);
+
+   return Success();
+}
+
+
+} // namespace crypto
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+

--- a/src/cpp/session/modules/shiny/SessionPyShiny.cpp
+++ b/src/cpp/session/modules/shiny/SessionPyShiny.cpp
@@ -50,8 +50,12 @@ std::string onDetectPyShinySourceType(
    if (!pDoc->path().empty() && pDoc->type().size() != 0 && pDoc->type() == kSourceDocumentTypePython)
    {
       FilePath filePath = module_context::resolveAliasedPath(pDoc->path());
-      // ShinyFileType type = getShinyFileType(filePath, pDoc->contents());
-      return kPyShinyXt;
+      std::string filename = filePath.getFilename();
+      if (boost::algorithm::iequals(filename, "app.py") &&
+          boost::algorithm::icontains(pDoc->contents(), "shiny"))
+      {
+         return kPyShinyXt;
+      }
    }
 
    return std::string();

--- a/src/cpp/session/modules/shiny/SessionPyShiny.hpp
+++ b/src/cpp/session/modules/shiny/SessionPyShiny.hpp
@@ -1,0 +1,40 @@
+/*
+ * SessionPyShiny.hpp
+ *
+ * Copyright (C) 2022 by RStudio, PBC
+ *
+ * Unless you have received this program directly from RStudio pursuant
+ * to the terms of a commercial license agreement with RStudio, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef SESSION_PY_SHINY_HPP
+#define SESSION_PY_SHINY_HPP
+
+#include <shared_core/json/Json.hpp>
+
+namespace rstudio {
+namespace core {
+   class Error;
+   class FilePath;
+}
+}
+ 
+namespace rstudio {
+namespace session {
+namespace modules { 
+namespace pyshiny {
+
+core::Error initialize();
+                       
+} // namespace shiny
+} // namespace modules
+} // namespace session
+} // namespace rstudio
+
+#endif // SESSION_PY_SHINY_HPP

--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -53,6 +53,7 @@ configure_file(rpostback-pdfviewer ${POSTBACK_SCRIPT_DIR}/rpostback-pdfviewer)
 configure_file(rpostback-gitssh ${POSTBACK_SCRIPT_DIR}/rpostback-gitssh)
 configure_file(rpostback-askpass ${POSTBACK_SCRIPT_DIR}/rpostback-askpass)
 configure_file(askpass-passthrough ${POSTBACK_SCRIPT_DIR}/askpass-passthrough)
+configure_file(rpostback-browser ${POSTBACK_SCRIPT_DIR}/rpostback-browser)
 
 # put rpostback in a place where it can be found for dev config
 if(NOT RSTUDIO_PACKAGE_BUILD)

--- a/src/cpp/session/postback/rpostback-browser
+++ b/src/cpp/session/postback/rpostback-browser
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# rpostback-browser
+#
+# Copyright (C) 2022 by RStudio, PBC
+#
+# Unless you have received this program directly from RStudio pursuant
+# to the terms of a commercial license agreement with RStudio, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+"$RS_RPOSTBACK_PATH" browser "$@"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6589,9 +6589,7 @@ public class TextEditingTarget implements
       source_.withSaveFilesBeforeCommand(() ->
       {
          String path = getPath();
-         // Some light shell escaping.
-         // TODO: More exhaustive escaping
-         path = path.replaceAll("([ '\"\\\\$])", "\\\\$1");
+         path = StringUtil.escapeBashPath(path, false);
          events_.fireEvent(new SendToTerminalEvent("command shiny run --reload --launch-browser --port=0 " + path + "\n", true));
       }, () -> {}, "Run Shiny Application");
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6588,9 +6588,11 @@ public class TextEditingTarget implements
    {
       source_.withSaveFilesBeforeCommand(() ->
       {
-         // TODO: quote or shell-escape file path
-         // TODO: launch URL
-         events_.fireEvent(new SendToTerminalEvent("command shiny run --reload " + getPath() + "\n", true));
+         String path = getPath();
+         // Some light shell escaping.
+         // TODO: More exhaustive escaping
+         path = path.replaceAll("([ '\"\\\\$])", "\\\\$1");
+         events_.fireEvent(new SendToTerminalEvent("command shiny run --reload --launch-browser --port=0 " + path + "\n", true));
       }, () -> {}, "Run Shiny Application");
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -190,6 +190,7 @@ import org.rstudio.studio.client.workbench.views.source.events.RecordNavigationP
 import org.rstudio.studio.client.workbench.views.source.events.SourceFileSavedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.*;
+import org.rstudio.studio.client.workbench.views.terminal.events.SendToTerminalEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.ConsoleProgressDialog;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.ShowVcsDiffEvent;
 import org.rstudio.studio.client.workbench.views.vcs.common.events.ShowVcsHistoryEvent;
@@ -6451,6 +6452,11 @@ public class TextEditingTarget implements
       // If this is a Python file, use reticulate.
       if (fileType_.isPython())
       {
+         if (extendedType_.startsWith(SourceDocument.XT_PY_SHINY_PREFIX))
+         {
+            runPyShinyApp();
+            return;
+         }
          sourcePython();
          return;
       }
@@ -6576,6 +6582,17 @@ public class TextEditingTarget implements
             events_.fireEvent(new LaunchPlumberAPIEvent(getPath()));
          }
       }, () -> {}, "Run Plumber API");
+   }
+
+   private void runPyShinyApp()
+   {
+      source_.withSaveFilesBeforeCommand(() ->
+      {
+         // TODO: quote or shell-escape file path
+         // TODO: launch URL
+         // TODO: figure out how to invoke venv!?
+         events_.fireEvent(new SendToTerminalEvent("command shiny run --reload " + getPath() + "\n", true));
+      }, () -> {}, "Run Shiny Application");
    }
 
    private void sourcePython()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -6590,7 +6590,6 @@ public class TextEditingTarget implements
       {
          // TODO: quote or shell-escape file path
          // TODO: launch URL
-         // TODO: figure out how to invoke venv!?
          events_.fireEvent(new SendToTerminalEvent("command shiny run --reload " + getPath() + "\n", true));
       }, () -> {}, "Run Shiny Application");
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -908,9 +908,15 @@ public class TextEditingTargetWidget
       testShinyButton_.setVisible(false);
       testThatButton_.setVisible(false);
       compareTestButton_.setVisible(false);
-      if (isShinyFile() || isPyShinyFile())
+      if (isShinyFile())
       {
          shinyLaunchButton_.setVisible(true);
+         plumberLaunchButton_.setVisible(false);
+         setSourceButtonFromShinyState();
+      }
+      else if (isPyShinyFile())
+      {
+         shinyLaunchButton_.setVisible(false);
          plumberLaunchButton_.setVisible(false);
          setSourceButtonFromShinyState();
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetWidget.java
@@ -848,7 +848,7 @@ public class TextEditingTargetWidget
 
       // don't show the run buttons for cpp files, or R files in Shiny/Tests/Plumber
       runButton_.setVisible(canExecuteCode && !canExecuteChunks && !isCpp &&
-            !(isShinyFile() || isTestFile() || isPlumberFile()) && !(isScript && !terminalAllowed));
+            !(isShinyFile() || isPyShinyFile() || isTestFile() || isPlumberFile()) && !(isScript && !terminalAllowed));
       runLastButton_.setVisible(runButton_.isVisible() && !canExecuteChunks && !isScript);
 
       // show insertion options for various knitr engines in rmarkdown v2
@@ -896,7 +896,7 @@ public class TextEditingTargetWidget
 
       commands_.enableProsemirrorDevTools().setVisible(isMarkdown);
 
-      if (isShinyFile() || isTestFile() || isPlumberFile())
+      if (isShinyFile() || isPyShinyFile() || isTestFile() || isPlumberFile())
       {
          sourceOnSave_.setVisible(false);
          srcOnSaveLabel_.setVisible(false);
@@ -908,7 +908,7 @@ public class TextEditingTargetWidget
       testShinyButton_.setVisible(false);
       testThatButton_.setVisible(false);
       compareTestButton_.setVisible(false);
-      if (isShinyFile())
+      if (isShinyFile() || isPyShinyFile())
       {
          shinyLaunchButton_.setVisible(true);
          plumberLaunchButton_.setVisible(false);
@@ -985,6 +985,12 @@ public class TextEditingTargetWidget
    {
       return extendedType_ != null &&
              extendedType_.startsWith(SourceDocument.XT_SHINY_PREFIX);
+   }
+
+   private boolean isPyShinyFile()
+   {
+      return extendedType_ != null &&
+             extendedType_.startsWith(SourceDocument.XT_PY_SHINY_PREFIX);
    }
 
    private boolean isVisualMode()
@@ -1076,7 +1082,7 @@ public class TextEditingTargetWidget
       
       
       texToolbarButton_.setText(width >= 520, constants_.format());
-      runButton_.setText(((width >= 480) && !isShinyFile()), constants_.run());
+      runButton_.setText(((width >= 480) && !(isShinyFile() || isPyShinyFile())), constants_.run());
       compilePdfButton_.setText(width >= 450, constants_.compilePdf());
       previewHTMLButton_.setText(width >= 450, previewCommandText_);
       knitDocumentButton_.setText(width >= 450, knitCommandText_);
@@ -1683,6 +1689,13 @@ public class TextEditingTargetWidget
             sourceButton_.setLeftImage(
                   commands_.debugContinue().getImageResource());
          }
+      }
+      else if (isPyShinyFile())
+      {
+         sourceCommandText_ = constants_.runApp();
+         sourceCommandDesc = constants_.runTheShinyApp();
+         sourceButton_.setLeftImage(
+               commands_.debugContinue().getImageResource());
       }
 
       sourceButton_.setTitle(sourceCommandDesc);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/SourceDocument.java
@@ -218,4 +218,6 @@ public class SourceDocument extends JavaScriptObject
    public final static String XT_SQL_PREVIEWABLE = "sql-previewable";
    public final static String XT_PLUMBER_API = "plumber-api";
    public final static String XT_R_CUSTOM_SOURCE = "r-custom-source";
+   public final static String XT_PY_SHINY_PREFIX = "pyshiny-";
+   public final static String XT_PY_SHINY = "pyshiny-app";
 }


### PR DESCRIPTION
### Intent

* Add a button for "Run App" for PyShiny apps
* Fix some issues with localhost port proxying that were exposed by PyShiny (specifically: chunked HTTP responses were being corrupted 100% of the time, and proxied WebSockets had a race condition that caused them to close 10% of the time).

To see this feature in action
1. Grab an example from https://shinylive.io/py/examples/, and save it as an `app.py` file.
2. Open that file in RStudio, and hit the "Run App" button to see it launch in a new window.
3. Arrange the app window and the RStudio window so that you can see them both, and make a trivial change to app.py. When you hit Save, you should see the app window reload itself.

### Approach

The intent was to do the "simplest possible" integration, unfortunately that ended up still being a bit complicated.

Hitting the Run App button should run the current PyShiny app at the RStudio Terminal, and launch an external browser. This needs to work on RStudio Server as well, and in order to serve multiple users simultaneously, a random port should be used by PyShiny each time.

* Add `RS_SERVER_URL`, `RS_SESSION_URL`, `RS_PORT_TOKEN`, and `rserver-url` functionality from RSP that is necessary for PyShiny to adapt its URLs to proxied URLs.
* Tell PyShiny to pick its own port (`--port 0`) and invoke the web browser `$BROWSER` when ready.
* In server mode, the `$BROWSER` is now an rpostback-browser script that causes a new browser window to be launched.

A couple of fixes to the proxy logic were required as well: 1) support for proxying chunked responses from upstream, and 2) removing a race condition in proxying WebSockets that would cause the response headers to be corrupted.

### Automated Tests

I don't know how to write automated tests for RStudio.

### QA Notes

I don't know how to build RStudio in desktop mode, so I've only tested this in server mode. It'll be important to test this in desktop mode as well.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
