### PR TITLE
allow slashes in DCF field names

### DIFF
--- a/src/gwt/acesupport/acemode/dcf_highlight_rules.js
+++ b/src/gwt/acesupport/acemode/dcf_highlight_rules.js
@@ -26,7 +26,7 @@ var DcfHighlightRules = function() {
         
         "start" : [ {
             token : ["keyword", "text"],
-            regex : "^" +"([\\w@-]+)" + "(\\:)"
+            regex : "^([^:]+)(:)"
         }, {
             token : "text",
             regex : ".+"


### PR DESCRIPTION
### Intent

Small feature-let to support highlight of DCF field names containing slashes.

#### Before

<img width="472" alt="Screenshot 2023-02-01 at 3 12 07 PM" src="https://user-images.githubusercontent.com/1976582/216188139-4b4220ae-4112-458b-93d1-67ebc9c31d52.png">

#### After

<img width="492" alt="Screenshot 2023-02-01 at 3 19 35 PM" src="https://user-images.githubusercontent.com/1976582/216189520-0b769d8c-685b-4d72-a8aa-f9517b64c094.png">

### Approach

Straightforward update of Ace highlight rules.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

None required.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
