### PR TITLE
optimize handling of console output / errors

### DIFF
--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -208,6 +208,8 @@ bool ClientEventQueue::eventAddedSince(const boost::posix_time::ptime& time)
 
 void ClientEventQueue::flushAllPendingConsoleOutput()
 {
+   // NOTE: Private helper so no lock required (mutex is not recursive)
+   //
    // NOTE: Order shouldn't matter here as long as we ensure that
    // stdout is flushed whenever stderr is received, and vice versa.
    // This happens as events are received so we should be safe.
@@ -217,6 +219,7 @@ void ClientEventQueue::flushAllPendingConsoleOutput()
 
 void ClientEventQueue::flushPendingConsoleOutput()
 {
+   // NOTE: Private helper so no lock required (mutex is not recursive)
    flushPendingOutputImpl(
             client_events::kConsoleWriteOutput,
             pendingConsoleOutput_);
@@ -224,6 +227,7 @@ void ClientEventQueue::flushPendingConsoleOutput()
 
 void ClientEventQueue::flushPendingConsoleErrors()
 {
+   // NOTE: Private helper so no lock required (mutex is not recursive)
    flushPendingOutputImpl(
             client_events::kConsoleWriteError,
             pendingConsoleErrors_);
@@ -231,6 +235,7 @@ void ClientEventQueue::flushPendingConsoleErrors()
 
 void ClientEventQueue::flushPendingOutputImpl(int event, std::string& output)
 {
+   // NOTE: Private helper so no lock required (mutex is not recursive)
    if (output.empty())
       return;
    

--- a/src/cpp/session/SessionClientEventQueue.cpp
+++ b/src/cpp/session/SessionClientEventQueue.cpp
@@ -122,7 +122,12 @@ void ClientEventQueue::add(const ClientEvent& event)
       else if (event.type() == client_events::kBuildOutput &&
                event.data().getType() == json::Type::OBJECT)
       {
-         buildOutput_.append(event.data().getObject()["output"].getString());
+         // read output -- don't log errors as this routine is called very frequently
+         // during build and we don't want to overload the logs
+         auto jsonData = event.data().getObject();
+         std::string output;
+         json::readObject(jsonData, "output", output);
+         buildOutput_.append(output);
       }
       else
       {

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -38,10 +38,34 @@ class ClientEventQueue;
 ClientEventQueue& clientEventQueue();
 
 class ClientEventQueue : boost::noncopyable
-{   
+{
 private:
    ClientEventQueue();
    friend void initializeClientEventQueue();
+   
+   class BufferedOutput : boost::noncopyable
+   {
+      
+   public:
+      BufferedOutput(int event, bool useConsoleActionLimit)
+         : event_(event),
+           useConsoleActionLimit_(useConsoleActionLimit)
+      {
+      }
+      
+      const std::string& output() const { return output_; }
+      int event() const { return event_; }
+      bool useConsoleActionLimit() const { return useConsoleActionLimit_; }
+      
+      void append(const std::string& data) { output_ += data; }
+      void clear() { output_.clear(); }
+      bool empty() const { return output_.empty(); }
+      
+   private:
+      int event_;
+      std::string output_;
+      bool useConsoleActionLimit_;
+   };
    
 public:
    // COPYING: boost::noncopyable
@@ -68,14 +92,10 @@ public:
    // the active console changed
    bool setActiveConsole(const std::string& console);
       
-private:   
-   void flushAllPendingConsoleOutput();
+private:
    
-   void flushPendingConsoleOutput();
-   void flushPendingConsoleErrors();
-
-   void flushPendingOutputImpl(int event, std::string& output);
-   void enqueueClientOutputEvent(int event, const std::string& text);
+   void flushBufferedOutput(BufferedOutput* pOutput);
+   void flushAllBufferedOutput();
  
 private:
    // synchronization objects. heap based so they are never destructed
@@ -85,14 +105,20 @@ private:
    // it is being destroyed
    boost::mutex* pMutex_;
    boost::condition* pWaitForEventCondition_;
-
+   
    // instance data
-   std::string pendingConsoleOutput_;
-   std::string pendingConsoleErrors_;
    std::string activeConsole_;
    std::vector<ClientEvent> pendingEvents_;
    boost::posix_time::ptime lastEventAddTime_;
    
+   // buffered outputs (required for parts that might overflow)
+   BufferedOutput consoleOutput_;
+   BufferedOutput consoleErrors_;
+   BufferedOutput buildOutput_;
+   
+   // keep vector of pointers to buffered outputs, just to make
+   // iteration easier in places where we need to flush all buffers
+   std::vector<BufferedOutput*> bufferedOutputs_;
 
 };
 

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -70,6 +70,7 @@ public:
       
 private:   
    void flushPendingConsoleOutput();
+   void flushPendingConsoleErrors();
 
    void enqueueClientOutputEvent(int event, const std::string& text);
  
@@ -84,6 +85,7 @@ private:
 
    // instance data
    std::string pendingConsoleOutput_;
+   std::string pendingConsoleErrors_;
    std::string activeConsole_;
    std::vector<ClientEvent> pendingEvents_;
    boost::posix_time::ptime lastEventAddTime_;

--- a/src/cpp/session/SessionClientEventQueue.hpp
+++ b/src/cpp/session/SessionClientEventQueue.hpp
@@ -69,9 +69,12 @@ public:
    bool setActiveConsole(const std::string& console);
       
 private:   
+   void flushAllPendingConsoleOutput();
+   
    void flushPendingConsoleOutput();
    void flushPendingConsoleErrors();
 
+   void flushPendingOutputImpl(int event, std::string& output);
    void enqueueClientOutputEvent(int event, const std::string& text);
  
 private:

--- a/src/cpp/session/SessionClientEventService.cpp
+++ b/src/cpp/session/SessionClientEventService.cpp
@@ -326,8 +326,7 @@ void ClientEventService::run()
             clientEventQueue.remove(&events);
             
             // convert to json and add event id
-            for (std::vector<ClientEvent>::const_iterator 
-                 it = events.begin(); it != events.end(); ++it)
+            for (auto it = events.begin(); it != events.end(); ++it)
             {
                json::Object event;
                it->asJsonObject(nextEventId++, &event);

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -365,4 +365,8 @@
         <arg value="org.rstudio.studio.client.RStudioUnitTestSuite"/>
      </java>
    </target>
+
+   <target name="test" depends="unittest">
+   </target>
+
 </project>

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -1257,8 +1257,18 @@ public class StringUtil
    }-*/;
 
    // Count newlines in a string
-   public static native int newlineCount(String str) /*-{
-      return (str.match(/\n/g)||[]).length;
+   public static native int newlineCount(String string)
+   /*-{
+      var count = 0;
+      
+      for (var index = string.indexOf('\n', 0);
+           index !== -1;
+           index = string.indexOf('\n', index + 1))
+      {
+          count++;
+      }
+      
+      return count;
    }-*/;
 
    // Automatically detect the indent size within a document (for documents

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -246,7 +246,24 @@ public class DomUtils
       }
       else
       {
-         return countLinesInternal(node);
+         // Just count the total number of <br> elements
+         switch (node.getNodeType())
+         {
+         
+         case Node.ELEMENT_NODE:
+            
+            if (Element.as(node).getTagName() == BRElement.TAG)
+            {
+               return 1;
+            }
+            else
+            {
+               return DomUtils.querySelectorAll(Element.as(node), "br").getLength();
+            }
+            
+         default:
+            return 0;
+         }
       }
    }
 

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -226,49 +226,61 @@ public class DomUtils
    /**
     *
     * @param node
-    * @param pre Count hard returns in text nodes as newlines (only true if
-    *    white-space mode is pre*)
+    * @param pre Count hard returns in text nodes as newlines
+    *   (only true if white-space mode is pre*)
     * @return
     */
    public static int countLines(Node node, boolean pre)
    {
-      switch (node.getNodeType())
+      if (pre)
       {
+         switch (node.getNodeType())
+         {
          case Node.TEXT_NODE:
-            return countLinesInternal((Text)node, pre);
+            return countLinesInternal((Text)node);
          case Node.ELEMENT_NODE:
-            return countLinesInternal((Element)node, pre);
+            return countLinesInternal((Element)node);
          default:
             return 0;
+         }
       }
-   }
-
-   private static int countLinesInternal(Text textNode, boolean pre)
-   {
-      if (!pre)
-         return 0;
-      String value = textNode.getData();
-      Pattern pattern = Pattern.create("\\n");
-      int count = 0;
-      Match m = pattern.match(value, 0);
-      while (m != null)
+      else
       {
-         count++;
-         m = m.nextMatch();
+         return countLinesInternal(node);
       }
-      return count;
    }
 
-   private static int countLinesInternal(Element elementNode, boolean pre)
+   private static int countLinesInternal(Node node)
    {
-      if (elementNode.getTagName().equalsIgnoreCase("br"))
-         return 1;
+      switch (node.getNodeType())
+      {
+      
+      case Node.TEXT_NODE:
+      {
+         Text textNode = Text.as(node);
+         String value = textNode.getData();
+         return StringUtil.newlineCount(value);
+      }
+      
+      case Node.ELEMENT_NODE:
+      {
+         Element elementNode = Element.as(node);
+         if (elementNode.getTagName().equalsIgnoreCase("br"))
+            return 1;
 
-      int result = 0;
-      NodeList<Node> children = elementNode.getChildNodes();
-      for (int i = 0; i < children.getLength(); i++)
-         result += countLines(children.getItem(i), pre);
-      return result;
+         int result = 0;
+         NodeList<Node> children = elementNode.getChildNodes();
+         for (int i = 0; i < children.getLength(); i++)
+            result += countLinesInternal(children.getItem(i));
+         return result;
+      }
+      
+      default:
+      {
+         return 0;
+      }
+      
+      }
    }
 
    private final static DomUtilsImpl impl = GWT.create(DomUtilsImpl.class);

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutput.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutput.java
@@ -41,4 +41,8 @@ public class CompileOutput extends JavaScriptObject
    public native final String getOutput() /*-{
       return this.output;
    }-*/;
+   
+   public native final void appendOutput(String output) /*-{
+      this.output += output;
+   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBuffer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBuffer.java
@@ -81,6 +81,11 @@ public class CompileOutputBuffer extends Composite
       output_.setText("");
       virtualConsole_ = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(output_.getElement());
    }
+   
+   @Override
+   public void onCompileCompleted()
+   {
+   }
  
    private PreWidget output_;
    private VirtualConsole virtualConsole_;

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
@@ -153,7 +153,7 @@ public class CompileOutputBufferWithHighlight extends Composite
    PanelState state_ = PanelState.OK;
    private int numDisplayedLines_;
    private int totalSubmittedLines_;
-   private String savedOutput_;
+   private String savedOutput_ = "";
    private BottomScrollPanel scrollPanel_;
    private ConsoleResources.ConsoleStyles styles_;
    

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputDisplay.java
@@ -26,6 +26,8 @@ public interface CompileOutputDisplay
    public void writeOutput(String output);
    public void writeError(String error);
    
+   public void onCompileCompleted();
+   
    public void clear();
    public void scrollToBottom();
    

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
@@ -186,6 +186,7 @@ public class CompilePanel extends Composite
    public void compileCompleted()
    {
       stopButton_.setVisible(false);
+      outputDisplay_.onCompileCompleted();
 
       if (isErrorPanelShowing())
          errorList_.focus();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -1144,6 +1144,5 @@ public class ClientEventDispatcher
    private final ArrayList<ClientEvent> pendingEvents_ = new ArrayList<>();
 
    private static final int MAX_EVENTS_AT_ONCE = 200;
-   private static final int MAX_COALESCED_CONSOLE_OUTPUT_EVENTS = 100;
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -233,7 +233,6 @@ public class ClientEventDispatcher
          {
             public boolean execute()
             {
-               final int MAX_EVENTS_AT_ONCE = 200;
                for (int i = 0;
                     i < MAX_EVENTS_AT_ONCE && pendingEvents_.size() > 0;
                     i++)
@@ -258,7 +257,8 @@ public class ClientEventDispatcher
       {
          ConsoleText output = event.getData();
          
-         for (int i = 0, n = Math.min(100, pendingEvents_.size()); i < n; i++)
+         int n = Math.min(pendingEvents_.size(), MAX_COALESCED_CONSOLE_OUTPUT_EVENTS);
+         for (int i = 0; i < n; i++)
          {
             ClientEvent peekedEvent = pendingEvents_.get(0);
             if (peekedEvent.getType() != ClientEvent.ConsoleOutput)
@@ -273,7 +273,8 @@ public class ClientEventDispatcher
       {
          ConsoleText output = event.getData();
          
-         for (int i = 0, n = Math.min(100, pendingEvents_.size()); i < n; i++)
+         int n = Math.min(pendingEvents_.size(), MAX_COALESCED_CONSOLE_OUTPUT_EVENTS);
+         for (int i = 0; i < n; i++)
          {
             ClientEvent peekedEvent = pendingEvents_.get(0);
             if (peekedEvent.getType() != ClientEvent.ConsoleError)
@@ -1185,5 +1186,7 @@ public class ClientEventDispatcher
 
    private final ArrayList<ClientEvent> pendingEvents_ = new ArrayList<>();
 
+   private static final int MAX_EVENTS_AT_ONCE = 200;
+   private static final int MAX_COALESCED_CONSOLE_OUTPUT_EVENTS = 100;
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -237,56 +237,13 @@ public class ClientEventDispatcher
                     i < MAX_EVENTS_AT_ONCE && pendingEvents_.size() > 0;
                     i++)
                {
-                  ClientEvent currentEvent = collectPendingEvent();
+                  ClientEvent currentEvent = pendingEvents_.remove(0);
                   dispatchEvent(currentEvent);
                }
                return pendingEvents_.size() > 0;
             }
          });
       }
-   }
-   
-   private ClientEvent collectPendingEvent()
-   {
-      // Get the next event.
-      ClientEvent event = pendingEvents_.remove(0);
-      
-      // If we have multiple console output events of the same type,
-      // coalesce them together to avoid flooding the console with events.
-      if (event.getType() == ClientEvent.ConsoleOutput)
-      {
-         ConsoleText output = event.getData();
-         
-         int n = Math.min(pendingEvents_.size(), MAX_COALESCED_CONSOLE_OUTPUT_EVENTS);
-         for (int i = 0; i < n; i++)
-         {
-            ClientEvent peekedEvent = pendingEvents_.get(0);
-            if (peekedEvent.getType() != ClientEvent.ConsoleOutput)
-               break;
-            
-            ConsoleText peekedOutput = peekedEvent.getData();
-            pendingEvents_.remove(0);
-            output.text = output.text + peekedOutput.text;
-         }
-      }
-      else if (event.getType() == ClientEvent.ConsoleError)
-      {
-         ConsoleText output = event.getData();
-         
-         int n = Math.min(pendingEvents_.size(), MAX_COALESCED_CONSOLE_OUTPUT_EVENTS);
-         for (int i = 0; i < n; i++)
-         {
-            ClientEvent peekedEvent = pendingEvents_.get(0);
-            if (peekedEvent.getType() != ClientEvent.ConsoleError)
-               break;
-            
-            ConsoleText peekedOutput = peekedEvent.getData();
-            pendingEvents_.remove(0);
-            output.text = output.text + peekedOutput.text;
-         }
-      }
-      
-      return event;
    }
    
    private void dispatchEvent(ClientEvent event) 

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/ClientEventDispatcher.java
@@ -258,7 +258,7 @@ public class ClientEventDispatcher
       {
          ConsoleText output = event.getData();
          
-         for (int i = 0, n = Math.max(20, pendingEvents_.size()); i < n; i++)
+         for (int i = 0, n = Math.min(100, pendingEvents_.size()); i < n; i++)
          {
             ClientEvent peekedEvent = pendingEvents_.get(0);
             if (peekedEvent.getType() != ClientEvent.ConsoleOutput)
@@ -273,7 +273,7 @@ public class ClientEventDispatcher
       {
          ConsoleText output = event.getData();
          
-         for (int i = 0, n = Math.max(200, pendingEvents_.size()); i < n; i++)
+         for (int i = 0, n = Math.min(100, pendingEvents_.size()); i < n; i++)
          {
             ClientEvent peekedEvent = pendingEvents_.get(0);
             if (peekedEvent.getType() != ClientEvent.ConsoleError)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -29,6 +29,7 @@ import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.FilePosition;
+import org.rstudio.core.client.JsVector;
 import org.rstudio.core.client.events.HasSelectionCommitHandlers;
 import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.files.FileSystemItem;
@@ -278,8 +279,11 @@ public class BuildPresenter extends BasePresenter
    {
       view_.buildStarted();
 
-      JsArray<CompileOutput> outputs = buildState.getOutputs();
-      for (int i = 0; i<outputs.length(); i++)
+      JsVector<CompileOutput> outputs = buildState.getOutputs().cast();
+      if (outputs.length() > 1000)
+         outputs = outputs.slice(outputs.length() - 1000);
+      
+      for (int i = 0; i < outputs.length(); i++)
          view_.showOutput(outputs.get(i), false);
 
       if (buildState.getErrors().length() > 0)


### PR DESCRIPTION
### Intent

Part of https://github.com/rstudio/rstudio/issues/12059.

### Approach

This PR bundles a number of changes that should improve the responsiveness of both the Console pane and the Build pane, in the cases where we're receiving a very large amount of text.

1. We now bundle output on `stderr` in the same way we bundle `stdout`. This is necessary as R users may produce output on `stderr` via the `message()` function, so it can become overloaded in the same way that `stdout` might.

2. We also now truncate output shown in the Build pane. This is especially important for projects that compile C / C++ code, as the Build pane can become overwhelmed by warning output from the compiler.

Just to drive the second point home, this is what I see if I compile the `rstan` package with `-Weverything`:

```
kevin@MBP-P2MQ:~/r/pkg/rstan/rstan/rstan [develop]
$ R CMD INSTALL --preclean . &> output.log
$ ll output.log
-rw-r--r--  1 kevin  staff    70M Oct  3 11:33 output.log
```

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12059.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
