### PR TITLE
Use `curl-minimal` in rhel9 docker image

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -18,7 +18,7 @@ RUN dnf install -y \
     boost-devel \
     bzip2-devel \
     clang-devel \
-    curl \
+    curl-minimal \
     expect \
     fakeroot \
     fuse-libs \


### PR DESCRIPTION
### Intent
Backport curl fix for EG builds

### Approach
Instead of `curl` to remove conflict with `curl-minimal` dependency of `RPM`

### Automated Tests
None

### QA Notes
None

### Documentation
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


