### PR TITLE
Fix 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Fixed issues with mouse back / forward navigation in Source pane, Help pane (#12932)
 - Fixed opening files from command-line with relative paths (#12495, #12563)
 - Fixed issue with column preview with older versions of the 'pillar' package. (#12863)
+- Fixed bug where the OK button was disabled in Choose R dialog when only one version of R installed (#12916)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -201,10 +201,21 @@ writeLines(sep = "\x1F", c(
 ))`;
 
   logger().logDebug(`Querying information about R executable at path: ${rExecutable}`);
+
+  // remove R-related environment variables before invoking R
+  const envCopy = Object.assign({}, process.env);
+  delete envCopy['R_HOME'];
+  delete envCopy['R_ARCH'];
+  delete envCopy['R_DOC_DIR'];
+  delete envCopy['R_INCLUDE_DIR'];
+  delete envCopy['R_RUNTIME'];
+  delete envCopy['R_SHARE_DIR'];
+
   const [result, error] = expect(() => {
     return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
       encoding: 'utf-8',
       input: rQueryScript,
+      env: envCopy,
     });
   });
 

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -119,7 +119,6 @@ ipcRenderer.on('initialize', (_event, data) => {
         const useCustomRadioInput = document.getElementById('use-custom') as any;
         useCustomRadioInput.checked = true;
 
-        selectEl.value = r64;
 
         selectWidget.disabled = false;
         selectWidget.focus();
@@ -141,7 +140,6 @@ ipcRenderer.on('initialize', (_event, data) => {
 
         selectWidget.disabled = false;
 
-        selectEl.value = r32;
         selectWidget.focus();
       }
     }


### PR DESCRIPTION
### Intent

Addresses [Can't select version of R when only one version installed #12916](https://github.com/rstudio/rstudio/issues/12916)

### Approach

Two separate problems are covered by this issue (and this fix).

First, when there was only a single choice available in the list of R versions, the OK button was disabled and could not be re-enabled. Fixed by not preselecting items as they are added to the list. Now the user can click the version they want (e.g. the only version), which will trigger enabling of the OK button.

Second, when the dialog was invoked from inside the IDE (Tools / Global Options / General / R version: Change), the radio buttons for "Use your machine's default 64-bit / 32-bit version of R" were disabled when they shouldn't have been.

This was caused when we invoked the default versions of R (determined from the registry) to fetch path info, but had the R environment variables set (especially R_ARCH). The IDE sets these for its selected version of R. Trying to invoke a different version of R would fail, and the buttons would be disabled as a result. The fix was to unset those environment variables when invoking the default version of R. This could also be a problem for the dialog at startup if those environment variables happened to be set.

### Automated Tests

None

### QA Notes

Be sure to test the Choose R dialog at startup (holding down Ctrl when you launch) and from inside the IDE.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


