### PR TITLE
Stub out a process creation time lookup for macOS

### DIFF
--- a/src/cpp/core/include/core/system/System.hpp
+++ b/src/cpp/core/include/core/system/System.hpp
@@ -328,7 +328,7 @@ struct ProcessInfo
    std::string state;
    std::vector<std::string> arguments;
 
-#if !defined _WIN32 && !defined __APPLE__
+#ifndef _WIN32
    core::Error creationTime(boost::posix_time::ptime* pCreationTime) const;
 #endif
 };

--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1955,6 +1955,11 @@ Error processInfo(const std::string& process, std::vector<ProcessInfo>* pInfo, b
 
    return Success();
 }
+
+Error ProcessInfo::creationTime(boost::posix_time::ptime* pCreationTime) const
+{
+   return systemError(boost::system::errc::not_supported, ERROR_LOCATION);
+}
 #endif
 
 std::ostream& operator<<(std::ostream& os, const ProcessInfo& info)


### PR DESCRIPTION
### Intent

We have an existing utility to look up the creation time of a process, but the only implementation is for Linux. This has been fine so far, as Launcher seems to be the only consumer of this API, but the compile-time guard is now generating issues for us when trying to build that project on macOS.

So this commit stubs out a macOS implementation that returns an error. Ideally, we'd actually implement this for macOS, but doing so [turns out to be nontrivial](https://stackoverflow.com/questions/31603885/get-process-creation-date-time-in-osx-with-c-c) so I don't think it's worth pursing at this time.

This should supersede https://github.com/rstudio/rstudio-pro/pull/3964. 

### Automated Tests

This change is a stub to avoid linker issues, so I don't think it needs any automated tests beyond "it compiles on macOS and Linux".

### QA Notes

This patch has near-zero risk.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests