### PR TITLE
update to Electron 23.2.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 ### New
 
 #### RStudio IDE
-- Updated to Electron 23.1.2 (#12785)
+- Updated to Electron 23.2.4 (#13030)
 - Moved Help panel font size setting to Appearance tab in Global Options (#12816)
 - Update openssl to 1.1.1t for Windows (rstudio/rstudio-pro#3675)
 - Improve visibility of focus rectangles on Server / Workbench Sign In page [Accessibility] (#12846)

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -46,7 +46,7 @@
         "chai": "4.3.6",
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.7.3",
-        "electron": "23.1.2",
+        "electron": "23.2.4",
         "electron-mocha": "11.0.2",
         "eslint": "8.35.0",
         "eslint-config-prettier": "8.6.0",
@@ -4837,9 +4837,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
-      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
+      "version": "23.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.4.tgz",
+      "integrity": "sha512-ceFd+KIhzK3srGY22kcBu8QH7hV1G3DHlgrg2LGjg7mgtzxlXeyKzk2Efq0iFNu3ly14QKfiN5gYdvEenmzOAA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -18749,9 +18749,9 @@
       "dev": true
     },
     "electron": {
-      "version": "23.1.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.1.2.tgz",
-      "integrity": "sha512-ajE6xzIwH7swf8TlTU5WklDqpI3mPj4Am6690YrpCXzcp+E+dmMBXIajUUNt4joDrFhJC/lC6ZqDS2Q1BApKgQ==",
+      "version": "23.2.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.4.tgz",
+      "integrity": "sha512-ceFd+KIhzK3srGY22kcBu8QH7hV1G3DHlgrg2LGjg7mgtzxlXeyKzk2Efq0iFNu3ly14QKfiN5gYdvEenmzOAA==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -43,7 +43,7 @@
     "chai": "4.3.6",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.3",
-    "electron": "23.1.2",
+    "electron": "23.2.4",
     "electron-mocha": "11.0.2",
     "eslint": "8.35.0",
     "eslint-config-prettier": "8.6.0",


### PR DESCRIPTION
### Intent

Addresses [Update to latest Electron 23 patch #13030](https://github.com/rstudio/rstudio/issues/13030)

Also curious if this has any impact on [R Studio suddenly does nothing on launch, Win 10, R 4.2.3, various RStudio versions #13007](https://github.com/rstudio/rstudio/issues/13007)

### Approach

Bump version, build and ensure it starts, and Electron unit tests still pass.

### Automated Tests

Nothing specific to Electron version

### QA Notes

Nothing is expected to change except all the bugs have been fixed so nothing will ever break again. Signed, Gary's Dad.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


