### PR TITLE
Enable RStudio to start even if legacy desktop.ini exists but is not readable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Fixed issue with column preview with older versions of the 'pillar' package. (#12863)
 - Fixed bug where the OK button was disabled in Choose R dialog when only one version of R installed (#12916)
 - Improved robustness when chosing custom R version in Windows desktop (#12969)
+- Fixed bug that prevented RStudio Desktop from starting on Linux if desktop.ini was unreadable (#12963)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/main/preferences/file-preferences.ts
+++ b/src/node/desktop/src/main/preferences/file-preferences.ts
@@ -34,7 +34,11 @@ class FilePreferences extends DesktopOptions {
     const desktopIni = userConfigDir.completePath(INI_FILE).getAbsolutePath().replace('rstudio', 'RStudio');
 
     if (FilePath.existsSync(desktopIni)) {
-      this.properties = PropertiesReader(desktopIni);
+      try {
+        this.properties = PropertiesReader(desktopIni);
+      } catch (err: unknown) {
+        console.error(err.message); // too early in startup for logging
+      }
     }
   }
 


### PR DESCRIPTION
### Intent

Addresses [RStudio Desktop on Linux won't start if ~/.config/RStudio/desktop.ini isn't readable #12963](https://github.com/rstudio/rstudio/issues/12963)

### Approach

Wrap the code in a try/catch, write an error message to stderr (too early in startup for the logging), and continue startup.

### Automated Tests

None

### QA Notes

The file ~/.config/RStudio/desktop.ini is where the Qt-based RStudio Desktop stored desktop preferences, and Electron is trying to read it to migrate those settings.

You can repro this bug by changing ownership/permissions on that file so current user can't read it, then start RStudio.

With this fix RStudio no longer crashes on startup in this situation and proceeds to startup. Of course we won't be able to migrate the settings from desktop.ini since we can't read them, but better to start than fail in an ugly fashion.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


