### PR TITLE
Use latest quarto and visual editor

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -32,15 +32,16 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  #git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
 else
   echo "quarto repo already cloned in '$QUARTO_DIR'"
 
   pushd $QUARTO_DIR
-  git fetch
+  # git fetch
   git reset --hard && git clean -dfx
-  git checkout release/rstudio-cherry-blossom
+  git checkout main
+  # git checkout release/rstudio-cherry-blossom
   git pull
   popd
 fi

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -30,6 +30,7 @@ fi
 # QUARTO_VERSION="1.2.335"
 
 # update to latest Quarto release
+# QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 QUARTO_VERSION=`curl https://quarto.org/docs/download/_prerelease.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 
 QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -27,13 +27,13 @@ fi
 
 # variables that control download + installation process
 # specify a version to pin for releases
-QUARTO_VERSION="1.2.335"
+# QUARTO_VERSION="1.2.335"
 
 # update to latest Quarto release
-# QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
+QUARTO_VERSION=`curl https://quarto.org/docs/download/_prerelease.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 
-#QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
-QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
+QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
+# QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
 
 QUARTO_SUBDIR="quarto"
 

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -44,12 +44,12 @@ set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
 REM Pin to specific Quarto version for releases
-set QUARTO_VERSION=1.2.335
+REM set QUARTO_VERSION=1.2.335
 
 REM Get latest Quarto release version
-REM cd install-quarto
-REM for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
-REM cd ..
+cd install-quarto
+for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
+cd ..
 
 set QUARTO_FILE=quarto-%QUARTO_VERSION%-win.zip
 

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -5,12 +5,15 @@ pushd ..\..\..\src\gwt\lib
 if not exist quarto (
   echo "Cloning quarto repo"
   git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
 ) else (
   echo "quarto repo already cloned"
 
   pushd quarto
   git reset --hard
   git clean -dfx
+  git checkout main
+  REM git checkout release/rstudio-cherry-blossom
   git pull
   popd
 )

--- a/dependencies/windows/install-quarto/get-quarto-version.ps1
+++ b/dependencies/windows/install-quarto/get-quarto-version.ps1
@@ -1,6 +1,6 @@
 # Retrieve latest Quarto version from GitHub
 
-$response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_download.json
+$response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_prerelease.json
 $releases = ConvertFrom-Json $response.content
 $version = $releases.version
 $quartoVersion = $version | Select-String -Pattern '[0-9]+\.[0-9]+\.[0-9]+'

--- a/dependencies/windows/install-quarto/get-quarto-version.ps1
+++ b/dependencies/windows/install-quarto/get-quarto-version.ps1
@@ -1,5 +1,6 @@
 # Retrieve latest Quarto version from GitHub
 
+# $response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_download.json
 $response = Invoke-WebRequest -UseBasicParsing -Uri https://quarto.org/docs/download/_prerelease.json
 $releases = ConvertFrom-Json $response.content
 $version = $releases.version


### PR DESCRIPTION
### Intent
Move back to using the 1.3 pre-release for Quarto and the `main` branch for the visual editor. 1.3 should be ready by April.

### Approach
Modify dependency scripts to use pre-release and `main`. The visual editor script does a checkout of `main` now to handle being on another branch.

### Automated Tests
None

### QA Notes
None

### Documentation
We can update the README with the Quarto version when the version is pinned for the Mountain Hydrangea release.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


