### PR TITLE
Improve `group_by()` specific completions

### DIFF
--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -322,7 +322,7 @@ options(help_type = "html")
                    .rs.acCompletionTypes$S4_METHOD,
                    .rs.acCompletionTypes$R5_METHOD))
       return(.rs.getHelpFunction(what, from))
-   else if (type == .rs.acCompletionTypes$ARGUMENT)
+   else if (type %in% c(.rs.acCompletionTypes$ARGUMENT, .rs.acCompletionTypes$DATATABLE_ARGUMENT))
       return(.rs.getHelpArgument(what, from, parent.frame()))
    else if (type == .rs.acCompletionTypes$PACKAGE)
       return(.rs.getHelpPackage(what))

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -322,7 +322,7 @@ options(help_type = "html")
                    .rs.acCompletionTypes$S4_METHOD,
                    .rs.acCompletionTypes$R5_METHOD))
       return(.rs.getHelpFunction(what, from))
-   else if (type %in% c(.rs.acCompletionTypes$ARGUMENT, .rs.acCompletionTypes$DATATABLE_ARGUMENT))
+   else if (type %in% c(.rs.acCompletionTypes$ARGUMENT, .rs.acCompletionTypes$SECUNDARY_ARGUMENT))
       return(.rs.getHelpArgument(what, from, parent.frame()))
    else if (type == .rs.acCompletionTypes$PACKAGE)
       return(.rs.getHelpPackage(what))

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -68,7 +68,7 @@ assign(x = ".rs.acCompletionTypes",
           COLUMN      = 27,
           R6_OBJECT   = 28, 
           DATATABLE_SPECIAL_SYMBOL = 29,
-          DATATABLE_ARGUMENT       = 30,
+          SECUNDARY_ARGUMENT       = 30,
 
           CONTEXT     = 99
        )
@@ -1338,7 +1338,7 @@ assign(x = ".rs.acCompletionTypes",
    typeScores[completions$type == .rs.acCompletionTypes$COLUMN] <- 2
    typeScores[completions$type == .rs.acCompletionTypes$DATATABLE_SPECIAL_SYMBOL] <- 3
    typeScores[completions$type == .rs.acCompletionTypes$DATAFRAME] <- 4
-   typeScores[completions$type == .rs.acCompletionTypes$DATATABLE_ARGUMENT] <- 5
+   typeScores[completions$type == .rs.acCompletionTypes$SECUNDARY_ARGUMENT] <- 5
    
    # additional scores based on the result
    scores <- if (nzchar(token)) 
@@ -1410,7 +1410,7 @@ assign(x = ".rs.acCompletionTypes",
                                                    numCommas, 
                                                    envir = envir, 
                                                    object = data.table:::`[.data.table`)
-      argCompletions$type[argCompletions$type == .rs.acCompletionTypes$ARGUMENT] <- .rs.acCompletionTypes$DATATABLE_ARGUMENT
+      argCompletions$type[argCompletions$type == .rs.acCompletionTypes$ARGUMENT] <- .rs.acCompletionTypes$SECUNDARY_ARGUMENT
       
       completions <- .rs.appendCompletions(
          completions, 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -977,27 +977,32 @@ assign(x = ".rs.acCompletionTypes",
          .data <- .rs.getAnywhere(matchedCall[[".data"]], envir = envir)
          if (!is.null(.data))
          {
-            .names <- .rs.getNames(.data)
+            # potential completions
+            .names <- .rs.selectFuzzyMatches(.rs.getNames(.data), token)
 
-            namesCall <- names(matchedCall)
-            
-            # drop from .names:
-            # - the named argument, e.g. group_by(a = foo())
-            .drop <- setdiff(namesCall, c("", ".data", ".drop", ".keep"))
-            
-            # - the unnamed arguments that are symbols
-            unnamed <- as.list(matchedCall)[namesCall == ""][-1]
-            for (arg in unnamed)
+            if (length(.names))
             {
-               if (is.symbol(arg))
-                  .drop <- c(.drop, as.character(arg))
-            }
+               namesCall <- names(matchedCall)
+               
+               # drop from .names:
+               # - the named argument, e.g. group_by(a = foo())
+               .drop <- setdiff(namesCall, c("", ".data", ".drop", ".keep"))
+               
+               # - the unnamed arguments that are symbols
+               unnamed <- as.list(matchedCall)[namesCall == ""][-1]
+               for (arg in unnamed)
+               {
+                  if (is.symbol(arg))
+                     .drop <- c(.drop, as.character(arg))
+               }
 
-            return(.rs.makeCompletions(token = token,
-                                       results = setdiff(.names, .drop),
-                                       quote = FALSE,
-                                       type = .rs.acCompletionTypes$COLUMN, 
-                                       package = as.character(matchedCall[[".data"]])))
+               groupByCompletions <- .rs.makeCompletions(token = token,
+                                                         results = setdiff(.names, .drop),
+                                                         quote = FALSE,
+                                                         type = .rs.acCompletionTypes$COLUMN, 
+                                                         package = as.character(matchedCall[[".data"]]))
+               return(groupByCompletions)
+            }
          }
       }
       

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1410,7 +1410,7 @@ assign(x = ".rs.acCompletionTypes",
                                                    numCommas, 
                                                    envir = envir, 
                                                    object = data.table:::`[.data.table`)
-      argCompletions$types[argCompletions$types == .rs.acCompletionTypes$ARGUMENT] <- .rs.acCompletionTypes$DATATABLE_ARGUMENT
+      argCompletions$type[argCompletions$type == .rs.acCompletionTypes$ARGUMENT] <- .rs.acCompletionTypes$DATATABLE_ARGUMENT
       
       completions <- .rs.appendCompletions(
          completions, 

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1333,12 +1333,15 @@ assign(x = ".rs.acCompletionTypes",
 {
 
    # type based scores
-   typeScores <- rep(NA, length(completions$results))
+   typeScores <- rep(100, length(completions$results))
    typeScores[completions$type == .rs.acCompletionTypes$ARGUMENT] <- 1
    typeScores[completions$type == .rs.acCompletionTypes$COLUMN] <- 2
    typeScores[completions$type == .rs.acCompletionTypes$DATATABLE_SPECIAL_SYMBOL] <- 3
    typeScores[completions$type == .rs.acCompletionTypes$DATAFRAME] <- 4
    typeScores[completions$type == .rs.acCompletionTypes$SECUNDARY_ARGUMENT] <- 5
+
+   typeScores[completions$type == .rs.acCompletionTypes$PACKAGE] <- 101
+   typeScores[completions$type == .rs.acCompletionTypes$CONTEXT] <- 102
    
    # additional scores based on the result
    scores <- if (nzchar(token)) 

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/Completions.java
@@ -172,5 +172,4 @@ public class Completions extends JavaScriptObject
       return this.language;
    }-*/;
    
-   
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -46,6 +46,7 @@ public class RCompletionType
    public static final int COLUMN      = 27;
    public static final int R6_OBJECT   = 28;
    public static final int DATATABLE_SPECIAL_SYMBOL = 29;
+   public static final int DATATABLE_ARGUMENT = 30;
    
    public static final int SNIPPET     = 98;
    public static final int CONTEXT     = 99;
@@ -63,4 +64,20 @@ public class RCompletionType
       return type == FILE ||
              type == DIRECTORY;
    }
+
+   public static int score(int type) 
+   {
+      // same logic as .rs.sortCompletions() on the server side
+      switch(type){
+         case ARGUMENT: return 1;
+         case COLUMN: return 2;
+         case DATATABLE_SPECIAL_SYMBOL: return 3;
+         case DATAFRAME: return 4;
+         case DATATABLE_ARGUMENT: return 5;
+         default: break;
+      }
+
+      return 10;
+   }
+
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -74,10 +74,13 @@ public class RCompletionType
          case DATATABLE_SPECIAL_SYMBOL: return 3;
          case DATAFRAME: return 4;
          case SECUNDARY_ARGUMENT: return 5;
+
+         case PACKAGE: return 101;
+         case CONTEXT: return 102;
          default: break;
       }
 
-      return 10;
+      return 100;
    }
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -46,7 +46,7 @@ public class RCompletionType
    public static final int COLUMN      = 27;
    public static final int R6_OBJECT   = 28;
    public static final int DATATABLE_SPECIAL_SYMBOL = 29;
-   public static final int DATATABLE_ARGUMENT = 30;
+   public static final int SECUNDARY_ARGUMENT = 30;
    
    public static final int SNIPPET     = 98;
    public static final int CONTEXT     = 99;
@@ -73,7 +73,7 @@ public class RCompletionType
          case COLUMN: return 2;
          case DATATABLE_SPECIAL_SYMBOL: return 3;
          case DATAFRAME: return 4;
-         case DATATABLE_ARGUMENT: return 5;
+         case SECUNDARY_ARGUMENT: return 5;
          default: break;
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
@@ -137,15 +137,19 @@ public class CompletionCache
          {
             int lhsType = typeNarrow.get(lhs);
             int rhsType = typeNarrow.get(rhs);
-            
+
+            int lhsTypeScore = RCompletionType.score(lhsType);
+            int rhsTypeScore = RCompletionType.score(rhsType);
+            if (lhsTypeScore < rhsTypeScore)
+               return -1;
+            else if (lhsTypeScore > rhsTypeScore)
+               return 1;
+
             String lhsName = completionsNarrow.get(lhs);
             String rhsName = completionsNarrow.get(rhs);
             
             int lhsScore = CodeSearchOracle.scoreMatch(lhsName, token, false);
             int rhsScore = CodeSearchOracle.scoreMatch(rhsName, token, false);
-            
-            if (lhsType == RCompletionType.ARGUMENT) lhsType -= 3;
-            if (rhsType == RCompletionType.ARGUMENT) rhsType -= 3;
             
             if (lhsScore == rhsScore)
                return lhsName.compareTo(rhsName);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -1064,7 +1064,7 @@ public class CompletionRequester
                   "[" + source + "]");
          }
 
-         if (type == RCompletionType.ARGUMENT) 
+         if (type == RCompletionType.ARGUMENT || type == RCompletionType.DATATABLE_ARGUMENT) 
          {
             SafeHtmlUtil.appendSpan(
                   sb,
@@ -1086,6 +1086,7 @@ public class CompletionRequester
          case RCompletionType.VECTOR:
             return new ImageResource2x(ICONS.variable2x());
          case RCompletionType.ARGUMENT:
+         case RCompletionType.DATATABLE_ARGUMENT:
             return new ImageResource2x(ICONS.variable2x());
          case RCompletionType.ARRAY:
          case RCompletionType.DATAFRAME:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -333,7 +333,7 @@ public class CompletionRequester
 
    }
 
-   private static final Pattern RE_EXTRACTION = Pattern.create("[$@:\\[]", "");
+   private static final Pattern RE_EXTRACTION = Pattern.create("[$@:\\[\\(=]", "");
    private boolean isTopLevelCompletionRequest()
    {
       String line = docDisplay_.getCurrentLineUpToCursor();
@@ -401,13 +401,9 @@ public class CompletionRequester
             JsArrayString meta = response.getMeta();
             ArrayList<QualifiedName> newComp = new ArrayList<>();
 
-            // [.data.table special case: the completions are already in the right order
-            // i.e. we don't want arguments first
-            boolean ordered = StringUtil.equals(response.getGuessedFunctionName(), "[.data.table");
-            if (ordered) 
+            for (int i = 0; i < comp.length(); i++)
             {
-               // Get all server completions at once
-               for (int i = 0; i < comp.length(); i++)
+               if (comp.get(i).endsWith(" = "))
                {
                   newComp.add(new QualifiedName(
                      comp.get(i), 
@@ -425,30 +421,6 @@ public class CompletionRequester
                }
             }
             
-            // Get function completions from the server
-            if (!ordered)
-            {
-               for (int i = 0; i < comp.length(); i++)
-               {
-                  if (comp.get(i).endsWith(" = "))
-                  {
-                     newComp.add(new QualifiedName(
-                        comp.get(i), 
-                        display.get(i),
-                        pkgs.get(i), 
-                        quote.get(i), 
-                        type.get(i), 
-                        suggestOnAccept.get(i), 
-                        replaceToEnd.get(i),
-                        meta.get(i), 
-                        response.getHelpHandler(), 
-                        response.getLanguage(), 
-                        response.getContext().get(i)
-                     ));
-                  }
-               }
-            }
-
             // Try getting our own function argument completions
             if (!response.getExcludeOtherArgumentCompletions() && !response.getExcludeOtherCompletions())
             {
@@ -468,29 +440,26 @@ public class CompletionRequester
             }
 
             // Get other server completions
-            if (!ordered)
+            for (int i = 0; i < comp.length(); i++)
             {
-               for (int i = 0; i < comp.length(); i++)
+               if (!comp.get(i).endsWith(" = "))
                {
-                  if (!comp.get(i).endsWith(" = "))
-                  {
-                     newComp.add(new QualifiedName(
-                        comp.get(i), 
-                        display.get(i),
-                        pkgs.get(i), 
-                        quote.get(i), 
-                        type.get(i), 
-                        suggestOnAccept.get(i),
-                        replaceToEnd.get(i),
-                        meta.get(i), 
-                        response.getHelpHandler(), 
-                        response.getLanguage(), 
-                        response.getContext().get(i)
-                     ));
-                  }
+                  newComp.add(new QualifiedName(
+                     comp.get(i), 
+                     display.get(i),
+                     pkgs.get(i), 
+                     quote.get(i), 
+                     type.get(i), 
+                     suggestOnAccept.get(i),
+                     replaceToEnd.get(i),
+                     meta.get(i), 
+                     response.getHelpHandler(), 
+                     response.getLanguage(), 
+                     response.getContext().get(i)
+                  ));
                }
             }
-            
+         
             // Get snippet completions. Bail if this isn't a top-level
             // completion -- TODO is to add some more context that allows us
             // to properly ascertain this.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -1064,7 +1064,7 @@ public class CompletionRequester
                   "[" + source + "]");
          }
 
-         if (type == RCompletionType.ARGUMENT || type == RCompletionType.DATATABLE_ARGUMENT) 
+         if (type == RCompletionType.ARGUMENT || type == RCompletionType.SECUNDARY_ARGUMENT) 
          {
             SafeHtmlUtil.appendSpan(
                   sb,
@@ -1086,7 +1086,7 @@ public class CompletionRequester
          case RCompletionType.VECTOR:
             return new ImageResource2x(ICONS.variable2x());
          case RCompletionType.ARGUMENT:
-         case RCompletionType.DATATABLE_ARGUMENT:
+         case RCompletionType.SECUNDARY_ARGUMENT:
             return new ImageResource2x(ICONS.variable2x());
          case RCompletionType.ARRAY:
          case RCompletionType.DATAFRAME:

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
@@ -78,6 +78,7 @@ public class HelpStrategy
             showRoxygenHelp(item, display);
             break;
          case RCompletionType.ARGUMENT:
+         case RCompletionType.DATATABLE_ARGUMENT:
          case RCompletionType.OPTION:
             showParameterHelp(item, display);
             break;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpStrategy.java
@@ -78,7 +78,7 @@ public class HelpStrategy
             showRoxygenHelp(item, display);
             break;
          case RCompletionType.ARGUMENT:
-         case RCompletionType.DATATABLE_ARGUMENT:
+         case RCompletionType.SECUNDARY_ARGUMENT:
          case RCompletionType.OPTION:
             showParameterHelp(item, display);
             break;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1942,6 +1942,7 @@ public class RCompletionManager implements CompletionManager
          if (type == RCompletionType.ROXYGEN ||
              type == RCompletionType.PACKAGE ||
              type == RCompletionType.ARGUMENT ||
+             type == RCompletionType.DATATABLE_ARGUMENT ||
              type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT ||
              type == RCompletionType.KEYWORD)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1942,7 +1942,7 @@ public class RCompletionManager implements CompletionManager
          if (type == RCompletionType.ROXYGEN ||
              type == RCompletionType.PACKAGE ||
              type == RCompletionType.ARGUMENT ||
-             type == RCompletionType.DATATABLE_ARGUMENT ||
+             type == RCompletionType.SECUNDARY_ARGUMENT ||
              type == RCompletionType.OPTION ||
              type == RCompletionType.CONTEXT ||
              type == RCompletionType.KEYWORD)


### PR DESCRIPTION
### Intent

addresses #12356

### Approach

Make the completions in the `group_by()` special case `COLUMN` completion types. 

This also thinks about order of completions being first driven by the types, and then later by `scoreMatch()` so that we can make sure we get the completions in the preferred order (arguments, column, ...). This might need more work/discussion. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


