### PR TITLE
Update addRemoteRef to use credentials for fetch

### DIFF
--- a/utils.groovy
+++ b/utils.groovy
@@ -20,7 +20,9 @@ boolean hasChangesIn(String module, boolean invertMatch = false) {
   */
 void addRemoteRef(String branchName) {
   sh "git config --add remote.origin.fetch +refs/heads/${branchName}:refs/remotes/origin/${branchName}"
-  sh "git fetch --no-tags origin ${branchName}"
+  // Split GIT_URL after https://
+  urlParts = env.GIT_URL.split('https://')
+  sh 'git fetch --no-tags --force --progress -- https://${GITHUB_LOGIN}' + "@${urlParts[1]} refs/heads/${branchName}:refs/remotes/origin/${branchName}"
 }
 
 return this

--- a/utils.groovy
+++ b/utils.groovy
@@ -19,10 +19,10 @@ boolean hasChangesIn(String module, boolean invertMatch = false) {
   * Adds a remote reference to the specified branch.
   */
 void addRemoteRef(String branchName) {
-  sh "git config --add remote.origin.fetch +refs/heads/${branchName}:refs/remotes/origin/${branchName}"
-  // Split GIT_URL after https://
-  urlParts = env.GIT_URL.split('https://')
-  sh 'git fetch --no-tags --force --progress -- https://${GITHUB_LOGIN}' + "@${urlParts[1]} refs/heads/${branchName}:refs/remotes/origin/${branchName}"
+  withCredentials([gitUsernamePassword(credentialsId: 'github-rstudio-jenkins', gitToolName: 'Default')]) {
+    sh "git config --add remote.origin.fetch +refs/heads/${branchName}:refs/remotes/origin/${branchName}"
+    sh "git fetch --no-tags --force --progress ${GIT_URL} refs/heads/${branchName}:refs/remotes/origin/${branchName}"
+  }
 }
 
 return this


### PR DESCRIPTION
### Intent

This change updates the addRemoteRef utility for Jenkinsfiles to use credentials when performing a git fetch, which is needed for private repositories such as our pro repo. This should fix the currently failing builds for PRs in the pro repo.

### Approach

We can use a `withCredentials` block so the git commands have the proper credentials for the fetch command

### Automated Tests

N/A

### QA Notes

N/A

### Documentation
N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


