### PR TITLE
fix a bug when /usr/local/bin is available

### DIFF
--- a/dependencies/common/install-sentry-cli
+++ b/dependencies/common/install-sentry-cli
@@ -30,6 +30,9 @@ fi
 # specify a version
 export SENTRY_CLI_VERSION=2.9.0
 
-curl -sL https://sentry.io/get-cli/ | bash || true
+curl -sL https://sentry.io/get-cli/ | bash || trueSENTRY_PATH="sentry-cli"
+if [[ -n "${INSTALL_DIR}" ]]; then
+	SENTRY_PATH="${INSTALL_DIR}/${SENTRY_PATH}"
+fi
 
-info "Installed Sentry CLI version: `${INSTALL_DIR}/sentry-cli --version`"
+info "Installed Sentry CLI version: `${SENTRY_PATH} --version`"

--- a/dependencies/common/install-sentry-cli
+++ b/dependencies/common/install-sentry-cli
@@ -30,7 +30,8 @@ fi
 # specify a version
 export SENTRY_CLI_VERSION=2.9.0
 
-curl -sL https://sentry.io/get-cli/ | bash || trueSENTRY_PATH="sentry-cli"
+curl -sL https://sentry.io/get-cli/ | bash || true
+SENTRY_PATH="sentry-cli"
 if [[ -n "${INSTALL_DIR}" ]]; then
 	SENTRY_PATH="${INSTALL_DIR}/${SENTRY_PATH}"
 fi


### PR DESCRIPTION
### Intent

Fix failing pro builds.

### Approach

Sometimes `/usr/local/bin` is available. In that case, we don't set an install dir, and the last line fails because `/sentry-cli` doesn't exist. This attempts to fix that by setting a `SENTRY_PATH` variable which is either `sentry-cli` or `${INSTALL_DIR}/sentry-cli`.

Another way we could fix it is to always install sentry to `${INSTALL_DIR}`.

### Automated Tests

Build system failure.

### QA Notes

Build system failure.

### Documentation

None, build system failure.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


