### PR TITLE
Fix bug where zlib decompression can hang on certain invalid string sequences

### DIFF
--- a/src/cpp/core/zlib/zlib.cpp
+++ b/src/cpp/core/zlib/zlib.cpp
@@ -247,7 +247,8 @@ Error decompressString(const std::vector<unsigned char>& compressedData,
 
       res = inflate(&zStream, Z_NO_FLUSH);
       destBuff.setDataSize(zStream.total_out);
-      if ((res == Z_DATA_ERROR) || (res == Z_NEED_DICT) || (res == Z_MEM_ERROR))
+      if ((res == Z_DATA_ERROR) || (res == Z_NEED_DICT) || (res == Z_MEM_ERROR) ||
+          (res == Z_BUF_ERROR && zStream.avail_in == 0 && remainIn == 0))
       {
          inflateEnd(&zStream);
          LOG_DEBUG_MESSAGE("Could not decompress data\"" +

--- a/src/cpp/core/zlib/zlibTests.cpp
+++ b/src/cpp/core/zlib/zlibTests.cpp
@@ -82,6 +82,18 @@ test_context("zlib")
 
       CHECK(empty == uncompressed);
    }
+
+
+   test_that("invalid compressed string fails to decompress")
+   {
+      const std::string invalidCompressed = "H\r:ßÓø";
+
+      std::vector<unsigned char> compressed;
+      std::copy(invalidCompressed.begin(), invalidCompressed.end(), std::back_inserter(compressed));
+
+      std::string uncompressed;
+      REQUIRE(decompressString(compressed, &uncompressed));
+   }
 }
 
 } // namespace zlib


### PR DESCRIPTION




### Intent

In some cases, zlib can indicate that no progress has been made and no progress will ever be made again as there is no more data in the buffer to process.

### Approach

In this case, we should error out.

Addresses https://github.com/rstudio/launcher/issues/497.

### Automated Tests

Added new zlib unit test to test this specific case.

### QA Notes

N/A - covered by unit tests.

