### PR TITLE
fix `findComponents` test failure

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -190,16 +190,11 @@ function findBuildRootsImpl(rootDir: string): string[] {
   const buildDirParents = [
     `${rootDir}`,
     `${rootDir}/src`,
-    `${rootDir}/src/cpp`
+    `${rootDir}/src/cpp`,
+    `${rootDir}/package/linux`,
+    `${rootDir}/package/osx`,
+    `${rootDir}/package/win32`,
   ];
-
-  if (app.isPackaged) {
-    buildDirParents.push(
-      `${rootDir}/package/linux`,
-      `${rootDir}/package/osx`,
-      `${rootDir}/package/win32`
-    );
-  }
 
   // list all files + directories in root folder
   for (const buildDirParent of buildDirParents) {

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -170,19 +170,19 @@ export function findRepoRoot(): string {
 }
 
 // used to help find built C++ sources in developer configurations
-function findBuildRoots(): string[] {
+function findBuildRoot(): string {
   // look for the project root directory. note that the current
   // working directory may differ depending on how we are launched
   // (e.g. unit tests will have their parent folder as the working directory)
   const dir = findRepoRoot();
   if (dir.length > 0) {
-    return findBuildRootsImpl(dir);
+    return findBuildRootImpl(dir);
   }
 
   throw rsessionNotFoundError();
 }
 
-function findBuildRootsImpl(rootDir: string): string[] {
+function findBuildRootImpl(rootDir: string): string {
   // array of discovered build directories
   const buildDirs = [];
 
@@ -212,7 +212,7 @@ function findBuildRootsImpl(rootDir: string): string[] {
 
   // if we didn't find anything, bail here
   if (buildDirs.length === 0) {
-    return [];
+    return '';
   }
 
   // sort build directories by last modified time
@@ -220,7 +220,10 @@ function findBuildRootsImpl(rootDir: string): string[] {
     return rhs.stat.mtime.getTime() - lhs.stat.mtime.getTime();
   });
 
-  return buildDirs.map((dir) => dir.path);
+  // return the newest one
+  const buildRoot = buildDirs[0].path;
+  logger().logDebug(`Using build root: ${buildRoot}`);
+  return buildRoot;
 }
 
 function rsessionNotFoundError(): Error {
@@ -231,15 +234,15 @@ function rsessionNotFoundError(): Error {
 }
 
 /**
- * @returns Determine paths for install path, config file, rsession, and desktop scripts.
+ * @returns Paths for install path, config file, rsession, and desktop scripts.
  */
 export function findComponents(): [FilePath, FilePath, FilePath, FilePath] {
   // determine paths to config file, rsession, and desktop scripts
   let confPath: FilePath = new FilePath();
   let sessionPath: FilePath = new FilePath();
 
+  const binRoot = new FilePath(getAppPath());
   if (app.isPackaged) {
-    const binRoot = new FilePath(getAppPath());
     // confPath is intentionally left empty for a package build
     sessionPath = binRoot.completePath(`bin/${rsessionExeName()}`);
     return [binRoot, confPath, sessionPath, new FilePath(getAppPath())];
@@ -256,21 +259,26 @@ export function findComponents(): [FilePath, FilePath, FilePath, FilePath] {
 
   // if we couldn't resolve the build root from RSTUDIO_CPP_BUILD_OUTPUT,
   // then fall back to lookup heuristics
-  const buildRootCandidates = !buildRoot ? findBuildRoots() : [buildRoot];
-  // check each build root candidate for rsession
-  for (const dir of buildRootCandidates) {
-    const buildRootPath = new FilePath(dir);
-    for (const subDir of ['.', 'src/cpp']) {
-      sessionPath = buildRootPath.completePath(`${subDir}/session/${rsessionExeName()}`);
-      if (sessionPath.existsSync()) {
-        logger().logDebug(`Using build root: ${dir}`);
-        confPath = buildRootPath.completePath(`${subDir}/conf/rdesktop-dev.conf`);
-        return [new FilePath(buildRoot), confPath, sessionPath, new FilePath(getAppPath())];
-      }
+  if (!buildRoot) {
+    buildRoot = findBuildRoot();
+  }
+
+  // if we still don't have a root, bail
+  if (!buildRoot) {
+    throw rsessionNotFoundError();
+  }
+
+  // try to find rsession in build root
+  const buildRootPath = new FilePath(buildRoot);
+  for (const subdir of ['.', 'src/cpp']) {
+    const sessionPath = buildRootPath.completePath(`${subdir}/session/${rsessionExeName()}`);
+    if (sessionPath.existsSync()) {
+      confPath = buildRootPath.completePath(`${subdir}/conf/rdesktop-dev.conf`);
+      return [new FilePath(buildRoot), confPath, sessionPath, new FilePath(getAppPath())];
     }
   }
 
-  // we didn't find a build root with rsession -- throw an error
+  // we found a build root, but not rsession -- throw an error
   throw rsessionNotFoundError();
 }
 


### PR DESCRIPTION
### Intent

Fixes https://github.com/rstudio/rstudio-pro/issues/4579

Might not be a coincidence after all! Seems like this issue started happening in a build that contained #13000.

### Approach
Don't conditionally exclude the package directories from the possible build dir candidates. Just include them by default. (this was the behaviour before #13000).

### Automated Tests

The `findComponents` Electron unit test should pass on all platforms now.

### QA Notes

1. Ensure you don't have any `build*` directories in `src/cpp`
2. Create a package build
3. In `src/node/desktop`, run `npm test`
4. `findComponents` test should now pass

### Documentation
N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


