### PR TITLE
Resize splash and allow dragging

### DIFF
--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -155,11 +155,10 @@ export class SessionLauncher {
         .then(() => {
           if (this.showSplash) {
             this.splash = new BrowserWindow({
-              width: 500,
-              height: 500,
+              width: 250,
+              height: 250,
               frame: false,
               transparent: true,
-              alwaysOnTop: true,
               center: true,
               resizable: false,
               show: false,

--- a/src/node/desktop/src/ui/splash/splash.html
+++ b/src/node/desktop/src/ui/splash/splash.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
 </head>
-<body>
+<body style="-webkit-app-region:drag">
   <?xml version="1.0" encoding="utf-8"?>
   <svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
     viewBox="0 0 215 215" style="enable-background:new 0 0 215 215;" xml:space="preserve">


### PR DESCRIPTION
### Intent
Resize the splash screen and allow dragging it

### Approach
Set to 250px square so it doesn't overwhelm lower resolution screens. Set the drag attribute and allow dragging from anywhere on the splash.

### Automated Tests
None

### QA Notes
`--startup-delay` can be set to the number of seconds to show the splash 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


