### PR TITLE
Feature/disable electron accessibility option

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -415,6 +415,7 @@ namespace prefs {
 #define kTextRendering "text_rendering"
 #define kTextRenderingAuto "auto"
 #define kTextRenderingGeometricPrecision "geometricPrecision"
+#define kDisableRendererAccessibility "disable_renderer_accessibility"
 
 class UserPrefValues: public Preferences
 {
@@ -1555,7 +1556,7 @@ public:
    core::Error setDataViewerMaxCellSize(int val);
 
    /**
-    * Support accessibility aids such as screen readers (RStudio Server).
+    * Support accessibility aids such as screen readers.
     */
    bool enableScreenReader();
    core::Error setEnableScreenReader(bool val);
@@ -1843,7 +1844,7 @@ public:
    core::Error setDiscardPendingConsoleInputOnError(bool val);
 
    /**
-    * A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+    * An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
     */
    int editorScrollMultiplier();
    core::Error setEditorScrollMultiplier(int val);
@@ -1853,6 +1854,12 @@ public:
     */
    std::string textRendering();
    core::Error setTextRendering(std::string val);
+
+   /**
+    * Disable Electron accessibility support.
+    */
+   bool disableRendererAccessibility();
+   core::Error setDisableRendererAccessibility(bool val);
 
 };
 

--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -35,6 +35,7 @@ namespace prefs {
 #define kViewZoomLevel "zoomLevel"
 #define kViewWindowBounds "windowBounds"
 #define kViewAccessibility "accessibility"
+#define kViewDisableRendererAccessibility "disableRendererAccessibility"
 #define kRemoteSession "remote_session"
 #define kRemoteSessionLastRemoteSessionUrl "lastRemoteSessionUrl"
 #define kRemoteSessionAuthCookies "authCookies"

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2481,7 +2481,7 @@ core::Error UserPrefValues::setDataViewerMaxCellSize(int val)
 }
 
 /**
- * Support accessibility aids such as screen readers (RStudio Server).
+ * Support accessibility aids such as screen readers.
  */
 bool UserPrefValues::enableScreenReader()
 {
@@ -3105,7 +3105,7 @@ core::Error UserPrefValues::setDiscardPendingConsoleInputOnError(bool val)
 }
 
 /**
- * A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+ * An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
  */
 int UserPrefValues::editorScrollMultiplier()
 {
@@ -3128,6 +3128,19 @@ std::string UserPrefValues::textRendering()
 core::Error UserPrefValues::setTextRendering(std::string val)
 {
    return writePref("text_rendering", val);
+}
+
+/**
+ * Disable Electron accessibility support.
+ */
+bool UserPrefValues::disableRendererAccessibility()
+{
+   return readPref<bool>("disable_renderer_accessibility");
+}
+
+core::Error UserPrefValues::setDisableRendererAccessibility(bool val)
+{
+   return writePref("disable_renderer_accessibility", val);
 }
 
 std::vector<std::string> UserPrefValues::allKeys()
@@ -3372,6 +3385,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDiscardPendingConsoleInputOnError,
       kEditorScrollMultiplier,
       kTextRendering,
+      kDisableRendererAccessibility,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1292,8 +1292,8 @@
         "enable_screen_reader": {
             "type": "boolean",
             "default": false,
-            "title": "Enable support for screen readers in RStudio Server",
-            "description": "Support accessibility aids such as screen readers (RStudio Server)."
+            "title": "Enable support for screen readers",
+            "description": "Support accessibility aids such as screen readers."
         },
         "typing_status_delay_ms": {
             "type": "integer",
@@ -1631,6 +1631,12 @@
             "type": "string",
             "enum": ["auto", "geometricPrecision"],
             "default": "auto"
+        },
+        "disable_renderer_accessibility": {
+            "type": "boolean",
+            "default": false,
+            "title": "Disable Electron accessibility support",
+            "description": "Disable Electron accessibility support."
         }
-    }
+     }
 }

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -58,12 +58,17 @@
                 "accessibility": {
                     "type": "boolean",
                     "description": "Screen reader support" 
+                },
+                "disableRendererAccessibility": {
+                    "type": "boolean",
+                    "description": "Disable Electron accessibility support"
                 }
-            },
+             },
             "default": {
                 "zoomLevel": 1.0,
                 "windowBounds": { "width": 1200, "height": 900, "x": 0, "y": 0 },
-                "accessibility": false
+                "accessibility": false,
+                "disableRendererAccessibility": false
             }
         },
         "remote_session": {

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -162,7 +162,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void getEnableAccessibility(CommandWithArg<Boolean> callback);
    void setEnableAccessibility(boolean enable);
-   
+   void setDisableRendererAccessibility(boolean disable);
+
    void getClipboardMonitoring(CommandWithArg<Boolean> callback);
    void setClipboardMonitoring(boolean monitoring);
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2722,7 +2722,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * Support accessibility aids such as screen readers (RStudio Server).
+    * Support accessibility aids such as screen readers.
     */
    public PrefValue<Boolean> enableScreenReader()
    {
@@ -3403,7 +3403,7 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+    * An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
     */
    public PrefValue<Integer> editorScrollMultiplier()
    {
@@ -3432,6 +3432,18 @@ public class UserPrefsAccessor extends Prefs
 
    public final static String TEXT_RENDERING_AUTO = "auto";
    public final static String TEXT_RENDERING_GEOMETRICPRECISION = "geometricPrecision";
+
+   /**
+    * Disable Electron accessibility support.
+    */
+   public PrefValue<Boolean> disableRendererAccessibility()
+   {
+      return bool(
+         "disable_renderer_accessibility",
+         _constants.disableRendererAccessibilityTitle(), 
+         _constants.disableRendererAccessibilityDescription(), 
+         false);
+   }
 
    public void syncPrefs(String layer, JsObject source)
    {
@@ -3913,6 +3925,8 @@ public class UserPrefsAccessor extends Prefs
          editorScrollMultiplier().setValue(layer, source.getInteger("editor_scroll_multiplier"));
       if (source.hasKey("text_rendering"))
          textRendering().setValue(layer, source.getString("text_rendering"));
+      if (source.hasKey("disable_renderer_accessibility"))
+         disableRendererAccessibility().setValue(layer, source.getBool("disable_renderer_accessibility"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -4156,6 +4170,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(discardPendingConsoleInputOnError());
       prefs.add(editorScrollMultiplier());
       prefs.add(textRendering());
+      prefs.add(disableRendererAccessibility());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1586,11 +1586,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String dataViewerMaxCellSizeDescription();
 
    /**
-    * Support accessibility aids such as screen readers (RStudio Server).
+    * Support accessibility aids such as screen readers.
     */
-   @DefaultStringValue("Enable support for screen readers in RStudio Server")
+   @DefaultStringValue("Enable support for screen readers")
    String enableScreenReaderTitle();
-   @DefaultStringValue("Support accessibility aids such as screen readers (RStudio Server).")
+   @DefaultStringValue("Support accessibility aids such as screen readers.")
    String enableScreenReaderDescription();
 
    /**
@@ -1976,11 +1976,11 @@ public interface UserPrefsAccessorConstants extends Constants {
    String discardPendingConsoleInputOnErrorDescription();
 
    /**
-    * A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+    * An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
     */
    @DefaultStringValue("Editor scroll speed sensitivity")
    String editorScrollMultiplierTitle();
-   @DefaultStringValue("A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.")
+   @DefaultStringValue("An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.")
    String editorScrollMultiplierDescription();
 
    /**
@@ -1990,6 +1990,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String textRenderingTitle();
    @DefaultStringValue("Control how text is rendered within the IDE surface.")
    String textRenderingDescription();
+
+   /**
+    * Disable Electron accessibility support.
+    */
+   @DefaultStringValue("Disable Electron accessibility support")
+   String disableRendererAccessibilityTitle();
+   @DefaultStringValue("Disable Electron accessibility support.")
+   String disableRendererAccessibilityDescription();
 
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -798,9 +798,9 @@ dataViewerMaxColumnsDescription = The maximum number of columns to show at once 
 dataViewerMaxCellSizeTitle = Maximum number of character in data viewer cells
 dataViewerMaxCellSizeDescription = The maximum number of characters to show in a data viewer cell.
 
-# Support accessibility aids such as screen readers (RStudio Server).
-enableScreenReaderTitle = Enable support for screen readers in RStudio Server
-enableScreenReaderDescription = Support accessibility aids such as screen readers (RStudio Server).
+# Support accessibility aids such as screen readers.
+enableScreenReaderTitle = Enable support for screen readers
+enableScreenReaderDescription = Support accessibility aids such as screen readers.
 
 # Number of milliseconds to wait after last keystroke before updating live region.
 typingStatusDelayMsTitle = Seconds to wait before updating ARIA live region
@@ -993,12 +993,16 @@ nativeFileDialogsDescription = Whether RStudio Desktop will use the operating sy
 discardPendingConsoleInputOnErrorTitle = Discard pending console input on error
 discardPendingConsoleInputOnErrorDescription = When enabled, any pending console input will be discarded when an (uncaught) R error occurs.
 
-# A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+# An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
 editorScrollMultiplierTitle = Editor scroll speed sensitivity
-editorScrollMultiplierDescription = A integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
+editorScrollMultiplierDescription = An integer value, 1-200, to set the editor scroll multiplier. The higher the value, the faster the scrolling.
 
 # Control how text is rendered within the IDE surface.
 textRenderingTitle = Text rendering
 textRenderingDescription = Control how text is rendered within the IDE surface.
+
+# Disable Electron accessibility support.
+disableRendererAccessibilityTitle = Disable Electron accessibility support
+disableRendererAccessibilityDescription = Disable Electron accessibility support.
 
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -779,9 +779,9 @@ dataViewerMaxColumnsDescription= Le nombre maximum de colonnes à afficher en m�
 dataViewerMaxCellSizeTitle = Nombre maximal de caractères dans les cellules du visualiseur de données
 dataViewerMaxCellSizeDescription = Le nombre maximal de caractères à afficher dans une cellule du visualiseur de données.
 
-# Support accessibility aids such as screen readers (RStudio Server).
-enableScreenReaderTitle= Activer la prise en charge des lecteurs d''écran dans RStudio Server
-enableScreenReaderDescription= Prise en charge des aides à l''accessibilité telles que les lecteurs d''écran (RStudio Server).
+# Support accessibility aids such as screen readers.
+enableScreenReaderTitle= Activer la prise en charge des lecteurs d''écran
+enableScreenReaderDescription= Prise en charge des aides à l''accessibilité telles que les lecteurs d''écran.
 
 # Number of milliseconds to wait after last keystroke before updating live region.
 typingStatusDelayMsTitle= Secondes à attendre avant de mettre à jour la région ARIA live
@@ -1003,3 +1003,8 @@ editorScrollMultiplierDescription = Un entier, entre 1 et 200, pour controller l
 # Control how text is rendered within the IDE surface.
 textRenderingTitle = Rendu du texte
 textRenderingDescription = Controle comment le texte est rendu à la surface de l''IDE. 
+
+# Disable Electron accessibility support.
+disableRendererAccessibilityTitle = Disable Electron accessibility support
+disableRendererAccessibilityDescription = Disable Electron accessibility support.
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -1005,6 +1005,6 @@ textRenderingTitle = Rendu du texte
 textRenderingDescription = Controle comment le texte est rendu à la surface de l''IDE. 
 
 # Disable Electron accessibility support.
-disableRendererAccessibilityTitle = Disable Electron accessibility support
-disableRendererAccessibilityDescription = Disable Electron accessibility support.
+disableRendererAccessibilityTitle = Désactiver le support d''accessibilité Electron
+disableRendererAccessibilityDescription = Désactiver le support d''accessibilité Electron.
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -119,6 +119,10 @@ public class UserStateAccessor extends Prefs
          return this && this.accessibility || false;
       }-*/;
 
+      public final native boolean getDisableRendererAccessibility() /*-{
+         return this && this.disableRendererAccessibility || false;
+      }-*/;
+
    }
 
    /**
@@ -482,8 +486,8 @@ public class UserStateAccessor extends Prefs
    {
       return bool(
          "enable_cloud_publish_ui",
-         _constants.enableCloudPublishUiTitle(),
-         _constants.enableCloudPublishUiDescription(),
+         _constants.enableCloudPublishUiTitle(), 
+         _constants.enableCloudPublishUiDescription(), 
          false);
    }
 
@@ -739,6 +743,8 @@ public class UserStateAccessor extends Prefs
          showPublishUi().setValue(layer, source.getBool("show_publish_ui"));
       if (source.hasKey("enable_rsconnect_publish_ui"))
          enableRsconnectPublishUi().setValue(layer, source.getBool("enable_rsconnect_publish_ui"));
+      if (source.hasKey("enable_cloud_publish_ui"))
+         enableCloudPublishUi().setValue(layer, source.getBool("enable_cloud_publish_ui"));
       if (source.hasKey("publish_account"))
          publishAccount().setValue(layer, source.getObject("publish_account"));
       if (source.hasKey("document_outline_width"))
@@ -787,6 +793,7 @@ public class UserStateAccessor extends Prefs
       prefs.add(compileRMarkdownNotebookPrefs());
       prefs.add(showPublishUi());
       prefs.add(enableRsconnectPublishUi());
+      prefs.add(enableCloudPublishUi());
       prefs.add(publishAccount());
       prefs.add(documentOutlineWidth());
       prefs.add(connectVia());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
@@ -277,4 +277,7 @@ public interface UserStateAccessorConstants extends Constants {
    String quartoWebsiteSyncEditorTitle();
    @DefaultStringValue("Sync source editor to Quarto website preview navigation.")
    String quartoWebsiteSyncEditorDescription();
+
+
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
@@ -89,7 +89,7 @@ enableRsconnectPublishUiTitle =
 enableRsconnectPublishUiDescription = Whether to show UI for publishing content to Posit Connect.
 
 # Whether to show UI for publishing content to Posit Cloud.
-enableCloudPublishUiTitle =
+enableCloudPublishUiTitle = 
 enableCloudPublishUiDescription = Whether to show UI for publishing content to Posit Cloud.
 
 # The default (last) account used for publishing

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -602,7 +602,7 @@ public class GeneralPreferencesPane extends PreferencesPane
          boolean disableRendererAccessibilityPrefValue = disableRendererAccessibility_.getValue();
          if (disableRendererAccessibilityPrefValue != initialDisableRendererAccessibility_)
          {
-            if (Desktop.hasDesktopFrame())
+            if (Desktop.hasDesktopFrame() && BrowseCap.isElectron())
                Desktop.getFrame().setDisableRendererAccessibility(disableRendererAccessibilityPrefValue);
             restartRequirement.setDesktopRestartRequired(true);
          }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -344,6 +344,8 @@ public class GeneralPreferencesPane extends PreferencesPane
          {
             nativeFileDialogs_ = checkboxPref(prefs_.nativeFileDialogs());
             advanced.add(nativeFileDialogs_);
+            disableRendererAccessibility_ = checkboxPref(prefs_.disableRendererAccessibility());
+            advanced.add(disableRendererAccessibility_);
          }
       }
 
@@ -494,6 +496,7 @@ public class GeneralPreferencesPane extends PreferencesPane
 
       initialUiLanguage_ = prefs_.uiLanguage().getValue();
       initialNativeFileDialogs_ = prefs_.nativeFileDialogs().getValue();
+      initialDisableRendererAccessibility_ = prefs_.disableRendererAccessibility().getValue();
    }
 
    @Override
@@ -595,6 +598,15 @@ public class GeneralPreferencesPane extends PreferencesPane
          {
             restartRequirement.setUiReloadRequired(true);
          }
+
+         boolean disableRendererAccessibilityPrefValue = disableRendererAccessibility_.getValue();
+         if (disableRendererAccessibilityPrefValue != initialDisableRendererAccessibility_)
+         {
+            if (Desktop.hasDesktopFrame())
+               Desktop.getFrame().setDisableRendererAccessibility(disableRendererAccessibilityPrefValue);
+            restartRequirement.setDesktopRestartRequired(true);
+         }
+
 
          boolean useWebDialogsCookieValue = WebDialogCookie.getUseWebDialogs();
          boolean useWebDialogsPrefValue = !useNativeDialogsPrefValue;
@@ -706,6 +718,7 @@ public class GeneralPreferencesPane extends PreferencesPane
    private CheckBox clipboardMonitoring_ = null;
    private CheckBox fullPathInTitle_ = null;
    private CheckBox nativeFileDialogs_ = null;
+   private CheckBox disableRendererAccessibility_ = null;
    private CheckBox useGpuExclusions_ = null;
    private CheckBox useGpuDriverBugWorkarounds_ = null;
    private SelectWidget renderingEngineWidget_ = null;
@@ -729,4 +742,5 @@ public class GeneralPreferencesPane extends PreferencesPane
    private final Session session_;
    private String initialUiLanguage_;
    private boolean initialNativeFileDialogs_;
+   private boolean initialDisableRendererAccessibility_;
 }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -680,6 +680,10 @@ export class GwtCallback extends EventEmitter {
       ElectronDesktopOptions().setAccessibility(enable);
     });
 
+    ipcMain.on('desktop_set_disable_renderer_accessibility', (event, disable) => {
+      ElectronDesktopOptions().setDisableRendererAccessibility(disable);
+    });
+
     ipcMain.handle('desktop_get_ignore_gpu_exclusion_list', (event, ignore) => {
       return !ElectronDesktopOptions().useGpuExclusionList();
     });

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -84,10 +84,11 @@ class RStudioMain {
   }
 
   private async initializeAccessibility() {
-    // disable chromium renderer accessibility by default (it can cause 
-    // slowdown when used in conjunction with some applications; see e.g. 
+    // there have been cases, historically, where Chromium accessibility
+    // would enable itself and introduce performance issues even though the
+    // user was not using an accessibility aid such as a screen reader, e.g.:
     // https://github.com/rstudio/rstudio/issues/1990) 
-    if (!ElectronDesktopOptions().accessibility()) {
+    if (ElectronDesktopOptions().disableRendererAccessibility()) {
       app.commandLine.appendSwitch('disable-renderer-accessibility');
     }
   }

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -31,6 +31,7 @@ const kFixedWidthFont = 'font.fixedWidthFont';
 const kZoomLevel = 'view.zoomLevel';
 const kWindowBounds = 'view.windowBounds';
 const kAccessibility = 'view.accessibility';
+const kDisableRendererAccessibility = 'view.disableRendererAccessibility';
 
 const kLastRemoteSessionUrl = 'session.lastRemoteSessionUrl';
 const kAuthCookies = 'session.authCookies';
@@ -213,6 +214,15 @@ export class DesktopOptionsImpl implements DesktopOptions {
   public accessibility(): boolean {
     return this.config.get(kAccessibility, properties.view.default.accessibility);
   }
+
+  public setDisableRendererAccessibility(accessibility: boolean): void {
+    this.config.set(kDisableRendererAccessibility, accessibility);
+  }
+
+  public disableRendererAccessibility(): boolean {
+    return this.config.get(kDisableRendererAccessibility, properties.view.default.accessibility);
+  }
+
 
   public setLastRemoteSessionUrl(lastRemoteSessionUrl: string): void {
     this.config.set(kLastRemoteSessionUrl, lastRemoteSessionUrl);

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -220,7 +220,7 @@ export class DesktopOptionsImpl implements DesktopOptions {
   }
 
   public disableRendererAccessibility(): boolean {
-    return this.config.get(kDisableRendererAccessibility, properties.view.default.accessibility);
+    return this.config.get(kDisableRendererAccessibility, properties.view.default.disableRendererAccessibility);
   }
 
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -440,6 +440,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_set_enable_accessibility', enable);
     },
 
+    setDisableRendererAccessibility: (disable: boolean) => {
+      ipcRenderer.send('desktop_set_disable_renderer_accessibility', disable);
+    },
+
     getIgnoreGpuExclusionList: (callback: VoidCallback<boolean>) => {
       ipcRenderer
         .invoke('desktop_get_ignore_gpu_exclusion_list')

--- a/src/node/desktop/test/unit/main/desktop-options.test.ts
+++ b/src/node/desktop/test/unit/main/desktop-options.test.ts
@@ -94,6 +94,7 @@ describe('DesktopOptions', () => {
     const newZoom = 1.5;
     const newWindowBounds = { width: 123, height: 321, x: 0, y: 0 };
     const newAccessibility = !(properties.view.default.accessibility as boolean);
+    const newDisableRendererAccessibility = !(properties.view.default.disableRendererAccessibility as boolean);
     const newLastRemoteSessionUrl = 'testLastRemoteSessionUrl';
     const newAuthCookies = ['test', 'Autht', 'Cookies'];
     const newTempAuthCookies = ['test', 'Temp', 'Auth', 'Cookies'];
@@ -112,6 +113,7 @@ describe('DesktopOptions', () => {
     options.setZoomLevel(newZoom);
     options.saveWindowBounds(newWindowBounds);
     options.setAccessibility(newAccessibility);
+    options.setDisableRendererAccessibility(newDisableRendererAccessibility);
     options.setLastRemoteSessionUrl(newLastRemoteSessionUrl);
     options.setAuthCookies(newAuthCookies);
     options.setTempAuthCookies(newTempAuthCookies);
@@ -124,6 +126,7 @@ describe('DesktopOptions', () => {
     assert.equal(options.zoomLevel(), newZoom);
     assert.deepEqual(options.windowBounds(), newWindowBounds);
     assert.equal(options.accessibility(), newAccessibility);
+    assert.equal(options.disableRendererAccessibility(), newDisableRendererAccessibility);
     assert.equal(options.lastRemoteSessionUrl(), newLastRemoteSessionUrl);
     assert.deepEqual(options.authCookies(), newAuthCookies);
     assert.deepEqual(options.tempAuthCookies(), newTempAuthCookies);


### PR DESCRIPTION
### Intent

Addresses #12321

### Approach

Allow Chromium (via Electron) to auto-enable the internal accessibility APIs when an accessibility tool such as a screen reader is running. This is the default behaviour of Electron (and Chrome).

I added yet-another obscure option (Electron-only) named "Disable Electron Accessibility support" under Global Options / General / Advanced which can be used to disable Chromium's accessibility support by passing Chromium the `disable-renderer-accessibility` switch.

This would only be needed if a user finds that accessibility support is being enabled when it shouldn't and impacting the product's performance. There have been historical cases of this (https://github.com/rstudio/rstudio/issues/1990), but none are currently known.

I didn't put this option under Accessibility because a user needing accessibility support is never going to want to use this. It's more of an anti-accessibility setting.

![screenshot of Global options showing General / Advanced with new option highlighted](https://user-images.githubusercontent.com/10569626/201713081-30ffcbec-6b17-4715-878d-80aec970cb81.png)

Note in the diffs that there are some minor changes related to the `enable_cloud_publish_ui` setting (whitespace primarily); this indicates that when this preference was added the source files commented with dire warnings of "do not edit this file directly" were edited directly instead of being generated by the generate-prefs.R script. This should be a no-op but thought I'd point it out.

Also I removed the suffix `(RStudio Server)` from the existing Enable Accessibility option since it's no longer server-specific.

### Automated Tests

Added unit test for new setting.

### QA Notes

To test:

* Start RStudio and make sure "General / Advanced / Disable Electron accessibility support" is UNCHECKED and "Accessibility / Screen reader support" is UNCHECKED; these are the defaults on a clean install
* Exit RStudio
* Start a screen reader (on a Mac, use Cmd+F5 to start VoiceOver, on Windows, use Win+Ctrl+Enter for Narrator)
* start RStudio
* Help / Diagnostics / Show Accessibility Diagnostics

The various checkboxes under "Accessibility modes" should be checked (might vary slightly between Windows and Mac; the main thing is the checkboxes should not be disabled). If you run the above scenario on an Electron build without this fix, they will be disabled.

![Screenshot 2022-11-14 at 09 39 39](https://user-images.githubusercontent.com/10569626/201716056-89df7e33-8118-47ba-bcd6-2e3509698faf.png)

There is a known issue if you toggle "Disable Electron accessibility support" via the command palette instead of the Global Options dialog -- we don't sync the desktop-side setting via that avenue. This bug exists with other such settings that have both a session-side user-preference and a desktop-side setting that needs to be kept in sync. Also, FWIW, changing settings via the command-palette doesn't trigger the necessary restart.

### Checklist


- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


