### PR TITLE
Enable WAL mode and set a busy timeout for SQLite connections

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -161,7 +161,7 @@ public:
    Error operator()(const SqliteConnectionOptions& options) const
    {
       std::string readonly = options.readonly ? " readonly=true" : "";
-      std::string connectionStr = "shared_cache=true" + readonly + " dbname=\"" + options.file + "\"";
+      std::string connectionStr = "shared_cache=true timeout=5" + readonly + " dbname=\"" + options.file + "\"";
       if (pConnectionStr_)
          *pConnectionStr_ = connectionStr;
 
@@ -175,6 +175,11 @@ public:
 
          // foreign keys must explicitly be enabled for sqlite
          Error error = pConnection->executeStr("PRAGMA foreign_keys = ON;");
+         if (error)
+            return error;
+
+         // enable WAL mode to improve read/write concurrency
+         error = pConnection->executeStr("PRAGMA journal_mode = WAL;");
          if (error)
             return error;
 


### PR DESCRIPTION
### Intent

Right now we don't have much load on the database, but recent scalability testing surfaced many `database is locked` errors from the login flow in the logs. In some cases these errors are merely advisory, but in others they propagate up into issues in the UI.

Currently, we run the SQLite database in the default "rollback journal mode". The most common advice for addressing `database is locked` issues is to instead enable WAL mode, which allows readers and writers to operate concurrently, and offers much better performance in general.

So this commit enables WAL mode on our database.

### Approach

Note that locking issue are not completely eliminated. From SQLite's [documentation on WAL mode](https://sqlite.org/wal.html#sometimes_queries_return_sqlite_busy_in_wal_mode):

> [An advantage] of WAL-mode is that writers do not block readers and readers to do not block writers. This is *mostly* true. But there are some obscure cases where a query against a WAL-mode database can return `SQLITE_BUSY`, so applications should be prepared for that happenstance.

As a guard against these cases, this commit also sets the [SQLite busy timeout](https://sqlite.org/c3ref/busy_timeout.html). This five-second timeout (and the use of WAL mode) match what is being used successfully by Connect, and should dramatically reduce the incidence of these `database is locked` errors.

Finally: it's still *possible* to encounter `SQLITE_LOCKED` or `SQLITE_BUSY` errors with these changes, but the only remedy in those cases is to catch the SQLite-specific exceptions from SOCI and retry the query using our own backoff logic.

This commit does not attempt to add this level of complexity to our query implementation, since the appropriate amount of time waiting for a query is pretty dependent on the context it's being executed in, and I'd rather see this responsibility pushed up to the caller.

### Automated Tests

This isn't really covered by automated tests (that verify the journal mode or timeout, at least), but the general behaviour of the internal database is fairly well-tested.

### QA Notes

Please advise.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests