### PR TITLE
Fix service reload Ubuntu 18

### DIFF
--- a/src/cpp/server/extras/systemd/rstudio-server.service.in
+++ b/src/cpp/server/extras/systemd/rstudio-server.service.in
@@ -7,7 +7,7 @@ Wants=network-online.target
 Type=forking
 PIDFile=/run/rstudio-server.pid
 ExecStart=${CMAKE_INSTALL_PREFIX}/bin/rserver
-ExecReload=/usr/bin/kill -HUP $MAINPID
+ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 
 [Install]


### PR DESCRIPTION
### Intent
Address #12371 

### Approach
`/usr/bin/kill` may not be present on all platforms and `/bin/kill` appears to be available.


### Automated Tests
None

### QA Notes
Jeff and I checked these platforms for the existence of `/bin/kill`. It is available on:
* RHEL 7/8 
* CentOS 7
* SLES 12.5
* OpenSUSE 15.2
* Ubuntu 18/22

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


