### PR TITLE
resolve issues with mouse back / forward navigation in Electron

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 - Fixed file-type icons not displaying in Finder on Mac (#12252)
 - Fixed saving and restoring window location when maximized or partially offscreen (#12463)
 - Set theme of menu bar, title bar, and dialogs (dark vs. light) based on RStudio theme (#12247)
+- Fixed issues with mouse back / forward navigation in Source pane, Help pane (#12932)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopHooks.java
@@ -34,7 +34,7 @@ import org.rstudio.core.client.widget.MessageDialog;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.LauncherServerEvent;
-import org.rstudio.studio.client.application.events.MouseNavigateEvent;
+import org.rstudio.studio.client.application.events.DesktopMouseNavigateEvent;
 import org.rstudio.studio.client.application.events.SaveActionChangedEvent;
 import org.rstudio.studio.client.application.events.SuicideEvent;
 import org.rstudio.studio.client.application.model.ProductEditionInfo;
@@ -257,7 +257,7 @@ public class DesktopHooks
 
    void mouseNavigateButtonClick(boolean forward, int x, int y)
    {
-      events_.fireEvent(new MouseNavigateEvent(forward, x, y));
+      events_.fireEvent(new DesktopMouseNavigateEvent(forward, x, y));
    }
    
    void onDragStart()

--- a/src/gwt/src/org/rstudio/studio/client/application/events/DesktopMouseNavigateEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/events/DesktopMouseNavigateEvent.java
@@ -22,10 +22,14 @@ import com.google.gwt.event.shared.GwtEvent;
 // associated WebEngine view, and so we are instead forced to synthesize
 // a synthetic navigation event that gets handled specially on the GWT side.
 //
+// We still make use of this in Electron, to handle a couple of cases where
+// we need to explicitly control mouse navigation. See the event handlers
+// registered in DesktopApplicationHeader.java.
+//
 // https://github.com/rstudio/rstudio/pull/7272
-public class MouseNavigateEvent extends GwtEvent<MouseNavigateEvent.Handler>
+public class DesktopMouseNavigateEvent extends GwtEvent<DesktopMouseNavigateEvent.Handler>
 {
-   public MouseNavigateEvent(boolean forward, int mouseX, int mouseY)
+   public DesktopMouseNavigateEvent(boolean forward, int mouseX, int mouseY)
    {
       forward_ = forward;
       mouseX_ = mouseX;
@@ -34,7 +38,7 @@ public class MouseNavigateEvent extends GwtEvent<MouseNavigateEvent.Handler>
 
    public interface Handler extends EventHandler
    {
-      void onMouseNavigate(MouseNavigateEvent event);
+      void onDesktopMouseNavigate(DesktopMouseNavigateEvent event);
    }
 
    @Override
@@ -46,7 +50,7 @@ public class MouseNavigateEvent extends GwtEvent<MouseNavigateEvent.Handler>
    @Override
    protected void dispatch(Handler handler)
    {
-      handler.onMouseNavigate(this);
+      handler.onDesktopMouseNavigate(this);
    }
 
    public boolean getForward()

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -694,7 +694,24 @@ public class DesktopApplicationHeader implements ApplicationHeader,
    /*-{
       
       var self = this;
+      
+      // Suppress 'mousedown' clicks from the back / forward mouse buttons.
+      // Otherwise, they might send focus just before attempting navigation,
+      // which is annoying if the mouse is within an editable text field
+      // (e.g. an editor in the Source pane).
       $doc.body.addEventListener("mousedown", $entry(function(event) {
+         
+         var button = event.button;
+         if (button === 3 || button == 4)
+         {
+            event.stopPropagation();
+            event.preventDefault();
+         }
+         
+      }), true);
+      
+      // Handle navigation attempts in 'mouseup'.
+      $doc.body.addEventListener("mouseup", $entry(function(event) {
          
          var button = event.button;
          if (button === 3)
@@ -711,6 +728,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          }
          
       }), true);
+      
    }-*/;
    
    public interface Binder

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -42,7 +42,7 @@ import org.rstudio.studio.client.application.DesktopInfo;
 import org.rstudio.studio.client.application.IgnoredUpdates;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.LogoutRequestedEvent;
-import org.rstudio.studio.client.application.events.MouseNavigateEvent;
+import org.rstudio.studio.client.application.events.DesktopMouseNavigateEvent;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
 import org.rstudio.studio.client.application.model.UpdateCheckResult;
 import org.rstudio.studio.client.application.ui.ApplicationHeader;
@@ -682,12 +682,12 @@ public class DesktopApplicationHeader implements ApplicationHeader,
    
    private void onMouseForward(NativeEvent event)
    {
-      eventBus_.fireEvent(new MouseNavigateEvent(true, event.getClientX(), event.getClientY()));
+      eventBus_.fireEvent(new DesktopMouseNavigateEvent(true, event.getClientX(), event.getClientY()));
    }
    
    private void onMouseBack(NativeEvent event)
    {
-      eventBus_.fireEvent(new MouseNavigateEvent(false, event.getClientX(), event.getClientY()));
+      eventBus_.fireEvent(new DesktopMouseNavigateEvent(false, event.getClientX(), event.getClientY()));
    }
    
    private final native void addBackForwardMouseDownHandlers()

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -694,6 +694,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
    /*-{
       
       var self = this;
+      var eventTarget = null;
       
       // Suppress 'mousedown' clicks from the back / forward mouse buttons.
       // Otherwise, they might send focus just before attempting navigation,
@@ -704,6 +705,11 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          var button = event.button;
          if (button === 3 || button == 4)
          {
+            // Save the event target, so we can detect if 'mousedown' and 'mouseup'
+            // happened over the same click target.
+            eventTarget = event.target;
+            
+            // Suppress events otherwise.
             event.stopPropagation();
             event.preventDefault();
          }
@@ -713,18 +719,35 @@ public class DesktopApplicationHeader implements ApplicationHeader,
       // Handle navigation attempts in 'mouseup'.
       $doc.body.addEventListener("mouseup", $entry(function(event) {
          
+         // Get the event targets.
+         var oldEventTarget = eventTarget;
+         var newEventTarget = event.target;
+         
+         // Clear the cached event target.
+         eventTarget = null;
+         
+         // If the event target changed, nothing to do.
+         var eventsMatch = oldEventTarget === newEventTarget;
+         
+         // Check and handle mouse back / forward buttons.
          var button = event.button;
          if (button === 3)
          {
             event.stopPropagation();
             event.preventDefault();
-            self.@org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader::onMouseBack(*)(event);
+            if (eventsMatch)
+            {
+               self.@org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader::onMouseBack(*)(event);
+            }
          }
          else if (button === 4)
          {
             event.stopPropagation();
             event.preventDefault();
-            self.@org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader::onMouseForward(*)(event);
+            if (eventsMatch)
+            {
+               self.@org.rstudio.studio.client.application.ui.impl.DesktopApplicationHeader::onMouseForward(*)(event);
+            }
          }
          
       }), true);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -79,7 +79,7 @@ import org.rstudio.core.client.widget.ToolbarButton;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.events.MouseNavigateEvent;
+import org.rstudio.studio.client.application.events.DesktopMouseNavigateEvent;
 import org.rstudio.studio.client.common.AutoGlassPanel;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -375,7 +375,8 @@ public class HelpPane extends WorkbenchPane
    private void handleMouseDown(NativeEvent event)
    {
       // Not required on Electron; back / forward navigation is handled
-      // natively within the iframe.
+      // via a top-level Javascript event handler. See DesktopApplicationHeader.java
+      // for more details.
       if (BrowseCap.isElectron())
          return;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/help/HelpPane.java
@@ -176,19 +176,6 @@ public class HelpPane extends WorkbenchPane
 
       prefs_.helpFontSizePoints().bind((Double value) -> refresh());
       
-      events_.addHandler(MouseNavigateEvent.TYPE, (MouseNavigateEvent event) ->
-      {
-         // check to see if we're targeting the Help pane
-         Element el = DomUtils.elementFromPoint(event.getMouseX(), event.getMouseY());
-         if (StringUtil.equals(el.getId(), ElementIds.getElementId(ElementIds.HELP_FRAME)))
-         {
-            if (event.getForward())
-               forward();
-            else
-               back();
-         }
-      });
-
       ensureWidget();
    }
 
@@ -387,6 +374,11 @@ public class HelpPane extends WorkbenchPane
    
    private void handleMouseDown(NativeEvent event)
    {
+      // Not required on Electron; back / forward navigation is handled
+      // natively within the iframe.
+      if (BrowseCap.isElectron())
+         return;
+      
       int button = EventProperty.button(event);
       if (button == EventProperty.MOUSE_BACKWARD)
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -80,7 +80,7 @@ import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
 import org.rstudio.studio.client.application.events.EventBus;
-import org.rstudio.studio.client.application.events.MouseNavigateEvent;
+import org.rstudio.studio.client.application.events.DesktopMouseNavigateEvent;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
@@ -221,7 +221,7 @@ public class Source implements InsertSourceEvent.Handler,
                                EditPresentation2SourceEvent.Handler,
                                XRefNavigationEvent.Handler,
                                NewDocumentWithCodeEvent.Handler,
-                               MouseNavigateEvent.Handler,
+                               DesktopMouseNavigateEvent.Handler,
                                RStudioApiRequestEvent.Handler,
                                CloseAllSourceDocsExceptEvent.Handler
 {
@@ -344,7 +344,7 @@ public class Source implements InsertSourceEvent.Handler,
       events_.addHandler(XRefNavigationEvent.TYPE, this);
       
       if (Desktop.hasDesktopFrame())
-         events_.addHandler(MouseNavigateEvent.TYPE, this);
+         events_.addHandler(DesktopMouseNavigateEvent.TYPE, this);
 
       events_.addHandler(SourcePathChangedEvent.TYPE,
             new SourcePathChangedEvent.Handler()
@@ -1888,7 +1888,7 @@ public class Source implements InsertSourceEvent.Handler,
    }
 
    @Override
-   public void onMouseNavigate(MouseNavigateEvent event)
+   public void onDesktopMouseNavigate(DesktopMouseNavigateEvent event)
    {
       if (isPointInSourcePane(event.getMouseX(), event.getMouseY()))
       {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12932.

### Approach

Electron appears to handle back / forward mouse buttons natively within iframes, so suppress the extra mouse handling we try to use in the iframe for Electron.

### Automated Tests

N/A

### QA Notes

Test that mouse back / forward buttons work as expected when the mouse lies over:

- The Source pane (should navigate back and forward through Source locations);
- The Help pane (should navigate back and forward through Help locations);
- Other locations (should do nothing)

You can create multiple documents with e.g. Cmd + Shift + N to test the back + forward behavior in the Source pane, and use something like:

```
help(rnorm)
help(c)
help(help)
```

to open some Help topics to test back / forward navigation in the Help pane.

NOTE: This change should only effect the desktop builds; server should be un-affected.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
