### PR TITLE
Ensure setting urls are local

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -399,18 +399,38 @@ export class DesktopBrowserWindow extends EventEmitter {
   }
 
   setViewerUrl(viewerUrl: string): void {
+    const url = new URL(viewerUrl);
+    if (!isLocalUrl(url)) {
+      return;
+    }
+
     this.viewerUrl = getAuthority(viewerUrl);
   }
 
   setTutorialUrl(tutorialUrl: string): void {
+    const url = new URL(tutorialUrl);
+    if (!isLocalUrl(url)) {
+      return;
+    }
+
     this.tutorialUrl = getAuthority(tutorialUrl);
   }
 
   setPresentationUrl(presentationUrl: string): void {
+    const url = new URL(presentationUrl);
+    if (!isLocalUrl(url)) {
+      return;
+    }
+
     this.presentationUrl = getAuthority(presentationUrl);
   }
 
   setShinyDialogUrl(shinyDialogUrl: string): void {
+    const url = new URL(shinyDialogUrl);
+    if (!isLocalUrl(url)) {
+      return;
+    }
+
     this.shinyDialogUrl = getAuthority(shinyDialogUrl);
   }
 

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -102,5 +102,35 @@ if (!isWindowsDocker()) {
       win.setShinyDialogUrl(shinyDialogUrl);
       assert.isTrue(win.allowNavigation(shinyDialogUrl));
     });
+
+    it('isSafeHost detects unsafe host that looks safe', () => {
+      const win = new DesktopBrowserWindow({
+        name: '_blank',
+        skipLocaleDetection: true,
+        baseUrl: baseUrl,
+        allowExternalNavigate: false,
+      });
+
+      win.setViewerUrl('http://127.0.0.1:123');
+      const unsafeUrl = 'http://www.example.com/127.0.0.1:123';
+
+      assert.isFalse(win.allowNavigation(unsafeUrl));
+    });
+
+    it('set viewer URL checks for local URL', () => {
+      const win = new DesktopBrowserWindow({
+        name: '_blank',
+        skipLocaleDetection: true,
+        baseUrl:  baseUrl,
+        allowExternalNavigate: false,
+      });
+
+      const unsafeUrl = 'http://www.example.com';
+      win.setViewerUrl(unsafeUrl);
+      win.setTutorialUrl(unsafeUrl);
+      win.setPresentationUrl(unsafeUrl);
+      win.setShinyDialogUrl(unsafeUrl);
+      assert.isFalse(win.allowNavigation(unsafeUrl));
+    });
   });
 }


### PR DESCRIPTION
### Intent
Address security for #10719 

### Approach
I found this when reviewing the [Electron security guidelines](https://www.electronjs.org/docs/latest/tutorial/security). Most of it is preventing navigating to unintended URLs. We allow specific local URLs and some specific safe hosts. GWT has to set specific local URLs for some panes like viewer, presentation, and tutorial as well as Shiny.

Since Electron has to make available a way for GWT to set this in the main process, this is exposed in the renderer process through the preload scripts. This PR ensures setting these  URLs are local to prevent an attack through the preload. Without this, the IDE could be set to load an arbitrary URL. Normally, we anything disallowed in the IDE is opened externally.

### Automated Tests
Some unit tests to ensure `allowNavigation` returns false when attempting to set these specific URLs.

### QA Notes
Previewing in the panes should still work. If there is an attempt to load an external URL, it will open in the user's default browser.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


