### PR TITLE
support for visual editor reference links option

### DIFF
--- a/src/cpp/session/modules/SessionQuarto.R
+++ b/src/cpp/session/modules/SessionQuarto.R
@@ -49,6 +49,9 @@
          if (!is.null(editor$markdown$references$prefix)) {
             editor$markdown$references$prefix <- scalarChar(editor$markdown$references$prefix)
          }
+         if (!is.null(editor$markdown$references$links)) {
+            editor$markdown$references$links <- .rs.scalar(as.logical(editor$markdown$references$links))
+         }
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWriterReferencesOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/PanmirrorWriterReferencesOptions.java
@@ -23,4 +23,5 @@ public class PanmirrorWriterReferencesOptions
 {    
    public String location;
    public String prefix;
+   public Boolean links;
 }

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorCommands.java
@@ -123,6 +123,8 @@ public class PanmirrorCommands
    public static final String RcppCodeChunk = "6BD2810B-6B20-4358-8AA4-74BBFFC92AC3";
    public static final String SQLCodeChunk = "41D61FD2-B56B-48A7-99BC-2F60BC0D9F78";
    public static final String StanCodeChunk = "65D33344-CBE9-438C-B337-A538F8D7FCE5";
+   public static final String MermaidCodeChunk = "FCA99491-2FCA-44BC-8349-A9AE2AE940DE";
+   public static final String GraphVizCodeChunk = "29970A38-2921-4F32-8363-F78CFE3FEBB4";
    public static final String ExpandAllChunks = "B217913B-67C9-457F-B766-7FCCB502F611";
    public static final String CollapseAllChunks = "9907A864-D707-4410-93A4-07871A8C43A6";
    public static final String ExpandChunk = "0226518C-559A-4BFC-A5BD-244BEE8175AA";

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/command/PanmirrorToolbarCommands.java
@@ -86,6 +86,8 @@ public class PanmirrorToolbarCommands implements CommandPaletteEntryProvider
       add(PanmirrorCommands.RcppCodeChunk, "Rcpp");
       add(PanmirrorCommands.SQLCodeChunk, "SQL");
       add(PanmirrorCommands.StanCodeChunk, "Stan");
+      add(PanmirrorCommands.MermaidCodeChunk, "Mermaid");
+      add(PanmirrorCommands.GraphVizCodeChunk, "GraphViz");
       add(PanmirrorCommands.ExpandChunk, constants_.expandChunkMenuText(), false);
       add(PanmirrorCommands.CollapseChunk, constants_.collapseChunkMenuText(), false);
       add(PanmirrorCommands.ExpandAllChunks, constants_.expandAllChunksMenuText(), false);

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/uitools/PanmirrorPandocFormatConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/uitools/PanmirrorPandocFormatConfig.java
@@ -34,6 +34,7 @@ public class PanmirrorPandocFormatConfig
    public String wrap;
    public String references_location;
    public String references_prefix;
+   public Boolean references_links;
    public boolean canonical;
    
  
@@ -61,7 +62,8 @@ public class PanmirrorPandocFormatConfig
    {
       return StringUtil.equals(a.wrap, b.wrap) &&
              a.references_location == b.references_location &&
-             a.references_prefix == b.references_prefix;         
+             a.references_prefix == b.references_prefix &&
+              a.references_links == b.references_links;
    }
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeMarkdownWriter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModeMarkdownWriter.java
@@ -96,6 +96,7 @@ public class VisualModeMarkdownWriter
       Integer wrapAtColumnPref = null;
       String referencesLocationPref= null;
       String referencesPrefixPref = null;
+      Boolean referencesLinksPref = null;
       if (VisualModeUtil.isDocInProject(workbenchContext_, docUpdateSentinel_))
       {
          // allow any prefs defined in quarto yaml to take precedence
@@ -121,6 +122,7 @@ public class VisualModeMarkdownWriter
                {
                   referencesLocationPref = quarto.project_editor.markdown.references.location;
                   referencesPrefixPref = quarto.project_editor.markdown.references.prefix;
+                  referencesLinksPref = quarto.project_editor.markdown.references.links;
                }
             }
          }
@@ -169,7 +171,12 @@ public class VisualModeMarkdownWriter
       
       if (formatConfig.references_location != null)
          options.references.location = formatConfig.references_location;
-      
+
+      if (formatConfig.references_links != null)
+         options.references.links = formatConfig.references_links;
+      else if (referencesLinksPref != null)
+         options.references.links = referencesLinksPref.booleanValue();
+
       // references prefix
       if ("none".equals(formatConfig.references_prefix))
       {


### PR DESCRIPTION
@timtmok This is a change intended to support the visual editor's new `editor: markdown: references: links` option (as described here: https://quarto.org/docs/visual-editor/vscode/#links)

My Homebrew installation on my dev Mac has become corrupted so I'm not actually able to compile/test this! In any case we should pair program on landing the change so you know what's going on. Message me when a good time to do this next week might be (I'll mark this PR as a draft in the meantime).