### PR TITLE
Chain completions with more complex `chainObjectName`

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -347,7 +347,7 @@ var RCodeModel = function(session, tokenizer,
    this.getDataFromInfixChain = function(tokenCursor)
    {
       var data = this.moveToDataObjectFromInfixChain(tokenCursor);
-      
+
       var additionalArgs = [];
       var excludeArgs = [];
       var name = "";
@@ -357,7 +357,18 @@ var RCodeModel = function(session, tokenizer,
          if (data.excludeArgsFromObject)
             excludeArgsFromObject = data.excludeArgsFromObject;
          
-         name = tokenCursor.currentValue();
+         var clone = tokenCursor.cloneCursor();
+         clone.findStartOfEvaluationContext();
+
+         name = this.$doc.getTextRange(new Range(
+            clone.currentPosition().row,
+            clone.currentPosition().column,
+
+            tokenCursor.currentPosition().row,
+            tokenCursor.currentPosition().column + tokenCursor.currentValue().length
+         ));
+         
+         // name = tokenCursor.currentValue();
          additionalArgs = data.additionalArgs;
          excludeArgs = data.excludeArgs;
 


### PR DESCRIPTION
### Intent

addresses #9612
 
### Approach

`getDataFromInfixChain()` sets `name` to the full evaluation context, rather than only the token before the first pipe. 

```r
library(tidyverse)

outer_lst <- list(
  lvl1_lst =list(
    inner_df = data.frame(inner_col_1 = 1:2, inner_col_2 = 3:4),
    inneer_x = 42
  ),
  lvl1_df = data.frame(lvl1_col_1 = 1:2, lvl1_col_2 = 3:4)
)
```

`outer_lst$lvl1_lst$inner_df %>% filter(` <kbd>TAB</kbd>
`outer_lst$lvl1_lst[[1]] %>% filter(` <kbd>TAB</kbd>
`outer_lst$lvl1_df %>% filter(` <kbd>TAB</kbd>
`outer_lst[[2]] %>% filter(` <kbd>TAB</kbd>

<img width="641" alt="image" src="https://user-images.githubusercontent.com/2625526/200810936-d736c1f1-0a6d-47f5-b806-26538cf1df4b.png">

<img width="594" alt="image" src="https://user-images.githubusercontent.com/2625526/200810987-c45b395c-477c-4801-89a9-7ddcd36dcdfd.png">

<img width="525" alt="image" src="https://user-images.githubusercontent.com/2625526/200812106-6dc649f3-2ee3-4ebd-bff9-8b6242b571aa.png">

<img width="496" alt="image" src="https://user-images.githubusercontent.com/2625526/200812169-99f6f2ec-c6e4-43f8-8b85-4392d4b55ba3.png">

The `chainObjectName` e.g. `outer_lst$lvl1_lst$inner_df` goes  through `.rs.getAnywhere()` which I believe is ok, since other paths retrieve completions, e.g. 

<img width="584" alt="image" src="https://user-images.githubusercontent.com/2625526/200812585-938c2abd-4711-4bb8-aaee-05731a2ed5f7.png">

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


