### PR TITLE
remove the `"Run Examples"` link from help pages

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -24,6 +24,7 @@
 #include <boost/range/iterator_range.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/regex.hpp>
 #include <boost/iostreams/filter/aggregate.hpp>
 
 #include <core/Algorithm.hpp>
@@ -375,9 +376,18 @@ public:
             boost::make_iterator_range(tempDest2.begin(), tempDest2.end()),
             "src=\"/",
             "src=\"" + baseUrl + "/");
+
+      // Remove the Run Examples link
+      Characters tempDest4;
+      boost::algorithm::replace_all_regex_copy(
+            std::back_inserter(tempDest4),
+            boost::make_iterator_range(tempDest3.begin(), tempDest3.end()),
+            boost::regex("<p><a href='[.][.]/Example/.*'>Run examples</a></p>"),
+            std::string(""));
+
       boost::algorithm::replace_all_copy(
             std::back_inserter(dest),
-            boost::make_iterator_range(tempDest3.begin(), tempDest3.end()),
+            boost::make_iterator_range(tempDest4.begin(), tempDest4.end()),
             "src='/",
             "src='" + baseUrl + "/");
       

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -98,16 +98,6 @@ exports.setNumFencedDivsColors = function(value) {
 
 var MarkdownHighlightRules = function() {
 
-    exports.setRainbowFencedDivs = function(value) {
-        $rainbowFencedDivs = value;
-    };
-    exports.getRainbowFencedDivs = function() {
-        return $rainbowFencedDivs;
-    };
-    exports.setNumFencedDivsColors = function(value) {
-        $numFencedDivsColors = value;
-    };
-    
     var slideFields = lang.arrayToMap(
         ("title|author|date|rtl|depends|autosize|width|height|transition|transition-speed|font-family|css|class|navigation|incremental|left|right|id|audio|video|type|at|help-doc|help-topic|source|console|console-input|execute|pause")
             .split("|")

--- a/src/gwt/acesupport/acemode/markdown_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/markdown_highlight_rules.js
@@ -98,6 +98,16 @@ exports.setNumFencedDivsColors = function(value) {
 
 var MarkdownHighlightRules = function() {
 
+    exports.setRainbowFencedDivs = function(value) {
+        $rainbowFencedDivs = value;
+    };
+    exports.getRainbowFencedDivs = function() {
+        return $rainbowFencedDivs;
+    };
+    exports.setNumFencedDivsColors = function(value) {
+        $numFencedDivsColors = value;
+    };
+    
     var slideFields = lang.arrayToMap(
         ("title|author|date|rtl|depends|autosize|width|height|transition|transition-speed|font-family|css|class|navigation|incremental|left|right|id|audio|video|type|at|help-doc|help-topic|source|console|console-input|execute|pause")
             .split("|")


### PR DESCRIPTION
### Intent

addresses #12170

### Approach

Remove the `Run Examples` link from the rendered help page. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


