### PR TITLE
debounce unmaximize handling

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -104,7 +104,7 @@ export class DesktopBrowserWindow extends EventEmitter {
 
   // debouncing due to https://github.com/rstudio/rstudio/issues/13027
   positionAndEnsureVisibleDebounced= debounce((window, requestedBounds, defaultWidth, defaultHeight) => 
-    positionAndEnsureVisible(window, requestedBounds, defaultWidth, defaultHeight) , 75);
+    positionAndEnsureVisible(window, requestedBounds, defaultWidth, defaultHeight), 75);
 
   // if loading fails and emits `did-fail-load` it will be followed by a
   // 'did-finish-load'; use this bool to differentiate

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -17,6 +17,7 @@ import { BrowserWindow, shell, WebContents } from 'electron';
 import { IpcMainEvent } from 'electron/main';
 
 import path from 'path';
+import debounce from 'lodash/debounce';
 
 import { EventEmitter } from 'stream';
 import { URL } from 'url';
@@ -100,6 +101,10 @@ export class DesktopBrowserWindow extends EventEmitter {
   presentationUrl: string | undefined;
   shinyDialogUrl: string | undefined;
   mainWindow?: MainWindow;
+
+  // debouncing due to https://github.com/rstudio/rstudio/issues/13027
+  positionAndEnsureVisibleDebounced= debounce((window, requestedBounds, defaultWidth, defaultHeight) => 
+    positionAndEnsureVisible(window, requestedBounds, defaultWidth, defaultHeight) , 75);
 
   // if loading fails and emits `did-fail-load` it will be followed by a
   // 'did-finish-load'; use this bool to differentiate
@@ -265,7 +270,7 @@ export class DesktopBrowserWindow extends EventEmitter {
     this.window.on('unmaximize', () => {
       // guard against restoring offscreen or too small
       // https://github.com/rstudio/rstudio/issues/12992
-      positionAndEnsureVisible(
+      this.positionAndEnsureVisibleDebounced(
         this.window, this.window.getBounds(),
         properties.view.default.windowBounds.width, properties.view.default.windowBounds.height);
     });


### PR DESCRIPTION
### Intent

Addresses [JavaScript exception when restoring window on Ubuntu 22 #13027](https://github.com/rstudio/rstudio/issues/13027)

### Approach

On this platform (and possibly other Linux desktops; I only tried Ubuntu 22), when a window is unmaximized, and the handler code adjusts the window size, it triggers a recursive flurry of new "unmaximized" events, leading to a stack overflow.

Fixed by adding a debounce of 75ms. For extra safety, I also added a try/catch to log an error instead of showing the generic exception dialog should this happen despite the debounce on some platforms.

### Automated Tests

None

### QA Notes

Test maximize and restore on Ubuntu 22. A sanity test of the same on Windows and Mac wouldn't hurt (hopefully).

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


