### PR TITLE
rationalize usages of rpostback + postback script paths

### DIFF
--- a/CMakeCompiler.txt
+++ b/CMakeCompiler.txt
@@ -53,6 +53,11 @@ if(MSVC)
   # these warnings are being triggered in the MSVC-supplied headers and we aren't touching those
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4068")
 
+  # disable C4003 warning: not enough arguments for function-like macro invocation
+  # C99, C++11 and above allow you to call function-like macros which accept 1 argument
+  # without any parameters, since macro arguments are allowed to be empty
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4003")
+
   # embed debug information into the generated objects
   # (otherwise we can run into annoying PDB errors during compilation)
   string(REGEX REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")

--- a/src/cpp/conf/rdesktop-dev.conf
+++ b/src/cpp/conf/rdesktop-dev.conf
@@ -32,7 +32,7 @@ r-session-library=${CMAKE_CURRENT_BINARY_DIR}/r/R/packages/library
 r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 
 # external binaries
-external-rpostback-path=${CMAKE_CURRENT_BINARY_DIR}/session/postback/rpostback
+external-rpostback-path=${CMAKE_CURRENT_BINARY_DIR}/session/postback/rpostback.exe
 external-consoleio-path=${CMAKE_CURRENT_BINARY_DIR}/session/consoleio/consoleio.exe
 external-gnudiff-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/gnudiff
 external-gnugrep-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/gnugrep/3.0

--- a/src/cpp/conf/rdesktop-dev.conf
+++ b/src/cpp/conf/rdesktop-dev.conf
@@ -32,7 +32,7 @@ r-session-library=${CMAKE_CURRENT_BINARY_DIR}/r/R/packages/library
 r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 
 # external binaries
-external-rpostback-path=${CMAKE_CURRENT_BINARY_DIR}/session/postback/postback/rpostback
+external-rpostback-path=${CMAKE_CURRENT_BINARY_DIR}/session/postback/rpostback
 external-consoleio-path=${CMAKE_CURRENT_BINARY_DIR}/session/consoleio/consoleio.exe
 external-gnudiff-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/gnudiff
 external-gnugrep-path=${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}/gnugrep/3.0

--- a/src/cpp/conf/rsession-dev.conf
+++ b/src/cpp/conf/rsession-dev.conf
@@ -30,8 +30,8 @@ r-resources-path=${CMAKE_CURRENT_SOURCE_DIR}/session/resources
 r-session-library=${CMAKE_CURRENT_BINARY_DIR}/r/R/packages/library
 r-session-package-archives=${RSTUDIO_DEPENDENCIES_DIR}/common
 
-# execute R postback from the build tree
-external-rpostback-path=session/postback/postback/rpostback
+# execute rpostback from build tree
+external-rpostback-path=session/postback/rpostback
 
 # common dependencies
 external-hunspell-dictionaries-path=${RSTUDIO_DEPENDENCIES_DICTIONARIES_DIR}

--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -74,12 +74,11 @@ template <typename T>
 void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)
 {
    // prepend in reverse order
-   std::vector<FilePath>::const_reverse_iterator it
-                                          = toolsInfo.pathEntries().rbegin();
+   auto it = toolsInfo.pathEntries().rbegin();
    for ( ; it != toolsInfo.pathEntries().rend(); ++it)
    {
       std::string path = it->getAbsolutePath();
-      boost::algorithm::replace_all(path, "/", "\\");
+      std::replace(path.begin(), path.end(), '/', '\\');
       core::system::addToPath(pTarget, path, true);
    }
 }

--- a/src/cpp/core/include/core/r_util/RToolsInfo.hpp
+++ b/src/cpp/core/include/core/r_util/RToolsInfo.hpp
@@ -83,7 +83,6 @@ void prependToSystemPath(const RToolsInfo& toolsInfo, T* pTarget)
    }
 }
 
-
 } // namespace r_util
 } // namespace core 
 } // namespace rstudio

--- a/src/cpp/r/RUtil.cpp
+++ b/src/cpp/r/RUtil.cpp
@@ -72,6 +72,29 @@ bool versionTest(const std::string& comparator, const std::string& version)
 
 } // anonymous namespace
 
+void setenv(const std::string& key, const std::string& value)
+{
+   Error error = r::exec::RFunction("base:::Sys.setenv")
+         .addParam(key, value)
+         .call();
+
+   if (error)
+      LOG_ERROR(error);
+}
+
+std::string getenv(const std::string& key)
+{
+   std::string value;
+   Error error = r::exec::RFunction("base:::Sys.getenv")
+         .addParam(key)
+         .call(&value);
+
+   if (error)
+      LOG_ERROR(error);
+
+   return value;
+}
+
 std::string expandFileName(const std::string& name)
 {
    return std::string(R_ExpandFileName(name.c_str()));

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -36,6 +36,15 @@ namespace rstudio {
 namespace r {
 namespace util {
 
+// NOTE: Environment variables set via core::system::setenv() won't
+// be visible in the R session.
+//
+// These routines should be preferred when getting and
+// setting environment variables in the R session.
+void setenv(const std::string& key, const std::string& value);
+std::string getenv(const std::string& key);
+
+
 std::string expandFileName(const std::string& name);
    
 std::string fixPath(const std::string& path);

--- a/src/cpp/r/include/r/RUtil.hpp
+++ b/src/cpp/r/include/r/RUtil.hpp
@@ -36,14 +36,24 @@ namespace rstudio {
 namespace r {
 namespace util {
 
-// NOTE: Environment variables set via core::system::setenv() won't
-// be visible in the R session.
+// NOTE: On Windows, environment variables set via core::system::setenv()
+// won't be visible in the R session.
 //
 // These routines should be preferred when getting and
 // setting environment variables in the R session.
 void setenv(const std::string& key, const std::string& value);
 std::string getenv(const std::string& key);
 
+void appendToSystemPath(const core::FilePath& path);
+void appendToSystemPath(const std::string& path);
+void prependToSystemPath(const core::FilePath& path);
+void prependToSystemPath(const std::string& path);
+
+template <typename T>
+void addToSystemPath(const T& path, bool prepend)
+{
+   prepend ? prependToSystemPath(path) : appendToSystemPath(path);
+}
 
 std::string expandFileName(const std::string& name);
    

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -94,7 +94,21 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 #else
    core::system::setHomeToUserProfile(&shellEnv);
 #endif
+   
+   // don't forward GIT_ASKPASS or SSH_ASKPASS if it's set to our rpostback
+   // handlers -- those aren't required in a terminal, as the user can be
+   // prompted for input via stdin, and it's likely that users will munge
+   // the PATH within a terminal a way that makes our utilities unavailable
+   //
+   // TODO: could we just set an absolute path to the rpostback-askpass util?
+   std::string gitAskpass = core::system::getenv("GIT_ASKPASS");
+   if (gitAskpass == "rpostback-askpass")
+      core::system::unsetenv(&shellEnv, "GIT_ASKPASS");
 
+   std::string sshAskpass = core::system::getenv("SSH_ASKPASS");
+   if (sshAskpass == "rpostback-askpass")
+      core::system::unsetenv(&shellEnv, "SSH_ASKPASS");
+   
    // amend shell paths as appropriate
    session::modules::workbench::ammendShellPaths(&shellEnv);
 

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -113,6 +113,7 @@
 #include "SessionAddins.hpp"
 
 #include "SessionModuleContextInternal.hpp"
+#include <session/SessionModuleContext.hpp>
 
 #include "SessionClientEventQueue.hpp"
 #include "SessionClientInit.hpp"
@@ -2160,10 +2161,7 @@ int main(int argc, char * const argv[])
          core::thread::safeLaunchThread(detectParentTermination);
 
       // set the rpostback absolute path
-      FilePath rpostback = options.rpostbackPath();
-      if (!rpostback.exists())
-         LOG_ERROR(fileNotFoundError(ERROR_LOCATION));
-      
+      FilePath rpostback = module_context::rPostbackPath();
       core::system::setenv(
             "RS_RPOSTBACK_PATH",
             string_utils::utf8ToSystem(rpostback.getAbsolutePath()));

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -2161,14 +2161,9 @@ int main(int argc, char * const argv[])
 
       // set the rpostback absolute path
       FilePath rpostback = options.rpostbackPath();
-   #ifndef __APPLE__
-      // package builds on Linux and Windows hoist the binary one level higher in the directory structure
-      if (rpostback.getAbsolutePath().find("session/postback") == std::string::npos) {
-         rpostback = rpostback.getParent().getParent();
-         rpostback = rpostback.completeChildPath("rpostback");
-      }
-   #endif
-
+      if (!rpostback.exists())
+         LOG_ERROR(fileNotFoundError(ERROR_LOCATION));
+      
       core::system::setenv(
             "RS_RPOSTBACK_PATH",
             string_utils::utf8ToSystem(rpostback.getAbsolutePath()));

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -108,56 +108,6 @@ namespace rstudio {
 namespace session {   
 namespace module_context {
 
-namespace {
-
-Error modifyPath(const core::FilePath& path, bool append)
-{
-   Error error;
-
-   std::string currentPath;
-   error = r::exec::RFunction("base:::Sys.getenv")
-         .addParam("PATH")
-         .call(&currentPath);
-
-   if (error)
-      return error;
-
-   std::string pathString = string_utils::utf8ToSystem(path.getAbsolutePath());
-
-#ifdef _WIN32
-   std::replace(pathString.begin(), pathString.end(), '/', '\\');
-#endif
-
-   std::string newPath = append
-         ? fmt::format("{}{}{}", currentPath, kPathSeparator, pathString)
-         : fmt::format("{}{}{}", pathString, kPathSeparator, currentPath);
-
-   // clean up duplicated path separators, if any
-   boost::regex reMultipleSeparators(kPathSeparator "+");
-   newPath = boost::regex_replace(newPath, reMultipleSeparators, kPathSeparator);
-
-   error = r::exec::RFunction("base:::Sys.setenv")
-         .addParam("PATH", newPath)
-         .call();
-
-   if (error)
-      return error;
-
-   return Success();
-}
-
-} // end anonymous namespace
-
-Error prependToPath(const core::FilePath& path)
-{
-   return modifyPath(path, false);
-}
-
-Error appendToPath(const core::FilePath& path)
-{
-   return modifyPath(path, true);
-}
-
 bool isSessionSslEnabled()
 {
    return !options().getOverlayOption(kSessionSslCertKeyOption).empty();

--- a/src/cpp/session/SessionModuleContext.cpp
+++ b/src/cpp/session/SessionModuleContext.cpp
@@ -96,9 +96,9 @@
 #include "session-config.h"
 
 #ifdef _WIN32
-# define kPathSeparator ';'
+# define kPathSeparator ";"
 #else
-# define kPathSeparator ':'
+# define kPathSeparator ":"
 #endif
 
 using namespace rstudio::core;
@@ -131,6 +131,10 @@ Error modifyPath(const core::FilePath& path, bool append)
    std::string newPath = append
          ? fmt::format("{}{}{}", currentPath, kPathSeparator, pathString)
          : fmt::format("{}{}{}", pathString, kPathSeparator, currentPath);
+
+   // clean up duplicated path separators, if any
+   boost::regex reMultipleSeparators(kPathSeparator "+");
+   newPath = boost::regex_replace(newPath, reMultipleSeparators, kPathSeparator);
 
    error = r::exec::RFunction("base:::Sys.setenv")
          .addParam("PATH", newPath)

--- a/src/cpp/session/SessionPostback.cpp
+++ b/src/cpp/session/SessionPostback.cpp
@@ -88,6 +88,22 @@ void handlePostback(const PostbackHandlerFunction& handlerFunction,
    
 } // anonymous namespace
 
+FilePath rPostbackPath()
+{
+   return session::options().rpostbackPath();
+}
+
+FilePath rPostbackScriptsDir()
+{
+   // postback scripts should lie in a 'postback' directory,
+   // located in the same folder as the 'rpostback' binary
+   return rPostbackPath().getParent().completeChildPath("postback");
+}
+
+FilePath rPostbackScriptPath(const std::string& scriptName)
+{
+   return rPostbackScriptsDir().completeChildPath(scriptName);
+}
 
 Error registerPostbackHandler(const std::string& name,
                               const PostbackHandlerFunction& handlerFunction,
@@ -104,8 +120,8 @@ Error registerPostbackHandler(const std::string& name,
       return error;
                                                     
    // compute the shell command required to invoke this handler and return it
-   Options& options = session::options();
-   *pShellCommand = options.rpostbackPath().getAbsolutePath() + "-" + name;
+   *pShellCommand = rPostbackScriptPath("rpostback-" + name).getAbsolutePath();
+   std::cerr << *pShellCommand << std::endl;
    
    // return success
    return Success();

--- a/src/cpp/session/SessionPostback.cpp
+++ b/src/cpp/session/SessionPostback.cpp
@@ -121,8 +121,7 @@ Error registerPostbackHandler(const std::string& name,
                                                     
    // compute the shell command required to invoke this handler and return it
    *pShellCommand = rPostbackScriptPath("rpostback-" + name).getAbsolutePath();
-   std::cerr << *pShellCommand << std::endl;
-   
+
    // return success
    return Success();
 }

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -148,7 +148,7 @@
 #endif
 
 #define kDefaultQuartoPath         "bin/quarto"
-#define kDefaultPostbackPath       "bin/postback/rpostback"
+#define kDefaultPostbackPath       "bin/rpostback"
 #define kDefaultRsclangPath        "bin/rsclang"
 
 // json rpc methods we handle (the rest are delegated to the HttpServer)

--- a/src/cpp/session/include/session/SessionConstants.hpp
+++ b/src/cpp/session/include/session/SessionConstants.hpp
@@ -148,8 +148,13 @@
 #endif
 
 #define kDefaultQuartoPath         "bin/quarto"
-#define kDefaultPostbackPath       "bin/rpostback"
 #define kDefaultRsclangPath        "bin/rsclang"
+
+#ifdef _WIN32
+# define kDefaultPostbackPath       "bin/rpostback.exe"
+#else
+# define kDefaultPostbackPath       "bin/rpostback"
+#endif
 
 // json rpc methods we handle (the rest are delegated to the HttpServer)
 const char * const kClientInit = "client_init";

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -104,10 +104,6 @@ core::FilePath safeCurrentPath();
 core::json::Object createFileSystemItem(const core::FileInfo& fileInfo);
 core::json::Object createFileSystemItem(const core::FilePath& filePath);
 
-// path helpers (needed for R on Windows)
-core::Error appendToPath(const core::FilePath& path);
-core::Error prependToPath(const core::FilePath& path);
-
 // postback helpers
 core::FilePath rPostbackPath();
 core::FilePath rPostbackScriptsDir();

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -26,6 +26,7 @@
 #include <core/BoostSignals.hpp>
 #include <core/HtmlUtils.hpp>
 #include <core/Version.hpp>
+#include <core/system/Environment.hpp>
 #include <core/system/System.hpp>
 #include <core/system/ShellUtils.hpp>
 #include <core/system/FileChangeEvent.hpp>
@@ -102,6 +103,11 @@ core::FilePath safeCurrentPath();
 
 core::json::Object createFileSystemItem(const core::FileInfo& fileInfo);
 core::json::Object createFileSystemItem(const core::FilePath& filePath);
+
+// postback helpers
+core::FilePath rPostbackPath();
+core::FilePath rPostbackScriptsDir();
+core::FilePath rPostbackScriptsPath(const std::string& scriptName);
    
 // r session info
 std::string rVersion();

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -104,6 +104,10 @@ core::FilePath safeCurrentPath();
 core::json::Object createFileSystemItem(const core::FileInfo& fileInfo);
 core::json::Object createFileSystemItem(const core::FilePath& filePath);
 
+// path helpers (needed for R on Windows)
+core::Error appendToPath(const core::FilePath& path);
+core::Error prependToPath(const core::FilePath& path);
+
 // postback helpers
 core::FilePath rPostbackPath();
 core::FilePath rPostbackScriptsDir();

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3359,8 +3359,9 @@ core::Error initialize()
       core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
 
    // add postback directory to PATH
-   FilePath postbackDir = module_context::rPostbackScriptsDir();
-   core::system::addToPath(postbackDir.getAbsolutePath());
+   error = module_context::appendToPath(module_context::rPostbackScriptsDir());
+   if (error)
+      LOG_ERROR(error);
 
    // add suspend/resume handler
    addSuspendHandler(SuspendHandler(boost::bind(onSuspend, _2), onResume));

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3354,9 +3354,9 @@ core::Error initialize()
       return error;
 
    // setup environment
-   core::system::setenv("GIT_ASKPASS", "rpostback-askpass");
+   r::util::setenv("GIT_ASKPASS", "rpostback-askpass");
    if (interceptAskPass)
-      core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
+      r::util::setenv("SSH_ASKPASS", "rpostback-askpass");
 
    // add postback directory to PATH
    error = module_context::appendToPath(module_context::rPostbackScriptsDir());

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -127,7 +127,7 @@ core::system::ProcessOptions procOptions()
    // (note that we also do this on init, but we do this again for
    // child processes just to ensure any user-initiated PATH munging
    // doesn't break builtin utilities)
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
+   FilePath postbackDir = module_context::rPostbackScriptsDir();
    core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
 
    options.workingDir = projects::projectContext().directory();
@@ -3354,21 +3354,12 @@ core::Error initialize()
       return error;
 
    // setup environment
-   BOOST_ASSERT(boost::algorithm::ends_with(sshAskCmd, "rpostback-askpass"));
    core::system::setenv("GIT_ASKPASS", "rpostback-askpass");
-
    if (interceptAskPass)
-   {
       core::system::setenv("SSH_ASKPASS", "rpostback-askpass");
-   }
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
-   if (postbackDir.getAbsolutePath().find("session/postback") == std::string::npos) {
-      // for package builds only, postback/rpostback-askpass in same directory as rpostback itself
-      postbackDir = postbackDir.completeChildPath("postback");
-   }
-
+   FilePath postbackDir = module_context::rPostbackScriptsDir();
    core::system::addToPath(postbackDir.getAbsolutePath());
 
    // add suspend/resume handler

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3359,9 +3359,7 @@ core::Error initialize()
       r::util::setenv("SSH_ASKPASS", "rpostback-askpass");
 
    // add postback directory to PATH
-   error = module_context::appendToPath(module_context::rPostbackScriptsDir());
-   if (error)
-      LOG_ERROR(error);
+   r::util::appendToSystemPath(module_context::rPostbackScriptsDir());
 
    // add suspend/resume handler
    addSuspendHandler(SuspendHandler(boost::bind(onSuspend, _2), onResume));

--- a/src/cpp/session/modules/SessionSVN.cpp
+++ b/src/cpp/session/modules/SessionSVN.cpp
@@ -118,13 +118,7 @@ core::system::ProcessOptions procOptions(bool requiresSsh)
    core::system::environment(&childEnv);
 
    // add postback directory to PATH
-   FilePath postbackDir = session::options().rpostbackPath().getParent();
-   if (postbackDir.getAbsolutePath().find("session/postback") == std::string::npos) {
-      // for package builds only, postback/rpostback-askpass in same directory as rpostback itself
-      // that is, rpostback-askpass is nested inside a folder called postback which we add to PATH
-      postbackDir = postbackDir.completeChildPath("postback");
-   }
-
+   FilePath postbackDir = module_context::rPostbackScriptsDir();
    core::system::addToPath(&childEnv, postbackDir.getAbsolutePath());
 
    // on windows add gnudiff directory to the path

--- a/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
+++ b/src/cpp/session/modules/build/SessionBuildEnvironment.cpp
@@ -29,6 +29,7 @@
 
 #include <r/RExec.hpp>
 #include <r/RVersionInfo.hpp>
+#include <r/RUtil.hpp>
 
 #include <session/SessionModuleContext.hpp>
 
@@ -144,8 +145,7 @@ bool doAddRtoolsToPathIfNecessary(T* pTarget,
 
     // enumerate them to see if we have a compatible version
     // (go in reverse order for most recent first)
-    std::vector<r_util::RToolsInfo>::const_reverse_iterator it = rTools.rbegin();
-    for ( ; it != rTools.rend(); ++it)
+    for (auto it = rTools.rbegin(); it != rTools.rend(); ++it)
     {
        if (module_context::isRtoolsCompatible(*it))
        {
@@ -214,7 +214,7 @@ bool addRtoolsToPathIfNecessary(std::string* pPath,
    {
       for (const core::system::Option& var : environmentVars)
       {
-         core::system::setenv(var.first, var.second);
+         r::util::setenv(var.first, var.second);
       }
       return true;
    }

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -38,6 +38,7 @@
 #include <core/system/Process.hpp>
 
 #include <r/RExec.hpp>
+#include <r/RUtil.hpp>
 
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSourceDatabase.hpp>
@@ -222,16 +223,7 @@ void detectQuartoInstallation()
             return;
 
          // prepend to path only if RSTUDIO_QUARTO is defined
-         Error error = prepend
-                  ? module_context::prependToPath(s_quartoPath.getParent())
-                  : module_context::appendToPath(s_quartoPath.getParent());
-
-         if (error)
-         {
-            LOG_DEBUG_MESSAGE("Error setting PATH: " + sysPath);
-            LOG_ERROR(error);
-         }
-
+         r::util::addToSystemPath(s_quartoPath.getParent(), prepend);
          return;
       }
    }
@@ -262,14 +254,7 @@ void detectQuartoInstallation()
          return;
 
       // append to path
-      Error error = prepend
-            ? module_context::prependToPath(s_quartoPath.getParent())
-            : module_context::appendToPath(s_quartoPath.getParent());
-      if (error)
-      {
-         LOG_DEBUG_MESSAGE("Error setting PATH: " + sysPath);
-         LOG_ERROR(error);
-      }
+      r::util::addToSystemPath(s_quartoPath.getParent(), prepend);
    }
    else
    {

--- a/src/cpp/session/postback/CMakeLists.txt
+++ b/src/cpp/session/postback/CMakeLists.txt
@@ -45,20 +45,15 @@ if (RSTUDIO_SERVER)
     )
 endif()
 
-# configure postback scripts for development mode
+# configure postback scripts
 set(POSTBACK_SCRIPT_DIR ${CMAKE_CURRENT_BINARY_DIR}/postback)
 file(MAKE_DIRECTORY ${POSTBACK_SCRIPT_DIR})
-configure_file(rpostback-editfile ${POSTBACK_SCRIPT_DIR}/rpostback-editfile)
-configure_file(rpostback-pdfviewer ${POSTBACK_SCRIPT_DIR}/rpostback-pdfviewer)
-configure_file(rpostback-gitssh ${POSTBACK_SCRIPT_DIR}/rpostback-gitssh)
-configure_file(rpostback-askpass ${POSTBACK_SCRIPT_DIR}/rpostback-askpass)
 configure_file(askpass-passthrough ${POSTBACK_SCRIPT_DIR}/askpass-passthrough)
-configure_file(rpostback-browser ${POSTBACK_SCRIPT_DIR}/rpostback-browser)
-
-# put rpostback in a place where it can be found for dev config
-if(NOT RSTUDIO_PACKAGE_BUILD)
-   set_target_properties(rpostback PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${POSTBACK_SCRIPT_DIR})
-endif()
+configure_file(rpostback-editfile  ${POSTBACK_SCRIPT_DIR}/rpostback-editfile)
+configure_file(rpostback-pdfviewer ${POSTBACK_SCRIPT_DIR}/rpostback-pdfviewer)
+configure_file(rpostback-gitssh    ${POSTBACK_SCRIPT_DIR}/rpostback-gitssh)
+configure_file(rpostback-askpass   ${POSTBACK_SCRIPT_DIR}/rpostback-askpass)
+configure_file(rpostback-browser   ${POSTBACK_SCRIPT_DIR}/rpostback-browser)
 
 # installation rules
 if(NOT RSTUDIO_SESSION_WIN32)

--- a/src/gwt/ant
+++ b/src/gwt/ant
@@ -33,5 +33,5 @@ if [ -z "${JAVA_HOME}" ]; then
 fi
 
 echo "Using JAVA_HOME: ${JAVA_HOME}"
-JAVA_HOME="${JAVA_HOME}" command -p ant "$@"
+JAVA_HOME="${JAVA_HOME}" ant "$@"
 


### PR DESCRIPTION
### Intent

Addresses (part of) https://github.com/rstudio/rstudio/issues/12390.

### Approach

- Make the development layout of postback utilities match that of package builds
- Try to rationalize usages of the `rpostback` path, plus the `postback` scripts directory

### Automated Tests

Not included.

### QA Notes

Test via various notes in https://github.com/rstudio/rstudio/issues/12390.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
