### PR TITLE
Assorted desktop logging fixes (electron)

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -63,7 +63,6 @@ used by these components are included below):
 - winston (npm)
 - i18next (npm)
 - copy-webpack-plugin (npm)
-- winston-daily-rotate-file
 - node-system-fonts
 - properties-reader (npm)
 - json-schema-to-typescript (npm)
@@ -4477,30 +4476,6 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-winston-daily-rotate-file (npm) License
-----------------------------------------------------------------------
-The MIT License (MIT)
-
-Copyright (c) 2015 winstonjs
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 node-system-fonts (npm) License
 ----------------------------------------------------------------------

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -26,15 +26,19 @@ if "%1" == "-h" goto :showhelp
 if "%1" == "help" goto :showhelp
 if "%1" == "/?" goto :showhelp
 
+SETLOCAL ENABLEDELAYEDEXPANSION
 for %%A in (%*) do (
-      if /I "%%A" == "clean" set CLEANBUILD=1	  
-      if /I "%%A" == "debug" set DEBUG_BUILD=1
-      if /I "%%A" == "desktop" set RSTUDIO_TARGET=Desktop
-      if /I "%%A" == "electron" set RSTUDIO_TARGET=Electron
-      if /I "%%A" == "multiarch" set MULTIARCH=1
-      if /I "%%A" == "nogwt" set BUILD_GWT=0
-      if /I "%%A" == "nozip" set NOZIP=1
-      if /I "%%A" == "quick" set QUICK=1
+      set KNOWN_ARG=0
+      if /I "%%A" == "clean" set CLEANBUILD=1 && set KNOWN_ARG=1
+      if /I "%%A" == "debug" set DEBUG_BUILD=1 && set KNOWN_ARG=1
+      if /I "%%A" == "desktop" set RSTUDIO_TARGET=Desktop && set KNOWN_ARG=1
+      if /I "%%A" == "electron" set RSTUDIO_TARGET=Electron && set KNOWN_ARG=1
+      if /I "%%A" == "multiarch" set MULTIARCH=1 && set KNOWN_ARG=1
+      if /I "%%A" == "nogwt" set BUILD_GWT=0 && set KNOWN_ARG=1
+      if /I "%%A" == "nozip" set NOZIP=1 && set KNOWN_ARG=1
+      if /I "%%A" == "quick" set QUICK=1 && set KNOWN_ARG=1
+
+      if "!KNOWN_ARG!" == "0" goto :showhelp
 )
 
 REM check for debug build

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -23,7 +23,6 @@
 #include <core/FileSerializer.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Xdg.hpp>
-#include <core/system/Environment.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -23,6 +23,7 @@
 #include <core/FileSerializer.hpp>
 #include <core/system/System.hpp>
 #include <core/system/Xdg.hpp>
+#include <core/system/Environment.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
@@ -53,11 +54,11 @@ void writeFile(const std::string& description, const core::FilePath& path, std::
       Error error = core::readStringFromFile(path, &contents);
       if (error)
          LOG_ERROR(error);
-      if (contents.empty())
-         ostr << "(Empty)" << std::endl << std::endl;
-      else
-         ostr << contents << std::endl << std::endl;
-   }
+         if (contents.empty())
+            ostr << "(Empty)" << std::endl << std::endl;
+         else
+            ostr << contents << std::endl << std::endl;
+      }
    else
    {
       ostr << "(Not Found)" << std::endl << std::endl;
@@ -85,9 +86,8 @@ void writeUserPrefs(std::ostream& ostr)
 
 int main(int argc, char** argv)
 {
-   core::log::setProgramId("rstudio-diagnostics");
-   core::system::initializeStderrLog("rstudio-diagnostics",
-                                    core::log::LogLevel::WARN);
+   // We intentionally avoid initializing logging as we don't want logging output from this
+   // executable getting injected into the diagnostics report
 
    // ignore SIGPIPE
    Error error = core::system::ignoreSignal(core::system::SigPipe);

--- a/src/cpp/diagnostics/DiagnosticsMain.cpp
+++ b/src/cpp/diagnostics/DiagnosticsMain.cpp
@@ -54,11 +54,11 @@ void writeFile(const std::string& description, const core::FilePath& path, std::
       Error error = core::readStringFromFile(path, &contents);
       if (error)
          LOG_ERROR(error);
-         if (contents.empty())
-            ostr << "(Empty)" << std::endl << std::endl;
-         else
-            ostr << contents << std::endl << std::endl;
-      }
+      if (contents.empty())
+         ostr << "(Empty)" << std::endl << std::endl;
+      else
+         ostr << contents << std::endl << std::endl;
+   }
    else
    {
       ostr << "(Not Found)" << std::endl << std::endl;

--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -223,9 +223,9 @@ sensitive information before submitting your diagnostics report.
     
     # detect release configurations
     sysname <- Sys.info()[["sysname"]]
-    if (identical(sysname, "Darwin"))
-      "../../MacOS/diagnostics"
-    else if (identical(sysname, "Windows"))
+    if (identical(sysname, "Darwin")) {
+      "../bin/diagnostics"
+    } else if (identical(sysname, "Windows"))
       "../bin/diagnostics.exe"
     else
       "../bin/diagnostics"

--- a/src/cpp/r/R/Diagnostics.R
+++ b/src/cpp/r/R/Diagnostics.R
@@ -223,9 +223,9 @@ sensitive information before submitting your diagnostics report.
     
     # detect release configurations
     sysname <- Sys.info()[["sysname"]]
-    if (identical(sysname, "Darwin")) {
+    if (identical(sysname, "Darwin"))
       "../bin/diagnostics"
-    } else if (identical(sysname, "Windows"))
+    else if (identical(sysname, "Windows"))
       "../bin/diagnostics.exe"
     else
       "../bin/diagnostics"

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -22,7 +22,6 @@
         "properties-reader": "2.2.0",
         "uuid": "9.0.0",
         "winston": "3.8.2",
-        "winston-daily-rotate-file": "4.7.1",
         "winston-syslog": "2.7.0"
       },
       "devDependencies": {
@@ -6323,14 +6322,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-stream-rotator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
-      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
-      "dependencies": {
-        "moment": "^2.29.1"
-      }
-    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -9419,14 +9410,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10104,14 +10087,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -13673,23 +13648,6 @@
       },
       "engines": {
         "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/winston-daily-rotate-file": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
-      "integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
-      "dependencies": {
-        "file-stream-rotator": "^0.6.1",
-        "object-hash": "^2.0.1",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "peerDependencies": {
-        "winston": "^3"
       }
     },
     "node_modules/winston-syslog": {
@@ -18970,14 +18928,6 @@
         "flat-cache": "^3.0.4"
       }
     },
-    "file-stream-rotator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
-      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
-      "requires": {
-        "moment": "^2.29.1"
-      }
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -21307,11 +21257,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.29.4",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
-    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -21856,11 +21801,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
-    },
-    "object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw=="
     },
     "object-inspect": {
       "version": "1.12.1",
@@ -24583,17 +24523,6 @@
             "util-deprecate": "^1.0.1"
           }
         }
-      }
-    },
-    "winston-daily-rotate-file": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz",
-      "integrity": "sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==",
-      "requires": {
-        "file-stream-rotator": "^0.6.1",
-        "object-hash": "^2.0.1",
-        "triple-beam": "^1.3.0",
-        "winston-transport": "^4.4.0"
       }
     },
     "winston-syslog": {

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -78,7 +78,6 @@
     "properties-reader": "2.2.0",
     "uuid": "9.0.0",
     "winston": "3.8.2",
-    "winston-daily-rotate-file": "4.7.1",
     "winston-syslog": "2.7.0"
   }
 }

--- a/src/node/desktop/src/core/logger.ts
+++ b/src/node/desktop/src/core/logger.ts
@@ -13,8 +13,6 @@
  *
  */
 
-import winston from 'winston';
-
 import { coreState } from './core-state';
 
 export interface Logger {
@@ -28,6 +26,8 @@ export interface Logger {
   logDebug(message: string): void;
   logDiagnostic(message: string): void;
   logDiagnosticEnvVar(name: string): void;
+  closeLogFile(): void;
+  ensureTransport(): void;
 }
 
 export interface LogOptions {
@@ -54,6 +54,8 @@ export class NullLogger implements Logger {
   logDebug(message: string): void {}
   logDiagnostic(message: string): void {}
   logDiagnosticEnvVar(name: string): void {}
+  closeLogFile(): void {}
+  ensureTransport(): void {}
 }
 
 /**

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -242,6 +242,16 @@ export class SessionLauncher {
     // pMainWindow_->connect(&activation(), &DesktopActivation::updateLicenseWarningBar,
     //                       pMainWindow_, &MainWindow::onUpdateLicenseWarningBar);
 
+    // On Windows, we have to close the log file when running diagnostics or diagnostics.exe
+    // fails to inject the log contents into the diagnostics report due to access-denied due
+    // to file being in use by another process
+    if (process.platform === 'win32' && appState().runDiagnostics) {
+      logger().closeLogFile();
+
+      // winston logging package emits warnings if we don't have any registered transport
+      logger().ensureTransport();
+    }
+
     // show the window (but don't if we are doing a --run-diagnostics)
     if (!appState().runDiagnostics) {
       finalPlatformInitialize(this.mainWindow);

--- a/src/node/desktop/src/main/session-launcher.ts
+++ b/src/node/desktop/src/main/session-launcher.ts
@@ -147,6 +147,11 @@ export class SessionLauncher {
       this.showSplash = false;
     }
 
+    // don't show splash screen if started using --run-diagnostics
+    if (appState().runDiagnostics) {
+      this.showSplash = false;
+    }
+
     // must check showSplash before and after the timeout
     // before to determine if the timeout is required
     // after to determine if the main window is ready to show


### PR DESCRIPTION
### Intent

Fix some issues with the Electron logging and diagnostics features to help with troubleshooting.

NOTE I am targeting Elsbeth branch.

Addresses #12556 (and several other issues described below)

### Approach

* stopped using and removed the `winston-daily-rotate-file` package (it never created `rdesktop.log`, only numbered log files, breaking the assumption in our diagnostics flow to always look for `rdesktop.log`)
* use the built-in log rotation feature of winston which does create/use `rdesktop.log`; set it to match the defaults of a max of 100 rotated logs and max log size of 2 MB (we don't currently obey `logging.conf` for these settings on desktop, but according to the Workbench docs those are the defaults)
* don't log from diagnostics[.exe]; it was emitting non-useful logging statements into the middle of the diagnostics report, especially if using the `RS_LOG_LEVEL=debug` environment variable technique
* fix Diagnostics.R to find the diagnostics executable on Mac (it was still assuming the old Qt .app layout); note this does mean injecting logs into diagnostics report will stop working on Qt RDP desktop, but I think that's not a significant problem as using desktop diagnostics is currently a hot topic for Electron but rarely used in the legacy Qt app (and the logs are still there)
* on Windows only, close the file logging transport when running diagnostics (`--run-diagnostics`); otherwise the diagnotics.exe could not open the rdesktop.log file and thus couldn't inject it into the diagnostics report
* don't show the splash screen when running with `--run-diagnostics`

The following changes aren't related to logging, they are dev workflow improvements:

* `make-package.bat` for package builds on Windows now gives an error and shows usage info if you supply an unknown command line argument (this isn't logging related, just a dev workflow improvement)
* when running a non package build (i.e. on a dev machine via `npm start`), we always enable console logging but were not doing file logging, making debugging file logging a bit of a pain; now we do both by default for a non-packaged build (console and file logging)

### Automated Tests

None

### QA Notes

Diagnostics test:

- start a command-prompt / terminal
- start RStudio from command-prompt / terminal with the `--log-level=debug --run-diagnostics` switches
    - (e.g. Windows): `"C:\Program Files\RStudio\rstudio.exe --log-level=debug --run-diagnostics`
- This should start RStudio with no UI (including no splash screen), generate a diagnostics-report.txt, and bring up a File Explorer / Finder showing the file. 
- open the diagnostics report and search for `rdesktop.log`: below that it should show the contents of the rdesktop.log file, which should contain some DEBUG-level logging

Log rotation test:

- the logs should rotate around 2 MB in size; the easiest way to test is close rstudio, open rdesktop.log in a text editor, and copy/paste your way to a 2 MB+ file size
- run RStudio, then close it
- look in the logs folder and confirm that rotation took place (e.g. there should be a rdesktop1.log in addition to the now smaller, if not empty, rdesktop.log)
- repeat that exercise again (make rdesktop.log > 2 MB), then you should end up with rdesktop2.log, and so forth
- if you are super-keen you could do this 100 times to see if the max of 100 log files is obeyed; I did not test that feature

Diagnostics on Mac:

- make sure there's an existing rdesktop.log file that isn't empty
- start RStudio
- Help / Diagnostics / Write Diagnostics Report
- You should get a finder window showing the report, open it and search for rdesktop.log
- It should be included (as well as session log, if any); this was not the case in the original release of Elsbeth Geranium

Related known issue: https://github.com/rstudio/rstudio/issues/12570

### Documentation

- none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


