### PR TITLE
Feature/jenkins version build numbers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,6 +280,9 @@ try {
                           returnStdout: true
                         ).trim()
                         echo "RStudio build version: ${rstudioVersion}"
+                        script {
+                            currentBuild.displayName = "${rstudioVersion}"
+                        }
 
                         // Split on [-+] first to avoid having to worry about splitting out .pro<n>
                         def version = rstudioVersion.split('[-+]')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -300,7 +300,7 @@ try {
                             rstudioVersionSuffix = '+' + version[1]
 
                         // update slack message to include build version
-                        messagePrefix = "Jenkins ${env.JOB_NAME} build: <${env.BUILD_URL}display/redirect|${env.BUILD_DISPLAY_NAME}>, version: ${rstudioVersion}"
+                        messagePrefix = "Jenkins ${env.JOB_NAME} build: <${env.BUILD_URL}display/redirect|${rstudioVersion}>"
                     }
                 }
             }

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -26,6 +26,10 @@ pipeline {
   stages {
 
     stage('dependencies') {
+      
+      script {
+        currentBuild.displayName = "${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
+      }
 
       environment {
         // boost won't compile without the brew version of openssl.

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -29,6 +29,10 @@ pipeline {
 
     stage('dependencies') {
 
+      script {
+        currentBuild.displayName = "${params.RSTUDIO_VERSION_MAJOR}.${params.RSTUDIO_VERSION_MINOR}.${params.RSTUDIO_VERSION_PATCH}${params.RSTUDIO_VERSION_SUFFIX}"
+      }
+
       environment {
         // boost won't compile without the brew version of openssl.
         // only add it to the dep resolve step though, or the ide build will compile against the wrong openssl


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/4145

Change the arbitrary monotonic Jenkins build numbers to match the version of the build
![image](https://user-images.githubusercontent.com/56326543/206243773-3da6217b-1274-4496-ae8a-a9fbf8c66fc2.png)

### Approach

The command `currentBuild.displayName` controls the Jenkins build number. Once a version has been secured, we set the Jenkins build number to the RStudio build number. For the first few moments of the build, it will display an arbitrary Jenkins build number, but once we complete the first stage the version number will update.

This commit changes our open-source, macOS, and macOS.electron builds

### Automated Tests

None. Build QoL update

### QA Notes

None.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


