### PR TITLE
Electron allowNavigation browser spawn fix

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -326,7 +326,11 @@ export class DesktopBrowserWindow extends EventEmitter {
 
     if (this.options.allowExternalNavigate) {
       return true;
-    } else if (isSafeHost(targetUrl.hostname)) {
+    } else if (isSafeHost(targetUrl.hostname) || isLocal) {
+      // check isLocal until it is determined why restarting R
+      // causes the old preview URL to load, even after the DOM
+      // updates to use the new URL
+      // https://github.com/rstudio/rstudio/issues/12256
       return true;
     } else {
       // open external browser only when not in test

--- a/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-browser-window.test.ts
@@ -52,7 +52,6 @@ if (!isWindowsDocker()) {
       });
 
       const presentationUrl = 'http://127.0.0.1:123';
-      assert.isFalse(win.allowNavigation(presentationUrl));
 
       win.setPresentationUrl(presentationUrl);
       assert.isTrue(win.allowNavigation(presentationUrl));
@@ -67,7 +66,6 @@ if (!isWindowsDocker()) {
       });
 
       const tutorialUrl = 'http://127.0.0.1:123';
-      assert.isFalse(win.allowNavigation(tutorialUrl));
 
       win.setTutorialUrl(tutorialUrl);
       assert.isTrue(win.allowNavigation(tutorialUrl));
@@ -82,7 +80,6 @@ if (!isWindowsDocker()) {
       });
 
       const viewerUrl = 'http://127.0.0.1:123';
-      assert.isFalse(win.allowNavigation(viewerUrl));
 
       win.setViewerUrl(viewerUrl);
       assert.isTrue(win.allowNavigation(viewerUrl));
@@ -97,7 +94,6 @@ if (!isWindowsDocker()) {
       });
 
       const shinyDialogUrl = 'http://127.0.0.1:123';
-      assert.isFalse(win.allowNavigation(shinyDialogUrl));
 
       win.setShinyDialogUrl(shinyDialogUrl);
       assert.isTrue(win.allowNavigation(shinyDialogUrl));


### PR DESCRIPTION
### Intent
Address #12256 

### Approach
When the R session restarts, it creates a new URL for the Viewer pane. GWT does set the viewer URL correctly so it is fine to load. However, the pane loads the old URL one last time just as the DOM changes the iframe to the new URL. This triggers an `allowNavigation` check, which fails. The failure causes the URL to open in an external browser.

This is a pretty quick fix to the issue but it might be simpler to allow all localhost URLs at this point. Or figure out why the old URL is loaded one last time (actually multiple times because multiple tabs open).

If Electron ever supports `will-frame-navigate` then the localhost check can be done only for iframes. I think it's still important to check the base URL's port to prevent a different UI running locally to be loaded in the IDE.

### Automated Tests
None

### QA Notes
Show anything in the Viewer pane. As long as there is content showing when R is restarted, it will load the old URL and cause the external windows to open.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


