### PR TITLE
add internal toggle for saving workspace

### DIFF
--- a/src/cpp/r/include/r/session/RSessionState.hpp
+++ b/src/cpp/r/include/r/session/RSessionState.hpp
@@ -44,6 +44,7 @@ bool save(const core::FilePath& statePath,
           bool serverMode,
           bool excludePackages,
           bool disableSaveCompression,
+          bool saveGlobalEnvironment,
           const std::string& ephemeralEnvVars);
 
 bool saveMinimal(const core::FilePath& statePath,

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -443,7 +443,7 @@ bool save(const FilePath& statePath,
    saveWorkingContext(statePath, &settings, &saved);
 
    // save search path (disable save compression if requested)
-   if (disableSaveCompression)
+   if (saveGlobalEnvironment && disableSaveCompression)
    {
       error = r::exec::RFunction(".rs.disableSaveCompression").call();
       if (error)

--- a/src/cpp/r/session/RSessionState.cpp
+++ b/src/cpp/r/session/RSessionState.cpp
@@ -366,6 +366,7 @@ bool save(const FilePath& statePath,
           bool serverMode,
           bool excludePackages,
           bool disableSaveCompression,
+          bool saveGlobalEnvironment,
           const std::string& ephemeralEnvVars)
 {
    // initialize context
@@ -449,7 +450,7 @@ bool save(const FilePath& statePath,
          LOG_ERROR(error);
    }
 
-   if (!excludePackages)
+   if (saveGlobalEnvironment && !excludePackages)
    {
       error = search_path::save(statePath);
       if (error)
@@ -458,7 +459,7 @@ bool save(const FilePath& statePath,
          saved = false;
       }
    }
-   else
+   else if (saveGlobalEnvironment)
    {
       error = search_path::saveGlobalEnvironment(statePath);
       if (error)

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -13,9 +13,11 @@
  *
  */
 
+#include <Rembedded.h>
+
 #include <shared_core/FilePath.hpp>
 
-#include <Rembedded.h>
+#include <core/system/Environment.hpp>
 
 #include <r/RExec.hpp>
 #include <r/session/RClientState.hpp>
@@ -56,12 +58,20 @@ bool saveSessionState(const RSuspendOptions& options,
    // suppress interrupts which occur during saving
    r::exec::IgnoreInterruptsScope ignoreInterrupts;
    
+   // check for save workspace
+   bool saveWorkspace = options.saveWorkspace;
+   
+   // allow env override
+   std::string envOverride = core::system::getenv("RSTUDIO_SUSPEND_SAVE_WORKSPACE");
+   if (!envOverride.empty())
+      saveWorkspace = string_utils::isTruthy(envOverride);
+   
    // save 
    if (options.saveMinimal)
    {
       // save minimal
       return r::session::state::saveMinimal(suspendedSessionPath,
-                                            options.saveWorkspace);
+                                            saveWorkspace);
 
    }
    else
@@ -70,6 +80,7 @@ bool saveSessionState(const RSuspendOptions& options,
                                      utils::isServerMode(),
                                      options.excludePackages,
                                      disableSaveCompression,
+                                     saveWorkspace,
                                      options.ephemeralEnvVars);
    }
 }

--- a/src/cpp/r/session/RSuspend.cpp
+++ b/src/cpp/r/session/RSuspend.cpp
@@ -58,17 +58,17 @@ bool saveSessionState(const RSuspendOptions& options,
    // suppress interrupts which occur during saving
    r::exec::IgnoreInterruptsScope ignoreInterrupts;
    
-   // check for save workspace
-   bool saveWorkspace = options.saveWorkspace;
-   
-   // allow env override
-   std::string envOverride = core::system::getenv("RSTUDIO_SUSPEND_SAVE_WORKSPACE");
-   if (!envOverride.empty())
-      saveWorkspace = string_utils::isTruthy(envOverride);
+   // check for save workspace override
+   std::string saveWorkspaceOverride =
+         core::system::getenv("RSTUDIO_SUSPEND_SAVE_WORKSPACE");
    
    // save 
    if (options.saveMinimal)
    {
+      bool saveWorkspace = string_utils::isTruthy(
+               saveWorkspaceOverride,
+               options.saveWorkspace);
+      
       // save minimal
       return r::session::state::saveMinimal(suspendedSessionPath,
                                             saveWorkspace);
@@ -76,6 +76,13 @@ bool saveSessionState(const RSuspendOptions& options,
    }
    else
    {
+      // NOTE: Just to preserve prior behavior, we always choose
+      // to save the workspace here, even if options.saveWorkspace
+      // is set to false. We still allow the environment override.
+      bool saveWorkspace = string_utils::isTruthy(
+               saveWorkspaceOverride,
+               true);
+      
       return r::session::state::save(suspendedSessionPath,
                                      utils::isServerMode(),
                                      options.excludePackages,


### PR DESCRIPTION
For internal use; allows developers to set an environment variable to disable saving / restoring of workspace during suspend. This has been requested internally by some who find the slowness from RStudio's attempts to save + restore the workspace frustrating.

We might want to consider exposing this publicly in the future as a number of users find it frustrating when overly-large workspaces are saved and restored, as this attempt can fail if objects are too large (and some users might be comfortable just throwing it away)