### PR TITLE
Support rtools 4.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Disable argument tooltips in script editor for unknown functions #12160
 - Sessions now have lower CPU priority during suspension on macOS and Linux #12623
 - Sessions run on Kubernetes or Slurm will no longer exit with nonzero codes under normal circumstances (rstudio/rstudio-pro#3375)
+- Add RTools 4.3 support
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,7 @@
 - Disable argument tooltips in script editor for unknown functions #12160
 - Sessions now have lower CPU priority during suspension on macOS and Linux #12623
 - Sessions run on Kubernetes or Slurm will no longer exit with nonzero codes under normal circumstances (rstudio/rstudio-pro#3375)
-- Add RTools 4.3 support
+- Add RTools 4.3 support #12528 
 
 ### Fixed
 

--- a/src/cpp/core/r_util/RToolsInfo.cpp
+++ b/src/cpp/core/r_util/RToolsInfo.cpp
@@ -281,29 +281,6 @@ RToolsInfo::RToolsInfo(const std::string& name,
       clangArgs.push_back("-D__GNUC__=10");
       clangArgs.push_back("-D__GNUC_MINOR__=3");
       clangArgs.push_back("-D__GNUC_PATCHLEVEL__=0");
-
-      // get C headers paths
-      auto cStems = {
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include",
-         "x86_64-w64-mingw32.static.posix/include",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include-fixed"
-      };
-
-      for (auto&& stem : cStems)
-         cIncludePaths.push_back(installPath.completeChildPath(stem).getAbsolutePath());
-
-      // get C++ headers
-      auto cppStems = {
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include/c++",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include/c++/x86_64-w64-mingw32.static.posix",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include/c++/backward",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include",
-         "x86_64-w64-mingw32.static.posix/include",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/10.3.0/include-fixed",
-      };
-
-      for (auto&& stem : cppStems)
-         cppIncludePaths.push_back(installPath.completeChildPath(stem).getAbsolutePath());
    }
    else if (name == "4.3")
    {
@@ -329,29 +306,6 @@ RToolsInfo::RToolsInfo(const std::string& name,
       clangArgs.push_back("-D__GNUC__=12");
       clangArgs.push_back("-D__GNUC_MINOR__=2");
       clangArgs.push_back("-D__GNUC_PATCHLEVEL__=0");
-
-      // get C headers paths
-      auto cStems = {
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include",
-         "x86_64-w64-mingw32.static.posix/include",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include-fixed"
-      };
-
-      for (auto&& stem : cStems)
-         cIncludePaths.push_back(installPath.completeChildPath(stem).getAbsolutePath());
-
-      // get C++ headers
-      auto cppStems = {
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include/c++",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include/c++/x86_64-w64-mingw32.static.posix",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include/c++/backward",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include",
-         "x86_64-w64-mingw32.static.posix/include",
-         "x86_64-w64-mingw32.static.posix/lib/gcc/x86_64-w64-mingw32.static.posix/12.2.0/include-fixed",
-      };
-
-      for (auto&& stem : cppStems)
-         cppIncludePaths.push_back(installPath.completeChildPath(stem).getAbsolutePath());
    }
    else
    {

--- a/src/cpp/session/modules/build/SessionInstallRtools.R
+++ b/src/cpp/session/modules/build/SessionInstallRtools.R
@@ -13,7 +13,7 @@
 #
 #
 
-.rs.addFunction("findRtools42Installer", function(url, fallbackUrl)
+.rs.addFunction("findRtoolsInstaller", function(url, fallbackUrl)
 {
    tryCatch({
        tmp <- tempfile()

--- a/src/cpp/session/modules/build/SessionInstallRtools.cpp
+++ b/src/cpp/session/modules/build/SessionInstallRtools.cpp
@@ -39,7 +39,7 @@ namespace session {
 namespace modules {
 namespace build {
 
-std::string kFallbackUrl = "https://rstudio.org/links/rtools42";
+std::string kFallbackUrl = "https://rstudio.org/links/rtools43";
 
 Error installRtools()
 {
@@ -47,6 +47,7 @@ Error installRtools()
    bool gcc49 = module_context::usingMingwGcc49();
    FilePath installPath("C:\\Rtools");
    std::vector<r_util::RToolsInfo> availableRtools;
+   availableRtools.push_back(r_util::RToolsInfo("4.3", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("4.2", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("4.0", installPath, gcc49));
    availableRtools.push_back(r_util::RToolsInfo("3.5", installPath, gcc49));
@@ -96,9 +97,9 @@ Error installRtools()
    if (error)
       return error;
 
-   if (version == "4.2")
+   if (version == "4.3")
    {
-     Error error = r::exec::RFunction(".rs.findRtools42Installer")
+     Error error = r::exec::RFunction(".rs.findRtoolsInstaller")
             .addParam("url", url)
             .addParam("fallbackUrl", kFallbackUrl)
             .call(&url);


### PR DESCRIPTION
### Intent
Address #12528 

### Approach
Update the logic to also check for RTools 4.3 if using R 4.3.x. Renamed `findRtools42Installer` since it can be used for 4.3 (and maybe >4.3).

A companion change for the fallback link redirect: https://github.com/rstudio/rstudio-web/pull/41

I think the code could also be refactored so there's less copy/paste if we're confident that the RTools release will be hosted the same way for versions >4.3.

### Automated Tests
None

### QA Notes
This required R 4.3, which is currently available in dev builds. https://cran.r-project.org/bin/windows/base/rdevel.html

`.rs.findRtoolsInstaller("https://cran.rstudio.com/bin/windows/Rtools/rtools43/rtools.html", "some fallback link to rtools")` could be called to ensure it finds the link to the RTools installer. I don't think this is used anywhere else but the function used to be called `findRtools42Installer`. The function will return something like this: `https://cran.rstudio.com/bin/windows/Rtools/rtools43/files/rtools43-5493-5475.exe` or `some fallback link to rtools` if the page link couldn't find the RTools download link. In the IDE, the fallback link is actually to the S3 bucket where the installer is mirrored.

### Documentation
updated NEWS.md

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


