### PR TITLE
special case `x-r-run:library(<...>)` hyperlinks

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/Hyperlink.java
@@ -157,6 +157,10 @@ public abstract class Hyperlink implements HelpPageShower
         {
             return new VignetteHyperlink(url, params, text, clazz);
         }
+        else if (LibraryHyperlink.handles(url))
+        {
+            return new LibraryHyperlink(url, params, text, clazz);
+        }
         else if (RunHyperlink.handles(url))
         {
             return new RunHyperlink(url, params, text, clazz);

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/LibraryHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/LibraryHyperlink.java
@@ -38,7 +38,8 @@ public class LibraryHyperlink extends Hyperlink
     }
 
     @Override
-    public void onClick() {
+    public void onClick()
+    {
         events_.fireEvent(new SendToConsoleEvent("library(" + package_ + ")", true));
     }
 

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/LibraryHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/LibraryHyperlink.java
@@ -1,0 +1,66 @@
+/*
+ * LibraryHyperlink.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.core.client.hyperlink;
+
+import java.util.Map;
+
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.gwt.user.client.ui.Widget;
+
+import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+import org.rstudio.studio.client.RStudioGinjector;
+import org.rstudio.studio.client.application.events.EventBus;
+import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
+
+public class LibraryHyperlink extends Hyperlink 
+{
+
+    public LibraryHyperlink(String url, Map<String, String> params, String text, String clazz)
+    {
+        super(url, params, text, clazz);
+        
+        Match match = HYPERLINK_RUN_LIBRARY_PATTERN.match(url, 0);
+        package_ = match.getGroup(2);
+    }
+
+    @Override
+    public void onClick() {
+        events_.fireEvent(new SendToConsoleEvent("library(" + package_ + ")", true));
+    }
+
+    @Override
+    public void getPopupContent(CommandWithArg<Widget> onReady)
+    {
+        final VerticalPanel panel = new VerticalPanel();
+
+        panel.add(new RunHyperlinkPopupHeader("library(" + package_ + ")"));
+        panel.add(new HelpPreview(package_ + "-package", package_, () -> 
+        {
+            onReady.execute(panel);
+        }));
+    }
+    
+    public static boolean handles(String url)
+    {
+        return HYPERLINK_RUN_LIBRARY_PATTERN.test(url);
+    }
+
+    String package_;
+    private static final EventBus events_ = RStudioGinjector.INSTANCE.getEventBus();
+    
+    private static final Pattern HYPERLINK_RUN_LIBRARY_PATTERN = Pattern.create("^(x-r-|rstudio:|ide:)run:library[(]([\\w.]+)[)]$", "");
+}

--- a/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
+++ b/src/gwt/src/org/rstudio/core/client/hyperlink/RunHyperlink.java
@@ -36,7 +36,7 @@ public class RunHyperlink extends Hyperlink
     {
         super(url, params, text, clazz);
         
-        Match match = HYPERLINK_PATTERN.match(url, 0);
+        Match match = HYPERLINK_RUN_PATTERN.match(url, 0);
         package_ = match.getGroup(2);
         fun_ = match.getGroup(3);
         code_ = url.replaceFirst("^(x-r-|ide:|rstudio:)run:", "");
@@ -72,7 +72,7 @@ public class RunHyperlink extends Hyperlink
 
     public static boolean handles(String url)
     {
-        Match match = HYPERLINK_PATTERN.match(url, 0);
+        Match match = HYPERLINK_RUN_PATTERN.match(url, 0);
         if (match == null) 
             return false;
 
@@ -95,5 +95,5 @@ public class RunHyperlink extends Hyperlink
     private Server server_;
 
     // allow code of the form pkg::fn(<args>) where args does not have ;()
-    private static final Pattern HYPERLINK_PATTERN = Pattern.create("^(x-r-|rstudio:|ide:)run:(\\w+)::(\\w+)[(][^();]*[)]$", "");
+    private static final Pattern HYPERLINK_RUN_PATTERN = Pattern.create("^(x-r-|rstudio:|ide:)run:(\\w+)::(\\w+)[(][^();]*[)]$", "");
 }


### PR DESCRIPTION
### Intent

addresses #12114 

### Approach

Allowing the url pattern : `x-r-run:library(pkg)`. The popup then shows the `pkg-package` help rather than help about the `library()` function. 

![image](https://user-images.githubusercontent.com/2625526/194612010-e4977617-6c65-44d8-8535-2ef250c01cd7.png)

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

```r
cli::style_hyperlink("library(data.table)", "x-r-run:library(data.table)")
```

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


