### PR TITLE
`.rs.getCompletionsLibraryContext()` uses `::` instead of `|||`

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -285,9 +285,9 @@ options(help_type = "html")
       return()
    
    # If we've encoded the package and function in 'what', pull it out
-   if (grepl("|||", what, fixed = TRUE))
+   if (grepl("::", what, fixed = TRUE))
    {
-      splat <- strsplit(what, "|||", fixed = TRUE)[[1]]
+      splat <- strsplit(what, "::", fixed = TRUE)[[1]]
       from <- splat[[1]]
       what <- splat[[2]]
    }


### PR DESCRIPTION
### Intent

addresses #12140 

### Approach

`.rs.getCompletionsLibraryContext()` uses `::` instead of `|||`. It matters because these are now displayed as part of the completion list: 

<img width="734" alt="image" src="https://user-images.githubusercontent.com/2625526/195616444-5c583e28-9564-4d76-8bcd-d85518bd9c8c.png">

Also, the way `.rs.getRCompletions()` works, it gets argument completion both from `.rs.getCompletionsLibraryContext()` and `.rs.getCompletionsFunction()`. We prefer those from `.rs.getCompletionsLibraryContext()` because the  `packages=` include the package and the function, e.g. `rlang::quos` instead of just the function. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


