### PR TITLE
`quoteIfNotSyntacticNameCompletion()` needs more backslash

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1979,10 +1979,9 @@ public class RCompletionManager implements CompletionManager
          {
             quote = true;
          }
-         
          // if this is already a syntactic identifier, no quote is required
          if (quote)
-            return "`" + value.replaceAll("`", "\\`") + "`";
+            return "`" + value.replaceAll("`", "\\\\`") + "`";
          
          return value;
       }
@@ -2131,7 +2130,7 @@ public class RCompletionManager implements CompletionManager
          {
             value = quoteIfNotSyntacticNameCompletion(qualifiedName);
          }
-
+         
          /* In some cases, applyValue can be called more than once
           * as part of the same completion instance--specifically,
           * if there's only one completion candidate and it is in


### PR DESCRIPTION
### Intent

addresses #8675

### Approach

More `\\` are needed in `quoteIfNotSyntacticNameCompletion()`

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

https://user-images.githubusercontent.com/2625526/205659154-7670b4e8-3ad1-481d-93f6-e92873e35041.mov

it seems the other issue from #8675 is already fixed: 

<img width="672" alt="image" src="https://user-images.githubusercontent.com/2625526/205659363-55edce5e-191e-4495-8862-8a32541c0114.png">

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


