### PR TITLE
Allow the use of the weak callback macros under Clang

### DIFF
--- a/src/cpp/core/include/core/WeakCallback.hpp
+++ b/src/cpp/core/include/core/WeakCallback.hpp
@@ -16,8 +16,8 @@
 #ifndef CORE_WEAK_CALLBACK_HPP
 #define CORE_WEAK_CALLBACK_HPP
 
-// these macros currently only work with GCC
-#if !defined(_WIN32) && !defined(__APPLE__)
+// these macros currently only work with GCC and Clang
+#if !defined(_WIN32)
 // macros to make the declaration and definition of weak callbacks much easier
 // usage: for a callback that would normally take a shared pointer that should only
 // capture a weak pointer, add WEAK_CALLBACK_DECL(instance type, return type, method name, arg 1 type, arg 1, ...);


### PR DESCRIPTION
### Intent

Note that these macros are not currently used in the IDE or Workbench at present, but only in Launcher.

These macros are documented in the original comments and commit as "only working on GCC", but that no longer seems to be the case -- I've observed that they work fine on recent Clang compilers on macOS.

### Automated Tests

This change won't affect any automated tests, because this code is unused in this repo.

### QA Notes

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests