### PR TITLE
exit early when embedded quarto is missing

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -244,6 +244,8 @@ void detectQuartoInstallation()
    FilePath embeddedQuartoPath = session::options().quartoPath()
       .completeChildPath("bin")
       .completeChildPath(target);
+   if (embeddedQuartoPath.isEmpty())
+      return;
    auto embeddedVersion = readQuartoVersion(embeddedQuartoPath);
    if (embeddedVersion >= kQuartoRequiredVersion)
    {


### PR DESCRIPTION
Addresses #12169 in case of missing embedded Quarto (such as in shipping distro of OpenSUSE)