### PR TITLE
Fix blank satellite window for data viewer and shiny apps

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 - Fixed setting rsession log level using command-line argument or logging.conf #12557
 - Fixed issue that allowed users to overwrite their home directory in server mode #12653
 - Fixed "Check for updates" incorrectly reports that there are no updates (rstudio-pro #3388)
+- Fixed data viewer's "Show in new window" results in empty window #12468
+- Fixed uncaught Shiny error breaks RStudio's "Run in Window" feature #12569
 
 ### Accessibility Improvements
 

--- a/src/node/desktop/src/main/satellite-window.ts
+++ b/src/node/desktop/src/main/satellite-window.ts
@@ -82,7 +82,9 @@ export class SatelliteWindow extends GwtWindow {
           } else {
             // not ready to close, revert close stage and take care of business
             this.closeStage = 'CloseStageOpen';
-            this.executeJavaScript('window.rstudioCloseSourceWindow()').catch(logger().logError);
+            this.executeJavaScript('window.rstudioCloseSourceWindow()')
+              .then(() => appState().gwtCallback?.unregisterOwner(this))
+              .catch(logger().logError);
           }
         })
         .catch(logger().logError);


### PR DESCRIPTION
### Intent

Addresses #12468 and #12569.

Catches the error causing the gwt callback to fail partway through opening up data viewer files and shiny apps in a satellite window.

### Approach

The underlying issue appears to be that some satellite windows are not unregistered once they are returned to the main window. As a result, when we iterate through the list of owners to find the `GwtWindow` that sent the "Open in new window" event, we hit some objects that have been destroyed (`TypeError: Object has been destroyed`), but not removed from the list of owners. Since the gwt callback errors out, we don't end up populating the window with the data being popped out from the main window.

This PR is stopgap fix to catch the error and continue iterating through the loop to find the correct owner. The data is then displayed successfully. In the future, we should ensure that satellite windows returned to the main window or satellite windows otherwise dismissed (not via the "Close" X button) are unregistered accordingly. Maybe there's a particular reason why those windows are not unregistered?

<details>
    <summary>Some relevant code areas:</summary>

- anything involving `desktop_allow_navigation`
- failure occurs during:
https://github.com/rstudio/rstudio/blob/497e47f994af46050b825d9351dec1b956e9fd6b/src/node/desktop/src/renderer/desktop-bridge.ts#L557
- error `TypeError: Object has been destroyed` is thrown here
https://github.com/rstudio/rstudio/blob/497e47f994af46050b825d9351dec1b956e9fd6b/src/node/desktop/src/main/gwt-callback.ts#L987
- https://github.com/rstudio/rstudio/blob/main/src/node/desktop/src/main/satellite-window.ts
</details>

### Automated Tests

Once we determine when owners should be unregistered, we can write some tests to check the different cases where owners are unregistered, such as when a satellite window is returned to the main window.

### QA Notes

- Please test with repro steps in #12468 and #12569
- Text files such as `.qmd`, `.js`, etc should be unaffected by this change
- For shiny apps, ensure "Run in Window" is selected before clicking "Run App"

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->