### PR TITLE
Build on OpenSuse15.3 to use libuser package

### DIFF
--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -1,5 +1,5 @@
 ARG ARCH=amd64
-FROM --platform=linux/$ARCH opensuse/leap:15.4
+FROM --platform=linux/$ARCH opensuse/leap:15.3
 ARG ARCH
 
 ENV OPERATING_SYSTEM=opensuse_leap15
@@ -27,6 +27,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     libcurl-devel \
     libgtk-3-0 \
     libopenssl-devel \
+    libuser-devel \
     libuuid-devel \
     libxml2-devel \
     libXcursor-devel \


### PR DESCRIPTION
### Intent

15.4 doesn't have `libuser` and there are currently no community packages available. Switch to using 15.3 for our builds. We just switched to 15.4 from 15.1 here: https://github.com/rstudio/rstudio/pull/12890



