### PR TITLE
use user data dir for message server socket

### DIFF
--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -178,7 +178,7 @@ export class Application implements AppState {
 
   // create a new local socket to co-ordinate and become the primary instance
   private createMessageServer() {
-    const path = Xdg.userDataDir('rstudio.socket');
+    const path = Xdg.userDataDir().completeChildPath('rstudio.socket');
     path.getParent().ensureDirectorySync();
     const options = { path: path.getAbsolutePath() };
     this.server = new Server(options);

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -47,6 +47,7 @@ import { WindowTracker } from './window-tracker';
 import { configureSatelliteWindow, configureSecondaryWindow } from './window-utils';
 import { Client, Server } from 'net-ipc';
 import { LoggerCallback } from './logger-callback';
+import { Xdg } from '../core/xdg';
 
 /**
  * The RStudio application
@@ -177,9 +178,11 @@ export class Application implements AppState {
 
   // create a new local socket to co-ordinate and become the primary instance
   private createMessageServer() {
-    const options = { path: 'rstudio' };
+    const path = Xdg.userDataDir('rstudio.socket');
+    path.getParent().ensureDirectorySync();
+    const options = { path: path.getAbsolutePath() };
     this.server = new Server(options);
-    logger().logDebug('net-ipc: creating new message server');
+    logger().logDebug(`net-ipc: creating new message server; socket=${path.getAbsolutePath()}`);
     this.server.start()
       .then(() => {
         this.client = undefined;
@@ -315,7 +318,7 @@ export class Application implements AppState {
           message: i18next.t('applicationTs.rstudioFailedToFindRInstalationsOnTheSystem'),
           buttons: [ i18next.t('common.buttonYes'), i18next.t('common.buttonNo') ],
         }).then(result => {
-          
+
           logger().logDebug(`You clicked ${result.response == 0 ? 'Yes' : 'No'}`);
           if (result.response == 0) {
             const rProjectUrl = 'https://www.rstudio.org/links/r-project';
@@ -323,7 +326,7 @@ export class Application implements AppState {
           }
         })
           .catch((error: unknown) => logger().logError(error));
-        
+
         return exitFailure();
       }
 


### PR DESCRIPTION
### Intent

Closes https://github.com/rstudio/rstudio/issues/12580.

### Approach

Use XDG data directory.

### Automated Tests

N/A

### QA Notes

Test that RStudio no longer creates a file called `~/rstudio`.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
