### PR TITLE
Update RStudio Docs to point to posit.docs.co

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -499,7 +499,7 @@ public class Application implements ApplicationEventHandlers
       if (customDocsURL.length() > 0)
          globalDisplay_.openWindow(customDocsURL);
       else
-         globalDisplay_.openRStudioLink(constants_.helpUsingRStudioLinkName());
+         globalDisplay_.openWindow("https://docs.posit.co/");
    }
 
    @Handler


### PR DESCRIPTION
### Intent

Addresses #12386 

Update the `Help -> RStudio Docs` menu selection to open https://docs.posit.co/

### Approach

Replace the call to `openRStudioLink` with a hardcoded value to this URL. Now that we have a professional docs website, we shouldn't be redirecting to the support page.

### Automated Tests

N/A

### QA Notes

See original request

### Documentation
N/A - I confirmed this menu isn't referenced in the user guide.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


