### PR TITLE
Fix yarn and panmirror location

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -491,7 +491,7 @@ try {
                                     }
 
                                 }
-                                    stage ('publish') {
+                                stage ('publish') {
                                     def packageVersion = "${rstudioVersionMajor}.${rstudioVersionMinor}.${rstudioVersionPatch}${rstudioVersionSuffix}"
                                     packageVersion = packageVersion.replace('+', '-')
 

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -18,6 +18,7 @@ pipeline {
       string(name: 'GIT_REVISION', defaultValue: 'main', description: 'Git revision to build')
       string(name: 'BRANCH_NAME', defaultValue: 'origin/main', description: 'Branch name to build')
       string(name: 'SLACK_CHANNEL', defaultValue: '#ide-builds', description: 'Slack channel to publish build message.')
+      booleanParam(name: 'PUBLISH', defaultValue: true, description: 'Runs publish stage if true')
   }
 
   environment {
@@ -93,6 +94,11 @@ pipeline {
 
     stage('notarize and upload') {
 
+      when {
+        expression {
+          return params.PUBLISH
+        }
+      }
       environment {
         PATH = "${env.HOME}/opt/bin:${env.PATH}"
       }

--- a/dependencies/common/install-yarn
+++ b/dependencies/common/install-yarn
@@ -25,22 +25,14 @@ DEPS_DIR="$(pwd)"
 NODE_BIN="${DEPS_DIR}/${NODE_SUBDIR}/bin"
 INSTALL_PATH="${NODE_BIN}:${PATH}"
 
+# try to ensure node is on the PATH
+PATH="${NODE_BIN}:${PATH}"
+
 # check for yarn installation
 # TODO: do we want to allow yarn installs from other PATH locations?
 if has-program yarn; then
   YARN_VERSION=$(PATH="${INSTALL_PATH}" yarn --version)
   echo "yarn ${YARN_VERSION} already installed at '$(which yarn)'"
 else
-  # download the yarn installer
-  YARN_INSTALL_URL="https://yarnpkg.com/install.sh"
-  YARN_INSTALL_SCRIPT="yarn-install.sh"
-  download "${YARN_INSTALL_URL}" "${YARN_INSTALL_SCRIPT}"
-
-  # run the installer script
-  chmod +x "${YARN_INSTALL_SCRIPT}"
-  PATH=${INSTALL_PATH} ./"${YARN_INSTALL_SCRIPT}"
-  rm "${YARN_INSTALL_SCRIPT}"
-
-  # update INSTALL_PATH
-  INSTALL_PATH="${HOME}/.yarn/bin:${HOME}/.config/yarn/global/node_modules/.bin:${INSTALL_PATH}"
+  npm install -g yarn
 fi

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -109,7 +109,14 @@
    <property name="panmirror.dir" value="./lib/quarto/libs/panmirror"/>
    <property name="panmirror.build.dir" value="./www/js/panmirror"/>
 
+   <!-- use panmirror from /opt/rstudio-tools if available (typical for Docker) -->
+   <available
+      property="panmirror.dir"
+      value="/opt/rstudio-tools/src/gwt/lib/quarto/libs/panmirror"
+      file="/opt/rstudio-tools/src/gwt/lib/quarto/libs/panmirror"/>
+
    <target name="panmirror" description="Compile panmirror library">
+      <echo message="yarn location: ${yarn.bin}"/>
       <mkdir dir="${panmirror.build.dir}"/>
       <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
          <arg value="install"/>


### PR DESCRIPTION
### Intent
Fix panmirror building in Jenkins

### Approach
Install `yarn` using `npm` instead of downloading the script. This is how it is done in Linux aarch64 and ensures the Node install has Yarn.

The panmirror location is in a separate location from the source checkout. So Jenkins specifically needs a different location to check when building GWT.

### Automated Tests
None

### QA Notes
None

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


