### PR TITLE
Chunk output calls `format()` for vctrs classes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 - Build output is now truncating when very large amounts of output are produced (e.g. from C++ compilation warnings).
 - Memory usage in the environment pane now works correctly on Linux when using cgroups v2. (#11894)
 - Fixed an issue where code execution could pause in RStudio Server after closing the browser tab even with active computations. (Pro #3943)
+- Chunk output calls `format()` method on vctrs-based classes stored in a dataframe. (#6878)
   
 ### Python
 

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -293,7 +293,7 @@
 
   columns <- unname(columns)
 
-  # vctrs-based classes should call custom format()
+  # preserve vctrs-based classes so custom format() is called
   is_list_not_vctrs <- function(x) is.list(x) && !inherits(x, "vctrs_vctr")
   is_list <- vapply(data, is_list_not_vctrs, logical(1))
   data[is_list] <- lapply(data[is_list], function(x) {

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -293,9 +293,10 @@
 
   columns <- unname(columns)
 
-  needs_obj_sum <- function(x) is.list(x) && !inherits(x, "vctrs_vctr")
-  col_needs_obj_sum <- vapply(data, needs_obj_sum, logical(1))
-  data[col_needs_obj_sum] <- lapply(data[col_needs_obj_sum], function(x) {
+  # vctrs-based classes should call custom format()
+  is_list_not_vctrs <- function(x) is.list(x) && !inherits(x, "vctrs_vctr")
+  is_list <- vapply(data, is_list_not_vctrs, logical(1))
+  data[is_list] <- lapply(data[is_list], function(x) {
         summary <- obj_sum(x)
         paste0("<", summary, ">")
       })

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -242,6 +242,11 @@
     )
   }
 
+  needs_obj_sum <- function(x) {
+    # vctrs-based classes use custom format() method
+    is.list(x) && !inherits(x, "vctrs_vctr")
+  }
+
   e <- new.env(parent = emptyenv())
   load(file = path, envir = e)
   
@@ -293,8 +298,8 @@
 
   columns <- unname(columns)
 
-  is_list <- vapply(data, is.list, logical(1))
-  data[is_list] <- lapply(data[is_list], function(x) {
+  col_needs_obj_sum <- vapply(data, needs_obj_sum, logical(1))
+  data[col_needs_obj_sum] <- lapply(data[col_needs_obj_sum], function(x) {
         summary <- obj_sum(x)
         paste0("<", summary, ">")
       })

--- a/src/cpp/session/modules/NotebookData.R
+++ b/src/cpp/session/modules/NotebookData.R
@@ -242,11 +242,6 @@
     )
   }
 
-  needs_obj_sum <- function(x) {
-    # vctrs-based classes use custom format() method
-    is.list(x) && !inherits(x, "vctrs_vctr")
-  }
-
   e <- new.env(parent = emptyenv())
   load(file = path, envir = e)
   
@@ -298,6 +293,7 @@
 
   columns <- unname(columns)
 
+  needs_obj_sum <- function(x) is.list(x) && !inherits(x, "vctrs_vctr")
   col_needs_obj_sum <- vapply(data, needs_obj_sum, logical(1))
   data[col_needs_obj_sum] <- lapply(data[col_needs_obj_sum], function(x) {
         summary <- obj_sum(x)


### PR DESCRIPTION
### Intent

R package developers use the [vctrs package](https://vctrs.r-lib.org) to implement custom vector data types with dedicated `format()` methods. These new vector types can be stored in a data frame just like atomic vector types. This PR enables their custom formatting methods to be called when generating the chunk output for a data frame.

Fixes #6878. This is a follow-up (and simplification) to #10777 by @markromanmiller. Also related: https://github.com/r-lib/vctrs/issues/1212.


### Approach

Many of these vctrs-based classes ultimately derive from lists (e.g., those based on `vctrs_list_of` and `vctrs_rcrd`), such that `is.list()` returns TRUE. Unfortunately, this means the chunk output formats them using `obj_sum()` instead of their custom `format()` method.

This PR checks prevents calling `obj_sum()` on a list-like class if it derives from `vctrs_vctr`. As a consequence, it will get formatted by the `format()` method later in the code.


### Automated Tests

I'm unsure how to add unit tests to this repo. Please advise on this.


### QA Notes

This change can be tested by substituting different vctrs-based classes for the `x` variable below:

```r
x <- blob::blob(charToRaw("foo"))
# x <- ipaddress::ip_address("192.168.0.1")
# x <- distributional::dist_normal()

# does x match y in chunk output?
tibble::tibble(x = x, y = format(x))
```

I'm not familiar enough with the code base to understand unintended consequences.


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


