### PR TITLE
go into postback folder to find rpostback-askpass

### DIFF
--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3363,11 +3363,12 @@ core::Error initialize()
    }
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath();
-   if (postbackDir.getAbsolutePath().find("session/postback") != std::string::npos) {
-      // special case for development builds only
-      postbackDir = postbackDir.getParent();
+   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   if (postbackDir.getAbsolutePath().find("session/postback") == std::string::npos) {
+      // for package builds only, postback/rpostback-askpass in same directory as rpostback itself
+      postbackDir = postbackDir.completeChildPath("postback");
    }
+
    core::system::addToPath(postbackDir.getAbsolutePath());
 
    // add suspend/resume handler

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -118,12 +118,13 @@ core::system::ProcessOptions procOptions(bool requiresSsh)
    core::system::environment(&childEnv);
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath();
-   if (postbackDir.getAbsolutePath().find("session/postback") != std::string::npos)
-   {
-      // special case for development builds only
-      postbackDir = postbackDir.getParent();
+   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   if (postbackDir.getAbsolutePath().find("session/postback") == std::string::npos) {
+      // for package builds only, postback/rpostback-askpass in same directory as rpostback itself
+      // that is, rpostback-askpass is nested inside a folder called postback which we add to PATH
+      postbackDir = postbackDir.completeChildPath("postback");
    }
+
    core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
 
    // on windows add gnudiff directory to the path


### PR DESCRIPTION
### Intent

Addresses #11693

### Approach

For Mac Electron package builds, the path to the rpostback executable is: `RStudio.app/Contents/Resources/app/bin/rpostback`
However the path to the rpostback-askpass executable is:
`RStudio.app/Contents/Resources/app/bin/postback/rpostback-askpass`

Similarly, for Windows Electron package builds, the path to the rpostback executable is:
`C:/Program Files/RStudio/resources/app/bin/rpostback`
However the path to the rpostback-askpass executable is:
`C:/Program Files/RStudio/resources/app/bin/postback/rpostback-askpass`

So what we need to do is fix the path for `rpostback-askpass` relative to `rpostback` in non-development builds.
We do this by taking the rpostback path, getting its parent, adding the `/postback` to that parent path, and adding that directory to the path. This way the RS_RPOSTBACK_PATH environment variable is set correctly, and the `bin/postback` folder containing the `rpostback-askpass` is added to the system path so we can find the askpass executable

### QA Notes
Needs to be retested on at least Windows and Mac, and with both password protected and non-password protected SSH keys. Be sure to clear out `~/.ssh/known_hosts` and start with a fresh SSH key as that seemed to impact testing
