### PR TITLE
Use `curl-minimal` in rhel9 docker image

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -18,7 +18,7 @@ RUN dnf install -y \
     boost-devel \
     bzip2-devel \
     clang-devel \
-    curl \
+    curl-minimal \
     expect \
     fakeroot \
     fuse-libs \


### PR DESCRIPTION
Instead of `curl` to remove conflict with `curl-minimal` dependency of `RPM`.



### Intent

Change rhel9 docker images to use `curl-minimal` instead of `curl` to remove conflict with `RPM`'s dependencies. Keep `libcurl-devel` unchanged, however.

### Approach

For a while now the rhel9 docker images have failed during `PullBuildPush` with the following error while `yum install`-ing dependencies:

```
Error: 
[2022-12-22T00:40:14.597Z]  Problem: problem with installed package curl-minimal-7.76.1-19.el9.aarch64
[2022-12-22T00:40:14.597Z]   - package curl-minimal-7.76.1-19.el9.aarch64 conflicts with curl provided by curl-7.76.1-19.el9.aarch64
[2022-12-22T00:40:14.597Z]   - conflicting requests
```

`curl-minimum` is a dependency of `RPM`, so pretty hard to get around. The automatic suggested fixes:

`[2022-12-22T00:40:14.597Z] (try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)`

seem a little hacky and heavy handed, while the internet's suggestion is to manually remove `curl-minimal` and then install `curl`, which is clunky for an automated image build.

"If you can't beat 'em, join 'em" seems like the easiest path forward here, and since we only need curl's basic functionality to download other dependencies later I don't see an immediate problem with the reduced functionality of `curl-minimum`

### Automated Tests

Built the image (x86_64 and arm) locally and successfully compiled Workbench in both.

### QA Notes

N/A Build fix

### Documentation
N/A Build fix

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


