### PR TITLE
Allow session suspend when Quarto job is running

### DIFF
--- a/src/cpp/core/include/core/system/ChildProcess.hpp
+++ b/src/cpp/core/include/core/system/ChildProcess.hpp
@@ -82,6 +82,9 @@ public:
    // Has this process generated any recent output?
    virtual bool hasRecentOutput() const;
 
+   // Check if process allows for parent process to be suspended
+   bool allowParentSuspend() const;
+
 protected:
    Error run();
 
@@ -98,6 +101,10 @@ private:
    std::vector<std::string> args_;
    ProcessOptions options_;
 };
+
+inline bool ChildProcess::allowParentSuspend() const {
+   return options_.allowParentSuspend;
+}
 
 
 // Child process which can be run synchronously

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -105,7 +105,8 @@ struct ProcessOptions
         redirectStdErrToStdOut(false),
         reportHasSubprocs(false),
         trackCwd(false),
-        callbacksRequireMainThread(true)
+        callbacksRequireMainThread(true),
+        allowParentSuspend(false)
 #else
       : terminateChildren(false),
         exitWithParent(false),
@@ -117,7 +118,8 @@ struct ProcessOptions
         reportHasSubprocs(false),
         trackCwd(false),
         threadSafe(false),
-        callbacksRequireMainThread(true)
+        callbacksRequireMainThread(true),
+        allowParentSuspend(false)
 #endif
    {
    }
@@ -215,6 +217,10 @@ struct ProcessOptions
    // user to run the process as - optional
    // if non is specified, the launching user is used
    std::string runAsUser;
+
+   // If this process is a child, this option indicates whether this process
+   // should be considered when determining if a parent process should be suspended
+   bool allowParentSuspend;
 };
 
 // Struct for returning output and exit status from a process
@@ -424,9 +430,10 @@ public:
    // Check whether any children are currently running
    bool hasRunningChildren();
 
-   // Check whether any children consider themselves active; non-active
-   // processes may be terminated without warning.
-   bool hasActiveChildren();
+   // Check whether any children consider themselves active and do not allow
+   // parent suspension; non-active processes or processes that allow parent
+   // suspension may be terminated without warning.
+   bool hasDurableChildren();
 
    // Poll for child (output and exit) events. returns true if there
    // are still children being supervised after the poll

--- a/src/cpp/core/system/Process.cpp
+++ b/src/cpp/core/system/Process.cpp
@@ -307,19 +307,19 @@ bool ProcessSupervisor::hasRunningChildren()
 
 namespace {
 
-bool hasActivity(const boost::shared_ptr<AsyncChildProcess>& childProc)
+bool hasDurableActivity(const boost::shared_ptr<AsyncChildProcess>& childProc)
 {
-   return
+   return !childProc->allowParentSuspend() && (
          childProc->hasNonIgnoredSubprocess() ||
          childProc->hasIgnoredSubprocess() ||
-         childProc->hasRecentOutput();
+         childProc->hasRecentOutput());
 }
 
 } // anonymous namespace
 
-bool ProcessSupervisor::hasActiveChildren()
+bool ProcessSupervisor::hasDurableChildren()
 {
-   return boost::algorithm::any_of(pImpl_->children, hasActivity);
+   return boost::algorithm::any_of(pImpl_->children, hasDurableActivity);
 }
 
 bool ProcessSupervisor::poll()

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -101,7 +101,7 @@ void consolePrompt(const std::string& prompt, bool addToHistory)
 bool canSuspend(const std::string& prompt)
 {
    bool suspendIsBlocked = false;
-   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveActiveChildren(), suspend::kChildProcess);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);

--- a/src/cpp/session/SessionMainProcess.cpp
+++ b/src/cpp/session/SessionMainProcess.cpp
@@ -87,9 +87,9 @@ void initThreadId()
    s_mainThreadId = boost::this_thread::get_id();
 }
 
-bool haveActiveChildren()
+bool haveDurableChildren()
 {
-   return module_context::processSupervisor().hasActiveChildren() ||
+   return module_context::processSupervisor().hasDurableChildren() ||
           modules::authoring::hasRunningChildren();
 }
 

--- a/src/cpp/session/SessionMainProcess.hpp
+++ b/src/cpp/session/SessionMainProcess.hpp
@@ -22,7 +22,7 @@ namespace main_process {
 
 void setupForkHandlers();
 bool wasForked();
-bool haveActiveChildren();
+bool haveDurableChildren();
 void initThreadId();
 
 } // namespace main_process

--- a/src/cpp/session/include/session/jobs/Job.hpp
+++ b/src/cpp/session/include/session/jobs/Job.hpp
@@ -26,6 +26,9 @@ namespace session {
 namespace modules {      
 namespace jobs {
 
+
+static constexpr auto kJobTagTransient = "transient";
+
 enum JobState {
    // invalid state sentry
    JobInvalid    = 0,

--- a/src/cpp/session/include/session/jobs/JobsApi.hpp
+++ b/src/cpp/session/include/session/jobs/JobsApi.hpp
@@ -87,7 +87,7 @@ void removeCompletedBackgroundJobs();
 
 void endAllJobStreaming();
 
-bool backgroundJobsRunning();
+bool durableJobsRunning();
 
 } // namespace jobs
 } // namespace modules

--- a/src/cpp/session/modules/jobs/JobsApi.cpp
+++ b/src/cpp/session/modules/jobs/JobsApi.cpp
@@ -241,11 +241,13 @@ void endAllJobStreaming()
    }
 }
 
-bool backgroundJobsRunning()
+bool durableJobsRunning()
 {
    for (auto& job: s_jobs)
    {
-      if (job.second->type() == JobType::JobTypeSession && !job.second->complete())
+      if (job.second->type() == JobType::JobTypeSession &&
+          !job.second->complete() &&
+          !algorithm::contains(job.second->tags(), kJobTagTransient))
       {
          return true;
       }

--- a/src/cpp/session/modules/jobs/SessionJobs.cpp
+++ b/src/cpp/session/modules/jobs/SessionJobs.cpp
@@ -469,8 +469,8 @@ core::json::Object jobState()
 
 bool isSuspendable()
 {
-   // don't suspend while we're running background jobs
-   return !backgroundJobsRunning();
+   // don't suspend while we're running durable jobs
+   return !durableJobsRunning();
 }
 
 core::Error initialize()

--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -48,6 +48,7 @@ Error QuartoJob::start()
 #endif
    options.workingDir = workingDir();
    options.callbacksRequireMainThread = true;
+   options.allowParentSuspend = true;
 
    // set environment variables
    core::system::Options env;
@@ -87,7 +88,18 @@ Error QuartoJob::start()
    // hit onCompleted (because our status won't be "running"). if we passed shared_from_this
    // then we'd be keeping this object around forever (because jobs are never discarded).
    jobActions.push_back(std::make_pair("stop", boost::bind(&QuartoJob::stop, this)));
-   pJob_ = addJob(name(), "", "", 0, false, JobRunning, JobTypeSession, false, R_NilValue, jobActions, true, {"quarto"});
+   pJob_ = addJob(name(),
+                  "",
+                  "",
+                  0,
+                  false,
+                  JobRunning,
+                  JobTypeSession,
+                  false,
+                  R_NilValue,
+                  jobActions,
+                  true,
+                  {"quarto", kJobTagTransient});
    pJob_->addOutput("\n", true);
 
    // return success


### PR DESCRIPTION
### Intent

<!--Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. -->

Addresses rstudio/rstudio-pro#3889. Adds the ability to mark jobs as transient and child processes as `allowParentSuspend` so that certain jobs and child processes, like the Quarto preview job, won't prevent session suspension when session idle suspension is triggered.

### Approach

<!--Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.-->

- Add the `allowParentSuspend` variable to `ProcessOptions`, defaulting to `false`
- Modify `hasActiveChildren` to `haveDurableChildren` and include `allowParentSuspend` in the logic so that child processes that have `allowParentSuspend` marked `true` don't count towards preventing suspension
- Add the `transient` tag option to the `Jobs` API, which will make a job suspendible even if it's running
- Update the Session Quarto Job to include the new `transient` tag
With the above changes, sessions will be suspendible even if the Quarto preview is running.

### Automated Tests

<!--Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.-->

N/A

### QA Notes

<!--Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues.-->

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


