### PR TITLE
remove redundant call to setApplicationMenu to avoid crash when holding Alt key

### DIFF
--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -105,8 +105,11 @@ export class MainWindow extends GwtWindow {
 
     showPlaceholderMenu();
 
-    this.menuCallback.on(MenuCallback.MENUBAR_COMPLETED, (menu: Menu) => {
-      Menu.setApplicationMenu(menu);
+    this.menuCallback.on(MenuCallback.MENUBAR_COMPLETED, (/*menu: Menu*/) => {
+      // We used to do `Menu.setApplicationMenu(menu);` here but that was causing crashes in
+      // Electron when holding down the Alt key (https://github.com/rstudio/rstudio/issues/12983).
+      // It seems some sort of clash between setting this here and the subsequent set
+      // that happens in MenuCallback.updateMenus().
     });
     this.menuCallback.on(MenuCallback.COMMAND_INVOKED, (commandId) => {
       this.invokeCommand(commandId);


### PR DESCRIPTION
### Intent

Addresses [Pressing Alt kills RStudio #12983](https://github.com/rstudio/rstudio/issues/12983)

### Approach

We were doing setApplicationMenu twice during startup, and this was (somehow) causing a dangling pointer inside Electron's accelerator key handling code. By removing the redundant call to setApplicationMenu, the issue appears resolved.

### Automated Tests

None

### QA Notes

Other than verifying that holding <kbd>Alt</kbd> doesn't crash the IDE on Windows, make sure the main menu is appearing and working correctly on all three desktop platforms (Mac, Windows, Linux). Quick sanity check should be sufficient.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


