### PR TITLE
Add logging for windows registry query / R installation search; plus fix system32 path issue

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -92,7 +92,7 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
     // discover available R installations
     const rInstalls = findRInstallationsWin32();
     if (rInstalls.length === 0) {
-      return err();
+      return err(Error('No R installations found via registry or common R install locations.'));
     }
 
     // ask the user what version of R they'd like to use
@@ -308,6 +308,7 @@ function scanForRPosix(): Expected<string> {
 }
 
 function queryRegistry(cmd: string, rInstallations: Set<string>): Set<string> {
+  logger().logDebug(`Querying registry for ${cmd}`);
   const [output, error] = executeCommand(cmd);
   if (error) {
     logger().logError(`Error querying the Windows registry: ${error}`);
@@ -357,7 +358,7 @@ export function findRInstallationsWin32(): string[] {
   ];
 
   for (const location of commonLocations) {
-
+    logger().logDebug(`Checking common R installation path: ${location}`)
     // nothing to do if it doesn't exist
     if (!existsSync(location)) {
       continue;

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -309,9 +309,11 @@ function scanForRPosix(): Expected<string> {
 
 function queryRegistry(cmd: string, rInstallations: Set<string>): Set<string> {
   const [output, error] = executeCommand(cmd);
-  if (error)      
+  if (error) {
+    logger().logError(`Error querying the Windows registry: ${error}`);
     return rInstallations;
-
+  }      
+    
   // parse the actual path from the output
   const lines = output.split(EOL);
   for (const line of lines) {
@@ -342,7 +344,7 @@ export function findRInstallationsWin32(): string[] {
     const rBinaryNames = ['R', 'R64'];
 
     const regQueryCommands = keyNames.flatMap(key => rBinaryNames.map(
-      rBin => `reg query ${key}\\SOFTWARE\\R-Core\\${rBin} /s /v InstallPath ${view}`));  
+      rBin => `%SystemRoot%\\System32\\reg.exe query ${key}\\SOFTWARE\\R-Core\\${rBin} /s /v InstallPath ${view}`));  
     regQueryCommands.map(cmd => queryRegistry(cmd, rInstallations));
   }
 
@@ -393,7 +395,7 @@ function findDefaultInstallPathWin32(version: string): string {
 
     // query registry for R install path
     const keyName = `HKEY_LOCAL_MACHINE\\SOFTWARE\\R-core\\${version}`;
-    const regQueryCommand = `reg query ${keyName} /v InstallPath ${view}`;
+    const regQueryCommand = `%SystemRoot%\\System32\\reg.exe query ${keyName} /v InstallPath ${view}`;
     const [output, error] = executeCommand(regQueryCommand);
     if (error) {
       logger().logError(error);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -385,6 +385,7 @@ export class GwtCallback extends EventEmitter {
       // discover available R installations
       const rInstalls = findRInstallationsWin32();
       if (rInstalls.length === 0) {
+        logger().logError(Error('No R installations found via registry or common R install locations.'));
         return '';
       }
 

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -32,9 +32,12 @@ function checkValid(data: CallbackData) {
 
   // try to run it
   const [rEnvironment, err] = detectREnvironment(rBinaryPath);
+
   if (err) {
     // something went wrong; let the user know they can't use
     // this version of R with RStudio
+    logger().logError(err);
+
     dialog.showMessageBoxSync({
       type: 'error',
       title: t('chooseRDialog.rLaunchFailedTitle'),


### PR DESCRIPTION
### Intent

Partially but sadly not at all fully address #12452

### Approach

For one user, this failed because C:\Windows\System32 wasn't on their path, so we use the absolute path to `reg.exe` rather than the shorthand `reg` to query the registry. For all other users, we haven't figured out exactly what the error is yet. Partly because logging is currently mostly useless. Adding a bunch more error logging here so we can at least get some useful feedback from users who do encounter this issue, now and in the future
