### PR TITLE
use persisted client state for theme info

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - The fuzzy finder indexes C(++) macros. (#11981)
 - Improved handling for large amounts of `message()` output in the Console pane. (#12059)
 - Build output is now truncating when very large amounts of output are produced (e.g. from C++ compilation warnings).
+- Fixed an issue where code execution could pause in RStudio Server after closing the browser tab even with active computations. (Pro #3943)
   
 ### Python
 

--- a/src/cpp/r/include/r/session/RClientState.hpp
+++ b/src/cpp/r/include/r/session/RClientState.hpp
@@ -64,14 +64,17 @@ public:
                       const core::json::Value& value);
    
    void putPersistent(const core::json::Object& persistentState);
+   
+   core::json::Value getPersistent(const std::string& scope,
+                                   const std::string& name);
 
    void putProjectPersistent(const std::string& scope,
                              const std::string& name,
                              const core::json::Value& value);
 
    void putProjectPersistent(const core::json::Object& projectPersistentState);
-   core::json::Value getProjectPersistent(std::string scope,
-                                          std::string name);
+   core::json::Value getProjectPersistent(const std::string& scope,
+                                          const std::string& name);
 
    core::Error commit(ClientStateCommitType commitType,
                       const core::FilePath& stateDir,

--- a/src/cpp/r/session/RClientState.cpp
+++ b/src/cpp/r/session/RClientState.cpp
@@ -236,6 +236,24 @@ void ClientState::putPersistent(const json::Object& persistentState)
    mergeState(persistentState, &persistentState_);
 }
 
+json::Value ClientState::getPersistent(const std::string& scope,
+                                       const std::string& name)
+{
+   auto it = persistentState_.find(scope);
+   if (it == persistentState_.end())
+      return json::Value();
+ 
+   auto value = (*it).getValue();
+   if (!value.isObject())
+      return json::Value();
+   
+   auto scopeObject = value.getObject();
+   if (!scopeObject.hasMember(name))
+      return json::Value();
+   
+   return scopeObject[name].clone();
+}
+
 void ClientState::putProjectPersistent(const std::string& scope,
                                        const std::string& name,
                                        const json::Value& value)
@@ -245,8 +263,8 @@ void ClientState::putProjectPersistent(const std::string& scope,
    putProjectPersistent(stateContainer);
 }
 
-json::Value ClientState::getProjectPersistent(std::string scope,
-                                              std::string name)
+json::Value ClientState::getProjectPersistent(const std::string& scope,
+                                              const std::string& name)
 {
    json::Object::Iterator i = projectPersistentState_.find(scope);
    if (i == projectPersistentState_.end())

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -70,7 +70,7 @@ typedef std::map<std::string, std::tuple<std::string, std::string, bool>> ThemeM
 
 ThemeInfo getThemeInfo()
 {
-   ThemeInfo themeInfo { "#ffffff", "#000000" };
+   ThemeInfo themeInfo { "#000000", "#ffffff" };
    
    json::Value valueJson =
          r::session::clientState().getPersistent("themes", "themeInfo");

--- a/src/cpp/session/modules/SessionThemes.cpp
+++ b/src/cpp/session/modules/SessionThemes.cpp
@@ -15,6 +15,10 @@
 
 #include "SessionThemes.hpp"
 
+#include <fstream>
+#include <map>
+#include <string>
+
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 #include <boost/algorithm/string.hpp>
@@ -23,26 +27,22 @@
 #include <boost/bind/bind.hpp>
 
 #include <shared_core/Error.hpp>
-#include <core/Exec.hpp>
 #include <shared_core/FilePath.hpp>
-#include <core/json/JsonRpc.hpp>
 
+#include <core/Exec.hpp>
 #include <core/http/Request.hpp>
 #include <core/http/Response.hpp>
-
+#include <core/json/JsonRpc.hpp>
 #include <core/system/Xdg.hpp>
-
-#include <session/SessionModuleContext.hpp>
-#include <session/prefs/UserPrefs.hpp>
-#include <session/prefs/UserState.hpp>
 
 #include <r/RExec.hpp>
 #include <r/RRoutines.hpp>
 #include <r/RSexp.hpp>
+#include <r/session/RClientState.hpp>
 
-#include <fstream>
-#include <map>
-#include <string>
+#include <session/SessionModuleContext.hpp>
+#include <session/prefs/UserPrefs.hpp>
+#include <session/prefs/UserState.hpp>
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -54,9 +54,11 @@ namespace themes {
 
 namespace {
 
-bool s_deferredInitComplete = false;
-bool s_shuttingDown = false;
-module_context::WaitForMethodFunction s_waitForThemeColors;
+struct ThemeInfo
+{
+   std::string foreground;
+   std::string background;
+};
 
 const std::string kDefaultThemeLocation = "theme/default/";
 const std::string kGlobalCustomThemeLocation = "theme/custom/global/";
@@ -64,7 +66,26 @@ const std::string kLocalCustomThemeLocation = "theme/custom/local/";
 
 // A map from the name of the theme to the location of the file and a boolean representing
 // whether or not the theme is dark.
-typedef std::map<std::string, std::tuple<std::string, std::string, bool> > ThemeMap;
+typedef std::map<std::string, std::tuple<std::string, std::string, bool>> ThemeMap;
+
+ThemeInfo getThemeInfo()
+{
+   ThemeInfo themeInfo { "#ffffff", "#000000" };
+   
+   json::Value valueJson =
+         r::session::clientState().getPersistent("themes", "themeInfo");
+   
+   if (!valueJson.isObject())
+      return themeInfo;
+   
+   Error error = json::readObject(valueJson.getObject(),
+                                  "foreground", themeInfo.foreground,
+                                  "background", themeInfo.background);
+   if (error)
+      LOG_ERROR(error);
+   
+   return themeInfo;
+}
 
 /**
  * @brief Gets an error out of the object, if there is one, and updates pResponse.
@@ -359,40 +380,13 @@ SEXP rs_getThemes()
  */
 SEXP rs_getThemeColors()
 {
-   // Don't attempt to call the WaitForMethod unless the session has fully initialized.
-   if (!s_deferredInitComplete)
-      return R_NilValue;
-   
-   // Don't do anything if we're shutting down
-   if (s_shuttingDown)
-      return R_NilValue;
-
-   // Query the client for its current theme colors
-   json::JsonRpcRequest request;
-
-   if (!s_waitForThemeColors(&request, 
-            ClientEvent(client_events::kComputeThemeColors, json::Value())))
-   {
-      // Client did not return colors
-      r::exec::warning("Active theme colors not available.");
-      return R_NilValue;
-   }
-   
-   // Parse the theme colors returned by the client
-   std::string foreground, background;
-   Error error = json::readParams(request.params, &foreground, &background);
-   if (error)
-   {
-      // Client returned something we didn't understand
-      r::exec::warning("No theme colors could be determined: " + error.getSummary());
-      return R_NilValue;
-   }
+   ThemeInfo info = getThemeInfo();
 
    // Form the list and return to caller 
    r::sexp::Protect protect;
    r::sexp::ListBuilder themeColors(&protect);
-   themeColors.add("foreground", foreground);
-   themeColors.add("background", background);
+   themeColors.add("foreground", info.foreground);
+   themeColors.add("background", info.background);
    return r::sexp::create(themeColors, &protect);
 }
 
@@ -559,14 +553,10 @@ Error removeTheme(const json::JsonRpcRequest& request,
    return error;
 }
 
-void onDeferredInit(bool)
+Error setComputedThemeColors(const json::JsonRpcRequest& request,
+                             json::JsonRpcResponse* pResponse)
 {
-   s_deferredInitComplete = true;
-}
-
-void onShutdown(bool exitedGracefully)
-{
-   s_shuttingDown = true;
+   return Success();
 }
 
 void setCacheableFile(const FilePath& filePath,
@@ -710,16 +700,11 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
-   s_waitForThemeColors = registerWaitForMethod("set_computed_theme_colors");
-
    RS_REGISTER_CALL_METHOD(rs_getThemes);
    RS_REGISTER_CALL_METHOD(rs_getLocalThemeDir);
    RS_REGISTER_CALL_METHOD(rs_getGlobalThemeDir);
    RS_REGISTER_CALL_METHOD(rs_getThemeColors);
    RS_REGISTER_CALL_METHOD(rs_getLocalThemePath);
-
-   events().onDeferredInit.connect(onDeferredInit);
-   events().onShutdown.connect(onShutdown);
 
    // We need to register our URI handlers twice to cover the data viewer grid document because those
    // links have a different prefix.
@@ -732,6 +717,7 @@ Error initialize()
       (bind(registerRpcMethod, "get_themes", getThemes))
       (bind(registerRpcMethod, "add_theme", addTheme))
       (bind(registerRpcMethod, "remove_theme", removeTheme))
+      (bind(registerRpcMethod, "set_computed_theme_colors", setComputedThemeColors))
       (bind(registerUriHandler, "/" + kDefaultThemeLocation, handleDefaultThemeRequest))
       (bind(registerUriHandler, "/" + kGlobalCustomThemeLocation, handleGlobalCustomThemeRequest))
       (bind(registerUriHandler, "/" + kLocalCustomThemeLocation, handleLocalCustomThemeRequest))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ClientStateUpdater.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ClientStateUpdater.java
@@ -54,7 +54,10 @@ public class ClientStateUpdater extends TimeBufferedCommand
       events_ = events;
       server_ = server;
 
-      events_.addHandler(PushClientStateEvent.TYPE, pushClientStateEvent -> reschedule());
+      events_.addHandler(PushClientStateEvent.TYPE, (event) ->
+      {
+         reschedule(event.getActive());
+      });
 
       events_.addHandler(LastChanceSaveEvent.TYPE, lastChanceSaveEvent ->
       {
@@ -82,6 +85,18 @@ public class ClientStateUpdater extends TimeBufferedCommand
    public void resumeSendingUpdates()
    {
       pauseSendingUpdates_ = false;
+   }
+   
+   private void reschedule(boolean isActive)
+   {
+      if (isActive)
+      {
+         nudge();
+      }
+      else
+      {
+         reschedule();
+      }
    }
 
    @Override
@@ -151,9 +166,7 @@ public class ClientStateUpdater extends TimeBufferedCommand
 
    private static final int INITIAL_INTERVAL_MILLIS = 2000;
    private static final int PASSIVE_INTERVAL_MILLIS = 5000;
-   private static final int ACTIVE_INTERVAL_MILLIS = Desktop.isDesktop()
-                                                     ? 100
-                                                     : 350;
+   private static final int ACTIVE_INTERVAL_MILLIS = Desktop.isDesktop() ? 100 : 350;
    private final EventBus events_;
    private final WorkbenchServerOperations server_;
    private Token barrierToken_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/events/PushClientStateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/events/PushClientStateEvent.java
@@ -28,7 +28,20 @@ public class PushClientStateEvent extends GwtEvent<PushClientStateEvent.Handler>
 
    public PushClientStateEvent()
    {
+      active_ = false;
    }
+   
+   public PushClientStateEvent(boolean active)
+   {
+      active_ = active;
+   }
+   
+   public boolean getActive()
+   {
+      return active_;
+   }
+   
+   private final boolean active_;
 
    @Override
    protected void dispatch(Handler handler)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
@@ -84,7 +84,7 @@ public abstract class ClientStateValue<T> implements SaveClientStateEvent.Handle
    protected abstract void onInit(T value);
    protected abstract T getValue();
 
-   public final void onSaveClientState(SaveClientStateEvent event)
+   public void onSaveClientState(SaveClientStateEvent event)
    {
       try
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/ClientStateValue.java
@@ -84,7 +84,7 @@ public abstract class ClientStateValue<T> implements SaveClientStateEvent.Handle
    protected abstract void onInit(T value);
    protected abstract T getValue();
 
-   public void onSaveClientState(SaveClientStateEvent event)
+   public final void onSaveClientState(SaveClientStateEvent event)
    {
       try
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/JSObjectStateValue.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/helper/JSObjectStateValue.java
@@ -42,10 +42,10 @@ public abstract class JSObjectStateValue extends ClientStateValue<JsObject>
 
    @Override
    protected final void doSet(ClientState state,
-                        String group,
-                        String name,
-                        JsObject value,
-                        int persist)
+                              String group,
+                              String name,
+                              JsObject value,
+                              int persist)
    {
       state.putObject(group, name, value, persist);
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3943.

### Approach

Rather than use a WaitForMethod client event (which requires an actual client!), persist the theme information as client state on the session side in a way that's easily accessible to the session.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/3943.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
