### PR TITLE
Fix compilation across different Boost versions

### DIFF
--- a/src/cpp/core/LogOptions.cpp
+++ b/src/cpp/core/LogOptions.cpp
@@ -17,6 +17,7 @@
 
 #include <vector>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 
 #include <core/system/Environment.hpp>

--- a/src/cpp/core/r_util/REnvironmentPosix.cpp
+++ b/src/cpp/core/r_util/REnvironmentPosix.cpp
@@ -21,6 +21,7 @@
 #include <boost/regex.hpp>
 #include <boost/tokenizer.hpp>
 #include <boost/format.hpp>
+#include <boost/algorithm/string/join.hpp>
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/predicate.hpp>

--- a/src/cpp/core/system/PosixParentProcessMonitor.cpp
+++ b/src/cpp/core/system/PosixParentProcessMonitor.cpp
@@ -18,6 +18,7 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include <boost/algorithm/string/join.hpp>
 #include <boost/assert.hpp>
 
 #include <shared_core/SafeConvert.hpp>

--- a/src/cpp/desktop/DesktopOptions.cpp
+++ b/src/cpp/desktop/DesktopOptions.cpp
@@ -32,6 +32,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/scope_exit.hpp>
 

--- a/src/cpp/session/SessionAsyncDownloadFile.cpp
+++ b/src/cpp/session/SessionAsyncDownloadFile.cpp
@@ -15,6 +15,8 @@
 
 #include <session/SessionAsyncDownloadFile.hpp>
 
+#include <boost/algorithm/string/join.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
 
 #include <shared_core/Error.hpp>

--- a/src/cpp/session/modules/SessionPath.cpp
+++ b/src/cpp/session/modules/SessionPath.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/bind/bind.hpp>
 #include <boost/regex.hpp>
-#include <boost/system/errc.hpp>
+#include <boost/system/error_code.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>


### PR DESCRIPTION
Some of the headers are missing when using non-default Boost versions. Add them for compatibility.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

I'm not certain about contributor agreements if we have this signed. This is just a trivial patch and you can use it under whatever license.