### PR TITLE
Accessibility tweaks to sign-in page

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,13 +7,12 @@
 - Updated to Electron 23.1.2 (#12785)
 - Moved Help panel font size setting to Appearance tab in Global Options (#12816)
 - Update openssl to 1.1.1t for Windows (rstudio/rstudio-pro#3675)
+- Improve visibility of focus rectangles on Server / Workbench Sign In page [Accessibility] (#12846)
 
 #### Posit Workbench
 - 
 
 ### Fixed
-- Fixed display problems with Choose R dialog when UI language is French #12717
-- Background script jobs are now run using the global environment. This fixes the behaviour of `source()` in backgrounds jobs. (#11866)
 
 #### RStudio IDE
 - Fixed display problems with Choose R dialog when UI language is French (#12717)
@@ -21,6 +20,8 @@
 - Fixed initial focus placement in Help Pane [Accessibility] (#10600)
 - Fixed invalid element role on session-suspended icon [Accessibility] (#12449)
 - Improve screen-reader support for Console pane toolbar [Accessibility] (#12825)
+- Fixed display problems with Choose R dialog when UI language is French #12717
+- Background script jobs are now run using the global environment. This fixes the behaviour of `source()` in backgrounds jobs. (#11866)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/gwt/www/rstudio.css
+++ b/src/gwt/www/rstudio.css
@@ -154,35 +154,6 @@ a img {
   padding: 8px;
 }
 
-#skipnav a {
-  position: absolute;
-  clip: rect(0 0 0 0);
-  border: 0;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  width: 1px;
-  white-space: nowrap;
-}
-
-#skipnav a:focus {
-  clip: auto;
-  left: 0;
-  top: 0;
-  width: 100%;
-  height: auto;
-  margin: 0;
-  padding: 10px 0;
-  background: #fdf6e7;
-  border: 2px solid #990000;
-  border-left: none;
-  border-right: none;
-  text-align: center;
-  font-weight: bold;
-  color: #990000;
-}
-
 .visuallyhidden {
   position: absolute;
   clip: rect(0 0 0 0);

--- a/src/gwt/www/signin.css
+++ b/src/gwt/www/signin.css
@@ -195,12 +195,12 @@ div.signinhidden {
 }
 
 :focus {
-  outline: none !important;
-  box-shadow: none !important;
+  outline: none;
+  box-shadow: none;
 }
 
 :focus-visible {
   outline-offset: 0;
   outline: 2px solid var(--primary) !important;
-  box-shadow: inset 0 0 0 2px var(--primary-fg) !important;
+  box-shadow: inset 0 0 0 2px var(--primary-fg);
 }

--- a/src/gwt/www/signin.css
+++ b/src/gwt/www/signin.css
@@ -39,6 +39,7 @@ input[type=text], input[type=password] {
   border: 1px solid #cdcecf;
   font-size: 14px;
   padding: 8px;
+  margin-top: 1px;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -191,4 +192,15 @@ div.signinhidden {
 
 .signin-hidden {
   display: none;
+}
+
+:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+:focus-visible {
+  outline-offset: 0;
+  outline: 2px solid var(--primary) !important;
+  box-shadow: inset 0 0 0 2px var(--primary-fg) !important;
 }

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -23,7 +23,6 @@
 
   <link rel="stylesheet" href="rstudio.css" type="text/css" />
   <link rel="stylesheet" href="signin.css" type="text/css" />
-  <link rel="stylesheet" href="css/focus-visible.css" type="text/css" />
 
   <style type="text/css">
     #errorpanel {
@@ -36,7 +35,6 @@
 
 </head>
 <body>
-  <div id="skipnav"><a href="#username">Skip navigation</a></div>
   <header id="banner" role="banner">
     <div id="logo">#!logoHtml#</div>
   </header>
@@ -70,6 +68,7 @@
                 value=""
                 id="username"
                 size="45"
+                aria-required="true"
               /><br />
             </p>
             <p>
@@ -84,6 +83,7 @@
                 value=""
                 id="password"
                 size="45"
+                aria-required="true"
               /><br />
             </p>
             <div style="display: #staySignedInDisplay#">
@@ -173,6 +173,5 @@
 
     <div id="login-html">#!loginPageHtml#</div>
   </main>
-  <script type="text/javascript" src="js/focus-visible.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### Intent

Addresses [Low contrast focus rectangle on Sign In button (server login page) and other misc. A11y #12846](https://github.com/rstudio/rstudio/issues/12846)

### Approach

- used same focus-visible styling as the workbench home page; add a tiny extra top margin to the input fields so the thicker focus rectangle doesn't bump up against the label
- removed use of the `focus-visible` polyfill from sign-in page, and just use native `focus-visible` now that it is supported by all browsers we support (the IDE itself is still using this polyfill so can't remove it altogether yet)
- removed skip-nav link from the sign-in page (and the associated styles; this was the only place using this); see the associated issue for why I'm removing it
- added `aria-required="true"` to the input fields

The button focused appearance:

<img width="401" alt="Screenshot of sign-in page with improved focus rectangle on sign-in button" src="https://user-images.githubusercontent.com/10569626/225431828-b4b75033-b0e8-459f-88bf-06c8e83d6613.png">

In dark mode:

<img width="380" alt="Screenshot of rstudio server sign-in page in dark mode" src="https://user-images.githubusercontent.com/10569626/225432669-93e1bef1-3302-4079-a887-e69f4dd358b1.png">

Here's an input field with focus:

<img width="356" alt="Screenshot of rstudio server sign-on page with username field focused" src="https://user-images.githubusercontent.com/10569626/225433407-3447fa3d-6ccd-4f46-a270-167c59be862c.png">

### Automated Tests

None

### QA Notes

- Verify improved visibility of focus rectangles (e.g. by tabbing through the page).
- Turn on screen reader and tab to the username and password fields; should now announce "required" as part of their descriptions
- Tab from the start of the page; the skip-nav link should no longer appear

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


