### PR TITLE
Prevent double slash in rserver-url -l output

### DIFF
--- a/src/cpp/server/url-ports/UrlPortsMain.cpp
+++ b/src/cpp/server/url-ports/UrlPortsMain.cpp
@@ -64,6 +64,10 @@ int main(int argc, char * const argv[])
 
       char* pServerPath = std::getenv("RS_SERVER_URL");
       std::string serverPath = pServerPath != NULL ? std::string(pServerPath) : std::string();
+      if (serverPath.back() == '/')
+      {
+         serverPath.pop_back();
+      }
 
       std::cout << serverPath + sessionPath + "p/" + transformedPort + "/" << std::endl;
    }


### PR DESCRIPTION
### Intent

Addresses rstudio/rstudio-pro#3912

 `rserver-url -l {port}` concatenates `$RS_SERVER_URL` and `$RS_SESSION_URL`, which can lead to a the URL output including a double slash:
```
$ echo $RS_SERVER_URL; echo $RS_SESSION_URL
https://dev1.rstudio.internal/
/s/4566a3c9ab5a75ae3a3d3/

$ /usr/lib/rstudio-server/bin/rserver-url -l 8050
https://dev1.rstudio.internal//s/4566a3c9ab5a75ae3a3d3/p/3393aabd/
```

This causes issues running applications in proxied environments with prefixes like `/rstudio` in their session ID. 

### Approach

`$RS_SESSION_URL` will always begin with a leading `/` so if we find a trailing `/` in `$RS_SERVER_URL`, we remove it before concatenating the output.

### Automated Tests

The recently added FastAPI automation will fail in our proxy fuzzbucket environment. This should resolve that.

### QA Notes


### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


