### PR TITLE
Add no splash check

### DIFF
--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -133,8 +133,8 @@ export class SessionLauncher {
   sessionStdout: string[] = [];
   sessionStderr: string[] = [];
   private nextSessionUrl?: string;
-  private splash: BrowserWindow;
-  private showSplash = true;
+  private splash: BrowserWindow | undefined;
+  private showSplash = process.env.NODE_ENV !== 'TEST';
 
   constructor(
     private sessionPath: FilePath,
@@ -142,27 +142,32 @@ export class SessionLauncher {
     private filename: FilePath,
     private appLaunch: ApplicationLaunch,
   ) {
-    this.splash = new BrowserWindow({
-      width: 500,
-      height: 500,
-      frame: false,
-      transparent: true,
-      alwaysOnTop: true,
-      center: true,
-      resizable: false,
-      show: false,
-    });
+    const splashDelay = process.env.RS_SPLASH_DELAY ? parseInt(process.env.RS_SPLASH_DELAY) : 500;
+    if (process.env.RS_NO_SPLASH) {
+      this.showSplash = false;
+    }
 
-    this.splash.loadURL(SPLASH_WEBPACK_ENTRY).catch((err: unknown) => logger().logError(err));
-    const splashDelay = process.env.RS_SPLASH_DELAY ? parseInt(process.env.RS_SPLASH_DELAY) : 250;
-
-    setTimeoutPromise(splashDelay)
-      .then(() => {
-        if (this.showSplash) {
-          this.splash.show();
-        }
-      })
-      .catch((err) => logger().logError(err));
+    if (splashDelay > 0) {
+      setTimeoutPromise(splashDelay)
+        .then(() => {
+          if (this.showSplash) {
+            this.splash = new BrowserWindow({
+              width: 500,
+              height: 500,
+              frame: false,
+              transparent: true,
+              alwaysOnTop: true,
+              center: true,
+              resizable: false,
+              show: false,
+            });
+  
+            this.splash.loadURL(SPLASH_WEBPACK_ENTRY).catch((err: unknown) => logger().logError(err));
+            this.splash.show();
+          }
+        })
+        .catch((err) => logger().logError(err));
+    }
   }
 
   launchFirstSession(): void {
@@ -239,7 +244,7 @@ export class SessionLauncher {
         }
         this.showSplash = false;
         this.mainWindow?.window.show();
-        this.splash.close();
+        this.splash?.close();
       });
       appState().activation().setMainWindow(this.mainWindow.window);
       this.appLaunch.activateWindow();

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -147,7 +147,10 @@ export class SessionLauncher {
       this.showSplash = false;
     }
 
-    if (splashDelay > 0) {
+    // must check showSplash before and after the timeout
+    // before to determine if the timeout is required
+    // after to determine if the main window is ready to show
+    if (splashDelay > 0 && this.showSplash) {
       setTimeoutPromise(splashDelay)
         .then(() => {
           if (this.showSplash) {


### PR DESCRIPTION
### Intent
Address automation issue and unit test failure for #11604 

### Approach
Add a `RS_NO_SPLASH` environment variable check. If set to anything, the splash will not be created.

Only creates the window for the splash if the delay is greater than 0.

Also disables the splash if running unit tests.

### Automated Tests
None

### QA Notes
Setting `RS_NO_SPLASH` to any value will not create a splash at all. Hopefully this resolves running automation. @jonvanausdeln 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


