### PR TITLE
Fix new proj from existing directory on Windows

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemItem.java
@@ -22,6 +22,8 @@ import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.common.filetypes.FileIconResources;
 import org.rstudio.studio.client.common.vcs.StatusAndPathInfo;
+import org.rstudio.core.client.BrowseCap;
+
 
 import com.google.gwt.core.client.JavaScriptObject;
 
@@ -36,11 +38,13 @@ public class FileSystemItem extends JavaScriptObject
 
    public static FileSystemItem createDir(String path)
    {
+      path = normalizeSeparatorsNative(path);
       return create(path, true, -1, 0);
    }
 
    public static FileSystemItem createFile(String path)
    {
+      path = normalizeSeparatorsNative(path);
       return create(path, false, -1, 0);
    }
 
@@ -130,6 +134,17 @@ public class FileSystemItem extends JavaScriptObject
          parentPath = path.substring(0, lastSlash);
          return FileSystemItem.createDir(parentPath);
       }
+   }
+
+   public final String getRootPath()
+   {
+      // returns remainder of path; inverse of getParenthPath
+      String path = getPath();
+      int lastSlash = path.lastIndexOf('/');
+      if (lastSlash <= 0)
+         return path;
+      else
+         return path.substring(lastSlash + 1);
    }
 
    public final String getParentPathString()
@@ -286,6 +301,15 @@ public class FileSystemItem extends JavaScriptObject
       return String.CASE_INSENSITIVE_ORDER.compare(getPath(),
                                                    other.getPath());
 
+   }
+
+   private final static String normalizeSeparatorsNative(String path)
+   {
+      if (BrowseCap.isWindows())
+      {
+         return path.replace('\\', '/');
+      }
+      return path;
    }
 
    public final static FileSystemItem home()

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -360,8 +360,10 @@ public class Projects implements OpenProjectFileEvent.Handler,
    public static String projFileFromDir(String dir)
    {
       FileSystemItem dirItem = FileSystemItem.createDir(dir);
-      return FileSystemItem.createFile(
-        dirItem.completePath(dirItem.getName() + ".Rproj")).getPath();
+      String projFilename = dirItem.getRootPath() + ".Rproj";
+      String completeProjFilename = dirItem.completePath(projFilename);
+      FileSystemItem projFile = FileSystemItem.createFile(completeProjFilename);
+      return projFile.getPath();
    }
 
    private void notifyTutorialCreateNewResult(NewProjectResult newProject,

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -189,7 +189,6 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_get_existing_directory',
       async (event, caption: string, label: string, dir: string, focusOwner: boolean) => {
-        console.log('desktop_get_existing_directory');
         const openDialogOptions: OpenDialogOptions = {
           title: caption,
           defaultPath: normalizeSeparatorsNative(resolveAliasedPath(dir)),


### PR DESCRIPTION
also normalize client paths on Windows automatically

### Intent
Addresses #11824

### Approach

- Extract project name (directory name) from absolute directory path to avoid path duplication
- Normalize path separators on Windows

### Automated Tests
No

### QA Notes
See issue reprex

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


