### PR TITLE
fix keyboard shortcut page banner layout and add tabstop

### DIFF
--- a/src/gwt/www/docs/keyboard.htm
+++ b/src/gwt/www/docs/keyboard.htm
@@ -35,8 +35,8 @@ References on default Ace shortcuts:
   https://github.com/ajaxorg/ace/blob/master/lib/ace/commands/default_commands.js
 -->
 <body>
-  <header id="banner"><img src="../images/rstudio.png" alt /></header>
-  <main>
+  <header id="banner"><img id="logo" src="../images/rstudio.png" alt /></header>
+  <main tabindex="0">
     <div style="margin-left: 20px; margin-right: 20px">
       <h1>Keyboard Shortcuts</h1>
       <p>


### PR DESCRIPTION
### Intent

This fixes a small regression introduced by https://github.com/rstudio/rstudio/pull/12884: the keyboard shortcut help static page (only seen when screen reader support is enabled) had its logo right-justified.

Also, [Axe identified that the page might be difficult to scroll via keyboard ](https://dequeuniversity.com/rules/axe/4.6/scrollable-region-focusable?application=AxeChrome)because there are no tabstops, so put a tabstop around the entire `main` region.

Not bothering to open an issue on this due to its extremely simple nature. Here's how it looked before this fix:

<img width="815" alt="Screenshot of keyboard shortcuts page with right-justified logo" src="https://user-images.githubusercontent.com/10569626/227009693-c670b8e9-4093-438f-9e20-0ae491e0921b.png">

After this fix:

<img width="891" alt="Screenshot of fixed keyboard shortcuts page with left-justified logo" src="https://user-images.githubusercontent.com/10569626/227009828-cb7af9f7-e596-4585-8be8-c1595244060b.png">


