### PR TITLE
Fix version stamping and rproj icon for Windows

### DIFF
--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -35,15 +35,38 @@ if "%1" == "/?" goto :showhelp
 SETLOCAL ENABLEDELAYEDEXPANSION
 for %%A in (%*) do (
       set KNOWN_ARG=0
-      if /I "%%A" == "clean" set CLEANBUILD=1 && set KNOWN_ARG=1
-      if /I "%%A" == "debug" set DEBUG_BUILD=1 && set KNOWN_ARG=1
-      if /I "%%A" == "desktop" set RSTUDIO_TARGET=Desktop && set KNOWN_ARG=1
-      if /I "%%A" == "electron" set RSTUDIO_TARGET=Electron && set KNOWN_ARG=1
-      if /I "%%A" == "multiarch" set MULTIARCH=1 && set KNOWN_ARG=1
-      if /I "%%A" == "nogwt" set BUILD_GWT=0 && set KNOWN_ARG=1
-      if /I "%%A" == "nozip" set NOZIP=1 && set KNOWN_ARG=1
-      if /I "%%A" == "quick" set QUICK=1 && set KNOWN_ARG=1
-
+      if /I "%%A" == "clean" (
+            set CLEANBUILD=1
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "debug" (
+            set DEBUG_BUILD=1
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "desktop" (
+            set RSTUDIO_TARGET=Desktop
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "electron" (
+            set RSTUDIO_TARGET=Electron
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "multiarch" (
+            set MULTIARCH=1
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "nogwt" (
+            set BUILD_GWT=0
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "nozip" (
+            set NOZIP=1
+            set KNOWN_ARG=1
+      )
+      if /I "%%A" == "quick" (
+            set QUICK=1
+            set KNOWN_ARG=1
+      )
       if "!KNOWN_ARG!" == "0" goto :showhelp
 )
 
@@ -227,6 +250,16 @@ echo     multiarch:  produce both 32-bit and 64-bit rsession executables
 echo     nogwt:      skip GWT build (use previous GWT build)
 echo     nozip:      skip creation of ZIP file
 echo     quick:      skip creation of setup package
+echo.
+echo     Environment variables specify the product's build version (default is 99.9.9).
+echo.
+echo     Example:
+echo.
+echo     set RSTUDIO_VERSION_MAJOR=2023
+echo     set RSTUDIO_VERSION_MINOR=8
+echo     set RSTUDIO_VERSION_PATCH=1
+echo     set RSTUDIO_VERSION_SUFFIX=-daily+321
+echo     make-package clean electron
 echo.
 exit /b 0
 


### PR DESCRIPTION
### Intent

Addresses #12684 

Unintentionally introduced a space at the end of "Electron " in the Windows make-package batch file, which caused comparisons to "Electron" to fail, thus electron-specific build steps weren't happening.

As a result the build version wasn't being stamped into the Electron app and `rstudio --version` would return 99.9.9.

It also failed to embed the .rproj icon.

### Approach

Tweaked the batch file to fix this, also added a bit of documentation on setting version environment vars to the `make-package --help` output.

### Automated Tests

None

### QA Notes

Verify that running rstudio.exe --version shows the version number (and not 99.9.9), and that .rproj icons are back again in Windows Explorer.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


