### PR TITLE
Refinements for roxygen fuzzy

### DIFF
--- a/src/cpp/core/include/core/r_util/RSourceIndex.hpp
+++ b/src/cpp/core/include/core/r_util/RSourceIndex.hpp
@@ -75,7 +75,8 @@ public:
       Class      = 3,
       Variable   = 4, 
       Test       = 11, 
-      Roxygen    = 12
+      Roxygen    = 12, 
+      Package    = 14
    };
 
 public:

--- a/src/cpp/core/r_util/RSourceIndex.cpp
+++ b/src/cpp/core/r_util/RSourceIndex.cpp
@@ -484,7 +484,7 @@ void stringAfterRoxygenIndexer(const RTokenCursor& cursor,
    findRoxygenTitle(clone, title);
 
    RSourceItem item(
-      RSourceItem::Roxygen,
+      (name == "\"_PACKAGE\"") ? RSourceItem::Package : RSourceItem::Roxygen,
       name,
       title,
       status.count(RToken::LBRACE),

--- a/src/cpp/session/modules/SessionCodeSearch.cpp
+++ b/src/cpp/session/modules/SessionCodeSearch.cpp
@@ -1443,7 +1443,8 @@ public:
       Math       = 10,
       Test       = 11, 
       Roxygen    = 12, 
-      Macro      = 13
+      Macro      = 13, 
+      Package    = 14
    };
 
    SourceItem()
@@ -1517,6 +1518,9 @@ SourceItem fromRSourceItem(const r_util::RSourceItem& rSourceItem)
       break;
    case RSourceItem::Roxygen:
       type = SourceItem::Roxygen;
+      break;
+   case RSourceItem::Package:
+      type = SourceItem::Package;
       break;
    case RSourceItem::None:
    default:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/CodeSearchSuggestion.java
@@ -108,6 +108,9 @@ class CodeSearchSuggestion implements Suggestion
       case SourceItem.MACRO:
          image = new ImageResource2x(CodeIcons.INSTANCE.macro2x());
          break;
+      case SourceItem.PACKAGE:
+         image = new ImageResource2x(CodeIcons.INSTANCE.rPackage2x());
+         break;
       case SourceItem.NONE:
       default:
          image = new ImageResource2x(CodeIcons.INSTANCE.keyword2x());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/codesearch/model/SourceItem.java
@@ -42,6 +42,7 @@ public class SourceItem extends JavaScriptObject
    public static final int TEST                 = 11;
    public static final int ROXYGEN              = 12;
    public static final int MACRO                = 13;
+   public static final int PACKAGE              = 14;
 
    public final native int getType() /*-{
       return this.type;


### PR DESCRIPTION
### Intent

follow up for #12149, #12150

### Approach

- Also show strings for roxygen before strings completion, and special case the `"_PACKAGE"` case:

<img width="376" alt="image" src="https://user-images.githubusercontent.com/2625526/196954874-34778f9a-1f8f-44c7-b145-38aace49a94a.png">

It could be useful to also follow the `@rdname` so that `band_instruments` and `band_instruments2` would have extra info, maybe in a follow up. 

- Also handle explicit `@title` instead of first line of roxygen chunk: 

<img width="591" alt="image" src="https://user-images.githubusercontent.com/2625526/196955443-6b91b7a0-03d3-4c5e-a93d-5b20486506c6.png">

gives: 

<img width="551" alt="image" src="https://user-images.githubusercontent.com/2625526/196955485-281a0eaa-3995-4cc0-83f7-4ef243df030b.png">


### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


