### PR TITLE
immediate bindings don't have external pointers

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -152,19 +152,24 @@ bool listHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
-namespace {
 bool frameBindingIsActive(SEXP binding) 
 {
    static unsigned int ACTIVE_BINDING_MASK = (1<<15);
    return reinterpret_cast<r::sxpinfo*>(binding)->gp & ACTIVE_BINDING_MASK;
 }
+
+bool frameBindingIsImmediate(SEXP binding)
+{
+   return reinterpret_cast<r::sxpinfo*>(binding)->extra;
 }
 
 bool frameHasExternalPointer(SEXP frame, bool nullPtr, std::set<SEXP>& visited)
 {
    while(frame != R_NilValue)
    {
-      if (!frameBindingIsActive(frame) && hasExternalPointer(CAR(frame), nullPtr, visited))
+      // - immediate bindings are scalars without attributes: they don't have external pointers
+      // - active bindings are ruled out to
+      if (!frameBindingIsImmediate(frame) && !frameBindingIsActive(frame) && hasExternalPointer(CAR(frame), nullPtr, visited))
          return true;
 
       frame = CDR(frame);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -248,6 +248,9 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
 
    switch(TYPEOF(obj))
    {
+      case SYMSXP: 
+         return false;
+         
       case ENVSXP: 
       {
          if (envHasExternalPointer(obj, nullPtr, visited))

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -124,19 +124,11 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited);
 
 bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::set<SEXP>& visited)
 {
-   while(list != R_NilValue)
-   {
-      // handle dotted pairs, e.g. CONS(x, y) where y is not another pairlist or NULL
-      // we need to check y for external pointers but stop there
-      if (TYPEOF(list) != LISTSXP && TYPEOF(list) != LANGSXP)
-         return hasExternalPointer(list, nullPtr, visited);
-         
-      // here we have a pairlist, so we can CAR() and CDR()
-      if (hasExternalPointer(CAR(list), nullPtr, visited))
-         return true;
+   if (hasExternalPointer(CAR(list), nullPtr, visited))
+      return true;
 
-      list = CDR(list);
-   }
+   if (hasExternalPointer(CDR(list), nullPtr, visited))
+      return true;
 
    return false;
 }
@@ -250,7 +242,7 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    {
       case SYMSXP: 
          return false;
-         
+
       case ENVSXP: 
       {
          if (envHasExternalPointer(obj, nullPtr, visited))


### PR DESCRIPTION
### Intent

addresses #12456

### Approach

Based on: 

```c
#define BNDCELL_TAG(e)	((e)->sxpinfo.extra)

static R_INLINE SEXP BINDING_VALUE(SEXP b)
{
    if (BNDCELL_TAG(b)) {
	R_expand_binding_value(b);
	return CAR0(b);
    }
    if (IS_ACTIVE_BINDING(b)) return getActiveValue(CAR(b));
    else return CAR(b);
}
```

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


