### PR TITLE
fuzzy only shows `@name` completions that have a title

### DIFF
--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -85,6 +85,7 @@ public:
 
    RSourceItem(int type,
                const std::string& name,
+               const std::string& extraInfo,
                const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
@@ -92,6 +93,7 @@ public:
                bool hidden)
       : type_(type),
         name_(name),
+        extraInfo_(extraInfo),
         signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
@@ -108,6 +110,7 @@ private:
    RSourceItem(const std::string& context,
                int type,
                const std::string& name,
+               const std::string& extraInfo,
                const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
@@ -116,6 +119,7 @@ private:
       : context_(context),
         type_(type),
         name_(name),
+        extraInfo_(extraInfo),
         signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
@@ -134,6 +138,7 @@ public:
    bool isTest() const { return type_ == Test; }
    const std::string& context() const { return context_; }
    const std::string& name() const { return name_; }
+   const std::string& extraInfo() const { return extraInfo_; }
    const std::vector<RS4MethodParam>& signature() const { return signature_; }
    const int braceLevel() const { return braceLevel_; }
    int line() const { return core::safe_convert::numberTo<std::size_t, int>(line_,0); }
@@ -167,6 +172,7 @@ public:
       return RSourceItem(context,
                          type_,
                          name_,
+                         extraInfo_,
                          signature_,
                          braceLevel_,
                          line_,
@@ -178,6 +184,7 @@ private:
    std::string context_;
    int type_;
    std::string name_;
+   std::string extraInfo_;
    std::vector<RS4MethodParam> signature_;
    int braceLevel_;
    std::size_t line_;

--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -86,7 +86,6 @@ public:
    RSourceItem(int type,
                const std::string& name,
                const std::string& extraInfo,
-               const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
                std::size_t column, 
@@ -94,7 +93,6 @@ public:
       : type_(type),
         name_(name),
         extraInfo_(extraInfo),
-        signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
         column_(column), 
@@ -111,7 +109,6 @@ private:
                int type,
                const std::string& name,
                const std::string& extraInfo,
-               const std::vector<RS4MethodParam>& signature,
                int braceLevel,
                std::size_t line,
                std::size_t column, 
@@ -120,7 +117,6 @@ private:
         type_(type),
         name_(name),
         extraInfo_(extraInfo),
-        signature_(signature),
         braceLevel_(braceLevel),
         line_(line),
         column_(column), 
@@ -139,7 +135,6 @@ public:
    const std::string& context() const { return context_; }
    const std::string& name() const { return name_; }
    const std::string& extraInfo() const { return extraInfo_; }
-   const std::vector<RS4MethodParam>& signature() const { return signature_; }
    const int braceLevel() const { return braceLevel_; }
    int line() const { return core::safe_convert::numberTo<std::size_t, int>(line_,0); }
    int column() const { return core::safe_convert::numberTo<std::size_t, int>(column_,0); }
@@ -173,7 +168,6 @@ public:
                          type_,
                          name_,
                          extraInfo_,
-                         signature_,
                          braceLevel_,
                          line_,
                          column_, 
@@ -185,7 +179,6 @@ private:
    int type_;
    std::string name_;
    std::string extraInfo_;
-   std::vector<RS4MethodParam> signature_;
    int braceLevel_;
    std::size_t line_;
    std::size_t column_;

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -325,7 +325,6 @@ private:
 
 void addSourceItem(RSourceItem::Type type,
                    const std::string& extraInfo,
-                   const std::vector<RS4MethodParam>& signature,
                    const RToken& token,
                    const IndexStatus& status,
                    bool hidden, 
@@ -335,7 +334,6 @@ void addSourceItem(RSourceItem::Type type,
                             type,
                             string_utils::strippedOfQuotes(token.contentAsUtf8()),
                             extraInfo,
-                            signature,
                             status.count(RToken::LBRACE),
                             token.row() + 1,
                             token.column() + 1, 
@@ -423,7 +421,6 @@ void testThatCallIndexer(const RTokenCursor& cursor,
          RSourceItem::Test,
          desc,
          "",
-         std::vector<RS4MethodParam>(), 
          status.count(RToken::LBRACE),
          cursor.row() + 1, 
          cursor.column() + 1, 
@@ -455,7 +452,6 @@ void stringAfterRoxygenIndexer(const RTokenCursor& cursor,
       RSourceItem::Roxygen,
       cursor.contentAsUtf8(),
       "",
-      std::vector<RS4MethodParam>(), 
       status.count(RToken::LBRACE),
       cursor.row() + 1, 
       cursor.column() + 1, 
@@ -516,7 +512,6 @@ void nameRoxygenIndexer(const RTokenCursor& cursor,
             RSourceItem::Roxygen,
             name,
             boost::regex_replace(line, titleRoxygenRegex, "\\1"),
-            std::vector<RS4MethodParam>(), 
             status.count(RToken::LBRACE),
             clone.row() + 1, 
             clone.column() + 1, 
@@ -586,9 +581,22 @@ void s4MethodIndexer(const RTokenCursor& cursor,
                         &signature);
       }
       
+      // calculate extraInfo from signature
+      std::string extraInfo;
+      if (signature.size() > 0) 
+      {
+         extraInfo.append("");
+         for (std::size_t i = 0; i < signature.size(); i++)
+         {
+            if (i > 0)
+               extraInfo.append(", ");
+            extraInfo.append(signature[i].type());
+         }
+         extraInfo.append("}");
+      }
+      
       addSourceItem(setType,
-                    "",
-                    signature,
+                    extraInfo,
                     nameToken,
                     status,
                     isReadOnlyFile,
@@ -704,7 +712,6 @@ void variableAssignmentIndexer(const RTokenCursor& cursor,
             type,
             text,
             "",
-            std::vector<RS4MethodParam>(),
             status.count(RToken::LBRACE),
             prevToken.row() + 1,
             prevToken.column() + 1, 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1524,27 +1524,11 @@ SourceItem fromRSourceItem(const r_util::RSourceItem& rSourceItem)
       break;
    }
 
-   // calculate extra info
-   std::string extraInfo = rSourceItem.extraInfo();
-   
-   if (extraInfo.size() == 0 && rSourceItem.signature().size() > 0)
-   {
-      extraInfo.append("{");
-      for (std::size_t i = 0; i < rSourceItem.signature().size(); i++)
-      {
-         if (i > 0)
-            extraInfo.append(", ");
-         extraInfo.append(rSourceItem.signature()[i].type());
-      }
-
-      extraInfo.append("}");
-   }
-
    // return source item
    return SourceItem(type,
                      rSourceItem.name(),
                      "",
-                     extraInfo,
+                     rSourceItem.extraInfo(),
                      rSourceItem.context(),
                      rSourceItem.line(),
                      rSourceItem.column(), 

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1525,8 +1525,9 @@ SourceItem fromRSourceItem(const r_util::RSourceItem& rSourceItem)
    }
 
    // calculate extra info
-   std::string extraInfo;
-   if (rSourceItem.signature().size() > 0)
+   std::string extraInfo = rSourceItem.extraInfo();
+   
+   if (extraInfo.size() == 0 && rSourceItem.signature().size() > 0)
    {
       extraInfo.append("{");
       for (std::size_t i = 0; i < rSourceItem.signature().size(); i++)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearch.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/ui/CodeSearch.css
@@ -35,7 +35,7 @@
 
 .smallCodeItem {
    position: relative;
-   margin-right: 7px;
+   margin-right: 10px;
    top: 3px;
 }
 
@@ -43,6 +43,7 @@
    position: relative;
    top: 3px;
    color: #888;
+   font-size: smaller;
 }
 
 .codeImage {
@@ -73,8 +74,10 @@
 
 .itemContext {
    position: relative;
-   top: -1px;
-   color: #888;
+   margin-right: 7px;
+   top: 3px;
+   color: #666;
+   font-size: smaller;
 }
 
 .codeSearchDialogMainWidget {


### PR DESCRIPTION
### Intent

addresses #12149 

### Approach

<img width="575" alt="image" src="https://user-images.githubusercontent.com/2625526/195889244-aa7fdae9-790d-48e8-8e9e-bc7bbc948760.png">

And showing the title as extra information. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


