### PR TITLE
fix display of macOS message box

### DIFF
--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -532,12 +532,23 @@ export class GwtCallback extends EventEmitter {
     ipcMain.handle(
       'desktop_show_message_box',
       async (event, type, caption, message, buttons, defaultButton, cancelButton) => {
-        const openDialogOptions: MessageBoxOptions = {
-          type: this.convertMessageBoxType(type),
-          title: caption,
-          message: message,
-          buttons: this.convertButtons(buttons),
-        };
+
+        let openDialogOptions: MessageBoxOptions;
+        if (process.platform === 'darwin') {
+          openDialogOptions = {
+            type: this.convertMessageBoxType(type),
+            message: caption,
+            detail: message,
+            buttons: this.convertButtons(buttons),
+          };
+        } else {
+          openDialogOptions = {
+            type: this.convertMessageBoxType(type),
+            title: caption,
+            message: message,
+            buttons: this.convertButtons(buttons),
+          };
+        }
 
         const focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusedWindow) {


### PR DESCRIPTION
Before:

<img width="276" alt="Screenshot 2023-03-28 at 3 50 07 PM" src="https://user-images.githubusercontent.com/1976582/228384221-11424dac-7cc9-4701-8613-e08089c61cf1.png">

After (dev build so icon is wrong; but you get the picture):

<img width="275" alt="Screenshot 2023-03-28 at 3 49 20 PM" src="https://user-images.githubusercontent.com/1976582/228384186-fe800565-965d-4bc3-8b4c-64e75c51c136.png">
