### PR TITLE
Update dracula.rstheme

### DIFF
--- a/src/cpp/session/resources/themes/dracula.rstheme
+++ b/src/cpp/session/resources/themes/dracula.rstheme
@@ -53,6 +53,9 @@
   border-color: #f8f8f2
 }
 .ace_keyword {
+  color: #bd93f9
+}
+.ace_keyword.ace_operator {
   color: #ff79c6
 }
 .ace_constant.ace_language {
@@ -71,7 +74,7 @@
   color: #bd93f9
 }
 .ace_support.ace_function {
-  color: #8be9fd
+  color: #50fa7b
 }
 .ace_support.ace_constant {
   color: #6be5fd


### PR DESCRIPTION
Currently, todo comments are not highlighted. Highlights it.
```r
#TODO:
```
Change the color of `ace_keyword.ace_operator` and `ace_support.ace_function` to match the actual Dracula theme from draculatheme.com.

![image](https://user-images.githubusercontent.com/31039074/213772503-77c3a24b-31cd-437a-adaa-8a0cb3897597.png)

vs the current

![image](https://user-images.githubusercontent.com/31039074/213774647-6ff8d7e6-9fc9-44f8-aeab-30813631f54b.png)

