### PR TITLE
`beginsuggest()` only include spaces on explicit completions in roxygen `@examples` 

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.workbench.views.source.editors.text.DocDisplay;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Position;
@@ -277,12 +276,12 @@ public class DocumentMode
    public static boolean isCursorInRoxygenExamples(DocDisplay docDisplay)
    {
       int i = docDisplay.getCurrentLineNum();
-      while (i > 0) 
+      while (i >= 0) 
       {
          String line = docDisplay.getLine(i);
          if (!PATTERN_ROXYGEN_LINE.test(line))
             return false;
-            
+
          if (PATTERN_ROXYGEN_EXAMPLES_LINE.test(line))
             return true;
          

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/DocumentMode.java
@@ -275,7 +275,7 @@ public class DocumentMode
    
    public static boolean isCursorInRoxygenExamples(DocDisplay docDisplay)
    {
-      int i = docDisplay.getCurrentLineNum();
+      int i = docDisplay.getCurrentLineNum() - 1;
       while (i >= 0) 
       {
          String line = docDisplay.getLine(i);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1131,7 +1131,7 @@ public class RCompletionManager implements CompletionManager
             // when below @examples, handle <TAB> here and take into account
             // the tab size, where the code begins (i.e. after |#' | ) and 
             // where the cursor currently is
-            if (DocumentMode.isCursorInRoxygenExamples(docDisplay_)) 
+            if (DocumentMode.isCursorInRoxygenExamples(docDisplay_) && !implicit) 
             {
                if (editor != null) 
                {
@@ -2275,6 +2275,7 @@ public class RCompletionManager implements CompletionManager
             @Override
             public void run()
             {
+               GWT.log("SuggestionTimer.run(flushCache_ = " + flushCache_ + ", implicit_ = " + implicit_ + ", canAutoInsert_ = " + canAutoInsert_);
                manager_.beginSuggest(
                      flushCache_,
                      implicit_,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -2275,7 +2275,6 @@ public class RCompletionManager implements CompletionManager
             @Override
             public void run()
             {
-               GWT.log("SuggestionTimer.run(flushCache_ = " + flushCache_ + ", implicit_ = " + implicit_ + ", canAutoInsert_ = " + canAutoInsert_);
                manager_.beginSuggest(
                      flushCache_,
                      implicit_,


### PR DESCRIPTION
### Intent

addresses #12070 

### Approach

only insert the spaces on explicit completions (when `<TAB>` was indeed pressed). 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


