### PR TITLE
Call completion event for background jobs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,3 +6,4 @@
 ### Fixed
 
 - Fixed an issue where the plots displayed in the inline preview were incorrectly scaled on devices with high DPI (#4521, #2098, #10825, #7028, #4913).
+- Fixed background jobs not showing the entire output #12389

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBuffer.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBuffer.java
@@ -86,6 +86,11 @@ public class CompileOutputBuffer extends Composite
    public void onCompileCompleted()
    {
    }
+
+   @Override
+   public void flushOutput()
+   {
+   }
  
    private PreWidget output_;
    private VirtualConsole virtualConsole_;

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
@@ -105,7 +105,8 @@ public class CompileOutputBufferWithHighlight extends Composite
    }
 
    @Override
-   public void flushOutput() {
+   public void flushOutput()
+   {
       String[] lines = savedOutput_.split("\n");
       int end = lines.length - 1;
       int start = Math.max(0, end - 100);

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputBufferWithHighlight.java
@@ -101,16 +101,17 @@ public class CompileOutputBufferWithHighlight extends Composite
       String outputClass = styles_.output();
       console_.submit("\n", outputClass);
 
-      flushOverloadBuffer(outputClass);
+      flushOutput();
    }
 
-   private void flushOverloadBuffer(String outputClass) {
+   @Override
+   public void flushOutput() {
       String[] lines = savedOutput_.split("\n");
       int end = lines.length - 1;
       int start = Math.max(0, end - 100);
       for (int i = start; i < end; i++)
       {
-         console_.submit(lines[i] + "\n", outputClass);
+         console_.submit(lines[i] + "\n", styles_.output());
          totalSubmittedLines_++;
       }
 
@@ -153,7 +154,7 @@ public class CompileOutputBufferWithHighlight extends Composite
 
          if (numLinesSaved_ > MAX_LINES_OVERLOAD_BUFFER)
          {
-            flushOverloadBuffer(className);
+            flushOutput();
             console_.submit(constants_.consoleBufferedMessage(MAX_LINES_OVERLOAD_BUFFER), styles_.warning());
          }
          return;

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompileOutputDisplay.java
@@ -27,7 +27,7 @@ public interface CompileOutputDisplay
    public void writeError(String error);
    
    public void onCompileCompleted();
-   
+   public void flushOutput();
    public void clear();
    public void scrollToBottom();
    

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
@@ -195,6 +195,11 @@ public class CompilePanel extends Composite
          errorList_.focus();
    }
 
+   public void showBufferedOutput()
+   {
+      outputDisplay_.flushOutput();
+   }
+
    public HasClickHandlers stopButton()
    {
       return stopButton_;

--- a/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/compile/CompilePanel.java
@@ -185,8 +185,11 @@ public class CompilePanel extends Composite
 
    public void compileCompleted()
    {
-      stopButton_.setVisible(false);
       outputDisplay_.onCompileCompleted();
+      if (stopButton_ != null)
+      {
+         stopButton_.setVisible(false);
+      }
 
       if (isErrorPanelShowing())
          errorList_.focus();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobOutputPanel.java
@@ -69,6 +69,11 @@ public class JobOutputPanel extends Composite
 
       output_.showOutput(output, scrollToBottom);
    }
+
+   public void showBufferedOutput()
+   {
+      output_.showBufferedOutput();
+   }
    
    @UiField(provided=true) CompilePanel output_;
    @UiField Label empty_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsDisplayImpl.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsDisplayImpl.java
@@ -84,10 +84,6 @@ public class JobsDisplayImpl implements JobsDisplay
             if (widgets_.isCurrent(job.id))
             {
                widgets_.showProgress(job);
-               if (job.completed > 0)
-               {
-                  widgets_.getOutputPanel().output_.compileCompleted();
-               }
             }
             break;
 
@@ -116,7 +112,7 @@ public class JobsDisplayImpl implements JobsDisplay
                output.get(i).output()), false /* scroll */);
       }
 
-      widgets_.getOutputPanel().output_.compileCompleted();
+      widgets_.getOutputPanel().output_.showBufferedOutput();
       // scroll to show all output so far
       widgets_.getOutputPanel().scrollToBottom();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsDisplayImpl.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsDisplayImpl.java
@@ -84,9 +84,13 @@ public class JobsDisplayImpl implements JobsDisplay
             if (widgets_.isCurrent(job.id))
             {
                widgets_.showProgress(job);
+               if (job.completed > 0)
+               {
+                  widgets_.getOutputPanel().output_.compileCompleted();
+               }
             }
             break;
-            
+
          default:
             Debug.logWarning("Unrecognized job update type " + updateType);
       }
@@ -111,7 +115,8 @@ public class JobsDisplayImpl implements JobsDisplay
                output.get(i).type(),
                output.get(i).output()), false /* scroll */);
       }
-      
+
+      widgets_.getOutputPanel().output_.compileCompleted();
       // scroll to show all output so far
       widgets_.getOutputPanel().scrollToBottom();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPaneOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPaneOperations.java
@@ -33,6 +33,7 @@ public interface JobsPaneOperations
    boolean isCurrent(String id);
    void updateProgress(int timestamp);
    void showProgress(Job job);
+   void showBufferedOutput();
    void addJob(Job job);
    void setInitialJobs(List<Job> jobs);
    void insertJob(Job job);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPaneWidgets.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/JobsPaneWidgets.java
@@ -150,7 +150,17 @@ public class JobsPaneWidgets implements JobsPaneOperations
          progress_ = new JobProgress(events_);
          toolbar_.addLeftWidget(progress_);
       }
+      if (job.completed > 0)
+      {
+         output_.showBufferedOutput();
+      }
       progress_.showJob(job);
+   }
+
+   @Override
+   public void showBufferedOutput()
+   {
+      output_.showBufferedOutput();
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/LauncherJobsPaneWidgets.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/jobs/view/LauncherJobsPaneWidgets.java
@@ -82,7 +82,12 @@ public class LauncherJobsPaneWidgets implements JobsPaneOperations
    public void showProgress(Job job)
    {
    }
-   
+
+   @Override
+   public void showBufferedOutput()
+   {
+   }
+
    @Override
    public void setInitialJobs(List<Job> jobs)
    {


### PR DESCRIPTION
### Intent
Address #12389 

### Approach
Call `compileCompleted()` once the job finishes or when the output is shown to ensure the output buffer is flushed. Added a check for changing stop button visibility since it isn't available when viewing the background jobs list.

### Automated Tests
None

### QA Notes
The output buffer will be flushed when:
* watching the output as the background job runs 
* selecting a finished background job

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


