### PR TITLE
Fix missing cross references on newly saved file

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoXRefs.cpp
@@ -374,8 +374,8 @@ json::Array resolvedXRefIndex(const FilePath& renderedIndexPath, const FilePath&
       srcXrefs = indexSourceFile(unsaved.get(), filename);
    }
    // otherwise, check to see if the src file is more recent than the renderedIndexPath
-   else if ((srcPath.getLastWriteTime() > renderedIndexPath.getLastWriteTime()) ||
-            !renderedIndexPath.exists())
+   else if (!renderedIndexPath.exists() || renderedIndexPath.getSize() == 0 ||
+            (srcPath.getLastWriteTime() > renderedIndexPath.getLastWriteTime()))
    {
       srcXrefs = indexSourceFile(srcPath, filename);
    }


### PR DESCRIPTION
### Intent
Address #12882 for newly saved files 

### Approach
Fixing another issue from a newly saved file. The cross reference index is generated for a rendered file after the file is saved without performing the indexing. The newer rendered index is preferred over performing the index on the saved file causing no cross references.

Since the rendered cross reference index is not populated with data, it can be size checked to determine if the saved file needs the cross references indexed. For a file that actually has no cross references, this rendered index would have a non-zero file size.

Reordered the index check to short circuit the expression check in this order: rendered index does not exist, rendered index has no content, file index is newer than rendered index

### Automated Tests
None

### QA Notes
Steps to reproduce:
1. Create a Quarto document using File -> New File -> Quarto Document
2. Add in content that would allow cross references to show (see issue)
3. Save the file
4. Invoke Insert -> Cross References

### Documentation
None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


