### PR TITLE
move help font size setting to appearance pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 #### RStudio IDE
 - Updated to Electron 23.1.2 (#12785)
+- Moved Help panel font size setting to Appearance tab in Global Options (#12816)
 
 #### Posit Workbench
 - 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -227,6 +227,14 @@ public class AppearancePreferencesPane extends PreferencesPane
          }
       });
       
+      helpFontSize_ = new SelectWidget(constants_.helpFontSizeLabel(),
+                                       labels,
+                                       values,
+                                       false); /* Multi select */
+      helpFontSize_.getListBox().setWidth("95%");
+      if (!helpFontSize_.setValue(userPrefs.helpFontSizePoints().getValue() + ""))
+         helpFontSize_.getListBox().setSelectedIndex(3);
+
       textRendering_ = new SelectWidget(
             constants_.textRenderingLabel(),
             new String[] {
@@ -317,6 +325,7 @@ public class AppearancePreferencesPane extends PreferencesPane
 
       leftPanel.add(textRendering_);
       leftPanel.add(fontSize_);
+      leftPanel.add(helpFontSize_);
       leftPanel.add(theme_);
       leftPanel.add(buttonPanel);
 
@@ -634,6 +643,11 @@ public class AppearancePreferencesPane extends PreferencesPane
    public RestartRequirement onApply(UserPrefs rPrefs)
    {
       RestartRequirement restartRequirement = super.onApply(rPrefs);
+
+      {
+         double helpFontSize = Double.parseDouble(helpFontSize_.getValue());
+         userPrefs_.helpFontSizePoints().setGlobalValue(helpFontSize);
+      }
 
       if (relaunchRequired_)
          restartRequirement.setUiReloadRequired(true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -362,16 +362,6 @@ public class GeneralPreferencesPane extends PreferencesPane
       for (int i = 0; i < labels.length; i++)
          values[i] = Double.parseDouble(labels[i]) + "";
 
-      helpFontSize_ = new SelectWidget(constants_.helpFontSizeLabel(),
-                                       labels,
-                                       values,
-                                       false, /* Multi select */
-                                       true, /* Horizontal label */
-                                       false /* List on left */);
-      if (!helpFontSize_.setValue(prefs_.helpFontSizePoints().getValue() + ""))
-         helpFontSize_.getListBox().setSelectedIndex(3);
-      advanced.add(helpFontSize_);
-
       Label experimentalLabel = headerLabel(constants_.experimentalLabel());
       spacedBefore(experimentalLabel);
       advanced.add(experimentalLabel);
@@ -509,11 +499,6 @@ public class GeneralPreferencesPane extends PreferencesPane
    public RestartRequirement onApply(UserPrefs prefs)
    {
       RestartRequirement restartRequirement = super.onApply(prefs);
-
-      {
-         double helpFontSize = Double.parseDouble(helpFontSize_.getValue());
-         prefs.helpFontSizePoints().setGlobalValue(helpFontSize);
-      }
 
       if (clipboardMonitoring_ != null &&
           desktopMonitoring_ != clipboardMonitoring_.getValue())
@@ -713,7 +698,6 @@ public class GeneralPreferencesPane extends PreferencesPane
    private RVersionSelectWidget rServerRVersion_ = null;
    private CheckBox rememberRVersionForProjects_ = null;
    private CheckBox reuseSessionsForProjectLinks_ = null;
-   private SelectWidget helpFontSize_;
    private SelectWidget uiLanguage_;
    private CheckBox clipboardMonitoring_ = null;
    private CheckBox fullPathInTitle_ = null;


### PR DESCRIPTION
### Intent

Addresses [Font size for help pane is misplaced in settings #12816](https://github.com/rstudio/rstudio/issues/12816)

### Approach

Moved the setting where it belongs. Essentially cut and pasted code from one place to another; should be very low risk ("never say that out loud").

I _suspect_ it was added to General / Advanced because at the time the Global Options dialog was shorter, and the Appearances pane didn't have sufficient vertical space.

The Options dialog has since been made taller, and now has room for this control.

<img width="615" alt="Screenshot of global options appearance pane showing moved setting" src="https://user-images.githubusercontent.com/10569626/224434458-cfff5717-84af-4ae2-a084-2dfaa41e2a2f.png">

### Automated Tests

None; I did run existing gwt unit tests.

### QA Notes

Verify that the setting functions correctly in the new location.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


