### PR TITLE
Allow embedded youtube videos in Quarto preview

### DIFF
--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -143,8 +143,7 @@ export class MainWindow extends GwtWindow {
 
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
-      const url = new URL(details.url);
-      if (details.resourceType === 'subFrame' && !isLocalUrl(url)) {
+      if (details.resourceType === 'subFrame' && !this.allowNavigation(details.url)) {
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
         callback({ cancel: false, redirectURL: details.frame?.url });
       } else {


### PR DESCRIPTION
### Intent
Address #12106 

### Approach
Use `allowNavigation` check which also checks against the safe external URL list. This allows the video to embed without navigating to the video in the default browser.

### Automated Tests
None

### QA Notes
See the issue for reprex. Requires Quarto 1.2 which is now packaged with RStudio.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


