### PR TITLE
Fix non-breaking space in NotebookPlots.R

### DIFF
--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -99,7 +99,7 @@
       dev.control(displaylist = "enable")
       # this introduces margins that makes the figure different from the actual output
       # as seen in the rendered document, so disable it
-      # .rs.setNotebookMargins()
+      # .rs.setNotebookMargins()
    })
 })
 


### PR DESCRIPTION
### Intent

This change looks a bit strange, because GitHub doesn't visualize non-breaking spaces (so it looks like there is no change). Nonetheless, this fixes a non-breaking space that was introduced in `NotebookPlots.R` and replaces it with a normal whitespace character, which should fix the failing 'R' tests that was occurring on certain [Jenkins pipelines](https://build.posit.it/blue/organizations/jenkins/IDE%2Fopen-source-pipeline/detail/main/1956/pipeline/2063).

### Approach

N/A

### Automated Tests

N/A

### QA Notes

Change will be validated when unit tests all pass on the open-source and pro pipelines.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


