### PR TITLE
fix macos s3 package upload path

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -182,7 +182,7 @@ pipeline {
                       withAWS(role: 'ide-build', region: 'us-east-1') {
                         retry(5) {
                           script {
-                            utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${FLAVOR.toLowerCase()}/macos/"
+                            utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${PRODUCT}/macos/"
                           }
                         }
                       }


### PR DESCRIPTION
### Intent

[MacOS Desktop Pro build urls](https://dailies.rstudio.com/rstudio/mountain-hydrangea/electron-pro/macos/) have been erroring:
```
<Error>
    <Code>NoSuchKey</Code>
    <Message>The specified key does not exist.</Message>
    <Key>electron-pro/macos/RStudio-pro-2023.05.0-daily-312.pro2.dmg</Key>
    <RequestId>...</RequestId>
    <HostId>...</HostId>
</Error>
```

I think this PR should fix the error above!

### Approach

Currently, the package is uploaded to S3 under `"${FLAVOR.toLowerCase()}/macos/"`, where `FLAVOR` resolves to `desktop` or `electron`. This works for Open Source because there's no `-pro` suffix appended as part of the product name:

https://github.com/rstudio/rstudio/blob/a232fe149ac4611b3f84a6b449e9061b91aba696/utils.groovy#L180-L192

However, the dailies site build `link` is constructed using `PRODUCT`:

https://github.com/rstudio/rstudio/blob/a232fe149ac4611b3f84a6b449e9061b91aba696/jenkins/Jenkinsfile.macos#L232-L233

https://github.com/rstudio/rstudio/blob/a232fe149ac4611b3f84a6b449e9061b91aba696/jenkins/Jenkinsfile.macos#L253-L254

So the links will use `desktop-pro` or `electron-pro`, but the builds are getting uploaded to `desktop` or `electron`. As a result, when a user clicks on the url, they will see the `NoSuchKey` error message.

Replacing `FLAVOR.toLowerCase()` with `PRODUCT` should align the upload location with the expected build location.

### Automated Tests

N/A

### QA Notes

@ronblum The Mac Pro daily build links should work once this is merged.

### Documentation
N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
~- [ ] This PR passes all local unit tests~

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


