### PR TITLE
Adjust `.rs.matchCall()` to keep unnamed arguments only before the cursor

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1022,6 +1022,8 @@ assign(x = ".rs.acCompletionTypes",
             results = formals$formals[keep],
             packages = formals$methods[keep],
             type = .rs.acCompletionTypes$ARGUMENT,
+            excludeOtherCompletions = FALSE,
+            excludeOtherArgumentCompletions = TRUE,
             fguess = fguess,
             orderStartsWithAlnumFirst = FALSE
          )
@@ -1192,6 +1194,7 @@ assign(x = ".rs.acCompletionTypes",
                                             meta = character(),
                                             fguess = "",
                                             excludeOtherCompletions = FALSE,
+                                            excludeOtherArgumentCompletions = FALSE,
                                             overrideInsertParens = FALSE,
                                             orderStartsWithAlnumFirst = TRUE,
                                             cacheable = TRUE,
@@ -1251,6 +1254,7 @@ assign(x = ".rs.acCompletionTypes",
         meta = meta,
         fguess = fguess,
         excludeOtherCompletions = .rs.scalar(excludeOtherCompletions),
+        excludeOtherArgumentCompletions = .rs.scalar(excludeOtherArgumentCompletions),
         overrideInsertParens = .rs.scalar(overrideInsertParens),
         cacheable = .rs.scalar(cacheable),
         helpHandler = .rs.scalar(helpHandler),
@@ -1292,6 +1296,9 @@ assign(x = ".rs.acCompletionTypes",
    
    if (length(new$excludeOtherCompletions) && new$excludeOtherCompletions)
       old$excludeOtherCompletions <- new$excludeOtherCompletions
+
+   if (length(new$excludeOtherArgumentCompletions) && new$excludeOtherArgumentCompletions)
+      old$excludeOtherArgumentCompletions <- new$excludeOtherArgumentCompletions
    
    if (length(new$overrideInsertParens) && new$overrideInsertParens)
       old$overrideInsertParens <- new$overrideInsertParens

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -692,6 +692,8 @@ assign(x = ".rs.acCompletionTypes",
    names <- names(call)
    if (is.null(names)) 
       names <- rep("", length(call))
+   funFormals <- names(formals(func))
+   hasDots <- any(funFormals == "...")
    
    if (is.null(numCommas))
       numCommas <- length(call)
@@ -703,9 +705,12 @@ assign(x = ".rs.acCompletionTypes",
       if (i > length(call))
          break
       
-      if (identical(call[[i]], quote(`...`)) || (names[i] == "" && j > numCommas))
+      # dropping from the call:
+      # - explicit ...
+      # - unnamed arguments after the cursor
+      # - named arguments not in the formals of fun (unless fun has ...)
+      if (identical(call[[i]], quote(`...`)) || (names[i] == "" && j > numCommas) || (!hasDots && names[i] != "" && !any(names[i] == funFormals)))
       {
-         # drop this argument from the call
          call <- call[-i]
          names <- names[-i]
       }  

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -691,14 +691,20 @@ assign(x = ".rs.acCompletionTypes",
 {
    ## NOTE: the ugliness here is necessary to handle missingness in calls
    ## e.g. `x <- call[[i]]` fails to assign to `x` if `call[[i]]` is missing
-   i <- 1
+   i <- 2
+   names <- names(call)
+   if (is.null(names)) 
+      names <- rep("", length(call))
    while (TRUE)
    {
       if (i > length(call))
          break
       
-      if (length(call[[i]]) == 1 && is.symbol(call[[i]]) && as.character(call[[i]]) == "...")
+      if (identical(call[[i]], quote(`...`)) || names[i] == "")
+      {
          call <- call[-i]
+         names <- names[-i]
+      }  
       else
          i <- i + 1
    }

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -689,12 +689,11 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("matchCall", function(func, call)
 {
-   ## NOTE: the ugliness here is necessary to handle missingness in calls
-   ## e.g. `x <- call[[i]]` fails to assign to `x` if `call[[i]]` is missing
    i <- 2
    names <- names(call)
    if (is.null(names)) 
       names <- rep("", length(call))
+   
    while (TRUE)
    {
       if (i > length(call))

--- a/src/cpp/tests/testthat/test-auto-completion.R
+++ b/src/cpp/tests/testthat/test-auto-completion.R
@@ -1,0 +1,109 @@
+#
+# test-auto-completion.R
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+library(testthat)
+
+context("auto-completion")
+
+test_that(".rs.matchCall() respects numCommas=", {
+    fun <- function(aaa, bbb, ccc){}
+
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, c))), 
+        quote(fun(aaa = a, bbb = b, ccc = c))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, c)), numCommas = 0), 
+        quote(fun())
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, c)), numCommas = 1), 
+        quote(fun(aaa = a))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, c)), numCommas = 2), 
+        quote(fun(aaa = a, bbb = b))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, c)), numCommas = 3), 
+        quote(fun(aaa = a, bbb = b, ccc = c))
+    )
+
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, aaa = c)), numCommas = 0), 
+        quote(fun(aaa = c))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, aaa = c)), numCommas = 1), 
+        quote(fun(aaa = c, bbb = a))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, aaa = c)), numCommas = 2), 
+        quote(fun(aaa = c, bbb = a, ccc = b))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, aaa = c)), numCommas = 3), 
+        quote(fun(aaa = c, bbb = a, ccc = b))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, b, aaa = c))), 
+        quote(fun(aaa = c, bbb = a, ccc = b))
+    )
+    
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(aaa = a, b, c)), numCommas = 0), 
+        quote(fun(aaa = a))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(aaa = a, b, c)), numCommas = 1), 
+        quote(fun(aaa = a))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(aaa = a, b, c)), numCommas = 2), 
+        quote(fun(aaa = a, bbb = b))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(aaa = a, b, c)), numCommas = 3), 
+        quote(fun(aaa = a, bbb = b, ccc = c))
+    )
+
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, bbb = d, c)), numCommas = 0), 
+        quote(fun(bbb = d))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, bbb = d, c)), numCommas = 1), 
+        quote(fun(aaa = a, bbb = d))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, bbb = d, c)), numCommas = 2), 
+        quote(fun(aaa = a, bbb = d))
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(a, bbb = d, c)), numCommas = 3), 
+        quote(fun(aaa = a, bbb = d, ccc = c))
+    )
+})
+
+test_that(".rs.matchCall() removes named arguments not in the formals", {
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(ddd = a))), 
+        quote(fun())
+    )
+    expect_identical(
+        .rs.matchCall(fun, quote(fun(ddd = a, a))), 
+        quote(fun(aaa = a))
+    )
+})

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
@@ -32,6 +32,7 @@ public class Completions extends JavaScriptObject
                                                       JsArrayString meta,
                                                       String fguess,
                                                       boolean excludeOtherCompletions,
+                                                      boolean excludeOtherArgumentCompletions,
                                                       boolean overrideInsertParens,
                                                       boolean cacheable,
                                                       String helpHandler,
@@ -51,6 +52,7 @@ public class Completions extends JavaScriptObject
          meta: meta,
          fguess: fguess ? [fguess] : null,
          excludeOtherCompletions: excludeOtherCompletions,
+         excludeOtherArgumentCompletions: excludeOtherArgumentCompletions,
          overrideInsertParens: overrideInsertParens,
          cacheable: cacheable,
          helpHandler: helpHandler,
@@ -153,7 +155,11 @@ public class Completions extends JavaScriptObject
    public final native boolean getExcludeOtherCompletions() /*-{
       return this.excludeOtherCompletions;
    }-*/;
-   
+
+   public final native boolean getExcludeOtherArgumentCompletions() /*-{
+      return this.excludeOtherArgumentCompletions;
+   }-*/;
+
    public final native boolean getOverrideInsertParens() /*-{
       return this.overrideInsertParens;
    }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
@@ -192,6 +192,7 @@ public class CompletionCache
             metaSorted.cast(),
             original.getGuessedFunctionName(),
             original.getExcludeOtherCompletions(),
+            original.getExcludeOtherArgumentCompletions(),
             original.getOverrideInsertParens(),
             original.isCacheable(),
             original.getHelpHandler(),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -450,9 +450,13 @@ public class CompletionRequester
             }
 
             // Try getting our own function argument completions
-            if (!response.getExcludeOtherCompletions())
+            if (!response.getExcludeOtherArgumentCompletions() && !response.getExcludeOtherCompletions())
             {
                addFunctionArgumentCompletions(token, newComp);
+            }
+
+            if (!response.getExcludeOtherCompletions())
+            {
                addScopedArgumentCompletions(token, newComp);
             }
 
@@ -581,7 +585,7 @@ public class CompletionRequester
          {
             RFunction scopedFunction = scopedFunctions.get(i);
             String functionName = scopedFunction.getFunctionName();
-
+            
             JsArrayString argNames = scopedFunction.getFunctionArgs();
             for (int j = 0; j < argNames.length(); j++)
             {
@@ -789,6 +793,7 @@ public class CompletionRequester
                   JsUtil.toJsArrayBoolean(new ArrayList<>(result.completions.length())),
                   JsUtil.toJsArrayString(new ArrayList<>(result.completions.length())),
                   "",
+                  true,
                   true,
                   false,
                   true,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/yaml/YamlCompletionManager.java
@@ -139,6 +139,7 @@ public class YamlCompletionManager extends CompletionManagerBase
                true,
                true,
                true,
+               true,
                null,
                null, 
                JsUtil.toJsArrayInteger(new ArrayList<>(values.size())));         


### PR DESCRIPTION
### Intent

addresses #12326

### Approach

`.rs.matchCall()` uses `numCommas` (as identified by the client) to decide whether to keep unnamed arguments. 

### Automated Tests

unit tests: https://github.com/rstudio/rstudio/blob/bf7a8c97300729e555146465ffe006aaab75ecb8/src/cpp/tests/testthat/test-auto-completion.R

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


