### PR TITLE
`file://` hyperlinks can handle `#123` and `#123:4` fragments

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/FileHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/FileHyperlink.java
@@ -22,6 +22,8 @@ import com.google.gwt.core.client.Scheduler;
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.ResultCallback;
 import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
 import org.rstudio.studio.client.server.ServerError;
@@ -34,25 +36,34 @@ public class FileHyperlink extends Hyperlink
     public FileHyperlink(String url, Map<String, String> params, String text, String clazz)
     {
         super(url, params, text, clazz);
-
-        if (url.matches("^file:///[a-zA-Z]:"))
-        {
-            filename = url.replaceFirst("^file:///", "");
-        }
-        else
-        {
-            filename = url.replaceFirst("file://", "");
-        }
-        
         line = -1;
         col = -1;
 
-        if (params.containsKey("line"))
-            line = StringUtil.parseInt(params.get("line"), -1);
-        
-        if (params.containsKey("col"))
-            col = StringUtil.parseInt(params.get("col"), -1);    
+        Match match = POSITION_FRAGMENT_PATTERN.match(url, 0);
+        if (match != null)
+        {
+            url = url.replaceFirst("#.*$", "");
+            
+            line = StringUtil.parseInt(match.getGroup(1), -1);
 
+            String second = match.getGroup(2);
+            if (second != null)
+                col = StringUtil.parseInt(match.getGroup(2).substring(1), -1);
+        }
+        else 
+        {
+            if (params.containsKey("line"))
+                line = StringUtil.parseInt(params.get("line"), -1);
+        
+            if (params.containsKey("col"))
+                col = StringUtil.parseInt(params.get("col"), -1);    
+        }
+
+        if (url.matches("^file:///[a-zA-Z]:"))
+            filename = url.replaceFirst("file:///", "");
+        else
+            filename = url.replaceFirst("file://", "");
+        
         server_ = RStudioGinjector.INSTANCE.getServer();
     }
 
@@ -66,24 +77,7 @@ public class FileHyperlink extends Hyperlink
             {
                 if (response.length() > 0)
                 {
-                    final SourceColumnManager columnManager = RStudioGinjector.INSTANCE.getSourceColumnManager(); 
-        
-                    columnManager.editFile(response, new ResultCallback<EditingTarget, ServerError>()
-                    {
-                        @Override
-                        public void onSuccess(final EditingTarget result)
-                        {
-                            if (line != -1) 
-                            {
-                                // give ace time to render before scrolling to position
-                                Scheduler.get().scheduleDeferred(() ->
-                                {
-                                    FilePosition position = FilePosition.create(line, Math.max(col, 1));
-                                    columnManager.scrollToPosition(position, true, () -> {});
-                                });
-                            }
-                        }
-                    });
+                    navigateToAliased(response);
                 }
                 else 
                 {
@@ -91,6 +85,28 @@ public class FileHyperlink extends Hyperlink
                         constants_.noSuchFile(),
                         constants_.doesNotExist(filename)
                         );
+                }
+            }
+        });
+    }
+
+    private void navigateToAliased(String file) 
+    {
+        final SourceColumnManager columnManager = RStudioGinjector.INSTANCE.getSourceColumnManager(); 
+        
+        columnManager.editFile(file, new ResultCallback<EditingTarget, ServerError>()
+        {
+            @Override
+            public void onSuccess(final EditingTarget result)
+            {
+                if (line != -1) 
+                {
+                    // give ace time to render before scrolling to position
+                    Scheduler.get().scheduleDeferred(() ->
+                    {
+                        FilePosition position = FilePosition.create(line, Math.max(col, 1));
+                        columnManager.scrollToPosition(position, true, () -> {});
+                    });
                 }
             }
         });
@@ -104,6 +120,8 @@ public class FileHyperlink extends Hyperlink
     private String filename;
     private int line;
     private int col;
+
+    public static final Pattern POSITION_FRAGMENT_PATTERN = Pattern.create("#([0-9]+)(:[0-9]+)?$");
 
     private SourceServerOperations server_;
     private static final HyperlinkConstants constants_ = GWT.create(HyperlinkConstants.class);

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
@@ -74,7 +74,7 @@ public abstract class Hyperlink implements HelpPageShower
                 // cancel previous timer
                 timer_.cancel();
 
-                // the link was just hovered: settting cancelPopup_ to false
+                // the link was just hovered: setting cancelPopup_ to false
                 // to signal that the popup should be shown
                 cancelPopup_ = false;
 


### PR DESCRIPTION
### Intent

addresses #12086 

### Approach

regex fu, when the url has fragment, this takes priority over the `[params]` 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


