### PR TITLE
Fix unpopulated choose R dialog

### DIFF
--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -31,6 +31,7 @@ export abstract class ModalDialog<T> extends BrowserWindow {
       height: 400,
       show: false,
       webPreferences: {
+        nodeIntegration: true,
         preload: preload,
       },
     };


### PR DESCRIPTION
### Intent
Address #12487 

### Approach
The Electron update defaults the `nodeIntegration` browser window preference to false, which prevents the preload script from running. The preload is necessary to hook up the UI listeners and populate the R versions. No other dialogs use a preload script so this is the only one affected.

### Automated Tests
None

### QA Notes
The choose R dialog is available in the preferences in the General section. This is the only dialog affected.

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


