### PR TITLE
Remove node from choose R modal

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -856,6 +856,14 @@ export class GwtCallback extends EventEmitter {
       return false;
     });
 
+    ipcMain.handle('fs_existsSync', (event, path: string) => {
+      return existsSync(path);
+    });
+
+    ipcMain.handle('path_normalize', (event, p: string) => {
+      return path.normalize(p);
+    });
+
     ipcMain.on('desktop_connect_to_launcher_server', () => {
       GwtCallback.unimpl('desktop_connect_to_launcher_server');
     });

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -856,14 +856,6 @@ export class GwtCallback extends EventEmitter {
       return false;
     });
 
-    ipcMain.handle('fs_existsSync', (event, path: string) => {
-      return existsSync(path);
-    });
-
-    ipcMain.handle('path_normalize', (event, p: string) => {
-      return path.normalize(p);
-    });
-
     ipcMain.on('desktop_connect_to_launcher_server', () => {
       GwtCallback.unimpl('desktop_connect_to_launcher_server');
     });

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -31,7 +31,7 @@ export abstract class ModalDialog<T> extends BrowserWindow {
       height: 400,
       show: false,
       webPreferences: {
-        nodeIntegration: true,
+        nodeIntegration: false,
         preload: preload,
       },
     };

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -23,6 +23,9 @@ import i18next, { t } from 'i18next';
 import { CallbackData } from './choose-r/preload';
 import { ElectronDesktopOptions } from '../../main/preferences/electron-desktop-options';
 
+import { existsSync } from 'fs';
+import { normalize } from 'path';
+
 declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
 
@@ -89,6 +92,14 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
     // listen for messages from the window
     return new Promise((resolve) => {
+      this.addIpcHandler('path_normalize', async (event, data) => {
+        return normalize(data);
+      });
+
+      this.addIpcHandler('fs_existsSync', async (event, data) => {
+        return existsSync(data);
+      });
+
       this.addIpcHandler('use-default-32bit', async (event, data: CallbackData) => {
         const installPath = initData.default32bitPath;
         data.binaryPath = `${installPath}/bin/i386/R.exe`;

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -96,8 +96,7 @@ ipcRenderer.on('initialize', (_event, data) => {
 
   rInstalls.forEach(async (rInstall) => {
     // normalize separators, etc
-    const normalRInstall: string = await ipcRenderer.invoke('path_normalize', rInstall);
-    rInstall = normalizeSeparatorsNative(normalRInstall);
+    rInstall = normalizeSeparatorsNative(await ipcRenderer.invoke('path_normalize', rInstall));
 
     // skip if we've already seen this
     if (visitedInstallations[rInstall]) {
@@ -107,8 +106,7 @@ ipcRenderer.on('initialize', (_event, data) => {
 
     // check for 64 bit executable
     const r64 = `${rInstall}/bin/x64/R.exe`;
-    const r64Exists: boolean = await ipcRenderer.invoke('fs_existsSync', r64);
-    if (r64Exists) {
+    if (await ipcRenderer.invoke('fs_existsSync', r64)) {
       const optionEl = window.document.createElement('option');
       optionEl.value = r64;
       optionEl.innerText = `[64-bit] ${rInstall}`;
@@ -127,8 +125,7 @@ ipcRenderer.on('initialize', (_event, data) => {
 
     // check for 32 bit executable
     const r32 = `${rInstall}/bin/i386/R.exe`;
-    const r32Exists: boolean = await ipcRenderer.invoke('fs_existsSync', r32);
-    if (r32Exists) {
+    if (await ipcRenderer.invoke('fs_existsSync', r32)) {
       const optionEl = window.document.createElement('option');
       optionEl.value = r32;
       optionEl.innerText = `[32-bit] ${rInstall}`;


### PR DESCRIPTION
### Intent

Addresses #12487, more specifically https://github.com/rstudio/rstudio/pull/12518#issuecomment-1371221990

### Approach

Disable node integration from preload and renderer scripts. Electron 20 limited Node.js modules allowed in preload scripts to `events`, `timers`, and `url` so this PR refactors calls to `fs` and `path` to the main process.

### Automated Tests

N/A - no noticeable user change. 

### QA Notes

This change should be invisible from the user's perspective. On Windows, the choose R modal should continue to load, populated with the available R versions.
![image](https://user-images.githubusercontent.com/5323711/219070782-fdcf1578-91e3-4b7c-83c4-d6d23142e804.png)


### Documentation
N/A - no new functionality

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


