### PR TITLE
Lower limit for max line console queue

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ChunkOutputStream.java
@@ -108,7 +108,7 @@ public class ChunkOutputStream extends FlowPanel
       
       // track number of newlines in output
       int newlineCount = 0;
-      int maxCount = Satellite.isCurrentWindowSatellite() ? 10000 : 2000;
+      int maxCount = Satellite.isCurrentWindowSatellite() ? 10000 : 500;
       
       for (int i = 0; i < output.length(); i++)
       {


### PR DESCRIPTION
### Intent
Partially address #12130 

### Approach
Lower the max line count for the console output queue. This seems to not crash the render thread.

Electron seems to process the R console output callbacks a lot faster than Qt. I don't know if the rsession is faster at processing or if there's less overhead with Electron allowing GWT to queue the messages faster. In any case, the renderer is overwhelmed by the output and the many updates to the DOM. It keeps updating the one node until it becomes too large for the renderer. This lower limit results in a smaller node and prevents the render thread from crashing.

### Automated Tests
None

### QA Notes
This is the same issue as reported in #5518 but with a lower limit.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


