### PR TITLE
update docs to mention Electron screen-reader support

### DIFF
--- a/docs/user/rstudio/ide/guide/accessibility/screen-reader.qmd
+++ b/docs/user/rstudio/ide/guide/accessibility/screen-reader.qmd
@@ -25,7 +25,7 @@ Several accessibility-related options are available under the Help / Accessibili
 
 ## RStudio Desktop
 
--   Notes: Due to underlying accessibility issues introduced by components used to build RStudio Desktop, we cannot yet recommend its use via a screen reader except in an experimental fashion. We are actively working with the developer of these components to get these issues addressed, and will be releasing updates with these fixes as soon as we can.
+-   Notes: Screen-reader support for RStudio Desktop requires the Electron-based open-source version 2022.12 (Elsbeth Geranium) or newer. RStudio Desktop Pro does not support screen-reader operation at this time.
 
 ## Posit Workbench / RStudio Server
 
@@ -48,11 +48,9 @@ In most cases, screen reader users will have to keep turning off their virtual c
 
 ### Screen reader settings
 
-When using Posit Workbench or RStudio Server or later with a screen reader, it is essential to enable screen reader support. Once set, this setting is persisted for future RStudio sessions. The option is available to toggle via the main menu at Help / Accessibility / Screen Reader Support, or via the Global Options dialog, under the Accessibility panel.
+When using Posit Workbench, RStudio Server. or RStudio Desktop 2022.12 open-source (or later) with a screen reader, it is essential to enable screen reader support. Once set, this setting is persisted for future RStudio sessions. The option is available to toggle via the main menu at Help / Accessibility / Screen Reader Support, or via the Global Options dialog, under the Accessibility panel.
 
-The easiest way to enable the \"Screen Reader Support\" mode, however, is using its own keyboard shortcut by pressing \"Alt+Shift+/ (forward slash)\" on Windows or Linux; \"Ctrl+Option+/ (forward slash)\" on Mac.
-
--   Notes for Mac Users: the default VoiceOver modifier (VO) key conflict with any RStudio\'s shortcuts using Ctrl+Opt key combinations like above. Please use the VoiceOver pass-through keys (Ctrl+Opt+Tab) each time before pressing any RStudio\'s shortcuts requiring Ctrl+Opt key combination. Or, you can change the VO modifier key into \"Caps Lock\" via VoiceOver Utility (VO+F8) / General / \"Keys to use as the VoiceOver modifier\" setting.
+The easiest way to enable the \"Screen Reader Support\" mode, however, is using its own keyboard shortcut by pressing \"Alt+Shift+/ (forward slash)\" on Windows or Linux; \"Ctrl+Shift+Q\" on Mac.
 
 Once the \"Screen Reader Support\" mode is toggled on, you will hear the following dialog message:
 


### PR DESCRIPTION
### Intent

The move to Electron opens up the ability for Desktop to support screen-reader software, so update the documentation.

### Approach

Updated the user guide and the equivalent support article (https://support.posit.co/hc/en-us/articles/360045612413-RStudio-Screen-Reader-Support) to mention the following:

* 2022.12 and newer (Desktop open source) now support screen-readers
* RStudio Desktop Pro does not at this time
* the keyboard shortcut on Mac for enabling screen-reader support has changed in Elsbeth

### Automated Tests

Docs-only changes

### QA Notes

Check user guide and the support article (already updated).

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


