### PR TITLE
Fix help pane scrollbar code background color

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -5,7 +5,7 @@
 
 @def CODE_COLOR #f0f0f0;
 
-@external rstudio-themes-dark, rstudio-themes-default;
+@external rstudio-themes-dark, rstudio-themes-light-menus, rstudio-themes-dark-menus;
 @external rstudio-themes-scrollbars;
 @external editor_dark;
 @external ace_editor_theme;
@@ -194,11 +194,11 @@ p + div[style="text-align: center;"]
    border-radius: 3px;
 }
 
-.rstudio-themes-default.ace_editor_theme div.sourceCode {
+.rstudio-themes-light-menus.ace_editor_theme div.sourceCode {
    background-color: CODE_BACKGROUND_COLOR_LIGHT;
 }
 
-.rstudio-themes-dark.editor_dark.ace_editor_theme div.sourceCode {
+.rstudio-themes-dark-menus.ace_editor_theme div.sourceCode {
    background-color: CODE_BACKGROUND_COLOR_DARK;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -5,7 +5,7 @@
 
 @def CODE_COLOR #f0f0f0;
 
-@external rstudio-themes-dark, rstudio-themes-light-menus, rstudio-themes-dark-menus;
+@external rstudio-themes-dark, rstudio-themes-default, rstudio-themes-alternate;
 @external rstudio-themes-scrollbars;
 @external editor_dark;
 @external ace_editor_theme;
@@ -194,11 +194,13 @@ p + div[style="text-align: center;"]
    border-radius: 3px;
 }
 
-.rstudio-themes-light-menus.ace_editor_theme div.sourceCode {
+/* These themes correspond to RStudio themes and are present for light editor themes */
+.rstudio-themes-default.ace_editor_theme div.sourceCode,
+.rstudio-themes-alternate.ace_editor_theme div.sourceCode {
    background-color: CODE_BACKGROUND_COLOR_LIGHT;
 }
 
-.rstudio-themes-dark-menus.ace_editor_theme div.sourceCode {
+.rstudio-themes-dark.ace_editor_theme div.sourceCode {
    background-color: CODE_BACKGROUND_COLOR_DARK;
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -1,9 +1,11 @@
 @charset "UTF-8";
 
 @def CODE_BACKGROUND_COLOR_DARK #1f1f1f;
+@def CODE_BACKGROUND_COLOR_LIGHT #f7f7f7;
+
 @def CODE_COLOR #f0f0f0;
 
-@external rstudio-themes-dark;
+@external rstudio-themes-dark, rstudio-themes-default;
 @external rstudio-themes-scrollbars;
 @external editor_dark;
 @external ace_editor_theme;
@@ -73,11 +75,6 @@ p + div[style="text-align: center;"]
 .rstudio-themes-dark.editor_dark.ace_editor_theme h3 + pre {
    color: #DEDEDE;
    background: none;
-}
-
-.rstudio-themes-dark.editor_dark.ace_editor_theme div.sourceCode {
-   background-color: CODE_BACKGROUND_COLOR_DARK;
-   border-radius: 3px;
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme pre,
@@ -188,5 +185,20 @@ p + div[style="text-align: center;"]
    color: inherit !important;
 }
 
+/**
+ * This styling ensures the sourceCode area has a solid, continuous
+ * background color, even if the view is narrowed and a scrollbar
+ * appears to allow for horizontal scrolling.
+ */
+ .ace_editor_theme div.sourceCode {
+   border-radius: 3px;
+}
 
+.rstudio-themes-default.ace_editor_theme div.sourceCode {
+   background-color: CODE_BACKGROUND_COLOR_LIGHT;
+}
+
+.rstudio-themes-dark.editor_dark.ace_editor_theme div.sourceCode {
+   background-color: CODE_BACKGROUND_COLOR_DARK;
+}
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -1,6 +1,6 @@
 @charset "UTF-8";
 
-@def CODE_BACKGROUND_COLOR #1f1f1f;
+@def CODE_BACKGROUND_COLOR_DARK #1f1f1f;
 @def CODE_COLOR #f0f0f0;
 
 @external rstudio-themes-dark;
@@ -76,13 +76,13 @@ p + div[style="text-align: center;"]
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme div.sourceCode {
-   background-color: CODE_BACKGROUND_COLOR;
+   background-color: CODE_BACKGROUND_COLOR_DARK;
    border-radius: 3px;
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme pre,
 .rstudio-themes-dark.editor_dark.ace_editor_theme pre code {
-   background-color: CODE_BACKGROUND_COLOR;
+   background-color: CODE_BACKGROUND_COLOR_DARK;
    color: CODE_COLOR;
    filter: none !important;
 }
@@ -94,7 +94,7 @@ p + div[style="text-align: center;"]
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme table thead,
 .rstudio-themes-dark.editor_dark.ace_editor_theme table tr.even {
-   background-color: CODE_BACKGROUND_COLOR !important;
+   background-color: CODE_BACKGROUND_COLOR_DARK !important;
    border-color: #999 !important;
 }
 
@@ -108,7 +108,7 @@ p + div[style="text-align: center;"]
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme blockquote {
-   background-color: CODE_BACKGROUND_COLOR !important;
+   background-color: CODE_BACKGROUND_COLOR_DARK !important;
    border-radius: 3px;
 }
 
@@ -118,8 +118,8 @@ p + div[style="text-align: center;"]
  */
 .rstudio-themes-dark.editor_dark.ace_editor_theme .code-toolbar
 {
-   background-color: CODE_BACKGROUND_COLOR;
-   border: 2px solid CODE_BACKGROUND_COLOR;
+   background-color: CODE_BACKGROUND_COLOR_DARK;
+   border: 2px solid CODE_BACKGROUND_COLOR_DARK;
    border-radius: 4px;
    padding: 2px 6px;
 }
@@ -145,7 +145,7 @@ p + div[style="text-align: center;"]
 /* Ugly hack, but we don't have a better way of targeting this element. */
 .rstudio-themes-dark.editor_dark.ace_editor_theme p + div[style="text-align: center;"]
 {
-   background-color: CODE_BACKGROUND_COLOR;
+   background-color: CODE_BACKGROUND_COLOR_DARK;
    padding: 8px 0;
 }
 
@@ -159,8 +159,8 @@ p + div[style="text-align: center;"]
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme .source
 {
-   background-color: CODE_BACKGROUND_COLOR;
-   border: 1px solid CODE_BACKGROUND_COLOR;
+   background-color: CODE_BACKGROUND_COLOR_DARK;
+   border: 1px solid CODE_BACKGROUND_COLOR_DARK;
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme .output,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPaneEditorStyles.css
@@ -7,7 +7,7 @@
 @external rstudio-themes-scrollbars;
 @external editor_dark;
 @external ace_editor_theme;
-@external sourceLine;
+@external sourceLine, sourceCode;
 @external odd;
 @external even;
 @external code-toolbar;
@@ -73,6 +73,11 @@ p + div[style="text-align: center;"]
 .rstudio-themes-dark.editor_dark.ace_editor_theme h3 + pre {
    color: #DEDEDE;
    background: none;
+}
+
+.rstudio-themes-dark.editor_dark.ace_editor_theme div.sourceCode {
+   background-color: CODE_BACKGROUND_COLOR;
+   border-radius: 3px;
 }
 
 .rstudio-themes-dark.editor_dark.ace_editor_theme pre,


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Addresses the code background color bug in #11520.

#### Dark Theme Fix Preview
<img width="367" alt="image" src="https://user-images.githubusercontent.com/25834218/213303116-dd7e7b36-d6d8-4165-923f-8c94893cb171.png">

#### Light Theme Fix Preview
<img width="371" alt="image" src="https://user-images.githubusercontent.com/25834218/213303289-402ded90-8a27-421b-8fb2-e64bd5412233.png">

### Approach
Sets the `background-colour` of the `div.sourceCode` to the light or dark code background color, depending on the active theme. The `border-radius` is also set to the same value as `pre`, otherwise the code box loses the rounded corners.

**Note:** The code background grey color is defined in `HelpPaneEditorStyles.css` and there is one grey used for all dark themes and another grey used for all light themes. It's possible the grey could be incompatible with some of the dark or light themes from an accessibility standpoint. Should a code background color be defined for each theme?

### Automated Tests
N/A?

### QA Notes

- Please test with a light editor theme and a dark editor theme
- Please test with both `Modern` and `Sky` RStudio themes for light and dark editor themes
- Other code areas outside of the help panel should not be affected by this change

### Documentation
N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


