### PR TITLE
More LSOF failure investigation

### DIFF
--- a/src/cpp/core/system/PosixSystemTests.cpp
+++ b/src/cpp/core/system/PosixSystemTests.cpp
@@ -326,6 +326,13 @@ test_context("PosixSystemTests")
 
    test_that("Current working directory determined correctly with lsof method")
    {
+      FilePath lsofPath;
+      Error error = findProgramOnPath("lsof", &lsofPath);
+      expect_false(error);
+      
+      std::string resolvedPath = lsofPath.getAbsolutePath();
+      expect_true(resolvedPath.find("lsof") != std::string::npos);
+
       FilePath emptyPath;
       FilePath startingDir = FilePath::safeCurrentPath(emptyPath);
       pid_t pid = fork();

--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -199,7 +199,6 @@ UNIT_TEST_FAILURE=false
 if has-scope "core"; then
 
    section "Running 'core' tests"
-   echo "location of losf: $(which lsof)"
 
    # Run only the tests that don't require root
    runWatchdogProcess 5m false "@CMAKE_CURRENT_BINARY_DIR@/core/${RSTUDIO_CORETEST_BIN} '~[requiresRoot]'"


### PR DESCRIPTION
### Intent

Continue investigating failing tests

### Approach

Try checking for LSOF from inside the actual test binary.

### Automated Tests

Trying to fix them.

### QA Notes

Test only change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


