### PR TITLE
RStudio Server lifecycle improvements for systemd

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -82,3 +82,5 @@
 - Fix for schema version comparison that breaks db in downgrade -> upgrade scenarios (rstudio-pro#3572)
 - Fixed an issue in the Electron build of the IDE on Macs where users could not clone a git repository via password-protected SSH or HTTPS (#11693)
 - Fixed scroll speed sensitivity for Mac and Linux and added a preference to adjust it (#11578)
+- Fixed an issue in server environments where invoking `systemd` directly could lead to orphaned processes and undefined behavior. Processes are now cleaned up more consistently as a part of server or launcher shutdown. (rstudio/rstudio-pro#2585)
+- RStudio sessions now shut down and suspend properly when they receive a `SIGTERM` signal, as they have for `SIGUSR2` (rstudio/rstudio-pro#2585)

--- a/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
-ExecStop=/usr/bin/killall -TERM rserver
+ExecReload=kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]

--- a/src/cpp/server/extras/systemd/rstudio-server.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
-ExecStop=/usr/bin/killall -TERM rserver
+ExecReload=kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Intent

Open source / `rstudio-server` companion to https://github.com/rstudio/rstudio-pro/pull/4002 and https://github.com/rstudio/rstudio-pro/issues/2585

The intent is to use `systemd`'s default shutdown behavior (kill the main service PID) and make `systemctl reload` a possibility by sending `SIGHUP` to the main service process. I have also added a `NEWS.md` entry to reflect this work.

### Approach

As discussed more thoroughly in https://github.com/rstudio/rstudio-pro/issues/3748 and https://github.com/rstudio/rstudio-pro/issues/3749

### Automated Tests

N/A.  No automated tests of init mechanisms

### QA Notes

Ensure that `rstudio-server` scripts work as expected and `systemctl stop/start/restart/reload` work as expected.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


