### PR TITLE
Lower CPU priority during session suspend

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 - Support searching for roxygen specific information in fuzzy finder (Go to File/Function) #12190
 - "Rainbow" fenced divs, controled by Options > R Markdown > [v] Use rainbow fenced divs #12115
 - Disable argument tooltips in script editor for unknown functions #12160
+- Sessions now have lower CPU priority during suspension on macOS and Linux #12623
 
 ### Fixed
 


### PR DESCRIPTION
### Intent

Large sessions can be CPU-intensive to serialize, and customers have often reported mysterious CPU spikes that were tracked down to session suspension. This CPU spike can be particularly inconvenient when it is caused by previously-dormant sessions that time out and are auto-suspended by Workbench on a busy system.

Recently, [a customer asked](https://app.prodpad.com/feedback/874d975e-9b8c-11ed-a544-2a7db0eb1d9c/canvas) if we could lower the session process's nice value right before suspending it. This seemed like a good idea to me, so this commit implements this for macOS and Linux. We could also do it on Windows with `SetPriorityClass()`, but on that OS the likelihood of being a multi-user system is much lower.

This change doesn't eliminate the CPU required to suspend, of course, (or the I/O to do so, which can be significant) but it does make suspension much less likely to interfere with other, more important workloads on the system.

I'm not 100% sure this is a unilaterally good idea, since it will affect Desktop as well. Any comments on that front are appreciated.

### Automated Tests

There are no automated tests that cover this. I did do manual testing and it works as expected.

### QA Notes

Please advise.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests