### PR TITLE
Update PR Jenkinsfile to use flower image

### DIFF
--- a/Jenkinsfile.pull-request
+++ b/Jenkinsfile.pull-request
@@ -1,8 +1,3 @@
-os = 'jammy'
-arch = 'amd64'
-flavor = 'server'
-type = 'DEB'
-AWS_ACCOUNT_ID = '749683154838'
 def utils
 
 pipeline {
@@ -18,6 +13,12 @@ pipeline {
 
   environment {
         GITHUB_LOGIN = credentials('github-rstudio-jenkins')
+        OS = 'jammy'
+        ARCH = 'amd64'
+        FLAVOR = 'server'
+        TYPE = 'DEB'
+        AWS_ACCOUNT_ID = '749683154838'
+        RSTUDIO_VERSION_FLOWER = ''
   }
 
   stages {
@@ -28,6 +29,7 @@ pipeline {
           sh "echo 'Loading utils from ${env.WORKSPACE}/utils.groovy'"
           utils = load "${env.WORKSPACE}/utils.groovy"
           utils.addRemoteRef("${env.CHANGE_TARGET}")
+          RSTUDIO_VERSION_FLOWER = readFile(file: 'version/RELEASE').replaceAll(" ", "-").toLowerCase().trim()
         }
       }
     }
@@ -47,8 +49,8 @@ pipeline {
             withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
               pullBuildPush(
                 image_name: 'jenkins/ide',
-                image_tag: "${os}-${arch}-${env.CHANGE_TARGET.replaceAll('/', '-')}",
-                dockerfile: "docker/jenkins/Dockerfile.${os}",
+                image_tag: "${OS}-${ARCH}-${RSTUDIO_VERSION_FLOWER}",
+                dockerfile: "docker/jenkins/Dockerfile.${OS}",
                 build_arg_jenkins_uid: 'JENKINS_UID',
                 build_arg_jenkins_gid: 'JENKINS_GID',
                 builds_args: "--build-arg GITHUB_LOGIN=${GITHUB_LOGIN}",
@@ -60,7 +62,7 @@ pipeline {
         stage('Build Package and Test') {
           agent {
             docker {
-              image "jenkins/ide:${os}-${arch}-${env.CHANGE_TARGET.replaceAll('/', '-')}"
+              image "jenkins/ide:${OS}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
               reuseNode true
             }
           }
@@ -72,7 +74,7 @@ pipeline {
                   // AWS is here for the S3 bucket that we use for sccache
                   withAWS(role: 'build', roleAccount: AWS_ACCOUNT_ID) {
                     // perform the compilation
-                    sh "SCCACHE_ENABLED=1 PACKAGE_OS=${os} ./make-${flavor}-package ${type} clean"
+                    sh "SCCACHE_ENABLED=1 PACKAGE_OS=${OS} ./make-${FLAVOR}-package ${type} clean"
                   }
                 }
               }
@@ -80,7 +82,7 @@ pipeline {
 
             stage('Run GWT Unit Tests') {
               steps {
-                dir ("package/linux/build-${flavor.capitalize()}-${type}/src/gwt") {
+                dir ("package/linux/build-${FLAVOR.capitalize()}-${TYPE}/src/gwt") {
                   // attempt to run ant (gwt) unit tests
                   sh "./gwt-unit-tests.sh"
                 }
@@ -89,7 +91,7 @@ pipeline {
 
             stage('Run C++ Unit Tests') {
               steps {
-                dir ("package/linux/build-${flavor.capitalize()}-${type}/src/cpp") {
+                dir ("package/linux/build-${FLAVOR.capitalize()}-${type}/src/cpp") {
                   // attempt to run cpp unit tests
                   sh "./rstudio-tests"
                 }


### PR DESCRIPTION
### Intent

This commit updates the Jenkinsfile.pull-request file to use the docker image tagging scheme that utilizes the version flower name. Since #12535 was merged, all jobs should be using the new flower name scheme for docker image tags. I also updated to use environment variables rather than globals.

### Approach

N/A

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


