### PR TITLE
Sync electron theme (dark/light) with RStudio theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - RStudio no longer uses `reg.exe` when attempting to enumerate R versions in the Windows registry (#12599)
 - Fixed file-type icons not displaying in Finder on Mac (#12252)
 - Fixed saving and restoring window location when maximized or partially offscreen (#12463)
+- Set theme of menu bar, title bar, and dialogs (dark vs. light) based on RStudio theme (#12247)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/main/application.ts
+++ b/src/node/desktop/src/main/application.ts
@@ -13,7 +13,7 @@
  *
  */
 
-import { app, BrowserWindow, dialog, Menu, nativeTheme, screen, shell, WebContents } from 'electron';
+import { app, BrowserWindow, dialog, Menu, screen, shell, WebContents } from 'electron';
 import i18next from 'i18next';
 import path from 'path';
 import { getenv, setenv } from '../core/environment';
@@ -23,7 +23,7 @@ import { kRStudioInitialProject, kRStudioInitialWorkingDir } from '../core/r-use
 import { generateRandomPort } from '../core/system';
 import { getDesktopBridge } from '../renderer/desktop-bridge';
 import { DesktopActivation } from './activation-overlay';
-import { appState, AppState } from './app-state';
+import { AppState } from './app-state';
 import { ApplicationLaunch } from './application-launch';
 import { ArgsManager } from './args-manager';
 import { prepareEnvironment, promptUserForR, scanForR, showRNotFoundError } from './detect-r';
@@ -276,12 +276,6 @@ export class Application implements AppState {
     const [confPath, sessionPath, scriptsPath] = findComponents();
     this.sessionPath = sessionPath;
     this.scriptsPath = scriptsPath;
-
-    // force light theme so menu bar matches title bar
-    // Electron 20+ will have support for matching
-    if (process.platform === 'win32') {
-      nativeTheme.themeSource = 'light';
-    }
 
     if (!app.isPackaged) {
       // sanity checking for dev config

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -14,7 +14,7 @@
  */
 
 import { exec, execSync } from 'child_process';
-import { app, BrowserWindow, clipboard, dialog, ipcMain, Rectangle, screen, shell, webFrameMain } from 'electron';
+import { app, nativeTheme, BrowserWindow, clipboard, dialog, ipcMain, Rectangle, screen, shell, webFrameMain } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
 import { existsSync, writeFileSync } from 'fs';
@@ -672,7 +672,9 @@ export class GwtCallback extends EventEmitter {
 
     ipcMain.on('desktop_change_title_bar_color', (event, red, green, blue) => {});
 
-    ipcMain.on('desktop_sync_to_editor_theme', (event, isDark) => {});
+    ipcMain.on('desktop_sync_to_editor_theme', (event, isDark: boolean) => {
+      nativeTheme.themeSource = isDark ? 'dark' : 'light';
+    });
 
     ipcMain.handle('desktop_get_enable_accessibility', () => {
       return ElectronDesktopOptions().accessibility();


### PR DESCRIPTION
### Intent

Addresses [The title bar above the menu bar is light even in the dark theme (in daily builds) #12247](https://github.com/rstudio/rstudio/issues/12247)

### Approach

Now that we're using a new-enough build of Electron, implement the callback to set the app's theme to match the RStudio theme (dark vs. light).

With this in place, the title bar, menu bar (on Windows) and system-supplied dialogs such as File Open will have their theme controlled by whether the RStudio theme is dark or light, not the operating system settings.

RStudio with dark theme on Windows:

![dark](https://user-images.githubusercontent.com/10569626/228376483-b43ed478-e250-4c98-8b04-553a2a580c97.png)

Light theme:

![light](https://user-images.githubusercontent.com/10569626/228376578-67de1716-f8dc-44ed-a355-947326e17eec.png)

### Automated Tests

N/A

### QA Notes

Ideally, test on both Windows-10 and 11 and macOS. Could also spot-check on some Linux distros to see what the behaviour is (the Electron docs don't say much about this).

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


