### PR TITLE
use '-w' flag for whole word

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed inserting cross references in a Quarto document showing no references (#12882)
 - Fixed keyboard shortcut help not displaying in Emacs or Sublime Text mode (#11376)
 - Fixed issue with rendering development documentation with R 4.3.0 (#12945)
+- Fixed issue with use of "Whole word" with Find in Files search (#13017)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1598,16 +1598,6 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
    return Success();
 }
 
-std::string escapeForRegex(const std::string& query)
-{
-   std::string specialChars("([.|*?+(){}^$\\[\\]])");
-   // Note that we need four backslashes in order to add a backslash before each special character to turn into a literal
-   // \\1 is a backreference that refers to the original symbol we want to escape
-   boost::regex_constants::syntax_option_type flags = 0;
-   std::string updatedQuery = boost::regex_replace(query, boost::regex(specialChars, flags), "\\\\\\1");
-   return updatedQuery;
-}
-
 core::Error beginFind(const json::JsonRpcRequest& request,
                       json::JsonRpcResponse* pResponse)
 {
@@ -1624,9 +1614,9 @@ core::Error beginFind(const json::JsonRpcRequest& request,
                                   &ignoreCase,
                                   &directory,
                                   &includeFilePatterns,
+                                  &excludeFilePatterns,
                                   &useGitGrep,
-                                  &excludeGitIgnore,
-                                  &excludeFilePatterns);
+                                  &excludeGitIgnore);
    if (error)
       return error;
 
@@ -1685,9 +1675,9 @@ core::Error previewReplace(const json::JsonRpcRequest& request,
                                   &ignoreCase,
                                   &directory,
                                   &includeFilePatterns,
+                                  &excludeFilePatterns,
                                   &useGitGrep,
                                   &excludeGitIgnore,
-                                  &excludeFilePatterns,
                                   &replacePattern);
    if (error)
       return error;

--- a/src/cpp/session/modules/SessionFind.cpp
+++ b/src/cpp/session/modules/SessionFind.cpp
@@ -1210,17 +1210,24 @@ class GrepOptions : public boost::noncopyable
 {
 public:
 
-   GrepOptions(std::string search, std::string directory,
-      json::Array includeFilePatterns, bool gitFlag, bool excludeGitIgnore, json::Array excludeFilePatterns,
-      bool asRegex, bool ignoreCase) :
-      asRegex_(asRegex),
-      ignoreCase_(ignoreCase),
-      searchPattern_(search),
-      directory_(directory),
-      includeFilePatterns_(includeFilePatterns),
-      gitFlag_(gitFlag),
-      excludeGitIgnore_(excludeGitIgnore),
-      excludeFilePatterns_(excludeFilePatterns)
+   GrepOptions(const std::string& search,
+               const std::string& directory,
+               json::Array includeFilePatterns,
+               json::Array excludeFilePatterns,
+               bool gitFlag,
+               bool excludeGitIgnore,
+               bool asRegex,
+               bool isWholeWord,
+               bool ignoreCase)
+      : asRegex_(asRegex),
+        isWholeWord_(isWholeWord),
+        ignoreCase_(ignoreCase),
+        searchPattern_(search),
+        directory_(directory),
+        includeFilePatterns_(includeFilePatterns),
+        gitFlag_(gitFlag),
+        excludeGitIgnore_(excludeGitIgnore),
+        excludeFilePatterns_(excludeFilePatterns)
    {
       processIncludeFilePatterns();
       processExcludeFilePatterns();
@@ -1229,6 +1236,11 @@ public:
    bool asRegex() const
    {
       return asRegex_;
+   }
+
+   bool isWholeWord() const
+   {
+      return isWholeWord_;
    }
 
    bool ignoreCase() const
@@ -1294,6 +1306,7 @@ public:
 private:
 
    bool asRegex_;
+   bool isWholeWord_;
    bool ignoreCase_;
 
    const std::string searchPattern_;
@@ -1481,8 +1494,13 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       cmd << (grepOptions.excludeGitIgnore() ? "--exclude-standard" : "--no-exclude-standard");
       cmd << "-Hn";
       cmd << "--color=always";
+
       if (grepOptions.ignoreCase())
          cmd << "-i";
+
+      if (grepOptions.isWholeWord())
+         cmd << "-w";
+
       if (grepOptions.asRegex())
          cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       else
@@ -1504,11 +1522,11 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
       }
       else 
       {
-         for (std::string arg : grepOptions.includeArgs())
+         for (const std::string& arg : grepOptions.includeArgs())
             cmd << arg;
       }
       
-      for (std::string arg : grepOptions.excludeArgs())
+      for (const std::string& arg : grepOptions.excludeArgs())
          cmd << arg;
    }
    else
@@ -1521,6 +1539,10 @@ core::Error runGrepOperation(const GrepOptions& grepOptions, const ReplaceOption
 #endif
       if (grepOptions.ignoreCase())
          cmd << "-i";
+
+      if (grepOptions.isWholeWord())
+         cmd << "-w";
+
       if (grepOptions.asRegex())
          cmd << "-E"; // use extended-grep (egrep) for Extended Regular Expressions
       else
@@ -1608,11 +1630,17 @@ core::Error beginFind(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   if (isWholeWord)
-      searchString = "(\\b|^)" + escapeForRegex(searchString) + "(\\b|$)";
+   GrepOptions grepOptions(
+            searchString,
+            directory,
+            includeFilePatterns,
+            excludeFilePatterns,
+            useGitGrep,
+            excludeGitIgnore,
+            asRegex,
+            isWholeWord,
+            ignoreCase);
 
-   GrepOptions grepOptions(searchString, directory, includeFilePatterns, useGitGrep, excludeGitIgnore, excludeFilePatterns,
-      asRegex, ignoreCase);
    error = runGrepOperation(grepOptions, ReplaceOptions(), nullptr, pResponse);
    if (error)
       LOG_DEBUG_MESSAGE("Error running grep operation with search string " + searchString);
@@ -1644,7 +1672,7 @@ core::Error previewReplace(const json::JsonRpcRequest& request,
 {
    std::string searchString;
    std::string replacePattern;
-   bool asRegex, ignoreCase;
+   bool asRegex, isWholeWord, ignoreCase;
    std::string directory;
    bool excludeGitIgnore;
    bool useGitGrep;
@@ -1653,6 +1681,7 @@ core::Error previewReplace(const json::JsonRpcRequest& request,
    Error error = json::readParams(request.params,
                                   &searchString,
                                   &asRegex,
+                                  &isWholeWord,
                                   &ignoreCase,
                                   &directory,
                                   &includeFilePatterns,
@@ -1662,11 +1691,21 @@ core::Error previewReplace(const json::JsonRpcRequest& request,
                                   &replacePattern);
    if (error)
       return error;
+
    if (!asRegex)
       LOG_DEBUG_MESSAGE("Regex should be true during preview");
 
-   GrepOptions grepOptions(searchString, directory, includeFilePatterns, useGitGrep, excludeGitIgnore, excludeFilePatterns,
-      asRegex, ignoreCase);
+   GrepOptions grepOptions(
+            searchString,
+            directory,
+            includeFilePatterns,
+            excludeFilePatterns,
+            useGitGrep,
+            excludeGitIgnore,
+            asRegex,
+            isWholeWord,
+            ignoreCase);
+
    ReplaceOptions replaceOptions(replacePattern);
    replaceOptions.preview = true;
    error = runGrepOperation(grepOptions, replaceOptions, nullptr, pResponse);
@@ -1701,15 +1740,20 @@ core::Error completeReplace(const json::JsonRpcRequest& request,
    if (error)
       return error;
 
-   if (isWholeWord)
-      searchString = "\\b" + escapeForRegex(searchString) + "\\b";
-
    // 5 was chosen based on testing to find a value that was both responsive
    // and not overly frequent
    static const int kUpdatePercent = 5;
    LocalProgress* pProgress = new LocalProgress(originalFindCount, kUpdatePercent);
-   GrepOptions grepOptions(searchString, directory, includeFilePatterns, useGitGrep, excludeGitIgnore, excludeFilePatterns,
-      asRegex, ignoreCase);
+   GrepOptions grepOptions(
+            searchString,
+            directory,
+            includeFilePatterns,
+            excludeFilePatterns,
+            useGitGrep,
+            excludeGitIgnore,
+            asRegex,
+            isWholeWord,
+            ignoreCase);
    ReplaceOptions replaceOptions(replacePattern);
 
    error = runGrepOperation(

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4530,9 +4530,9 @@ public class RemoteServer implements Server
                          boolean ignoreCase,
                          FileSystemItem directory,
                          JsArrayString includeFilePatterns,
+                         JsArrayString excludeFilePatterns,
                          boolean useGitGrep, 
                          boolean excludeGitIgnore,
-                         JsArrayString excludeFilePatterns,
                          ServerRequestCallback<String> requestCallback)
    {
       JSONArray params = new JSONArray();
@@ -4543,9 +4543,9 @@ public class RemoteServer implements Server
       params.set(4, new JSONString(directory == null ? ""
                                                      : directory.getPath()));
       params.set(5, new JSONArray(includeFilePatterns));
-      params.set(6, JSONBoolean.getInstance(useGitGrep));
-      params.set(7, JSONBoolean.getInstance(excludeGitIgnore));
-      params.set(8, new JSONArray(excludeFilePatterns));
+      params.set(6, new JSONArray(excludeFilePatterns));
+      params.set(7, JSONBoolean.getInstance(useGitGrep));
+      params.set(8, JSONBoolean.getInstance(excludeGitIgnore));
       sendRequest(RPC_SCOPE, BEGIN_FIND, params, requestCallback);
    }
 
@@ -4569,9 +4569,9 @@ public class RemoteServer implements Server
                               boolean searchIgnoreCase,
                               FileSystemItem directory,
                               JsArrayString includeFilePatterns,
+                              JsArrayString excludeFilePatterns,
                               boolean useGitGrep,
                               boolean excludeGitIgnore,
-                              JsArrayString excludeFilePatterns,
                               String replaceString,
                               ServerRequestCallback<String> requestCallback)
    {
@@ -4583,9 +4583,9 @@ public class RemoteServer implements Server
       params.set(4, new JSONString(directory == null ? ""
                                                      : directory.getPath()));
       params.set(5, new JSONArray(includeFilePatterns));
-      params.set(6, JSONBoolean.getInstance(useGitGrep));
-      params.set(7, JSONBoolean.getInstance(excludeGitIgnore));
-      params.set(8, new JSONArray(excludeFilePatterns));
+      params.set(6, new JSONArray(excludeFilePatterns));
+      params.set(7, JSONBoolean.getInstance(useGitGrep));
+      params.set(8, JSONBoolean.getInstance(excludeGitIgnore));
       params.set(9, new JSONString(replaceString));
 
       sendRequest(RPC_SCOPE, PREVIEW_REPLACE, params, requestCallback);
@@ -4598,9 +4598,9 @@ public class RemoteServer implements Server
                                boolean searchIgnoreCase,
                                FileSystemItem directory,
                                JsArrayString includeFilePatterns,
+                               JsArrayString excludeFilePatterns,
                                boolean useGitGrep,
                                boolean excludeGitIgnore,
-                               JsArrayString excludeFilePatterns,
                                int searchResults,
                                String replaceString,
                                ServerRequestCallback<String> requestCallback)

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -4565,6 +4565,7 @@ public class RemoteServer implements Server
    @Override
    public void previewReplace(String searchString,
                               boolean regex,
+                              boolean isWholeWord,
                               boolean searchIgnoreCase,
                               FileSystemItem directory,
                               JsArrayString includeFilePatterns,
@@ -4577,14 +4578,15 @@ public class RemoteServer implements Server
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(searchString));
       params.set(1, JSONBoolean.getInstance(regex));
-      params.set(2, JSONBoolean.getInstance(searchIgnoreCase));
-      params.set(3, new JSONString(directory == null ? ""
+      params.set(2, JSONBoolean.getInstance(isWholeWord));
+      params.set(3, JSONBoolean.getInstance(searchIgnoreCase));
+      params.set(4, new JSONString(directory == null ? ""
                                                      : directory.getPath()));
-      params.set(4, new JSONArray(includeFilePatterns));
-      params.set(5, JSONBoolean.getInstance(useGitGrep));
-      params.set(6, JSONBoolean.getInstance(excludeGitIgnore));
-      params.set(7, new JSONArray(excludeFilePatterns));
-      params.set(8, new JSONString(replaceString));
+      params.set(5, new JSONArray(includeFilePatterns));
+      params.set(6, JSONBoolean.getInstance(useGitGrep));
+      params.set(7, JSONBoolean.getInstance(excludeGitIgnore));
+      params.set(8, new JSONArray(excludeFilePatterns));
+      params.set(9, new JSONString(replaceString));
 
       sendRequest(RPC_SCOPE, PREVIEW_REPLACE, params, requestCallback);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindInFilesDialog.java
@@ -185,19 +185,6 @@ public class FindInFilesDialog extends ModalDialog<FindInFilesDialog.State>
       setExampleIdAndAriaProperties(spanPatternExample_, txtFilePattern_);
       setExampleIdAndAriaProperties(spanExcludePatternExample_, txtExcludeFilePattern_);
 
-      checkboxRegex_.addValueChangeHandler(event ->
-      {
-         // Disable "Whole Word" checkbox when regex is selected
-         if (event.getValue())
-            checkboxWholeWord_.setValue(false);
-      });
-
-      checkboxWholeWord_.addValueChangeHandler(event ->
-      {
-         if (event.getValue())
-            checkboxRegex_.setValue(false);
-      });
-
       listPresetFilePatterns_.addChangeHandler(event ->
       {
          manageFilePattern();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -230,9 +230,9 @@ public class FindOutputPresenter extends BasePresenter
                                    !dialogState_.isCaseSensitive(),
                                    searchPath,
                                    includeFilePatterns,
+                                   excludeFilePatterns,
                                    dialogState_.getUseGitGrep(),
                                    dialogState_.getExcludeGitIgnore(),
-                                   excludeFilePatterns,
                                    view_.getReplaceText(),
                                    new SimpleRequestCallback<String>()
                                    {
@@ -315,14 +315,14 @@ public class FindOutputPresenter extends BasePresenter
                         String serverQuery = dialogState_.getQuery();
 
                         server_.completeReplace(serverQuery,
-                                                dialogState_.isRegex() || dialogState_.isWholeWord(),
+                                                dialogState_.isRegex(),
                                                 dialogState_.isWholeWord(),
                                                 !dialogState_.isCaseSensitive(),
                                                 searchPath,
                                                 includeFilePatterns,
+                                                excludeFilePatterns,
                                                 dialogState_.getUseGitGrep(),
                                                 dialogState_.getExcludeGitIgnore(),
-                                                excludeFilePatterns,
                                                 dialogState_.getResultsCount(),
                                                 view_.getReplaceText(),
                                                 new SimpleRequestCallback<String>()
@@ -504,15 +504,16 @@ public class FindOutputPresenter extends BasePresenter
 
       String serverQuery = dialogState_.getQuery();
 
-      server_.beginFind(serverQuery,
-         dialogState_.isRegex() || dialogState_.isWholeWord(),
+      server_.beginFind(
+         serverQuery,
+         dialogState_.isRegex(),
          dialogState_.isWholeWord(),
          !dialogState_.isCaseSensitive(),
          searchPath,
          includeFilePatterns,
+         excludeFilePatterns,
          dialogState_.getUseGitGrep(),
          dialogState_.getExcludeGitIgnore(),
-         excludeFilePatterns,
          new SimpleRequestCallback<String>()
          {
             @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/FindOutputPresenter.java
@@ -224,10 +224,9 @@ public class FindOutputPresenter extends BasePresenter
             for (String pattern : dialogState_.getExcludeFilePatterns())
                excludeFilePatterns.push(pattern);
 
-            // this event is only ever triggered when dialogState_.isRegex() is true
-            // so we don't need to check for and handle dialogState_.isWholeWord() here
             server_.previewReplace(dialogState_.getQuery(),
                                    dialogState_.isRegex(),
+                                   dialogState_.isWholeWord(),
                                    !dialogState_.isCaseSensitive(),
                                    searchPath,
                                    includeFilePatterns,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
@@ -39,6 +39,7 @@ public interface FindInFilesServerOperations
 
    void previewReplace(String searchString,
                        boolean regex,
+                       boolean isWholeWord,
                        boolean searchIgnoreCase,
                        FileSystemItem dictionary,
                        JsArrayString includeFilePatterns,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/output/find/model/FindInFilesServerOperations.java
@@ -27,9 +27,9 @@ public interface FindInFilesServerOperations
                   boolean ignoreCase,
                   FileSystemItem directory,
                   JsArrayString includeFilePatterns,
+                  JsArrayString excludeFilePatterns,
                   boolean useGitGrep, 
                   boolean excludeGitIgnore,
-                  JsArrayString excludeFilePatterns,
                   ServerRequestCallback<String> requestCallback);
 
    void stopFind(String findOperationHandle,
@@ -43,9 +43,9 @@ public interface FindInFilesServerOperations
                        boolean searchIgnoreCase,
                        FileSystemItem dictionary,
                        JsArrayString includeFilePatterns,
+                       JsArrayString excludeFilePatterns,
                        boolean useGitGrep,
                        boolean excludeGitIgnore,
-                       JsArrayString excludeFilePatterns,
                        String replaceString,
                        ServerRequestCallback<String> requestCallback);
 
@@ -55,9 +55,9 @@ public interface FindInFilesServerOperations
                         boolean searchIgnoreCase,
                         FileSystemItem dictionary,
                         JsArrayString includeFilePatterns,
+                        JsArrayString excludeFilePatterns,
                         boolean useGitGrep,
                         boolean excludeGitIgnore,
-                        JsArrayString excludeFilePatterns,
                         int searchResults,
                         String replaceString,
                         ServerRequestCallback<String> requestCallback);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13017.

### Approach

Rather than adorn the search query with `\\b` word boundaries, use the `-w` flag which is supported both by all common implementations of `grep`, as well as `git grep`.

### Automated Tests

Hopefully covered by existing tests.

### QA Notes

Test via notes in #13017.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
