### PR TITLE
Jenkins trigger qa automation

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -282,7 +282,7 @@ pipeline {
                   TAR_PACKAGE_DIR= "${PACKAGE_DIR}/_CPack_Packages/Linux/${ext_map[env.OS].toUpperCase()}"
                   TAR_PACKAGE_FILE = "${renameTarFile(TAR_PACKAGE_DIR)}"
                   BUILD_TYPE = "sh(script: 'cat version/BUILDTYPE', returnStdout: true).trim().toLowerCase()"
-                  AWS_PATH = "${PRODUCT}/${OS}/${utils.getArchForOs(env.OS, env.ARCH)}"
+                  AWS_PATH = "${PRODUCT}/${OS}/${utils.getArchForOs(OS, ARCH)}"
                 }
 
                 stages {
@@ -332,14 +332,14 @@ pipeline {
                   stage("Publish") {
                     environment {
                       GITHUB_LOGIN = credentials('github-rstudio-jenkins')
-                      DAILIES_PATH = "${PRODUCT}/${OS}-${utils.getArchForOs(env.OS, env.ARCH)}"
+                      DAILIES_PATH = "${PRODUCT}/${OS}-${utils.getArchForOs(OS, ARCH)}"
                     }
 
                     steps {
                       dir("${PACKAGE_DIR}") {
                         script {
                           // publish build to dailies page
-                          utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH
+                          utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
                         }
                       }
                     }

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -376,6 +376,35 @@ pipeline {
         }
       }
     }
+
+    stage('Trigger Automation Testing') {
+      agent { label 'linux' }
+
+      // Skip for hourly builds, non-published builds, and branches that don't 
+      // have corresponding automation branches
+      when {
+        allOf {
+          expression { return params.DAILY }
+          expression { return params.PUBLISH }
+          expression { return env.BRANCH_NAME != "release-ghost-orchid" }
+          expression { return env.BRANCH_NAME != "v1.4-juliet-rose" }
+        }
+      }
+
+      steps {
+        build wait: false,
+          job: "IDE/qa-opensource-automation",
+          parameters: [
+            string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}")
+            string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}")
+            string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}")
+            string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}")
+            string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}")
+            string(name: 'GIT_REVISION', value: "${params.COMMIT_HASH}")
+            string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
+          ]
+      }
+    }
   }
 
   post {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -395,12 +395,12 @@ pipeline {
         build wait: false,
           job: "IDE/qa-${IS_PRO ? '' : 'opensource-'}automation",
           parameters: [
-            string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}")
-            string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}")
-            string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}")
-            string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}")
-            string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}")
-            string(name: 'GIT_REVISION', value: "${params.COMMIT_HASH}")
+            string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}"),
+            string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}"),
+            string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}"),
+            string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}"),
+            string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}"),
+            string(name: 'GIT_REVISION', value: "${params.COMMIT_HASH}"),
             string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
           ]
       }

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -393,7 +393,7 @@ pipeline {
 
       steps {
         build wait: false,
-          job: "IDE/qa-opensource-automation",
+          job: "IDE/qa-${IS_PRO ? '' : 'opensource-'}automation",
           parameters: [
             string(name: 'RSTUDIO_VERSION_MAJOR', value: "${RSTUDIO_VERSION_MAJOR}")
             string(name: 'RSTUDIO_VERSION_MINOR', value: "${RSTUDIO_VERSION_MINOR}")

--- a/utils.groovy
+++ b/utils.groovy
@@ -113,10 +113,14 @@ def sentryUpload(String symbolType) {
   * Publish a build to the dailies site.
   * Does not work on windows.
   */
-def publishToDailiesSite(String packageFile, String destinationPath) {
+def publishToDailiesSite(String packageFile, String destinationPath, String urlPath = '') {
   def channel = ''
   if (!params.DAILY) {
     channel = ' --channel Hourly'
+  }
+  if (urlPath == '')
+  {
+    urlPath = destinationPath
   }
 
   sh '${WORKSPACE}/docker/jenkins/publish-build.sh --pat ${GITHUB_LOGIN_PSW} ' +
@@ -126,7 +130,7 @@ def publishToDailiesSite(String packageFile, String destinationPath) {
     ' --build ' +
     destinationPath +
     ' --url https://s3.amazonaws.com/rstudio-ide-build/' +
-    destinationPath +
+    urlPath +
     '/' +
     packageFile +
     ' --file ' +
@@ -135,11 +139,16 @@ def publishToDailiesSite(String packageFile, String destinationPath) {
 
 /** 
   * Convert an architecture to the operating specific version of that arch.
-  * x86_64 -> amd64 on Debian
+  * amd64  -> x86_64 on non-Debian
+  * x86_64 -> amd64  on Debian
   */
 def getArchForOs(String os, String arch) {
   if ((arch == "amd64") && (os != "bionic") && (os != "jammy")) {
     return "x86_64"
+  }
+
+  if ((arch == "x86_64") && ((os == "bionic") || (os == "jammy"))) {
+    return "amd64"
   }
 
   if (arch == "aarch64") {


### PR DESCRIPTION
### Intent

Add a build trigger for the QA Open Source Automation job after a linux build has finished
Tweak uploads to be consistent with the paths we use

Successful OpenSource build (this one only built `bionic` to speed up the build. previous full builds were also successful): https://build.posit.it/blue/organizations/jenkins/IDE%2FOS-Builds%2FPlatforms%2Flinux-pipeline/detail/jenkins-trigger-qa-automation/8/pipeline/1574/
Successful QA Build: https://build.posit.it/blue/organizations/jenkins/IDE%2Fqa-opensource-automation/detail/qa-opensource-automation/1779/pipeline

### Approach

The QA job _won't_ be triggered for the following linux builds:

- Hourly Builds
- Builds that aren't published
- Builds on the `v1.4-juliet-rose` or `release-ghost-orchid` branches, because they don't have corresponding branches on the QA repo

### Automated Tests

N/A, build change to launcher automated tests

### QA Notes

N/A build change

### Documentation

N/A build change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->

