### PR TITLE
fix windows-path-related test failures

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -190,11 +190,16 @@ function findBuildRootImpl(rootDir: string): string {
   const buildDirParents = [
     `${rootDir}`,
     `${rootDir}/src`,
-    `${rootDir}/src/cpp`,
-    `${rootDir}/package/linux`,
-    `${rootDir}/package/osx`,
-    `${rootDir}/package/win32`,
+    `${rootDir}/src/cpp`
   ];
+
+  if (app.isPackaged) {
+    buildDirParents.push(
+      `${rootDir}/package/linux`,
+      `${rootDir}/package/osx`,
+      `${rootDir}/package/win32`
+    );
+  }
 
   // list all files + directories in root folder
   for (const buildDirParent of buildDirParents) {

--- a/src/node/desktop/test/unit/core/system.test.ts
+++ b/src/node/desktop/test/unit/core/system.test.ts
@@ -61,10 +61,11 @@ describe('System', () => {
   it('fixupExecutablePath adds missing exe extension on Windows', () => {
     const path = new FilePath('hello');
     const fixedPath = fixupExecutablePath(path);
+    const exeExtension = '.exe';
     if (process.platform === 'win32') {
-      assert.equal(fixedPath.getAbsolutePath(), 'hello.exe');
+      assert.isTrue(fixedPath.getAbsolutePath().endsWith(exeExtension));
     } else {
-      assert.equal(path.getAbsolutePath(), fixedPath.getAbsolutePath());
+      assert.isFalse(fixedPath.getAbsolutePath().endsWith(exeExtension));
     }
   });
   it('fixupExecutablePath does not add exe extension if already there', () => {


### PR DESCRIPTION
### Intent
Fixes for the following tests:
- System test `fixupExecutablePath adds missing exe extension on Windows`
- Utils test `findComponents returns session and scripts paths`

### Approach

### System test `fixupExecutablePath adds missing exe extension on Windows`
- The test previously used an incomplete file path that would cause the test to always fail on Windows
- Test was modified to check the extension matches `.exe` for Windows, and doesn't match for non-Windows

### Utils test `findComponents returns session and scripts paths`
- enhancement on `findBuildRootImpl` in utils to only use package build dirs if the app is a package build

Fixes the scenario I was experiencing:
- Run a package build (doesn't have to be successful, you can cancel it partway through)
- Run electron unit tests (`npm test`)
- Will use the package build dir since it's the most recently modified build dir, but the test isn't running a package build and there may not be an rsession.exe available, so the test fails

### Automated Tests
N/A, test fix

### QA Notes
N/A, test fix

### Documentation
N/A, test fix

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` ~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


