### PR TITLE
Use light theme on Windows

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, dialog, Menu, screen, shell, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, Menu, nativeTheme, screen, shell, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -267,6 +267,12 @@ export class Application implements AppState {
     const [confPath, sessionPath, scriptsPath] = findComponents();
     this.sessionPath = sessionPath;
     this.scriptsPath = scriptsPath;
+
+    // force light theme so menu bar matches title bar
+    // Electron 20+ will have support for matching
+    if (process.platform === 'win32') {
+      nativeTheme.themeSource = 'light';
+    }
 
     if (!app.isPackaged) {
       // sanity checking for dev config


### PR DESCRIPTION
### Intent
Address #12247

### Approach
Electron 20 adds support for theming the title bar. Until Electron is upgraded, it looks more consistent to have the theme set to `light` on Windows. Then the menu bar and title bar will have consistent theming. Linux (Ubuntu 22) and Mac do not have this issue.

With Electron 20, we can then add in event hooks to adjust the `nativeTheme` and maybe even match it to the options that are selected in the Appearance options.

### Automated Tests
None

### QA Notes
It is noticeable on Windows when setting the system theme to dark.

Mac does not have this issue since the menu bar is always at the top and is themed according to the system.

Linux appeared fine on Ubuntu 22 but may vary depending on the windowing environment. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


