### PR TITLE
Fix incorrect bitmap plot image copying

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@
 - Fixed intermittent hanging logins in Workbench using ActiveDirectory (rstudio-pro #4285)
 - Fixed previewing rendered html_document causes URLs to open in browser #12494
 - Fixed link opens in browser after Render with qml file when hypothes.is comments are turned on in `_quarto.yml` #12413
+- Fixed copy Plot to Clipboard - pasting bitfile option not working correctly in latest build #12466
 
 ### Accessibility Improvements
 

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -91,6 +91,9 @@ public interface DesktopFrame extends JavaScriptPassthrough
    
    void copyPageRegionToClipboard(int left, int top, int width, int height,
                                   Command onCopied);
+
+   void copyImageAtXYToClipboard(int absoluteLeft, int absoluteTop,
+                                 Command completed);
    
    void exportPageRegionToFile(String targetPath, 
                                String format, 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
@@ -90,14 +90,21 @@ public class CopyPlotToClipboardDesktopDialog
                Element img = images.getItem(0);
                DesktopFrame frame = Desktop.getFrame();
                
-               // NOTE: we use a one-pixel fudge factor here to avoid copying
-               // bits of the border; see https://github.com/rstudio/rstudio/issues/4864
-               frame.copyPageRegionToClipboard(
-                     ElementEx.getClientLeft(img) + 1,
-                     ElementEx.getClientTop(img) + 1,
-                     img.getClientWidth(),
-                     img.getClientHeight(),
-                     completed);
+               if (BrowseCap.isElectron()) {
+                  frame.copyImageAtXYToClipboard(
+                        img.getAbsoluteLeft(),
+                        img.getAbsoluteTop(),
+                        completed);
+               } else {
+                  // NOTE: we use a one-pixel fudge factor here to avoid copying
+                  // bits of the border; see https://github.com/rstudio/rstudio/issues/4864
+                  frame.copyPageRegionToClipboard(
+                        ElementEx.getClientLeft(img) + 1,
+                        ElementEx.getClientTop(img) + 1,
+                        img.getClientWidth(),
+                        img.getClientHeight(),
+                        completed);
+               }
             }
             else
             {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/exportplot/clipboard/CopyPlotToClipboardDesktopDialog.java
@@ -91,9 +91,14 @@ public class CopyPlotToClipboardDesktopDialog
                DesktopFrame frame = Desktop.getFrame();
                
                if (BrowseCap.isElectron()) {
+                  // The x and y calculations here will give us the approximate (x,y)
+                  // point in the middle of the img. The top-left corner is not used
+                  // because it doesn't consistently mark the top-left of the img element.
+                  int imgX = (img.getClientWidth() / 2) + ElementEx.getClientLeft(img);
+                  int imgY = (img.getClientHeight() / 2) + ElementEx.getClientTop(img);
                   frame.copyImageAtXYToClipboard(
-                        img.getAbsoluteLeft(),
-                        img.getAbsoluteTop(),
+                        imgX,
+                        imgY,
                         completed);
                } else {
                   // NOTE: we use a one-pixel fudge factor here to avoid copying

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -492,11 +492,26 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_copy_page_region_to_clipboard',
       (_event, x: number, y: number, width: number, height: number) => {
+        const rect: Rectangle = { x, y, width, height };
+        this.mainWindow.window
+          .capturePage(rect)
+          .then((image) => {
+            clipboard.writeImage(image);
+          })
+          .catch((error) => {
+            logger().logError(error);
+          });
+      },
+    );
+
+    ipcMain.handle(
+      'desktop_copy_image_at_xy_to_clipboard',
+      (_event, x: number, y: number) => {
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow?.webContents) {
-          focusedWindow.webContents.copyImageAt(x + width, y + height);
+          focusedWindow.webContents.copyImageAt(x, y);
         } else {
-          logger().logError("Failed to copy page region to clipboard");
+          logger().logError(`Failed to copy image at x: ${x}, y: ${y} to clipboard`);
         }
       },
     );

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -496,7 +496,8 @@ export class GwtCallback extends EventEmitter {
         this.mainWindow.window
           .capturePage(rect)
           .then((image) => {
-            clipboard.writeImage(image);
+            const buffer: Buffer = image.toJPEG(100);;
+            clipboard.writeBuffer('jpeg', buffer);
           })
           .catch((error) => {
             logger().logError(error);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -492,16 +492,12 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_copy_page_region_to_clipboard',
       (_event, x: number, y: number, width: number, height: number) => {
-        const rect: Rectangle = { x, y, width, height };
-        this.mainWindow.window
-          .capturePage(rect)
-          .then((image) => {
-            const buffer: Buffer = image.toJPEG(100);;
-            clipboard.writeBuffer('jpeg', buffer);
-          })
-          .catch((error) => {
-            logger().logError(error);
-          });
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (focusedWindow?.webContents) {
+          focusedWindow.webContents.copyImageAt(x + width, y + height);
+        } else {
+          logger().logError("Failed to copy page region to clipboard");
+        }
       },
     );
 

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -293,6 +293,13 @@ export function getDesktopBridge() {
         .catch((error) => reportIpcError('desktop_copy_page_region_to_clipboard', error));
     },
 
+    copyImageAtXYToClipboard: (x: number, y: number, callback: () => void) => {
+      ipcRenderer
+        .invoke('desktop_copy_image_at_xy_to_clipboard', x, y, width, height)
+        .then(() => callback())
+        .catch((error) => reportIpcError('desktop_copy_image_at_xy_to_clipboard', error));
+    },
+
     exportPageRegionToFile: (
       targetPath: string,
       format: string,

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -295,7 +295,7 @@ export function getDesktopBridge() {
 
     copyImageAtXYToClipboard: (x: number, y: number, callback: () => void) => {
       ipcRenderer
-        .invoke('desktop_copy_image_at_xy_to_clipboard', x, y, width, height)
+        .invoke('desktop_copy_image_at_xy_to_clipboard', x, y)
         .then(() => callback())
         .catch((error) => reportIpcError('desktop_copy_image_at_xy_to_clipboard', error));
     },


### PR DESCRIPTION
### Intent

Addresses #12466. Avoids the "shifted" screen capture when copying a plot to the clipboard using `Export > Copy to Clipboard... > Copy Plot (Bitmap)` from the `Plots` pane. Note that this only seems to occur on Windows.

<details>
    <summary>sample images before/after</summary>

#### before this PR
![image](https://user-images.githubusercontent.com/25834218/220409695-338c1db7-10c1-4df0-8c7e-6d62f4e0fd5b.png)
- some parts of the RStudio UI are getting captured and the some of the plot is missing

#### after this PR
![image](https://user-images.githubusercontent.com/25834218/220409875-cbf70d6e-5f41-4e93-9a7f-4e08a5fddd17.png)
- only the plot is captured and no parts of the plot are missing

</details>

As a note, I was running into [this issue](https://github.com/rstudio/rstudio/issues/11739) when debugging and building this fix.

### Approach

Instead of drawing a rectangle around the plot image and using a page capture method to "screenshot" the plot and copy it to the clipboard, this PR uses Electron's `webContents.copyImageAt()`, which locates the `img` element at the provided `x` and `y` coordinates, and copies it to the clipboard ([electron documentation](https://www.electronjs.org/docs/latest/api/web-contents#contentscopyimageatx-y)).

This PR does not address the existing plot scale/resolution/etc issues https://github.com/rstudio/rstudio/issues?q=is:issue+is:open+label:plots.

This PR does not change how tables are copied to clipboard from the Viewer pane.

### Automated Tests
N/A

### QA Notes

- this fix should only affect Electron and non-Mac builds
- copying a table to clipboard from the Viewer pane should be unaffected
- test with different zoom levels (`View > Zoom In`, `View > Actual Size`, `View > Zoom Out`)
    - note that there are existing issues with the plot image in the copy image dialog having different sizing/resolution than the original plot in the Plot pane (https://github.com/rstudio/rstudio/issues?q=is:issue+is:open+label:plots)

#### Suggested test steps
1. Use one of: `View > Zoom In`, `View > Actual Size`, `View > Zoom Out`
2. In R console, `plot(iris)`
3. In Plots pane, `Export > Copy to Clipboard... > Copy Plot (Bitmap)`
4. Paste the image somewhere (google docs, microsoft word, etc) and confirm the entire plot and only the plot is captured in the image

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


