### PR TITLE
adjust sign-in page logo text and link

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,3 +41,5 @@
 - Homepage modal dialogs are now implemented correctly for keyboard and screen reader use (rstudio-pro #4208)
 - Focus and keyboard-focus styles have been improved on the homepage
 - Keyboard support has been added to the job summary drop-down in session list items on the homepage
+- Improved alt-text and updated link to posit.co on sign-in page logo (rstudio-pro #4096)
+

--- a/NEWS.md
+++ b/NEWS.md
@@ -39,6 +39,7 @@
 - Editor Selection widget in New Session dialog supports screen reader usage (rstudio-pro #4206)
 - Editor icons in New Session dialog are marked as cosmetic for screen readers (rstudio-pro #4207)
 - Homepage modal dialogs are now implemented correctly for keyboard and screen reader use (rstudio-pro #4208)
+- Posit logo on home page marked as cosmetic for screen readers (rstudio-pro #4209)
 - Focus and keyboard-focus styles have been improved on the homepage
 - Keyboard support has been added to the job summary drop-down in session list items on the homepage
 - Improved alt-text and updated link to posit.co on sign-in page logo (rstudio-pro #4096)

--- a/src/cpp/server/ServerLoginPages.cpp
+++ b/src/cpp/server/ServerLoginPages.cpp
@@ -93,8 +93,8 @@ void fillLoginFields(const core::http::Request& request,
       variables[kLoginPageHtml] = server::options().authLoginPageHtml();
 
       // render logo with links
-      std::string logoImgHtml = boost::str(logoImgHtmlFormat % "RStudio Server Logo (goes to external site)");
-      variables[kLogoHtml] = R"DELIM(<a href="https://www.rstudio.com/">)DELIM" + logoImgHtml + "</a>";
+      std::string logoImgHtml = boost::str(logoImgHtmlFormat % "Posit Software PBC (goes to external site)");
+      variables[kLogoHtml] = R"DELIM(<a href="https://posit.co/">)DELIM" + logoImgHtml + "</a>";
    }
    else
    {


### PR DESCRIPTION
### Intent

Easy accessibility fix.

Addresses https://github.com/rstudio/rstudio-pro/issues/4096 (Sign-in page logo has incorrect / inadequate alt-text).

Issue was opened in rstudio-pro repo but also applies to open-source server.

### Approach

Change the alt-text from "RStudio Server Logo (goes to external site)" to "Posit Software PBC (goes to external site)" to better represent what the link is for.

Also updated the target from "https://www.rstudio.com" to "https://posit.co".

### Automated Tests

None

### QA Notes

With a screen reader running, either use Tab/Shift+Tab to move focus to the image, or the screen-reader cursor, and confirm that the alt text has been updated. Also try clicking the link to ensure it goes to posit.co.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


