### PR TITLE
Add an echo to investigate some test failures

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -199,6 +199,8 @@ UNIT_TEST_FAILURE=false
 if has-scope "core"; then
 
    section "Running 'core' tests"
+   echo "location of losf: $(which lsof)"
+
    # Run only the tests that don't require root
    runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} '~[requiresRoot]'"
 


### PR DESCRIPTION
### Intent

I was only able to reproduce the below failures by moving `lsof`. I tried a `which lsof` in the Jenkinsfile before the tests run, but it came up okay.

### Approach

Add a `which lsof` call in the test script to try to see if `lsof` is missing from the path in the script context.

### Automated Tests

Trying to fix them

### QA Notes

Build system only

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


