### PR TITLE
Fix mangled Choose R dialog when UI is in French

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - Fixed link opens in browser after Render with qml file when hypothes.is comments are turned on in `_quarto.yml` #12413
 - Fixed incorrect icons displayed in the sessions drop-down menu in RStudio Pro (rstudio-pro #4257)
 - Fixed Copy Plot to Clipboard - pasting bitfile option not working correctly in latest build #12466
+- Fixed display problems with Choose R dialog when UI language is French #12717
 
 ### Accessibility Improvements
 

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -25,9 +25,9 @@ export abstract class ModalDialog<T> extends BrowserWindow {
 
   constructor(url: string, preload: string, parentWindow: BrowserWindow | null = null) {
     let options: BrowserWindowConstructorOptions = {
-      minWidth: 400,
+      minWidth: 450,
       minHeight: 400,
-      width: 400,
+      width: 450,
       height: 400,
       show: false,
       webPreferences: {

--- a/src/node/desktop/src/ui/widgets/choose-r/ui.html
+++ b/src/node/desktop/src/ui/widgets/choose-r/ui.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="UTF-8">
     <title data-i18n="documentTitle"></title>
   </head>
 


### PR DESCRIPTION
### Intent

Addresses  #12717

The Choose R dialog, when UI is in French, was mangled because the page wasn't set to UTF-8, thus it was treating accented characters incorrectly. There is also a layout issue due to the French text being longer than the English text.

### Approach

Set the charset of the page to utf-8. Slightly increase the width of the dialog to prevent text wrapping in French.

### Automated Tests

None

### QA Notes

Dialog should now display correctly in French:

Before:

![screenshot of Choose R dialog in French with mangled text highlighted](https://user-images.githubusercontent.com/10569626/221300376-6081c842-5114-4ee6-8fa1-e1bd894b2502.png)

After:
![screenshot of Choose R dialog in French with fixes](https://user-images.githubusercontent.com/10569626/221313536-8724e938-e5bd-488a-bfc4-8897164c880b.png)

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


