### PR TITLE
forgiving parsing free form Arguments section

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/model/HelpInfo.java
@@ -173,7 +173,12 @@ public class HelpInfo extends JavaScriptObject
                                Element heading)
    {
       Element table = findArgumentTable(heading);
-      assert table != null : "Unexpected help format, no argblock table found";
+      
+      // early exit, but just acts as if there are no arguments
+      // this usually happens with free form \section{Arguments}
+      // instead of \arguments{}
+      if (table == null) 
+         return;
       
       TableElement t = (TableElement) table;
       NodeList<TableRowElement> rows = t.getRows();


### PR DESCRIPTION
### Intent

address #12568 as a followup to #10844

### Approach

Make `parseArguments` more forgiving of free form `Arguments` section such as those when documenting R6 objects with `\section{Arguments}` ...

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

<img width="717" alt="image" src="https://user-images.githubusercontent.com/2625526/217266237-28310bcb-5e05-43ba-ae5b-e03cca5c4722.png">

<img width="648" alt="image" src="https://user-images.githubusercontent.com/2625526/217266359-8b2b875f-b160-4262-b9bf-a1686ac4743d.png">

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


