### PR TITLE
import excel: only update column definitions if change of sheet or range

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImport.java
@@ -129,12 +129,16 @@ public class DataImport extends Composite
          @Override
          public void onValueChange(ValueChangeEvent<DataImportOptions> dataImportOptions)
          {
-            previewDataImport();
-            
             if (dataImportMode_ == DataImportModes.XLS)
             {
-               resetColumnDefinitions();
+               DataImportOptionsXls options = (DataImportOptionsXls)dataImportOptions.getValue();
+               if (options.needsColumnDefinitionsReset())
+               {
+                  resetColumnDefinitions();
+               }
             }
+            
+            previewDataImport();
          }
       });
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsUiXls.java
@@ -66,7 +66,8 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          !naTextBox_.getValue().isEmpty() ? naTextBox_.getValue() : null,
          openDataViewerCheckBox_.getValue().booleanValue(),
          !maxTextBox_.getValue().isEmpty() ? Integer.parseInt(maxTextBox_.getValue()) : null,
-         !rangeTextBox_.getValue().isEmpty() ? rangeTextBox_.getValue() : null
+         !rangeTextBox_.getValue().isEmpty() ? rangeTextBox_.getValue() : null, 
+         lastSource_!= null && (lastSource_.equals(sheetListBox_) || lastSource_.equals(rangeTextBox_))
       );
    }
    
@@ -133,6 +134,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          @Override
          public void onValueChange(ValueChangeEvent<String> arg0)
          {
+            lastSource_ = arg0.getSource();
             triggerChange();
          }
       };
@@ -143,6 +145,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          @Override
          public void onChange(ChangeEvent arg0)
          {
+            lastSource_ = arg0.getSource();
             triggerChange();
          }
       };
@@ -153,6 +156,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          @Override
          public void onValueChange(ValueChangeEvent<Boolean> arg0)
          {
+            lastSource_ = arg0.getSource();
             triggerChange();
          }
       };
@@ -163,6 +167,7 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
          @Override
          public void onValueChange(ValueChangeEvent<String> arg0)
          {
+            lastSource_ = arg0.getSource();
             maxTextBox_.setEnabled(rangeTextBox_.getValue().isEmpty());
             skipTextBox_.setEnabled(rangeTextBox_.getValue().isEmpty());
             triggerChange();
@@ -200,6 +205,8 @@ public class DataImportOptionsUiXls extends DataImportOptionsUi
    @UiField
    TextBox rangeTextBox_;
    
+   private Object lastSource_;
+
    private static native final String[] getSheetsFromResponse(DataImportPreviewResponse response) /*-{
       return response && response.options && response.options.sheets ? response.options.sheets : [];
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/environment/dataimport/DataImportOptionsXls.java
@@ -29,7 +29,8 @@ public class DataImportOptionsXls extends DataImportOptions
       String na,
       boolean openDataViewer,
       Integer nMax,
-      String range
+      String range, 
+      boolean needsColumnDefinitionsReset
       ) /*-{
          return {
             "mode": "xls",
@@ -40,7 +41,13 @@ public class DataImportOptionsXls extends DataImportOptions
             "na": na,
             "openDataViewer": openDataViewer,
             "nMax": nMax,
-            "range": range
-       }
+            "range": range, 
+            "needsColumnDefinitionsReset": needsColumnDefinitionsReset
+        };
    }-*/;
+
+   public final native boolean needsColumnDefinitionsReset() /*-{
+      return this.needsColumnDefinitionsReset;
+   }-*/;
+
 }


### PR DESCRIPTION
### Intent

addresses #3955

### Approach

Only change the column definitions if this is a change of sheet, or a change of range. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


