### PR TITLE
Re-enable the Disconnect button for all rstudio.cloud accounts

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -399,8 +399,7 @@ public class PublishingPreferencesPane extends PreferencesPane
    private void setButtonEnabledState()
    {
       disconnectButton_.setEnabled(
-            accountList_.getSelectedAccount() != null &&
-            !accountList_.getSelectedAccount().isCloudAccount());
+            accountList_.getSelectedAccount() != null);
 
       reconnectButton_.setEnabled(
             accountList_.getSelectedAccount() != null &&


### PR DESCRIPTION
### Intent

Addresses #12206 
### Approach
Hosted team originally requested the Disconnect button be disabled for rstudio.cloud accounts, but they changed their minds and now want it unconditionally enabled for these accounts until further notice.