### PR TITLE
Don't send unrelated and unneeded git commit info to QA automation

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -407,7 +407,6 @@ pipeline {
             string(name: 'RSTUDIO_VERSION_PATCH', value: "${RSTUDIO_VERSION_PATCH}"),
             string(name: 'RSTUDIO_VERSION_SUFFIX', value: "${RSTUDIO_VERSION_SUFFIX}"),
             string(name: 'SLACK_CHANNEL', value: "${params.SLACK_CHANNEL}"),
-            string(name: 'GIT_REVISION', value: "${params.COMMIT_HASH}"),
             string(name: 'BRANCH_NAME', value: "${env.BRANCH_NAME}")
           ]
       }


### PR DESCRIPTION
### Intent

I mistakenly included the rstudio repo commit in the job trigger for the qa automation job, which doesn't make sense because that commit wouldn't exist in the qa automation repo so the QA job has been failing: https://build.posit.it/job/IDE/job/qa-opensource-automation/1787/parameters/

### Approach

Don't send commit info to QA automation job trigger

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


