### PR TITLE
Backport 12984

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -31,7 +31,6 @@ import { ElectronDesktopOptions, fixWindowsRExecutablePath } from './preferences
 import { FilePath } from '../core/file-path';
 import { dialog } from 'electron';
 
-import { EOL } from 'os';
 import { kWindowsRExe } from '../ui/utils';
 
 let kLdLibraryPathVariable: string;

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -24,6 +24,7 @@ import { RStudioUserState } from '../../types/user-state-schema';
 
 import { generateSchema, legacyPreferenceManager } from './../preferences/preferences';
 import DesktopOptions from './desktop-options';
+import { kWindowsRExe } from '../../ui/utils';
 
 const kProportionalFont = 'font.proportionalFont';
 const kFixedWidthFont = 'font.fixedWidthFont';
@@ -348,4 +349,44 @@ if (process.platform === 'darwin') {
   defaultFonts = ['Lucida Console', 'Consolas'];
 } else {
   defaultFonts = ['Ubuntu Mono', 'Droid Sans Mono', 'DejaVu Sans Mono', 'Monospace'];
+}
+
+/**
+ * If user manually chooses bin\R.exe, sessions won't load, so insert the 
+ * architecture folder (i386 if they are on a 32-bit machine, otherwise x64).
+ *
+ * If they want to use 32-bit R on a 64-bit machine they will need to
+ * choose it directly from the i386 folder.
+ * 
+ * Use Rterm.exe instead of R.exe (or anything else the user might have
+ * chosen; we can't prevent them from choosing arbitrary files).
+ * 
+ * @param rExePath Full path to Rterm.exe
+ * @returns Full path to Rterm.exe including arch folder
+ */
+export function fixWindowsRExecutablePath(rExePath: string): string {
+  if (process.platform !== 'win32' ||
+      !existsSync(rExePath) || 
+      lstatSync(rExePath).isDirectory()) {
+
+    // unexpected situation: just leave it as-is
+    return rExePath;
+  }
+
+  const selectedDir = basename(dirname(rExePath)).toLowerCase();
+  const origPath = rExePath;
+  if (selectedDir === 'bin') {
+    // User picked bin\*.exe; insert the subfolder matching the machine's architecture.
+    const archDir = process.arch === 'x32' ? 'i386' : 'x64';
+    rExePath = join(dirname(rExePath), archDir, kWindowsRExe);
+    logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
+  } else {
+    // Even if they chose the right folder, make sure they picked Rterm.exe
+    const exe = basename(rExePath).toLowerCase();
+    if (exe !== kWindowsRExe.toLowerCase()) {
+      rExePath = join(dirname(rExePath), kWindowsRExe);
+      logger().logDebug(`User selected ${origPath}, replacing with ${rExePath}`);
+    }
+  }
+  return rExePath;
 }

--- a/src/node/desktop/src/main/preferences/electron-desktop-options.ts
+++ b/src/node/desktop/src/main/preferences/electron-desktop-options.ts
@@ -16,7 +16,8 @@
 
 import { BrowserWindow, Rectangle, screen } from 'electron';
 import Store from 'electron-store';
-import { dirname } from 'path';
+import { existsSync, lstatSync } from 'fs';
+import { basename, dirname, join } from 'path';
 import { properties } from '../../../../../cpp/session/resources/schema/user-state-schema.json';
 import { normalizeSeparatorsNative } from '../../core/file-path';
 import { logger } from '../../core/logger';

--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -16,6 +16,7 @@
 import { BrowserWindow, BrowserWindowConstructorOptions, ipcMain } from 'electron';
 import { err, Expected, ok } from '../core/expected';
 import { safeError } from '../core/err';
+import { getenv } from '../core/environment';
 
 export abstract class ModalDialog<T> extends BrowserWindow {
   abstract onShowModal(): Promise<T>;
@@ -83,6 +84,11 @@ export abstract class ModalDialog<T> extends BrowserWindow {
 
     // show the window after loading everything
     this.show();
+
+    const showDevTools = getenv('RSTUDIO_DESKTOP_MODAL_DEVTOOLS').length !== 0;
+    if (showDevTools) {
+      this.webContents.openDevTools();
+    }
 
     // invoke derived class's callback and return the response
     return this.onShowModal();

--- a/src/node/desktop/src/ui/utils.ts
+++ b/src/node/desktop/src/ui/utils.ts
@@ -86,3 +86,6 @@ export function normalizeSeparatorsNative(path: string) {
   const separator = process.platform === 'win32' ? '\\' : '/';
   return normalizeSeparators(path, separator);
 }
+
+// executable to use on Windows when spawning R to query path information
+export const kWindowsRExe = 'Rterm.exe';

--- a/src/node/desktop/src/ui/widgets/choose-r.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r.ts
@@ -25,6 +25,7 @@ import { ElectronDesktopOptions } from '../../main/preferences/electron-desktop-
 
 import { existsSync } from 'fs';
 import { normalize } from 'path';
+import { kWindowsRExe } from '../utils';
 
 declare const CHOOSE_R_WEBPACK_ENTRY: string;
 declare const CHOOSE_R_PRELOAD_WEBPACK_ENTRY: string;
@@ -81,8 +82,8 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
     const r32 = findDefault32Bit();
     const r64 = findDefault64Bit();
     const initData = {
-      default32bitPath: isValidInstallation(r32) ? r32 : '',
-      default64bitPath: isValidInstallation(r64) ? r64 : '',
+      default32bitPath: isValidInstallation(r32, 'i386') ? r32 : '',
+      default64bitPath: isValidInstallation(r64, 'x64') ? r64 : '',
       rInstalls: this.rInstalls,
       renderingEngine: ElectronDesktopOptions().renderingEngine(),
       selectedRVersion: ElectronDesktopOptions().rExecutablePath(),
@@ -102,14 +103,14 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
 
       this.addIpcHandler('use-default-32bit', async (event, data: CallbackData) => {
         const installPath = initData.default32bitPath;
-        data.binaryPath = `${installPath}/bin/i386/R.exe`;
+        data.binaryPath = `${installPath}/bin/i386/${kWindowsRExe}`;
         logger().logDebug(`Using default 32-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);
       });
 
       this.addIpcHandler('use-default-64bit', async (event, data: CallbackData) => {
         const installPath = initData.default64bitPath;
-        data.binaryPath = `${installPath}/bin/x64/R.exe`;
+        data.binaryPath = `${installPath}/bin/x64/${kWindowsRExe}`;
         logger().logDebug(`Using default 64-bit version of R (${data.binaryPath})`);
         return this.maybeResolve(resolve, data);
       });
@@ -123,6 +124,7 @@ export class ChooseRModalWindow extends ModalDialog<CallbackData | null> {
         const response = dialog.showOpenDialogSync(this, {
           title: i18next.t('uiFolder.chooseRExecutable'),
           properties: ['openFile'],
+          defaultPath: kWindowsRExe,
           filters: [{ name: i18next.t('uiFolder.rExecutable'), extensions: ['exe'] }],
         });
 

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -14,7 +14,7 @@
  */
 import { contextBridge, ipcRenderer } from 'electron';
 import { getDesktopLoggerBridge } from '../../../renderer/logger-bridge';
-import { normalizeSeparatorsNative } from '../../utils';
+import { normalizeSeparatorsNative, kWindowsRExe } from '../../utils';
 
 export interface CallbackData {
   binaryPath?: string | unknown;
@@ -53,7 +53,7 @@ ipcRenderer.on('initialize', (_event, data) => {
   if (default32Bit) {
     use32?.removeAttribute('disabled');
 
-    if (isRVersionSelected('' + data.selectedRVersion, default32Bit + '/bin/i386/R.exe')) {
+    if (isRVersionSelected('' + data.selectedRVersion, default32Bit + `/bin/i386/${kWindowsRExe}`)) {
       use32.checked = true;
       isDefault32Selected = true;
     }
@@ -65,7 +65,7 @@ ipcRenderer.on('initialize', (_event, data) => {
   if (default64Bit) {
     use64?.removeAttribute('disabled');
 
-    if (isRVersionSelected('' + data.selectedRVersion, default64Bit + '/bin/x64/R.exe')) {
+    if (isRVersionSelected('' + data.selectedRVersion, default64Bit + `/bin/x64/${kWindowsRExe}`)) {
       use64.checked = true;
       isDefault64Selected = true;
     }
@@ -105,7 +105,8 @@ ipcRenderer.on('initialize', (_event, data) => {
     visitedInstallations[rInstall] = true;
 
     // check for 64 bit executable
-    const r64 = `${rInstall}/bin/x64/R.exe`;
+    const r64 = `${rInstall}/bin/x64/${kWindowsRExe}`;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (await ipcRenderer.invoke('fs_existsSync', r64)) {
       const optionEl = window.document.createElement('option');
       optionEl.value = r64;
@@ -124,7 +125,8 @@ ipcRenderer.on('initialize', (_event, data) => {
     }
 
     // check for 32 bit executable
-    const r32 = `${rInstall}/bin/i386/R.exe`;
+    const r32 = `${rInstall}/bin/i386/${kWindowsRExe}`;
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (await ipcRenderer.invoke('fs_existsSync', r32)) {
       const optionEl = window.document.createElement('option');
       optionEl.value = r32;

--- a/version/news/NEWS-2023.03.1-cherry-blossom.md
+++ b/version/news/NEWS-2023.03.1-cherry-blossom.md
@@ -6,6 +6,7 @@
 #### RStudio IDE
 - Upgrade Quarto to 1.2.475 (#12887)
 - Fix no cross references when inserting (#12882)
+- Fix Windows Choose R dialog error after selecting an R installation (#12984)
 
 #### Posit Workbench
 - Cache results for user and group lookups (rstudio/rstudio-pro#4451)


### PR DESCRIPTION
### Intent
Backport for #12984, addresses #13076

### Approach
Cherry pick the change from `main`. Just some merge conflicts with the imports.

### Automated Tests
none

### QA Notes
With debug logging, it will show that R info was queried with `Rterm.exe`.

`2023-05-02T17:32:37.341Z DEBUG Querying information about R executable at path: C:/R/R-devel/bin/i386/Rterm.exe`  

### Documentation
none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


