### PR TITLE
Break image layer cache if panmirror source is updated

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -99,6 +99,8 @@ RUN bash /tmp/install-crashpad bionic
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+# break image layer cache if panmirror changes
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -102,6 +102,8 @@ RUN scl enable llvm-toolset-7 "/bin/bash /tmp/install-crashpad centos7"
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+# break image layer cache if panmirror changes
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-common centos7"
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -87,6 +87,7 @@ RUN bash /tmp/install-crashpad bionic
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -85,6 +85,8 @@ RUN update-alternatives --set java /usr/lib64/jvm/jre-1.8.0-openjdk/bin/java
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+# break image layer cache if panmirror changes
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -87,6 +87,8 @@ RUN bash /tmp/install-crashpad rhel8
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+# break image layer cache if panmirror changes
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8
 # panmirror needs to be able to build in this location

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -90,6 +90,8 @@ RUN bash /tmp/install-crashpad rhel8
 RUN mkdir -p /opt/rstudio-tools/dependencies/common
 COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
+# break image layer cache if panmirror changes
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9
 # panmirror needs to be able to build in this location


### PR DESCRIPTION
### Intent
Getting ahead of the builds since a change just went in that changes where to look for the `panmirror` source. The Docker images won't update the image layer to pull the new `panmirror` code. This change ensures the changes are pulled in so the builds will continue to work.

### Approach
Grabs the latest commit SHA for the repo where `panmirror` lives and will break the image layer cache if it changes.

### Automated Tests
None

### QA Notes
Ran the docker build locally and it detects a commit change. A second run uses the cache.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


