### PR TITLE
not using `EXTPTR_PROT` and `EXTPTR_TAG`

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -832,6 +832,16 @@ void clearExternalPtr(SEXP extptr)
    R_ClearExternalPtr(extptr);
 }
 
+SEXP getExternalPtrProtected(SEXP extptr)
+{
+   return R_ExternalPtrProtected(extptr);
+}
+
+SEXP getExternalPtrTag(SEXP extptr)
+{
+   return R_ExternalPtrTag(extptr);
+}
+
 core::Error getNamedListSEXP(SEXP listSEXP,
                              const std::string& name,
                              SEXP* pValueSEXP)

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -135,6 +135,8 @@ SEXP makeExternalPtr(void* ptr, R_CFinalizer_t fun, Protect* protect);
 SEXP makeExternalPtr(void* ptr, SEXP prot, SEXP tag);
 void* getExternalPtrAddr(SEXP extptr);
 void clearExternalPtr(SEXP extptr);
+SEXP getExternalPtrProtected(SEXP extptr);
+SEXP getExternalPtrTag(SEXP extptr);
 
 // extract c++ type from R SEXP
 core::Error extract(SEXP valueSEXP, int* pInt);

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -234,10 +234,10 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
       if (nullPtr == (r::sexp::getExternalPtrAddr(obj) == nullptr))
          return true;
 
-      if (hasExternalPointer(EXTPTR_PROT(obj), nullPtr, visited))
+      if (hasExternalPointer(r::sexp::getExternalPtrProtected(obj), nullPtr, visited))
          return true;
 
-      if (hasExternalPointer(EXTPTR_TAG(obj), nullPtr, visited))
+      if (hasExternalPointer(r::sexp::getExternalPtrTag(obj), nullPtr, visited))
          return true;
    }
 


### PR DESCRIPTION
### Intent

addresses #12591

### Approach

Define and use the `r::sexp::getExternalPtrProtected()` and `r::sexp::getExternalPtrTag()` functions. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


