### PR TITLE
Use a 0 size for missing file metadata

### DIFF
--- a/docker/jenkins/publish-build.sh
+++ b/docker/jenkins/publish-build.sh
@@ -141,7 +141,11 @@ if [ ! -z $channel ]; then
 fi
 
 # Determine file size
-size=$(wc -c $file | awk '{print $1}')
+if [[ -f $file  ]]; then
+    size=$(wc -c $file | awk '{print $1}')
+else
+    size=0
+fi
 
 # Determine file SHA256 sum
 if [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
### Intent

Minor change to address #13005
Now defaults to a 0 byte size for an unknown file, leading to valid json, even if the build is missing.
Windows ps already returns a 0 for a missing file, so this isn't a problem there

### Approach

Uses bash file existence test to either get the file size, or set size to 0

### Automated Tests

No automated tests, build is the test

### QA Notes

No qa needed

### Documentation
No docs

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


