### PR TITLE
add rhel7 builds to quarto upload script

### DIFF
--- a/dependencies/tools/upload-quarto.sh
+++ b/dependencies/tools/upload-quarto.sh
@@ -12,6 +12,7 @@ AWS_BUCKET="s3://rstudio-buildtools"
 
 PLATFORMS=(
     linux-amd64.tar.gz
+    linux-rhel7-amd64.tar.gz
     macos.tar.gz
     win.zip
 )


### PR DESCRIPTION
### Intent

Part of #12697 

Upload the linux rhel7 quarto builds to the S3 bucket. The initial build after merging rstudio/rstudio-pro#4303 failed because the rhel7 build of quarto wasn't available in the S3 bucket: https://build.posit.it/blue/organizations/jenkins/IDE%2FOS-Builds%2Fopen-source-pipeline/detail/main/2049/pipeline. I manually uploaded the tarball to resolve the build issue, but this PR adds the rhel7 build to our upload script. 

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


