### PR TITLE
data completions don't get high priority on `::` and `:::` contexts

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1383,7 +1383,13 @@ assign(x = ".rs.acCompletionTypes",
    typeScores[completions$type == .rs.acCompletionTypes$ARGUMENT] <- 1
    typeScores[completions$type == .rs.acCompletionTypes$COLUMN] <- 2
    typeScores[completions$type == .rs.acCompletionTypes$DATATABLE_SPECIAL_SYMBOL] <- 3
-   typeScores[completions$type == .rs.acCompletionTypes$DATAFRAME] <- 4
+
+   # data has high priority, unless it's requested from a :: or ::: context
+   # rationale: https://github.com/rstudio/rstudio/issues/12678)
+   typeScores[
+      completions$type == .rs.acCompletionTypes$DATAFRAME & 
+      ! completions$context %in% c(.rs.acContextTypes$NAMESPACE_EXPORTED, .rs.acContextTypes$NAMESPACE_ALL)
+      ] <- 4
    typeScores[completions$type == .rs.acCompletionTypes$SECUNDARY_ARGUMENT] <- 5
 
    typeScores[completions$type == .rs.acCompletionTypes$PACKAGE] <- 101

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -14,6 +14,8 @@
  */
 package org.rstudio.studio.client.common.codetools;
 
+import org.rstudio.studio.client.workbench.views.console.shell.assist.RCompletionManager.AutocompletionContext;
+
 public class RCompletionType
 {
    public static final int UNKNOWN     =  0;
@@ -65,14 +67,21 @@ public class RCompletionType
              type == DIRECTORY;
    }
 
-   public static int score(int type) 
+   public static int score(int type, int context) 
    {
       // same logic as .rs.sortCompletions() on the server side
       switch(type){
          case ARGUMENT: return 1;
          case COLUMN: return 2;
          case DATATABLE_SPECIAL_SYMBOL: return 3;
-         case DATAFRAME: return 4;
+         case DATAFRAME: 
+         {
+            if (context != AutocompletionContext.TYPE_NAMESPACE_EXPORTED && context != AutocompletionContext.TYPE_NAMESPACE_ALL)
+               return 4;
+
+            break;
+         }
+            
          case SECUNDARY_ARGUMENT: return 5;
 
          case PACKAGE: return 101;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionCache.java
@@ -88,25 +88,26 @@ public class CompletionCache
       String token = original.getToken() + line.substring(substring.length());
       
       // Extract the vector elements of the completion string
-      JsArrayString completions = original.getCompletions();
-      JsArrayString display     = original.getCompletionsDisplay();
-      JsArrayString packages    = original.getPackages();
-      JsArrayBoolean quote      = original.getQuote();
-      JsArrayInteger type       = original.getType();
-      JsArrayInteger context    = original.getContext();
+      JsArrayString completions      = original.getCompletions();
+      JsArrayString display          = original.getCompletionsDisplay();
+      JsArrayString packages         = original.getPackages();
+      JsArrayBoolean quote           = original.getQuote();
+      JsArrayInteger type            = original.getType();
+      JsArrayInteger context         = original.getContext();
       JsArrayBoolean suggestOnAccept = original.getSuggestOnAccept();
-      JsArrayBoolean replaceToEnd = original.getReplaceToEnd();
-      JsArrayString meta        = original.getMeta();
+      JsArrayBoolean replaceToEnd    = original.getReplaceToEnd();
+      JsArrayString meta             = original.getMeta();
       
       // Now, generate narrowed versions of the above
-      final JsVectorString completionsNarrow = JsVectorString.createVector().cast();
-      final JsVectorString displayNarrow     = JsVectorString.createVector().cast();
-      final JsVectorString packagesNarrow    = JsVectorString.createVector().cast();
-      final JsVectorBoolean quoteNarrow      = JsVectorBoolean.createVector().cast();
-      final JsVectorInteger typeNarrow       = JsVectorInteger.createVector().cast();
+      final JsVectorString completionsNarrow     = JsVectorString.createVector().cast();
+      final JsVectorString displayNarrow         = JsVectorString.createVector().cast();
+      final JsVectorString packagesNarrow        = JsVectorString.createVector().cast();
+      final JsVectorBoolean quoteNarrow          = JsVectorBoolean.createVector().cast();
+      final JsVectorInteger typeNarrow           = JsVectorInteger.createVector().cast();
       final JsArrayBoolean suggestOnAcceptNarrow = JsVectorBoolean.createVector().cast();
-      final JsArrayBoolean replaceToEndNarrow = JsVectorBoolean.createVector().cast();
-      final JsVectorString metaNarrow        = JsVectorString.createVector().cast();
+      final JsArrayBoolean replaceToEndNarrow    = JsVectorBoolean.createVector().cast();
+      final JsVectorString metaNarrow            = JsVectorString.createVector().cast();
+      final JsVectorInteger contextNarrow        = JsVectorInteger.createVector().cast();
       
       for (int i = 0, n = completions.length(); i < n; i++)
       {
@@ -121,6 +122,7 @@ public class CompletionCache
             suggestOnAcceptNarrow.push(suggestOnAccept.get(i));
             replaceToEndNarrow.push(replaceToEnd.get(i));
             metaNarrow.push(meta.get(i));
+            contextNarrow.push(context.get(i));
          }
       }
       
@@ -135,11 +137,14 @@ public class CompletionCache
          @Override
          public int compare(Integer lhs, Integer rhs)
          {
+            int lhsContext = contextNarrow.get(lhs);
+            int rhsContext = contextNarrow.get(rhs);
+
             int lhsType = typeNarrow.get(lhs);
             int rhsType = typeNarrow.get(rhs);
 
-            int lhsTypeScore = RCompletionType.score(lhsType);
-            int rhsTypeScore = RCompletionType.score(rhsType);
+            int lhsTypeScore = RCompletionType.score(lhsType, lhsContext);
+            int rhsTypeScore = RCompletionType.score(rhsType, rhsContext);
             if (lhsTypeScore < rhsTypeScore)
                return -1;
             else if (lhsTypeScore > rhsTypeScore)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionRequester.java
@@ -187,8 +187,8 @@ public class CompletionRequester
          public int compare(QualifiedName lhs, QualifiedName rhs)
          {
             // compare completion type first
-            int lhsTypeScore = RCompletionType.score(lhs.type);
-            int rhsTypeScore = RCompletionType.score(rhs.type);
+            int lhsTypeScore = RCompletionType.score(lhs.type, lhs.context);
+            int rhsTypeScore = RCompletionType.score(rhs.type, rhs.context);
             if (lhsTypeScore < rhsTypeScore)
                return -1;
             else if (lhsTypeScore > rhsTypeScore)


### PR DESCRIPTION
### Intent

addresses #12678

### Approach

This is a quick "band aid on bullet hole" kind of fix, and hopefully we can revisit when approaching completions as a whole. The idea is that data completions don't get special sorting treatment when this is a `::` or `:::` context. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

This works on initial completions: `pak::p<TAB>`: 

<img width="656" alt="image" src="https://user-images.githubusercontent.com/2625526/218720204-77825033-b841-423b-bc2b-d1af6dc9fee0.png">

and on narrowing : `pak::<TAB>p<wait for narrow>`: 

<img width="666" alt="image" src="https://user-images.githubusercontent.com/2625526/218720394-4905675d-bda4-458d-bb60-9a365b0ad75a.png">

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


