### PR TITLE
allow admin to control suspend behavior for connections / external pointers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,8 @@
 - Improve visibility of focus rectangles on Server / Workbench Sign In page [Accessibility] (#12846)
 
 #### Posit Workbench
-- 
+- Added the `session-connections-block-suspend` session option, controlling whether active connections can block suspension of an R session.
+- Added the `session-external-pointers-block-suspend` session option, controlling whether R objects containing external pointers can block suspension of an R session.
 
 ### Fixed
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -102,14 +102,18 @@ void consolePrompt(const std::string& prompt, bool addToHistory)
 bool canSuspend(const std::string& prompt)
 {
    bool suspendIsBlocked = false;
+   
    suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
    suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
-   suspendIsBlocked |= !modules::overlay::isSuspendable();
 
-   if (prefs::userPrefs().checkNullExternalPointers())
+   if (session::options().sessionConnectionsBlockSuspend())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
+   
+   if (session::options().sessionExternalPointersBlockSuspend())
       suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
+   
+   suspendIsBlocked |= !modules::overlay::isSuspendable();
    
    return !suspendIsBlocked;
 }

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -122,6 +122,12 @@ protected:
       "Whether or not to reuse last used bound ports when restarting a Launcher session.");
 
    pSession->add_options()
+      ("session-connections-block-suspend",
+      value<bool>(&sessionConnectionsBlockSuspend_)->default_value(true),
+      "Whether or not an active database connection should block attempts to suspend the session after timeout.")
+      ("session-external-pointers-block-suspend",
+      value<bool>(&sessionExternalPointersBlockSuspend_)->default_value(true),
+      "Whether or not R objects containing external pointers should block attempts to suspend the session after timeout.")
       (kTimeoutSessionOption,
       value<int>(&timeoutMinutes_)->default_value(120),
       "The amount of minutes before a session times out, at which point the session will either suspend or exit.")
@@ -422,6 +428,8 @@ public:
    bool standalone() const { return standalone_; }
    bool verifySignatures() const { return verifySignatures_; }
    bool wwwReusePorts() const { return wwwReusePorts_; }
+   bool sessionConnectionsBlockSuspend() const { return sessionConnectionsBlockSuspend_; }
+   bool sessionExternalPointersBlockSuspend() const { return sessionExternalPointersBlockSuspend_; }
    int timeoutMinutes() const { return timeoutMinutes_; }
    bool timeoutSuspend() const { return timeoutSuspend_; }
    int disconnectedTimeoutMinutes() const { return disconnectedTimeoutMinutes_; }
@@ -525,6 +533,8 @@ protected:
    bool standalone_;
    bool verifySignatures_;
    bool wwwReusePorts_;
+   bool sessionConnectionsBlockSuspend_;
+   bool sessionExternalPointersBlockSuspend_;
    int timeoutMinutes_;
    bool timeoutSuspend_;
    int disconnectedTimeoutMinutes_;

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -142,6 +142,17 @@
       ],
       "session": [
          {
+            "name": "session-connections-block-suspend",
+            "type": "bool",
+            "memberName": "sessionConnectionsBlockSuspend_",
+            "description": "Whether or not an active database connection should block attempts to suspend the session after timeout."
+         },
+         {
+            "name": "session-external-pointers-block-suspend",
+            "type": "bool",
+            "description": "Whether or not R objects containing external pointers should block attempts to suspend the session after timeout."
+         },
+         {
             "name": {"constant": "kTimeoutSessionOption", "value": "session-timeout-minutes"},
             "type": "int",
             "memberName": "timeoutMinutes_",

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -144,7 +144,6 @@
          {
             "name": "session-connections-block-suspend",
             "type": "bool",
-            "memberName": "sessionConnectionsBlockSuspend_",
             "description": "Whether or not an active database connection should block attempts to suspend the session after timeout."
          },
          {


### PR DESCRIPTION
### Intent

Adds two boolean session options:

- `session-connections-block-suspend`
- `session-external-pointers-block-suspend`

to control whether the above two things are checked when checking if a session is suspendable.

### Approach

Straightforward update + generation of options.

### Automated Tests

N/A

### QA Notes

Test that these settings do (or don't) block suspend as described. 

### Documentation

TODO

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
