### PR TITLE
completion with pipe chains also displayed as `COLUMN` type. 

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2689,6 +2689,20 @@ assign(x = ".rs.acCompletionTypes",
    ## `%>%` chain -- use completions from the associated data object.
    result <- .rs.emptyCompletions()
    
+   if (length(additionalArgs))
+   {
+      argsToAdd <- .rs.selectFuzzyMatches(additionalArgs, token)
+      result <- .rs.appendCompletions(
+         result,
+         .rs.makeCompletions(
+            token = token,
+            results = argsToAdd,
+            packages = paste0(chainObjectName, " %>% ..."),
+            type = .rs.acCompletionTypes$COLUMN
+         )
+      )
+   }
+   
    if (!is.null(chainObjectName) && !excludeArgsFromObject)
    {
       object <- .rs.getAnywhere(chainObjectName, envir = envir)
@@ -2697,7 +2711,7 @@ assign(x = ".rs.acCompletionTypes",
       
       if (length(object))
       {
-         objectNames <- .rs.getNames(object)
+         objectNames <- setdiff(.rs.getNames(object), additionalArgs)
          if (length(objectNames))
          {
             completions <- .rs.selectFuzzyMatches(objectNames, token)
@@ -2717,29 +2731,17 @@ assign(x = ".rs.acCompletionTypes",
                packages <- paste("[", chainObjectName, "]", sep = "") 
             }
             
-            result <- .rs.makeCompletions(
-               token = token,
-               results = completions,
-               packages = packages,
-               quote = FALSE,
-               type = types
+            result <- .rs.appendCompletions(
+               result, .rs.makeCompletions(
+                  token = token,
+                  results = completions,
+                  packages = packages,
+                  quote = FALSE,
+                  type = types
+               )
             )
          }
       }
-   }
-   
-   if (length(additionalArgs))
-   {
-      argsToAdd <- .rs.selectFuzzyMatches(additionalArgs, token)
-      result <- .rs.appendCompletions(
-         result,
-         .rs.makeCompletions(
-            token = token,
-            results = argsToAdd,
-            packages = paste("*", chainObjectName, "*", sep = ""),
-            type = .rs.acCompletionTypes$COLUMN
-         )
-      )
    }
    
    if (length(excludeArgs))

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2737,7 +2737,7 @@ assign(x = ".rs.acCompletionTypes",
             token = token,
             results = argsToAdd,
             packages = paste("*", chainObjectName, "*", sep = ""),
-            type = .rs.acCompletionTypes$UNKNOWN
+            type = .rs.acCompletionTypes$COLUMN
          )
       )
    }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2544,7 +2544,6 @@ assign(x = ".rs.acCompletionTypes",
                                additionalArgs,
                                excludeArgs,
                                excludeArgsFromObject,
-                               discardFirst,
                                envir)
    )
    
@@ -2683,7 +2682,6 @@ assign(x = ".rs.acCompletionTypes",
                                                  additionalArgs,
                                                  excludeArgs,
                                                  excludeArgsFromObject,
-                                                 discardFirst,
                                                  envir)
 {
    ## chainObjectName will be provided if the client detected

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -373,7 +373,6 @@ var RCodeModel = function(session, tokenizer,
    };
 
    var $dplyrMutaterVerbs = [
-      "pull",
       "mutate", "summarise", "summarize", "rename", "transmute",
       "select", "rename_vars",
       "inner_join", "left_join", "right_join", "semi_join", "anti_join",
@@ -418,12 +417,6 @@ var RCodeModel = function(session, tokenizer,
       if (fnName === "select")
       {
          data.excludeArgsFromObject = true;
-      }
-
-      if (fnName === "pull")
-      {
-         data.excludeArgsFromObject = true;
-         data.additionalArgs = [];
       }
 
       do
@@ -559,9 +552,18 @@ var RCodeModel = function(session, tokenizer,
          // If this identifier is a dplyr 'mutate'r, then parse
          // those variables.
          var value = clone.currentValue();
+
+         // pull() cancels the column completions
+         if (value === "pull")
+         {
+            data.excludeArgsFromObject = true;
+            data.additionalArgs = [];
+            break;
+         }
+
          if (contains($dplyrMutaterVerbs, value))
             addDplyrArguments(clone.cloneCursor(), data, tokenCursor, value);
-
+         
          // Move off of identifier, on to new infix operator.
          // Note that we may already be at the start of the document,
          // so check for that.

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -373,6 +373,7 @@ var RCodeModel = function(session, tokenizer,
    };
 
    var $dplyrMutaterVerbs = [
+      "pull",
       "mutate", "summarise", "summarize", "rename", "transmute",
       "select", "rename_vars",
       "inner_join", "left_join", "right_join", "semi_join", "anti_join",
@@ -417,6 +418,12 @@ var RCodeModel = function(session, tokenizer,
       if (fnName === "select")
       {
          data.excludeArgsFromObject = true;
+      }
+
+      if (fnName === "pull")
+      {
+         data.excludeArgsFromObject = true;
+         data.additionalArgs = [];
       }
 
       do

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -361,6 +361,13 @@ var RCodeModel = function(session, tokenizer,
          name = tokenCursor.currentValue();
          additionalArgs = data.additionalArgs;
          excludeArgs = data.excludeArgs;
+
+         if (data.cancel == true)
+         {
+            excludeArgsFromObject = true;
+            additionalArgs = [];
+            excludeArgs = [];
+         }
       }
 
       return {
@@ -526,7 +533,8 @@ var RCodeModel = function(session, tokenizer,
       // Fill custom args
       var data = {
          additionalArgs: [],
-         excludeArgs: []
+         excludeArgs: [], 
+         cancel: false
       };
       
       // Repeat the walk -- keep walking as we can find '%%'
@@ -552,15 +560,11 @@ var RCodeModel = function(session, tokenizer,
          // If this identifier is a dplyr 'mutate'r, then parse
          // those variables.
          var value = clone.currentValue();
-
+         
          // pull() cancels the column completions
          if (value === "pull")
-         {
-            data.excludeArgsFromObject = true;
-            data.additionalArgs = [];
-            break;
-         }
-
+            data.cancel = true;
+         
          if (contains($dplyrMutaterVerbs, value))
             addDplyrArguments(clone.cloneCursor(), data, tokenCursor, value);
          

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -404,7 +404,14 @@ var RCodeModel = function(session, tokenizer,
       {
          if (!cursor.moveToNextToken())
             return false;
-         data.excludeArgs.push(cursor.currentValue());
+
+         if (cursor.currentValue() === "=")
+         {
+            if (!cursor.moveToNextToken())
+               return false;
+            
+            data.excludeArgs.push(cursor.currentValue());
+         }
       }
 
       if (fnName === "select")


### PR DESCRIPTION
### Intent

addresses #12067

### Approach

mark the completions that have been deduced from a `dplyr`  chain as `COLUMN`, put them on top, and hint about the modification with `[mtcars %>% ...]`

![image](https://user-images.githubusercontent.com/2625526/193234450-4964c92f-4397-4613-a9d9-e8081ccab04e.png)

<img width="473" alt="image" src="https://user-images.githubusercontent.com/2625526/193234578-ae43a501-b999-46a7-b4b8-cd6bb0cfd708.png">


### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


