### PR TITLE
completion for arrow tables and datasets

### DIFF
--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -610,7 +610,7 @@
 .rs.addFunction("getNames", function(object)
 {
    tryCatch({
-      if (is.environment(object))
+      if (is.environment(object) && !inherits(object, "R6"))
          ls(object, all.names = TRUE)
       else if (inherits(object, "tbl") && "dplyr" %in% loadedNamespaces())
          dplyr::tbl_vars(object)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -66,6 +66,8 @@ assign(x = ".rs.acCompletionTypes",
           OPTION      = 23,
           DATASET     = 24,
           COLUMN      = 27,
+          R6_OBJECT   = 28, 
+          
           CONTEXT     = 99
        )
 )
@@ -85,6 +87,10 @@ assign(x = ".rs.acCompletionTypes",
       .rs.acCompletionTypes$R5_CLASS
    else if (inherits(object, "refClass"))
       .rs.acCompletionTypes$R5_OBJECT
+
+   # R6
+   else if (inherits(object, "R6"))
+      .rs.acCompletionTypes$R6_OBJECT
    
    # S4
    else if (isS4(object))

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2736,7 +2736,7 @@ assign(x = ".rs.acCompletionTypes",
          {
             completions <- .rs.selectFuzzyMatches(objectNames, token)
 
-            if (inherits(object, c("data.frame")) || (isNamespaceLoaded("arrow") && inherits(object, c("ArrowTabular", "Dataset"))))
+            if (inherits(object, c("data.frame")) || (isNamespaceLoaded("arrow") && inherits(object, c("ArrowTabular", "Dataset", "arrow_dplyr_query"))))
             {
                # when the chain object is a data frame, 
                # set the completion type to COLUMN

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -67,7 +67,7 @@ assign(x = ".rs.acCompletionTypes",
           DATASET     = 24,
           COLUMN      = 27,
           R6_OBJECT   = 28, 
-          
+
           CONTEXT     = 99
        )
 )
@@ -2735,7 +2735,8 @@ assign(x = ".rs.acCompletionTypes",
          if (length(objectNames))
          {
             completions <- .rs.selectFuzzyMatches(objectNames, token)
-            if (inherits(object, "data.frame"))
+
+            if (inherits(object, c("data.frame")) || (isNamespaceLoaded("arrow") && inherits(object, c("ArrowTabular", "Dataset"))))
             {
                # when the chain object is a data frame, 
                # set the completion type to COLUMN

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -44,6 +44,8 @@ public class RCompletionType
    public static final int YAML_KEY    = 25;
    public static final int YAML_VALUE  = 26;
    public static final int COLUMN      = 27;
+   public static final int R6_OBJECT   = 28;
+   
    public static final int SNIPPET     = 98;
    public static final int CONTEXT     = 99;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -1042,6 +1042,7 @@ public class CompletionRequester
          case RCompletionType.S4_OBJECT:
          case RCompletionType.R5_CLASS:
          case RCompletionType.R5_OBJECT:
+         case RCompletionType.R6_OBJECT:
             return new ImageResource2x(ICONS.clazz2x());
          case RCompletionType.FILE:
             return getIconForFilename(name);


### PR DESCRIPTION
### Intent

addresses #11629

### Approach

special case `.rs.getRChainCompletions()` 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

```r
library(arrow)
library(dplyr)

# Create dataset
tf <- tempfile()
data <- dplyr::group_by(mtcars, cyl)
write_dataset(data, tf)
ds <- open_dataset(tf)
tab <- arrow_table(mtcars)

ds %>% filter(<TAB> )
tab %>% filter(<TAB> )
```

give: 

<img width="392" alt="image" src="https://user-images.githubusercontent.com/2625526/197210972-8724c721-6673-49a8-9207-f60c85039144.png">

<img width="438" alt="image" src="https://user-images.githubusercontent.com/2625526/197211108-76289b9b-b6d1-4b7f-bf0a-787e92b85fd8.png">

cc @nealrichardson

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


