### PR TITLE
handle grep results without `./` prefix

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -990,12 +990,12 @@ private:
             std::string file = module_context::createAliasedPath(FilePath(match[1]));
 
             // replace the leading './' with the directory name
-            // (git grep doesn't prepend a '.' so we need to be careful here)
+            // (git grep and GNU grep might not prepend a './' by default)
             if (boost::algorithm::starts_with(file, "./"))
             {
                file = workingDir_ + file.substr(1);
             }
-            else if (findResults().gitFlag())
+            else
             {
                file = workingDir_ + "/" + file;
             }

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -986,10 +986,11 @@ private:
          boost::regex pattern = getGrepOutputRegex(findResults().gitFlag());
          if (regex_utils::match(line, match, pattern) && match.size() > 1)
          {
-            
             // build the file path -- note that 'grep' results may or may not include
-            // a leading './', so we need to be careful to handle both forms of output
-            std::string file = ([&]{
+            // a leading './', so we need to be careful to handle both forms of output.
+            //
+            // use a helper lambda just to make control flow a bit easier to manage
+            auto resolveFile = [&] {
                
                // check for absolute paths
                std::string file = match[1];
@@ -1003,9 +1004,10 @@ private:
                // all else fails, assume we need to prepend the working directory
                return module_context::createAliasedPath(FilePath(workingDir_)) + "/" + file;
                
-            })();
+            };
 
             // normal skip heuristics
+            std::string file = resolveFile();
             if (shouldSkipFile(file))
                continue;
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12082.

### Approach

Explicitly handle absolute vs. `./`-prefixed vs. relative paths from grep.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12082.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
