### PR TITLE
Add linux tarball publishing

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -355,6 +355,10 @@ pipeline {
                         script {
                           // publish build to dailies page
                           utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
+
+                          if (FLAVOR == "Electron") {
+                            utils.publishToDailiesSite TAR_PACKAGE_FILE, DAILIES_PATH, AWS_PATH
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
### Intent

I noticed that linux tarballs aren't publishing to the dailies site: https://dailies.rstudio.com/version/2023.03.1+422.pro3/

Looks like the publish command for tarballs wasn't included in the publish step (but it has been happening to the S3 bucket, so they're available, just hidden ATM)

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


