### PR TITLE
Always use the configured database.conf file

### DIFF
--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -406,7 +406,7 @@ Error initialize(const std::string& databaseConfigFile,
    if (error)
       return error;
    
-   if(getConfiguredDriver(options) == Driver::Postgresql)
+   if (getConfiguredDriver(options) == Driver::Postgresql)
    {
       validateMinimumPostgreSqlVersion();
    }

--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -341,6 +341,11 @@ Error migrationsDir(FilePath* pMigrationsDir)
    return Success();
 }
 
+core::database::Driver getConfiguredDriver(ConnectionOptions options) {
+   ConfiguredDriverVisitor visitor;
+   return boost::apply_visitor(visitor, options);
+}
+
 } // anonymous namespace
 
 core::database::Driver getConfiguredDriver(const std::string& databaseConfigFile)
@@ -353,8 +358,7 @@ core::database::Driver getConfiguredDriver(const std::string& databaseConfigFile
       return core::database::Driver::Unknown;
    }
 
-   ConfiguredDriverVisitor visitor;
-   return boost::apply_visitor(visitor, options);
+   return getConfiguredDriver(options);
 }
 
 Error initialize(const std::string& databaseConfigFile,
@@ -402,7 +406,7 @@ Error initialize(const std::string& databaseConfigFile,
    if (error)
       return error;
    
-   if(getConfiguredDriver(databaseConfigFile) == Driver::Postgresql)
+   if(getConfiguredDriver(options) == Driver::Postgresql)
    {
       validateMinimumPostgreSqlVersion();
    }

--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -402,7 +402,7 @@ Error initialize(const std::string& databaseConfigFile,
    if (error)
       return error;
    
-   if(getConfiguredDriver() == Driver::Postgresql)
+   if(getConfiguredDriver(databaseConfigFile) == Driver::Postgresql)
    {
       validateMinimumPostgreSqlVersion();
    }


### PR DESCRIPTION
### Intent

Ensure we never check the database.conf settings without reading it at the configured location.

### Approach

Only read the config file once by separating the function that checks the driver type and passing the existing config object.

### Automated Tests

I don't think we have anything around this. It was caught by @kevinushey when he tried to start a dev rstudio-server instance on MacOS. We could test by configuring an alternate path in one or more of our fuzzbucket environments.

### QA Notes

If we configure an alternate database.conf location, we should get the settings it has, not the defaults. 

### Documentation

No documentation - we already document how to change the location, this just ensures it will work.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


