### PR TITLE
Use absolute path in rserver-service

### DIFF
--- a/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.redhat.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
-ExecReload=kill -HUP $MAINPID
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]

--- a/src/cpp/server/extras/systemd/rstudio-server.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
-ExecReload=kill -HUP $MAINPID
+ExecReload=/usr/bin/kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Intent
Address #12371 

### Approach
Use an absolute path when invoking `kill`. It used to call `killall` and it was an absolute path.

### Automated Tests
None

### QA Notes
I don't have Ubuntu 18 so I tried this on Ubuntu 22 as a sanity check.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


