### PR TITLE
Companion commit to performance improvements for caching/locking

### DIFF
--- a/src/cpp/core/CMakeLists.txt
+++ b/src/cpp/core/CMakeLists.txt
@@ -121,6 +121,7 @@ set(CORE_SOURCE_FILES
    system/Process.cpp
    system/ShellUtils.cpp
    system/System.cpp
+   system/User.cpp
    system/Xdg.cpp
    system/file_monitor/FileMonitor.cpp
    terminal/PrivateCommand.cpp

--- a/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
+++ b/src/cpp/core/include/core/http/TcpIpAsyncConnector.hpp
@@ -121,7 +121,7 @@ private:
             if (pSocket_->is_open())
                pSocket_->cancel();
             else
-               LOG_ERROR_MESSAGE("Socket to: " + address_ + ":" + port_ + " is already closed in onConnectionTimeout");
+               LOG_DEBUG_MESSAGE("Socket to: " + address_ + ":" + port_ + " is already closed in onConnectionTimeout");
 
             // invoke error handler since the connection has failed
             handleError(systemError(boost::system::errc::timed_out, ERROR_LOCATION));

--- a/src/cpp/core/include/core/system/PosixGroup.hpp
+++ b/src/cpp/core/include/core/system/PosixGroup.hpp
@@ -43,6 +43,8 @@ Error groupFromName(const std::string& name, Group* pGroup);
 Error groupFromId(gid_t gid, Group* pGroup);
 std::vector<GidType> userGroupIds(const User& user);
 Error userGroups(const std::string& userName, std::vector<Group>* pGroups);
+void removeUserFromGroupCache(const std::string& username);
+
 
 } // namespace group
 } // namespace system

--- a/src/cpp/core/include/core/system/User.hpp
+++ b/src/cpp/core/include/core/system/User.hpp
@@ -1,0 +1,44 @@
+/*
+ * User.hpp
+ * 
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant to the terms of a commercial license agreement
+ * with Posit, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef CORE_USER_HPP
+#define CORE_USER_HPP
+
+#include <shared_core/system/User.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+
+Error getUserFromUsername(const std::string& in_username, User& out_user);
+
+Error getUserFromUserId(const UidType in_userId, User& out_user);
+
+void removeUserFromCache(const std::string& in_username);
+
+} // namespace system
+} // namespace core
+} // namespace rstudio
+
+
+#endif

--- a/src/cpp/core/system/User.cpp
+++ b/src/cpp/core/system/User.cpp
@@ -1,0 +1,219 @@
+/*
+ * User.cpp
+ * 
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant to the terms of a commercial license agreement
+ * with Posit, then this program is licensed to you under the following terms:
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include <shared_core/system/User.hpp>
+
+#include <pwd.h>
+
+#include <boost/algorithm/string.hpp>
+
+#include <chrono>
+
+#include <shared_core/Error.hpp>
+#include <shared_core/FilePath.hpp>
+#include <shared_core/SafeConvert.hpp>
+#include <shared_core/system/PosixSystem.hpp>
+
+#include <core/system/PosixGroup.hpp>
+
+#include <core/Thread.hpp>
+#include <core/Log.hpp>
+
+namespace rstudio {
+namespace core {
+namespace system {
+
+namespace {
+
+struct UserCache {
+   User user;
+   std::chrono::steady_clock::time_point cacheTime;
+};
+
+std::map<std::string, UserCache> s_usernameCache;
+std::map<UidType, UserCache> s_userIdCache;
+
+boost::mutex s_userCacheMutex;
+
+constexpr const std::chrono::duration<double> s_userCacheDuration = std::chrono::milliseconds(5*60*1000);
+
+void addUserToCache(User& user)
+{
+   UserCache cacheEnt;
+   cacheEnt.user = user;
+   cacheEnt.cacheTime = std::chrono::steady_clock::now();
+   LOCK_MUTEX(s_userCacheMutex)
+   {
+      s_usernameCache[user.getUsername()] = cacheEnt;
+      s_userIdCache[user.getUserId()] = cacheEnt;
+   }
+   END_LOCK_MUTEX
+}
+
+bool getUserFromNameCache(const std::string& in_username, User* pUser, bool* pExpired)
+{
+   std::chrono::steady_clock::time_point cacheTime;
+   User cacheUser;
+
+   LOCK_MUTEX(s_userCacheMutex)
+   {
+      auto it = s_usernameCache.find(in_username);
+      if (it == s_usernameCache.end())
+      {
+         *pExpired = false;
+         return false;
+      }
+      else
+      {
+         cacheUser = it->second.user;
+         cacheTime = it->second.cacheTime;
+      }
+   }
+   END_LOCK_MUTEX
+
+   std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+   if (cacheTime + s_userCacheDuration > now)
+   {
+      *pUser = cacheUser;
+      *pExpired = false;
+      return true;
+   }
+   else
+      *pExpired = true;
+   return false;
+}
+
+bool getUserFromIdCache(UidType in_userId, User* pUser, bool* pExpired)
+{
+   std::chrono::steady_clock::time_point cacheTime;
+   User cacheUser;
+
+   LOCK_MUTEX(s_userCacheMutex)
+   {
+      auto it = s_userIdCache.find(in_userId);
+      if (it == s_userIdCache.end())
+      {
+         *pExpired = false;
+         return false;
+      }
+      else
+      {
+         cacheUser = it->second.user;
+         cacheTime = it->second.cacheTime;
+      }
+   }
+   END_LOCK_MUTEX
+
+   std::chrono::steady_clock::time_point now = std::chrono::steady_clock::now();
+   if (cacheTime + s_userCacheDuration > now)
+   {
+      *pUser = cacheUser;
+      *pExpired = false;
+      return true;
+   }
+   else
+      *pExpired = true;
+   return false;
+}
+
+Error updateUserCacheByUsername(const std::string& in_username, User& out_user, const std::string& opNameForLog)
+{
+   Error error = User::getUserFromIdentifier(in_username, out_user);
+   if (!error)
+   {
+      addUserToCache(out_user);
+      LOG_DEBUG_MESSAGE(opNameForLog + " user to cache for user: " + in_username + ":" + std::to_string(out_user.getUserId()) + " by name");
+
+      return Success();
+   }
+   else
+   {
+      LOG_DEBUG_MESSAGE("Error from getUserFromIdentifier during: '" + opNameForLog + "' user: " + in_username + ": " + error.asString());
+      return error;
+   }
+}
+
+Error updateUserCacheByUserId(const UidType& in_userId, User& out_user, const std::string& opNameForLog)
+{
+   Error error = User::getUserFromIdentifier(in_userId, out_user);
+   if (!error)
+   {
+      addUserToCache(out_user);
+      LOG_DEBUG_MESSAGE("Added user: " + out_user.getUsername() + ":" + std::to_string(in_userId) + " from id lookup");
+
+       return Success();
+   }
+   else
+   {
+      LOG_DEBUG_MESSAGE("Error from getUserFromIdentifier for: " + std::to_string(in_userId) + ": " + error.asString());
+      return error;
+   }
+}
+
+} // anon namespace 
+
+Error getUserFromUsername(const std::string& in_username, User& out_user)
+{
+   bool expired;
+
+   if (!getUserFromNameCache(in_username, &out_user, &expired))
+      return updateUserCacheByUsername(in_username, out_user, expired ? "Updating" : "Adding");
+
+   return Success();
+}
+
+Error getUserFromUserId(UidType in_userId, User& out_user)
+{
+   bool expired;
+
+   if (!getUserFromIdCache(in_userId, &out_user, &expired))
+      return updateUserCacheByUserId(in_userId, out_user, expired ? "Updating" : "Adding");
+
+   return Success();
+}
+
+void removeUserFromCache(const std::string& in_username)
+{
+   int newSize;
+   LOCK_MUTEX(s_userCacheMutex)
+   {
+      auto it = s_usernameCache.find(in_username);
+      if (it != s_usernameCache.end())
+      {
+          UidType uid = it->second.user.getUserId();
+          s_usernameCache.erase(in_username);
+          s_userIdCache.erase(uid);
+      }
+      newSize = s_usernameCache.size();
+   }
+   END_LOCK_MUTEX
+
+   group::removeUserFromGroupCache(in_username);
+
+   LOG_DEBUG_MESSAGE("Removed user: " + in_username + " from cache - (now: " + std::to_string(newSize) + ")");
+}
+
+} // namespace system
+} // namespace core
+} // namespace rstudio
+

--- a/src/cpp/server/auth/ServerAuthCommon.cpp
+++ b/src/cpp/server/auth/ServerAuthCommon.cpp
@@ -23,6 +23,8 @@
 #include <core/http/Cookie.hpp>
 #include <core/http/CSRFToken.hpp>
 
+#include <core/system/User.hpp>
+
 #include <server_core/http/SecureCookie.hpp>
 
 #include <server/ServerConstants.hpp>
@@ -462,7 +464,7 @@ std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
       // here. See case 5413 for details.
       core::system::User user;
       // This call getpwnam - that will return the passwd line that matches this user identifier
-      Error error = core::system::User::getUserFromIdentifier(userIdentifier, user);
+      Error error = core::system::getUserFromUsername(userIdentifier, user);
       if (error)
       {
          // log the error and return the original user identifier as a fallback
@@ -473,7 +475,7 @@ std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
       {
          // This gets the passwd entry for the user-id - this is what the session will do so
          // when a uid is aliased, we need to go back to the uid for the real username
-         error = core::system::User::getUserFromIdentifier(user.getUserId(), user);
+         error = core::system::getUserFromUserId(user.getUserId(), user);
          if (error)
          {
             // log the error and return the original user identifier as a fallback
@@ -488,6 +490,8 @@ std::string userIdentifierToLocalUsername(const std::string& userIdentifier)
                LOG_DEBUG_MESSAGE("Auth handler mapped incoming user identifier: " + userIdentifier + " to system username: " + username);
          }
       }
+
+      LOG_DEBUG_MESSAGE("Caching auth userIdentifier: " + userIdentifier + " for system username: " + username);
 
       // cache the username -- we do this even if the lookup fails since
       // otherwise we're likely to keep hitting (and logging) the error on

--- a/src/cpp/server/auth/ServerAuthHandler.cpp
+++ b/src/cpp/server/auth/ServerAuthHandler.cpp
@@ -26,6 +26,7 @@
 #include <core/Log.hpp>
 #include <core/json/JsonRpc.hpp>
 #include <core/system/PosixUser.hpp>
+#include <core/system/User.hpp>
 #include <core/Thread.hpp>
 #include <core/PeriodicCommand.hpp>
 #include <server/ServerScheduler.hpp>
@@ -98,8 +99,15 @@ std::map<std::string, boost::posix_time::ptime> s_loginTimes;
 // allows for quickly removing the first element
 std::deque<RevokedCookie> s_revokedCookies;
 
+// Stores revoked cookies that have been expired and can be purged from the db
+std::vector<RevokedCookie> s_expiredCookies;
+
 // Tracks the set of cookies that are authorized for the user session, so they can all be revoked on signout
 std::map<std::string,boost::shared_ptr<UserSession>> s_userSessions;
+
+std::map<std::string,UidType> s_usernameToUID;
+
+std::map<UidType,std::string> s_UIDToUsername;
 
 boost::posix_time::ptime s_lastCookieCheckTime = boost::posix_time::second_clock::universal_time();
 boost::posix_time::time_duration s_cookieCheckDuration = boost::posix_time::seconds(5);
@@ -249,6 +257,9 @@ Error readRevocationListFromFile(const FilePath& revocationList,
 
 bool invalidateExpiredSessions()
 {
+   int expiredSessions = 0;
+   int preservedSessions = 0;
+
    RECURSIVE_LOCK_MUTEX(s_mutex)
    {
       if (s_userSessions.size() == 0)
@@ -269,14 +280,13 @@ bool invalidateExpiredSessions()
                // Because the user's session has passively expired, we are not going to actively revoke the cookies across the cluster.
                // Each cookie has an expire time built in so it will expire on its own in the browser
                // pUserSession->invalidateSessionCookies();
-               LOG_DEBUG_MESSAGE("Expired UserSession for: " + pUserSession->username());
+               expiredSessions++;
 
                it = s_userSessions.erase(it);
             }
             else
             {
-               LOG_DEBUG_MESSAGE("Preserving expired UserSession with: " + std::to_string(pUserSession->numConnections()) +
-                                 " for: " + pUserSession->username());
+               preservedSessions++;
                ++it;
             }
          }
@@ -287,6 +297,11 @@ bool invalidateExpiredSessions()
       }
    }
    END_LOCK_MUTEX
+
+   if (expiredSessions > 0)
+      LOG_DEBUG_MESSAGE("Expired " + std::to_string(expiredSessions) + " sessions");
+   if (preservedSessions > 0)
+      LOG_DEBUG_MESSAGE("Preserved " + std::to_string(preservedSessions) + " expired sessions with open streaming connections");
 
    return true;
 }
@@ -311,6 +326,47 @@ void addToUserSessionConnections(const std::string& username, int val)
    END_LOCK_MUTEX
 }
 
+void removeExpiredCookies()
+{
+   std::vector<RevokedCookie> toRemove;
+
+   RECURSIVE_LOCK_MUTEX(s_mutex)
+   {
+      if (s_expiredCookies.size() == 0)
+         return;
+
+      // Get cookies to remove and clear the old list
+      toRemove.swap(s_expiredCookies);
+   }
+   END_LOCK_MUTEX
+
+   boost::shared_ptr<IConnection> connection;
+   server_core::database::getConnection(boost::posix_time::milliseconds(500), &connection);
+
+   if (connection)
+   {
+      LOG_DEBUG_MESSAGE("Begin expiring " + std::to_string(toRemove.size()) + " cookies");
+
+      for (auto it = toRemove.begin(); it != toRemove.end(); it++)
+      {
+         const RevokedCookie& toRemove = *it;
+         removeStaleCookieFromDatabase(toRemove, connection);
+      }
+      LOG_DEBUG_MESSAGE("Finished expiring cookies");
+   }
+   else
+   {
+      LOG_WARNING_MESSAGE("Failed to get db connection in 500ms - delaying expired cookie removal");
+
+      RECURSIVE_LOCK_MUTEX(s_mutex)
+      {
+         for (auto it = toRemove.begin(); it != toRemove.end(); it++)
+            s_expiredCookies.push_back(*it);
+      }
+      END_LOCK_MUTEX
+   }
+}
+
 } // anonymous namespace
 
 bool isCookieRevoked(const std::string& cookie)
@@ -318,13 +374,16 @@ bool isCookieRevoked(const std::string& cookie)
    if (cookie.empty())
       return true;
 
-   bool attemptedConnection = false;
-   boost::shared_ptr<IConnection> connection;
    boost::posix_time::ptime now = boost::posix_time::second_clock::universal_time();
+
+   std::vector<RevokedCookie> expiredCookies;
+
+   bool removeStaleCookies;
+   bool expireCookies = false;
 
    RECURSIVE_LOCK_MUTEX(s_mutex)
    {
-      bool removeStaleCookies = now > s_lastCookieCheckTime + s_cookieCheckDuration;
+      removeStaleCookies = now > s_lastCookieCheckTime + s_cookieCheckDuration;
 
       if (removeStaleCookies)
       {
@@ -342,29 +401,11 @@ bool isCookieRevoked(const std::string& cookie)
 
          if (removeStaleCookies && other.expiration <= now)
          {
-            if (!attemptedConnection)
-            {
-               // grab a connection from the pool, but only wait for a short amount of time
-               // this ensures that we do not delay the sign in process too long - deleting stale
-               // cookies from the database immediately is not of critical importance, as this operation will
-               // be retried on all subsequent auths / process restarts
-               server_core::database::getConnection(boost::posix_time::milliseconds(500), &connection);
-               attemptedConnection = true;
-            }
-
-            if (connection)
-            {
-               removeStaleCookieFromDatabase(other, connection);
-
-               // we only erase cookies from the memory map if they were also removed from the database
-               // to ensure that if we couldn't delete them immediately, we retry the operation later
-               it = s_revokedCookies.erase(it);
-               continue;
-            }
-            else
-            {
-               ++it;
-            }
+            expireCookies = true;
+            // Put it in the list to remove from the DB
+            s_expiredCookies.push_back(other);
+            // Remove it from this list
+            it = s_revokedCookies.erase(it);
          }
          else
          {
@@ -373,6 +414,9 @@ bool isCookieRevoked(const std::string& cookie)
       }
    }
    END_LOCK_MUTEX
+
+   if (expireCookies)
+      removeExpiredCookies();
 
    return false;
 }
@@ -383,7 +427,7 @@ Error getUserFromDatabase(const boost::shared_ptr<IConnection>& connection,
                           boost::posix_time::ptime* pLastSignin,
                           bool* pExists)
 {
-   LOG_DEBUG_MESSAGE("Getting user from database: " + user.getUsername());
+   LOG_DEBUG_MESSAGE("User db query start: " + user.getUsername());
    
    *pLocked = true;
 
@@ -439,6 +483,11 @@ Error getUserFromDatabase(const boost::shared_ptr<IConnection>& connection,
    }
 
    *pExists = foundUser;
+
+   if (foundUser)
+      LOG_DEBUG_MESSAGE("Found user in db: " + user.getUsername());
+   else
+      LOG_DEBUG_MESSAGE("No record found for user in db: " + user.getUsername());
    return Success();
 }
 
@@ -459,7 +508,7 @@ Error addUser(boost::asio::io_service& ioService,
    }
    
    system::User user;
-   Error error = system::User::getUserFromIdentifier(username, user);
+   Error error = system::getUserFromUsername(username, user);
    if (error)
       return error;
 
@@ -550,12 +599,16 @@ json::Array getAllUsers()
 Error updateLastSignin(const boost::shared_ptr<IConnection>& connection,
                        const system::User& user)
 {
+   LOG_DEBUG_MESSAGE("Begin update last signIn time");
+
    std::string currentTime = date_time::format(boost::posix_time::microsec_clock::universal_time(),
                                                date_time::kIso8601Format);
    Query updateSignin =
          connection->query("UPDATE licensed_users SET last_sign_in = :val WHERE user_id = :uid")
             .withInput(currentTime)
             .withInput(user.getUserId());
+
+   LOG_DEBUG_MESSAGE("End update last signIn time");
 
    return connection->execute(updateSignin);
 }
@@ -592,7 +645,7 @@ Error isUserLicensed(const std::string& username,
                      bool* pLicensed)
 {
    system::User user;
-   Error error = system::User::getUserFromIdentifier(username, user);
+   Error error = system::getUserFromUsername(username, user);
    if (error)
       return error;
 
@@ -764,6 +817,8 @@ Error getNumActiveUsers(const boost::shared_ptr<IConnection>& connection,
    size_t numActive = 0;
    bool dataReturned = false;
 
+   LOG_DEBUG_MESSAGE("Retrieving active licensed user count - begin");
+
    std::string queryStr = "SELECT COUNT(*) FROM licensed_users WHERE locked = false AND last_sign_in > :exp";
    if (connection->driver() == Driver::Sqlite)
       boost::replace_all(queryStr, "false", "0");
@@ -782,6 +837,8 @@ Error getNumActiveUsers(const boost::shared_ptr<IConnection>& connection,
                          "Database returned no count of licensed users",
                          ERROR_LOCATION);
    }
+
+   LOG_DEBUG_MESSAGE("Retrieving active licensed user count - result: " + std::to_string(numActive));
 
    *pNumActiveUsers = numActive;
    return Success();
@@ -877,11 +934,41 @@ RevokedCookie::RevokedCookie(const std::string& cookie)
    this->expiration = cookieExpiration(cookie);
 }
 
+void ensureDatabaseUser(const std::string& username)
+{
+   // Lookup the user in the database
+   system::User user;
+   Error error = system::getUserFromUsername(username, user);
+   if (error)
+   {
+      LOG_ERROR(error);
+      return;
+   }
+
+   bool locked, exists;
+   boost::posix_time::ptime lastSignIn;
+   boost::shared_ptr<IConnection> connection = server_core::database::getConnection();
+   error = getUserFromDatabase(connection, user, &locked, &lastSignIn, &exists);
+   if (error)
+   {
+      LOG_ERROR(error);
+   }
+   else if (!exists)
+   {
+      error = addUserToDatabase(connection, user, false);
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+   }
+}
+
 boost::shared_ptr<UserSession> UserSession::createUserSession(const std::string& username)
 {
+   boost::shared_ptr<UserSession> pUserSession;
    RECURSIVE_LOCK_MUTEX(s_mutex)
    {
-      boost::shared_ptr<UserSession> pUserSession = UserSession::lookupUserSession(username);
+      pUserSession = UserSession::lookupUserSession(username);
       if (pUserSession)
       {
          LOG_DEBUG_MESSAGE("Reusing active session for: " + username + " that did not expire and was not logged out");
@@ -896,10 +983,13 @@ boost::shared_ptr<UserSession> UserSession::createUserSession(const std::string&
 
          LOG_DEBUG_MESSAGE("Created new UserSession for: " + username + " (total: " + std::to_string(s_userSessions.size()) + ")");
       }
-      return pUserSession;
    }
    END_LOCK_MUTEX
-   return boost::shared_ptr<UserSession>();
+
+   // Make sure there's a database record for the user when creating the session
+   ensureDatabaseUser(username);
+
+   return pUserSession;
 }
 
 void UserSession::updateSessionLastActiveTime(const std::string& username)
@@ -934,46 +1024,6 @@ boost::shared_ptr<UserSession> UserSession::lookupUserSession(const std::string&
    {
       std::map<std::string, boost::shared_ptr<UserSession>>::iterator it = s_userSessions.find(username);
       bool sessionFound = it != s_userSessions.end();
-
-      // Lookup the user in the database
-      system::User user;
-      Error error = system::User::getUserFromIdentifier(username, user);
-      if (error)
-      {
-         LOG_ERROR(error);
-
-         if (sessionFound)
-            removeUserSession(username);
-
-         return boost::shared_ptr<UserSession>();
-      }
-
-      bool locked, exists;
-      boost::posix_time::ptime lastSignIn;
-      boost::shared_ptr<IConnection> connection = server_core::database::getConnection();
-      error = getUserFromDatabase(connection, user, &locked, &lastSignIn, &exists);
-      if (error)
-      {
-         LOG_ERROR(error);
-
-         if (sessionFound)
-            removeUserSession(username);
-
-         return boost::shared_ptr<UserSession>();
-      }
-      else if (!exists)
-      {
-         error = addUserToDatabase(connection, user, false);
-         if (error)
-         {
-            LOG_ERROR(error);
-
-            if (sessionFound)
-               removeUserSession(username);
-
-            return boost::shared_ptr<UserSession>();
-         }
-      }
 
       if (!sessionFound)
          return boost::shared_ptr<UserSession>();
@@ -1022,6 +1072,9 @@ void UserSession::removeUserSession(const std::string& username)
       s_userSessions.erase(username);
    }
    END_LOCK_MUTEX
+
+   // Remove the user from the username and uid caches so we revalidate from scratch next time
+   core::system::removeUserFromCache(username);
 }
 
 bool UserSession::invalidateUserSession(const std::string& username)
@@ -1067,7 +1120,8 @@ void UserSession::updateLastCookieRefreshTime()
 std::string getUserIdentifier(const core::http::Request& request,
                               bool requireUserListCookie)
 {
-   if (isCookieRevoked(request.cookieValue(kUserIdCookie)))
+   std::string cookieValue = request.cookieValue(kUserIdCookie);
+   if (isCookieRevoked(cookieValue))
       return std::string();
 
    std::string userIdentifier = s_handler.getUserIdentifier(request);
@@ -1269,11 +1323,11 @@ void applyRemoteRevokedCookie(const std::string& cookieValue)
 }
 
 
-void insertRevokedCookie(const RevokedCookie& cookie)
+bool insertRevokedCookie(const RevokedCookie& cookie)
 {
    // do not insert the cookie if it is already expired
    if (cookie.expiration <= boost::posix_time::second_clock::universal_time())
-      return;
+      return false;
 
    RECURSIVE_LOCK_MUTEX(s_mutex)
    {
@@ -1283,7 +1337,7 @@ void insertRevokedCookie(const RevokedCookie& cookie)
          if (other.expiration > cookie.expiration)
          {
             s_revokedCookies.insert(it, cookie);
-            return;
+            return true;
          }
       }
 
@@ -1291,13 +1345,13 @@ void insertRevokedCookie(const RevokedCookie& cookie)
       s_revokedCookies.insert(s_revokedCookies.end(), cookie);
    }
    END_LOCK_MUTEX
+
+   return true;
 }
 
 void invalidateAuthCookie(const std::string& cookie,
                           ExponentialBackoffPtr backoffPtr)
 {
-   LOG_DEBUG_MESSAGE("Invalidated auth cookie: " + cookie);
-
    if (cookie.empty())
       return;
 
@@ -1306,15 +1360,16 @@ void invalidateAuthCookie(const std::string& cookie,
    // store the revoked cookie in memory - we only check the memory cache when
    // checking incoming requests to see if the cookie presented has been revoked
    // because it is too expensive to hit the disk every time
-   insertRevokedCookie(revokedCookie);
+   if (insertRevokedCookie(revokedCookie))
+   {
+      // attempt to revoke the cookie - if the database insert fails, we still notify
+      // other nodes so they can at least update their in-memory cache
+      Error error = writeRevokedCookieToDatabase(revokedCookie);
+      if (error)
+         LOG_ERROR(error);
 
-   // attempt to revoke the cookie - if the database insert fails, we still notify
-   // other nodes so they can at least update their in-memory cache
-   Error error = writeRevokedCookieToDatabase(revokedCookie);
-   if (error)
-      LOG_ERROR(error);
-
-   onCookieRevoked(cookie);
+      onCookieRevoked(cookie);
+   }
 }
 
 Error initialize()

--- a/src/cpp/server/auth/ServerValidateUser.cpp
+++ b/src/cpp/server/auth/ServerValidateUser.cpp
@@ -24,6 +24,7 @@
 
 #include <core/system/PosixSystem.hpp>
 #include <core/system/PosixUser.hpp>
+#include <core/system/User.hpp>
 
 #include <server/ServerOptions.hpp>
 
@@ -44,7 +45,7 @@ bool validateUser(const std::string& username,
    
    // get the user
    core::system::User user;
-   Error error = core::system::User::getUserFromIdentifier(username, user);
+   Error error = core::system::getUserFromUsername(username, user);
    if (error)
    {
       // log the error only if it is unexpected
@@ -59,25 +60,25 @@ bool validateUser(const std::string& username,
    // return the same username but if it doesn't, there is another user with
    // same uid and we bail to prevent unexpected behaviors down the road
    core::system::User tmpUser;
-   error = core::system::User::getUserFromIdentifier(user.getUserId(), tmpUser);
+   error = core::system::getUserFromUserId(user.getUserId(), tmpUser);
    if (error)
    {
-       // log the error only if it is unexpected
-       if (!core::system::isUserNotFoundError(error))
-           LOG_ERROR(error);
+      // log the error only if it is unexpected
+      if (!core::system::isUserNotFoundError(error))
+         LOG_ERROR(error);
 
-       // not found either due to non-existence or an unexpected error
-       return false;
+      // not found either due to non-existence or an unexpected error
+      return false;
    }
    if (user.getUsername() != tmpUser.getUsername())
    {
-       boost::format fmt(
-               "User '%1%' could not be authenticated "
-               "because another user with the same UID %2% exists. "
-               "The conflicting user is '%3%'.");
-       std::string msg = boost::str(fmt % user.getUsername() % user.getUserId() % tmpUser.getUsername());
-       LOG_ERROR_MESSAGE(msg);
-       return false;
+      boost::format fmt(
+            "User '%1%' could not be authenticated "
+            "because another user with the same UID %2% exists. "
+            "The conflicting user is '%3%'.");
+      std::string msg = boost::str(fmt % user.getUsername() % user.getUserId() % tmpUser.getUsername());
+      LOG_ERROR_MESSAGE(msg);
+      return false;
    }
 
    // validate minimum user id

--- a/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
+++ b/src/cpp/server/include/server/auth/ServerAuthHandler.hpp
@@ -189,7 +189,7 @@ void signOut(const core::http::Request& request,
 // used to prevent inordinate generation of expired tokens
 bool isUserSignInThrottled(const std::string& user);
 
-void insertRevokedCookie(const RevokedCookie& cookie);
+bool insertRevokedCookie(const RevokedCookie& cookie);
 void applyRemoteRevokedCookie(const std::string& cookie);
 
 // refreshes the auth cookie silently (without user intervention)


### PR DESCRIPTION
Reviewed in:

   https://github.com/rstudio/rstudio-pro/pull/4499

- cache users and groups
- no db or log messages while holding locks to avoid bottlenecking
- eliminate redundant "get user" queries


