### PR TITLE
Sync to the latest patch release of quarto v1.2

### DIFF
--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -27,7 +27,7 @@ fi
 
 # variables that control download + installation process
 # specify a version to pin for releases
-QUARTO_VERSION="1.2.269"
+QUARTO_VERSION="1.2.280"
 
 # update to latest Quarto release
 # QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -44,7 +44,7 @@ set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
 REM Pin to specific Quarto version for releases
-set QUARTO_VERSION=1.2.269
+set QUARTO_VERSION=1.2.280
 
 REM Get latest Quarto release version
 REM cd install-quarto


### PR DESCRIPTION
This fixes an important issue that prevents tinytex package auto-installation from working on osx.

If you end up doing another EG build this patch is worth taking (it has the change described above along with 2 other minor fixes). If you don't end up taking it we'll just need to tell users who encounter this problem to update manually (as RStudio will use the later externally installed version in preference to the internal version).
