### PR TITLE
column name chain completions with prefixed function, e.g. `dplyr::mutate()`

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -646,6 +646,9 @@ assign(x = ".rs.acCompletionTypes",
    if (is.null(objectForDispatch))
       return(NULL)
    
+   # handle e.g. dplyr::mutate(): the generic is "mutate", not "dplyr::mutate"
+   functionName <- sub("^.*:{2,3}", "", functionName)
+
    # iterate over the known classes for the object, and see if we have
    # an appropriate S3 method that could be used for dispatch
    classes <- class(objectForDispatch)

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -463,8 +463,6 @@ var RCodeModel = function(session, tokenizer,
                }
 
             }
-            
-
          }
          
       } while (cursor.moveToNextToken());
@@ -487,14 +485,14 @@ var RCodeModel = function(session, tokenizer,
             return false;
 
          // Move over '::' qualifiers
-         if (clone.currentValue() === ":")
+         if (clone.currentValue() === "::" || clone.currentValue() === ":::")
          {
-            while (clone.currentValue() === ":")
-               if (!clone.moveToPreviousToken())
-                  return false;
+            // Move of to pkg identifier
+            if (!clone.moveToPreviousToken())
+               return false;
 
             // Move off of identifier
-            if (!clone.moveToPreviousToken())
+            if (!pIdentifier(clone.currentToken()) || !clone.moveToPreviousToken())
                return false;
          }
 
@@ -582,11 +580,11 @@ var RCodeModel = function(session, tokenizer,
          }
 
          // Move over '::' qualifiers
-         if (clone.currentValue() === ":")
+         if (clone.currentValue() === "::" || clone.currentValue() === ":::")
          {
-            while (clone.currentValue() === ":")
-               if (!clone.moveToPreviousToken())
-                  return false;
+            // Move off of ::
+            if (!clone.moveToPreviousToken())
+               return false;
 
             // Move off of identifier
             if (!clone.moveToPreviousToken())


### PR DESCRIPTION
### Intent

addresses #9786

### Approach

R code model was under the impression it would get two `:` tokens, when in fact `::` is tokenized as once entity. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

<img width="890" alt="image" src="https://user-images.githubusercontent.com/2625526/200320739-35c51a32-3e0f-4d97-b515-0e2580e9e60b.png">

In addition to #9786, this gets arguments correctly (with dispatch) when the function is prefixed with package name:

<img width="956" alt="image" src="https://user-images.githubusercontent.com/2625526/200320107-f0a89662-89a8-46dc-a186-4067b4341cde.png">

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


