### PR TITLE
Creating time_date_facet is expensive

### DIFF
--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -307,21 +307,25 @@ boost::posix_time::time_facet s_httpDateFacet(kHttpDateFormat,
                                               boost::posix_time::time_facet::special_values_formatter_type(),
                                               boost::posix_time::time_facet::date_gen_formatter_type(),
                                               1);
-   
+
+boost::posix_time::time_input_facet s_httpDateInputFacet(kHttpDateFormat, 1);
+
 boost::posix_time::ptime parseDate(const std::string& date, const char* format)
 {
    using namespace boost::posix_time;
    
+   // Warning - creating the time_input_facet is fairly expensive so avoiding it for http date
    // facet for date (construct w/ a_ref == 1 so we manage memory)
    time_input_facet dateFacet(1);
    dateFacet.format(format);
-   
+
    // parse from string
    std::stringstream dateStream;
    dateStream.str(date);
    dateStream.imbue(std::locale(dateStream.getloc(), &dateFacet));
    ptime posixDate(not_a_date_time);
    dateStream >> posixDate;
+
    return posixDate;
 }   
 
@@ -335,7 +339,16 @@ boost::posix_time::ptime parseAtomDate(const std::string& date)
 
 boost::posix_time::ptime parseHttpDate(const std::string& date)
 {
-   return parseDate(date, kHttpDateFormat);
+   using namespace boost::posix_time;
+
+   // parse from string
+   std::stringstream dateStream;
+   dateStream.str(date);
+   dateStream.imbue(std::locale(dateStream.getloc(), &s_httpDateInputFacet));
+   ptime posixDate(not_a_date_time);
+   dateStream >> posixDate;
+
+   return posixDate;
 }
    
 std::string httpDate(const boost::posix_time::ptime& datetime)


### PR DESCRIPTION
and locale/facet objects are referenced counted and shared like shared_ptr so should be threadsafe (and we already use time_facet that way in httpDate)

Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/4555
