### PR TITLE
rework `hasExternalPointer` internals

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -788,14 +788,6 @@ bool isNullExternalPointer(SEXP object)
          R_ExternalPtrAddr(object) == nullptr;
 }
 
-SEXP makeTestExternalPointer(bool nullPtr) 
-{
-   // this creates an external pointer that is or is not null
-   // for test purposes, it does not need a finalizer
-   // R_EmptyEnv here is irrelevant, it just needs to be a pointer
-   return R_MakeExternalPtr(nullPtr ? nullptr : R_EmptyEnv, R_NilValue, R_NilValue);
-}
-
 SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit)
 {
    return R_MakeWeakRefC(key, val, fun, onexit);
@@ -823,6 +815,11 @@ SEXP makeExternalPtr(void* ptr, R_CFinalizer_t fun, Protect* pProtect)
       pProtect->add(s);
    registerFinalizer(s, fun);
    return s;
+}
+
+SEXP makeExternalPtr(void* ptr, SEXP prot, SEXP tag) 
+{
+   return R_MakeExternalPtr(ptr, prot, tag);
 }
 
 void* getExternalPtrAddr(SEXP extptr)

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -40,7 +40,6 @@
 #include <r/RExec.hpp>
 #include <r/RErrorCategory.hpp>
 #include <r/RUtil.hpp>
-#include <r/RSxpInfo.hpp>
 
 // clean out global definitions of TRUE and FALSE so we can
 // use the Rboolean variations of them
@@ -693,12 +692,6 @@ bool isPrimitiveEnvironment(SEXP object)
 bool isUserDefinedDatabase(SEXP object)
 {
    return OBJECT(object) && Rf_inherits(object, "UserDefinedDatabase");
-}
-
-bool isActiveBinding(SEXP binding) 
-{
-   static unsigned int ACTIVE_BINDING_MASK = (1<<15);
-   return reinterpret_cast<r::sxpinfo*>(binding)->gp & ACTIVE_BINDING_MASK;
 }
 
 bool isNumeric(SEXP object)

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -40,6 +40,7 @@
 #include <r/RExec.hpp>
 #include <r/RErrorCategory.hpp>
 #include <r/RUtil.hpp>
+#include <r/RSxpInfo.hpp>
 
 // clean out global definitions of TRUE and FALSE so we can
 // use the Rboolean variations of them
@@ -687,6 +688,17 @@ bool isNull(SEXP object)
 bool isPrimitiveEnvironment(SEXP object)
 {
    return TYPEOF(object) == ENVSXP;
+}
+
+bool isUserDefinedDatabase(SEXP object)
+{
+   return OBJECT(object) && Rf_inherits(object, "UserDefinedDatabase");
+}
+
+bool isActiveBinding(SEXP binding) 
+{
+   static unsigned int ACTIVE_BINDING_MASK = (1<<15);
+   return reinterpret_cast<r::sxpinfo*>(binding)->gp & ACTIVE_BINDING_MASK;
 }
 
 bool isNumeric(SEXP object)

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -800,6 +800,16 @@ SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit)
    return R_MakeWeakRefC(key, val, fun, onexit);
 }
 
+SEXP getWeakRefKey(SEXP ref)
+{
+   return VECTOR_ELT(ref, 0);
+}
+
+SEXP getWeakRefValue(SEXP ref)
+{
+   return VECTOR_ELT(ref, 1);
+}
+
 void registerFinalizer(SEXP s, R_CFinalizer_t fun)
 {
    R_RegisterCFinalizer(s, fun);

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -795,6 +795,14 @@ bool isNullExternalPointer(SEXP object)
          R_ExternalPtrAddr(object) == nullptr;
 }
 
+SEXP makeTestExternalPointer(bool nullPtr) 
+{
+   // this creates an external pointer that is or is not null
+   // for test purposes, it does not need a finalizer
+   // R_EmptyEnv here is irrelevant, it just needs to be a pointer
+   return R_MakeExternalPtr(nullPtr ? nullptr : R_EmptyEnv, R_NilValue, R_NilValue);
+}
+
 SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit)
 {
    return R_MakeWeakRefC(key, val, fun, onexit);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -127,6 +127,7 @@ void listNamedAttributes(SEXP obj, Protect *pProtect, std::vector<Variable>* pVa
 // weak/external pointers and finalizers
 bool isExternalPointer(SEXP object);
 bool isNullExternalPointer(SEXP object);
+SEXP makeTestExternalPointer(bool nullPtr);
 
 SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit);
 SEXP getWeakRefKey(SEXP ref);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -129,6 +129,8 @@ bool isExternalPointer(SEXP object);
 bool isNullExternalPointer(SEXP object);
 
 SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit);
+SEXP getWeakRefKey(SEXP ref);
+SEXP getWeakRefValue(SEXP ref);
 void registerFinalizer(SEXP s, R_CFinalizer_t fun);
 SEXP makeExternalPtr(void* ptr, R_CFinalizer_t fun, Protect* protect);
 void* getExternalPtrAddr(SEXP extptr);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -104,6 +104,8 @@ bool isNull(SEXP object);
 bool isEnvironment(SEXP object);
 bool isPrimitiveEnvironment(SEXP object);
 bool isNumeric(SEXP object);
+bool isUserDefinedDatabase(SEXP object);
+bool isActiveBinding(SEXP binding);
 
 // type coercions
 std::string asString(SEXP object);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -105,7 +105,6 @@ bool isEnvironment(SEXP object);
 bool isPrimitiveEnvironment(SEXP object);
 bool isNumeric(SEXP object);
 bool isUserDefinedDatabase(SEXP object);
-bool isActiveBinding(SEXP binding);
 
 // type coercions
 std::string asString(SEXP object);

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -126,13 +126,13 @@ void listNamedAttributes(SEXP obj, Protect *pProtect, std::vector<Variable>* pVa
 // weak/external pointers and finalizers
 bool isExternalPointer(SEXP object);
 bool isNullExternalPointer(SEXP object);
-SEXP makeTestExternalPointer(bool nullPtr);
 
 SEXP makeWeakRef(SEXP key, SEXP val, R_CFinalizer_t fun, Rboolean onexit);
 SEXP getWeakRefKey(SEXP ref);
 SEXP getWeakRefValue(SEXP ref);
 void registerFinalizer(SEXP s, R_CFinalizer_t fun);
 SEXP makeExternalPtr(void* ptr, R_CFinalizer_t fun, Protect* protect);
+SEXP makeExternalPtr(void* ptr, SEXP prot, SEXP tag);
 void* getExternalPtrAddr(SEXP extptr);
 void clearExternalPtr(SEXP extptr);
 

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -624,6 +624,11 @@
       val1
 })
 
+.rs.addFunction("hasExternalPointer", function(object, nullPtr = FALSE)
+{
+   .Call("rs_hasExternalPointer", object, nullPtr, PACKAGE = "(embedding)")
+})
+
 .rs.addFunction("describeObject", function(env, objName, computeSize = TRUE)
 {
    obj <- get(objName, env)
@@ -647,7 +652,7 @@
    # opt-in to checking for null pointers if required.
    checkNullPtr <- .rs.readUiPref("check_null_external_pointers")
    hasNullPtr <- if (identical(checkNullPtr, TRUE))
-      .Call("rs_hasExternalPointer", obj, TRUE, PACKAGE = "(embedding)")
+      .rs.hasExternalPointer(obj, TRUE)
    else
       FALSE
    
@@ -894,6 +899,11 @@
 .rs.addFunction("hasAltrep", function(var)
 {
    .Call("rs_hasAltrep", var, PACKAGE = "(embedding)")
+})
+
+.rs.addFunction("testExternalPointer", function(null = FALSE)
+{
+   .Call("rs_newTestExternalPointer", null, PACKAGE = "(embedding)")
 })
 
 .rs.addFunction("resolveContextSourceRefs", function(callfun)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -901,11 +901,6 @@
    .Call("rs_hasAltrep", var, PACKAGE = "(embedding)")
 })
 
-.rs.addFunction("testExternalPointer", function(null = FALSE)
-{
-   .Call("rs_newTestExternalPointer", null, PACKAGE = "(embedding)")
-})
-
 .rs.addFunction("resolveContextSourceRefs", function(callfun)
 {
    calls <- sys.calls()

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -272,6 +272,17 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
          }
          break;
       }
+      case CLOSXP:
+      {
+         if (hasExternalPointer(FORMALS(obj), nullPtr, visited))
+            return true;
+
+         if (hasExternalPointer(BODY(obj), nullPtr, visited))
+            return true;
+
+         if (hasExternalPointer(CLOENV(obj), nullPtr, visited))
+            return true;
+      }
       default:
          break;
    }

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -275,20 +275,10 @@ bool hasExternalPtr(SEXP obj,      // environment to search for external pointer
 
 SEXP rs_hasExternalPointer(SEXP objSEXP, SEXP nullSEXP)
 {
-   bool nullPtr = r::sexp::asLogical(nullSEXP);
    r::sexp::Protect protect;
-   bool hasPtr = false;
-   if (r::sexp::isExternalPointer(objSEXP))
-   {
-      // object is an external pointer itself
-      hasPtr = r::sexp::isNullExternalPointer(objSEXP) == nullPtr;
-   }
-   else if (r::sexp::isPrimitiveEnvironment(objSEXP) || TYPEOF(objSEXP) == S4SXP)
-   {
-      // object is an environment; check it for external pointers
-      hasPtr = hasExternalPtr(objSEXP, nullPtr);
-   }
-   return r::sexp::create(hasPtr, &protect);
+   
+   bool nullPtr = r::sexp::asLogical(nullSEXP);
+   return r::sexp::create(hasExternalPtr(objSEXP, nullPtr), &protect);
 }
 
 // Does an object contain an ALTREP anywhere? ALTREP (alternative representation) objects often

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -344,7 +344,8 @@ SEXP rs_isAltrep(SEXP obj)
 
 SEXP rs_newTestExternalPointer(SEXP nullSEXP)
 {
-   return r::sexp::makeTestExternalPointer(r::sexp::asLogical(nullSEXP));
+   bool nullPtr = r::sexp::asLogical(nullSEXP);
+   return r::sexp::makeExternalPtr(nullPtr ? nullptr : R_EmptyEnv, R_NilValue, R_NilValue);
 }
 
 // Construct a simulated source reference from a context containing a

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -193,8 +193,9 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
       // NOTE: this includes UserDefinedDatabase, aka 
       //       external pointers to R_ObjectTable
 
-      // this is an external pointer, but nullPtr might give it a pass
-      if (r::sexp::getExternalPtrAddr(obj) != nullptr || !nullPtr)
+      // when nullPtr is true, only return true for null pointer xp
+      // otherwise only return true for non null pointer xp
+      if (nullPtr == (r::sexp::getExternalPtrAddr(obj) == nullptr))
          return true;
 
       if (hasExternalPointer(EXTPTR_PROT(obj), nullPtr, visited))

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -34,7 +34,7 @@
 #include <session/SessionSourceDatabase.hpp>
 #include <session/SessionPersistentState.hpp>
 #include <session/prefs/UserPrefs.hpp>
-#include <Rversion.h>
+#include <r/RSxpInfo.hpp>
 
 #include "EnvironmentUtils.hpp"
 
@@ -151,11 +151,19 @@ bool listHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
+namespace {
+bool frameBindingIsActive(SEXP binding) 
+{
+   static unsigned int ACTIVE_BINDING_MASK = (1<<15);
+   return reinterpret_cast<r::sxpinfo*>(binding)->gp & ACTIVE_BINDING_MASK;
+}
+}
+
 bool frameHasExternalPointer(SEXP frame, bool nullPtr, std::set<SEXP>& visited)
 {
    while(frame != R_NilValue)
    {
-      if (!r::sexp::isActiveBinding(frame) && hasExternalPointer(CAR(frame), nullPtr, visited))
+      if (!frameBindingIsActive(frame) && hasExternalPointer(CAR(frame), nullPtr, visited))
          return true;
 
       frame = CDR(frame);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -248,8 +248,16 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
 
             // WEAKREF_FINALIZER ?
          }
+         break;
       }
-      // case PROMSXP: 
+      case PROMSXP: 
+      {
+         SEXP value = PRVALUE(var);
+         if (value != R_UnboundValue && hasExternalPointer(value, nullPtr, visited))
+            return true;
+         
+         break;
+      }
       default:
          break;
    }

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -194,17 +194,17 @@ test_that("hasExternalPointer finds external pointers", {
    expect_true(count == 0)
 
    # promises are not forced
-   h <- new.env(hash = TRUE, parent = emptyenv())
-   # NOTE: eval.env = globalenv() otherwise xp would be picked up 
-   #       as part of checking if PRENV(<promise>) has an external pointer 
-   delayedAssign("p", .rs.testExternalPointer(FALSE), assign.env = h, eval.env = globalenv())
-   expect_true(count == 0)
-   expect_true(!.rs.hasExternalPointer(h))
+   local({
+      h <- new.env(hash = TRUE, parent = emptyenv())
+      delayedAssign("p", .rs.testExternalPointer(FALSE), assign.env = h)
+      expect_true(count == 0)
+      expect_true(!.rs.hasExternalPointer(h))
+      
+      # ... but if they are, the value is checked
+      force(h$p)
+      expect_true(.rs.hasExternalPointer(h))
+   })
    
-   # ... but if they are, the value is checked
-   force(h$p)
-   expect_true(.rs.hasExternalPointer(h))
-
    # S4 
    Env <- setClass("Env", contains = "environment")
    hEnv <- Env(

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -219,3 +219,34 @@ test_that("hasExternalPointer finds external pointers", {
    hEnv$a <- nullxp
    expect_true(.rs.hasExternalPointer(hEnv, nullPtr = TRUE))
 })
+
+test_that(".rs.hasExternalPointer() finds xp in functions", {
+   expect_false(.rs.hasExternalPointer(function(x = 2) x))
+   
+   # formals
+   expect_true(
+      .rs.hasExternalPointer(
+         local({
+            `formals<-`(function(x = 42) x, value = pairlist(x = .rs.testExternalPointer(FALSE)))
+         })
+      )
+   )
+
+   # body
+   expect_true(
+      .rs.hasExternalPointer(
+         substitute(function() x, list(x = .rs.testExternalPointer(FALSE)))
+      )
+   )
+
+   # environment
+   expect_true(
+      .rs.hasExternalPointer(
+         local({
+            xp <- .rs.testExternalPointer(FALSE)
+            function(x = 2) x
+         })
+      )
+   )
+
+})

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -16,7 +16,6 @@
 context("environment")
 
 test_that("environment object listings are correct", {
-
    # temporarily disable showing the .Last.value so we don't have to account for it in test results
    lastValue <- .rs.api.readRStudioPreference("show_last_dot_value")
    on.exit(.rs.api.writeRStudioPreference("show_last_dot_value", lastValue))
@@ -133,8 +132,8 @@ test_that("missing arguments can be described", {
 })
 
 test_that("hasExternalPointer finds external pointers", {
-   xp <- .rs.testExternalPointer(FALSE)
-   nullxp <- .rs.testExternalPointer(TRUE)
+   xp <- .Call("rs_newTestExternalPointer", FALSE, PACKAGE = "(embedding)")
+   nullxp <- .Call("rs_newTestExternalPointer", TRUE, PACKAGE = "(embedding)")
 
    # NULL
    expect_true(!.rs.hasExternalPointer(NULL))
@@ -196,7 +195,7 @@ test_that("hasExternalPointer finds external pointers", {
    # promises are not forced
    local({
       h <- new.env(hash = TRUE, parent = emptyenv())
-      delayedAssign("p", .rs.testExternalPointer(FALSE), assign.env = h)
+      delayedAssign("p", .Call("rs_newTestExternalPointer", FALSE, PACKAGE = "(embedding)"), assign.env = h)
       expect_true(count == 0)
       expect_true(!.rs.hasExternalPointer(h))
       
@@ -221,13 +220,14 @@ test_that("hasExternalPointer finds external pointers", {
 })
 
 test_that(".rs.hasExternalPointer() finds xp in functions", {
+   
    expect_false(.rs.hasExternalPointer(function(x = 2) x))
    
    # formals
    expect_true(
       .rs.hasExternalPointer(
          local({
-            `formals<-`(function(x = 42) x, value = pairlist(x = .rs.testExternalPointer(FALSE)))
+            `formals<-`(function(x = 42) x, value = pairlist(x = .Call("rs_newTestExternalPointer", FALSE, PACKAGE = "(embedding)")))
          })
       )
    )
@@ -235,7 +235,7 @@ test_that(".rs.hasExternalPointer() finds xp in functions", {
    # body
    expect_true(
       .rs.hasExternalPointer(
-         substitute(function() x, list(x = .rs.testExternalPointer(FALSE)))
+         substitute(function() x, list(x = .Call("rs_newTestExternalPointer", FALSE, PACKAGE = "(embedding)")))
       )
    )
 
@@ -243,7 +243,7 @@ test_that(".rs.hasExternalPointer() finds xp in functions", {
    expect_true(
       .rs.hasExternalPointer(
          local({
-            xp <- .rs.testExternalPointer(FALSE)
+            xp <- .Call("rs_newTestExternalPointer", FALSE, PACKAGE = "(embedding)")
             function(x = 2) x
          })
       )


### PR DESCRIPTION
### Intent

related to #12328 (somewhat orthogonal to #12399)

### Approach

Rework the internals of `hasExternalPtr` to more efficiently traverse, i.e. without relying on `listEnvironment`. 

With the code from #12328 that essentially just creates a big environment: 

```
> h <- hash::hash(1:120000, 1:120000)
> system.time(.Call("rs_hasExternalPointer", globalenv(), FALSE, PACKAGE = "(embedding)"))
   user  system elapsed 
  0.071   0.005   0.078 
```

where the same code on #12399 (which addresses the issue of #12328 without changing the traversing approach):

```
> h <- hash::hash(1:120000, 1:120000)
> system.time(.Call("rs_hasExternalPointer", globalenv(), FALSE, PACKAGE = "(embedding)"))
   user  system elapsed 
  0.414   0.030   0.465 
```

That half of a second is noticeable when this is called each time `canSuspend()` is used, i.e. on each `bool rConsoleRead()`

```cpp
bool canSuspend(const std::string& prompt)
{
   bool suspendIsBlocked = false;
   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
   suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
   suspendIsBlocked |= !modules::overlay::isSuspendable();

   return !suspendIsBlocked;
}
```

### Automated Tests

will add some. 

### QA Notes



### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


