### PR TITLE
revert use of `.rs.isSymbolic`

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1539,6 +1539,9 @@ assign(x = ".rs.acCompletionTypes",
       if (is.integer(types) && length(types) == length(names))
          type <- types
       
+      else if (inherits(object, "data.frame"))
+         type <- .rs.acCompletionTypes$COLUMN
+
       # NOTE: Getting the types forces evaluation; we avoid that if
       # there are too many names to evaluate.
       else if (length(names) > 2E2)


### PR DESCRIPTION
This reverts the use of `.rs.isSymbolic` from #12273 as it was too strict, i.e. was preventing things like `a$b$` to complete. 