### PR TITLE
Fix for rpostback-askpass (follow up)

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3363,7 +3363,11 @@ core::Error initialize()
    }
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   FilePath postbackDir = session::options().rpostbackPath();
+   if (postbackDir.getAbsolutePath().find("session/postback") != std::string::npos) {
+      // special case for development builds only
+      postbackDir = postbackDir.getParent();
+   }
    core::system::addToPath(postbackDir.getAbsolutePath());
 
    // add suspend/resume handler

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -118,7 +118,12 @@ core::system::ProcessOptions procOptions(bool requiresSsh)
    core::system::environment(&childEnv);
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   FilePath postbackDir = session::options().rpostbackPath();
+   if (postbackDir.getAbsolutePath().find("session/postback") != std::string::npos)
+   {
+      // special case for development builds only
+      postbackDir = postbackDir.getParent();
+   }
    core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
 
    // on windows add gnudiff directory to the path


### PR DESCRIPTION
### Intent

Addresses #11693 for password-protected authentication specifically 

### Approach
We used to assume that the postback directory containing `rpostback-askpass` is the parent of the directory containing the actual rpostback executable. But this is no longer true.

In package builds, for both Qt and Electron, we have the `rpostback` binary in the same level as the `postback` directory containing the `rpostback-askpass` executable. The `rpostback` binary doesn't live in the postback directory with `rpostback-askpass` itself, except for in development builds.

### QA Notes

This should be retested on both Mac and Windows with both password-protected and non-password protected SSH keys. Previous testing failed to catch an issue with password-protected keys
