### PR TITLE
fix building on Macs with up-to-date brew dependencies (postgres)

### DIFF
--- a/dependencies/common/install-soci
+++ b/dependencies/common/install-soci
@@ -31,8 +31,20 @@ BOOST_DIR="$RSTUDIO_TOOLS_ROOT/boost/boost_$BOOST_VERSION"
 
 # install SOCI if it isn't already installed
 if [ -d "${SOCI_BIN_DIR}/lib" ]; then
-   echo "SOCI already installed at '${SOCI_DIR}'"
-   exit 0
+   SOCI_FOUND=true
+
+   # Detect macOS situation where soci was built without postgres and proceed to rebuild
+   # https://github.com/rstudio/rstudio/issues/12288
+   if [[ "$OSTYPE" = "darwin"* ]]; then
+      if [ ! -e "${SOCI_BIN_DIR}/lib/libsoci_postgresql.a" ]; then
+         SOCI_FOUND=false
+      fi
+   fi
+
+   if [[ $SOCI_FOUND = true ]]; then
+      echo "SOCI already installed at '${SOCI_DIR}'"
+      exit 0
+   fi
 fi
 
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"
@@ -72,6 +84,13 @@ then
    MAKEFLAGS="-w dupbuild=warn ${MAKEFLAGS}"
 else
    CMAKE_GENERATOR="Unix Makefiles"
+fi
+
+# Help cmake find the homebrew-installed postgresql libs on macOS
+# https://github.com/rstudio/rstudio/issues/12288
+if [[ "$OSTYPE" = "darwin"* ]]; then
+   HOMEBREW_PREFIX=$(brew --prefix)
+   export POSTGRESQL_ROOT="${HOMEBREW_PREFIX}/opt/libpq"
 fi
 
 "${CMAKE}" -G"${CMAKE_GENERATOR}"                      \


### PR DESCRIPTION
### Intent

Addresses ##12288

A recent change in homebrew's Postgres formula made it keg-only. This prevented the SOCI build (done when installing rstudio build dependencies) from finding the Postgres libs. SOCI still builds, just without Postgres support. That then breaks the rstudio IDE build when cmake fails to find the SOCI Postgres libs.

This manifests on recently configured Mac dev machines, but not on ones set up before this change (unless an explicit `brew update` was performed recently AND the SOCI libs rebuilt). The Mac official build machine is never `brew updated`, so it hasn't hit this problem.

### Approach

When building SOCI on a Mac, set the environment variable `POSTGRESQL_ROOT` to the location of the homebrew postgres files. This environment variable is documented in the cmake module for postgres detection included with SOCI.

Also, detect if SOCI had been built (on a Mac) without Postgres support, and rebuild it. This is to help devs who got their machines in this state; it _should_ fix itself when re-running `install-dependencies-osx`.

### Automated Tests

N/A

### QA Notes

Purely a build-time thing, and currently only an issue on dev machines (Macs).

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


