### PR TITLE
Remove `jenkins-aws` credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -480,8 +480,7 @@ try {
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.exe package\\win32\\build\\${packageName}.exe"
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.zip package\\win32\\build\\${packageName}.zip"
 
-                                    // windows docker container cannot reach instance-metadata endpoint. supply credentials at upload.
-
+                                    // Explicitly assume the IDE alias of the main `build` account
                                     withAWS(role: 'ide-build') {
                                         retry(5) {
                                             bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -480,7 +480,7 @@ try {
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.exe package\\win32\\build\\${packageName}.exe"
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.zip package\\win32\\build\\${packageName}.zip"
 
-                                    // Explicitly assume the IDE alias of the main `build` role
+                                    // Explicitly assume the ide-build role in the main AWS account
                                     withAWS(role: 'ide-build') {
                                         retry(5) {
                                             bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -480,7 +480,7 @@ try {
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.exe package\\win32\\build\\${packageName}.exe"
                                     bat "move package\\win32\\build\\${packageName}-RelWithDebInfo.zip package\\win32\\build\\${packageName}.zip"
 
-                                    // Explicitly assume the IDE alias of the main `build` account
+                                    // Explicitly assume the IDE alias of the main `build` role
                                     withAWS(role: 'ide-build') {
                                         retry(5) {
                                             bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -384,7 +384,7 @@ try {
                 def current_container = containers[index]
                 node("${current_container.arch} && linux") {
                     def current_image
-                    docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:jenkins-aws') {
+                    docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:aws-build-role') {
                         stage('prepare ws/container') {
                           prepareWorkspace()
                           def image_tag = "${current_container.os}-${current_container.arch}-${rstudioVersionFlower}"
@@ -426,7 +426,7 @@ try {
                     node('windows') {
                         stage('prepare container') {
                             checkout scm
-                            docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:jenkins-aws') {
+                            docker.withRegistry('https://263245908434.dkr.ecr.us-east-1.amazonaws.com', 'ecr:us-east-1:aws-build-role') {
                                 def image_tag = "${current_container.os}-${rstudioVersionFlower}"
                                 windows_image = docker.image("jenkins/ide:" + image_tag)
                                 windows_image.pull()
@@ -482,7 +482,7 @@ try {
 
                                     // windows docker container cannot reach instance-metadata endpoint. supply credentials at upload.
 
-                                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+                                    withAWS(role: 'ide-build') {
                                         retry(5) {
                                             bat "aws s3 cp package\\win32\\build\\${packageName}.exe ${buildDest}/${packageName}.exe"
                                             bat "aws s3 cp package\\win32\\build\\${packageName}.zip ${buildDest}/${packageName}.zip"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -112,7 +112,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // this job is going to run on a macOS slave, which cannot use an instance-profile
+          // Explicitly assume the IDE alias of the main `build` account
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -112,7 +112,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // Explicitly assume the IDE alias of the main `build` role
+          // Explicitly assume the ide-build role in the main AWS account
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -113,7 +113,7 @@ pipeline {
           }
 
           // this job is going to run on a macOS slave, which cannot use an instance-profile
-          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+          withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"
             }

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -112,7 +112,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // Explicitly assume the IDE alias of the main `build` account
+          // Explicitly assume the IDE alias of the main `build` role
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -128,7 +128,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // Explicitly assume the IDE alias of the main `build` role
+          // Explicitly assume the ide-build role in the main AWS account
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -128,7 +128,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // Explicitly assume the IDE alias of the main `build` account
+          // Explicitly assume the IDE alias of the main `build` role
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -129,7 +129,7 @@ pipeline {
           }
 
           // this job is going to run on a macOS slave, which cannot use an instance-profile
-          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'jenkins-aws']]) {
+          withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"
             }

--- a/Jenkinsfile.macos.electron
+++ b/Jenkinsfile.macos.electron
@@ -128,7 +128,7 @@ pipeline {
             sh "docker/jenkins/notarize-release.sh package/osx/build/${packageFile}"
           }
 
-          // this job is going to run on a macOS slave, which cannot use an instance-profile
+          // Explicitly assume the IDE alias of the main `build` account
           withAWS(role: 'ide-build') {
             retry(5) {
               sh "aws s3 cp package/osx/build/${packageFile} ${buildDest}"


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/3022.

The `jenkins-aws` credential will be turned off by CI at the end of the day today. We've removed it as part of our Jenkins restructuring, but those changes are sitting in an epic branch and it won't be merged into `main` for at least a week, so fixing this now.

### Approach

Switch to `ide-build` or `aws-build-role` instead

### Automated Tests

N/A. Build system change

### QA Notes

N/A Build system Change

### Documentation

N/A Build system change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


