### PR TITLE
Change enable_cloud_publish from a user state to a user pref

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -223,6 +223,7 @@ namespace prefs {
 #define kRmdViewerTypePane "pane"
 #define kRmdViewerTypeNone "none"
 #define kShowPublishDiagnostics "show_publish_diagnostics"
+#define kEnableCloudPublishUi "enable_cloud_publish_ui"
 #define kPublishCheckCertificates "publish_check_certificates"
 #define kUsePublishCaBundle "use_publish_ca_bundle"
 #define kPublishCaBundle "publish_ca_bundle"
@@ -1152,6 +1153,12 @@ public:
     */
    bool showPublishDiagnostics();
    core::Error setShowPublishDiagnostics(bool val);
+
+   /**
+    * Whether to show UI for publishing content to Posit Cloud.
+    */
+   bool enableCloudPublishUi();
+   core::Error setEnableCloudPublishUi(bool val);
 
    /**
     * Whether to check remote server SSL certificates when publishing content.

--- a/src/cpp/session/include/session/prefs/UserStateValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserStateValues.hpp
@@ -81,7 +81,6 @@ namespace prefs {
 #define kCompileRMarkdownNotebookPrefsFormat "format"
 #define kShowPublishUi "show_publish_ui"
 #define kEnableRsconnectPublishUi "enable_rsconnect_publish_ui"
-#define kEnableCloudPublishUi "enable_cloud_publish_ui"
 #define kPublishAccount "publish_account"
 #define kPublishAccountName "name"
 #define kPublishAccountServer "server"
@@ -225,12 +224,6 @@ public:
     */
    bool enableRsconnectPublishUi();
    core::Error setEnableRsconnectPublishUi(bool val);
-
-   /**
-    * Whether to show UI for publishing content to Posit Cloud.
-    */
-   bool enableCloudPublishUi();
-   core::Error setEnableCloudPublishUi(bool val);
 
    /**
     * The default (last) account used for publishing

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1610,6 +1610,19 @@ core::Error UserPrefValues::setShowPublishDiagnostics(bool val)
 }
 
 /**
+ * Whether to show UI for publishing content to Posit Cloud.
+ */
+bool UserPrefValues::enableCloudPublishUi()
+{
+   return readPref<bool>("enable_cloud_publish_ui");
+}
+
+core::Error UserPrefValues::setEnableCloudPublishUi(bool val)
+{
+   return writePref("enable_cloud_publish_ui", val);
+}
+
+/**
  * Whether to check remote server SSL certificates when publishing content.
  */
 bool UserPrefValues::publishCheckCertificates()
@@ -3268,6 +3281,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kRmdPreferredTemplatePath,
       kRmdViewerType,
       kShowPublishDiagnostics,
+      kEnableCloudPublishUi,
       kPublishCheckCertificates,
       kUsePublishCaBundle,
       kPublishCaBundle,

--- a/src/cpp/session/prefs/UserStateValues.cpp
+++ b/src/cpp/session/prefs/UserStateValues.cpp
@@ -258,19 +258,6 @@ core::Error UserStateValues::setEnableRsconnectPublishUi(bool val)
 }
 
 /**
- * Whether to show UI for publishing content to Posit Cloud.
- */
-bool UserStateValues::enableCloudPublishUi()
-{
-   return readPref<bool>("enable_cloud_publish_ui");
-}
-
-core::Error UserStateValues::setEnableCloudPublishUi(bool val)
-{
-   return writePref("enable_cloud_publish_ui", val);
-}
-
-/**
  * The default (last) account used for publishing
  */
 core::json::Object UserStateValues::publishAccount()
@@ -460,7 +447,6 @@ std::vector<std::string> UserStateValues::allKeys()
       kCompileRMarkdownNotebookPrefs,
       kShowPublishUi,
       kEnableRsconnectPublishUi,
-      kEnableCloudPublishUi,
       kPublishAccount,
       kDocumentOutlineWidth,
       kConnectVia,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -839,6 +839,11 @@
             "title": "Show diagnostic info when publishing",
             "description": "Whether to show verbose diagnostic information when publishing content."
         },
+        "enable_cloud_publish_ui": {
+            "type": "boolean",
+            "default": false,
+            "description": "Whether to show UI for publishing content to Posit Cloud."
+        },
         "publish_check_certificates": {
             "type": "boolean",
             "default": true,

--- a/src/cpp/session/resources/schema/user-state-schema.json
+++ b/src/cpp/session/resources/schema/user-state-schema.json
@@ -294,11 +294,6 @@
             "default": true,
             "description": "Whether to show UI for publishing content to Posit Connect."
         },
-        "enable_cloud_publish_ui": {
-          "type": "boolean",
-          "default": false,
-          "description": "Whether to show UI for publishing content to Posit Cloud."
-        },
         "publish_account": {
             "type": "object",
             "default": {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/RSConnect.java
@@ -240,7 +240,7 @@ public class RSConnect implements SessionInitEvent.Handler,
       input.setConnectUIEnabled(
             pUserState_.get().enableRsconnectPublishUi().getGlobalValue());
       input.setCloudUIEnabled(
-            pUserState_.get().enableCloudPublishUi().getGlobalValue());
+            pUserPrefs_.get().enableCloudPublishUi().getGlobalValue());
       input.setExternalUIEnabled(
             session_.getSessionInfo().getAllowExternalPublish());
       input.setDescription(event.getDescription());

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSAccountConnector.java
@@ -101,7 +101,7 @@ public class RSAccountConnector implements EnableRStudioConnectUIEvent.Handler
          final OperationWithInput<Boolean> onCompleted)
    {
       if (pUserState_.get().enableRsconnectPublishUi().getGlobalValue() ||
-         pUserState_.get().enableCloudPublishUi().getGlobalValue())
+         pUserPrefs_.get().enableCloudPublishUi().getGlobalValue())
       {
          showAccountTypeWizard(forFirstAccount, withCloudOption, onCompleted);
       }
@@ -188,8 +188,8 @@ public class RSAccountConnector implements EnableRStudioConnectUIEvent.Handler
    @Override
    public void onEnablePositCloudUI(EnableRStudioConnectUIEvent event)
    {
-      pUserState_.get().enableCloudPublishUi().setGlobalValue(event.getCloudEnable());
-      pUserState_.get().writeState();
+      pUserPrefs_.get().enableCloudPublishUi().setGlobalValue(event.getCloudEnable());
+      pUserPrefs_.get().writeUserPrefs();
    }
 
    // Private methods --------------------------------------------------------
@@ -234,7 +234,7 @@ public class RSAccountConnector implements EnableRStudioConnectUIEvent.Handler
             withCloudOption &&
                SessionUtils.showExternalPublishUi(session_, pUserState_.get()),
             pUserState_.get().enableRsconnectPublishUi().getGlobalValue(),
-            pUserState_.get().enableCloudPublishUi().getGlobalValue(),
+            pUserPrefs_.get().enableCloudPublishUi().getGlobalValue(),
             new ProgressOperationWithInput<NewRSConnectAccountResult>()
       {
          @Override

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -195,7 +195,7 @@ public class RSConnectDeploy extends Composite
       final boolean rsConnectEnabled = 
             userState_.enableRsconnectPublishUi().getGlobalValue();
       final boolean positCloudEnabled =
-         userState_.enableCloudPublishUi().getGlobalValue();
+         userPrefs_.enableCloudPublishUi().getGlobalValue();
       
       // Invoke the "add account" wizard if either Shiny app or Connect enabled
       if (contentType == RSConnect.CONTENT_TYPE_APP || rsConnectEnabled)
@@ -444,7 +444,7 @@ public class RSConnectDeploy extends Composite
       boolean isPositCloudContent = contentType == RSConnect.CONTENT_TYPE_PLUMBER_API ||
          contentType == RSConnect.CONTENT_TYPE_DOCUMENT || contentType == RSConnect.CONTENT_TYPE_PRES;
       boolean positCloudEnabled =
-         userState_.enableCloudPublishUi().getGlobalValue() && isPositCloudContent;
+         userPrefs_.enableCloudPublishUi().getGlobalValue() && isPositCloudContent;
 
       if (positCloudEnabled != accountList_.getShowPositCloudAccounts())
       {

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -743,7 +743,7 @@ public class RSConnectPublishButton extends Composite
    private boolean recomputeMenuVisibility()
    {
       if (pUserState_.get().enableRsconnectPublishUi().getGlobalValue() ||
-         pUserState_.get().enableCloudPublishUi().getGlobalValue())
+         pUserPrefs_.get().enableCloudPublishUi().getGlobalValue())
       {
          // always show the menu when RSConnect or Posit Cloud is enabled
          return true;
@@ -775,7 +775,7 @@ public class RSConnectPublishButton extends Composite
       // if both internal and external publishing is disabled, hide ourselves
       if (!session_.getSessionInfo().getAllowExternalPublish() &&
           !pUserState_.get().enableRsconnectPublishUi().getGlobalValue() &&
-          !pUserState_.get().enableCloudPublishUi().getGlobalValue())
+          !pUserPrefs_.get().enableCloudPublishUi().getGlobalValue())
          return false;
       
       // if we're bound to a command's visibility/enabled state, check that
@@ -803,7 +803,7 @@ public class RSConnectPublishButton extends Composite
       // If publishing to Connect and Cloud are both disabled, then we can't publish APIs
       if (contentType_ == RSConnect.CONTENT_TYPE_PLUMBER_API &&
           !pUserState_.get().enableRsconnectPublishUi().getGlobalValue() &&
-          !pUserState_.get().enableCloudPublishUi().getGlobalValue())
+          !pUserPrefs_.get().enableCloudPublishUi().getGlobalValue())
       {
          return false;
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1780,6 +1780,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to show UI for publishing content to Posit Cloud.
+    */
+   public PrefValue<Boolean> enableCloudPublishUi()
+   {
+      return bool(
+         "enable_cloud_publish_ui",
+         _constants.enableCloudPublishUiTitle(), 
+         _constants.enableCloudPublishUiDescription(), 
+         false);
+   }
+
+   /**
     * Whether to check remote server SSL certificates when publishing content.
     */
    public PrefValue<Boolean> publishCheckCertificates()
@@ -3691,6 +3703,8 @@ public class UserPrefsAccessor extends Prefs
          rmdViewerType().setValue(layer, source.getString("rmd_viewer_type"));
       if (source.hasKey("show_publish_diagnostics"))
          showPublishDiagnostics().setValue(layer, source.getBool("show_publish_diagnostics"));
+      if (source.hasKey("enable_cloud_publish_ui"))
+         enableCloudPublishUi().setValue(layer, source.getBool("enable_cloud_publish_ui"));
       if (source.hasKey("publish_check_certificates"))
          publishCheckCertificates().setValue(layer, source.getBool("publish_check_certificates"));
       if (source.hasKey("use_publish_ca_bundle"))
@@ -4053,6 +4067,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(rmdPreferredTemplatePath());
       prefs.add(rmdViewerType());
       prefs.add(showPublishDiagnostics());
+      prefs.add(enableCloudPublishUi());
       prefs.add(publishCheckCertificates());
       prefs.add(usePublishCaBundle());
       prefs.add(publishCaBundle());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1040,6 +1040,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String showPublishDiagnosticsDescription();
 
    /**
+    * Whether to show UI for publishing content to Posit Cloud.
+    */
+   @DefaultStringValue("")
+   String enableCloudPublishUiTitle();
+   @DefaultStringValue("Whether to show UI for publishing content to Posit Cloud.")
+   String enableCloudPublishUiDescription();
+
+   /**
     * Whether to check remote server SSL certificates when publishing content.
     */
    @DefaultStringValue("Check SSL certificates when publishing")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -525,6 +525,10 @@ rmdViewerTypeDescription = Where to display R Markdown documents when they have 
 showPublishDiagnosticsTitle = Show diagnostic info when publishing
 showPublishDiagnosticsDescription = Whether to show verbose diagnostic information when publishing content.
 
+# Whether to show UI for publishing content to Posit Cloud.
+enableCloudPublishUiTitle = 
+enableCloudPublishUiDescription = Whether to show UI for publishing content to Posit Cloud.
+
 # Whether to check remote server SSL certificates when publishing content.
 publishCheckCertificatesTitle = Check SSL certificates when publishing
 publishCheckCertificatesDescription = Whether to check remote server SSL certificates when publishing content.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -516,6 +516,10 @@ rmdViewerTypeDescription= Où afficher les documents R Markdown lorsqu''ils ont 
 showPublishDiagnosticsTitle= Afficher les informations de diagnostic lors de la publication
 showPublishDiagnosticsDescription= Si on doit afficher des informations de diagnostic verbeuses lors de la publication du contenu.
 
+# Whether to show UI for publishing content to Posit Cloud.
+enableCloudPublishUiTitle=
+enableCloudPublishUiDescription= Afficher ou non l''interface utilisateur·rice pour la publication de contenu sur Posit Cloud.
+
 # Whether to check remote server SSL certificates when publishing content.
 publishCheckCertificatesTitle= Vérifier les certificats SSL lors de la publication
 publishCheckCertificatesDescription= Indiquer ou non, si les certificats SSL du serveur distant doivent être vérifiés lors de la publication du contenu.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessor.java
@@ -480,18 +480,6 @@ public class UserStateAccessor extends Prefs
    }
 
    /**
-    * Whether to show UI for publishing content to Posit Cloud.
-    */
-   public PrefValue<Boolean> enableCloudPublishUi()
-   {
-      return bool(
-         "enable_cloud_publish_ui",
-         _constants.enableCloudPublishUiTitle(), 
-         _constants.enableCloudPublishUiDescription(), 
-         false);
-   }
-
-   /**
     * The default (last) account used for publishing
     */
    public PrefValue<PublishAccount> publishAccount()
@@ -743,8 +731,6 @@ public class UserStateAccessor extends Prefs
          showPublishUi().setValue(layer, source.getBool("show_publish_ui"));
       if (source.hasKey("enable_rsconnect_publish_ui"))
          enableRsconnectPublishUi().setValue(layer, source.getBool("enable_rsconnect_publish_ui"));
-      if (source.hasKey("enable_cloud_publish_ui"))
-         enableCloudPublishUi().setValue(layer, source.getBool("enable_cloud_publish_ui"));
       if (source.hasKey("publish_account"))
          publishAccount().setValue(layer, source.getObject("publish_account"));
       if (source.hasKey("document_outline_width"))
@@ -793,7 +779,6 @@ public class UserStateAccessor extends Prefs
       prefs.add(compileRMarkdownNotebookPrefs());
       prefs.add(showPublishUi());
       prefs.add(enableRsconnectPublishUi());
-      prefs.add(enableCloudPublishUi());
       prefs.add(publishAccount());
       prefs.add(documentOutlineWidth());
       prefs.add(connectVia());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants.java
@@ -167,14 +167,6 @@ public interface UserStateAccessorConstants extends Constants {
    String enableRsconnectPublishUiDescription();
 
    /**
-    * Whether to show UI for publishing content to Posit Cloud.
-    */
-   @DefaultStringValue("")
-   String enableCloudPublishUiTitle();
-   @DefaultStringValue("Whether to show UI for publishing content to Posit Cloud.")
-   String enableCloudPublishUiDescription();
-
-   /**
     * The default (last) account used for publishing
     */
    @DefaultStringValue("")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserStateAccessorConstants_en.properties
@@ -88,10 +88,6 @@ showPublishUiDescription = Whether to show UI for publishing content.
 enableRsconnectPublishUiTitle = 
 enableRsconnectPublishUiDescription = Whether to show UI for publishing content to Posit Connect.
 
-# Whether to show UI for publishing content to Posit Cloud.
-enableCloudPublishUiTitle = 
-enableCloudPublishUiDescription = Whether to show UI for publishing content to Posit Cloud.
-
 # The default (last) account used for publishing
 publishAccountTitle = 
 publishAccountDescription = The default (last) account used for publishing

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PreferencesDialog.java
@@ -104,7 +104,7 @@ public class PreferencesDialog extends PreferencesDialogBase<UserPrefs>
 
       else if (!session.getSessionInfo().getAllowExternalPublish() &&
                !userState.enableRsconnectPublishUi().getValue() &&
-               !userState.enableCloudPublishUi().getValue())
+               !userPrefs.enableCloudPublishUi().getValue())
       {
          hidePane(PublishingPreferencesPane.class);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -199,7 +199,7 @@ public class PublishingPreferencesPane extends PreferencesPane
       lessSpaced(rsconnectPanel);
 
       final CheckBox chkEnablePositCloud = checkboxPref(constants_.chkEnableCloudLabel(),
-         userState_.enableCloudPublishUi());
+         userPrefs_.enableCloudPublishUi());
 
       add(headerLabel(constants_.settingsHeaderLabel()));
       CheckBox chkEnablePublishing = checkboxPref(constants_.chkEnablePublishingLabel(),


### PR DESCRIPTION
I create the `enable_cloud_publish_ui` in Global Options -> Publishing as a user state, based on the way the similar option was configured for RS Connect. Unfortunately, if we want admins to be able to set the default preference in a file (`rstudio-prefs.json`) then I think it has to be a user preference, not a user state. This is necessary because we want this option to be off by default in RStudio Desktop/other IDE products, but allow the Cloud-hosted instance of the IDE to turn it on by default. Migrating this to User Prefs so the Hosted team can manage that via file on their end.