### PR TITLE
update the testthat > 3 error regex

### DIFF
--- a/src/cpp/session/modules/build/SessionBuildErrors.cpp
+++ b/src/cpp/session/modules/build/SessionBuildErrors.cpp
@@ -34,7 +34,7 @@
 #include <session/projects/SessionProjects.hpp>
 
 #define kAnsiEscapeRegex "(?:\033\\[\\d+m)*"
-#define kAnsiUrlRegex "(?:\u001B]8;[^\u0007]*\u0007)*"
+#define kAnsiUrlRegex "(?:\u001B]8;.*?(?:\u0007|\033\\\\))*"
 
 using namespace rstudio::core;
 using namespace boost::placeholders;
@@ -293,15 +293,17 @@ std::vector<module_context::SourceMarker> parseTestThatErrors(
                   "\\s+"           // separating space
                   "\\("            // opening paren
                   kAnsiUrlRegex    // opening hyperlink
+                  kAnsiEscapeRegex // color
                   "([^:\\n]+)"     // file name           (2)
                   ":"              // colon separator
                   "([0-9]+)"       // file line           (3)
-                  ":"              // colon separator
-                  "([0-9]+)"       // file column         (4)
+                  "((?::)[0-9]+)?" // optional column     (4)
+                  kAnsiEscapeRegex // color
                   kAnsiUrlRegex    // closing hyperlink
                   "\\)"            // closing paren
                   ":"              // colon separator
                   "\\s+"           // separating space
+                  kAnsiEscapeRegex // color
                   "([[:print:]]*)" // error message       (5)
                   kAnsiEscapeRegex // color
                   );


### PR DESCRIPTION
### Intent

bring back the [Output | Issues] in testthat output:

<img width="156" alt="image" src="https://user-images.githubusercontent.com/2625526/207279054-4d230b26-3f7c-406c-becf-29db8058038d.png">

### Approach

regex update

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


