### PR TITLE
ignore `max-len` for strings and template literals

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -31,6 +31,8 @@ module.exports = {
         code: 120,
         tabWidth: 2,
         ignoreUrls: true,
+        ignoreStrings: true,
+        ignoreTemplateLiterals: true
       },
     ],
 


### PR DESCRIPTION
### Intent

Enhancement to `eslint` settings to permit strings and template literals to exceed the maximum line length. Splitting up strings and template literals can be left up to the developer to decide how the string/template literal should be split onto multiple lines for readability.

### Approach
Use `es-lint` `max-len` rules `ignoreStrings` and `ignoreTemplateLiterals`. See https://eslint.org/docs/latest/rules/max-len.

Tested by adding the following changes and running `eslint`:

```js
console.log('LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOONG STRING',);
console.log(`LOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOONG TEMPLATE LITERAL`);
```

These would previously cause the `eslint` command to error, but now pass.

### Automated Tests
N/A

### QA Notes
N/A

### Documentation
N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
~- [ ] This PR passes all local unit tests~

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


