### PR TITLE
Improve robustness of chosing custom R version via browsing on Windows (Electron)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,7 @@
 - Fixed opening files from command-line with relative paths (#12495, #12563)
 - Fixed issue with column preview with older versions of the 'pillar' package. (#12863)
 - Fixed bug where the OK button was disabled in Choose R dialog when only one version of R installed (#12916)
+- Improved robustness when chosing custom R version in Windows desktop (#12969)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -417,12 +417,19 @@ export function fixWindowsRExecutablePath(rExePath: string): string {
   }
 
   const selectedDir = basename(dirname(rExePath)).toLowerCase();
+  const origPath = rExePath;
   if (selectedDir === 'bin') {
     // User picked bin\*.exe; insert the subfolder matching the machine's architecture.
-    const origPath = rExePath;
     const archDir = process.arch === 'x32' ? 'i386' : 'x64';
     rExePath = join(dirname(rExePath), archDir, 'R.exe');
     logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
+  } else {
+    // Even if they chose the right folder, make sure they picked R.exe
+    const exe = basename(rExePath).toLowerCase();
+    if (exe !== 'r.exe') {
+      rExePath = join(dirname(rExePath), 'R.exe');
+      logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
+    }
   }
   return rExePath;
 }

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -21,7 +21,7 @@ import { ModalDialog } from '../modal-dialog';
 import { initI18n } from '../../main/i18n-manager';
 import i18next, { t } from 'i18next';
 import { CallbackData } from './choose-r/preload';
-import { ElectronDesktopOptions } from '../../main/preferences/electron-desktop-options';
+import { ElectronDesktopOptions, fixWindowsRExecutablePath } from '../../main/preferences/electron-desktop-options';
 
 import { existsSync } from 'fs';
 import { normalize } from 'path';
@@ -71,6 +71,9 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
   }
 
   async maybeResolve(resolve: (data: CallbackData) => void, data: CallbackData) {
+    if (data.binaryPath) {
+      data.binaryPath = fixWindowsRExecutablePath(data.binaryPath);
+    }
     if (checkValid(data)) {
       resolve(data);
       return true;
@@ -125,6 +128,7 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
         const response = dialog.showOpenDialogSync(this, {
           title: i18next.t('uiFolder.chooseRExecutable'),
           properties: ['openFile'],
+          defaultPath: 'R.exe',
           filters: [{ name: i18next.t('uiFolder.rExecutable'), extensions: ['exe'] }],
         });
 


### PR DESCRIPTION
### Intent

Addresses [RStudio (Windows Electron) fails to start session if certain R.exe selected by user #12969](https://github.com/rstudio/rstudio/issues/12969)

### Approach

After user picks a custom R via browsing, perform fixups. Also do these fixups when loading the path from preferences to handle incorrect paths from earlier versions.

* if they chose `bin\R.exe` change that to `bin\x64\R.exe` (if they are on a 64-bit machine) or `bin\i386\R.exe` if on a 32-bit machine (if a user on a 64-bit machine wants to use 32-bit R, they'll have to browse specifically to it in the i386 folder)
* if they chose something other than R.exe, such as Rscript.exe, substitute R.exe (in addition to the path fixup)

Also, the file chooser dialog now prepopulates `R.exe` in the filename field, giving a hint about what they should be selecting.

### Automated Tests

None

### QA Notes

This is Windows-only (Electron). In the Choose R dialog (both at startup via holding down Ctrl and from Global Options), try choosing (via custom/browse) `R.exe` from the `bin` folder. Also try directly picking `x64\R.exe` and `i386\R.exe` (older versions of R required). The session should load in all cases.

Additionally, if you pick the wrong executable, for example "RScript.exe", it will now work.

Finally, try picking `bin\R.exe` using an older build of RStudio. The session should fail to load. Then run this newer build; it should automatically correct the situation and the session will work.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


