### PR TITLE
remove `openExternal` call from `allowNavigation` check 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Removed empty spell check tooltips #11306
 - Fixed package completion tooltips #12147
 - Fixed setting rsession log level using command-line argument or logging.conf #12557
+- Fixed previewing rendered html_document causes URLs to open in browser #12494
 
 ### Accessibility Improvements
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -33,7 +33,6 @@
 - Removed empty spell check tooltips #11306
 - Fixed package completion tooltips #12147
 - Fixed setting rsession log level using command-line argument or logging.conf #12557
-- Fixed previewing rendered html_document causes URLs to open in browser #12494
 
 ### Accessibility Improvements
 

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -333,7 +333,7 @@ export class DesktopBrowserWindow extends EventEmitter {
       // https://github.com/rstudio/rstudio/issues/12256
       return true;
     } else {
-      logger().logDebug('allowNavigation: no external navigation in IDE, unsafe host, open in browser');
+      logger().logDebug('allowNavigation: external navigation within IDE is not allowed and URL host is unsafe. URL must be explicitly opened in the browser.');
       return false;
     }
   }

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -332,16 +332,9 @@ export class DesktopBrowserWindow extends EventEmitter {
       // updates to use the new URL
       // https://github.com/rstudio/rstudio/issues/12256
       return true;
-    } else {
-      // open external browser only when not in test
-      if (process.env.NODE_ENV !== 'TEST') {
-        // when not allowing external navigation, open an external browser
-        // to view the URL
-        void shell.openExternal(url);
-      }
-      logger().logDebug('allowNavigation: no external navigation in IDE, unsafe host, open in browser');
-      return false;
     }
+
+    return false;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -332,9 +332,10 @@ export class DesktopBrowserWindow extends EventEmitter {
       // updates to use the new URL
       // https://github.com/rstudio/rstudio/issues/12256
       return true;
+    } else {
+      logger().logDebug('allowNavigation: no external navigation in IDE, unsafe host, open in browser');
+      return false;
     }
-
-    return false;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
### Intent

To address #12494 and #12413, this PR removes code that can lead to urls being opened multiple times.

#### **Note** that this PR reduces the amount of duplicate tabs open, but further investigation is needed to determine the source of the remaining duplicate tabs.

### Approach

`allowNavigation()` checks if navigation should be allowed, but in the final `else` case, it also opens the specified url via `shell.openExternal()`.

This side effect of opening the url should be removed from the function because the function should only serve a single purpose: to check if navigation should be allowed.

Other code which calls `allowNavigation()` uses the boolean result to determine if the url should be opened or not (and opens the url accordingly), which seems to be why multiple opens are getting triggered (`allowNavigation()` may open a url and the calling code may open the url again).

### Automated Tests

N/A

### QA Notes

- Follow steps from issue description #12494 and #12413
- Test on both Chrome and Safari (I personally could not reproduce in Safari and was only getting 1 duplicate tab in Chrome)
- Only 1 tab/window should be opened per url
- Other areas which cause urls to be opened should not be affected

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->