### PR TITLE
Bump opensuse docker version to 15.4 and update packages

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -1,17 +1,13 @@
 ARG ARCH=amd64
-FROM --platform=linux/$ARCH opensuse/leap:15.1
+FROM --platform=linux/$ARCH opensuse/leap:15.4
 ARG ARCH
 
-ENV OPERATING_SYSTEM=opensus_leap15
-
-# needed to build RPMs; see https://build.opensuse.org/repositories/systemsmanagement:wbem
-RUN zypper --non-interactive addrepo https://download.opensuse.org/repositories/systemsmanagement:wbem/openSUSE_Tumbleweed/systemsmanagement:wbem.repo
+ENV OPERATING_SYSTEM=opensuse_leap15
 
 # refresh repos and install required packages
 RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     zypper --non-interactive install -y \
     ant \
-    boost-devel \
     clang \
     curl \
     expect \
@@ -30,7 +26,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libcups2 \
     libcurl-devel \
     libgtk-3-0 \
-    libuser-devel \
+    libopenssl-devel \
     libuuid-devel \
     libxml2-devel \
     libXcursor-devel \
@@ -38,8 +34,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     lsof \
     make \
     ninja \
-    openssl-devel \
-    p7zip \
+    p7zip-full \
     pam-devel \
     pango-devel \
     postgresql-devel \
@@ -48,7 +43,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     python3 \
     R \
     rpm-build \
-    sqlite-devel \
+    sqlite3-devel \
     sudo \
     tar \
     unzip \


### PR DESCRIPTION
### Intent

We've been building opensuse images on 15.1 for the last 4 years. This bumps the docker image to use the 15.4 base image.

Changes/removes packages to match 15.4 packages

Fixed `OPERATING_SYSTEM` env variable typo

Once approved I'll merge `rel-cherry-blossom` forward into main

### Approach

Version bump

### Automated Tests

N/A Build change

### QA Notes

N/A Build change

### Documentation

N/A Build change

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


