### PR TITLE
fixes for opening files and projects using relative paths from command-line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,7 +29,7 @@
 - Fixed display of macOS message dialogs (#12928)
 - Set theme of menu bar, title bar, and dialogs (dark vs. light) based on RStudio theme (#12247)
 - Fixed issues with mouse back / forward navigation in Source pane, Help pane (#12932)
-- Fixed opening files from command-line with relative paths (#12495)
+- Fixed opening files from command-line with relative paths (#12495, #12563)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 - Fixed display of macOS message dialogs (#12928)
 - Set theme of menu bar, title bar, and dialogs (dark vs. light) based on RStudio theme (#12247)
 - Fixed issues with mouse back / forward navigation in Source pane, Help pane (#12932)
+- Fixed opening files from command-line with relative paths (#12495)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)


### PR DESCRIPTION
### Intent

Addresses [rstudio fails to open projects using relative path from command line #12495](https://github.com/rstudio/rstudio/issues/12495) and [RStudio fails to open working directories using the command line #12563](https://github.com/rstudio/rstudio/issues/12563)

### Approach

Three closely-related fixes:

(1) Resolve relative paths received on command-line to fully qualified paths (as was done in the Qt desktop)
(2) If a folder is passed on command line (i.e. no file), look for an .rproj in that folder and open that if present, otherwise just set the working directory to that folder (Qt desktop does this)
(3) in case 2, when an .rproj wasn't found, don't try to open the folder as a file (resulted in an error message and a blank editor pane)

### Automated Tests

Would be nice.

### QA Notes

This isn't specific to Ubuntu 22 (as the issue title said), so can be tested on any platform.

Try opening things using relative paths, e.g.:

```
rstudio ../../foo/bar/bar.Rproj  --> should open the project
rstudio ../../foo/bar --> should open the project, if there is one, otherwise just set the working directory
rstudio ../../foo/bar/stuff.R --> should open the source file
```

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


