### PR TITLE
Compute gcc version automatically from installed RTools

### DIFF
--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -304,12 +304,6 @@ RToolsInfo::RToolsInfo(const std::string& name,
              gccPath.completeChildPath("include-fixed")
           };
 
-          for (auto&& stem : cStems)
-          {
-             cIncludePaths.push_back(stem.getAbsolutePath());
-             cppIncludePaths.push_back(stem.getAbsolutePath());
-          }
-
           // get C++ headers
           std::vector<FilePath> cppStems = {
              gccPath.completeChildPath("include/c++"),
@@ -317,8 +311,14 @@ RToolsInfo::RToolsInfo(const std::string& name,
              gccPath.completeChildPath("include/c++/backward")
           };
 
+          // Note: the order of these args matters. c++ headers should appear before c headers
           for (auto&& stem : cppStems)
              cppIncludePaths.push_back(stem.getAbsolutePath());
+          for (auto&& stem : cStems)
+          {
+             cIncludePaths.push_back(stem.getAbsolutePath());
+             cppIncludePaths.push_back(stem.getAbsolutePath());
+          }
       }
    }
    else

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -277,18 +277,20 @@ RToolsInfo::RToolsInfo(const std::string& name,
       clangArgs.push_back("-U_MSC_VER");
 
       std::string toolDir = "x86_64-w64-mingw32.static.posix";
-      FilePath gccRootPath = installPath.completeChildPath(toolDir + "lib/gcc" + toolDir);
+      FilePath gccRootPath = installPath.completeChildPath(toolDir + "/lib/gcc/" + toolDir);
       std::vector<FilePath> gccPaths;
       Error error = gccRootPath.getChildren(gccPaths);
       if (error)
           LOG_ERROR(error);
       for (const FilePath& gccPath : gccPaths)
       {
-          std::string gccVersionStem = gccPath.getStem();
+          std::string gccVersionStr = gccPath.getFilename();
           std::vector<std::string> gccVersionNums;
-          boost::split(gccVersionNums, gccVersionStem, boost::is_any_of("."));
-          if (gccVersionNums.size() != 3)
+          boost::split(gccVersionNums, gccVersionStr, boost::is_any_of("."));
+          if (gccVersionNums.size() != 3) {
               LOG_DEBUG_MESSAGE("Not able to detect gcc version from installed RTools");
+              continue;
+          }
           // set GNUC levels
           // (required for _mingw.h, which otherwise tries to use incompatible MSVC defines)
           clangArgs.push_back("-D__GNUC__=" + gccVersionNums[0]);
@@ -299,7 +301,7 @@ RToolsInfo::RToolsInfo(const std::string& name,
           std::vector<FilePath> cStems = {
              gccPath.completeChildPath("include"),
              installPath.completeChildPath(toolDir + "/include"),
-             gccPath.completeChildPath("/include-fixed")
+             gccPath.completeChildPath("include-fixed")
           };
 
           for (auto&& stem : cStems)


### PR DESCRIPTION
### Intent

Addresses #12382 
### Approach
While we could choose to update RCompilationDatabase.cpp so that `discoverSystemIncludePaths` runs on Windows as well as Unix, it is more straightforward and requires less path/separator normalization to just update the existing RToolsInfo.cpp code so that rather than hardcoding gcc for a particular version of RTools, we infer the gcc version from the installation directory.

### Automated Tests

None
### QA Notes

See https://github.com/rstudio/rstudio/issues/12382#issuecomment-1344583816
### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [X] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [X] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


