### PR TITLE
alternate implementation for suspendable environment

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -930,12 +930,12 @@
 .rs.addFunction("environment.isSuspendableImpl", function(value, depth)
 {
    # Avoid overly-deep recursions.
-   if (depth >= 8)
+   if (depth >= 8L)
       return(TRUE)
    
    # Skip overly-large objects.
    n <- length(value)
-   if (n >= 10000)
+   if (n >= 10000L)
       return(TRUE)
    
    # Python objects are connected to the underlying session, and so

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -919,3 +919,58 @@
    
 })
 
+.rs.addFunction("environment.isSuspendable", function()
+{
+   tryCatch(
+      .rs.environment.isSuspendableImpl(globalenv(), 1L),
+      error = function(e) TRUE
+   )
+})
+
+.rs.addFunction("environment.isSuspendableImpl", function(value, depth)
+{
+   # Avoid overly-deep recursions.
+   if (depth >= 8)
+      return(TRUE)
+   
+   # Skip overly-large objects.
+   n <- length(value)
+   if (n >= 10000)
+      return(TRUE)
+   
+   # Python objects are connected to the underlying session, and so
+   # cannot be restored after a suspend.
+   if (is.environment(value) && inherits(value, "python.builtin.object"))
+      return(FALSE)
+   
+   # Database connections cannot be serialized and restored.
+   if (inherits(value, "DBIConnection"))
+      return(FALSE)
+   
+   # Arrow objects cannot be serialized and restored.
+   if (inherits(value, "ArrowObject"))
+      return(FALSE)
+   
+   # Assume that data.frame objects won't contain external pointers.
+   if (is.data.frame(value))
+      return(TRUE)
+   
+   # Iterate through other recursive objects.
+   if (is.environment(value)) {
+      keys <- ls(envir = value, all.names = TRUE)
+      for (key in keys) {
+         if (!.rs.environment.isSuspendableImpl(value[[key]], depth + 1L)) {
+            return(FALSE)
+         }
+      }
+   } else if (is.recursive(value)) {
+      for (i in seq_along(value)) {
+         if (!.rs.environment.isSuspendableImpl(value[[i]], depth + 1L)) {
+            return(FALSE)
+         }
+      }
+   }
+      
+   # Assume that other kinds of objects can be restored.
+   TRUE
+})

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -951,6 +951,10 @@
    if (inherits(value, "ArrowObject"))
       return(FALSE)
    
+   # Objects containing external pointers cannot be serialized.
+   if (typeof(value) %in% c("externalptr", "weakref"))
+      return(FALSE)
+   
    # Assume that data.frame objects won't contain external pointers.
    if (is.data.frame(value))
       return(TRUE)

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -1416,8 +1416,15 @@ SEXP rs_dumpContexts()
 
 bool isSuspendable()
 {
-   // suppress suspension if any object has a live external pointer; these can't be restored
-   return !hasExternalPtr(R_GlobalEnv, false);
+   bool suspendable = false;
+   
+   Error error =
+         r::exec::RFunction(".rs.environment.isSuspendable")
+         .call(&suspendable);
+   if (error)
+      LOG_ERROR(error);
+   
+   return suspendable;
 }
 
 Error initialize()


### PR DESCRIPTION
### Intent

Uses an alternate implementation to check whether a session is suspendable, using some heuristics to avoid overly-expensive lookups.

### Approach

See PR.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
