### PR TITLE
Archive version/RELEASE in linux builds for automated tests

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -145,6 +145,7 @@ pipeline {
             }
 
             buildName "${RSTUDIO_VERSION}"
+            archiveArtifacts artifacts: 'version/RELEASE', followSymlinks: false
           }
         }
       }


### PR DESCRIPTION
### Intent

The automated tests require version/RELEASE to be uploaded to generate Jenkinsfiles: https://github.com/rstudio/rstudio-ide-automation/blob/033abd769083dfd61e6eeebd8735d4cf1caf1179/Jenkins/fuzzbucket-template.Jenkinsfile#L43

Since all the generated templates are for linux builds, I've uploaded the artifact from the linux pipeline

### Approach

Upload the version/RELEASE file from the linux pipeline

### Automated Tests

N/A build fix

### QA Notes

The jenkins template job will need to be updated to pull artifacts from `IDE/OS-Builds/Platforms/linux-pipeline`

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


