### PR TITLE
`.rs.getHelpPackage()` fallback to use information from `utils::packageDescription()`

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -467,7 +467,24 @@ options(help_type = "html")
    # We might be getting the completion with colons appended, so strip those out.
    pkgName <- sub(":*$", "", pkgName, perl = TRUE)
    topic <- paste(pkgName, "-package", sep = "")
-   .rs.getHelp(topic, pkgName)
+   out <- .rs.getHelp(topic, pkgName)
+   if (is.null(out))
+   {
+      pkgDescription <- suppressWarnings(utils::packageDescription(pkgName))
+      if (!identical(pkgDescription, NA)) 
+      {
+         title <- .rs.htmlEscape(pkgDescription$Title)
+         description <- .rs.htmlEscape(pkgDescription$Description)
+         
+         # Format like what HelpInfo.parse() expects
+         out <- list(
+            html = paste0("<h2>", title, "</h2><h3>Description</h3><p>", description, "</p>"),
+            signature = NULL, 
+            pkgname = pkgName
+         )
+      }
+   }
+   out
 })
 
 .rs.addFunction("getHelpArgument", function(functionName, src, envir)

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -754,7 +754,11 @@ options(help_type = "html")
    pkgName <- sub(":*$", "", pkgName)
    topic <- paste(pkgName, "-package", sep = "")
    call <- .rs.makeHelpCall(topic, pkgName)
-   print(eval(call, envir = parent.frame()))
+   helpfile <- eval(call, envir = parent.frame())
+   if (length(helpfile) == 0)
+      browseURL(paste0("http://127.0.0.1:", .rs.httpdPort(), "/library/", pkgName, "/html/00Index.html"))
+   else 
+      print(helpfile)
 })
 
 .rs.addFunction("showHelpTopic", function(topic, package)


### PR DESCRIPTION
### Intent

addresses #12147

### Approach

When the `<pkg>-package` topic does not exist, use information from the `DESCRIPTION` instead. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

<img width="596" alt="image" src="https://user-images.githubusercontent.com/2625526/195821212-e0ae0018-a511-4cf0-973f-b5b6c24c530b.png">

<img width="623" alt="image" src="https://user-images.githubusercontent.com/2625526/195821259-3cac4960-3210-49c3-ac19-b9d26dd192af.png">

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


