### PR TITLE
Updates to Linux Pipeline

### DIFF
--- a/Jenkinsfile.pull-request
+++ b/Jenkinsfile.pull-request
@@ -2,7 +2,7 @@ def utils
 
 pipeline {
   agent {
-    label 'linux && amd64'
+    label 'linux && x86_64'
   }
 
   options {
@@ -14,7 +14,7 @@ pipeline {
   environment {
         GITHUB_LOGIN = credentials('github-rstudio-jenkins')
         OS = 'jammy'
-        ARCH = 'amd64'
+        ARCH = 'x86_64'
         FLAVOR = 'server'
         TYPE = 'DEB'
         AWS_ACCOUNT_ID = '749683154838'

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -172,7 +172,7 @@ pipeline {
           exclude {
             axis {
               name 'OS'
-              values 'centos7', 'opensuse15'
+              values 'bionic', 'centos7', 'rhel8', 'opensuse15'
             }
             axis {
               name 'ARCH'
@@ -198,7 +198,6 @@ pipeline {
                 image "jenkins/ide:${IS_PRO? 'pro-' : '' }${OS}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
                 registryCredentialsId 'ecr:us-east-1:aws-build-role'
                 registryUrl 'https://263245908434.dkr.ecr.us-east-1.amazonaws.com'
-                reuseNode true
                 label "${getAgentLabel(ARCH)}"
               }
             }
@@ -355,6 +354,11 @@ pipeline {
                     }
                   }
                 }
+              }
+            }
+            post {
+              always {
+                deleteDir()
               }
             }
           }

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -115,7 +115,7 @@ pipeline {
           exclude {
             axis {
               name 'os'
-              values 'centos7', 'windows', 'opensuse15'
+              values 'bionic', 'centos7', 'rhel8', 'windows', 'opensuse15'
             }
             axis {
               name 'arch'


### PR DESCRIPTION
This change contains a variety of updates for the Linux pipeline. 

I've added `deleteDir` as a post step to the agents that actually do the building. I think the last post step with `deleteDir` will only clean up the workspace on the top-level agent. 

I removed `reuseNode true` from the docker block since we are actually grabbing the linux agent for the matrix build and running within docker from the same step. 

I've also added `bionic` and `rhel8` to the `arm64` exclude list, which should fix the license-manager activation linker errors on the pro pipeline. The old pipeline didn't produce `bionic` and `rhel8` `arm64` builds.