### PR TITLE
Fix Electron clipboard image paste

### DIFF
--- a/src/gwt/panmirror/src/editor/src/nodes/image/image-events.ts
+++ b/src/gwt/panmirror/src/editor/src/nodes/image/image-events.ts
@@ -71,6 +71,19 @@ function imagePaste(ui: EditorUI) {
         event.preventDefault();
         return true;
       }
+
+      // Electron specific clipboard check
+      for (const item of clipboardEvent.clipboardData.items) {
+        if (item.type === 'image/png') {
+          ui.context.clipboardImage().then(image => {
+            if (image) {
+              handleImageUris(view, view.state.selection.from, event, [image], ui);
+            }
+          });
+          event.preventDefault();
+          return true;
+        }
+      }
     }
 
     return false;

--- a/src/node/desktop/src/core/file-path.ts
+++ b/src/node/desktop/src/core/file-path.ts
@@ -21,6 +21,8 @@ import path, { sep } from 'path';
 import { Err, success, safeError } from './err';
 import { userHomePath } from './user';
 import { err, Expected, ok } from './expected';
+import os from 'os';
+import { randomString } from '../main/utils';
 
 /** An Error containing 'path' that triggered the error */
 export class FilePathError extends Error {
@@ -54,6 +56,23 @@ function normalizeSeparators(path: string, separator = '/') {
  */
 export function normalizeSeparatorsNative(path: string) {
   return normalizeSeparators(path, sep);
+}
+
+/**
+ * Creates a random file name located in the tmp directory
+ *
+ * @param extension The extension, if any, for the filename to have
+ * @param label A label, if any, to include inside the random name. Useful to
+ * identify the origin of any leftover files from a unit test that weren't
+ * cleaned up properly
+ *
+ * @returns The FilePath to the randomly generated filename
+ */
+export function tempFilename(extension = '', label = ''): FilePath {
+  const tempName = label
+    ? path.join(os.tmpdir(), label + '-' + randomString())
+    : path.join(os.tmpdir(), randomString());
+  return new FilePath(extension ? tempName + '.' + extension : tempName);
 }
 
 /**

--- a/src/node/desktop/test/unit/core/file-path.test.ts
+++ b/src/node/desktop/test/unit/core/file-path.test.ts
@@ -13,20 +13,20 @@
  *
  */
 
-import { describe } from 'mocha';
 import { assert } from 'chai';
-import { randomString } from '../unit-utils';
+import { describe } from 'mocha';
 
 import fs from 'fs';
 import fsPromises from 'fs/promises';
+import os from 'os';
 import path from 'path';
-import os, { platform } from 'os';
 
-import { FilePath, normalizeSeparatorsNative } from '../../../src/core/file-path';
-import { userHomePath } from '../../../src/core/user';
-import { setLogger, NullLogger } from '../../../src/core/logger';
 import { clearCoreSingleton } from '../../../src/core/core-state';
 import { isFailure, isSuccessful } from '../../../src/core/err';
+import { FilePath, normalizeSeparatorsNative } from '../../../src/core/file-path';
+import { NullLogger, setLogger } from '../../../src/core/logger';
+import { userHomePath } from '../../../src/core/user';
+import { randomString } from '../../../src/main/utils';
 
 function realpathSync(path: string): string {
   return fs.realpathSync(path);
@@ -144,7 +144,7 @@ describe('FilePath', () => {
       assert.isTrue(f.existsSync());
       assert.isNotEmpty(f.getCanonicalPathSync());
     });
-    it("getCanonicalPathSync should return an empty path for a path that doesn't exist", () => {
+    it('getCanonicalPathSync should return an empty path for a path that doesn\'t exist', () => {
       const f = new FilePath('/some/really/bogus/path');
       assert.isFalse(f.existsSync());
       assert.isEmpty(f.getCanonicalPathSync());
@@ -163,7 +163,7 @@ describe('FilePath', () => {
       assert.isTrue(await f.existsAsync());
       assert.isNotEmpty(await f.getCanonicalPath());
     });
-    it("getCanonicalPath should return an empty path for a path that doesn't exist", async () => {
+    it('getCanonicalPath should return an empty path for a path that doesn\'t exist', async () => {
       const f = new FilePath('/some/really/bogus/path');
       assert.isFalse(await f.existsAsync());
       const result = await f.getCanonicalPath();
@@ -229,7 +229,7 @@ describe('FilePath', () => {
       assert.strictEqual(currentPath.getAbsolutePath(), cwd.getAbsolutePath());
       assert.strictEqual(realpathSync(cwd.getAbsolutePath()), realpathSync(process.cwd()));
     });
-    it("safeCurrentPathSync should change to supplied safe path if it exists if cwd doesn't exist", () => {
+    it('safeCurrentPathSync should change to supplied safe path if it exists if cwd doesn\'t exist', () => {
       const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = getTestDir().getAbsolutePath();
@@ -251,7 +251,7 @@ describe('FilePath', () => {
       assert.strictEqual(realpathSync(origDir.getAbsolutePath()), realpathSync(process.cwd()));
       assert.strictEqual(realpathSync(currentPath.getAbsolutePath()), realpathSync(process.cwd()));
     });
-    it("safeCurrentPathSync should change to home folder when both cwd and revert paths don't exist", () => {
+    it('safeCurrentPathSync should change to home folder when both cwd and revert paths don\'t exist', () => {
       const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = getTestDir().getAbsolutePath();
@@ -279,7 +279,7 @@ describe('FilePath', () => {
       assert.strictEqual(currentPath.getAbsolutePath(), cwd.getAbsolutePath());
       assert.strictEqual(await realpath(cwd.getAbsolutePath()), await realpath(process.cwd()));
     });
-    it("safeCurrentPath should change to supplied safe path if it exists if cwd doesn't exist", async () => {
+    it('safeCurrentPath should change to supplied safe path if it exists if cwd doesn\'t exist', async () => {
       const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = getTestDir().getAbsolutePath();
@@ -301,7 +301,7 @@ describe('FilePath', () => {
       assert.strictEqual(await realpath(origDir.getAbsolutePath()), await realpath(process.cwd()));
       assert.strictEqual(await realpath(currentPath.getAbsolutePath()), await realpath(process.cwd()));
     });
-    it("safeCurrentPath should change to home folder when both cwd and revert paths don't exist", async () => {
+    it('safeCurrentPath should change to home folder when both cwd and revert paths don\'t exist', async () => {
       const origDir = new FilePath(process.cwd());
       // create a temp folder, chdir to it, then delete it
       let testDir = getTestDir().getAbsolutePath();
@@ -325,22 +325,22 @@ describe('FilePath', () => {
   });
 
   describe('Path existence checks', () => {
-    it("isEmpty should detect if this object's path is empty", () => {
+    it('isEmpty should detect if this object\'s path is empty', () => {
       assert.isTrue(new FilePath().isEmpty());
     });
-    it("existsSync should detect when object's path exists", () => {
+    it('existsSync should detect when object\'s path exists', () => {
       assert.isTrue(new FilePath(os.tmpdir()).existsSync());
     });
     it('existsSync should return false for empty path', () => {
       assert.isFalse(new FilePath('').existsSync());
     });
-    it("existsSync should detect when object's path doesn't exist", () => {
+    it('existsSync should detect when object\'s path doesn\'t exist', () => {
       assert.isFalse(new FilePath(bogusPath).existsSync());
     });
     it('existsSync should detect when a supplied path exists', () => {
       assert.isTrue(FilePath.existsSync(os.tmpdir()));
     });
-    it("existsSync should detect when a supplied path doesn't exist", () => {
+    it('existsSync should detect when a supplied path doesn\'t exist', () => {
       assert.isFalse(FilePath.existsSync(bogusPath));
     });
     it('existsSync should return false for existence of a null path', () => {
@@ -349,16 +349,16 @@ describe('FilePath', () => {
     it('exists should return false for empty path', async () => {
       assert.isFalse(await new FilePath().existsAsync());
     });
-    it("exists should detect when object's path exists", async () => {
+    it('exists should detect when object\'s path exists', async () => {
       assert.isTrue(await new FilePath(os.tmpdir()).existsAsync());
     });
-    it("exists should detect when object's path doesn't exist", async () => {
+    it('exists should detect when object\'s path doesn\'t exist', async () => {
       assert.isFalse(await new FilePath(bogusPath).existsAsync());
     });
     it('exists should detect when a supplied path exists', async () => {
       assert.isTrue(await FilePath.existsAsync(os.tmpdir()));
     });
-    it("exists should detect when a supplied path doesn't exist", async () => {
+    it('exists should detect when a supplied path doesn\'t exist', async () => {
       assert.isFalse(await FilePath.existsAsync(bogusPath));
     });
     it('exists should return false for existence of a null path', async () => {
@@ -561,12 +561,12 @@ describe('FilePath', () => {
       const result = FilePath.resolveAliasedPathSync('', home);
       assert.strictEqual(result.getAbsolutePath(), home.getAbsolutePath());
     });
-    it("resolveAliasedPathSync should resolve '~' as home", () => {
+    it('resolveAliasedPathSync should resolve \'~\' as home', () => {
       const home = userHomePath();
       const result = FilePath.resolveAliasedPathSync('~', home);
       assert.strictEqual(result.getAbsolutePath(), home.getAbsolutePath());
     });
-    it("resolveAliasedPathSync should replace '~' in path", () => {
+    it('resolveAliasedPathSync should replace \'~\' in path', () => {
       const start = '~/foo/bar';
       const result = FilePath.resolveAliasedPathSync(start, userHomePath());
       const resultStr = result.getAbsolutePath();
@@ -726,12 +726,12 @@ describe('FilePath', () => {
   });
 
   describe('enumerate children', () => {
-    it("getChildren returns error if it doesn't exist", () => {
+    it('getChildren returns error if it doesn\'t exist', () => {
       const testDir = getTestDir();
       const children: FilePath[] = [];
       assert(isFailure(testDir.getChildren(children)));
     });
-    it("getChildren returns error if it isn' a directory", () => {
+    it('getChildren returns error if it isn\' a directory', () => {
       const testDir = getTestDir();
       testDir.createDirectorySync();
       const fileName = testDir.completeChildPath(randomString());

--- a/src/node/desktop/test/unit/core/file-serializer.test.ts
+++ b/src/node/desktop/test/unit/core/file-serializer.test.ts
@@ -13,16 +13,15 @@
  *
  */
 
-import { describe } from 'mocha';
 import { assert } from 'chai';
-import path from 'path';
-import os from 'os';
 import fs from 'fs';
+import { describe } from 'mocha';
+import os from 'os';
+import path from 'path';
 
-import { randomString } from '../unit-utils';
-
-import { readStringArrayFromFile } from '../../../src/core/file-serializer';
 import { FilePath } from '../../../src/core/file-path';
+import { readStringArrayFromFile } from '../../../src/core/file-serializer';
+import { randomString } from '../../../src/main/utils';
 
 function writeTestFile(lineCount: number, includeBlanks: boolean): FilePath {
   const file = new FilePath(path.join(os.tmpdir(), 'rstudio-temp-test-file-' + randomString()));

--- a/src/node/desktop/test/unit/unit-utils.ts
+++ b/src/node/desktop/test/unit/unit-utils.ts
@@ -19,10 +19,7 @@ import os from 'os';
 import { createStubInstance, StubbableType, SinonStubbedInstance, SinonStubbedMember, SinonSandbox } from 'sinon';
 import { getenv } from '../../src/core/environment';
 import { FilePath } from '../../src/core/file-path';
-
-export function randomString(): string {
-  return Math.trunc(Math.random() * 2147483647).toString();
-}
+import { randomString } from '../../src/main/utils';
 
 /**
  * save and clear specific env vars
@@ -83,23 +80,6 @@ export function tempDirectory(label = ''): FilePath {
     ? path.join(os.tmpdir(), label + '-' + randomString())
     : path.join(os.tmpdir(), randomString());
   return new FilePath(tempName);
-}
-
-/**
- * Creates a random file name located in the tmp directory
- *
- * @param extension The extension, if any, for the filename to have
- * @param label A label, if any, to include inside the random name. Useful to
- * identify the origin of any leftover files from a unit test that weren't
- * cleaned up properly
- *
- * @returns The FilePath to the randomly generated filename
- */
-export function tempFilename(extension = '', label = ''): FilePath {
-  const tempName = label
-    ? path.join(os.tmpdir(), label + '-' + randomString())
-    : path.join(os.tmpdir(), randomString());
-  return new FilePath(extension ? tempName + '.' + extension : tempName);
 }
 
 /**


### PR DESCRIPTION
### Intent
Address #11783 

### Approach
Add Electron specific clipboard check in image paste event handling. Qt adds images to the clipboard event as `application/qt-image`. Electron seems to add images as `image/png` to data items, which can be checked if it is an `image/png`.

### Automated Tests
The random string code was removed from a unit test util. There's a random string util in the core code that is identical. So some unit test refactoring was done to fix the imports.

### QA Notes
This will work on all platforms. It does not address the server issue.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


