### PR TITLE
prefer unordered set

### DIFF
--- a/src/cpp/core/system/Environment.cpp
+++ b/src/cpp/core/system/Environment.cpp
@@ -16,13 +16,13 @@
 #include <core/system/Environment.hpp>
 
 #include <algorithm>
+
+#include <boost/bind/bind.hpp>
 #include <boost/regex.hpp>
 
 #include <core/Algorithm.hpp>
-
 #include <core/Log.hpp>
 
-#include <boost/bind/bind.hpp>
 
 #ifdef _WIN32
 #define kPathSeparator ";"

--- a/src/cpp/r/include/r/RSexp.hpp
+++ b/src/cpp/r/include/r/RSexp.hpp
@@ -16,11 +16,12 @@
 #ifndef R_R_SEXP_HPP
 #define R_R_SEXP_HPP
 
-#include <string>
-#include <vector>
 #include <deque>
 #include <map>
 #include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
 
 #include <yaml-cpp/yaml.h>
 
@@ -146,6 +147,7 @@ core::Error extract(SEXP valueSEXP, std::vector<int>* pVector);
 core::Error extract(SEXP valueSEXP, std::string* pString, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::vector<std::string>* pVector, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::set<std::string>* pSet, bool asUtf8 = false);
+core::Error extract(SEXP valueSEXP, std::unordered_set<std::string>* pSet, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, std::map<std::string, std::set<std::string>>* pMap, bool asUtf8 = false);
 core::Error extract(SEXP valueSEXP, core::json::Value* pJson);
 core::Error extract(SEXP valueSEXP, core::FilePath* pFilePath);
@@ -408,7 +410,7 @@ core::Error objects(SEXP environment,
 core::Error getNamespaceExports(SEXP ns,
                                 std::vector<std::string>* pNames);
 
-const std::set<std::string>& nsePrimitives();
+const std::unordered_set<std::string>& nsePrimitives();
 
 // NOTE: Primarily to be used with boost::bind, to add functions that are then
 // called on each node within the call. Functions can return true to signal the

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -295,10 +295,10 @@ SEXP resolveFunctionAssociatedWithCall(RTokenCursor cursor,
    return resolveObjectAssociatedWithCall(cursor, pProtect, true, pCacheable);
 }
 
-std::set<std::wstring> makeWideNsePrimitives()
+std::unordered_set<std::wstring> makeWideNsePrimitives()
 {
-   std::set<std::wstring> wide;
-   const std::set<std::string>& nsePrimitives = r::sexp::nsePrimitives();
+   std::unordered_set<std::wstring> wide;
+   const std::unordered_set<std::string>& nsePrimitives = r::sexp::nsePrimitives();
    
    for (const std::string& primitive : nsePrimitives)
    {
@@ -308,9 +308,9 @@ std::set<std::wstring> makeWideNsePrimitives()
    return wide;
 }
 
-const std::set<std::wstring>& wideNsePrimitives()
+const std::unordered_set<std::wstring>& wideNsePrimitives()
 {
-   static std::set<std::wstring> wideNsePrimitives = makeWideNsePrimitives();
+   static std::unordered_set<std::wstring> wideNsePrimitives = makeWideNsePrimitives();
    return wideNsePrimitives;
 }
 
@@ -326,7 +326,7 @@ bool maybePerformsNSE(RTokenCursor cursor)
    if (!endCursor.fwdToMatchingToken())
       return false;
    
-   const std::set<std::wstring>& nsePrimitives = wideNsePrimitives();
+   const std::unordered_set<std::wstring>& nsePrimitives = wideNsePrimitives();
    
    const RTokens& rTokens = cursor.tokens();
    std::size_t offset = cursor.offset();
@@ -1757,7 +1757,7 @@ void addExtraScopedSymbolsForCall(RTokenCursor startCursor,
       if (!endCursor.fwdToMatchingToken())
          return;
       
-      std::set<std::string> symbols;
+      std::unordered_set<std::string> symbols;
       r::exec::RFunction getSetRefClassCall(".rs.getSetRefClassSymbols");
       getSetRefClassCall.addParam(
                string_utils::wideToUtf8(
@@ -1785,7 +1785,7 @@ void addExtraScopedSymbolsForCall(RTokenCursor startCursor,
       if (!endCursor.fwdToMatchingToken())
          return;
       
-      std::set<std::string> symbols;
+      std::unordered_set<std::string> symbols;
       r::exec::RFunction getR6ClassSymbols(".rs.getR6ClassSymbols");
       getR6ClassSymbols.addParam(
                string_utils::wideToUtf8(std::wstring(startCursor.begin(), endCursor.end())));

--- a/src/cpp/session/modules/environment/EnvironmentUtils.cpp
+++ b/src/cpp/session/modules/environment/EnvironmentUtils.cpp
@@ -15,6 +15,8 @@
 
 #include "EnvironmentUtils.hpp"
 
+#include <unordered_set>
+
 #include <r/RCntxt.hpp>
 #include <r/RCntxtUtils.hpp>
 #include <r/RExec.hpp>
@@ -96,7 +98,7 @@ bool isAltrep(SEXP var)
    return isAltrepImpl(var);
 }
 
-bool hasAltrepImpl(SEXP var, std::set<SEXP>& visited, unsigned maxDepth)
+bool hasAltrepImpl(SEXP var, std::unordered_set<SEXP>& visited, unsigned maxDepth)
 {
    // ignore if already visited
    if (visited.find(var) != visited.end())
@@ -136,7 +138,7 @@ bool hasAltrep(SEXP var)
       return false;
 
    // recursively scan for ALTREP objects
-   std::set<SEXP> visited;
+   std::unordered_set<SEXP> visited;
    return hasAltrepImpl(var, visited, MAX_ALTREP_DEPTH);
 }
 

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -17,6 +17,7 @@
 #include "EnvironmentMonitor.hpp"
 
 #include <algorithm>
+#include <unordered_set>
 
 #include <core/Exec.hpp>
 #include <core/RecursionGuard.hpp>
@@ -120,9 +121,9 @@ bool handleRBrowseEnv(const core::FilePath& filePath)
    }
 }
 
-bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited);
+bool hasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited);
 
-bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::set<SEXP>& visited)
+bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    if (hasExternalPointer(CAR(list), nullPtr, visited))
       return true;
@@ -133,7 +134,7 @@ bool pairlistHasExternalPointer(SEXP list, bool nullPtr, std::set<SEXP>& visited
    return false;
 }
 
-bool listHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+bool listHasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    R_xlen_t n = XLENGTH(obj);
    for (R_xlen_t i = 0; i < n; i++)
@@ -150,7 +151,7 @@ bool frameBindingIsActive(SEXP binding)
    return reinterpret_cast<r::sxpinfo*>(binding)->gp & ACTIVE_BINDING_MASK;
 }
 
-bool frameBindingHasExternalPointer(SEXP b, bool nullPtr, std::set<SEXP>& visited) 
+bool frameBindingHasExternalPointer(SEXP b, bool nullPtr, std::unordered_set<SEXP>& visited) 
 {
    if (frameBindingIsActive(b))
       return false;
@@ -193,7 +194,7 @@ bool frameBindingHasExternalPointer(SEXP b, bool nullPtr, std::set<SEXP>& visite
    return hasExternalPointer(CAR(b), nullPtr, visited);
 }
 
-bool frameHasExternalPointer(SEXP frame, bool nullPtr, std::set<SEXP>& visited)
+bool frameHasExternalPointer(SEXP frame, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    while(frame != R_NilValue)
    {
@@ -206,7 +207,7 @@ bool frameHasExternalPointer(SEXP frame, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
-bool envHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+bool envHasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    SEXP hash = HASHTAB(obj);
    if (hash == R_NilValue)
@@ -221,7 +222,7 @@ bool envHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
-bool weakrefHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+bool weakrefHasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    SEXP key = r::sexp::getWeakRefKey(obj);
    if (key != R_NilValue)
@@ -237,7 +238,7 @@ bool weakrefHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
-bool altrepHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+bool altrepHasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    if (hasExternalPointer(CAR(obj), nullPtr, visited))
       return true;
@@ -248,7 +249,7 @@ bool altrepHasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
    return false;
 }
 
-bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
+bool hasExternalPointer(SEXP obj, bool nullPtr, std::unordered_set<SEXP>& visited)
 {
    if (obj == nullptr || obj == R_NilValue || visited.count(obj))
       return false;
@@ -359,7 +360,7 @@ bool hasExternalPointer(SEXP obj, bool nullPtr, std::set<SEXP>& visited)
 bool hasExternalPtr(SEXP obj,      // environment to search for external pointers
                     bool nullPtr)  // whether to look for NULL pointers
 {
-   std::set<SEXP> visited;
+   std::unordered_set<SEXP> visited;
    return hasExternalPointer(obj, nullPtr, visited);
 }
 


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio/issues/12923.

### Approach

Use `std::unordered_set` rather than `std::set`, to avoid the cost of potentially expensive searches when the set grows very large.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12923.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

