### PR TITLE
Fix saving to UNC paths on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@
 - Improved robustness when chosing custom R version in Windows desktop (#12969)
 - Fixed bug that prevented RStudio Desktop from starting on Linux if desktop.ini was unreadable (#12963)
 - Improved RStudio Desktop startup behavior when user state folder inaccessible (#12988)
+- Fixed saving files to UNC paths on Windows (#12935)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,7 +35,7 @@
 - Improved robustness when chosing custom R version in Windows desktop (#12969)
 - Fixed bug that prevented RStudio Desktop from starting on Linux if desktop.ini was unreadable (#12963)
 - Improved RStudio Desktop startup behavior when user state folder inaccessible (#12988)
-- Fixed saving files to UNC paths on Windows (#12935)
+- Fixed saving files to UNC paths on Windows (#12652, #12935)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -14,8 +14,9 @@
  */
 
 import { ipcRenderer, SaveDialogReturnValue, webContents } from 'electron';
-import { logger } from '../core/logger';
+import { logString } from './logger-bridge';
 import { normalizeSeparators } from '../ui/utils';
+import { safeError } from '../core/err';
 
 interface VoidCallback<Type> {
   (result: Type): void;
@@ -27,7 +28,7 @@ interface CursorPosition {
 }
 
 function reportIpcError(name: string, error: Error) {
-  console.log(`${name}: ${error.message}`);
+  logString('err', `IpcError: ${name}: ${error.message}`);
 }
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
@@ -373,7 +374,7 @@ export function getDesktopBridge() {
         path = path.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n');
         webcontents[0]
           .executeJavaScript(`window.desktopHooks.openFile("${path}")`)
-          .catch((error: unknown) => logger().logError(error));
+          .catch((error: unknown) => logString('err', safeError(error).message));
       }
     },
 

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -62,7 +62,13 @@ export const checkForNewLanguage = async () => {
  * @return {*}
  */
 export function normalizeSeparators(path: string, separator = '/') {
-  return path.replace(/[\\/]+/g, separator);
+  // don't mess with leading '\\' on a UNC path
+  let prefix = '';
+  if (path.startsWith('\\\\')) {
+    prefix = `${separator}${separator}`;
+    path = path.substring(2);
+  }
+  return `${prefix}${path.replace(/[\\/]+/g, separator)}`;
 }
 
 /**


### PR DESCRIPTION
### Intent

Addresses [Can't save to scripts to UNC path from RStudio 2023.03.0 #12935](https://github.com/rstudio/rstudio/issues/12935) and [Saving New Scripts Or Changes to Existing Scripts Produces File Not Found Error #12652](https://github.com/rstudio/rstudio/issues/12652)

### Approach

Code was incorrectly removing one of the leading backslashes from a UNC path.

Also noticed and corrected logging calls in the desktop-bridge.

### Automated Tests

None

### QA Notes

Sanity test saving files to both UNC paths and regular paths with Windows Desktop (Electron). Note that any recent files entries created before this fix will be wrong, but new ones added with the fix should be correct.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


