### PR TITLE
Send `SIGKILL` to child processes during forced exit to avoid zombies

### DIFF
--- a/src/cpp/core/system/PosixChildProcess.cpp
+++ b/src/cpp/core/system/PosixChildProcess.cpp
@@ -1547,7 +1547,10 @@ struct AsioAsyncChildProcess::Impl : public boost::enable_shared_from_this<AsioA
 
             cleanup();
 
-            exitCode_ = -1;
+            // send the process SIGKILL in an effort to avoid it hanging around
+            // as a zombie or in a broken state forever
+            ::kill(parent_->pImpl_->pid, SIGKILL);
+            exitCode_ = 137;
          }
       }
       END_LOCK_MUTEX


### PR DESCRIPTION
### Intent

The Package Manager team[ initially noticed this](https://positpbc.slack.com/archives/C7312LBPY/p1663804027257349) when the Kubernetes Launcher plugin would hang indefinitely but never exit. @jeffvroom has [also found the symptoms of this](https://positpbc.slack.com/archives/C7312LBPY/p1677121768420139?thread_ts=1677023476.856099&cid=C7312LBPY) in some customer logs.

### Approach

We already "force" an exit event after 30 seconds, this commit just piggybacks on that timer to send it `SIGKILL` at that point as well.

### Automated Tests

I don't think there are tests for this.

### QA Notes

Please advise.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests