### PR TITLE
handle "context" in .rs.sortCompletions() and .rs.appendCompletions()

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1291,7 +1291,7 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("subsetCompletions", function(completions, indices)
 {
-   for (name in c("results", "packages", "quote", "type"))
+   for (name in c("results", "packages", "quote", "type", "context"))
       completions[[name]] <- completions[[name]][indices]
    
    if (!is.null(completions[["suggestOnAccept"]]))
@@ -1328,7 +1328,7 @@ assign(x = ".rs.acCompletionTypes",
 {
    old[["suggestOnAccept"]] <- .rs.appendCompletionsOptionalElement(old, new, "suggestOnAccept", FALSE)
    
-   for (name in c("results", "packages", "quote", "type", "meta"))
+   for (name in c("results", "packages", "quote", "type", "meta", "context"))
       old[[name]] <- c(old[[name]], new[[name]])
 
    # resolve duplicates -- a completion is duplicated if its result
@@ -1340,7 +1340,7 @@ assign(x = ".rs.acCompletionTypes",
    
    if (length(drop))
    {
-      for (name in c("results", "packages", "quote", "type", "meta"))
+      for (name in c("results", "packages", "quote", "type", "meta", "context"))
          old[[name]] <- old[[name]][-c(drop)]
 
       if (!is.null(old[["suggestOnAccept"]])) {


### PR DESCRIPTION
### Intent

Followup on #12678 

### Approach

#12709 introduced a bug because it started to make use of the `$context` in completions, but it was not properly handled in `.rs.subsetCompletions()` and `.rs.appendCompletions()` so we sometimes had a smaller `$context` compared to the `$type` which was the cause for https://github.com/rstudio/rstudio/issues/12678#issuecomment-1433466281

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


