### PR TITLE
Pin Quarto 1.2.269

### DIFF
--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -26,14 +26,16 @@ if [ "$(arch)" = "aarch64" ]; then
 fi
 
 # variables that control download + installation process
-# update to latest Quarto release 
-QUARTO_VERSION=`curl https://quarto.org/docs/download/_prerelease.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
-QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
-
 # specify a version to pin for releases
-#QUARTO_VERSION="0.9.230"
-QUARTO_SUBDIR="quarto"
+QUARTO_VERSION="1.2.269"
+
+# update to latest Quarto release
+# QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
+
+QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
 #QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
+
+QUARTO_SUBDIR="quarto"
 
 # move to tools root
 sudo-if-necessary-for "${RSTUDIO_TOOLS_ROOT}" "$@"

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -43,12 +43,13 @@ set PANDOC_VERSION=2.18
 set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
-REM set QUARTO_VERSION=0.9.230
+REM Pin to specific Quarto version for releases
+set QUARTO_VERSION=1.2.269
 
 REM Get latest Quarto release version
-cd install-quarto
-for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
-cd ..
+REM cd install-quarto
+REM for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
+REM cd ..
 
 set QUARTO_FILE=quarto-%QUARTO_VERSION%-win.zip
 

--- a/dependencies/windows/install-quarto/get-quarto-version.ps1
+++ b/dependencies/windows/install-quarto/get-quarto-version.ps1
@@ -1,6 +1,6 @@
 # Retrieve latest Quarto version from GitHub
 
-$response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_prerelease.json
+$response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_download.json
 $releases = ConvertFrom-Json $response.content
 $version = $releases.version
 $quartoVersion = $version | Select-String -Pattern '[0-9]+\.[0-9]+\.[0-9]+'

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -114,7 +114,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -117,7 +117,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-quarto"
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -102,7 +102,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -110,7 +110,7 @@ RUN cd /tmp && \
     make install
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -115,7 +115,7 @@ RUN cd gnupg-1.4.23 && ./configure --prefix=/gnupg1 && make && make install
 RUN ln -s /gnupg1/bin/gpg /usr/local/bin/gpg1 
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -105,7 +105,7 @@ RUN export QT_VERSION=5.12.8 && \
     cd /tmp && /bin/bash ./install-qt-linux
 
 # cachebust for Quarto release
-ADD https://quarto.org/docs/download/_prerelease.json quarto_releases
+ADD https://quarto.org/docs/download/_download.json quarto_releases
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
 
 # set github login from build argument if defined


### PR DESCRIPTION
### Intent
Pins Quarto to 1.2.269, the current latest release.

### Approach
Moved some lines around to group the version settings together. Changed the URL version check to use the release versions as well so that patch releases will use those instead of prerelease.

`install-quarto` and `install-dependencies.cmd` are the scripts that download and unpack quarto and are called from the Dockerfiles for the build.

### Automated Tests
Ran on Windows and Mac to confirm 1.2.269 is installed

### QA Notes
None 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


