### PR TITLE
ansi escapes in custom source markers

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -244,9 +244,9 @@
          marker$file <- .rs.scalar(.rs.normalizePath(marker$file, mustWork = TRUE))
          marker$line <- .rs.scalar(as.numeric(marker$line))
          marker$column <- .rs.scalar(as.numeric(marker$column))
-         marker$message <- .rs.scalar(marker$message)
          marker$messageHTML <- .rs.scalar(inherits(marker$message, "html"))
-
+         marker$message <- .rs.scalar(marker$message)
+         
          marker
       })
    } else {

--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -222,10 +222,6 @@
 
       # normalize paths
       markers$file <- .rs.normalizePath(markers$file, mustWork = TRUE)
-
-      # check for html
-      markers$messageHTML <- inherits(markers$message, "html")
-
    } else if (is.list(markers)) {
       markers <- lapply(markers, function(marker) {
          markerTypes <- c("error", "warning", "box", "info", "style", "usage")
@@ -244,7 +240,6 @@
          marker$file <- .rs.scalar(.rs.normalizePath(marker$file, mustWork = TRUE))
          marker$line <- .rs.scalar(as.numeric(marker$line))
          marker$column <- .rs.scalar(as.numeric(marker$column))
-         marker$messageHTML <- .rs.scalar(inherits(marker$message, "html"))
          marker$message <- .rs.scalar(marker$message)
          
          marker

--- a/src/cpp/session/modules/SessionDiagnostics.R
+++ b/src/cpp/session/modules/SessionDiagnostics.R
@@ -96,8 +96,7 @@
          file = file,
          line = x$start.row,
          column = x$start.column,
-         message = x$message,
-         messageHTML = FALSE
+         message = x$message
       )
    })
 })

--- a/src/cpp/session/modules/SessionMarkers.cpp
+++ b/src/cpp/session/modules/SessionMarkers.cpp
@@ -391,15 +391,13 @@ SEXP rs_sourceMarkers(SEXP nameSEXP,
             std::string path;
             double line, column;
             std::string message;
-            bool messageHTML;
             Error error = json::readObject(
                markerJson.getObject(),
                "type", type,
                "file", path,
                "line", line,
                "column", column,
-               "message", message,
-               "messageHTML", messageHTML);
+               "message", message);
             if (error)
             {
                LOG_ERROR(error);
@@ -411,7 +409,7 @@ SEXP rs_sourceMarkers(SEXP nameSEXP,
                 FilePath(path),
                 safe_convert::numberTo<double, int>(line, 1),
                 safe_convert::numberTo<double, int>(column, 1),
-                core::html_utils::HTML(message, messageHTML),
+                core::html_utils::HTML(message, false),
                 true,
                 true);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/DiagnosticsBackgroundPopup.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/DiagnosticsBackgroundPopup.java
@@ -42,7 +42,7 @@ import com.google.gwt.resources.client.CssResource;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
-import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 
@@ -202,7 +202,11 @@ public class DiagnosticsBackgroundPopup
              marker.getRange().getEnd().getRow() >= row)
          {
             activeMarker_ = marker;
-            showPopup(annotation.text(), marker.getRange());
+            String text = annotation.html();
+            if (StringUtil.isNullOrEmpty(text))
+               text = annotation.text();
+            showPopup(text, marker.getRange());
+
             return;
          }
       }
@@ -226,7 +230,7 @@ public class DiagnosticsBackgroundPopup
             }
          });
          addStyleName(RES.styles().popup());
-         setWidget(new Label(text));
+         setWidget(new HTML(text));
       }
 
       private final Range range_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintMarkers.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/LintMarkers.java
@@ -40,6 +40,7 @@ public class LintMarkers
          return AceAnnotation.create(
                anchor_.getRow(),
                anchor_.getColumn(),
+               annotation_.html(),
                annotation_.text(),
                annotation_.type());
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
@@ -35,5 +35,6 @@ public class AceAnnotation extends JavaScriptObject
    public final native int row() /*-{ return this.row; }-*/;
    public final native int column() /*-{ return this.column; }-*/;
    public final native String text() /*-{ return this.text; }-*/;
+   public final native String html() /*-{ return this.html; }-*/;
    public final native String type() /*-{ return this.type; }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/AceAnnotation.java
@@ -22,14 +22,21 @@ public class AceAnnotation extends JavaScriptObject
    
    public static native AceAnnotation create(int row,
                                              int column,
+                                             String html,
                                              String text,
                                              String type) /*-{
-      return {
+
+      var aceAnnotation = {
          row: row,
          column: column,
-         text: text,
          type: type
-      }
+      };
+      if (html) 
+         aceAnnotation.html = html;
+      else
+         aceAnnotation.text = text;
+
+      return aceAnnotation;
    }-*/;
    
    public final native int row() /*-{ return this.row; }-*/;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -36,7 +36,6 @@ public class LintItem extends JavaScriptObject
          "end.row": endRow,
          "end.column": endColumn,
          "text": text,
-         "raw": text,
          "type": type
       };
                                 
@@ -72,6 +71,14 @@ public class LintItem extends JavaScriptObject
 
    public final native void setText(String text) /*-{
       this["text"] = text;
+   }-*/;
+   
+   public final native String getHtml() /*-{
+      return this["html"];
+   }-*/;
+
+   public final native void setHtml(String html) /*-{
+      this["html"] = html;
    }-*/;
    
    public final native String getType() /*-{
@@ -112,11 +119,11 @@ public class LintItem extends JavaScriptObject
             column: item["start.column"],
             type: type
          };
-         var html = item["text"]
+         var html = item["html"]
          if (html)
             annotation.html = html;
          else 
-            annotation.text = item["raw"];
+            annotation.text = item["text"];
          
          aceAnnotations.push(annotation);
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -97,6 +97,7 @@ public class LintItem extends JavaScriptObject
       return AceAnnotation.create(
             getStartRow(),
             getStartColumn(),
+            getHtml(),
             getText(),
             getType());
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/lint/model/LintItem.java
@@ -102,17 +102,23 @@ public class LintItem extends JavaScriptObject
       
       for (var key in items)
       {
-         var type = items[key]["type"];
+         var item = items[key];
+         var type = item["type"];
          if (type === "style" || type === "note")
             type = "info";
 
-         aceAnnotations.push({
-            row: items[key]["start.row"],
-            column: items[key]["start.column"],
-            html: items[key]["text"],
-            text: items[key]["raw"],
+         var annotation = {
+            row: item["start.row"],
+            column: item["start.column"],
             type: type
-         });
+         };
+         var html = item["text"]
+         if (html)
+            annotation.html = html;
+         else 
+            annotation.text = item["raw"];
+         
+         aceAnnotations.push(annotation);
       }
       
       return aceAnnotations;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -1038,6 +1038,7 @@ public class AceEditorWidget extends Composite
          return AceAnnotation.create(
                anchor_.getRow(),
                anchor_.getColumn(),
+               annotation_.html(),
                annotation_.text(),
                annotation_.type());
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetLintSource.java
@@ -18,6 +18,8 @@ import com.google.gwt.core.client.JsArray;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.user.client.Command;
+
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.VirtualConsole;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.common.filetypes.TextFileType;
@@ -98,14 +100,17 @@ public class TextEditingTargetLintSource implements LintSource
       {
          for (int i = 0; i < lint.length(); i++) {
             LintItem lintItem = lint.get(i);
-            DivElement element = Document.get().createDivElement();
-            VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(element);
 
-            vc.setPreserveHTML(true);
-            vc.submit(lintItem.getText());
-            String renderedText = element.getInnerHTML();
+            if (StringUtil.isNullOrEmpty(lintItem.getHtml()))
+            {
+               DivElement element = Document.get().createDivElement();
+               VirtualConsole vc = RStudioGinjector.INSTANCE.getVirtualConsoleFactory().create(element);
 
-            lintItem.setText(renderedText);
+               vc.setPreserveHTML(true);
+               vc.submit(lintItem.getText());
+               String renderedText = element.getInnerHTML();
+               lintItem.setHtml(renderedText);
+            }
          }
 
          target_.getDocDisplay().showLint(lint);


### PR DESCRIPTION
### Intent

addresses #12425 

### Approach

Avoid to create an `AceAnnotation` with both `.text` and `.html` because otherwise `.text` is prefered as per this code in ace: 

```js
var annoText = annotation.text;
annoText = annoText ? lang.escapeHTML(annoText) : annotation.html || "";
```

_Alternatively, the ace code could use `annotation.html ?` instead of `annotation.text ?` so that the html version would have priority._ 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

Save this file as `test.R` in the current working directory: 

```r
tmpfile <- "test.R"

foo <- cli::bg_br_white(cli::col_red("I am red!"))
bar <- cli::bg_br_yellow(cli::col_cyan("I am cyan!"))

markers <- list(
  list(
    type = "error",
    file = tmpfile,
    line = 6,
    column = 1,
    message = structure("<i>I am Groot</i>", class = "html")
  ),
  list(
    type = "info", 
    file = tmpfile,
    line = 12,
    column = 1,
    message = bar))

.rs.api.sourceMarkers("Test Name", markers)
```

and then run it. 

Expected: 

Markers tab: 

<img width="356" alt="image" src="https://user-images.githubusercontent.com/2625526/207590521-11a85be8-9c0c-421b-8f51-8e339cb2ad5c.png">

Annotations: 

<img width="219" alt="image" src="https://user-images.githubusercontent.com/2625526/207590585-412ea2da-e57b-454b-b765-cd14139fd7d0.png">

<img width="463" alt="image" src="https://user-images.githubusercontent.com/2625526/207590633-537ba3fc-1d84-466f-8e8c-2b04258dc64c.png">

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


