### PR TITLE
Support optional `$suggestOnAccept` in server side completions

### DIFF
--- a/src/cpp/tests/testthat/test-auto-completion.R
+++ b/src/cpp/tests/testthat/test-auto-completion.R
@@ -107,3 +107,79 @@ test_that(".rs.matchCall() removes named arguments not in the formals", {
         quote(fun(aaa = a))
     )
 })
+
+test_that(".rs.makeCompletions() handle optional $suggestOnAccept", {
+    expect_null(
+        .rs.makeCompletions("", c("a", "b"))$suggestOnAccept
+    )
+    expect_equal(
+        .rs.makeCompletions("", c("a", "b"), suggestOnAccept = logical())$suggestOnAccept, 
+        c(FALSE, FALSE)
+    )
+    expect_equal(
+        .rs.makeCompletions("", c("a", "b"), suggestOnAccept = TRUE)$suggestOnAccept, 
+        c(TRUE, TRUE)
+    )
+    expect_equal(
+        .rs.makeCompletions("", c("a", "b"), suggestOnAccept = c(TRUE, FALSE))$suggestOnAccept, 
+        c(TRUE, FALSE)
+    )
+})
+
+test_that(".rs.appendCompletions() handle optional $suggestOnAccept", {
+    expect_null(
+        .rs.appendCompletions(
+            .rs.makeCompletions("", c("a", "b")), 
+            .rs.makeCompletions("", c("c", "d", "e"))
+        )$suggestOnAccept
+    )
+
+    expect_equal(
+        .rs.appendCompletions(
+            .rs.makeCompletions("", c("a", "b"), suggestOnAccept = c(TRUE, FALSE)), 
+            .rs.makeCompletions("", c("c", "d", "e"))
+        )$suggestOnAccept, 
+        c(TRUE, FALSE, FALSE, FALSE, FALSE)
+    )
+
+    expect_equal(
+        .rs.appendCompletions(
+            .rs.makeCompletions("", c("a", "b")), 
+            .rs.makeCompletions("", c("c", "d", "e"), suggestOnAccept = c(TRUE, FALSE, TRUE))
+        )$suggestOnAccept, 
+        c(FALSE, FALSE, TRUE, FALSE, TRUE)
+    )
+
+    expect_equal(
+        .rs.appendCompletions(
+            .rs.makeCompletions("", c("a", "b")     , suggestOnAccept = c(FALSE, TRUE)), 
+            .rs.makeCompletions("", c("c", "d", "e"), suggestOnAccept = c(TRUE, FALSE, TRUE))
+        )$suggestOnAccept, 
+        c(FALSE, TRUE, TRUE, FALSE, TRUE)
+    )
+})
+
+test_that(".rs.subsetCompletions() handle optional $suggestOnAccept", {
+    expect_equal(
+        .rs.subsetCompletions(
+            .rs.makeCompletions("", c("c", "d", "e"), suggestOnAccept = c(TRUE, FALSE, TRUE)), 
+            1
+        )$suggestOnAccept, 
+        TRUE
+    )
+
+    expect_equal(
+        .rs.subsetCompletions(
+            .rs.makeCompletions("", c("c", "d", "e"), suggestOnAccept = c(TRUE, FALSE, TRUE)), 
+            c(TRUE, TRUE, FALSE)
+        )$suggestOnAccept, 
+        c(TRUE, FALSE)
+    )
+    
+    expect_null(
+        .rs.subsetCompletions(
+            .rs.makeCompletions("", c("c", "d", "e")), 
+            1
+        )$suggestOnAccept
+    )
+})


### PR DESCRIPTION
### Intent

Support the optional element `suggestOnAccept` in server side completions. This will be useful when e.g. we do: 

<img width="342" alt="image" src="https://user-images.githubusercontent.com/2625526/205073226-cf15691f-69ea-49d7-a6e2-355ce82ca902.png">

we accept `.by = ` and the server side "knows" there are possible completions for `.by = `

### Approach

Added support in `.rs.makeCompletions()`, `.rs.subsetCompletions()` and `.rs.appendCompletions()`

### Automated Tests

added tests in `test-auto-completion.R`

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


