### PR TITLE
Add capability for logging from preload and renderer code (Electron)

### DIFF
--- a/src/node/desktop/src/main/app-state.ts
+++ b/src/node/desktop/src/main/app-state.ts
@@ -20,6 +20,7 @@ import { FilePath } from '../core/file-path';
 import { DesktopActivation } from './activation-overlay';
 import { Application } from './application';
 import { GwtCallback } from './gwt-callback';
+import { LoggerCallback } from './logger-callback';
 import { PendingWindow } from './pending-window';
 import { WindowTracker } from './window-tracker';
 
@@ -35,6 +36,7 @@ export interface AppState {
   generateNewPort(): void;
   windowTracker: WindowTracker;
   gwtCallback?: GwtCallback;
+  loggerCallback?: LoggerCallback;
   setScratchTempDir(path: FilePath): void;
   scratchTempDir(defaultPath: FilePath): FilePath;
   sessionStartDelaySeconds: number;

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -23,7 +23,7 @@ import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-use
 import { generateRandomPort } from '../core/system';
 import { getDesktopBridge } from '../renderer/desktop-bridge';
 import { DesktopActivation } from './activation-overlay';
-import { AppState } from './app-state';
+import { appState, AppState } from './app-state';
 import { ApplicationLaunch } from './application-launch';
 import { ArgsManager } from './args-manager';
 import { prepareEnvironment, promptUserForR } from './detect-r';
@@ -46,6 +46,7 @@ import {
 import { WindowTracker } from './window-tracker';
 import { configureSatelliteWindow, configureSecondaryWindow } from './window-utils';
 import { Client, Server } from 'net-ipc';
+import { LoggerCallback } from './logger-callback';
 
 /**
  * The RStudio application
@@ -58,6 +59,7 @@ export class Application implements AppState {
   port = generateRandomPort();
   windowTracker = new WindowTracker();
   gwtCallback?: GwtCallback;
+  loggerCallback?: LoggerCallback;
   sessionStartDelaySeconds = 0;
   sessionEarlyExitCode = 0;
   startupDelayMs = 0;
@@ -297,6 +299,9 @@ export class Application implements AppState {
     initializeLang();
 
     this.argsManager.handleAppReadyCommands(this);
+
+    // provide logging capabiity to renderer and preload
+    this.loggerCallback = new LoggerCallback();
 
     // on Windows, ask the user what version of R they'd like to use
     let rPath = '';

--- a/src/node/desktop/src/main/logger-callback.ts
+++ b/src/node/desktop/src/main/logger-callback.ts
@@ -1,0 +1,48 @@
+/*
+ * logger-callback.ts
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+
+import { ipcMain } from 'electron';
+import EventEmitter from 'events';
+import { logger } from '../core/logger';
+
+/**
+ * This is the main-process side of the DesktopLogger Callbacks; dispatched from renderer processes
+ * via the ContextBridge to enable logging from preload and renderer code.
+ */
+export class LoggerCallback extends EventEmitter {
+  constructor() {
+    super();
+    ipcMain.on('desktop_log_message', (_event, level: string, message: string) => {
+      level = level.toLowerCase();
+      switch (level) {
+        case 'err':
+        case 'error':
+          logger().logErrorMessage(message);
+          break;
+        case 'warn':
+        case 'warning':
+          logger().logWarning(message);
+          break;
+        case 'info':
+          logger().logInfo(message);
+          break;
+        case 'debug':
+          logger().logDebug(message);
+          break;
+      }
+    });
+  }
+}

--- a/src/node/desktop/src/renderer/logger-bridge.ts
+++ b/src/node/desktop/src/renderer/logger-bridge.ts
@@ -1,0 +1,53 @@
+/*
+ * logger-bridge.ts
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { ipcRenderer } from 'electron';
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function getDesktopLoggerBridge() {
+  return {
+    logString: (level: 'err'|'warn'|'info'|'debug', message: string) => {
+      logString(level, message);
+    },
+
+    logError: (error: unknown) => {
+      logError(error);
+    },
+  };
+}
+
+/**
+ * Log a string in the main process (renderer process cannot directly use logger)
+ *
+ * @param level logging level (err|warn|info|debug)
+ * @param message  string to log
+ */
+export function logString(level: 'err'|'warn'|'info'|'debug', message: string): void {
+  ipcRenderer.send('desktop_log_message', level, message);
+}
+
+/**
+ * Log an Error in the main process (renderer process cannot directly use logger)
+ *
+ * @param error  Error to log
+ */
+export function logError(error: unknown): void {
+
+  if (error instanceof Error) {
+    logString('err', error.message);
+  } else {
+    logString('err', 'unknown error type in logger bridge');
+  }
+}

--- a/src/node/desktop/src/renderer/preload.ts
+++ b/src/node/desktop/src/renderer/preload.ts
@@ -20,6 +20,7 @@ import { getDesktopInfoBridge } from './desktop-info-bridge';
 import { getMenuBridge } from './menu-bridge';
 import { getDesktopBridge } from './desktop-bridge';
 import { firstStartingWith } from '../core/array-utils';
+import { getDesktopLoggerBridge, logString } from './logger-bridge';
 
 /**
  * The preload script is run in the renderer before our GWT code and enables
@@ -35,22 +36,27 @@ import { firstStartingWith } from '../core/array-utils';
  * Actual implementation happens in the main process, reached via ipcRenderer.
  */
 
+contextBridge.exposeInMainWorld('desktopLogger', getDesktopLoggerBridge());
+
 const apiKeys = removeDups(firstStartingWith(process.argv, '--api-keys=').split('|'));
 for (const apiKey of apiKeys) {
   switch (apiKey) {
     case 'desktop':
+      logString('debug', '[preload] connecting desktop hooks');
       contextBridge.exposeInMainWorld(apiKey, getDesktopBridge());
       break;
     case 'desktopInfo':
+      logString('debug', '[preload] connecting desktopInfo hooks');
       contextBridge.exposeInMainWorld(apiKey, getDesktopInfoBridge());
       break;
     case 'desktopMenuCallback':
+      logString('debug', '[preload] connecting desktopMenuCallback hooks');
       contextBridge.exposeInMainWorld(apiKey, getMenuBridge());
       break;
     // case 'remoteDesktop':
     //   // TODO: RDP-only
     //   break;
     default:
-      console.error(`Preload ignoring unsupported apiKey: '${apiKey}'`);
+      logString('debug', `[preload] ignoring unsupported apiKey: '${apiKey}'`);
   }
 }

--- a/src/node/desktop/src/ui/renderer-logging.ts
+++ b/src/node/desktop/src/ui/renderer-logging.ts
@@ -1,0 +1,24 @@
+/*
+ * renderer-logging.ts
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export function logString(level: 'err'|'warn'|'info'|'debug', message: string): void {
+  (window as any).desktopLogger.logString(level, message);
+}
+
+export function logError(error: unknown): void {
+  (window as any).desktopLogger.logError(error);
+}

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -20,8 +20,8 @@ import { Callbacks, CallbackData } from './preload';
 import { changeLanguage, initI18n, localize } from '../../../main/i18n-manager';
 
 import './styles.css';
-import { logger } from '../../../core/logger';
 import { checkForNewLanguage } from '../../utils';
+import { logString } from '../../renderer-logging';
 
 declare global {
   interface Window {
@@ -78,7 +78,7 @@ buttonBrowse.addEventListener('click', async () => {
       window.close();
     }
   } catch (err) {
-    logger().logDebug(`Error occurred when trying to browse for R: ${err}`);
+    logString('debug', `Error occurred when trying to browse for R: ${err}`);
   } finally {
     /** 
     * Without this timeout, the Choose R Modal will also be closed together with the Browse Dialog.

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -15,6 +15,7 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import { existsSync } from 'fs';
 import path from 'path';
+import { getDesktopLoggerBridge } from '../../../renderer/logger-bridge';
 import { normalizeSeparatorsNative } from '../../utils';
 
 export interface CallbackData {
@@ -29,6 +30,9 @@ export interface Callbacks {
   browse(data: CallbackData): Promise<boolean>;
   cancel(): void;
 }
+
+// this needs to be done in the preload of any widget wanting to use logging
+contextBridge.exposeInMainWorld('desktopLogger', getDesktopLoggerBridge());
 
 ipcRenderer.on('css', (event, data) => {
   const styleEl = document.createElement('style');


### PR DESCRIPTION
NOTE: I'm targeting Elsbeth in case we need these logging capabilities for troubleshooting.

### Intent

Add the capability to do logging from preload scripts and code running in the renderer (e.g. the `load.ts` code for the Choose R dialog on Windows).

### Approach

Code running in the preload script or the renderer process can now log via the `logString(level, message)` and `logError(error)` helpers. These will then be invoked as regular logging calls in the main process via the ContextBridge mechanism.

An example of logging from preload in src/node/desktop/src/renderer/preload.ts:

```
import { getDesktopLoggerBridge, logString } from './logger-bridge';

logString('debug', `[preload] ignoring unsupported apiKey: '${apiKey}'`);
```

An example of logging from renderer code in src/node/desktop/src/ui/widgets/choose-r/load.ts:

```
import { logString } from '../../renderer-logging';

logString('debug', `Error occurred when trying to browse for R: ${err}`);
```

Currently not being used, but you can also do logging from any code running in the renderer (e.g. GWT code, dev tools console), via: `window.desktopLogger.logString()`. This would only work for Electron desktop so would require additional logic to prevent invocation on Server or Qt desktop.

### Automated Tests

None

### QA Notes

Nothing to specifically test.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


