### PR TITLE
discard pending console output on interrupt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ### R
 
 * Whether pending console input is discarded on error can now be controlled via a preference in the Console pane. (#10391)
+* RStudio now drops pending console input when the console is interrupted. (#12059)
 * Improved handling of diagnostics within pipeline expressions. (#11780)
 * Improved handling of diagnostics within glue() expressions. 
 * RStudio now provides autocompletion results for packages used but not loaded within a project.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 ### R
 
 * Whether pending console input is discarded on error can now be controlled via a preference in the Console pane. (#10391)
-* RStudio now drops pending console input when the console is interrupted. (#12059)
+* RStudio now drops pending console output when the console is interrupted. (#12059)
 * Improved handling of diagnostics within pipeline expressions. (#11780)
 * Improved handling of diagnostics within glue() expressions. 
 * RStudio now provides autocompletion results for packages used but not loaded within a project.

--- a/src/cpp/r/include/r/session/RSession.hpp
+++ b/src/cpp/r/include/r/session/RSession.hpp
@@ -189,12 +189,13 @@ struct RCallbacks
 {
    boost::function<core::Error(const RInitInfo&)> init;
    boost::function<void()> initComplete;
-   boost::function<bool(const std::string&, bool, RConsoleInput*)> consoleRead;
    boost::function<void(const std::string&)> browseURL;
    boost::function<void(const core::FilePath&)> browseFile;
    boost::function<void(const std::string&)> showHelp;
    boost::function<void(const std::string&, core::FilePath&, bool)> showFile;
+   boost::function<bool(const std::string&, bool, RConsoleInput*)> consoleRead;
    boost::function<void(const std::string&, int)> consoleWrite;
+   boost::function<void()> consoleInterruptHandled;
    boost::function<void()> consoleHistoryReset;
    boost::function<void()> consoleReset;
    boost::function<bool(double*, double*)> locator;

--- a/src/cpp/r/session/RStdCallbacks.cpp
+++ b/src/cpp/r/session/RStdCallbacks.cpp
@@ -23,6 +23,9 @@
 #include <boost/regex.hpp>
 #include <boost/bind/bind.hpp>
 
+#include <core/FileSerializer.hpp>
+#include <core/RegexUtils.hpp>
+
 #include <r/RExec.hpp>
 #include <r/ROptions.hpp>
 #include <r/RSourceManager.hpp>
@@ -33,9 +36,6 @@
 #include <r/session/RConsoleHistory.hpp>
 #include <r/session/RSession.hpp>
 #include <r/session/RSessionState.hpp>
-
-#include <core/FileSerializer.hpp>
-#include <core/RegexUtils.hpp>
 
 #include "RInit.hpp"
 #include "REmbedded.hpp"
@@ -384,7 +384,7 @@ int RReadConsole(const char *pmt,
          return 0;
       }
    }
-   catch(r::exec::InterruptException&)
+   catch (r::exec::InterruptException&)
    {
       // set interrupts pending
       r::exec::setInterruptsPending(true);
@@ -435,7 +435,7 @@ void RShowMessage(const char* msg)
    CATCH_UNEXPECTED_EXCEPTION
 }
 
-void RWriteConsoleEx (const char *buf, int buflen, int otype)
+void RWriteConsoleEx(const char *buf, int buflen, int otype)
 {
    try
    {
@@ -450,6 +450,7 @@ void RWriteConsoleEx (const char *buf, int buflen, int otype)
          if (isInterruptOutput)
          {
             r::exec::setWasInterrupted(false);
+            s_callbacks.consoleInterruptHandled();
             return;
          }
          

--- a/src/cpp/session/SessionClientEvent.cpp
+++ b/src/cpp/session/SessionClientEvent.cpp
@@ -212,6 +212,8 @@ const int kJobsActivate = 194;
 const int kPresentationPreview = 195;
 const int kSuspendBlocked = 196;
 const int kClipboardAction = 197;
+const int kInterruptHandled = 198;
+
 }
 
 void ClientEvent::init(int type, const json::Value& data)
@@ -589,11 +591,12 @@ std::string ClientEvent::typeName() const
          return "presentation_preview";
       case client_events::kSuspendBlocked:
          return "session_suspend_blocked";
-	  case client_events::kClipboardAction:
-		 return "clipboard_action";
+	   case client_events::kClipboardAction:
+		   return "clipboard_action";
+      case client_events::kInterruptHandled:
+         return "interrupt_handled";
       default:
-         LOG_WARNING_MESSAGE("unexpected event type: " + 
-                             safe_convert::numberToString(type_));
+         LOG_WARNING_MESSAGE("unexpected event type: " + safe_convert::numberToString(type_));
          return "";
    }
 }

--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -148,6 +148,15 @@ void ClientEventQueue::remove(std::vector<ClientEvent>* pEvents)
    END_LOCK_MUTEX
 }
 
+void ClientEventQueue::removeIf(boost::function<bool(const ClientEvent&)> predicate)
+{
+   LOCK_MUTEX(*pMutex_)
+   {
+      core::algorithm::expel_if(pendingEvents_, predicate);
+   }
+   END_LOCK_MUTEX
+}
+
 void ClientEventQueue::clear()
 {
    LOCK_MUTEX(*pMutex_)
@@ -157,8 +166,7 @@ void ClientEventQueue::clear()
    }
    END_LOCK_MUTEX
 }
-  
-   
+
 bool ClientEventQueue::waitForEvent(
                         const boost::posix_time::time_duration& waitDuration)
 {
@@ -198,8 +206,7 @@ bool ClientEventQueue::eventAddedSince(const boost::posix_time::ptime& time)
 void ClientEventQueue::flushPendingConsoleOutput()
 {
    // NOTE: private helper so no lock required (mutex is not recursive) 
-   
-   if ( !pendingConsoleOutput_.empty() )
+   if (!pendingConsoleOutput_.empty())
    {
       // If there's more console output than the client can even show, then
       // truncate it to the amount that the client can show. Too much output

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -55,6 +55,9 @@ public:
    // are there any events pending?
    bool hasEvents();
    
+   // clear events matching some predicate
+   void removeIf(boost::function<bool(const ClientEvent&)> predicate);
+   
    // clear the event queue
    void clear();
    

--- a/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
+++ b/src/cpp/session/include/session/worker_safe/session/SessionClientEvent.hpp
@@ -213,6 +213,8 @@ extern const int kJobsActivate;
 extern const int kPresentationPreview;
 extern const int kSuspendBlocked;
 extern const int kClipboardAction;
+extern const int kInterruptHandled;
+
 }
    
 class ClientEvent

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEvent.java
@@ -203,6 +203,7 @@ class ClientEvent extends JavaScriptObject
    public static final String PresentationPreview = "presentation_preview";
    public static final String SuspendBlocked = "session_suspend_blocked";
    public static final String ClipboardAction = "clipboard_action";
+   public static final String InterruptHandled = "interrupt_handled";
    
    protected ClientEvent()
    {

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -22,7 +22,6 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
-import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.command.CommandCallbacksChangedEvent;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.HighlightEvent;

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -22,6 +22,7 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.core.client.Scheduler.RepeatingCommand;
 
+import org.rstudio.core.client.Mutable;
 import org.rstudio.core.client.command.CommandCallbacksChangedEvent;
 import org.rstudio.core.client.events.ExecuteAppCommandEvent;
 import org.rstudio.core.client.events.HighlightEvent;
@@ -245,6 +246,16 @@ public class ClientEventDispatcher
             }
          });
       }
+   }
+   
+   public void removeConsoleOutputEvents()
+   {
+      pendingEvents_.removeIf((ClientEvent event) ->
+      {
+         return
+               event.getType() == ClientEvent.ConsoleOutput ||
+               event.getType() == ClientEvent.ConsoleError;
+      });
    }
    
    private void dispatchEvent(ClientEvent event) 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -21,6 +21,8 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 import com.google.gwt.user.client.Window.ClosingHandler;
 
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.jsonrpc.RpcError;
 import org.rstudio.core.client.jsonrpc.RpcRequest;
 import org.rstudio.core.client.jsonrpc.RpcRequestCallback;
@@ -268,7 +270,7 @@ class RemoteServerEventListener
                // only process events if we are still listening
                if (isListening_ && (events != null))
                {
-                  for (int i=0; i<events.length(); i++)
+                  for (int i = 0, n = events.length(); i < n; i++)
                   {
                      // we can stop listening in the middle of dispatching
                      // events (e.g. if we dispatch a Suicide event) so we 
@@ -286,7 +288,7 @@ class RemoteServerEventListener
             }
             // catch all here to make sure that in all cases we call
             // listen() again after processing
-            catch(Throwable e)
+            catch (Throwable e)
             {
                GWT.log("ERROR: Processing client events", e);
             }
@@ -376,6 +378,14 @@ class RemoteServerEventListener
    {
       // do some special handling before calling the standard dispatcher
       String type = event.getType();
+      
+      // if we receive notice that the R session has processed an interrupt,
+      // then clear out pending console output so we don't blow up the console
+      if (type == ClientEvent.InterruptHandled)
+      {
+         eventDispatcher_.removeConsoleOutputEvents();
+         return;
+      }
       
       // we handle async completions directly
       if (type == ClientEvent.AsyncCompletion)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerEventListener.java
@@ -21,8 +21,6 @@ import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.Window.ClosingEvent;
 import com.google.gwt.user.client.Window.ClosingHandler;
 
-import org.rstudio.core.client.Debug;
-import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.jsonrpc.RpcError;
 import org.rstudio.core.client.jsonrpc.RpcRequest;
 import org.rstudio.core.client.jsonrpc.RpcRequestCallback;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12059.

### Approach

Relatively straightforward wiring of callbacks into our existing interrupt handlers:

- The `rConsoleInterrupted` callback sends a client event notifying that an interrupt was sent,
- The client processes that event eagerly, and uses that as a signal to discard any pending output

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12059.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
