### PR TITLE
Don't fail silently at startup when user state folder inaccessible

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 - Fixed bug where the OK button was disabled in Choose R dialog when only one version of R installed (#12916)
 - Improved robustness when chosing custom R version in Windows desktop (#12969)
 - Fixed bug that prevented RStudio Desktop from starting on Linux if desktop.ini was unreadable (#12963)
+- Improved RStudio Desktop startup behavior when user state folder inaccessible (#12988)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/main/args-manager.ts
+++ b/src/node/desktop/src/main/args-manager.ts
@@ -28,6 +28,7 @@ import { getComponentVersions } from './utils';
 import { activateWindow } from './window-utils';
 import { resolveProjectFile } from './application-launch';
 import { existsSync } from 'fs';
+import { safeError } from '../core/err';
 
 // RStudio command-line switches
 export const kRunDiagnosticsOption = '--run-diagnostics';
@@ -215,7 +216,10 @@ export class ArgsManager {
 
   handleLogLevel() {
     const logOptions = new LogOptions();
-
-    setLogger(new WinstonLogger(logOptions));
+    try {
+      setLogger(new WinstonLogger(logOptions));
+    } catch (error: unknown) {
+      console.error(safeError(error));
+    }
   }
 }


### PR DESCRIPTION
### Intent

Addresses [Poor experience starting RStudio desktop if user-state folder inaccessible #12988](https://github.com/rstudio/rstudio/issues/12988)

### Approach

Our logging package (Winston) was throwing an uncaught exception, preventing a bunch of initialization code from running. Fixed by catching the exception and writing to stderr. This permits startup to continue so the window appears and existing error-handling code can report the problem.

Not pretty (especially on Windows), but at least it doesn't make it appear nothing happened, and the user can close RStudio instead of accumulating processes in the background.

### Automated Tests

None

### QA Notes

On Mac and Linux, the main window should now appear and show basic error information.

The experience on Windows is still somewhat gruesome. R shows a modal dialog box with an error, which may show up under the splash screen (but you can move the splash screen), then once you dismiss that the main window appears with no particularly useful information. This is still better than it was and reasonably close to what Qt did (Qt didn't have the splash screen).

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


