### PR TITLE
Accessibility fixes to Console region

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 - Fixed display problems with Choose R dialog when UI language is French (#12717)
 - Fixed focus switching to Help Pane search box after executing ? in the console [Accessibility] (#12741)
 - Fixed initial focus placement in Help Pane [Accessibility] (#10600)
+- Fixed invalid element role on session-suspended icon [Accessibility] (#12449)
+- Improve screen-reader support for Console pane toolbar [Accessibility] (#12825)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
+++ b/src/gwt/src/org/rstudio/core/client/theme/PrimaryWindowFrame.java
@@ -75,7 +75,7 @@ public class PrimaryWindowFrame extends WindowFrame
          }
       });
       
-      separator_ = new HTML("&centerdot;");
+      separator_ = new HTML("<span aria-hidden=\"true\">&centerdot;</span>");
       separator_.addStyleName(ThemeStyles.INSTANCE.toolbarDotSeparator());
 
       subtitle_ = new Label();
@@ -97,9 +97,19 @@ public class PrimaryWindowFrame extends WindowFrame
       panel_.insert(title_, 0);
    }
 
+   public Widget getTitleWidget()
+   {
+      return title_;
+   }
+
    public void setSubtitle(String subtitle)
    {
       subtitle_.setText(subtitle);
+   }
+
+   public Widget getSubtitleWidget()
+   {
+      return subtitle_;
    }
 
    public void addLeftWidget(Widget widget)

--- a/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/AriaLiveService.java
@@ -51,7 +51,6 @@ public class AriaLiveService
    public static final String TAB_KEY_MODE = "tab_key_mode";
    public static final String TOOLBAR_VISIBILITY = "toolbar_visibility";
    public static final String WARNING_BAR = "warning_bar";
-   public static final String SESSION_SUSPENDED = "session_suspended";
 
    // Announcement requested by a user, not controlled by a preference since it is on-demand.
    // Do not include in the announcements_ map.
@@ -84,7 +83,6 @@ public class AriaLiveService
       announcements_.put(TAB_KEY_MODE, constants_.tabKeyFocusAnnouncement());
       announcements_.put(TOOLBAR_VISIBILITY, constants_.toolBarVisibilityAnnouncement());
       announcements_.put(WARNING_BAR, constants_.warningBarsAnnouncement());
-      announcements_.put(SESSION_SUSPENDED, constants_.sessionSuspendAnnouncement());
 
       alwaysEnabledAnnouncements_ = new HashSet<>();
       alwaysEnabledAnnouncements_.add(ON_DEMAND);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/ui/ConsoleTabPanel.java
@@ -373,11 +373,22 @@ public class ConsoleTabPanel extends WorkbenchTabPanel
                             !dataTabVisible_ &&
                             !backgroundJobsTabVisible_ &&
                             !workbenchJobsTabVisible_;
-      
+
+      consolePane_.setIsTabPanel(!consoleOnly);;
       if (consoleOnly)
+      {
          owner_.addStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
+         owner_.getTitleWidget().getElement().removeAttribute("aria-hidden");
+         owner_.getSubtitleWidget().getElement().removeAttribute("aria-hidden");
+         goToWorkingDirButton_.getElement().removeAttribute("aria-hidden");
+      }
       else
+      {
          owner_.removeStyleName(ThemeResources.INSTANCE.themeStyles().consoleOnlyWindowFrame());
+         owner_.getTitleWidget().getElement().setAttribute("aria-hidden", "true");
+         owner_.getSubtitleWidget().getElement().setAttribute("aria-hidden", "true");
+         goToWorkingDirButton_.getElement().setAttribute("aria-hidden", "true");
+      }
       
       if (!consoleOnly)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleInterpreterVersion.java
@@ -116,7 +116,8 @@ public class ConsoleInterpreterVersion
       html.getElement().getStyle().setDisplay(Display.INLINE_BLOCK);
       
       Element svg = html.getElement().getFirstChildElement();
-      
+      svg.setAttribute("role", "presentation");
+
       // NOTE: GWT chokes when modifying the className
       // attribute of an SVG element so we do it "by hand" here
       addClassName(svg, RES.styles().icon());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -81,11 +81,7 @@ public class ConsolePane extends WorkbenchPane
 
       ElementIds.assignElementId(this, ElementIds.WORKBENCH_PANEL + "_console");
 
-      // technically this is only playing aria-tabpanel role when the console pane
-      // has tabs (e.g. at least one other pane is being shown, such as Terminal), but
-      // having it always marked with that role is fine
-      Roles.getTabpanelRole().set(this.getElement());
-      Roles.getTabpanelRole().setAriaLabelProperty(this.getElement(), constants_.consoleLabel());
+      setIsTabPanel(false);
 
       // console is interacted with immediately so we make sure it
       // is always created during startup
@@ -107,6 +103,22 @@ public class ConsolePane extends WorkbenchPane
    public void focus()
    {
       shell_.getDisplay().focus();
+   }
+
+   public void setIsTabPanel(boolean isTabPanel)
+   {
+      // only playing aria-tabpanel role when the console pane
+      // has tabs (e.g. at least one other pane is being shown, such as Terminal)
+      if (isTabPanel)
+      {
+         Roles.getTabpanelRole().set(this.getElement());
+         Roles.getTabpanelRole().setAriaLabelProperty(this.getElement(), constants_.consoleLabel());
+      }
+      else
+      {
+         this.getElement().removeAttribute("role");
+         this.getElement().removeAttribute("aria-label");
+      }
    }
 
    @Override
@@ -168,7 +180,7 @@ public class ConsolePane extends WorkbenchPane
       consoleInterpreterVersion_ = new ConsoleInterpreterVersion(true);
       toolbar.addLeftWidget(consoleInterpreterVersion_);
       
-      HTML separator = new HTML("&centerdot;");
+      HTML separator = new HTML("<span aria-hidden=\"true\">&centerdot;</span>");
       separator.addStyleName(ThemeStyles.INSTANCE.toolbarDotSeparator());
       toolbar.addLeftWidget(separator);
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsolePane.java
@@ -74,7 +74,6 @@ public class ConsolePane extends WorkbenchPane
       progressProvider_ = progressProvider;
       commands_ = commands;
       session_ = session;
-      ariaLive_ = ariaLive;
 
       // the secondary toolbar can have several possible states that obscure
       // each other; we keep track of the stack here
@@ -153,6 +152,7 @@ public class ConsolePane extends WorkbenchPane
    public void onSuspendedBlockedEvent(SessionSuspendBlockedEvent event) {
       consoleSuspendBlockedIcon_.setVisible(event.isBlocked());
       consoleSuspendBlockedIcon_.setTitle(event.getMsg());
+      consoleSuspendBlockedIcon_.setAltText(event.getMsg());
    }
 
    public int getCharacterWidth()
@@ -186,11 +186,11 @@ public class ConsolePane extends WorkbenchPane
       profilerInterruptButton_ = ConsoleInterruptProfilerButton.CreateProfilerButton();
       profilerInterruptButton_.setVisible(false);
 
-      boolean announce = !ariaLive_.isDisabled(AriaLiveService.SESSION_SUSPENDED);
-      consoleSuspendBlockedIcon_ = new ConsoleSuspendBlockedIcon(announce).getSuspendBlocked();
+      consoleSuspendBlockedIcon_ = new ConsoleSuspendBlockedIcon().getSuspendBlocked();
       consoleSuspendBlockedIcon_.setVisible(false);
-      consoleSuspendedIcon_ = new ConsoleSuspendBlockedIcon(announce).getSuspended();
+      consoleSuspendedIcon_ = new ConsoleSuspendBlockedIcon().getSuspended();
       consoleSuspendedIcon_.setTitle(constants_.sessionSuspendedTitle());
+      consoleSuspendedIcon_.setAltText(constants_.sessionSuspendedTitle());
       consoleSuspendedIcon_.setVisible(false);
 
       toolbar.addRightWidget(consoleSuspendedIcon_);
@@ -394,7 +394,6 @@ public class ConsolePane extends WorkbenchPane
    private final Commands commands_;
    private Shell shell_;
    private Session session_;
-   private AriaLiveService ariaLive_;
    private Label workingDir_;
    private ToolbarButton consoleInterruptButton_;
    private ToolbarButton consoleClearButton_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleSuspendBlockedIcon.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/ConsoleSuspendBlockedIcon.java
@@ -14,7 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.console;
 
-import com.google.gwt.aria.client.Roles;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.Image;
@@ -27,7 +26,7 @@ public class ConsoleSuspendBlockedIcon
    extends Composite
 
 {
-   public ConsoleSuspendBlockedIcon(boolean announce)
+   public ConsoleSuspendBlockedIcon()
    {
       ImageResource sus = new ImageResource2x(ThemeResources.INSTANCE.suspended());
       ImageResource blocked = new ImageResource2x(ThemeResources.INSTANCE.suspendBlocked());
@@ -38,12 +37,6 @@ public class ConsoleSuspendBlockedIcon
       suspended_.getElement().setId(ElementIds.CONSOLE_SESSION_SUSPENDED);
       suspendBlocked_ = new Image(blocked);
       suspendBlocked_.getElement().setId(ElementIds.CONSOLE_SESSION_SUSPEND_BLOCKED);
-
-      if (announce)
-      {
-         Roles.getAlertRole().set(suspended_.getElement());
-         Roles.getAlertRole().set(suspendBlocked_.getElement());
-      }
    }
 
    public Image getSuspendBlocked()


### PR DESCRIPTION
### Intent

Addresses:

* [Invalid role on Console session suspend status icons #12449](https://github.com/rstudio/rstudio/issues/12449)
* [No-tabs console toolbar always visible to screen reader #12825](https://github.com/rstudio/rstudio/issues/12825)

### Approach

#### Suspend Status Icons
- removed the role="alert" from the suspend and unable-to-suspend icons; we already issue a notification when a session suspends ("Backing up R session"), so having another one wasn't necessary
- also added alt-text to the icons (matching the titles): the titles are what you see if you hover over icons with the mouse; the alt-text is read when you navigate to the image with a screen reader

#### Console Toolbar
- marked the "dot" separator in toolbar as aria-hidden so it is ignored by screen reader (it is purely cosmetic)
- when the Console region has tabs, apply `aria-hidden="true"` to the controls in the hidden non-tab toolbar region so they aren't visible to a screen reader user
- gave the language icons (R, Python) `role="presentation"` to hide them from screen reader; the language is already described in text so adding text to the icons would be redundant
- marked the console area as `role="tabpanel"` ONLY when showing tabs; when there are no tabs, leave the console area as a generic element

### Automated Tests

None

### QA Notes

There should be no visual or functional difference except when using a screen reader. Let me know if you'd like assistance in testing this.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


