### PR TITLE
Update Pro linux hourly subset build filter

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -30,9 +30,10 @@ def shouldBuild(boolean isDaily, boolean isPro) {
   def inHourlySubset = true
   if (!isDaily) {
     if (isPro) {
-      // build an x86_64 rhel8 WB and an arm64 jammy RDP
+      // build an x86_64 rhel8 WB, an x86_64 jammy RDP (Qt), and an arm64 jammy RDP (Electron)
       inHourlySubset = ((env.OS == 'rhel8' && env.ARCH == 'x86_64' && env.FLAVOR == 'Server') ||
-        (env.OS == 'jammy' && env.ARCH == 'arm64' && env.FLAVOR == 'Desktop'))
+        (env.OS == 'jammy' && env.ARCH == 'x86_64' && env.FLAVOR == 'Desktop')) ||
+        (env.OS == 'jammy' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron')
     } else {
       // build an arm64 rhel9 Desktop and an x86_64 bionic Server
       inHourlySubset = ((env.OS == 'rhel9' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron') ||


### PR DESCRIPTION
Update the hourly subset filter for pro linux builds.

The build matrix does not build `jammy` on `arm64`, so update to `x86_64`. Also, add an `arm64` `Electron` build on `jammy`, so that we at least have 1 build on `arm64`.