### PR TITLE
Add Quarto to RHEL7/CentOS7

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -233,25 +233,11 @@ endif()
 # pandoc version
 set(PANDOC_VERSION "2.18" CACHE INTERNAL "Pandoc version")
 
-# detect Centos 7, because we don't support Quarto on Centos7
-set(IS_CENTOS7 FALSE)
-if(LINUX AND EXISTS "/etc/centos-release")
-   file(READ "/etc/centos-release" CENTOS_RELEASE)
-   string(FIND "${CENTOS_RELEASE}" "release 7" CENTOS_RELEASE_POS)
-   if(CENTOS_RELEASE_POS GREATER 0)
-     set(IS_CENTOS7 TRUE)
-   endif()
-endif()
-
 # quarto support
 if(NOT DEFINED QUARTO_ENABLED)
    if(LINUX AND UNAME_M STREQUAL aarch64)
       # disabled on linux aarch64
       message(STATUS "quarto does not yet support aarch64 builds of Linux; disabling quarto")
-      set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
-   elseif(IS_CENTOS7)
-      # disable quarto on Centos 7
-      message(STATUS "quarto is not supported on Centos7; disabling quarto")
       set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
    else()
       # enable by default

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@
 ### Quarto
 
 - Support for v2 format of Quarto crossref index
+- Support for RHEL7 and CentOS7 and fixes missing Pandoc for RMarkdown (rstudio-pro#3804)
 
 ### Posit Workbench
 

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -67,9 +67,16 @@ case "${PLATFORM}" in
 
 "Linux-64")
   SUBDIR="linux"
-  FILES=(
-    "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"
-  )
+  if [ "$OS_DISTRO" == "centos7" ]; then
+    FILES=(
+      "quarto-${QUARTO_VERSION}-linux-rhel7-amd64.tar.gz"
+    )
+  else
+    FILES=(
+      "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"
+    )
+  fi
+
   ;;
 
 *)

--- a/dependencies/linux/install-dependencies-centos7
+++ b/dependencies/linux/install-dependencies-centos7
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+#
+# install-dependencies-centos7
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+set -e
+
+OS_DISTRO=centos7 ./install-dependencies-yum "$@"

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -71,6 +71,9 @@ ENV CC="/opt/rh/devtoolset-7/root/usr/bin/gcc"
 ENV CXX="/opt/rh/devtoolset-7/root/usr/bin/c++"
 ENV CPP="/opt/rh/devtoolset-7/root/usr/bin/cpp"
 
+# for Centos 7 specific dependencies such as Quarto
+ENV OS_DISTRO="centos7"
+
 # sudo defaults to requiretty on centos7
 RUN sed -i  's/Defaults    requiretty/Defaults !requiretty/' /etc/sudoers
 


### PR DESCRIPTION
### Intent
Address rstudio/rstudio-pro#3804

### Approach
Check `OS_DISTRO` and if equals `centos7` then download the specific archive for the platform.

Updates the dev dependency installer (new Centos7 script that calls the existing yum script after setting `OS_DISTRO`) and the Dockerfile for the build (sets `OS_DISTRO`).

### Automated Tests
None

### QA Notes
Quarto will be enabled for the RHEL7/CentOS7 build. The menu option to create a .qmd file will be available. Also addresses missing Pandoc when working with RMarkdown files.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


