### PR TITLE
Fix decision about UI refreshing when checking web vs native dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -591,17 +591,18 @@ public class GeneralPreferencesPane extends PreferencesPane
       if (BrowseCap.isElectron())
       {
          boolean useNativeDialogsPrefValue = nativeFileDialogs_.getValue();
-         boolean useWebDialogsPrefValue = WebDialogCookie.getUseWebDialogs();
          if (useNativeDialogsPrefValue != initialNativeFileDialogs_)
          {
             restartRequirement.setUiReloadRequired(true);
          }
 
+         boolean useWebDialogsCookieValue = WebDialogCookie.getUseWebDialogs();
+         boolean useWebDialogsPrefValue = !useNativeDialogsPrefValue;
          // The choice of native versus web dialogs is mirrored in a cookie telling GWT which dialogs to use
          // Ensure consistency here and force a page reload if necessary.
-         if (useWebDialogsPrefValue == useNativeDialogsPrefValue)
+         if (useWebDialogsCookieValue != useWebDialogsPrefValue)
          {
-            WebDialogCookie.setUseWebDialogs(!useNativeDialogsPrefValue);
+            WebDialogCookie.setUseWebDialogs(useWebDialogsPrefValue);
             restartRequirement.setUiReloadRequired(true);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -591,16 +591,17 @@ public class GeneralPreferencesPane extends PreferencesPane
       if (BrowseCap.isElectron())
       {
          boolean useNativeDialogsPrefValue = nativeFileDialogs_.getValue();
+         boolean useWebDialogsPrefValue = WebDialogCookie.getUseWebDialogs();
          if (useNativeDialogsPrefValue != initialNativeFileDialogs_)
          {
             restartRequirement.setUiReloadRequired(true);
          }
 
-         // The uiLanguage preference is mirrored in a cookie telling GWT which language to display.
+         // The choice of native versus web dialogs is mirrored in a cookie telling GWT which dialogs to use
          // Ensure consistency here and force a page reload if necessary.
-         if (WebDialogCookie.getUseWebDialogs() != useNativeDialogsPrefValue)
+         if (useWebDialogsPrefValue == useNativeDialogsPrefValue)
          {
-            WebDialogCookie.setUseWebDialogs(useNativeDialogsPrefValue);
+            WebDialogCookie.setUseWebDialogs(!useNativeDialogsPrefValue);
             restartRequirement.setUiReloadRequired(true);
          }
       }


### PR DESCRIPTION
### Intent

Addresses #11811 forcing unnecessary UI reload anytime any General Pref is changed in Electron
### Approach
Fix logic error
### Automated Tests

No
### QA Notes
Toggle on/off Soft wrap in General Preferences > Code. There should be no UI reload or session restart

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


