### PR TITLE
don't initialize python from restored env null ptr

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1568,6 +1568,14 @@ def _rstudio_html_generator_():
 #  $ contents_deferred: 'rs.scalar' logi FALSE
 .rs.addFunction("reticulate.describeObject", function(name, parent)
 {
+
+   object <- if (inherits(parent, "python.builtin.dict"))
+      reticulate::py_get_item(parent, name)
+   else if (inherits(parent, "python.builtin.object"))
+      reticulate::py_get_attr(parent, name)
+   else
+      get(name, envir = parent)
+
    # is this a null pointer? if so, handle that up-front
    if (reticulate:::py_is_null_xptr(object))
    {
@@ -1589,12 +1597,6 @@ def _rstudio_html_generator_():
 
    builtins <- reticulate::import_builtins(convert = TRUE)
 
-   object <- if (inherits(parent, "python.builtin.dict"))
-      reticulate::py_get_item(parent, name)
-   else if (inherits(parent, "python.builtin.object"))
-      reticulate::py_get_attr(parent, name)
-   else
-      get(name, envir = parent)
    # is this object 'data'? consider non-callable, non-module objects as data
    isData <- !(
       grepl("^__.*__$", name) ||

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1595,8 +1595,6 @@ def _rstudio_html_generator_():
       return(result)
    }
 
-   builtins <- reticulate::import_builtins(convert = TRUE)
-
    # is this object 'data'? consider non-callable, non-module objects as data
    isData <- !(
       grepl("^__.*__$", name) ||

--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -1568,15 +1568,6 @@ def _rstudio_html_generator_():
 #  $ contents_deferred: 'rs.scalar' logi FALSE
 .rs.addFunction("reticulate.describeObject", function(name, parent)
 {
-   builtins <- reticulate::import_builtins(convert = TRUE)
-   
-   object <- if (inherits(parent, "python.builtin.dict"))
-      reticulate::py_get_item(parent, name)
-   else if (inherits(parent, "python.builtin.object"))
-      reticulate::py_get_attr(parent, name)
-   else
-      get(name, envir = parent)
-   
    # is this a null pointer? if so, handle that up-front
    if (reticulate:::py_is_null_xptr(object))
    {
@@ -1592,10 +1583,18 @@ def _rstudio_html_generator_():
          contents          = list(),
          contents_deferred = .rs.scalar(FALSE)
       )
-      
+
       return(result)
    }
-   
+
+   builtins <- reticulate::import_builtins(convert = TRUE)
+
+   object <- if (inherits(parent, "python.builtin.dict"))
+      reticulate::py_get_item(parent, name)
+   else if (inherits(parent, "python.builtin.object"))
+      reticulate::py_get_attr(parent, name)
+   else
+      get(name, envir = parent)
    # is this object 'data'? consider non-callable, non-module objects as data
    isData <- !(
       grepl("^__.*__$", name) ||


### PR DESCRIPTION
closes https://github.com/rstudio/reticulate/issues/710


### Intent

Issue: when a reticulate python object is automatically loaded from a previous R session `.RData` file, the IDE causes reticulate to initialize python while the IDE is generating the object summary for presentation in the env pane.    

### Approach

Add an early return in `rs.describeObject()` that checks for the case of the object being a reticulate null ptr, this avoids running code that otherwise assumes python is already initialized (e.g., `reticulate::import_builtins()`). Reticulate objects loaded from `.RData` will always be null ptrs.

### Automated Tests

NA

### QA Notes

To test locally:

1. create a .RData containing an R object
```r
x = reticulate::py_eval("1", convert = FALSE)
save.image()
``` 
2. Start a fresh R session and restore `.RData`
```r
load(".RData")
if (reticulate::python_available()) 
  stop("Python should not be initialized from merely loading .RData")
```

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


