### PR TITLE
alter systemd configuration to avoid KillMode=none

### DIFF
--- a/src/cpp/server/extras/admin/rstudio-server.in
+++ b/src/cpp/server/extras/admin/rstudio-server.in
@@ -39,15 +39,11 @@ case "$1" in
 
     stop)
         daemonCmd "stop"
-        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     restart)
         testConfig || exit $?
         daemonCmd "restart"
-        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     test-config)
@@ -116,8 +112,6 @@ case "$1" in
         mkdir -p /var/lib/rstudio-server
         touch /var/lib/rstudio-server/offline
         daemonCmd "restart"
-        if (pidof rsession >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rsession; fi
-        if (pidof rworkspaces >/dev/null); then killall -s USR2 $2 $3 $4 $5 $6 $7 $8 $9 rworkspaces; fi
         ;;
 
     online)

--- a/src/cpp/server/extras/admin/rstudio-server.mac.in
+++ b/src/cpp/server/extras/admin/rstudio-server.mac.in
@@ -26,16 +26,12 @@ case "$1" in
 
     stop)
         launchctl stop com.rstudio.launchd.rserver
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     restart)
         testConfig || exit $?
         launchctl stop com.rstudio.launchd.rserver
         launchctl start com.rstudio.launchd.rserver
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     test-config)
@@ -102,8 +98,6 @@ case "$1" in
         touch /var/lib/rstudio-server/offline
         launchctl stop com.rstudio.launchd.rserver
         launchctl start com.rstudio.launchd.rserver
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rsession 2>/dev/null
-        killall -USR2 $2 $3 $4 $5 $6 $7 $8 $9  rworkspaces 2>/dev/null
         ;;
 
     online)

--- a/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
@@ -8,7 +8,6 @@ Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
 ExecStop=/usr/bin/killall -TERM rserver
-KillMode=none
 Restart=on-failure
 
 [Install]

--- a/src/cpp/server/extras/systemd/rstudio-server.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.service.in
@@ -8,7 +8,6 @@ Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
 ExecStop=/usr/bin/killall -TERM rserver
-KillMode=none
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Intent

Now that we have #12074 , we can relax our `KillMode=none` restriction and the extra `killall USR2` that we send to `rsession` and `rworkspaces`, trusting that they will get cleaned up properly by the process tree / supervisor.

Aside: `KillMode=none` is expressly discouraged in [the systemd docs](https://www.freedesktop.org/software/systemd/man/systemd.kill.html)

> If set to none, no process is killed (strongly recommended against!). In this case, only the stop command will be executed on unit stop, but no process will be killed otherwise. Processes remaining alive after stop are left in their control group and the control group continues to exist after stop unless empty.

Another note from `launchctl` docs at launchd.info:

> Stopping a job will send the signal SIGTERM to the process.

### Approach

- Remove `USR2` kill commands
- remove `KillMode=none` config in systemd unit files
- disregard other init mechanisms, since they are mostly artifacts of older systems we no longer support at this point (i.e. Xenial)

### Automated Tests

N/A

### QA Notes

Install on various systems, start homepage and session processes, stop/restart/offline the service and ensure:
- sessions / rworkspaces processes are stopped and cleaned up
- no "orphans" (process children of pid 1 that should not be - i.e. `rsession` and `rworkspaces`)
- starting sessions after being suspended in this way do not yell / error about an "unclean shutdown" and potentially lost files / etc.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


