### PR TITLE
Fix fedora 37 symlink bug

### DIFF
--- a/package/linux/rpm-script/postinst-desktop.sh.in
+++ b/package/linux/rpm-script/postinst-desktop.sh.in
@@ -22,6 +22,7 @@ then
   # verify if release version number is greater than 25
   if compare_versions $version_number 25
   then
+    mkdir -p ${CMAKE_INSTALL_PREFIX}/bin
     ln -s -f /$architecture_dir/libssl.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libssl.so.1.0.0
     ln -s -f /$architecture_dir/libcrypto.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libcrypto.so.1.0.0
   fi

--- a/package/linux/rpm-script/postinst-electron.sh.in
+++ b/package/linux/rpm-script/postinst-electron.sh.in
@@ -22,6 +22,7 @@ then
   # verify if release version number is greater than 25
   if compare_versions $version_number 25
   then
+    mkdir -p ${CMAKE_INSTALL_PREFIX}/bin
     ln -s -f /$architecture_dir/libssl.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libssl.so.1.0.0
     ln -s -f /$architecture_dir/libcrypto.so.10 ${CMAKE_INSTALL_PREFIX}/bin/libcrypto.so.1.0.0
   fi


### PR DESCRIPTION
### Intent

Addresses #12614 
Fedora 37 installs of rstudio displayed the following error, but appeared to work as expected:
```
ln: failed to create symbolic link '/usr/lib/rstudio/bin/libssl.so.1.0.0': No such file or directory
ln: failed to create symbolic link '/usr/lib/rstudio/bin/libcrypto.so.1.0.0': No such file or directory
```


### Approach

This was failing because `/usr/lib/rstudio/bin` didn't yet exist. Creating the directory before the symlinks resolves the issue. 

### Automated Tests

N/A

### QA Notes

The product should install without error.

### Documentation
N/A - install bug fix

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


