### PR TITLE
Update Electron Windows installer with running instance check

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -270,6 +270,8 @@ set(CMAKE_MODULE_PATH "${ROOT_SRC_DIR}/cmake/modules/")
 # dependencies
 if(WIN32)
    set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies/windows")
+   set(CPACK_DEPENDENCIES_DIR "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}")
+   set(CPACK_NSPROCESS_VERSION "1.6")
 else()
    # look for system-wide (global) dependencies folder
    if(EXISTS "/opt/rstudio-tools/dependencies")

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 ### New
 
 * RStudio now displays a splash screen on startup, while the R session is being initialized. (#11604)
+* Updated RStudio Desktop installer on Windows to detect running RStudio by process name. (#10588)
 
 ### R
 

--- a/dependencies/windows/.gitignore
+++ b/dependencies/windows/.gitignore
@@ -3,6 +3,7 @@ boost*win*/
 boost-*
 gnudiff/
 gnugrep/
+nsprocess/
 msys_ssh/
 msys-ssh*/
 hunspell/

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -35,6 +35,9 @@ set OPENSSL_FILES=openssl-1.1.1i.zip
 set BOOST_FILES=boost-1.78.0-win-msvc142.zip
 set YAML_CPP_FILES=yaml-cpp-0.6.3.zip
 
+set NSIS_NSPROCESS_VERSION=1.6
+set NSIS_NSPROCESS_FILE=NsProcess.zip
+
 set PANDOC_VERSION=2.18
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
@@ -137,6 +140,14 @@ if not exist breakpad-tools-windows (
   echo Unzipping breakpad tools
   unzip %UNZIP_ARGS% breakpad-tools-windows.zip -d breakpad-tools-windows
   del breakpad-tools-windows.zip
+)
+
+if not exist "nsprocess/%NSIS_NSPROCESS_VERSION%" (
+  wget %WGET_ARGS% "%BASEURL%nsprocess/%NSIS_NSPROCESS_FILE%"
+  echo Unzipping NSIS NsProcess plugin
+  mkdir nsprocess\%NSIS_NSPROCESS_VERSION%
+  unzip %UNZIP_ARGS% "%NSIS_NSPROCESS_FILE%" -d nsprocess\1.6
+  del %NSIS_NSPROCESS_FILE%
 )
 
 pushd ..\common

--- a/package/win32/cmake/modules/NSIS.template.in.electron
+++ b/package/win32/cmake/modules/NSIS.template.in.electron
@@ -37,6 +37,13 @@
   InstallDir "$PROGRAMFILES64\@CPACK_PACKAGE_INSTALL_DIRECTORY@"
 
 ;--------------------------------
+;Include NsProcess to detect running RStudio instance
+
+  !addincludedir "@CPACK_DEPENDENCIES_DIR@/nsprocess/@CPACK_NSPROCESS_VERSION@/Include"
+  !addplugindir "@CPACK_DEPENDENCIES_DIR@/nsprocess/@CPACK_NSPROCESS_VERSION@/Plugin"
+  !include "nsProcess.nsh"
+
+;--------------------------------
 ;General
 
   ;Name and file
@@ -984,51 +991,12 @@ Function .onInit
 
   ; Detect whether the application is running
 
-  Push $0    ; window HWND
-  Push $1    ; window title/classname
-  Push $2    ; truncated title
-  Push $3    ; found 
-
-  ; Loop through all open windows--we want one that has window class "QWidget"
-  ; or "Qt5WindowIcon" and title containing "RStudio"
-  ;
-  ; TODO: for Electron, the window class is "Chrome_WidgetWin_1", but the same window
-  ; class is used by Chrome, Edge, and other Electron apps, so relying on that and
-  ; "RStudio" in the title would also match Chrome tabs (e.g. the RStudio download page).
-  ; So, we need something different to handle the Electron case. Maybe look for running
-  ; rstudio.exe (there's an ancient nsProcess plugin for NSIS that does this).
-  search_loop:
-   FindWindow  $0  ""  ""  0  $0
-    IntCmp  $0  0  not_running
-     IsWindow  $0  0  search_loop
-      ; check to see if we found a Qt window 
-      System::Call 'user32.dll::GetClassName(i r0, t .r1, i ${NSIS_MAX_STRLEN}) i .n'
-      StrCmp  $1  "QWidget"  found_qt_window
-      StrCmp  $1  "Qt5QWindowIcon"  found_qt_window
-      Goto search_loop
-
-      ; check to see if its title contains RStudio
-      found_qt_window:
-      System::Call 'user32.dll::GetWindowText(i r0, t .r1, i ${NSIS_MAX_STRLEN}) i .n'
-      Push $1
-      Push "@CPACK_PACKAGE_NAME@"
-      Call StrStr
-      Pop $3
-
-      ; title does not contain RStudio, continue
-      StrCmp  $3  ""  search_loop
-
-      ; title contains RStudio, bail out
-      MessageBox MB_OK|MB_ICONEXCLAMATION "@CPACK_PACKAGE_NAME@ is currently running. Please close it before installing a new version." /SD IDOK
-      Abort
-
-  not_running:
-
-  ; reload registers
-  Pop $0
-  Pop $1
-  Pop $2
-  Pop $3
+  ${nsProcess::FindProcess} "rstudio.exe" $R0
+  ${If} $R0 = 0
+    MessageBox MB_OK|MB_ICONEXCLAMATION "@CPACK_PACKAGE_NAME@ is currently running. Please close it before installing a new version." /SD IDOK
+    Abort
+  ${EndIf}
+  ${nsProcess::Unload}
 
   ; Reads components status for registry
   !insertmacro SectionList "InitSection"


### PR DESCRIPTION
### Intent
Address #10588 to detect if RStudio is running when installer is run

### Approach
Detects if RStudio is running by process name. This detects Qt and Electron since it is checking for a `rstudio.exe` process. The error message remains the same and the installer exits when it sees RStudio is running.

The NSIS plugin has been uploaded to the `rstudio-buildtools` S3 with read permissions set. It's v1.6 and the unicode DLL was used. The zip was repackaged so only the include and DLL are in the archive.

`install-dependencies.cmd` will be called in the Jenkins build to install the NSIS plugin.

### Automated Tests
None

### QA Notes
Running the Windows installer with either Qt or Electron version running will be detected by the installer.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


