### PR TITLE
fix keyboard shortcut help not displaying when editor in Emacs or Sublime Text mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -44,6 +44,7 @@
 - Fixed window disappearing when restoring from maximized on macOS (#13010)
 - Fixed Project Build Tools preferences pane showing &mdash text in French UI (#11134)
 - Fixed inserting cross references in a Quarto document showing no references (#12882)
+- Fixed keyboard shortcut help not displaying in Emacs or Sublime Text mode (#11376)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
@@ -56,14 +56,14 @@ public class ShortcutInfo
          // if there is a command, then the shortcut must NOT match BOTH the
          // custom shortcut AND the default shortcut for that command,
          // Add to the list otherwise.
-         if (getCommand() == null)
+         if (getCommand() == null) 
             shortcuts.add(shortcut.toString(true));
          else if ( 
                !shortcut.equals(getCommand().getShortcut(false)) &&
                !shortcut.equals(getCommand().getShortcut(true))
                )
             shortcuts.add(shortcut.toString(true));
-         }
+      }
 
       // if there is a command, add the shortcut here. This will choose the
       // correct shortcut: the custom one if it exists, otherwise the default one

--- a/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
+++ b/src/gwt/src/org/rstudio/core/client/command/ShortcutInfo.java
@@ -53,21 +53,21 @@ public class ShortcutInfo
       List<String> shortcuts = new ArrayList<>();
       for (KeyboardShortcut shortcut: shortcuts_)
       {
-         // if there is a command, then the shorcut must NOT match BOTH the
+         // if there is a command, then the shortcut must NOT match BOTH the
          // custom shortcut AND the default shortcut for that command,
          // Add to the list otherwise.
-         if (getCommand() == null) 
+         if (getCommand() == null)
             shortcuts.add(shortcut.toString(true));
          else if ( 
                !shortcut.equals(getCommand().getShortcut(false)) &&
                !shortcut.equals(getCommand().getShortcut(true))
                )
             shortcuts.add(shortcut.toString(true));
-      }
+         }
 
-      // if there is a command, add the shorcut here. This will choose the
-      // correct shorcut: the custom one if it exists, otherwise the default one
-      if (getCommand() != null) 
+      // if there is a command, add the shortcut here. This will choose the
+      // correct shortcut: the custom one if it exists, otherwise the default one
+      if (getCommand() != null && getCommand().getShortcut() != null)
          shortcuts.add(getCommand().getShortcut().toString(true));
 
       return shortcuts;

--- a/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/ShortcutInfoPanel.java
@@ -103,6 +103,7 @@ public class ShortcutInfoPanel extends Composite
             sb.appendHtmlConstant("</h2><table>");
             for (ShortcutInfo info : shortcuts) {
                if (info.getDescription() == null ||
+                       info.getShortcuts() == null ||
                        info.getShortcuts().isEmpty() ||
                        !info.getGroupName().equals(groupNames[i][j])) {
                   continue;


### PR DESCRIPTION
### Intent

Addresses [Keyboard shortcut help not displaying #11376](https://github.com/rstudio/rstudio/issues/11376)

### Approach

Commands that are Emacs-only or Sublime-text only were causing a variable to be null that the code assumed was not null triggering exceptions (in GWT code). Added checks.

Given the timing of when this broke, I suspect this change came with the localization work, but I didn't dive into the gory details to see why.

### Automated Tests

None

### QA Notes

Test display of keyboard shortcut help in all editor modes (default, vim, emacs, sublime), using the keyboard shortcut, the menu, and the command palette.

If you are ambitious you could spot-check that the shortcuts being displayed match expectations (e.g. for commands that differ depending on editor mode). Probably easiest to do this by comparing with 2021.09.4-403, the last version where this was working.

While you're at it, double-check that the rarely seen, possibly top-secret, vim shortcut help is also working. This is done from the editor, in vim mode, via <kbd>:help</kbd>.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


