### PR TITLE
`x-r-help:`, `x-r-run:`, and `x-r-vignette:` schemes

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/HelpHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/HelpHyperlink.java
@@ -30,7 +30,7 @@ public class HelpHyperlink extends Hyperlink
     public HelpHyperlink(String url, Map<String, String> params, String text, String clazz) 
     {
         super(url, params, text, clazz);
-        if (url.startsWith("ide:help:") || url.startsWith("rstudio:help:"))
+        if (url.startsWith("x-r-help:") || url.startsWith("ide:help:") || url.startsWith("rstudio:help:"))
         {
             String suffix = url.replaceFirst("^.*help:", "");
             String[] splat = suffix.split("::");
@@ -64,10 +64,10 @@ public class HelpHyperlink extends Hyperlink
 
     public static boolean handles(String url, Map<String, String> params)
     {
-        if (StringUtil.equals(url, "ide:help") || StringUtil.equals(url, "rstudio:help"))
+        if (StringUtil.isOneOf(url, "x-r-help", "ide:help", "rstudio:help"))
             return params.containsKey("topic") && params.containsKey("package");
         
-        return url.matches("^(ide|rstudio):help:([\\w.]+)::([\\w.-]+)$");
+        return url.matches("^(x-r-|ide:|rstudio:)help:([\\w.]+)::([\\w.-]+)$");
     }
 
     private String topic_;

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -39,7 +39,7 @@ public class RunHyperlink extends Hyperlink
         Match match = HYPERLINK_PATTERN.match(url, 0);
         package_ = match.getGroup(2);
         fun_ = match.getGroup(3);
-        code_ = url.replaceFirst("^(ide|rstudio):run:", "");
+        code_ = url.replaceFirst("^(x-r-|ide:|rstudio:)run:", "");
         
         server_ = RStudioGinjector.INSTANCE.getServer();
     }
@@ -94,5 +94,5 @@ public class RunHyperlink extends Hyperlink
     private Server server_;
 
     // allow code of the form pkg::fn(<args>) where args does not have ;()
-    private static final Pattern HYPERLINK_PATTERN = Pattern.create("^(rstudio|ide):run:(\\w+)::(\\w+)[(][^();]*[)]$", "");
+    private static final Pattern HYPERLINK_PATTERN = Pattern.create("^(x-r-|rstudio:|ide:)run:(\\w+)::(\\w+)[(][^();]*[)]$", "");
 }

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -77,7 +77,7 @@ public class RunHyperlink extends Hyperlink
             return false;
 
         String pkg = match.getGroup(2);
-        if (StringUtil.equals(pkg, "base") || StringUtil.equals(pkg, "utils") || StringUtil.equals(pkg, "stats"))
+        if (StringUtil.isOneOf(pkg, "base", "utils", "stats"))
             return false;
         
         return true;

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -83,7 +83,8 @@ public class RunHyperlink extends Hyperlink
         return true;
     }
 
-    public void showHelp(){
+    public void showHelp()
+    {
         server_.showHelpTopic(fun_, package_, RCompletionType.FUNCTION);
     }
 

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/VignetteHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/VignetteHyperlink.java
@@ -120,7 +120,7 @@ public class VignetteHyperlink extends Hyperlink
         if (StringUtil.isOneOf(url, "x-r-vignette", "ide:vignette", "rstudio:vignette"))
             return params.containsKey("topic") && params.containsKey("package");
         
-        return url.matches("^(x-r-vignette|ide:|rstudio:)vignette:(\\w+)::([\\w-]+)$");
+        return url.matches("^(x-r-|ide:|rstudio:)vignette:(\\w+)::([\\w-]+)$");
     }
     
     private String topic_;

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/VignetteHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/VignetteHyperlink.java
@@ -113,16 +113,14 @@ public class VignetteHyperlink extends Hyperlink
 
             }
         });
-
-        
     }
 
     public static boolean handles(String url, Map<String, String> params)
     {
-        if (StringUtil.equals(url, "ide:vignette") || StringUtil.equals(url, "rstudio:vignette"))
+        if (StringUtil.isOneOf(url, "x-r-vignette", "ide:vignette", "rstudio:vignette"))
             return params.containsKey("topic") && params.containsKey("package");
         
-        return url.matches("^(ide|rstudio):vignette:(\\w+)::([\\w-]+)$");
+        return url.matches("^(x-r-vignette|ide:|rstudio:)vignette:(\\w+)::([\\w-]+)$");
     }
     
     private String topic_;


### PR DESCRIPTION
### Intent

addresses #12084 

### Approach

Allow the `x-r-*` prefixes in addition to `ide:*` and `rstudio:*`. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


