### PR TITLE
use resolved path when passing to windows explorer event

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/Files.java
@@ -914,7 +914,9 @@ public class Files
    @Handler
    void onShowFolder()
    {
-      eventBus_.fireEvent(new ShowFolderEvent(currentPath_));
+      String path = server_.resolveAliasedPath(currentPath_);
+      FileSystemItem resolvedCurrentDir = FileSystemItem.createDir(path);
+      eventBus_.fireEvent(new ShowFolderEvent(resolvedCurrentDir));
    }
 
    public void onFileChange(FileChangeEvent event)


### PR DESCRIPTION
### Intent
Addresses #11888 on Windows.

### Approach
Use pre-existing resolveAliasedPath since path gets passed/used directly by Windows and not RStudio


### QA Notes

Follow instructions in issue. Now yields a new Windows Explorer window open to the current directory showing in the Files Pane.


### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


