### PR TITLE
Avoid external browser navigation when loading iframe src

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,8 @@
 - Fixed setting rsession log level using command-line argument or logging.conf #12557
 - Fixed issue that allowed users to overwrite their home directory in server mode #12653
 - Fixed "Check for updates" incorrectly reports that there are no updates (rstudio-pro #3388)
+- Fixed previewing rendered html_document causes URLs to open in browser #12494
+- Fixed link opens in browser after Render with qml file when hypothes.is comments are turned on in `_quarto.yml` #12413
 
 ### Accessibility Improvements
 

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -139,13 +139,15 @@ export class MainWindow extends GwtWindow {
     // 1. Open the page externally,
     // 2. Re-direct the iframe back to the source URL (bleh).
     //
+    // Once https://github.com/electron/electron/pull/34418 is merged, we can leverage
+    // the 'will-frame-navigate' instead of intercepting the request.
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
 
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
       if (details.resourceType === 'subFrame' && !this.allowNavigation(details.url)) {
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
-        callback({ cancel: false, redirectURL: details.frame?.url });
+        callback({ cancel: true, redirectURL: details.frame?.url });
       } else {
         callback({ cancel: false });
       }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -135,12 +135,18 @@ export class MainWindow extends GwtWindow {
     // url in a browser.
     // Once https://github.com/electron/electron/pull/34418 is merged, we can leverage
     // the 'will-frame-navigate' instead of intercepting the request.
+
+    // this intercepts every request from an iframe, but we only want to intercept
+    // when a navigation request to an external URL occurs in an iframe, not in cases
+    // where the src of the iframe
+
+    // Basically, onBeforeRequest is too broad
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
       if (details.resourceType === 'subFrame' && !this.allowNavigation(details.url)) {
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
-        callback({ cancel: true });
+        callback({ cancel: false, redirectURL: details.frame?.url });
       } else {
         callback({ cancel: false });
       }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -131,18 +131,21 @@ export class MainWindow extends GwtWindow {
 
     registerWebContentsDebugHandlers(this.window.webContents);
 
-    // Detect attempts to navigate externally within an iframe, and instead open the
-    // url in a browser.
+    // Detect attempts to navigate to an external url in an iframe, and open the
+    // url in an external browser instead of in the IDE.
     // Once https://github.com/electron/electron/pull/34418 is merged, we can leverage
     // the 'will-frame-navigate' event instead of intercepting the request.
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
+
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
-      // Navigation is happening from the iframe (i.e. clicking on an anchor tag within
-      // an iframe) as opposed to a request to load the iframe src if `details.frame.url`
-      // is defined
+      // If `details.frame.url` is defined, navigation is being triggered in the iframe
+      // (e.g. clicking on an anchor tag within an iframe) as opposed to a request to load
+      // the url from the iframe src 
       if (details.resourceType === 'subFrame' && details.frame?.url && !this.allowNavigation(details.url)) {
+        // Open the page externally
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
+        // Re-direct the iframe back to the source URL (bleh)
         callback({ cancel: false, redirectURL: details.frame?.url });
       } else {
         callback({ cancel: false });

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -131,23 +131,16 @@ export class MainWindow extends GwtWindow {
 
     registerWebContentsDebugHandlers(this.window.webContents);
 
-    // Detect attempts to navigate externally within subframes, and prevent them.
-    // The implementation here is pretty sub-optimal, but it's the best we can do until
-    // we get 'will-frame-navigate' support. In effect, we detect attempts to navigate
-    // externally within an iframe, and instead:
-    //
-    // 1. Open the page externally,
-    // 2. Re-direct the iframe back to the source URL (bleh).
-    //
+    // Detect attempts to navigate externally within an iframe, and instead open the
+    // url in a browser.
     // Once https://github.com/electron/electron/pull/34418 is merged, we can leverage
     // the 'will-frame-navigate' instead of intercepting the request.
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
-
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
       if (details.resourceType === 'subFrame' && !this.allowNavigation(details.url)) {
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
-        callback({ cancel: true, redirectURL: details.frame?.url });
+        callback({ cancel: true });
       } else {
         callback({ cancel: false });
       }

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -134,17 +134,14 @@ export class MainWindow extends GwtWindow {
     // Detect attempts to navigate externally within an iframe, and instead open the
     // url in a browser.
     // Once https://github.com/electron/electron/pull/34418 is merged, we can leverage
-    // the 'will-frame-navigate' instead of intercepting the request.
-
-    // this intercepts every request from an iframe, but we only want to intercept
-    // when a navigation request to an external URL occurs in an iframe, not in cases
-    // where the src of the iframe
-
-    // Basically, onBeforeRequest is too broad
+    // the 'will-frame-navigate' event instead of intercepting the request.
     this.window.webContents.session.webRequest.onBeforeRequest((details, callback) => {
       logger().logDebug(`${details.method} ${details.url} [${details.resourceType}]`);
 
-      if (details.resourceType === 'subFrame' && !this.allowNavigation(details.url)) {
+      // Navigation is happening from the iframe (i.e. clicking on an anchor tag within
+      // an iframe) as opposed to a request to load the iframe src if `details.frame.url`
+      // is defined
+      if (details.resourceType === 'subFrame' && details.frame?.url && !this.allowNavigation(details.url)) {
         shell.openExternal(details.url).catch((error) => { logger().logError(error); });
         callback({ cancel: false, redirectURL: details.frame?.url });
       } else {


### PR DESCRIPTION
### Intent

A follow-up to PR #12660 to address the iframe (subframe) external browser navigation bug for issues https://github.com/rstudio/rstudio/issues/12494 and https://github.com/rstudio/rstudio/issues/12413.

In this PR, I narrow the scope of which iframe requests should have their urls opened externally (basically we want to avoid requests where the iframe src url is being requested).

Note: we should refactor this code once the [`will-frame-navigate` event is available](https://github.com/electron/electron/pull/34418).

### Approach

To specifically target iframes which trigger navigation to external urls, we need to check that `details.frame?.url` exists. Otherwise, we end up opening external browser windows for requests to load the url for iframe `src`'s. 

Thank you @kevinushey for the extra context you provided in #12660!

### Automated Tests

N/A

### QA Notes

- test in Chrome and Safari
- use test cases from dropdown in https://github.com/rstudio/rstudio/issues/12494#issuecomment-1428449186

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


