### PR TITLE
Add QA Automation build trigger for open source linux builds

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -376,6 +376,35 @@ pipeline {
         }
       }
     }
+
+    stage('Trigger Automation Testing') {
+      agent { label 'linux' }
+
+      // Skip for hourly builds, non-published builds, and branches that don't 
+      // have corresponding automation branches
+      when {
+        allOf {
+          expression { return params.DAILY }
+          expression { return params.PUBLISH }
+          expression { return env.BRANCH_NAME != "release-ghost-orchid" }
+          expression { return env.BRANCH_NAME != "v1.4-juliet-rose" }
+        }
+      }
+
+      steps {
+        build wait: false,
+          job: "IDE/qa-opensource-automation",
+          parameters: [
+            string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}")
+            string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}")
+            string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}")
+            string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}")
+            string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}")
+            string(name: 'GIT_REVISION', value: "${params.COMMIT_HASH}")
+            string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
+          ]
+      }
+    }
   }
 
   post {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -393,7 +393,7 @@ pipeline {
 
       steps {
         build wait: false,
-          job: "IDE/qa-opensource-automation",
+          job: "IDE/qa-${IS_PRO ? '' : 'opensource-'}automation",
           parameters: [
             string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}")
             string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}")


### PR DESCRIPTION
### Intent

Add a build trigger for the QA Open Source Automation job after a linux build has finished

### Approach

The QA job _won't_ be triggered for the following linux builds:

- Hourly Builds
- Builds that aren't published
- Builds on the `v1.4-juliet-rose` or `release-ghost-orchid` branches, because they don't have corresponding branches on the QA repo

### Automated Tests

N/A, build change to launcher automated tests

### QA Notes

N/A build change

### Documentation

N/A build change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


