### PR TITLE
don't scan global environment for null pointers by default

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -31,6 +31,7 @@
 #include "modules/jobs/SessionJobs.hpp"
 #include "modules/overlay/SessionOverlay.hpp"
 
+#include <session/prefs/UserPrefs.hpp>
 #include <session/SessionModuleContext.hpp>
 #include <session/SessionSuspend.hpp>
 
@@ -103,11 +104,13 @@ bool canSuspend(const std::string& prompt)
    bool suspendIsBlocked = false;
    suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
    suspendIsBlocked |= !modules::overlay::isSuspendable();
 
+   if (prefs::userPrefs().checkNullExternalPointers())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
+   
    return !suspendIsBlocked;
 }
 


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/12908.
Addresses https://github.com/rstudio/rstudio/issues/12923.

If we want to reintroduce this as an always-on feature, I think we need to be more targeted in terms of what R objects we choose to scan for null pointers. IIRC we did this in the past because certain R objects would cause a session crash when trying to examine those objects (due to internal null pointers) but it might be better to just explicitly filter those objects out in the cases where examining those objects cause a crash.

I vaguely recall https://cran.r-project.org/web/packages/ff/index.html being one culprit but unfortunately don't have a reproducible example.