### PR TITLE
Fix initial Choose R dialog state

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 - Fixed setting rsession log level using command-line argument or logging.conf #12557
 - Fixed issue that allowed users to overwrite their home directory in server mode #12653
 - Fixed "Check for updates" incorrectly reports that there are no updates (rstudio-pro #3388)
+- Fixed default options for Choose R dialog on Windows (#12452)
 
 ### Accessibility Improvements
 

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -36,6 +36,7 @@ function checkValid(data: CallbackData) {
   if (err) {
     // something went wrong; let the user know they can't use
     // this version of R with RStudio
+    logger().logErrorMessage(`Selected R path: ${rBinaryPath ?? 'no path chosen'}`);
     logger().logError(err);
 
     dialog.showMessageBoxSync({

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -40,6 +40,8 @@ const updateLabels = () => {
 // radio button is checked
 const selectWidget = document.getElementById('select') as HTMLSelectElement;
 const radioChooseCustom = document.getElementById('use-custom') as HTMLInputElement;
+const radioChoose32 = document.getElementById('use-default-32') as HTMLInputElement;
+const radioChoose64 = document.getElementById('use-default-64') as HTMLInputElement;
 const radioButtons = document.querySelectorAll('input[type="radio"]');
 
 radioButtons.forEach((radioButton) => {
@@ -65,6 +67,10 @@ function callbackData(binaryPath?: string): CallbackData {
 }
 
 buttonOk.addEventListener('click', accept);
+radioChoose32.addEventListener('input', validate);
+radioChoose64.addEventListener('input', validate);
+radioChooseCustom.addEventListener('input', validate);
+selectWidget.addEventListener('input', validate);
 
 buttonCancel.addEventListener('click', closeWindow);
 
@@ -125,6 +131,12 @@ window.addEventListener('load', () => {
 function closeWindow() {
   window.callbacks.cancel();
   window.close();
+}
+
+async function validate() {
+  buttonOk.disabled = !((selectWidget.value)
+    || radioChoose32.checked
+    || radioChoose64.checked);
 }
 
 async function accept() {

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -34,7 +34,7 @@ export interface Callbacks {
 // this needs to be done in the preload of any widget wanting to use logging
 contextBridge.exposeInMainWorld('desktopLogger', getDesktopLoggerBridge());
 
-ipcRenderer.on('css', (event, data) => {
+ipcRenderer.on('css', (_event, data) => {
   const styleEl = document.createElement('style');
   styleEl.setAttribute('language', 'text/css');
   styleEl.innerText = data;
@@ -42,16 +42,21 @@ ipcRenderer.on('css', (event, data) => {
 });
 
 // initialize select input
-ipcRenderer.on('initialize', (event, data) => {
+ipcRenderer.on('initialize', (_event, data) => {
+  const use32 = document.getElementById('use-default-32') as HTMLInputElement;
+  const use64 = document.getElementById('use-default-64') as HTMLInputElement;
+  const useCustomEl = document.getElementById('use-custom') as HTMLInputElement;
+  const selectCustom = document.getElementById('select') as HTMLSelectElement;
+  const buttonOk = document.getElementById('button-ok') as HTMLButtonElement;
+
   // if we have a default 32-bit R installation, enable it
   const default32Bit = data.default32bitPath as string;
   let isDefault32Selected = false;
   if (default32Bit) {
-    const el = document.getElementById('use-default-32') as any;
-    el?.removeAttribute('disabled');
+    use32?.removeAttribute('disabled');
 
     if (isRVersionSelected('' + data.selectedRVersion, default32Bit + '/bin/i386/R.exe')) {
-      el.checked = true;
+      use32.checked = true;
       isDefault32Selected = true;
     }
   }
@@ -60,11 +65,10 @@ ipcRenderer.on('initialize', (event, data) => {
   const default64Bit = data.default64bitPath as string;
   let isDefault64Selected = false;
   if (default64Bit) {
-    const el = document.getElementById('use-default-64') as any;
-    el?.removeAttribute('disabled');
+    use64?.removeAttribute('disabled');
 
     if (isRVersionSelected('' + data.selectedRVersion, default64Bit + '/bin/x64/R.exe')) {
-      el.checked = true;
+      use64.checked = true;
       isDefault64Selected = true;
     }
   }
@@ -90,7 +94,7 @@ ipcRenderer.on('initialize', (event, data) => {
   });
 
   const selectWidget = document.getElementById('select') as HTMLSelectElement;
-  selectWidget.disabled = true;
+  selectWidget.disabled = !(rInstalls.length > 0 && useCustomEl.checked);
 
   rInstalls.forEach((rInstall) => {
     // normalize separators, etc
@@ -140,6 +144,11 @@ ipcRenderer.on('initialize', (event, data) => {
       }
     }
   });
+
+  useCustomEl.checked = !default32Bit && !default64Bit && (rInstalls.length > 0);
+  selectWidget.disabled = !useCustomEl.checked;
+
+  buttonOk.disabled = !((useCustomEl.checked && selectCustom.value) || use32.checked || use64.checked) ;
 });
 
 // export callbacks


### PR DESCRIPTION
### Intent
Address some issues in #12452

### Approach
The initial dialog state could have an invalid selection such as using the default 64-bit R when none was found in the registry or the user selecting a specific version of R option but not selecting a version from the list. This results in an error that may not be obvious to the user why R could not be found.

Fixes:
* Cancelling the dialog doesn't try to show the download R prompt since the application closes before it can be read (Qt would exit without prompting the user to download R)
* Added logging after querying the registry if an R installation was found to lessen the impact of error log messages registry queries not finding R
* Add `HKEY_CURRENT_USER` hive query to the default 32/64 bit search to address users that do not have admin privileges (R would be installed to `%LOCALAPPDATA%\Programs` and registry keys written to `HKCU` hive)
* Added logging if validating selected R installation fails so it records which R was selected
* Changed initial selection when Choose R dialog is shown
   * Choose a specific version is selected if default R installations are not found so that a disabled option is not initially selected
   * OK button is disabled (as Qt behaved) if selection is invalid (i.e. specific version is selected but no version is selected in list)

### Automated Tests
None

### QA Notes
The fix list above describes specific scenarios that were addressed. Mainly, it should not be allowed to click OK if there is no R version selected.

### Documentation
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


