### PR TITLE
Add support for serving static files precompressed with Gzip/Brotli

### DIFF
--- a/src/cpp/core/http/Message.cpp
+++ b/src/cpp/core/http/Message.cpp
@@ -29,6 +29,7 @@ namespace core {
 namespace http {
   
 // encodings
+const char * const kBrotliEncoding = "br";
 const char * const kGzipEncoding = "gzip";
 const char * const kDeflateEncoding = "deflate";
 

--- a/src/cpp/core/include/core/http/Message.hpp
+++ b/src/cpp/core/include/core/http/Message.hpp
@@ -42,6 +42,7 @@ class FilePath;
 namespace http {
 
 // encodings
+extern const char * const kBrotliEncoding;
 extern const char * const kGzipEncoding;
 extern const char * const kDeflateEncoding;
 extern const char * const kTransferEncoding;


### PR DESCRIPTION
### Intent

At present, we compress static files at runtime to reduce the bandwidth cost of sending them over the network. Unfortunately, this compression is by no means free, and we incur significant CPU overhead to serve files this way (not to mention the latency added while we do so).

This has an especially large performance impact for the large Javascript/CSS assets on the Workbench Homepage, which are static files that never change.

It's common practice to avoid the runtime compression cost for static assets by precompressing the files beforehand, either with Gzip or, more commonly these days, with Brotli.

This commit modifies the static file handler to substitute in precompressed files when they exist, much like NGINX's popular `gzip_static` and `brotli_static` directives.

Note that this patch *does not* actually compress any of the assets that we serve. It only makes it possible to do so.

### Automated Tests

This part of the core library isn't covered by unit tests, but I did confirm it works manually in the browser.

### QA Notes

This change is low risk as it should have no effect on existing behaviour; it makes other changes possible in the future.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests