### PR TITLE
Add timeout option to builds

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -195,10 +195,10 @@ pipeline {
         stages {
           stage ('Build, Test and Upload'){
 
-            // If nothing appears in logs for 30 minutes then we should timeout
+            // Timeout after no activity in the logs
             // Placing timeout here so only this OS/ARCH/FLAVOR build will timeout
             options {
-              timeout(time: 30, unit: 'MINUTES', activity: true)
+              timeout(time: 2, unit: 'HOURS', activity: true)
             }
 
             agent {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -194,6 +194,13 @@ pipeline {
 
         stages {
           stage ('Build, Test and Upload'){
+
+            // If nothing appears in logs for 30 minutes then we should timeout
+            // Placing timeout here so only this OS/ARCH/FLAVOR build will timeout
+            options {
+              timeout(time: 30, unit: 'MINUTES', activity: true)
+            }
+
             agent {
               docker {
                 image "jenkins/ide:${IS_PRO? 'pro-' : '' }${OS}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -2,9 +2,9 @@ def utils
 
 pipeline {
 
-  // If nothing appears in logs for 30 minutes then we should timeout
+  // Timeout after no activity in the logs
   options {
-    timeout(time: 30, unit: 'MINUTES', activity: true)
+    timeout(time: 2, unit: 'HOURS', activity: true)
   }
 
   agent { label 'macos-v1.4-arm64' }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -2,6 +2,11 @@ def utils
 
 pipeline {
 
+  // If nothing appears in logs for 30 minutes then we should timeout
+  options {
+    timeout(time: 30, unit: 'MINUTES', activity: true)
+  }
+
   agent { label 'macos-v1.4-arm64' }
 
   options {

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -14,8 +14,8 @@ pipeline {
         numToKeepStr: '100'
       )
     )
-    // If nothing appears in logs for 30 minutes then we should timeout
-    timeout(time: 30, unit: 'MINUTES', activity: true)
+    // Timeout after no activity in the logs
+    timeout(time: 2, unit: 'HOURS', activity: true)
   }
 
   parameters {

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -14,6 +14,8 @@ pipeline {
         numToKeepStr: '100'
       )
     )
+    // If nothing appears in logs for 30 minutes then we should timeout
+    timeout(time: 30, unit: 'MINUTES', activity: true)
   }
 
   parameters {


### PR DESCRIPTION
### Intent

Edit: timeout changed to 2 hours after feedback

[This build](https://build.posit.it/blue/organizations/jenkins/IDE%2FPro-Builds%2FPlatforms%2Flinux-pipeline/detail/epic-4140-jenkinsfile-restructure/38/pipeline/1468/) sat "in the queue" for 3 days before I noticed it. That absolutely should not happen. 

Rather than cap the build time at some high number (3-5 hours), we can opt to have builds timeout after not making any progress (no changes to a build's logs). I think 30 minutes seems a reasonable amount of time of inactivity to be confident that a build is stuck

### Approach

Adds a `timeout` block to the Windows/Mac/Linux Jenkinsfiles. I _think_ that adding the timeout inside individual matrix builds in the Linux builds will only timeout that particular OS/ARCH/FLAVOR combination, rather than fail the whole build, which could be useful. If not we can put it over the whole pipeline like in Windows/MacOS

```
  // If nothing appears in logs for 30 minutes then we should timeout
  options {
    timeout(time: 30, unit: 'MINUTES', activity: true)
  }
```

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


