### PR TITLE
Fix scrolling on html pages that are much larger than the viewport

### DIFF
--- a/src/gwt/www/rstudio.css
+++ b/src/gwt/www/rstudio.css
@@ -32,6 +32,7 @@ html, body {
   left: 0;
   height: 100vh;
   margin: 0;
+  overflow: auto;
 }
 
 #posit-logo {


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio/issues/12362

### Intent

If long static pages are loaded, which is usually just `keyboard.htm`, then there is no scrolling enabled. This is due to a change to the css file that fixes the viewport to the window boundaries. We do not want to hide overflowing content if it exceeds the limits of the page.

### Approach

Add `overflow: auto` to the `html, body` section so that overflowing content will receive scrollbars. The only page this really affects is the `keyboard.htm` page, as the others are already laid out relative to the viewport boundaries. I already verified the other static files by loading them in a browser to check that they were not going to be broken by this change.

### Automated Tests / QA Notes

N / A - visual pass only. I verified this in Firefox, Chrome, and Safari

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


