### PR TITLE
Prevent intermittent test failures

### DIFF
--- a/src/cpp/tests/testthat/test-api.R
+++ b/src/cpp/tests/testthat/test-api.R
@@ -38,7 +38,9 @@ test_that("command callbacks are invoked", {
    expect_equal(invoked, 2)
    
    # unregister the callback
-   .rs.api.unregisterCommandCallback(handle)
+   if (!is.null(handle) && !is.na(handle)) {
+      .rs.api.unregisterCommandCallback(handle)
+   }
    
    # record a third command execution
    .rs.invokeRpc("record_command_execution", "insertChunk")
@@ -64,7 +66,9 @@ test_that("command stream callbacks are invoked", {
    expect_equal(commands, c("insertChunk", "showHelpMenu", "startJob"))
    
    # unregister the callback
-   .rs.api.unregisterCommandCallback(handle)
+   if (!is.null(handle) && !is.na(handle)) {
+      .rs.api.unregisterCommandCallback(handle)
+   }
    
    # invoke one more command execution
    .rs.invokeRpc("record_command_execution", "startProfiler")


### PR DESCRIPTION
### Intent

Prevent unstable builds caused by unit test warnings in a few environments:
```
[2022-11-02T03:53:25.365Z] Warning message:

[2022-11-02T03:53:25.365Z] Character set is not UTF-8; please change your locale 

[2022-11-02T03:53:25.365Z] v | F W S  OK | Context

[2022-11-02T03:53:25.365Z] 
/ |         0 | api                                                             
/ |         0 | rstudioapi                                                      
v |   2     6 | rstudioapi [0.1s]

[2022-11-02T03:53:25.365Z] --------------------------------------------------------------------------------

[2022-11-02T03:53:25.365Z] Warning (ine<c2><a0>=<c2><a0>41:col<c2><a0>=<c2><a0>1;file:///var/lib/jenkins/workspace/IDE/open-source-pipeline/main/src/cpp/tests/testthat/test-api.Rtest-api.R:41ommand callbacks are invoked

[2022-11-02T03:53:25.365Z] is.na() applied to non-(list or vector) of type 'NULL'

[2022-11-02T03:53:25.365Z] Backtrace:

[2022-11-02T03:53:25.365Z]   1. .rs.api.unregisterCommandCallback(handle)

[2022-11-02T03:53:25.365Z]        at ine = 41:col = 3;file:///var/lib/jenkins/workspace/IDE/open-source-pipeline/main/src/cpp/tests/testthat/test-api.Rtest-api.R:41:339m

[2022-11-02T03:53:25.365Z]   6. .rs.getCommandsWithCallbacks()

[2022-11-02T03:53:25.365Z]   9. base::sort.default(...)

[2022-11-02T03:53:25.365Z]  10. base::sort.int(...)

[2022-11-02T03:53:25.365Z] 

[2022-11-02T03:53:25.365Z] Warning (ine<c2><a0>=<c2><a0>67:col<c2><a0>=<c2><a0>1;file:///var/lib/jenkins/workspace/IDE/open-source-pipeline/main/src/cpp/tests/testthat/test-api.Rtest-api.R:67ommand stream callbacks are invoked

[2022-11-02T03:53:25.365Z] is.na() applied to non-(list or vector) of type 'NULL'

[2022-11-02T03:53:25.365Z] Backtrace:

[2022-11-02T03:53:25.365Z]   1. .rs.api.unregisterCommandCallback(handle)

[2022-11-02T03:53:25.365Z]        at ine = 67:col = 3;file:///var/lib/jenkins/workspace/IDE/open-source-pipeline/main/src/cpp/tests/testthat/test-api.Rtest-api.R:67:339m

[2022-11-02T03:53:25.365Z]   6. .rs.getCommandsWithCallbacks()

[2022-11-02T03:53:25.365Z]   9. base::sort.default(...)

[2022-11-02T03:53:25.365Z]  10. base::sort.int(...)
```

### Approach

I tried to manually reproduce this failure in two of the environments we're seeing it but couldn't, so I added some wrapping to the calls to `unregisterCallbackHandle` to ensure that `handle` is not NULL, which is what's causing the tests to fail. This is a bit of a bandaid fix to get us stable builds since we'll be producing RCs soon(ish).  

### Automated Tests

Fixing automated tests.

### QA Notes

N/A - test will be builds being marked as stable. 
### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


