### PR TITLE
Add error if using an unsupported version of macOS

### DIFF
--- a/docs/user/rstudio/index.qmd
+++ b/docs/user/rstudio/index.qmd
@@ -7,7 +7,7 @@ date-format: iso
 
 RStudio is an integrated development environment (IDE) designed to support multiple languages, including both R and Python. It includes a console, syntax-highlighting editor that supports direct code execution, and a variety of robust tools for plotting, viewing history, debugging and managing your workspace. 
 
-RStudio is available in open source and commercial editions and runs on the desktop (Windows, Mac, and Linux) or in a browser connected to RStudio Server or Posit Workbench. Development of the open source and commercial RStudio IDE variants is supported by Posit Software, PBC (formerly named RStudio, PBC). Please review our [Blog post/FAQ](https://pos.it/rebrand-faq/) for additional information about the rebrand.
+RStudio is available in open source and commercial editions and runs on the desktop (Windows, macOS 11+, and Linux) or in a browser connected to RStudio Server or Posit Workbench. Development of the open source and commercial RStudio IDE variants is supported by Posit Software, PBC (formerly named RStudio, PBC). Please review our [Blog post/FAQ](https://pos.it/rebrand-faq/) for additional information about the rebrand.
 
 Please visit the individual product pages for additional information about the open source [RStudio IDE](https://posit.co/products/open-source/rstudio/) or RStudio within [Posit Workbench](https://posit.co/products/enterprise/workbench/). 
 

--- a/docs/user/rstudio/index.qmd
+++ b/docs/user/rstudio/index.qmd
@@ -7,7 +7,7 @@ date-format: iso
 
 RStudio is an integrated development environment (IDE) designed to support multiple languages, including both R and Python. It includes a console, syntax-highlighting editor that supports direct code execution, and a variety of robust tools for plotting, viewing history, debugging and managing your workspace. 
 
-RStudio is available in open source and commercial editions and runs on the desktop (Windows, macOS 11+, and Linux) or in a browser connected to RStudio Server or Posit Workbench. Development of the open source and commercial RStudio IDE variants is supported by Posit Software, PBC (formerly named RStudio, PBC). Please review our [Blog post/FAQ](https://pos.it/rebrand-faq/) for additional information about the rebrand.
+RStudio is available in open source and commercial editions and runs on the desktop (Windows 10+, macOS 11+, and Linux) or in a browser connected to RStudio Server or Posit Workbench. Development of the open source and commercial RStudio IDE variants is supported by Posit Software, PBC (formerly named RStudio, PBC). Please review our [Blog post/FAQ](https://pos.it/rebrand-faq/) for additional information about the rebrand.
 
 Please visit the individual product pages for additional information about the open source [RStudio IDE](https://posit.co/products/open-source/rstudio/) or RStudio within [Posit Workbench](https://posit.co/products/enterprise/workbench/). 
 

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -28,6 +28,7 @@ import {
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
 import { existsSync, writeFileSync } from 'fs';
+import { platform, release } from 'os';
 import i18next from 'i18next';
 import { findFontsSync } from 'node-system-fonts';
 import path, { dirname } from 'path';
@@ -49,7 +50,6 @@ import {
   getAppPath, handleLocaleCookies, resolveAliasedPath
 } from './utils';
 import { activateWindow, focusedWebContents } from './window-utils';
-import os, { version } from 'os';
 
 export enum PendingQuit {
   PendingQuitNone,
@@ -911,10 +911,8 @@ export class GwtCallback extends EventEmitter {
   }
 
   addMacOSVersionError(): void {
-    if (os.platform() === 'darwin') {
-      const release = os.release();
-      const release_major = parseInt(release.substring(0, release.indexOf('.')));
-
+    if (platform() === 'darwin') {
+      const release_major = parseInt(release().substring(0, release().indexOf('.')));
       // macOS 11.0 uses darwin 20.0.0
       if (release_major < 20) {
         let versionError = 'You are using an unsupported operating system.' +

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -917,7 +917,7 @@ export class GwtCallback extends EventEmitter {
 
       // macOS 11.0 uses darwin 20.0.0
       if (release_major < 20) {
-        let versionError = 'You are using an unsupported Operating System.' +
+        let versionError = 'You are using an unsupported operating system.' +
         ' RStudio requires macOS 11 or higher.';
         if (this.errorPageData.get('process_error')) {
           const launch_failed = this.errorPageData.get('process_error');


### PR DESCRIPTION
### Intent

Addresses #12607 

Alert the user on startup when RStudio failed to launch due to an unsupported version. 

![image](https://user-images.githubusercontent.com/5323711/217041220-0f7dad41-9ca1-48a6-8cd1-75d669a5b23e.png)

### Approach

When we detect a launch failure, check the operating system version. If we're using an unsupported version of macOS, prefix the launch error with: `You are using an unsupported operating system. RStudio requires macOS 11 or higher.` 

Reviewer note: I'm unsure if this is the correct place to add this function. I wanted to include it in the electron code rather than the C++ code since it only applies to desktop and to take advantage of node's `os` module for determining the specific OS release. Please let me know if this should be moved to somewhere in `node/desktop/src/core` instead.

### Automated Tests

No unit tests were added since the functionality depends on the system running the test. 

### QA Notes

This requires testing on a version of macOS prior to 11. I have an alternate laptop I was able to downgrade so I've verified this works as expected. 

### Documentation
The Desktop Pro Admin guide already mentioned this requirement. I've added it to the open-source user guide. 

### Checklist

- [ don't think this is necessary? ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


