### PR TITLE
Remove dependency stage from Windows build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -435,11 +435,6 @@ try {
                         }
                         docker.image(image_name).inside() {
                             timeout(time: 180, units: 'MINUTES', activity: false) {
-                                stage('dependencies') {
-                                    withCredentials([usernameColonPassword(credentialsId: 'github-rstudio-jenkins', variable: "GITHUB_LOGIN")]) {
-                                        bat 'cd dependencies/windows && set RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN && set RSTUDIO_SKIP_QT=1 && install-dependencies.cmd && cd ../..'
-                                    }
-                                }
                                 stage('build'){
                                     def env = "set \"RSTUDIO_VERSION_MAJOR=${rstudioVersionMajor}\" && set \"RSTUDIO_VERSION_MINOR=${rstudioVersionMinor}\" && set \"RSTUDIO_VERSION_PATCH=${rstudioVersionPatch}\" && set \"RSTUDIO_VERSION_SUFFIX=${rstudioVersionSuffix}\""
                                     bat "cd package/win32 && ${env} && set \"PACKAGE_OS=Windows\" && make-package.bat clean ${current_container.flavor} && cd ../.."


### PR DESCRIPTION
### Intent
Remove the Windows dependency install stage (#2212)

### Approach
The Windows builds are already using the new dependency location so the dependency stage can be removed.

### Automated Tests
None

### QA Notes
None

### Documentation
None

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


