### PR TITLE
Spellcheck tooltip

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -36,6 +36,7 @@ public class LintItem extends JavaScriptObject
          "end.row": endRow,
          "end.column": endColumn,
          "text": text,
+         "raw": text,
          "type": type
       };
                                 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1090,10 +1090,10 @@ public class AceEditorWidget extends Composite
             clazz = lintStyles_.warning();
 
          int id = editor_.getSession().addMarker(range, clazz, "text", true);
-            annotations_.add(new AnchoredAceAnnotation(
-               annotations.get(i),
-               range,
-               id));
+         annotations_.add(new AnchoredAceAnnotation(
+            annotations.get(i),
+            range,
+            id));
       }
    }
 


### PR DESCRIPTION
### Intent

addresses #11306 

### Approach

Fix `LintItem.create()` so that the object has `"raw"` as well as `"text"`. 

I haven'nt figure out how what part of ace brings the tooltip, so that change at least puts back the word: 

<img width="265" alt="image" src="https://user-images.githubusercontent.com/2625526/195656050-3ca1fe88-6e43-4952-b0e6-6e978aeef100.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


