### PR TITLE
Uncomment `git fetch` in install-panmirror

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -38,7 +38,7 @@ else
   echo "quarto repo already cloned in '$QUARTO_DIR'"
 
   pushd $QUARTO_DIR
-  # git fetch
+  git fetch
   git reset --hard && git clean -dfx
   # git checkout main
   git checkout release/rstudio-mountain-hydrangea


### PR DESCRIPTION
### Intent

Resolves an error (`error: pathspec 'release/rstudio-mountain-hydrangea' did not match any file(s) known to git`) when installing dependencies, where we try to checkout a new quarto branch that is unknown because we haven't fetched the latest changes from the repo.

### Approach

Uncomment the `git fetch` command.

### Automated Tests

N/A

### QA Notes

dependency install scripts should now run successfully without hitting this error: `error: pathspec 'release/rstudio-mountain-hydrangea' did not match any file(s) known to git`

### Documentation
N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


