### PR TITLE
Fix reading cached cross reference

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - Fixed saving files to UNC paths on Windows (#12652, #12935)
 - Fixed window disappearing when restoring from maximized on macOS (#13010)
 - Fixed Project Build Tools preferences pane showing &mdash text in French UI (#11134)
+- Fixed inserting cross references in a Quarto document showing no references (#12882)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
@@ -73,8 +73,7 @@ FilePath quartoCrossrefDirV2(const FilePath& projectDir)
       .completeChildPath("xref");
 }
 
-
-json::Array readXRefIndex(const FilePath& indexPath, const std::string& filename, bool* pExists = nullptr)
+json::Array readXRefIndex(const FilePath& indexPath, const std::string& filename, bool fileCache = false, bool* pExists = nullptr)
 {
    // default to not exists
    if (pExists)
@@ -98,35 +97,61 @@ json::Array readXRefIndex(const FilePath& indexPath, const std::string& filename
 
    // parse json w/ validation
    json::Object quartoIndexJson;
-   error = quartoIndexJson.parseAndValidate(
-      index,
-      resourceFileAsString("schema/quarto-xref.json")
-   );
+
+   if (fileCache)
+   {
+      error = quartoIndexJson.parse(index);
+   } else
+   {
+      error = quartoIndexJson.parseAndValidate(
+          index,
+          resourceFileAsString("schema/quarto-xref.json")
+      );
+   }
+
    if (error)
    {
       LOG_ERROR(error);
       return json::Array();
    }
 
-   // read xrefs (already validated so don't need to dance around types/existence)
    json::Array xrefs;
-   boost::regex keyRegex("^(\\w+)-(.*?)(-\\d+)?$");
-   json::Array entries = quartoIndexJson["entries"].getArray();
-   for (const json::Value& entry : entries)
+
+   if (fileCache)
    {
-      json::Object valObject = entry.getObject();
-      std::string key, caption;
-      json::readObject(valObject, "key", key, "caption", caption);
-      boost::smatch match;
-      if (boost::regex_search(key, match, keyRegex))
+      json::Array entries = quartoIndexJson["entries"].getArray();
+      for (const json::Value& entry : entries)
       {
-         json::Object xref;
-         xref[kFile] = filename;
-         xref[kType] = match[1].str();
-         xref[kId] = match[2].str();
-         xref[kSuffix] = (match.length() > 3) ? match[3].str() : "";
-         xref[kTitle] = caption;
-         xrefs.push_back(xref);
+         std::string filename, type, id;
+         json::Object valObject = entry.getObject();
+         json::readObject(valObject, "file", filename, "type", type, "id", id);
+         if (!filename.empty() && !type.empty() && !id.empty())
+         {
+           xrefs.push_back(entry);
+         }
+      }
+   }
+   else
+   {
+      // read xrefs (already validated so don't need to dance around types/existence)
+      boost::regex keyRegex("^(\\w+)-(.*?)(-\\d+)?$");
+      json::Array entries = quartoIndexJson["entries"].getArray();
+      for (const json::Value& entry : entries)
+      {
+          json::Object valObject = entry.getObject();
+          std::string key, caption;
+          json::readObject(valObject, "key", key, "caption", caption);
+          boost::smatch match;
+          if (boost::regex_search(key, match, keyRegex))
+          {
+            json::Object xref;
+            xref[kFile] = filename;
+            xref[kType] = match[1].str();
+            xref[kId] = match[2].str();
+            xref[kSuffix] = (match.length() > 3) ? match[3].str() : "";
+            xref[kTitle] = caption;
+            xrefs.push_back(xref);
+          }
       }
    }
 
@@ -270,7 +295,7 @@ json::Array indexSourceFile(const FilePath& srcFile, const std::string& filename
       if (srcFileIndex.getLastWriteTime() > srcFile.getLastWriteTime())
       {
          bool exists = false;
-         json::Array xrefs = readXRefIndex(srcFileIndex, filename, &exists);
+         json::Array xrefs = readXRefIndex(srcFileIndex, filename, true, &exists);
          if (exists)
             return xrefs;
       }


### PR DESCRIPTION
### Intent
Address #12882 

### Approach
Saving a file and inserting a cross reference creates a cache. If the insert cross reference dialog is shown again, it reads the cache if the document didn't change. The cache has already converted the cross references from the key/caption format.

The change reads the cache without going through the json validation with the key/caption format. That was causing it to ignore the entries in the cache and resulted in no entries shown in the insert cross reference dialog.

### Automated Tests
none

### QA Notes
Reproducing the error requires a saved Quarto document. Invoking the insert cross reference action will index the cross references. Invoking it a second time will read this cache as long as the document has not changed. 

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


