### PR TITLE
Check editor existence before setting scroll

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorMonitor.java
@@ -54,7 +54,7 @@ public class AceEditorMonitor
       int scrollMultiplier = prefs.editorScrollMultiplier().getValue().intValue();
       // calculate speed ratio, lower scroll speed = higher ratio = faster scroll
       double ratio = WindowEx.get().getDevicePixelRatio() * (100.0 / scrollMultiplier);
-      if (devicePixelRatio_ != ratio)
+      if (devicePixelRatio_ != ratio && editor_ != null)
       {
          devicePixelRatio_ = ratio;
          editor_.setScrollSpeed(ACE_EDITOR_DEFAULT_SCROLL_SPEED / ratio);


### PR DESCRIPTION
### Intent
Fix for set scroll speed errors

### Approach
Check if `editor_` is null before trying to set the scroll speed. I'm not sure how to get into this state since the UI is single-threaded. The `endMonitoring()` call would completely execute before the UI thread can run the `monitor()` code and vice versa.

### Automated Tests
None

### QA Notes
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


