### PR TITLE
Cache the dependencies in the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !dependencies/osx/install-*
 !dependencies/windows/*
 !dependencies/tools/rstudio-tools.sh
+!dependencies/tools/rstudio-tools.cmd
 !docker/jenkins
 !docker/docker-compile.sh
 !package/linux/install-dependencies

--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -269,7 +269,12 @@ set(CMAKE_MODULE_PATH "${ROOT_SRC_DIR}/cmake/modules/")
 
 # dependencies
 if(WIN32)
-   set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies/windows")
+   if(EXISTS "C:/rstudio-tools/dependencies")
+      set(RSTUDIO_DEPENDENCIES_DIR "C:/rstudio-tools/dependencies")
+      set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${RSTUDIO_DEPENDENCIES_DIR}/windows")
+   else()
+      set(RSTUDIO_WINDOWS_DEPENDENCIES_DIR "${ROOT_SRC_DIR}/dependencies/windows")
+   endif()
    set(CPACK_DEPENDENCIES_DIR "${RSTUDIO_WINDOWS_DEPENDENCIES_DIR}")
    set(CPACK_NSPROCESS_VERSION "1.6")
 else()

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -203,9 +203,9 @@ wget %WGET_ARGS% https://github.com/quarto-dev/quarto-cli/releases/download/v%QU
 echo Unzipping Quarto %QUARTO_FILE%
 rmdir /s /q quarto
 mkdir quarto
-cd quarto
+pushd quarto
 unzip %UNZIP_ARGS% ..\%QUARTO_FILE%
-cd ..
+popd
 del %QUARTO_FILE%
 
 
@@ -240,10 +240,12 @@ if not defined JENKINS_URL (
   )
 )
 
+cd
 echo "Installing panmirror (visual editor)"
 pushd ..\windows\install-panmirror
 call clone-quarto-repo.cmd
 popd
+cd
 
 call install-packages.cmd
 

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -9,6 +9,8 @@ if not exist quarto (
   echo "quarto repo already cloned"
 
   pushd quarto
+  git reset --hard
+  git clean -dfx
   git pull
   popd
 )

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -4,7 +4,7 @@ pushd ..\..\..\src\gwt\lib
 
 if not exist quarto (
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git
+  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
 ) else (
   echo "quarto repo already cloned"
 

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -1,5 +1,8 @@
 @REM @echo off
 
+@REM show current directory
+cd
+
 pushd ..\..\..\src\gwt\lib
 
 if not exist quarto (
@@ -9,6 +12,9 @@ if not exist quarto (
   echo "quarto repo already cloned"
 
   pushd quarto
+  @REM show current directory
+  cd
+
   git reset --hard
   git clean -dfx
   git pull

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -68,6 +68,7 @@ COPY dependencies/tools/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\r
 COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
+WORKDIR C:/rstudio-tools/dependencies/windows
 RUN C:/rstudio-tools/dependencies/windows/install-dependencies.cmd
 
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -64,7 +64,7 @@ RUN mkdir -p 'C:\rstudio-tools\dependencies\tools'
 RUN mkdir -p 'C:\rstudio-tools\dependencies\common'
 RUN mkdir -p 'C:\rstudio-tools\dependencies\windows'
 
-COPY dependencies/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\rstudio-tools.cmd'
+COPY dependencies/tools/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\rstudio-tools.cmd'
 COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -68,7 +68,7 @@ COPY dependencies/tools/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\r
 COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
-RUN 'C:\rstudio-tools\dependencies\windows\install-dependencies.cmd'
+RUN C:/rstudio-tools/dependencies/windows/install-dependencies.cmd
 
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -68,6 +68,8 @@ COPY dependencies/tools/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\r
 COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
 COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
+RUN 'C:\rstudio-tools\dependencies\windows\install-dependencies.cmd'
+
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####
 ##### follow https://issues.jenkins-ci.org/browse/JENKINS-36776 to track docker windows support on jenkins #####

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -58,11 +58,20 @@ RUN [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 
 # Newer choco doesn't have this so don't fail if not found
 RUN if (Test-Path 'C:\ProgramData\chocolatey\bin\cpack.exe') { Remove-Item -Force 'C:\ProgramData\chocolatey\bin\cpack.exe' }
 
+RUN choco install -y git
+
+RUN mkdir -p 'C:\rstudio-tools\dependencies\tools'
+RUN mkdir -p 'C:\rstudio-tools\dependencies\common'
+RUN mkdir -p 'C:\rstudio-tools\dependencies\windows'
+
+COPY dependencies/rstudio-tools.cmd 'C:\rstudio-tools\dependencies\tools\rstudio-tools.cmd'
+COPY dependencies/common 'C:\rstudio-tools\dependencies\common'
+COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
+
 #### this docker container will currently be used as a jenkins swarm slave, rather than instantiated on a swarm ####
 ##### the items below this are dependencies relevant to jenkins-swarm. #####
 ##### follow https://issues.jenkins-ci.org/browse/JENKINS-36776 to track docker windows support on jenkins #####
 
-RUN choco install -y git
 ENV JENKINS_SWARM_VERSION 3.15
 RUN [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12 ; `
   Invoke-WebRequest $('https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/{0}/swarm-client-{0}.jar' -f $env:JENKINS_SWARM_VERSION) -OutFile 'C:\swarm-client.jar' -UseBasicParsing ;

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -4,7 +4,13 @@ setlocal
 set PACKAGE_DIR="%CD%"
 set ELECTRON_SOURCE_DIR=%PACKAGE_DIR%\..\..\src\node\desktop
 
-call %PACKAGE_DIR%\..\..\dependencies\tools\rstudio-tools.cmd
+if not exist c:\rstudio-tools\dependencies (
+      set RSTUDIO_DEPENDENCIES=%PACKAGE_DIR%\..\..\dependencies
+) else (
+      set RSTUDIO_DEPENDENCIES=c:\rstudio-tools\dependencies
+)
+
+call %RSTUDIO_DEPENDENCIES%\tools\rstudio-tools.cmd
 
 set BUILD_GWT=1
 set QUICK=
@@ -59,7 +65,7 @@ for %%F in (ant cmake) do (
 )
 
 REM find node
-set NODE_DIR=%PACKAGE_DIR%\..\..\dependencies\common\node\%RSTUDIO_NODE_VERSION%
+set NODE_DIR=%RSTUDIO_DEPENDENCIES%\common\node\%RSTUDIO_NODE_VERSION%
 set NODE=%NODE_DIR%\node.exe
 if not exist %NODE% (
       echo node.exe not found at %NODE_DIR%; exiting
@@ -89,7 +95,7 @@ echo Using npx: %NPX%
 REM Put node on the path
 set PATH=%NODE_DIR%;%PATH%
 
-set REZH=%PACKAGE_DIR%\..\..\dependencies\windows\resource-hacker\ResourceHacker.exe
+set REZH=%RSTUDIO_DEPENDENCIES%\windows\resource-hacker\ResourceHacker.exe
 if not exist %REZH% (
       echo ResourceHacker.exe not found; re-run install-dependencies.cmd and try again; exiting
       endlocal

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -127,6 +127,7 @@
 
    <target name="panmirror" description="Compile panmirror library">
       <echo message="yarn location: ${yarn.bin}"/>
+      <echo message="panmirror location: ${panmirror.dir}"/>
       <mkdir dir="${panmirror.build.dir}"/>
       <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
          <arg value="install"/>

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -105,6 +105,11 @@
       property="yarn.bin"
       value="/opt/rstudio-tools/dependencies/common/node/${node.version}/node_modules/yarn/bin/yarn"
       file="/opt/rstudio-tools/dependencies/common/node/${node.version}/node_modules/yarn/bin/yarn"/>
+   <!-- use yarn from c:/rstudio-tools if installed (typical for Docker on Windows) -->
+   <available
+      property="yarn.bin"
+      value="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"
+      file="c:\rstudio-tools\dependencies\common\node\${node.version}\node_modules\yarn\bin\yarn.cmd"/>
 
    <property name="panmirror.dir" value="./lib/quarto/apps/panmirror"/>
    <property name="panmirror.build.dir" value="./www/js/panmirror"/>
@@ -114,6 +119,11 @@
       property="panmirror.dir"
       value="/opt/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"
       file="/opt/rstudio-tools/src/gwt/lib/quarto/apps/panmirror"/>
+   <!-- use yarn from c:/rstudio-tools if installed (typical for Docker on Windows) -->
+   <available
+      property="panmirror.dir"
+      value="c:\rstudio-tools\src\gwt\lib\quarto\apps\panmirror"
+      file="c:\rstudio-tools\src\gwt\lib\quarto\apps\panmirror"/>
 
    <target name="panmirror" description="Compile panmirror library">
       <echo message="yarn location: ${yarn.bin}"/>

--- a/src/node/CMakeNodeTools.txt
+++ b/src/node/CMakeNodeTools.txt
@@ -44,6 +44,7 @@ else()
       NAMES node
       NO_DEFAULT_PATH PATH_SUFFIXES "bin"
       PATHS "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
 
    find_program(NPM
@@ -51,6 +52,7 @@ else()
       PATH_SUFFIXES "bin"
       NO_DEFAULT_PATH 
       PATHS "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
 
    find_program(NPX
@@ -58,6 +60,7 @@ else()
       PATH_SUFFIXES "bin"
       NO_DEFAULT_PATH 
       PATHS "/opt/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
+      "c:/rstudio-tools/dependencies/common/node/${RSTUDIO_NODE_VERSION}"
       "${CMAKE_CURRENT_LIST_DIR}/../../dependencies/common/node/${RSTUDIO_NODE_VERSION}")
 
 endif()

--- a/src/node/desktop/envvars.bat
+++ b/src/node/desktop/envvars.bat
@@ -2,9 +2,10 @@
 
 REM Run this script with 'call envvars.bat' to update the PATH in your
 REM cmd.exe shell, so that the appropriate versions of node are found
-call :NormalizePath NODE_PATH "..\..\..\dependencies\common\node\16.14.0"
+set node_paths="..\..\..\dependencies\common\node\16.14.0" "c:\rstudio-tools\dependencies\common\node\16.14.0"
+call :SetNodePath
 if not exist "%NODE_PATH%" (
-    echo "Error: %NODE_PATH% does not exist"
+    echo "Error: node path not found"
     exit /b
 )
 
@@ -24,4 +25,17 @@ exit /b
 
 :SetVar
     for /f "tokens=* delims=" %%A in ('%2 %3 %4 %5 %6') do set "%1=%%A"
+    exit /b
+
+:SetNodePath
+    for %%a in (%node_paths%) do (
+        call :NormalizePath %%a %%a
+        if not exist "%%a" (
+            echo %%a does not exist
+        ) else (
+            echo Using %%a
+            set NODE_PATH="%%a"
+        )
+    )
+
     exit /b

--- a/src/node/desktop/scripts/run-unit-tests.cmd
+++ b/src/node/desktop/scripts/run-unit-tests.cmd
@@ -18,5 +18,6 @@ setlocal
 call envvars.bat
 echo Executing Electron unit tests
 set RSTUDIO_DOCKER_WINDOWS=1
+set PATH=c:\rstudio-tools\dependencies\node\${RSTUDIO_NODE_VERSION}\bin;%PATH%
 npm test
 endlocal

--- a/src/node/desktop/scripts/run-unit-tests.cmd
+++ b/src/node/desktop/scripts/run-unit-tests.cmd
@@ -18,6 +18,6 @@ setlocal
 call envvars.bat
 echo Executing Electron unit tests
 set RSTUDIO_DOCKER_WINDOWS=1
-set PATH=c:\rstudio-tools\dependencies\node\${RSTUDIO_NODE_VERSION}\bin;%PATH%
+set PATH=c:\rstudio-tools\dependencies\node\${RSTUDIO_NODE_VERSION};%PATH%
 npm test
 endlocal

--- a/src/node/desktop/scripts/run-unit-tests.cmd
+++ b/src/node/desktop/scripts/run-unit-tests.cmd
@@ -18,6 +18,5 @@ setlocal
 call envvars.bat
 echo Executing Electron unit tests
 set RSTUDIO_DOCKER_WINDOWS=1
-set PATH=c:\rstudio-tools\dependencies\node\${RSTUDIO_NODE_VERSION};%PATH%
 npm test
 endlocal


### PR DESCRIPTION
### Intent
Address #2212

### Approach
Run the dependency installer script when building the Docker image. Install them to a location outside of the source root. Update build and test scripts to check this location when specifying where to look for dependencies.

### Automated Tests
None

### QA Notes
None 

### Documentation
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


