### PR TITLE
Pin Quarto and Panmirror

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -32,16 +32,16 @@ info "QUARTO_DIR: ${QUARTO_DIR}"
 # clone quarto monorepo if not already cloned
 if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
-  # git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
 else
   echo "quarto repo already cloned in '$QUARTO_DIR'"
 
   pushd $QUARTO_DIR
   # git fetch
   git reset --hard && git clean -dfx
-  git checkout main
-  # git checkout release/rstudio-cherry-blossom
+  # git checkout main
+  git checkout release/rstudio-mountain-hydrangea
   git pull
   popd
 fi

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -27,14 +27,14 @@ fi
 
 # variables that control download + installation process
 # specify a version to pin for releases
-# QUARTO_VERSION="1.2.335"
+QUARTO_VERSION="1.3.340"
 
 # update to latest Quarto release
 # QUARTO_VERSION=`curl https://quarto.org/docs/download/_download.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
-QUARTO_VERSION=`curl https://quarto.org/docs/download/_prerelease.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
+# QUARTO_VERSION=`curl https://quarto.org/docs/download/_prerelease.json | jq ".version" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'`
 
-QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
-# QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
+# QUARTO_URL_BASE="https://github.com/quarto-dev/quarto-cli/releases/download/v${QUARTO_VERSION}"
+QUARTO_URL_BASE="https://s3.amazonaws.com/rstudio-buildtools/quarto/${QUARTO_VERSION}"
 
 QUARTO_SUBDIR="quarto"
 

--- a/dependencies/tools/upload-quarto.sh
+++ b/dependencies/tools/upload-quarto.sh
@@ -5,13 +5,14 @@
 # tools (awscli) installed, and configured with a valid AWS account.
 
 # Modify to set the Quarto version to upload
-QUARTO_VERSION=1.2.335
+QUARTO_VERSION=1.3.340
 
 BASEURL="https://github.com/quarto-dev/quarto-cli/releases/download/"
 AWS_BUCKET="s3://rstudio-buildtools"
 
 PLATFORMS=(
     linux-amd64.tar.gz
+    linux-arm64.tar.gz
     linux-rhel7-amd64.tar.gz
     macos.tar.gz
     win.zip

--- a/dependencies/windows/install-dependencies.cmd
+++ b/dependencies/windows/install-dependencies.cmd
@@ -44,12 +44,12 @@ set PANDOC_NAME=pandoc-%PANDOC_VERSION%
 set PANDOC_FILE=%PANDOC_NAME%-windows-x86_64.zip
 
 REM Pin to specific Quarto version for releases
-REM set QUARTO_VERSION=1.2.335
+set QUARTO_VERSION=1.3.340
 
 REM Get latest Quarto release version
-cd install-quarto
-for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
-cd ..
+REM cd install-quarto
+REM for /F "delims=" %%L in ('powershell.exe -File get-quarto-version.ps1') do (set "QUARTO_VERSION=%%L")
+REM cd ..
 
 REM Check for errors.
 if not "%QUARTO_VERSION%" == "%QUARTO_VERSION:ERROR=%" (
@@ -206,8 +206,8 @@ if not exist pandoc\%PANDOC_VERSION% (
 
 
 
-REM wget %WGET_ARGS% https://s3.amazonaws.com/rstudio-buildtools/quarto/%QUARTO_VERSION%/%QUARTO_FILE%
-wget %WGET_ARGS% https://github.com/quarto-dev/quarto-cli/releases/download/v%QUARTO_VERSION%/%QUARTO_FILE%
+wget %WGET_ARGS% https://s3.amazonaws.com/rstudio-buildtools/quarto/%QUARTO_VERSION%/%QUARTO_FILE%
+REM wget %WGET_ARGS% https://github.com/quarto-dev/quarto-cli/releases/download/v%QUARTO_VERSION%/%QUARTO_FILE%
 echo Unzipping Quarto %QUARTO_FILE%
 rmdir /s /q quarto
 mkdir quarto

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -4,8 +4,8 @@ pushd ..\..\..\src\gwt\lib
 
 if not exist quarto (
   echo "Cloning quarto repo"
-  git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
-  REM git clone --branch release/rstudio-cherry-blossom https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
 ) else (
   echo "quarto repo already cloned"
 
@@ -13,8 +13,8 @@ if not exist quarto (
   git fetch
   git reset --hard
   git clean -dfx
-  git checkout main
-  REM git checkout release/rstudio-cherry-blossom
+  REM git checkout main
+  git checkout release/rstudio-mountain-hydrangea
   git pull
   popd
 )


### PR DESCRIPTION
### Intent
Housekeeping tasks for MH release #13053 
Quarto pinned to 1.3.340
Panmirror pinned to release/rstudio-mountain-hydrangea

### Approach
Ran the `upload-quarto.sh` script to get copies of Quarto in S3. Updated the scripts to download Quarto from there.

JJ created the `release/rstudio-mountain-hydrangea` branch in the `quarto-dev/quarto` repo. It'll receive urgent fixes only. Updated the scripts to clone/pull panmirror from that branch.

Pro branch will have its own commit for the doc build. https://github.com/rstudio/rstudio-pro/pull/4593

### Automated Tests
None

### QA Notes
None 

### Documentation
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


