### PR TITLE
Bump Electron to latest v23 release (23.3.0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 ### New
 
 #### RStudio IDE
-- Updated to Electron 23.2.4 (#13030)
+- Updated to Electron 23.3.0 (#13030)
 - Moved Help panel font size setting to Appearance tab in Global Options (#12816)
 - Update openssl to 1.1.1t for Windows (rstudio/rstudio-pro#3675)
 - Improve visibility of focus rectangles on Server / Workbench Sign In page [Accessibility] (#12846)

--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -46,7 +46,7 @@
         "chai": "4.3.6",
         "copy-webpack-plugin": "11.0.0",
         "css-loader": "6.7.3",
-        "electron": "23.2.4",
+        "electron": "23.3.0",
         "electron-mocha": "11.0.2",
         "eslint": "8.35.0",
         "eslint-config-prettier": "8.6.0",
@@ -4837,9 +4837,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "23.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.4.tgz",
-      "integrity": "sha512-ceFd+KIhzK3srGY22kcBu8QH7hV1G3DHlgrg2LGjg7mgtzxlXeyKzk2Efq0iFNu3ly14QKfiN5gYdvEenmzOAA==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
+      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -18749,9 +18749,9 @@
       "dev": true
     },
     "electron": {
-      "version": "23.2.4",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-23.2.4.tgz",
-      "integrity": "sha512-ceFd+KIhzK3srGY22kcBu8QH7hV1G3DHlgrg2LGjg7mgtzxlXeyKzk2Efq0iFNu3ly14QKfiN5gYdvEenmzOAA==",
+      "version": "23.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-23.3.0.tgz",
+      "integrity": "sha512-DVAtptpOSxM7ycgriphSxzlkb3R92d28sFKG1hMtmPkAwHl/e87reaHXhGwyj8Xu4GY69e6yUoAJqma20w0Vgw==",
       "dev": true,
       "requires": {
         "@electron/get": "^2.0.0",

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -43,7 +43,7 @@
     "chai": "4.3.6",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "6.7.3",
-    "electron": "23.2.4",
+    "electron": "23.3.0",
     "electron-mocha": "11.0.2",
     "eslint": "8.35.0",
     "eslint-config-prettier": "8.6.0",


### PR DESCRIPTION
### Intent

Noticed this new release came out and has a fix to an API (shell.openExternal) that is causing us trouble so I tried it out. Didn't solve our problem (not a surprise) but still should take the latest.

Release notes: https://releases.electronjs.org/release/v23.3.0

### Approach

Bump version, `npm i`, test that app still starts and unit tests pass.

### Automated Tests

N/A - this is a minor Electron update so major version of Chromium won't change.

### QA Notes

Nothing to specifically test.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


