### PR TITLE
only split `from::what` when there is a `what`

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -285,7 +285,7 @@ options(help_type = "html")
       return()
    
    # If we've encoded the package and function in 'what', pull it out
-   if (grepl("::", what, fixed = TRUE))
+   if (grepl("::.", what))
    {
       splat <- strsplit(what, "::", fixed = TRUE)[[1]]
       from <- splat[[1]]


### PR DESCRIPTION
### Intent

addresses #12145

### Approach

update the regex

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


