### PR TITLE
not triggering active binding on completion

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -69,6 +69,7 @@ assign(x = ".rs.acCompletionTypes",
           R6_OBJECT   = 28, 
           DATATABLE_SPECIAL_SYMBOL = 29,
           SECUNDARY_ARGUMENT       = 30,
+          ACTIVE_BINDING = 31,
 
           CONTEXT     = 99
        )
@@ -2023,8 +2024,14 @@ assign(x = ".rs.acCompletionTypes",
       if (packages[[i]] == "")
          return(.rs.acCompletionTypes$UNKNOWN)
       
+      name <- results[[i]]
+      env <- as.environment(packages[[i]])
+
+      if (bindingIsActive(name, env))
+         return(.rs.acCompletionTypes$ACTIVE_BINDING)
+
       object <- tryCatch(
-         get(results[[i]], packages[[i]]),
+         get(name, envir = env),
          error = identity
       )
       

--- a/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/codetools/RCompletionType.java
@@ -49,6 +49,7 @@ public class RCompletionType
    public static final int R6_OBJECT   = 28;
    public static final int DATATABLE_SPECIAL_SYMBOL = 29;
    public static final int SECUNDARY_ARGUMENT = 30;
+   public static final int ACTIVE_BINDING = 31;
    
    public static final int SNIPPET     = 98;
    public static final int CONTEXT     = 99;


### PR DESCRIPTION
### Intent

addresses (partially maybe) #4414
 
### Approach

`.rs.getCompletionsSearchPath()`  check if a binding is active before calling `get()`. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


