### PR TITLE
add missing headers for gcc13

### DIFF
--- a/src/cpp/core/include/core/Thread.hpp
+++ b/src/cpp/core/include/core/Thread.hpp
@@ -17,6 +17,7 @@
 #define CORE_THREAD_HPP
 
 #include <queue>
+#include <set>
 
 #include <boost/utility.hpp>
 #include <boost/function.hpp>

--- a/src/cpp/shared_core/include/shared_core/system/Crypto.hpp
+++ b/src/cpp/shared_core/include/shared_core/system/Crypto.hpp
@@ -32,6 +32,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace rstudio {
 namespace core {


### PR DESCRIPTION
### Intent

RStudio fails to build with gcc13 due to a couple of missing headers from the STL.

### Approach

Here I add them as suggested by gcc's own error messages. One is for uint types, the other is for sets.

### Automated Tests

No additional tests.

### QA Notes

The change is simple enough. No risks identified.

### Documentation

No additional docs.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


