### PR TITLE
If Posit Cloud compatible content, then add new account wizard should…

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -426,6 +426,24 @@ public class RSConnectDeploy extends Composite
       // for Plumber APIs and static Rmd docs, we want to allow for posit.cloud but not for shinyapps.io
       boolean isPositCloudContent = contentType == RSConnect.CONTENT_TYPE_PLUMBER_API ||
          contentType == RSConnect.CONTENT_TYPE_DOCUMENT || contentType == RSConnect.CONTENT_TYPE_PRES;
+
+      if (isPositCloudContent)
+      {
+         addAccountAnchor_.setClickHandler(() ->
+         {
+            connector_.showAccountWizard(false,
+               true,
+               successful ->
+               {
+                  if (successful)
+                  {
+                     accountList_.refreshAccountList();
+                  }
+               });
+         });
+      }
+
+
       if (isPositCloudContent != accountList_.getShowPositCloudAccounts())
       {
          accountList_.setShowPositCloudAccounts(isPositCloudContent);


### PR DESCRIPTION
… allow users to add a new cloud account of their choice

### Intent

Addresses #12205 

### Approach

Click Publish Document on an Rmd. User is shown the following UI:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/7817881/197629876-4e119cd5-4ee2-4620-a016-0e2e7f73087d.png">

User selects Posit Cloud. Publish wizard appears showing the list of accounts compatible with this content:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/7817881/197629990-76ce9fa2-6c51-4aed-9bdf-d8e482632855.png">

User doesn't have a Posit Cloud account set up, or wants to set up a new one, so user clicks on Add New Account. Here's what changed: 
<img width="534" alt="image" src="https://user-images.githubusercontent.com/7817881/197631903-579a03b5-daea-4a8c-bbfd-09c6fdd139cc.png">


The Connect Account now shows Cloud accounts in addition to Connect to which the user may want to connect.

User selects Posit Cloud
<img width="536" alt="image" src="https://user-images.githubusercontent.com/7817881/197630236-a104bdfa-1f5b-4e58-bcfc-e0abfee1dcbb.png">
And gets the instructions/link for setting up a new Posit Cloud account as usual.

This isn't a perfect approach (for example it allows the user to connect a new shinyapps.io account, even though those accounts will be filtered out because they aren't compatible with rmarkdown publishing) but it is better than the current state in which a user would not be able to connect a new Posit Cloud account at all from this screen. This I think accomplishes the main purpose and is probably the best that is feasible in the timeframe for the next release, without a major refactoring of our publishing code.
