### PR TITLE
completions after `::` or `:::` may need to be backticked

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1026,7 +1026,8 @@ assign(x = ".rs.acCompletionTypes",
          packages = string,
          quote = FALSE,
          type = type,
-         excludeOtherCompletions = TRUE
+         excludeOtherCompletions = TRUE, 
+         context = if (exportsOnly) .rs.acContextTypes$NAMESPACE_EXPORTED else .rs.acContextTypes$NAMESPACE_ALL
       )
    }
    
@@ -1450,7 +1451,8 @@ assign(x = ".rs.acCompletionTypes",
          quote = FALSE,
          type = type,
          excludeOtherCompletions = TRUE,
-         helpHandler = helpHandler
+         helpHandler = helpHandler, 
+         context = if (isAt) .rs.acContextTypes$AT else .rs.acContextTypes$DOLLAR
       )
    }
    

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1037,7 +1037,8 @@ assign(x = ".rs.acCompletionTypes",
                                              excludeOtherCompletions = FALSE,
                                              overrideInsertParens = FALSE,
                                              orderStartsWithAlnumFirst = TRUE,
-                                             language = "R")
+                                             language = "R", 
+                                             context = .rs.acContextTypes$UNKNOWN)
 {
    .rs.makeCompletions(
       token = token,
@@ -1049,7 +1050,8 @@ assign(x = ".rs.acCompletionTypes",
       excludeOtherCompletions = .rs.scalar(excludeOtherCompletions),
       overrideInsertParens = .rs.scalar(overrideInsertParens),
       orderStartsWithAlnumFirst = .rs.scalar(orderStartsWithAlnumFirst),
-      language = .rs.scalar(language)
+      language = .rs.scalar(language), 
+      context = context
    )
 })
 
@@ -1100,7 +1102,8 @@ assign(x = ".rs.acCompletionTypes",
                                             orderStartsWithAlnumFirst = TRUE,
                                             cacheable = TRUE,
                                             helpHandler = NULL,
-                                            language = "R")
+                                            language = "R", 
+                                            context = .rs.acContextTypes$UNKNOWN)
 {
    if (is.null(results))
       results <- character()
@@ -1156,7 +1159,8 @@ assign(x = ".rs.acCompletionTypes",
         overrideInsertParens = .rs.scalar(overrideInsertParens),
         cacheable = .rs.scalar(cacheable),
         helpHandler = .rs.scalar(helpHandler),
-        language = .rs.scalar(language))
+        language = .rs.scalar(language), 
+        context = context)
 })
 
 .rs.addFunction("subsetCompletions", function(completions, indices)
@@ -2006,7 +2010,7 @@ assign(x = ".rs.acCompletionTypes",
                        type = .rs.acCompletionTypes$STRING)
 })
 
-.rs.addFunction("readlineCompletions", function(token) 
+.rs.addFunction("readlineCompletions", function(token, context = .rs.acContextTypes$UNKNOWN) 
 {
    nframes <- sys.nframe()
    for (i in seq_len(nframes)) {
@@ -2028,11 +2032,12 @@ assign(x = ".rs.acCompletionTypes",
             return(.rs.makeCompletions(token = token,
                                        results = results,
                                        quote = FALSE,
-                                       type = .rs.acCompletionTypes$STRING))
+                                       type = .rs.acCompletionTypes$STRING, 
+                                       context = context))
          }
          else 
          {
-            return(.rs.emptyCompletions(excludeOtherCompletions = TRUE))
+            return(.rs.emptyCompletions(excludeOtherCompletions = TRUE, context = context))
          }
       }  
    }
@@ -2065,7 +2070,7 @@ assign(x = ".rs.acCompletionTypes",
    
    # if base::readline() is on the stack, try to extract choices i.e. (yes/no)
    # and offer those as completions.
-   readLineCompletions <- .rs.readlineCompletions()
+   readLineCompletions <- .rs.readlineCompletions(token, context)
    if (!is.null(readLineCompletions))
       return(readLineCompletions)
 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2006,33 +2006,8 @@ assign(x = ".rs.acCompletionTypes",
                        type = .rs.acCompletionTypes$STRING)
 })
 
-.rs.addJsonRpcHandler("get_completions", function(token,
-                                                  string,
-                                                  context,
-                                                  numCommas,
-                                                  functionCallString,
-                                                  chainObjectName,
-                                                  additionalArgs,
-                                                  excludeArgs,
-                                                  excludeArgsFromObject,
-                                                  filePath,
-                                                  documentId,
-                                                  line,
-                                                  isConsole)
+.rs.addFunction("readlineCompletions", function(token) 
 {
-   # Ensure UTF-8 encoding, as that's the encoding set when passed down from
-   # the client
-   token <- .rs.setEncodingUnknownToUTF8(token)
-   string <- .rs.setEncodingUnknownToUTF8(string)
-   functionCallString <- .rs.setEncodingUnknownToUTF8(functionCallString)
-   chainObjectName <- .rs.setEncodingUnknownToUTF8(chainObjectName)
-   additionalArgs <- .rs.setEncodingUnknownToUTF8(additionalArgs)
-   excludeArgs <- .rs.setEncodingUnknownToUTF8(excludeArgs)
-   excludeArgsFromObject <- .rs.setEncodingUnknownToUTF8(excludeArgsFromObject)
-   filePath <- .rs.setEncodingUnknownToUTF8(filePath)
-   
-   # if base::readline() is on the stack, try to extract choices i.e. (yes/no)
-   # and offer those as completions.
    nframes <- sys.nframe()
    for (i in seq_len(nframes)) {
       fun <- sys.function(i)
@@ -2061,6 +2036,38 @@ assign(x = ".rs.acCompletionTypes",
          }
       }  
    }
+})
+
+.rs.addJsonRpcHandler("get_completions", function(token,
+                                                  string,
+                                                  context,
+                                                  numCommas,
+                                                  functionCallString,
+                                                  chainObjectName,
+                                                  additionalArgs,
+                                                  excludeArgs,
+                                                  excludeArgsFromObject,
+                                                  filePath,
+                                                  documentId,
+                                                  line,
+                                                  isConsole)
+{
+   # Ensure UTF-8 encoding, as that's the encoding set when passed down from
+   # the client
+   token <- .rs.setEncodingUnknownToUTF8(token)
+   string <- .rs.setEncodingUnknownToUTF8(string)
+   functionCallString <- .rs.setEncodingUnknownToUTF8(functionCallString)
+   chainObjectName <- .rs.setEncodingUnknownToUTF8(chainObjectName)
+   additionalArgs <- .rs.setEncodingUnknownToUTF8(additionalArgs)
+   excludeArgs <- .rs.setEncodingUnknownToUTF8(excludeArgs)
+   excludeArgsFromObject <- .rs.setEncodingUnknownToUTF8(excludeArgsFromObject)
+   filePath <- .rs.setEncodingUnknownToUTF8(filePath)
+   
+   # if base::readline() is on the stack, try to extract choices i.e. (yes/no)
+   # and offer those as completions.
+   readLineCompletions <- .rs.readlineCompletions()
+   if (!is.null(readLineCompletions))
+      return(readLineCompletions)
 
    # If the R console is requesting completions, but the Python REPL is
    # active, then delegate to that machinery.

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
@@ -35,7 +35,8 @@ public class Completions extends JavaScriptObject
                                                       boolean overrideInsertParens,
                                                       boolean cacheable,
                                                       String helpHandler,
-                                                      String language)
+                                                      String language, 
+                                                      JsArrayInteger context)
    /*-{
       return {
          token: [token],
@@ -44,6 +45,7 @@ public class Completions extends JavaScriptObject
          packages: packages,
          quote: quote,
          type: type,
+         context: context,
          suggestOnAccept: suggestOnAccept,
          replaceToEnd: replaceToEnd,
          meta: meta,
@@ -116,6 +118,10 @@ public class Completions extends JavaScriptObject
    
    public final native JsArrayString getMeta() /*-{
       return this.meta;
+   }-*/;
+
+   public final native JsArrayInteger getContext() /*-{
+      return this.context;
    }-*/;
 
    // provide suggestOnAccept if it isn't present (server completions will 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
@@ -93,6 +93,7 @@ public class CompletionCache
       JsArrayString packages    = original.getPackages();
       JsArrayBoolean quote      = original.getQuote();
       JsArrayInteger type       = original.getType();
+      JsArrayInteger context    = original.getContext();
       JsArrayBoolean suggestOnAccept = original.getSuggestOnAccept();
       JsArrayBoolean replaceToEnd = original.getReplaceToEnd();
       JsArrayString meta        = original.getMeta();
@@ -159,6 +160,7 @@ public class CompletionCache
       final JsVectorString packagesSorted    = JsVectorString.createVector().cast();
       final JsVectorBoolean quoteSorted      = JsVectorBoolean.createVector().cast();
       final JsVectorInteger typeSorted       = JsVectorInteger.createVector().cast();
+      final JsVectorInteger contextSorted    = JsVectorInteger.createVector().cast();
       final JsVectorBoolean suggestOnAcceptSorted = JsVectorBoolean.createVector().cast();
       final JsVectorBoolean replaceToEndSorted = JsVectorBoolean.createVector().cast();
       final JsVectorString metaSorted        = JsVectorString.createVector().cast();
@@ -171,6 +173,7 @@ public class CompletionCache
          packagesSorted.push(packagesNarrow.get(index));
          quoteSorted.push(quoteNarrow.get(index));
          typeSorted.push(typeNarrow.get(index));
+         contextSorted.push(context.get(index));
          suggestOnAcceptSorted.push(suggestOnAcceptNarrow.get(index));
          replaceToEndSorted.push(replaceToEndNarrow.get(index));
          metaSorted.push(metaNarrow.get(index));
@@ -192,7 +195,9 @@ public class CompletionCache
             original.getOverrideInsertParens(),
             original.isCacheable(),
             original.getHelpHandler(),
-            original.getLanguage());
+            original.getLanguage(), 
+            contextSorted.cast()
+            );
    }
    
    private final SafeMap<String, Completions> cache_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -755,7 +755,8 @@ public class CompletionRequester
                   false,
                   true,
                   null,
-                  null);
+                  null, 
+                  JsUtil.toJsArrayInteger(new ArrayList<>(result.completions.length())));
 
             // Unlike other completion types, Sweave completions are not
             // guaranteed to narrow the candidate list (in particular
@@ -842,6 +843,21 @@ public class CompletionRequester
                            String helpHandler,
                            String language)
       {
+         this(name, display, source, shouldQuote, type, suggestOnAccept, replaceToEnd, meta, helpHandler, language, RCompletionManager.AutocompletionContext.TYPE_UNKNOWN);
+      }
+
+      public QualifiedName(String name,
+                           String display,
+                           String source,
+                           boolean shouldQuote,
+                           int type,
+                           boolean suggestOnAccept,
+                           boolean replaceToEnd,
+                           String meta,
+                           String helpHandler,
+                           String language, 
+                           int context)
+      {
          this.name = name;
          this.display = display;
          this.source = source;
@@ -852,6 +868,7 @@ public class CompletionRequester
          this.meta = meta;
          this.helpHandler = helpHandler;
          this.language = language;
+         this.context = context;
       }
 
       public static QualifiedName createSnippet(String name)
@@ -1122,6 +1139,7 @@ public class CompletionRequester
       public final String source;
       public final boolean shouldQuote;
       public final int type;
+      public final int context;
       public final boolean suggestOnAccept;
       public final boolean replaceToEnd;
       public final String meta;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1944,8 +1944,7 @@ public class RCompletionManager implements CompletionManager
              type == RCompletionType.ARGUMENT ||
              type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT ||
-             type == RCompletionType.KEYWORD ||
-             type == RCompletionType.FUNCTION)
+             type == RCompletionType.KEYWORD)
          {
             return value;
          }
@@ -1959,12 +1958,32 @@ public class RCompletionManager implements CompletionManager
          if (isSpecialSource)
             return value;
          
-         // if this is already a syntactic identifier, no quote is required
-         if (RegexUtil.isSyntacticRIdentifier(value) && !isKeyword(value))
-            return value;
+         // quote if: 
+         // - keywords, but just in a ::, :::, $, or @ contexts
+         // - non syntactic
+         boolean quote = false;
+
+         int context = name.context;
+         if (isKeyword(value)) 
+         {
+            if (context == AutocompletionContext.TYPE_AT ||
+                context == AutocompletionContext.TYPE_DOLLAR ||
+                context == AutocompletionContext.TYPE_NAMESPACE_EXPORTED ||
+                context == AutocompletionContext.TYPE_NAMESPACE_ALL)
+            {
+               quote = true;
+            }
+         }
+         else if (!RegexUtil.isSyntacticRIdentifier(value))
+         {
+            quote = true;
+         }
          
-         // otherwise, quote
-         return "`" + value.replaceAll("`", "\\`") + "`";
+         // if this is already a syntactic identifier, no quote is required
+         if (quote)
+            return "`" + value.replaceAll("`", "\\`") + "`";
+         
+         return value;
       }
 
       private boolean isKeyword(String value)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1936,6 +1936,7 @@ public class RCompletionManager implements CompletionManager
       private String quoteIfNotSyntacticNameCompletion(QualifiedName name)
       {
          String value = name.name;
+         
          // we don't quote for certain completion types
          int type = name.type;
          if (type == RCompletionType.ROXYGEN ||
@@ -1943,7 +1944,8 @@ public class RCompletionManager implements CompletionManager
              type == RCompletionType.ARGUMENT ||
              type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT ||
-             type == RCompletionType.KEYWORD)
+             type == RCompletionType.KEYWORD ||
+             type == RCompletionType.FUNCTION)
          {
             return value;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1936,7 +1936,6 @@ public class RCompletionManager implements CompletionManager
       private String quoteIfNotSyntacticNameCompletion(QualifiedName name)
       {
          String value = name.name;
-         
          // we don't quote for certain completion types
          int type = name.type;
          if (type == RCompletionType.ROXYGEN ||
@@ -1944,8 +1943,7 @@ public class RCompletionManager implements CompletionManager
              type == RCompletionType.ARGUMENT ||
              type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT ||
-             type == RCompletionType.KEYWORD ||
-             type == RCompletionType.FUNCTION)
+             type == RCompletionType.KEYWORD)
          {
             return value;
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -919,7 +919,7 @@ public class RCompletionManager implements CompletionManager
    // 2. The associated function call (if any -- for arguments),
    // 3. The associated data for a `[` call (if any -- completions from data object),
    // 4. The associated data for a `[[` call (if any -- completions from data object)
-   class AutocompletionContext {
+   public class AutocompletionContext {
       
       // Be sure to sync these with 'SessionRCompletions.R'!
       public static final int TYPE_UNKNOWN = 0;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
@@ -140,7 +140,8 @@ public class YamlCompletionManager extends CompletionManagerBase
                true,
                true,
                null,
-               null);         
+               null, 
+               JsUtil.toJsArrayInteger(new ArrayList<>(values.size())));         
          response.setCacheable(cacheable);
          context.onResponseReceived(response); 
       });


### PR DESCRIPTION
### Intent

addresses #12091 

### Approach

send back the completion context (from `.rs.acContextTypes` as part of the completion result, to eventually make the `QualifiedName` object. 

Then update `quoteIfNotSyntacticNameCompletion()` so that it quotes non syntactic functions, and keywords (but only in `::`, `:::`, `$`, and `@` contexts. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

In addition to the example in #12091, we should also consider if there is a regression of https://github.com/rstudio/rstudio/issues/11503 and https://github.com/rstudio/rstudio/issues/11591

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


