### PR TITLE
Bugfix/hourly upload

### DIFF
--- a/docker/jenkins/publish-build.sh
+++ b/docker/jenkins/publish-build.sh
@@ -22,6 +22,8 @@ if [ $# -eq 0 ]; then
     echo ""
     echo "--pat     The Github Personal Access Token (PAT) to be used to authorize the commit."
     echo "          May be specified in the environment variable GITHUB_PAT instead."
+    echo ""
+    echo "--channel (optional) The Channel type for the build. One of Hourly, Daily, Preview, Release"
     exit 0
 fi
 
@@ -36,6 +38,7 @@ ARGUMENT_LIST=(
     "file"
     "version"
     "pat"
+    "channel"
 )
 
 # Parse arguments with getopt
@@ -76,6 +79,11 @@ while [[ $# -gt 0 ]]; do
 
         --pat)
             pat=$2
+            shift 2
+            ;;
+
+        --channel)
+            channel=$2
             shift 2
             ;;
 
@@ -136,7 +144,9 @@ timestamp=$(date +"%Y-%m-%dT%H:%M:%S%z")
 
 # Determine release channel (build type) and flower
 RSTUDIO_ROOT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && cd ../.. && pwd )"
-channel="$(cat "$RSTUDIO_ROOT_DIR/version/BUILDTYPE" | tr '[ ]' '-' | tr -d '[:space:]')"
+if [ -z "$channel" ]; then
+    channel="$(cat "$RSTUDIO_ROOT_DIR/version/BUILDTYPE" | tr '[ ]' '-' | tr -d '[:space:]')"
+fi
 flower="$(cat "$RSTUDIO_ROOT_DIR/version/RELEASE" | tr '[ ]' '-' | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')"
 
 # Determine commit (use local hash)

--- a/utils.groovy
+++ b/utils.groovy
@@ -114,7 +114,14 @@ def sentryUpload(String symbolType) {
   * Does not work on windows.
   */
 def publishToDailiesSite(String packageFile, String destinationPath) {
-  sh '${WORKSPACE}/docker/jenkins/publish-build.sh --pat ${GITHUB_LOGIN_PSW} --version ' +
+  def channel = ''
+  if (!params.DAILY) {
+    channel = ' --channel Hourly'
+  }
+
+  sh '${WORKSPACE}/docker/jenkins/publish-build.sh --pat ${GITHUB_LOGIN_PSW} ' +
+    channel +
+    ' --version ' +
     RSTUDIO_VERSION +
     ' --build ' +
     destinationPath +
@@ -123,7 +130,7 @@ def publishToDailiesSite(String packageFile, String destinationPath) {
     '/' +
     packageFile +
     ' --file ' +
-    packageFile
+    packageFile 
 }
 
 /** 


### PR DESCRIPTION
### Intent

Fixes the upload logic in the builds to send hourly builds to the correct channel on the Dailies Page

### Approach

Hourly builds are denoted by the `channel` metadata value for a build. Daily, Preview, and Release channels are all determined automatically by the value in `version/BUILDTYPE`. The Hourly channel needs to be provided manually to override looking at that file.

Hourly build files are also uploaded to a different location in `latest-builds` under `content/rstudio-hourly/...` instead of the regular `content/rstudio/...` location for daily builds. When the `channel` is set to `Hourly` the script will automatically upload the file to the correct location

### Automated Tests

N/A

### QA Notes

N/A

### Documentation
N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


