### PR TITLE
Update install-sccache with macOS support

### DIFF
--- a/dependencies/common/install-sccache
+++ b/dependencies/common/install-sccache
@@ -19,10 +19,6 @@ set -e
 
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 
-if is-macos; then
-   exit 0
-fi
-
 section "Installing sccache"
 
 # install dir
@@ -33,22 +29,38 @@ fi
 
 VERSION=0.3.1
 
-# default architecture to amd64/x86_64
-ARCH=x86_64
-SCCACHE_PACKAGE_HASH="94ea33aac8dcb358753f8240cc87345963cf83cda7c6af0395dff31ffdc88df4"
-
-# override to aarch64 if running on arm
-if [ "$(arch)" = "aarch64" ] ; then
+if [ "$(arch)" = "aarch64" ] || [ "$(arch)"  = "arm64" ] ; then
     ARCH=aarch64
-    SCCACHE_PACKAGE_HASH="1bf58385dc27b66324bb9ee82084e65c4d2e60baa19e3d16d2ab4da6c1ae66b2"
+else
+    # Assume x86_64 if not aarch64
+    ARCH=x86_64
 fi
 
-URL=https://github.com/mozilla/sccache/releases/download/v${VERSION}/sccache-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz
+echo "${ARCH}"
 
-wget --progress=bar:force:noscroll ${URL} -O sccache.tar.gz \
-    && echo "${SCCACHE_PACKAGE_HASH}  sccache.tar.gz" | sha256sum -c -
+BASE_URL=https://github.com/mozilla/sccache/releases/download/v${VERSION}
 
-tar -zxvpf sccache.tar.gz
+if is-macos; then
+    URL=${BASE_URL}/sccache-v${VERSION}-${ARCH}-apple-darwin.tar.gz
+    if [ "${ARCH}" = "x86_64" ] ; then
+        SCCACHE_PACKAGE_HASH="d8ade8d98cef392e6b256d184690e1d722f263c9f0bd83938fdd524e839c9e58"
+    else
+        SCCACHE_PACKAGE_HASH="303d8e905c44eb5401adc55561a4c44b36906516f3c1c0de386c4844d38151bc"
+    fi
+else
+    # Assume Linux if not macOS
+    URL=${BASE_URL}/sccache-v${VERSION}-${ARCH}-unknown-linux-musl.tar.gz
+    if [ "${ARCH}" = "x86_64" ] ; then
+        SCCACHE_PACKAGE_HASH="94ea33aac8dcb358753f8240cc87345963cf83cda7c6af0395dff31ffdc88df4"
+    else
+        SCCACHE_PACKAGE_HASH="1bf58385dc27b66324bb9ee82084e65c4d2e60baa19e3d16d2ab4da6c1ae66b2"
+    fi
+fi
+
+download ${URL} sccache.tar.gz \
+    && echo "${SCCACHE_PACKAGE_HASH} sccache.tar.gz" | sha256sum -c -
+
+extract sccache.tar.gz
 mkdir -p ${INSTALL_DIR}
 if [ ! -f ${INSTALL_DIR}/sccache ]; then
   mv sccache-v${VERSION}-*/sccache ${INSTALL_DIR}/sccache

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -304,6 +304,20 @@ MAKEFLAGS="${MAKEFLAGS} -j$(sysctl -n hw.ncpu)"
 # set up JAVA_HOME if necessary
 find-java-home
 
+# if SCCACHE_ENABLED environment variable is set, use sccache
+if [ -n "$SCCACHE_ENABLED" ]; then
+    echo "Using sccache"
+   
+    if [ -n "$AWS_ACCESS_KEY_ID" ] || [ $(aws sts get-caller-identity --query "Account" --profile ${AWS_PROFILE:-sso}) -eq 14 ]; then
+        echo "AWS credentials valid, using S3 build cache"
+        export SCCACHE_BUCKET="rstudio-build-cache"
+    else
+        echo "No valid AWS SSO session, using only local build cache"
+        export SCCACHE_DIR=$(pwd)/object_file_cache
+        mkdir -p $SCCACHE_DIR
+    fi
+fi
+
 # perform an x86_64 build
 if [ -n "${build_x86_64}" ]; then
 
@@ -339,6 +353,7 @@ if [ -n "${build_x86_64}" ]; then
       -DGWT_BIN_DIR="${BUILD_DIR_X86_64}/gwt/bin"            \
       -DGWT_WWW_DIR="${BUILD_DIR_X86_64}/gwt/www"            \
       -DGWT_EXTRAS_DIR="${BUILD_DIR_X86_64}/gwt/extras"      \
+      -DSCCACHE_ENABLED=$SCCACHE_ENABLED                     \
       "${PKG_DIR}/../.."
    info "Done!"
 
@@ -351,6 +366,9 @@ if [ -n "${build_x86_64}" ]; then
    unset npm_config_target_arch
    info "Done!"
 
+   if [ -n "$SCCACHE_ENABLED" ]; then
+   sccache --show-stats
+   fi
 fi
 
 # perform an arm64 build
@@ -385,6 +403,7 @@ if [ -n "${build_arm64}" ]; then
       -DRSTUDIO_TOOLS_ROOT="${RSTUDIO_TOOLS_ROOT}/../arm64" \
       -DGWT_BUILD=0                                         \
       -DGWT_COPY=0                                          \
+      -DSCCACHE_ENABLED=$SCCACHE_ENABLED                    \
       "${PKG_DIR}/../.."
    info "Done!"
 
@@ -395,6 +414,10 @@ if [ -n "${build_arm64}" ]; then
    unset npm_config_arch
    unset npm_config_target_arch
    info "Done!"
+
+   if [ -n "$SCCACHE_ENABLED" ]; then
+   sccache --show-stats
+   fi
 
 fi
 


### PR DESCRIPTION
### Intent

Adresses #12532. Add ssccache support for macOS builds.

### Approach

Updated the sccache install script to support installing on macOS, and update the osx/make-package script to use sccache if the SCCACHE_ENABLED environment variable is set. I tested this on arm64 macOS the build seemed to succeed.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


