### PR TITLE
open source companion to rstudio/rstudio-pro#4570

### DIFF
--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -4,9 +4,16 @@
     "buttonCancel": "Cancel",
     "buttonBrowse": "Browse...",
     "unknownErrorOccurred": "An unknown error occurred.",
+    "workingOnIt": "Working on it...",
     "buttonYes": "Yes",
     "buttonNo": "No",
     "buttonQuit": "Quit"
+  },
+  "imgAlt": {
+    "dialogQuestion": "Question Mark Icon",
+    "dialogInfo": "Information Icon",
+    "dialogWarning": "Warning Icon",
+    "dialogError": "Error Icon"
   },
   "contextMenu": {
     "saveImageAsDots": "Save image as...",

--- a/src/node/desktop/webpack.renderer.config.js
+++ b/src/node/desktop/webpack.renderer.config.js
@@ -1,10 +1,23 @@
 const rules = require('./webpack.rules');
 const plugins = require('./webpack.plugins');
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const path = require('path');
 
 rules.push({
   test: /\.css$/,
   use: [{ loader: 'style-loader' }, { loader: 'css-loader' }],
 });
+
+const copyWebpackPlugin = new CopyWebpackPlugin({
+  patterns: [
+    {
+      from: path.resolve(__dirname, 'src', 'assets'),
+      to: path.resolve(__dirname, '.webpack/renderer', 'assets'),
+    },
+  ],
+});
+
+plugins.push(copyWebpackPlugin);
 
 module.exports = {
   module: {


### PR DESCRIPTION
open source companion to rstudio/rstudio-pro#4570
- update some i18n strings
- copy assets to renderer webpack directory

<!--
### Intent

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

-->

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! 


