### PR TITLE
don't scroll into view when focus returns after window blur

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 
 ### Fixed
 
+- Fixed an issue where the console history scroll position was not preserved when switching focus to a separate application (#1638)
 - Fixed an issue where Find in Files could omit matches in some cases on Windows (#11736)
 - Fixed an issue where the Git History window inverted the display of merge diffs (#10150)
 - Fixed an issue where Find in Files could fail to find results with certain versions of git (#11822)

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -127,11 +127,13 @@ public class ShellWidget extends Composite implements ShellDisplay,
       
       input_.addFocusHandler((FocusEvent event) ->
       {
-         if (!ignoreNextFocus_)
+         if (ignoreNextFocus_)
          {
             ignoreNextFocus_ = false;
-            scrollIntoView();  
+            return;
          }
+
+         scrollIntoView();  
       });
 
       // NOTE: we cannot scroll into view immediately after the cursor

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -121,6 +121,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
       
       WindowEx.addBlurHandler((BlurEvent event) ->
       {
+         // https://github.com/rstudio/rstudio/issues/1638
          ignoreNextFocus_ = true;
       });
       

--- a/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/shell/ShellWidget.java
@@ -25,6 +25,7 @@ import org.rstudio.core.client.TimeBufferedCommand;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.core.client.dom.DOMRect;
 import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.jsonrpc.RpcObjectList;
 import org.rstudio.core.client.widget.BottomScrollPanel;
 import org.rstudio.core.client.widget.FontSizer;
@@ -54,6 +55,7 @@ import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.SpanElement;
 import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.FocusEvent;
@@ -116,7 +118,20 @@ public class ShellWidget extends Composite implements ShellDisplay,
          input_.setNewLineMode(NewLineMode.Unix);
 
       input_.addClickHandler(secondaryInputHandler);
-      input_.addFocusHandler((FocusEvent event) -> scrollIntoView());
+      
+      WindowEx.addBlurHandler((BlurEvent event) ->
+      {
+         ignoreNextFocus_ = true;
+      });
+      
+      input_.addFocusHandler((FocusEvent event) ->
+      {
+         if (!ignoreNextFocus_)
+         {
+            ignoreNextFocus_ = false;
+            scrollIntoView();  
+         }
+      });
 
       // NOTE: we cannot scroll into view immediately after the cursor
       // has changed, as Ace may not have rendered the updated cursor
@@ -1010,6 +1025,7 @@ public class ShellWidget extends Composite implements ShellDisplay,
    }
 
    private boolean cleared_ = false;
+   private boolean ignoreNextFocus_ = false;
    private final ConsoleOutputWriter output_;
    private final PreWidget pendingInput_;
    private final HTML prompt_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/1638.

### Approach

Ignore the next focus event after a blur.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/1638.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
