### PR TITLE
Make sure to propagate context in `QualifiedName` constructor

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -151,7 +151,8 @@ public abstract class CompletionManagerBase
                completions.getReplaceToEnd().get(i),
                completions.getMeta().get(i),
                completions.getHelpHandler(),
-               completions.getLanguage()));
+               completions.getLanguage(), 
+               completions.getContext().get(i)));
       }
       
       if (userPrefs_.enableSnippets().getValue())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -307,7 +307,9 @@ public class CompletionRequester
             replaceToEnd.get(i),
             meta.get(i), 
             response.getHelpHandler(), 
-            response.getLanguage())
+            response.getLanguage(),
+            response.getContext().get(i)
+            )
          );
       }
 
@@ -410,7 +412,8 @@ public class CompletionRequester
                      replaceToEnd.get(i),
                      meta.get(i), 
                      response.getHelpHandler(), 
-                     response.getLanguage()
+                     response.getLanguage(), 
+                     response.getContext().get(i)
                   ));
                }
             }
@@ -444,7 +447,8 @@ public class CompletionRequester
                      replaceToEnd.get(i),
                      meta.get(i), 
                      response.getHelpHandler(), 
-                     response.getLanguage()
+                     response.getLanguage(), 
+                     response.getContext().get(i)
                   ));
                }
             }
@@ -823,29 +827,15 @@ public class CompletionRequester
                            int type,
                            boolean suggestOnAccept)
       {
-         this(name, name, source, shouldQuote, type, suggestOnAccept, false, "", null, "R");
+         this(name, name, source, shouldQuote, type, suggestOnAccept, false, "", null, "R", RCompletionManager.AutocompletionContext.TYPE_UNKNOWN);
       }
 
       public QualifiedName(String name,
                            String source)
       {
-         this(name, name, source, false, RCompletionType.UNKNOWN, false, false, "", null, "R");
+         this(name, name, source, false, RCompletionType.UNKNOWN, false, false, "", null, "R", RCompletionManager.AutocompletionContext.TYPE_UNKNOWN);
       }
       
-      public QualifiedName(String name,
-                           String display,
-                           String source,
-                           boolean shouldQuote,
-                           int type,
-                           boolean suggestOnAccept,
-                           boolean replaceToEnd,
-                           String meta,
-                           String helpHandler,
-                           String language)
-      {
-         this(name, display, source, shouldQuote, type, suggestOnAccept, replaceToEnd, meta, helpHandler, language, RCompletionManager.AutocompletionContext.TYPE_UNKNOWN);
-      }
-
       public QualifiedName(String name,
                            String display,
                            String source,
@@ -883,7 +873,8 @@ public class CompletionRequester
                false,
                "",
                null,
-               "R");
+               "R", 
+               RCompletionManager.AutocompletionContext.TYPE_UNKNOWN);
       }
       
       public QualifiedName withSuggestOnAccept()
@@ -898,7 +889,8 @@ public class CompletionRequester
             this.replaceToEnd,
             this.meta,
             this.helpHandler,
-            this.language  
+            this.language, 
+            this.context
          );
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/StanCompletionManager.java
@@ -145,7 +145,9 @@ public class StanCompletionManager extends CompletionManagerBase
                false,
                "",
                null,
-               "Stan");
+               "Stan",
+               RCompletionManager.AutocompletionContext.TYPE_UNKNOWN
+               );
          
          discoveredIdentifiers.add(value);
          completions.add(name);


### PR DESCRIPTION
### Intent

addresses #11503 after regression caused by #12102

### Approach

Make sure the `context` is propagated to `QualifiedName` objects created from completion results. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


