### PR TITLE
handle SigTerm just like SigUsr2

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -420,21 +420,46 @@ Error waitForSignals()
          // closing pam sessions
          //
 
+         // send SIGTERM signal to specific Workbench child processes
+         // this way user processes will not receive the signal until it traverses the tree
+         std::set<std::string> interruptProcs =  {"rsession",
+                                                   "rserver-launcher",
+                                                   "rstudio-launcher",
+                                                   "rworkspaces",
+                                                   "rserver-monitor"};
+
+         Error error = core::system::sendSignalToSpecifiedChildProcesses(interruptProcs, SIGTERM);
+         if (error)
+         {
+            std::string message = "Error occurred while notifying child processes of ";
+            message += strsignal(sig);
+            error.addProperty("description", message);
+            LOG_ERROR(error);
+         }
+         else
+         {
+            std::string message = "Successfully notified children of ";
+            message += strsignal(sig);
+            LOG_INFO_MESSAGE(message);
+         }
+
          // call overlay shutdown
          overlay::shutdown();
 
          // clear the signal mask
-         Error error = core::system::clearSignalMask();
-         if (error)
+         error = core::system::clearSignalMask();
+         if (error) {
             LOG_ERROR(error);
+         }
 
          // reset the signal to its default
          struct sigaction sa;
          ::memset(&sa, 0, sizeof sa);
          sa.sa_handler = SIG_DFL;
          int result = ::sigaction(sig, &sa, nullptr);
-         if (result != 0)
+         if (result != 0) {
             LOG_ERROR(systemError(result, ERROR_LOCATION));
+         }
 
          // re-raise the signal
          ::kill(::getpid(), sig);
@@ -445,7 +470,7 @@ Error waitForSignals()
       {
          reloadConfiguration();
 
-         // forward signal to specific RStudio child processes
+         // forward signal to specific child processes
          // this will allow them to also reload their configuration / logging if applicable
          // care is taken not to send errant SIGHUP signals to processes we don't control
          std::set<std::string> reloadableProcs =  {"rsession",

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -411,12 +411,13 @@ Error registerSignalHandlers()
    registerBlock.addFunctions()
          (bind(handleSignal, SigInt, handleINT));
 
-   // USR1 and USR2: perform suspend in server mode
+   // USR1, USR2, and TERM: perform suspend in server mode
    if (rsession::options().programMode() == kSessionProgramModeServer)
    {
       registerBlock.addFunctions()
          (bind(handleSignal, SigUsr1, suspend::handleUSR1))
-         (bind(handleSignal, SigUsr2, suspend::handleUSR2));
+         (bind(handleSignal, SigUsr2, suspend::handleUSR2))
+         (bind(handleSignal, SigTerm, suspend::handleUSR2));
    }
    // USR1 and USR2: ignore in desktop mode
    else


### PR DESCRIPTION

### Intent

The goal here is to work more nicely with supervisors like `systemd` without requiring a custom shutdown script or other unit customization. It is possible that ignoring SigTerm on Desktop alters some other implicit functionality, but we thought this would be preferable and more explicit.

open source companion to rstudio/rstudio-pro#3811

### Approach

### Automated Tests

### QA Notes

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


