### PR TITLE
Open Source Portion of 2423 User Warning Effort

### DIFF
--- a/src/cpp/core/include/core/http/Response.hpp
+++ b/src/cpp/core/include/core/http/Response.hpp
@@ -64,6 +64,8 @@ enum Code {
    MovedTemporarily = 302,
    SeeOther = 303,
    NotModified = 304,
+   TemporaryRedirect = 307,
+   PermanentRedirect = 308,
    TooManyRedirects = 310,
    BadRequest = 400,
    Unauthorized = 401,

--- a/src/cpp/core/include/core/json/JsonRpc.hpp
+++ b/src/cpp/core/include/core/json/JsonRpc.hpp
@@ -70,7 +70,11 @@ enum errc_t {
    // Transmission errors -- These errors leave the application in an unknown
    // state (it is not known whether the method finished all, some, or none
    // of its work).
-   TransmissionError = 200
+   TransmissionError = 200,
+
+   // JSON RPC Request responded with a redirect,
+   // however that is not yet implemented
+   RedirectNotImplementedError = 300
 };
 
 } // namespace errc

--- a/src/cpp/core/json/JsonRpc.cpp
+++ b/src/cpp/core/json/JsonRpc.cpp
@@ -462,6 +462,9 @@ std::string JsonRpcErrorCategory::message( int ev ) const
       case errc::LimitSessionsReached:
          return "The maximum amount of concurrent session allowed for the user profile has been reached";
 
+      case errc::RedirectNotImplementedError:
+         return "Unsupported redirection requested";
+
       default:
          BOOST_ASSERT(false);
          return "Unknown error type";

--- a/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcError.java
+++ b/src/gwt/src/org/rstudio/core/client/jsonrpc/RpcError.java
@@ -69,6 +69,9 @@ public class RpcError extends JavaScriptObject
      
    // transmission error (application state indeterminate)
    public final static int TRANSMISSION_ERROR = 200;
+
+   // Unimplemented redirection request
+   public final static int REDIRECTION_ERROR = 300;
    
    public final native int getCode() /*-{
       return this.code;

--- a/src/gwt/src/org/rstudio/studio/client/server/ServerError.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/ServerError.java
@@ -42,6 +42,9 @@ public interface ServerError
    
    // errors indicating the license usage limit has been reached
    public static final int LICENSE_USAGE_LIMIT = 7;
+
+   // errors indicating the license usage limit has been reached
+   public static final int REDIRECT_ERROR = 300;
  
    // error type
    int getCode();

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerError.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServerError.java
@@ -122,6 +122,8 @@ class RemoteServerError implements ServerError
       case RpcError.MAX_SESSIONS_REACHED:
       case RpcError.MAX_USERS_REACHED:
          return ServerError.LICENSE_USAGE_LIMIT;
+      case RpcError.REDIRECTION_ERROR:
+         return ServerError.REDIRECT_ERROR;
                
       default:
          return ServerError.SUCCESS;


### PR DESCRIPTION
This puts in place the necessary pieces to show an error to the user in the event that a workbench job submission returns a redirect, which we currently don't support

Open source portion to address rstudio/rstudio-pro#2423

### Intent

In the event that a workbench session issues a redirect, the user can be notified of the issue and recommendations given to fix the most common problem.

### Approach

Instead of simply returning true or false, the error is also propagated back up through the session to the ui.

### Automated Tests

Messaging changes, low risk.

### QA Notes

See workbench pr

### Documentation
Documentation is not updated for this.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


