### PR TITLE
Switch visual editor to cherry blossom branch

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -32,12 +32,14 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
 else
   echo "quarto repo already cloned in '$QUARTO_DIR'"
 
   pushd $QUARTO_DIR
+  git fetch
   git reset --hard && git clean -dfx
+  git checkout release/rstudio-cherry-blossom
   git pull
   popd
 fi

--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -32,6 +32,7 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
+  #git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
 else
   echo "quarto repo already cloned in '$QUARTO_DIR'"


### PR DESCRIPTION
### Intent
The visual editor dependency has a `release/rstudio-cherry-blossom` branch now (https://github.com/quarto-dev/quarto/commits/release/rstudio-cherry-blossom). This will only get bug fixes from `main`.

### Approach
Update dependency installer scripts to checkout the `release/rstudio-cherry-blossom` branch or switch to it if the repository has already been cloned.

### Automated Tests
n/a

### QA Notes
This pulls commits from the branch link above. There may be changes from `quarto-dev/quarto` `main` that won't be included since the last build because the `main` branch has already diverged.

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


