### PR TITLE
`listEnvironment()` no longer protecting the values

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -372,7 +372,6 @@ Error asPrimitiveEnvironment(SEXP envirSEXP,
 void listEnvironment(SEXP env, 
                      bool includeAll,
                      bool includeLastDotValue,
-                     Protect* pProtect,
                      std::vector<Variable>* pVariables)
 {
    if (!ASSERT_MAIN_THREAD())
@@ -415,7 +414,6 @@ void listEnvironment(SEXP env,
 
       if (varSEXP != R_UnboundValue) // should never be unbound
       {
-         pProtect->add(varSEXP);
          pVariables->push_back(std::make_pair(var, varSEXP));
       }
       else

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -61,10 +61,15 @@ SEXP forcePromise(SEXP objectSEXP);
    
 // variables within an environment
 typedef std::pair<std::string,SEXP> Variable;
+
+// fills pVariables with Variable from the environment
+// 
+// The caller must make sure that `env` is protected for 
+// as long as the SEXPs in pVariables are used, because 
+// they are not protected
 void listEnvironment(SEXP env, 
                      bool includeAll,
                      bool includeLastDotValue,
-                     Protect* pProtect,
                      std::vector<Variable>* pVariables);
       
 // object info

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -230,7 +230,7 @@
       return(.rs.valueDescription(expr))
    
    # we have a call; try to deparse it
-   sanitized <- .rs.sanitizeCall(call)
+   sanitized <- .rs.sanitizeCall(expr)
    .rs.deparse(sanitized)
 })
 

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -230,8 +230,7 @@
       return(.rs.valueDescription(expr))
    
    # we have a call; try to deparse it
-   sanitized <- .rs.sanitizeCall(expr)
-   .rs.deparse(sanitized)
+   .rs.describeCall(expr)
 })
 
 # used to create descriptions for language objects and symbols
@@ -604,6 +603,27 @@
    class(obj)[[1L]]
 })
 
+.rs.addFunction("describeCall", function(call)
+{
+   # defend against very large calls; e.g. those with R objects inlined
+   # as part of the call (can happen in do.call contexts)
+   #
+   # this is primarily used for the Environment pane, where we try to display
+   # a single-line summary of an R object -- so we can enforce that when
+   # deparsing calls here as well
+   #
+   # https://github.com/rstudio/rstudio/issues/5158
+   sanitized <- .rs.sanitizeCall(call)
+   val1 <- .rs.deparse(sanitized, nlines = 1L)
+   val2 <- .rs.deparse(sanitized, nlines = 2L)
+   
+   # indicate if there is more output
+   val <- if (!identical(val1, val2))
+      paste(val1, "<...>")
+   else
+      val1
+})
+
 .rs.addFunction("describeObject", function(env, objName, computeSize = TRUE)
 {
    obj <- get(objName, env)
@@ -660,24 +680,7 @@
    }
    else if (is.language(obj))
    {
-      # defend against very large calls; e.g. those with R objects inlined
-      # as part of the call (can happen in do.call contexts)
-      #
-      # this is primarily used for the Environment pane, where we try to display
-      # a single-line summary of an R object -- so we can enforce that when
-      # deparsing calls here as well
-      #
-      # https://github.com/rstudio/rstudio/issues/5158
-      sanitized <- .rs.sanitizeCall(obj)
-      val1 <- .rs.deparse(sanitized, nlines = 1L)
-      val2 <- .rs.deparse(sanitized, nlines = 2L)
-      
-      # indicate if there is more output
-      val <- if (!identical(val1, val2))
-         paste(val1, "<...>")
-      else
-         val1
-
+      .rs.describeCall(obj)  
    }
    else if (!hasNullPtr)
    {

--- a/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentMonitor.cpp
@@ -128,7 +128,6 @@ void EnvironmentMonitor::listEnv(std::vector<r::sexp::Variable>* pEnv)
    r::sexp::listEnvironment(getMonitoredEnvironment(),
                             false,
                             prefs::userPrefs().showLastDotValue(),
-                            &rProtect,
                             pEnv);
 }
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -160,7 +160,7 @@ bool hasExternalPtrImpl(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
       r::sexp::listEnvironment(envir,
                                true,  // include all values
                                false, // don't include last dot
-                               &rProtect, &vars);
+                               &vars);
    }
 
    // check for external pointers
@@ -409,7 +409,6 @@ json::Array environmentListAsJson()
        listEnvironment(env,
                        false,
                        prefs::userPrefs().showLastDotValue(),
-                       &rProtect,
                        &vars);
 
        // get object details and transform to json

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -35,11 +35,14 @@ test_that("environment object listings are correct", {
    # active binding
    makeActiveBinding("obj4", env = globalenv(), local({
       count <- 0
-      function(){ count <<- count + 1; count}
+      function(){
+         count <<- count + 1
+         count
+      }
    }))
 
    # promise
-   delayedAssign("obj5", 1:10, globalenv(), globalenv())
+   delayedAssign("obj5", c(1, 2, 3), globalenv(), globalenv())
 
    # list the global environment
    .rs.invokeRpc("set_environment", "R_GlobalEnv")
@@ -63,6 +66,7 @@ test_that("environment object listings are correct", {
    obj5 <- contents[[5]]
    expect_equal(obj5[["name"]], "obj5")
    expect_equal(obj5[["type"]], "promise")
+   expect_equal(obj5[["value"]], "c(1, 2, 3)")
 })
 
 test_that("flag must be specified when removing objects", {

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -32,12 +32,21 @@ test_that("environment object listings are correct", {
    assign("obj2", "two", envir = globalenv())
    assign("obj3", list(1, 2, 3), envir = globalenv())
 
+   # active binding
+   makeActiveBinding("obj4", env = globalenv(), local({
+      count <- 0
+      function(){ count <<- count + 1; count}
+   }))
+
+   # promise
+   delayedAssign("obj5", 1:10, globalenv(), globalenv())
+
    # list the global environment
    .rs.invokeRpc("set_environment", "R_GlobalEnv")
    contents <- .rs.invokeRpc("list_environment")
 
    # verify contents (newly added plus the initial runAllTests function)
-   expect_equal(length(contents), 4)
+   expect_equal(length(contents), 6)
    obj1 <- contents[[1]]
    expect_equal(obj1[["name"]], "obj1")
    expect_equal(obj1[["value"]], "1")
@@ -47,6 +56,13 @@ test_that("environment object listings are correct", {
    obj3 <- contents[[3]]
    expect_equal(obj3[["name"]], "obj3")
    expect_equal(obj3[["length"]], 3)
+   obj4 <- contents[[4]]
+   expect_equal(obj4[["name"]], "obj4")
+   expect_equal(obj4[["type"]], "active binding")
+   expect_equal(obj4[["value"]], "<Active binding>")
+   obj5 <- contents[[5]]
+   expect_equal(obj5[["name"]], "obj5")
+   expect_equal(obj5[["type"]], "promise")
 })
 
 test_that("flag must be specified when removing objects", {

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -42,7 +42,10 @@ test_that("environment object listings are correct", {
    }))
 
    # promise
-   delayedAssign("obj5", c(1, 2, 3), globalenv(), globalenv())
+   delayedAssign("obj5", local({
+      assign("obj6", 6, globalenv())
+      5
+   }), globalenv(), globalenv())
 
    # list the global environment
    .rs.invokeRpc("set_environment", "R_GlobalEnv")
@@ -66,7 +69,13 @@ test_that("environment object listings are correct", {
    obj5 <- contents[[5]]
    expect_equal(obj5[["name"]], "obj5")
    expect_equal(obj5[["type"]], "promise")
-   expect_equal(obj5[["value"]], "c(1, 2, 3)")
+   expect_equal(obj5[["value"]], "local({ <...>")
+
+   # check that active binding wasn't forced yet
+   expect_equal(get("obj4", globalenv()), 1)
+
+   # check that the promise wasn't evaluated yet
+   expect_true(!exists("obj6", globalenv()))
 })
 
 test_that("flag must be specified when removing objects", {


### PR DESCRIPTION
### Intent

addresses #12328 

### Approach

based on @kevinushey suggestion. `listEnvironment()` loses its `pProtect` argument, and no longer protects individual objects from the environment, because they are already defacto protected by the environment. 

The caveat the environment that is traversed by `listEnvironment()` needs to remain protected for as long as `pVariables` is in use. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


