### PR TITLE
Remove restriction on navigation that limits to website quarto

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -309,18 +309,13 @@ public class VisualModePanmirrorContext
       uiDisplay.navigateToFile = (String file) -> {
          if (this.docUpdateSentinel_.getPath() != null)
          {
-            // only navigate in website projects
             QuartoConfig config = sessionInfo_.getQuartoConfig();
             FileSystemItem projectDir = FileSystemItem.createDir(config.project_dir);
             FileSystemItem editorFile = FileSystemItem.createFile(this.docUpdateSentinel_.getPath());
-            if (QuartoHelper.isQuartoWebsiteDoc(editorFile.getPath(), config))
-            {
-               // absolute links go relative to website root
-               FileSystemItem targetFile = FileSystemItem.createFile(file.startsWith("/") 
-                  ? projectDir.completePath(file.substring(1))
-                  : editorFile.getParentPath().completePath(file));
-               events_.fireEvent(new OpenSourceFileEvent(targetFile));   
-            }
+            FileSystemItem targetFile = FileSystemItem.createFile(file.startsWith("/")
+               ? projectDir.completePath(file.substring(1))
+               : editorFile.getParentPath().completePath(file));
+            events_.fireEvent(new OpenSourceFileEvent(targetFile));
          }        
       };
 


### PR DESCRIPTION
### Intent

Address #11845 (part 2)

### Approach

Part of this issue was previously addressed by JJ. However, in testing the issue we noticed that relative links to files in Visual Mode don't work -- clicking on the link does not navigate to the file in question. This is because the navigateToFile lambda is explicitly disabled for everything but Quarto website projects in Visual mode. Not sure if there is a good reason for this restriction or a more nuanced solution is needed, but in this case simply removing this check gives the file navigation behavior in visual mode the same capability as in source mode

### Automated Tests
None

### QA Notes
See issue

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


