### PR TITLE
remove unsetting of Windows tempdir env vars when detecting R

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -212,20 +212,6 @@ writeLines(sep = "\x1F", c(
   delete envCopy['R_RUNTIME'];
   delete envCopy['R_SHARE_DIR'];
 
-  // On Windows, unset temporary directory environment variables: the R docs state that
-  // when using R from command-line on Windows:
-  //
-  //   https://cran.r-project.org/doc/manuals/R-intro.html
-  //
-  //   "You need to ensure that either the environment variables TMPDIR, TMP, and TEMP
-  //    are either unset or one of them points to a valid place to create temporary
-  //    files and directories."
-  if (process.platform === 'win32') {
-    delete envCopy['TMP'];
-    delete envCopy['TMPDIR'];
-    delete envCopy['TEMP'];
-  }
-
   const [result, error] = expect(() => {
     return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
       encoding: 'utf-8',


### PR DESCRIPTION
### Intent

Remove some experimental code I had added while trying to understand issues that were causing some users problems starting RStudio on Windows.

Specifically, I was unsetting the three Windows temp-dir environment variables before starting RTerm.exe as part of R discovery. I did not do the same before we start the rsession itself, so that in itself could be problematic (one scenario might work and the other won't), but in general, we shouldn't be tampering with these variables.

See https://github.com/rstudio/rstudio/issues/13012 for more discussion.

### Approach

Delete the code.

### Automated Tests

None.

### QA Notes

The scenario that this code breaks:

* Windows-specific
* Username has a space in it (e.g. `C:\Users\some person\` is the home directory)
* The filesystem is configured to NOT generate 8.3 filenames (this can be done via `fsutil behavior set disable8dot3` and rebooting
* At this point, this user will not be able to run R (confirmed with R 4.2.3) and will get the error `Fatal error: 'R_TempDir' contains spaces`
* They then set TMPDIR=C:\TEMP (or any accessible path without a space in it).
* Now they can run R successfully, but RStudio itself will fail when trying to choose that version of R because it will unset that variable before starting rterm.exe to query for paths

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


