### PR TITLE
Remove python dependency from electron test

### DIFF
--- a/src/node/desktop/test/unit/main/browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/browser-window.test.ts
@@ -17,25 +17,17 @@ import { describe } from 'mocha';
 import { assert } from 'chai';
 
 import { BrowserWindow } from 'electron';
-import { execSync, spawn } from 'child_process';
+import * as http from 'http';
 
 describe('BrowserWindow', () => {
 
   it('fires events in the expected order', async () => {
+    const server = http.createServer(function (_req, res) {
+      res.writeHead(200);
+      res.end('hello world');
+    });
 
-    const pythonVersion = execSync(
-      'python -c "import sys; print(sys.version_info[0])"',
-      { encoding: 'utf-8' }
-    );
-
-    let args : string[] = [];
-    if (pythonVersion.trim() === '2') {
-      args = ['-m', 'SimpleHTTPServer', '9876'];
-    } else {
-      args = ['-m', 'http.server', '9876'];
-    }
-
-    const server = spawn('python', args, {});
+    server.listen(9875);
 
     const win = new BrowserWindow({ show: false });
     const eventHistory: string[] = [];
@@ -54,12 +46,10 @@ describe('BrowserWindow', () => {
       });
     }
 
-    await win.loadURL('http://localhost:9876');
-    server.kill();
+    await win.loadURL('http://localhost:9875');
+    server.close();
 
     assert.deepEqual(eventHistory, events);
-
-
   });
 
 });

--- a/src/node/desktop/test/unit/main/browser-window.test.ts
+++ b/src/node/desktop/test/unit/main/browser-window.test.ts
@@ -17,12 +17,12 @@ import { describe } from 'mocha';
 import { assert } from 'chai';
 
 import { BrowserWindow } from 'electron';
-import * as http from 'http';
+import { createServer } from 'http';
 
 describe('BrowserWindow', () => {
 
   it('fires events in the expected order', async () => {
-    const server = http.createServer(function (_req, res) {
+    const server = createServer(function (_req, res) {
       res.writeHead(200);
       res.end('hello world');
     });


### PR DESCRIPTION
### Intent
The `browser-window-test` was failing on RHEL9 arm64 since it doesn't have python 2 on it. Python 3 is there but probably requires calling `python3`. This should fix it for that platform and hopefully address the intermittent failures on other platforms if the server doesn't come up fast enough.

### Approach
Use node's http module to create a listen server. No need to spawn another thread so it will be ready to accept requests when trying to load the URL.

The chosen port also happens to be the same as the GWT dev server. So it would seem that it passes every time if you have it running and wouldn't encounter an intermittent failure if the Python server didn't come up fast enough. It's been changed to avoid the conflict.

### Automated Tests
Unit test passes locally

### QA Notes
n/a 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


