### PR TITLE
Not showing argument tooltip for unknown functions

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1091,9 +1091,7 @@
       }
    }
 
-   # all else fails, just provide a dummy return value
-   .rs.scalar("(...)")
-
+   .rs.scalar("")
 })
 
 .rs.addFunction("getActiveArgument", function(object,


### PR DESCRIPTION
### Intent

addresses #12159

### Approach

return `""` instead of `"(...)"`  in the `get_args` rpc. 

<img width="447" alt="image" src="https://user-images.githubusercontent.com/2625526/196194266-2734e983-9b79-43ad-a511-2ed57224513f.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


