### PR TITLE
Fix OS Mac Builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -547,14 +547,14 @@ try {
         }
 
         // trigger macos build if we're in open-source repo
-        if (env.JOB_NAME.startsWith('IDE/open-source-pipeline')) {
+        if (env.JOB_NAME.startsWith('IDE/OS-Builds/open-source-pipeline')) {
           trigger_external_build('IDE/macos-electron')
         }
 
         parallel parallel_containers
 
         // Ensure we don't build automation on the branches that don't exist
-        if (env.JOB_NAME.startsWith('IDE/open-source-pipeline') &&
+        if (env.JOB_NAME.startsWith('IDE/OS-Builds/open-source-pipeline') &&
             ("${rstudioReleaseBranch}" != "release-ghost-orchid") &&
             ("${rstudioReleaseBranch}" != "v1.4-juliet-rose")) {
           trigger_external_build('IDE/qa-opensource-automation')


### PR DESCRIPTION
OS Mac Builds weren't being triggered because we moved the folder containing our non mac builds.

Fixed by adding the folder name to the conditional triggering the mac builds


### Intent
Get Mac builds triggering again

### Approach

Added full path to the conditional that triggers the mac builds
The display name and 'real' name of the `Open Source Builds` folder differ, I double checked in several build's outputs to directly read the JOB_NAME env variable to confirm the path.

### Automated Tests
None, build only change

### QA Notes
None build only change

### Documentation
None build only change

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


