### PR TITLE
use Rterm.exe instead of R.exe on Windows when checking R installation status

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -211,6 +211,20 @@ writeLines(sep = "\x1F", c(
   delete envCopy['R_RUNTIME'];
   delete envCopy['R_SHARE_DIR'];
 
+  // On Windows, unset temporary directory environment variables: the R docs state that 
+  // when using R from command-line on Windows:
+  //
+  //   https://cran.r-project.org/doc/manuals/R-intro.html
+  //
+  //   "You need to ensure that either the environment variables TMPDIR, TMP, and TEMP
+  //    are either unset or one of them points to a valid place to create temporary
+  //    files and directories."
+  if (process.platform === 'win32') {
+    delete envCopy['TMP'];
+    delete envCopy['TMPDIR'];
+    delete envCopy['TEMP'];
+  }
+
   const [result, error] = expect(() => {
     return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
       encoding: 'utf-8',

--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -26,12 +26,13 @@ import { ChooseRModalWindow } from '..//ui/widgets/choose-r';
 import { createStandaloneErrorDialog, handleLocaleCookies } from './utils';
 import { t } from 'i18next';
 
-import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
+import { ElectronDesktopOptions, fixWindowsRExecutablePath } from './preferences/electron-desktop-options';
 import { FilePath } from '../core/file-path';
 import { dialog } from 'electron';
 
 import desktop from '../native/desktop.node';
 import { EOL } from 'os';
+import { kWindowsRExe } from '../ui/utils';
 
 let kLdLibraryPathVariable: string;
 if (process.platform === 'darwin') {
@@ -73,7 +74,7 @@ export async function promptUserForR(platform = process.platform): Promise<Expec
       // if the user selected a version of R previously, then use it
       const rBinDir = ElectronDesktopOptions().rBinDir();
       if (rBinDir) {
-        const rPath = `${rBinDir}/R.exe`;
+        const rPath = fixWindowsRExecutablePath(`${rBinDir}/${kWindowsRExe}`);
         logger().logDebug(`Trying version of R stored in RStudio Desktop options: ${rPath}`);
         if (isValidBinary(rPath)) {
           logger().logDebug(`Validation succeeded; using R: ${rPath}`);
@@ -181,7 +182,7 @@ export function detectREnvironment(rPath: string): Expected<REnvironment> {
   // resolve path to binary if we were given a directory
   let rExecutable = new FilePath(rPath);
   if (rExecutable.isDirectory()) {
-    rExecutable = rExecutable.completeChildPath(process.platform === 'win32' ? 'R.exe' : 'R');
+    rExecutable = rExecutable.completeChildPath(process.platform === 'win32' ? kWindowsRExe : 'R');
   }
 
   // generate small script for querying information about R
@@ -374,9 +375,13 @@ export function findRInstallationsWin32(): string[] {
   return uniqueInstallations;
 }
 
-export function isValidInstallation(rInstallPath: string): boolean {
-  const rExeName = process.platform === 'win32' ? 'R.exe' : 'R';
-  const rExePath = path.normalize(`${rInstallPath}/bin/${rExeName}`);
+export function isValidInstallation(rInstallPath: string, archDir: string): boolean {
+  if (process.platform !== 'win32') {
+    logger().logErrorMessage('Windows-only API invoked on non-Windows codepath (isValidInstallation)');
+    return true;
+  }
+
+  const rExePath = path.normalize(`${rInstallPath}/bin/${archDir}/${kWindowsRExe}`);
   return isValidBinary(rExePath);
 }
 
@@ -417,7 +422,7 @@ function scanForRWin32(): Expected<string> {
   if (process.arch !== 'x32') {
     const x64InstallPath = findDefaultInstallPathWin32('R64');
     if (x64InstallPath) {
-      const x64BinaryPath = `${x64InstallPath}/bin/x64/R.exe`;
+      const x64BinaryPath = `${x64InstallPath}/bin/x64/${kWindowsRExe}`;
       if (isValidBinary(x64BinaryPath)) {
         logger().logDebug(`Using R ${x64BinaryPath} (found via registry)`);
         return ok(x64BinaryPath);
@@ -428,7 +433,7 @@ function scanForRWin32(): Expected<string> {
   // look for a 32-bit version of R
   const i386InstallPath = findDefaultInstallPathWin32('R');
   if (i386InstallPath) {
-    const i386BinaryPath = `${i386InstallPath}/bin/i386/R.exe`;
+    const i386BinaryPath = `${i386InstallPath}/bin/i386/${kWindowsRExe}`;
     if (isValidBinary(i386BinaryPath)) {
       logger().logDebug(`Using R ${i386BinaryPath} (found via registry)`);
       return ok(i386BinaryPath);

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -25,6 +25,7 @@ import { RStudioUserState } from '../../types/user-state-schema';
 
 import { generateSchema, legacyPreferenceManager } from './../preferences/preferences';
 import DesktopOptions from './desktop-options';
+import { kWindowsRExe } from '../../ui/utils';
 
 const kProportionalFont = 'font.proportionalFont';
 const kFixedWidthFont = 'font.fixedWidthFont';
@@ -401,11 +402,11 @@ if (process.platform === 'darwin') {
  * If they want to use 32-bit R on a 64-bit machine they will need to
  * choose it directly from the i386 folder.
  * 
- * Also correct the case where they selected something other than R.exe, such 
- * as RScript.exe.
+ * Use Rterm.exe instead of R.exe (or anything else the user might have
+ * chosen; we can't prevent them from choosing arbitrary files).
  * 
- * @param rExePath Full path to R.exe
- * @returns Full path to R.exe including arch folder
+ * @param rExePath Full path to Rterm.exe
+ * @returns Full path to Rterm.exe including arch folder
  */
 export function fixWindowsRExecutablePath(rExePath: string): string {
   if (process.platform !== 'win32' ||
@@ -421,13 +422,13 @@ export function fixWindowsRExecutablePath(rExePath: string): string {
   if (selectedDir === 'bin') {
     // User picked bin\*.exe; insert the subfolder matching the machine's architecture.
     const archDir = process.arch === 'x32' ? 'i386' : 'x64';
-    rExePath = join(dirname(rExePath), archDir, 'R.exe');
+    rExePath = join(dirname(rExePath), archDir, kWindowsRExe);
     logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
   } else {
-    // Even if they chose the right folder, make sure they picked R.exe
+    // Even if they chose the right folder, make sure they picked Rterm.exe
     const exe = basename(rExePath).toLowerCase();
-    if (exe !== 'r.exe') {
-      rExePath = join(dirname(rExePath), 'R.exe');
+    if (exe !== kWindowsRExe.toLowerCase()) {
+      rExePath = join(dirname(rExePath), kWindowsRExe);
       logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
     }
   }

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain } from 'electron';
 import { err, Expected, ok } from '../core/expected';
 import { safeError } from '../core/err';
+import { getenv } from '../core/environment';
 
 export abstract class ModalDialog<T> extends BrowserWindow {
   abstract onShowModal(): Promise<T>;
@@ -83,6 +84,11 @@ export abstract class ModalDialog<T> extends BrowserWindow {
 
     // show the window after loading everything
     this.show();
+
+    const showDevTools = getenv('RSTUDIO_DESKTOP_MODAL_DEVTOOLS').length !== 0;
+    if (showDevTools) {
+      this.webContents.openDevTools();
+    }
 
     // invoke derived class's callback and return the response
     return this.onShowModal();

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -77,3 +77,6 @@ export function normalizeSeparatorsNative(path: string) {
   const separator = process.platform === 'win32' ? '\\' : '/';
   return normalizeSeparators(path, separator);
 }
+
+// executable to use on Windows when spawning R to query path information
+export const kWindowsRExe = 'Rterm.exe';

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -25,6 +25,7 @@ import { ElectronDesktopOptions, fixWindowsRExecutablePath } from '../../main/pr
 
 import { existsSync } from 'fs';
 import { normalize } from 'path';
+import { kWindowsRExe } from '../utils';
 
 declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
@@ -86,8 +87,8 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
     const r32 = findDefault32Bit();
     const r64 = findDefault64Bit();
     const initData = {
-      default32bitPath: isValidInstallation(r32) ? r32 : '',
-      default64bitPath: isValidInstallation(r64) ? r64 : '',
+      default32bitPath: isValidInstallation(r32, 'i386') ? r32 : '',
+      default64bitPath: isValidInstallation(r64, 'x64') ? r64 : '',
       rInstalls: this.rInstalls,
       renderingEngine: ElectronDesktopOptions().renderingEngine(),
       selectedRVersion: ElectronDesktopOptions().rExecutablePath(),
@@ -107,14 +108,14 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
       this.addIpcHandler('use-default-32bit', async (event, data: CallbackData) => {
         const installPath = initData.default32bitPath;
-        data.binaryPath = `${installPath}/bin/i386/R.exe`;
+        data.binaryPath = `${installPath}/bin/i386/${kWindowsRExe}`;
         logger().logDebug(`Using default 32-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);
       });
 
       this.addIpcHandler('use-default-64bit', async (event, data: CallbackData) => {
         const installPath = initData.default64bitPath;
-        data.binaryPath = `${installPath}/bin/x64/R.exe`;
+        data.binaryPath = `${installPath}/bin/x64/${kWindowsRExe}`;
         logger().logDebug(`Using default 64-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);
       });
@@ -128,7 +129,7 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
         const response = dialog.showOpenDialogSync(this, {
           title: i18next.t('uiFolder.chooseRExecutable'),
           properties: ['openFile'],
-          defaultPath: 'R.exe',
+          defaultPath: kWindowsRExe,
           filters: [{ name: i18next.t('uiFolder.rExecutable'), extensions: ['exe'] }],
         });
 

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -14,7 +14,7 @@
  */
 import { contextBridge, ipcRenderer } from 'electron';
 import { getDesktopLoggerBridge } from '../../../renderer/logger-bridge';
-import { normalizeSeparatorsNative } from '../../utils';
+import { normalizeSeparatorsNative, kWindowsRExe } from '../../utils';
 
 export interface CallbackData {
   binaryPath?: string;
@@ -54,7 +54,7 @@ ipcRenderer.on('initialize', (_event, data) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     use32?.removeAttribute('disabled');
 
-    if (isRVersionSelected('' + data.selectedRVersion, default32Bit + '/bin/i386/R.exe')) {
+    if (isRVersionSelected('' + data.selectedRVersion, default32Bit + `/bin/i386/${kWindowsRExe}`)) {
       use32.checked = true;
       isDefault32Selected = true;
     }
@@ -67,7 +67,7 @@ ipcRenderer.on('initialize', (_event, data) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     use64?.removeAttribute('disabled');
 
-    if (isRVersionSelected('' + data.selectedRVersion, default64Bit + '/bin/x64/R.exe')) {
+    if (isRVersionSelected('' + data.selectedRVersion, default64Bit + `/bin/x64/${kWindowsRExe}`)) {
       use64.checked = true;
       isDefault64Selected = true;
     }
@@ -107,7 +107,7 @@ ipcRenderer.on('initialize', (_event, data) => {
     visitedInstallations[rInstall] = true;
 
     // check for 64 bit executable
-    const r64 = `${rInstall}/bin/x64/R.exe`;
+    const r64 = `${rInstall}/bin/x64/${kWindowsRExe}`;
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (await ipcRenderer.invoke('fs_existsSync', r64)) {
       const optionEl = window.document.createElement('option');
@@ -126,7 +126,7 @@ ipcRenderer.on('initialize', (_event, data) => {
     }
 
     // check for 32 bit executable
-    const r32 = `${rInstall}/bin/i386/R.exe`;
+    const r32 = `${rInstall}/bin/i386/${kWindowsRExe}`;
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (await ipcRenderer.invoke('fs_existsSync', r32)) {
       const optionEl = window.document.createElement('option');


### PR DESCRIPTION
### Intent

Addresses [RStudio failing to query R for path locations using R.exe on Windows but RTerm.exe works #12984](https://github.com/rstudio/rstudio/issues/12984)

### Approach

On Windows, when checking if an R installation is valid (and when querying an R installation for various paths) use `Rterm.exe` instead of `R.exe`. Haven't isolated why, but on some customer configurations `Rterm.exe` works and `R.exe` does not. The R documentation suggests `Rterm.exe` is preferred on Windows (though it doesn't say why), and we used `RTerm.exe` in the Qt desktop for a similar exercise, so this seems like the "right thing".

Additionally, when checking the default 32/64-bit R installations found in the registry, check using the architecture-specific Rterm.exe instead of the generic `bin\R.exe`.

Added another diagnostic environment variable: `RSTUDIO_DESKTOP_MODAL_DEVTOOLS`. If this is set when the Choose R dialog is displayed (or any other future dialogs built in a similar fashion), that dialog will show the Chrome devtools, which can be handy for debugging.

### Automated Tests

No new tests.

### QA Notes

Sanity testing of the various Choose R scenarios on Windows. Ultimately having broad customer testing will be essential since we haven't isolated the exact trigger for this problem in order to reproduce it.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


