### PR TITLE
Avoid non-zero exit codes when running sessions under Launcher

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - "Rainbow" fenced divs, controled by Options > R Markdown > [v] Use rainbow fenced divs #12115
 - Disable argument tooltips in script editor for unknown functions #12160
 - Sessions now have lower CPU priority during suspension on macOS and Linux #12623
+- Sessions run on Kubernetes or Slurm will no longer exit with nonzero codes under normal circumstances (rstudio/rstudio-pro#3375)
 
 ### Fixed
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -768,7 +768,15 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
 
             // exit status
             int status = switchToProject.empty() ? EXIT_SUCCESS : EX_CONTINUE;
-            
+            if (options().getBoolOverlayOption(kLauncherSessionOption))
+            {
+               // Avoid generating nonzero exit codes when running under
+               // Launcher. Error codes from normal behaviour like this are
+               // confusing for Slurm and Kubernetes administrators unfamiliar
+               // with our workloads.
+               status = EXIT_SUCCESS;
+            }
+
             // acknowledge request & quit session
             json::JsonRpcResponse response;
             response.setResult(true);

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -459,8 +459,18 @@ void checkForSuspend(const boost::function<bool()>& allowSuspend)
             "computations may have been interrupted.");
       }
 
+      // exit status
+      int status = EX_FORCE;
+      if (options().getBoolOverlayOption(kLauncherSessionOption))
+      {
+         // Avoid generating nonzero exit codes when running under Launcher.
+         // Error codes from normal behaviour like this are confusing for Slurm
+         // and Kubernetes administrators unfamiliar with our workloads.
+         status = EXIT_SUCCESS;
+      }
+
       // execute the forced suspend (does not return)
-      suspendSession(true, EX_FORCE);
+      suspendSession(true, status);
    }
 
    // cooperative suspend request


### PR DESCRIPTION
### Intent

Users sometimes raise concerns about the number of nonzero exit codes they see from Workbench sessions on Slurm and Kubernetes (see one [recent example](https://rstudio.slack.com/archives/C7312LBPY/p1670494955085729)). This is because we use exit code 101 and 103 to signify switching between projects and suspending, respectively, both of which are common operations in these environments.

This only affects Workbench. I extracted my original patch from that repo because it only affects the open-source codebase.

### Approach

It seems that we don't rely on the exit code when running sessions under Launcher at all, so this is an easy change to make.

### Automated Tests

I don't think there are any automated tests for this. In my manual testing, switching between projects and suspending sessions continues to work just fine with zero as the exit code.

### QA Notes

This will break switching between projects and suspending (with either Launcher or without it), which I believe should be caught by existing testing.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests