### PR TITLE
Prevent sccache install script on macOS

### DIFF
--- a/dependencies/common/install-sccache
+++ b/dependencies/common/install-sccache
@@ -18,6 +18,11 @@
 set -e
 
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
+
+if is-macos; then
+   exit 0
+fi
+
 section "Installing sccache"
 
 # install dir


### PR DESCRIPTION
This is a temporary fix to prevent the sccache install script from running on macOS until rstudio/rstudio#12532 is implemented.

Instead of moving the script, we can just prevent the install from running for now.
