### PR TITLE
Fixed bug where failing to delete a rotated log file could cause a log line to be emitted, causing deadlock.

### DIFF
--- a/src/cpp/shared_core/FileLogDestination.cpp
+++ b/src/cpp/shared_core/FileLogDestination.cpp
@@ -350,7 +350,9 @@ struct FileLogDestination::Impl
       {
          // Check to see if the logfile is stale
          // If so, we will delete it instead of rotating it
-         std::time_t lastWrite = logFile.getLastWriteTime();
+         // note: we swallow any potential error here and simply do not delete the file
+         std::time_t lastWrite = 0;
+         logFile.getLastWriteTime(lastWrite);
          boost::posix_time::ptime lastWriteTime = lastWrite != 0 ? core::date_time::timeFromStdTime(lastWrite) :
                                                                    boost::posix_time::microsec_clock::universal_time();
          boost::posix_time::ptime now = boost::posix_time::microsec_clock::universal_time();

--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1064,6 +1064,24 @@ std::time_t FilePath::getLastWriteTime() const
    }
 }
 
+Error FilePath::getLastWriteTime(std::time_t& out_lastWriteTime) const
+{
+   if (!exists())
+      return notFoundError(*this, ERROR_LOCATION);
+
+   boost::system::error_code ec;
+   std::time_t lastWriteTime = boost::filesystem::last_write_time(m_impl->Path, ec);
+   if (ec)
+   {
+      Error error(ec, ERROR_LOCATION);
+      addErrorProperties(m_impl->Path, &error);
+      return error;
+   }
+
+   out_lastWriteTime = lastWriteTime;
+   return Success();
+}
+
 std::string FilePath::getLexicallyNormalPath() const
 {
    if (isEmpty())

--- a/src/cpp/shared_core/include/shared_core/FilePath.hpp
+++ b/src/cpp/shared_core/include/shared_core/FilePath.hpp
@@ -471,6 +471,15 @@ public:
    /**
     * @brief Get the last time this file path was written.
     *
+    * @param out_lastWriteTime  The last write time of the file.
+    *
+    * @return Success if the last write time could be retrieved; Error otherwise.
+    */
+   core::Error getLastWriteTime(std::time_t& out_lastWriteTime) const;
+
+   /**
+    * @brief Get the last time this file path was written.
+    *
     * @return The time of the last write.
     */
    std::time_t getLastWriteTime() const;


### PR DESCRIPTION







### Intent

Fix https://github.com/rstudio/rstudio/issues/12167

This is because the call to `FilePath::getLastWriteTime` can fail and end up emitting a log line, which causes recursion in the logging code leading to attempting to re-acquire a mutex that was already acquired.

### Approach

The fix is to make sure we aren't logging by adding a new method overload that returns the error instead of logging it.

### Automated Tests

Existing unit tests still pass.

### QA Notes

Check with @MariaSemple for better repro steps. Only repros in certain environments.

