### PR TITLE
Add opt-in via environment variable for Electron crash dump generation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 - Moved Help panel font size setting to Appearance tab in Global Options (#12816)
 - Update openssl to 1.1.1t for Windows (rstudio/rstudio-pro#3675)
 - Improve visibility of focus rectangles on Server / Workbench Sign In page [Accessibility] (#12846)
+- Added ability to enable minidump generation for Electron crashes (#13025)
 
 #### Posit Workbench
 - Added the `session-connections-block-suspend` session option, controlling whether active connections can block suspension of an R session.

--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -409,6 +409,17 @@ public class Application implements ApplicationEventHandlers
       }
    }
 
+   @Handler
+   void onCrashDesktopApplication()
+   {
+      globalDisplay_.showYesNoMessage(
+            GlobalDisplay.MSG_WARNING,
+            constants_.reallyCrashCaption(),
+            constants_.reallyCrashMessage(),
+            () -> Desktop.getFrame().crashDesktopApplication(),
+            false);
+   }
+
    @Override
    public void onUnauthorized(UnauthorizedEvent event)
    {
@@ -1019,6 +1030,11 @@ public class Application implements ApplicationEventHandlers
          StringUtil.isNullOrEmpty(sessionInfo.getUserHomePageUrl()))
       {
          commands_.loadServerHome().remove();
+      }
+
+      if (!BrowseCap.isElectron())
+      {
+         commands_.crashDesktopApplication().remove();
       }
 
       if (!sessionInfo.getWorkbenchJobsEnabled())

--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -212,6 +212,8 @@ public interface DesktopFrame extends JavaScriptPassthrough
 
    void onSessionQuit();
 
+   void crashDesktopApplication();
+
    void getSessionServer(CommandWithArg<SessionServer> callback);
    void getSessionServers(CommandWithArg<JsArray<SessionServer>> callback);
    void reconnectToSessionServer(SessionServer server);

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants.java
@@ -1438,4 +1438,22 @@ public interface StudioClientApplicationConstants extends com.google.gwt.i18n.cl
     @DefaultMessage("Automatic update notifications were disabled for {0}.")
     @Key("updateDisabledForVersionText")
     String updateDisabledForVersionText(String version);
+
+    /**
+     * Translated "Danger!".
+     *
+     * @return translated "Danger!"
+     */
+    @DefaultMessage("Danger!")
+    @Key("reallyCrashCaption")
+    String reallyCrashCaption();
+
+    /**
+     * Translated "This will cause RStudio to immediately crash. You may lose work. Trigger crash?".
+     *
+     * @return translated "This will cause RStudio to immediately crash. You may lose work. Trigger crash?"
+     */
+    @DefaultMessage("This will cause RStudio to immediately crash. You may lose work. Trigger crash?")
+    @Key("reallyCrashMessage")
+    String reallyCrashMessage();
 }

--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_en.properties
@@ -156,3 +156,5 @@ activeText=(active)
 requestLogVisualization=<p>Click on a request to see details. Click on the background to show these instructions again.</p><h4>Available commands:</h4><ul><li>Esc: Close</li><li>P: Play/pause</li><li>E: Export</li><li>I: Import</li><li>+/-: Zoom in/out</li></ul>
 visitWebsiteForNewVersionText=Please visit https://posit.co/download/rstudio-desktop/ to check if a new version is available.
 updateDisabledForVersionText=Automatic update notifications were disabled for {0}.
+reallyCrashCaption=Danger!
+reallyCrashMessage=This will cause RStudio to immediately crash. You may lose work. Trigger crash?

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants.java
@@ -3924,6 +3924,10 @@ public interface CmdConstants extends Constants {
     @DefaultStringValue("Show _Keyboard Shortcut Commands") // $NON-NLS-1$
     String showShortcutCommandMenuLabel();
     
+    // crashDesktopApplication
+    @DefaultStringValue("Crash RStudio Desktop (DA_NGER)") // $NON-NLS-1$
+    String crashDesktopApplicationMenuLabel();
+    
     // showCommandPalette
     @DefaultStringValue("Show Command Palette") // $NON-NLS-1$
     String showCommandPaletteLabel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_en.properties
@@ -2569,6 +2569,9 @@ focusSourceColumnSeparatorMenuLabel = Adjust Source Column Spli_tter
 # showShortcutCommand
 showShortcutCommandMenuLabel = Show _Keyboard Shortcut Commands
 
+# crashDesktopApplication
+crashDesktopApplicationMenuLabel = Crash RStudio Desktop (DA_NGER)
+
 # showCommandPalette
 showCommandPaletteLabel = Show Command Palette
 showCommandPaletteMenuLabel = Show _Command Palette

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml
@@ -609,6 +609,7 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
             <separator/>
             <cmd refid="showDomElements"/>
             <cmd refid="showShortcutCommand"/>
+            <cmd refid="crashDesktopApplication"/>
             <separator/>
             <cmd refid="enableProsemirrorDevTools"/>
          </menu>
@@ -4201,6 +4202,10 @@ See `/src/gwt/tools/i18n-helpers/README.md`.
 
    <cmd id="showShortcutCommand"
         menuLabel="Show _Keyboard Shortcut Commands"
+        rebindable="false"/>
+
+   <cmd id="crashDesktopApplication"
+        menuLabel="Crash RStudio Desktop (DA_NGER)"
         rebindable="false"/>
 
    <cmd id="showCommandPalette"

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml.MD5
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.cmd.xml.MD5
@@ -1,1 +1,1 @@
-36bae467f3afb5f9b6fb43d36be51d52
+fc52cbfb84ea58e7c60c3e6570dbb008

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/Commands.java
@@ -734,4 +734,5 @@ public abstract class
    // Internal
    public abstract AppCommand showDomElements();
    public abstract AppCommand showShortcutCommand();
+   public abstract AppCommand crashDesktopApplication();
 }

--- a/src/gwt/test/org/rstudio/studio/client/workbench/commands/DummyCommands.java
+++ b/src/gwt/test/org/rstudio/studio/client/workbench/commands/DummyCommands.java
@@ -3120,4 +3120,8 @@ public class DummyCommands extends Commands {
         return null;
     }
 
+    @Override
+    public AppCommand crashDesktopApplication() {
+        return null;
+    }
 }

--- a/src/node/desktop/src/main/crash-handler.ts
+++ b/src/node/desktop/src/main/crash-handler.ts
@@ -26,7 +26,7 @@ import path from 'path';
  * If Electron/RStudio crashes, the results will be found under:
  * 
  *     Windows: %appdata%\RStudio\Crashpad
- *     Mac:     ~/.config/rstudio/Crashpad
+ *     Mac:     ~/Library/Application Support/RStudio/Crashpad
  *     Linux:   ~/.config/rstudio/Crashpad
  */
 export function initCrashHandler() {

--- a/src/node/desktop/src/main/crash-handler.ts
+++ b/src/node/desktop/src/main/crash-handler.ts
@@ -1,0 +1,45 @@
+/*
+ * crash-handler.ts
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+import { app, crashReporter } from 'electron';
+import { getenv } from '../core/environment';
+import path from 'path';
+
+/**
+ * Enable Electron crash handling. Until we've done more testing to see if this clashes with
+ * our use of a different build of crashpad in rsession, this is OFF by default.
+ * 
+ * Enable by setting RSTUDIO_ENABLE_CRASHPAD=1 before starting RStudio.
+ * 
+ * If Electron/RStudio crashes, the results will be found under:
+ * 
+ *     Windows: %appdata%\RStudio\Crashpad
+ *     Mac:     ~/.config/rstudio/Crashpad
+ *     Linux:   ~/.config/rstudio/Crashpad
+ */
+export function initCrashHandler() {
+  const enableCrashpad = getenv('RSTUDIO_ENABLE_CRASHPAD');
+  if (enableCrashpad === '1' || enableCrashpad.toLowerCase() === 'true') {
+    console.log(`Starting crash logging to ${crashDumpLocation()}`);
+    crashReporter.start({uploadToServer: false});
+  }
+}
+
+/**
+ * Returns the location of Electron crash dumps (if any).
+ */
+export function crashDumpLocation() {
+  return path.join(app.getPath('userData'), 'Crashpad');
+}

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -847,6 +847,10 @@ export class GwtCallback extends EventEmitter {
       this.emit(GwtCallback.SESSION_QUIT);
     });
 
+    ipcMain.on('desktop_stop_main_thread', () => {
+      process.crash();
+    });
+
     ipcMain.handle('desktop_get_session_server', () => {
       GwtCallback.unimpl('desktop_get_session_server');
       return {};

--- a/src/node/desktop/src/main/main.ts
+++ b/src/node/desktop/src/main/main.ts
@@ -23,6 +23,7 @@ import { initI18n } from './i18n-manager';
 import { ElectronDesktopOptions } from './preferences/electron-desktop-options';
 import { parseStatus } from './program-status';
 import { createStandaloneErrorDialog } from './utils';
+import { initCrashHandler } from './crash-handler';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -128,6 +129,7 @@ class RStudioMain {
 }
 
 // Startup
+initCrashHandler();
 initI18n();
 
 const main = new RStudioMain();

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -587,6 +587,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_on_session_quit');
     },
 
+    crashDesktopApplication: () => {
+      ipcRenderer.send('desktop_stop_main_thread');
+    },
+
     getSessionServer: (callback: VoidCallback<Record<string, unknown>>) => {
       ipcRenderer
         .invoke('desktop_get_session_server')


### PR DESCRIPTION
### Intent

Addresses [Add ability to opt-in Electron crash handling via environment variable #13025](https://github.com/rstudio/rstudio/issues/13025)

### Approach

Set the environment variable `RSTUDIO_ENABLE_CRASHPAD` to "1" or "true", then start RStudio Desktop (Electron-only). This will enable the electron [crashReporter feature](https://www.electronjs.org/docs/latest/api/crash-reporter), but only in local mode (it won't try to upload). If you run RStudio from a command line, you'll also see a message such as: `Starting crash logging to C:\Users\username\AppData\Roaming\RStudio\Crashpad`.

This is an interim step on the way to fully implementing Electron crash handling (tracked in https://github.com/rstudio/rstudio/issues/13022). Not comfortable enabling this by default without further testing and research, but being able to turn it on when there's a crash happening could be useful.

When Electron crash reporting is on, and Electron itself (i.e. RStudio[.exe]) has a crash, a `dmp` file will be generated. These will continue to accumulate unless manually deleted (one of the reasons we don't want this on by default at this time).

Windows: ` %appdata%\RStudio\Crashpad`
Mac: `~/Library/Application Support/RStudio/Crashpad`
Linux: `~/.config/RStudio/Crashpad`

To aid in testing this, added a new menu command: Help / Diagnostics / Crash RStudio Desktop (DANGER). This should only show up in Electron desktop, not Server or Qt desktop.

When invoked it shows a Yes/No dialog warning that work could be lost, etc. If "Yes" is selected, it invokes `process.crash()` which does as it is told.

Screenshots (Windows):

![menu](https://user-images.githubusercontent.com/10569626/233498462-8bcaea1d-e870-474d-9065-8ea010d6c46c.jpg)

![dialog](https://user-images.githubusercontent.com/10569626/233498469-1a1308b1-d508-4e2b-bc4b-d39a53135f0a.jpg)

### Automated Tests

None

### QA Notes

- without the environment var set to 1 or true (or set to 0 or false), no Crashpad output is generated if Electron crashes, but if the env-var is set (BEFORE starting RStudio), a .dmp file will be generated
- force a crash with the new menu command; verify that clicking "No" prevents a crash, and "Yes" triggers one
- Recommend running RStudio from command line to see the message indicating when it is enabled, and where the info will be written
- Note that when you trigger a crash WITHOUT the reporting on, you may see a message like `[16472:0420/160015.694:ERROR:crashpad_client_win.cc(844)] not connected` (this is expected)
- Check that the menu item isn't shown in Server / Server Pro / Qt Desktop (it wouldn't do anything if it was)

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


