### PR TITLE
Flush build pane buffer periodically

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
@@ -85,6 +85,8 @@ public class CompileOutputBufferWithHighlight extends Composite
       totalSubmittedLines_ = 0;
       numDisplayedLines_ = 0;
       output_.setText("");
+      savedOutput_ = "";
+      numLinesSaved_ = 0;
    }
    
    @Override
@@ -96,14 +98,24 @@ public class CompileOutputBufferWithHighlight extends Composite
       
       String outputClass = styles_.output();
       console_.submit("\n", outputClass);
-      
+
+      flushOverloadBuffer(outputClass);
+   }
+
+   private void flushOverloadBuffer(String outputClass) {
       String[] lines = savedOutput_.split("\n");
       int end = lines.length - 1;
       int start = Math.max(0, end - 100);
       for (int i = start; i < end; i++)
+      {
          console_.submit(lines[i] + "\n", outputClass);
+         totalSubmittedLines_++;
+      }
+
+      savedOutput_ = "";
+      numLinesSaved_ = 0;
    }
-   
+
    private void write(String output, OutputType outputType, String className)
    {
       switch (state_)
@@ -122,19 +134,25 @@ public class CompileOutputBufferWithHighlight extends Composite
             numDisplayedLines_ = MAX_LINES_DISPLAY;
          }
 
-         if (totalSubmittedLines_ > MAX_LINES_OVERLOAD)
+         if (totalSubmittedLines_ > MAX_LINES_OVERLOAD_BUFFER)
          {
             state_ = PanelState.OVERLOADED;
-            console_.submit("\n\n[Detected output overflow; truncating build output]\n\n", className);
+            console_.submit("\n\n[Detected output overflow; buffering build output]\n\n", styles_.console());
          }
 
          scrollPanel_.onContentSizeChanged();
          return;
       }
-         
+
       case OVERLOADED:
       {
+         numLinesSaved_++;
          savedOutput_ += output;
+
+         if (numLinesSaved_ > MAX_LINES_OVERLOAD_BUFFER)
+         {
+            flushOverloadBuffer(className);
+         }
          return;
       }
       
@@ -154,9 +172,10 @@ public class CompileOutputBufferWithHighlight extends Composite
    private int numDisplayedLines_;
    private int totalSubmittedLines_;
    private String savedOutput_ = "";
+   private int numLinesSaved_ = 0;
    private BottomScrollPanel scrollPanel_;
    private ConsoleResources.ConsoleStyles styles_;
    
    private static final int MAX_LINES_DISPLAY = 500;
-   private static final int MAX_LINES_OVERLOAD = 5000;
+   private static final int MAX_LINES_OVERLOAD_BUFFER = 5000;
 }


### PR DESCRIPTION
### Intent
Address #12354

### Approach
Periodically flush the saved output so the user can see build progress. I don't think this would have an adverse effect on the ability to display the output since the `onCompileCompleted()` would submit everything that was saved.

### Automated Tests
None

### QA Notes
Building the Quarto book mentioned in #12354 has enough output to display a message that output would be buffered. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


