### PR TITLE
deal with dotted pairs in `.rs.hasExternalPointer()`

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -126,16 +126,16 @@ bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::set<SEXP>& visited
 {
    while(list != R_NilValue)
    {
+      // handle dotted pairs, e.g. CONS(x, y) where y is not another pairlist or NULL
+      // we need to check y for external pointers but stop there
+      if (TYPEOF(list) != LISTSXP && TYPEOF(list) != LANGSXP)
+         return hasExternalPointer(list, nullPtr, visited);
+         
       // here we have a pairlist, so we can CAR() and CDR()
       if (hasExternalPointer(CAR(list), nullPtr, visited))
          return true;
 
       list = CDR(list);
-
-      // handle dotted pairs, e.g. CONS(x, y) where y is not another pairlist or NULL
-      // we need to check y for external pointers but stop there
-      if (TYPEOF(list) != LISTSXP && TYPEOF(list) != LANGSXP)
-         return hasExternalPointer(list, nullPtr, visited);
    }
 
    return false;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -126,18 +126,19 @@ bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::set<SEXP>& visited
 {
    while(list != R_NilValue)
    {
+      // here we have a pairlist, so we can CAR() and CDR()
       if (hasExternalPointer(CAR(list), nullPtr, visited))
          return true;
-      
+
       list = CDR(list);
+
+      // handle dotted pairs, e.g. CONS(x, y) where y is not another pairlist or NULL
+      // we need to check y for external pointers but stop there
+      if (TYPEOF(list) != LISTSXP && TYPEOF(list) != LANGSXP)
+         return hasExternalPointer(list, nullPtr, visited);
    }
 
    return false;
-}
-
-bool attributesHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
-{
-   return pairlistHasExternalPointer(ATTRIB(obj), nullPtr, visited);
 }
 
 bool listHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
@@ -203,9 +204,20 @@ bool weakrefHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
+bool altrepHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+{
+   if (hasExternalPointer(CAR(obj), nullPtr, visited))
+      return true;
+
+   if (hasExternalPointer(CDR(obj), nullPtr, visited))
+      return true;
+
+   return false;
+}
+
 bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
 {
-   if (obj == R_NilValue || visited.count(obj))
+   if (obj == nullptr || obj == R_NilValue || visited.count(obj))
       return false;
 
    // mark SEXP as visited
@@ -294,20 +306,16 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
       default:
          break;
    }
-
-   // check attributes, this includes slots for S4 objects
-   if (attributesHasExternalPointer(obj, nullPtr, visited))
-      return true;
-
-   // altrep objects might be implemented with external pointers
+   
+   // altrep objects use ATTRIB() to hold class info, so no need
+   // to check ATTRIB() on them, but altrepHasExternalPointer() 
+   // checks for their data1 and data2, aka CAR() and CDR()
    if (isAltrep(obj))
-   {
-      if (hasExternalPointer(CAR(obj), nullPtr, visited))
-         return true;
-
-      if (hasExternalPointer(CDR(obj), nullPtr, visited))
-         return true;
-   } 
+      return altrepHasExternalPointer(obj, nullPtr, visited);
+      
+   // check attributes, this includes slots for S4 objects
+   if (hasExternalPointer(ATTRIB(obj), nullPtr, visited))
+      return true;
 
    return false;
 }


### PR DESCRIPTION
### Intent

Followup to #12408, dealing with https://github.com/rstudio/rstudio/commit/b735c1582c8088cc8939c93131573e238808f985#commitcomment-93066075

### Approach

This initially came up because of deferred strings, i.e. made by this function in `altclasses.c`: 

```c
attribute_hidden SEXP R_deferred_coerceToString(SEXP v, SEXP info)
{
    SEXP ans = R_NilValue;
    switch (TYPEOF(v)) {
    case INTSXP:
    case REALSXP:
	PROTECT(v); /* may not be needed, but to be safe ... */
	if (info == NULL) {
	    PrintDefaults(); /* to set R_print from options */
	    info = ScalarInteger(R_print.scipen);
	    if (strcmp(OutDec, ".")) {
		/* non-default OutDec setting -- attach as an attribute */
		PROTECT(info);
		if (R_OutDecSym == NULL)
		    R_OutDecSym = install("OutDec");
		setAttrib(info, R_OutDecSym, GetOption1(R_OutDecSym));
		UNPROTECT(1); /* info */
	    }
	}
	MARK_NOT_MUTABLE(v); /* make sure it can't change once captured */
	ans = PROTECT(MAKE_DEFERRED_STRING_STATE(v, info));
	ans = R_new_altrep(R_deferred_string_class, ans, R_NilValue);
	UNPROTECT(2); /* ans, v */
	break;
    default:
	error("unsupported type for deferred string coercion");
    }
    return ans;
}
```

with: 

```c
#define MAKE_DEFERRED_STRING_STATE(v, sp) CONS(v, sp)
```

so the `data1` of the altrep for deferred strings was the result of `CONS(v, sp)`. 

Then the issue really was that the code was assuming the `CDR()` of a pairlist could only be another pairlist or NULL, but that's not what `CONS` does, the `CDR()` can be whatever. 

The approach is consistent with what e.g. `.Internal(inspect())` does: https://github.com/r-devel/r-svn/blob/b7a3736e38919613e8a1ba44977ebca7a640938b/src/main/inspect.c#L232-L238

```
	case LISTSXP: case LANGSXP:
	    {
		SEXP lc = v;
		while (lc != R_NilValue) {
		    if (TYPEOF(lc) != LISTSXP && TYPEOF(lc) != LANGSXP) {
			/* a dotted pair */
			pp(pre + 2);
			Rprintf(".\n");
			inspect_tree(pre + 2, lc, deep - 1, pvec);
			break;
		    }
```

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


