### PR TITLE
Fix find in files with older versions of git

### DIFF
--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1475,8 +1475,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << "-c" << "grep.patternType=default";
       cmd << "-c" << "grep.extendedRegexp=true";
       cmd << "-c" << "grep.fullName=false";
-      cmd << "-C";
-      cmd << dirPath.getAbsolutePath();
       cmd << "grep";
       cmd << "-I"; // ignore binaries
       cmd << "--untracked"; // include files not tracked by git...

--- a/version/news/NEWS-2023.03.0-cherry-blossom.md
+++ b/version/news/NEWS-2023.03.0-cherry-blossom.md
@@ -54,6 +54,7 @@
 - Fixed previewing rendered html_document causes URLs to open in browser #12494
 - Fixed link opens in browser after Render with qml file when hypothes.is comments are turned on in `_quarto.yml` #12413
 - Fixed Copy Plot to Clipboard - pasting bitfile option not working correctly in latest build #12466
+- Fixed Find in Files with git projects and older version of git #11822
 
 #### Posit Workbench
 - Fixed intermittent hanging logins in Workbench using ActiveDirectory (rstudio-pro #4285)


### PR DESCRIPTION
### Intent

Addresses #11822 

Fix find in files when using older versions of git. 

### Approach

Remove passing the `-C` argument to the `grep` command since we're already running the command from the working directory. See https://github.com/rstudio/rstudio/issues/11822#issuecomment-1452650385

### Automated Tests

I ran the existing unit tests and they continue to pass. 

### QA Notes

This was broken on CentOS7 which has an older system version of git. It only affects git projects that have the "Exclude files matched by .gitignore" selection checked in the Find in Files pane:
![image](https://user-images.githubusercontent.com/5323711/223231826-9d8f2c77-d7c7-4b62-85b7-6ac81b06b986.png)
Functionality should continue to work as expected with Find In Files and newer versions of git.

### Documentation
N/A - bugfix

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


