### PR TITLE
Fixes to Help Pane keyboard focus behaviour

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,12 +1,20 @@
+
 ## RStudio 2023.05.0 "Mountain Hydrangea" Release Notes
 
 ### New
--
+
+#### RStudio IDE
+- 
+
+#### Posit Workbench
+- 
 
 ### Fixed
+
+#### RStudio IDE
 - Fixed display problems with Choose R dialog when UI language is French #12717
--
+- Fixed focus switching to Help Pane search box after executing ? in the console [Accessibility] #12741
+- Fixed initial focus placement in Help Pane [Accessibility] #10600
 
-### Accessibility Improvements
+#### Posit Workbench
 -
-

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -223,13 +223,15 @@ public class HelpPane extends WorkbenchPane
          return;
 
       windowEl.setScrollPosition(scrollPos_);
-      setFocus();
    }
 
+   /**
+    * Invoked when switching panes via F6 / Shift+F6
+    */
    @Override
    public void setFocus()
    {
-      focusSearchHelp();
+      focus();
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses #12741, #10600.

I also adjusted the NEWS.md structure to match what we did for Cherry Blossom.

### Approach

When entering the Help pane via <kbd>Ctrl+3</kbd> ("Show Help Pane"), <kbd>F6</kbd> ("Focus Next Pane") or <kbd>Shift+F6</kbd> ("Focus Previous Pane"), place keyboard focus on the help content instead of the search box. This allows immediate scrolling of the content via the keyboard instead of hitting the tab key several times first.

When showing help from the Console (e.g. `?length`) keep the focus on the Console. This is how it used to behave (several versions ago).

More details:

* Removed the call to `setFocus()` from the end of HelpPane's `onSelected()` because it was causing the undesired focus switch when using `?foo` from the console. Having this call was unnecessary because the focus was already set via a call to `HelpPane::focus()` when using the Ctrl+3 command.
* Changed `setFocus()` to place it on the help content instead of the search box; this gets called when switching panes via F6 and Shift+F6.


### Automated Tests

None

### QA Notes

When invoking the Help pane via the keyboard shortcuts mentioned above, verify the help content gets focused, not the Search box.

When showing help from the Console via `?topic`, verify that keyboard focus remains in the console. Try doing this after scrolling the existing help content, as that triggered the undesired behaviour.

NOTE: The Help content iframe doesn't show a focus indicator so to confirm keyboard focus location:

* hit Tab to select the first focusable element (e.g. link) in the Help content, OR
* hit the down arrow key and see if help content scrolls (assuming it needs to scroll)

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


