### PR TITLE
remove unused mac-terminal script

### DIFF
--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -30,12 +30,6 @@ if (LINUX)
 endif()
 
 
-# install mac-terminal script on apple
-if(APPLE)
-   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/mac-terminal.in
-                  ${CMAKE_CURRENT_BINARY_DIR}/mac-terminal)
-endif()
-
 # install desktop integration files on linux
 if(RSTUDIO_INSTALL_FREEDESKTOP)
 

--- a/src/node/desktop/mac-terminal.in
+++ b/src/node/desktop/mac-terminal.in
@@ -1,9 +1,0 @@
-#!/usr/bin/osascript
-on run argv
-  set dir to quoted form of (first item of argv)
-  tell app "Terminal"
-     activate
-     do script "cd " & dir
-  end tell
-end run
-


### PR DESCRIPTION
### Intent

Remove the unused `mac-terminal` script from Electron desktop. This was only used for the Tools / Shell command, which I removed from Electron in https://github.com/rstudio/rstudio/pull/11465.

Very safe; it wasn't even being included in the built RStudio.app (and the callback that used it was never implemented in Electron).

### Approach

Delete delete delete

### Automated Tests

N/A

### QA Notes

Nothing to test, deleting something that never made it into the product.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


