### PR TITLE
Upload build archives to s3

### DIFF
--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -149,7 +149,7 @@ pipeline {
                 }
               }
 
-              /* stage('Test') {
+              stage('Test') {
                 environment {
                   PATH = "${env.HOME}/opt/bin:${env.PATH}"
                 }
@@ -280,7 +280,7 @@ pipeline {
                     }
                   }
                 }
-              } */
+              }
             }
           }
         }
@@ -291,7 +291,7 @@ pipeline {
   post {
     always {
       deleteDir()
-      /* sendNotifications slack_channel: SLACK_CHANNEL */
+      sendNotifications slack_channel: SLACK_CHANNEL
     }
   }
 

--- a/Jenkinsfile.macos
+++ b/Jenkinsfile.macos
@@ -132,7 +132,24 @@ pipeline {
                 }
               }
 
-              stage('Test') {
+              stage('Upload Build Archive') {
+                environment {
+                  AWS_ACCOUNT_ID = '749683154838'
+                  AWS_PATH="s3://rstudio-sentry-upload/${FLAVOR.toLowerCase()}/macos/"
+                }
+                steps {
+                  dir("package/osx/build") {
+                    sh "zip -r build-${FLAVOR.capitalize()}.zip ./*"
+                  }
+                  withAWS(role: 'ide-build') {
+                    retry(5) {
+                      sh "aws s3 cp package/osx/build/build-${FLAVOR.capitalize()}.zip ${AWS_PATH}"
+                    }
+                  }
+                }
+              }
+
+              /* stage('Test') {
                 environment {
                   PATH = "${env.HOME}/opt/bin:${env.PATH}"
                 }
@@ -263,7 +280,7 @@ pipeline {
                     }
                   }
                 }
-              }
+              } */
             }
           }
         }
@@ -274,7 +291,7 @@ pipeline {
   post {
     always {
       deleteDir()
-      sendNotifications slack_channel: SLACK_CHANNEL
+      /* sendNotifications slack_channel: SLACK_CHANNEL */
     }
   }
 

--- a/Jenkinsfile.windows
+++ b/Jenkinsfile.windows
@@ -137,6 +137,21 @@ pipeline {
                     }
                   }
 
+                  stage('Upload Build Archive') {
+                    environment {
+                      AWS_ACCOUNT_ID = '749683154838'
+                      AWS_PATH="s3://rstudio-sentry-upload/${FLAVOR.toLowerCase()}/windows/"
+                    }
+                    steps {
+                      bat "7z.exe a -tzip build-${FLAVOR.capitalize()}.zip package\\win32\\build"
+                      withAWS(role: 'ide-build') {
+                        retry(5) {
+                          bat "aws s3 cp build-${FLAVOR.capitalize()}.zip ${AWS_PATH}"
+                        }
+                      }
+                    }
+                  }
+
                   stage('Tests') {
                     steps {
                       bat 'cd package/win32/build/src/cpp && rstudio-tests.bat --scope core'


### PR DESCRIPTION
### Intent

Address part of https://github.com/rstudio/rstudio-pro/issues/4229

### Approach

Currently we are using `sentry-cli` to upload debug symbols from `package/{OS}/build/src/cpp`. 

This PR adds a new stage as part of the build matrix for the macos and windows pipelines, which creates a zip archive of the package build folder (`package/{OS}/build`) and uploads it to a [new s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/rstudio-sentry-upload?region=us-east-1&tab=objects) `rstudio-sentry-upload` created in the IDE subaccount. 

The structure of the new bucket follows the structure similar to the bucket for our installers, i.e. `rstudio-sentry-upload/{flavor}/{os}/[{arch}/]/name-of-build-archive.zip`.

The intent is to be able to use this archive to upload debug symbols to sentry, in the case that the sentry upload stage fails during the pipeline build.

_Note on the current "Sentry Upload" stage for Windows:_ we're converting pbd symbols to breakpad format, but it now looks like [Sentry supports PBD files](https://docs.sentry.io/platforms/native/data-management/debug-files/) for Windows. It may simplify this stage if we wanted to look into that as well.

### Automated Tests

n/a

### QA Notes

This has yet to be tested in the full pipeline in action; only some POC testing has been done in an experimental pipeline.

### Documentation

n/a

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


