### PR TITLE
Backport fix macos s3 package upload path (#13064)

### DIFF
--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -162,6 +162,7 @@ pipeline {
                     returnStdout: true
                   ).trim().toLowerCase()}"""
                   PRODUCT = "${utils.getProductName()}"
+                  AWS_PATH = "${FLAVOR.toLowerCase()}/macos"
                 }
                 
                 stages {
@@ -182,7 +183,7 @@ pipeline {
                       withAWS(role: 'ide-build', region: 'us-east-1') {
                         retry(5) {
                           script {
-                            utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${FLAVOR.toLowerCase()}/macos/"
+                            utils.uploadPackageToS3 "package/osx/build/${PACKAGE_FILE}", "${AWS_PATH}/"
                           }
                         }
                       }
@@ -224,13 +225,14 @@ pipeline {
                   stage("Publish") {
                     environment {
                       GITHUB_LOGIN = credentials('github-rstudio-jenkins')
+                      DAILIES_PATH = "${PRODUCT}/macos"
                     }
 
                     steps {
                       dir("package/osx/build") {
                         script {
                           // publish build to dailies page
-                          utils.publishToDailiesSite "${env.PACKAGE_FILE}", "${env.PRODUCT}/macos"
+                          utils.publishToDailiesSite PACKAGE_FILE, DAILIES_PATH, AWS_PATH
                         }
                       }
                     }
@@ -251,7 +253,7 @@ pipeline {
                     steps {
                       script {
                         // upload daily build redirects
-                        utils.updateDailyRedirects "${PRODUCT}/macos/${PACKAGE_FILE}"
+                        utils.updateDailyRedirects "${AWS_PATH}/${PACKAGE_FILE}"
                       }
                     }
                   }


### PR DESCRIPTION
### Intent
Backport #13064. I didn't realize that the build urls are based on the Jenkinsfiles in the corresponding release branches, so the Mac S3 urls were still being constructed incorrectly for Cherry Blossom builds (pro builds specifically).

### Approach
Cherry-picked the change from `main`.

### Automated Tests
N/A

### QA Notes

Any builds generated after this PR goes in should have the correct url. Test by clicking on the Filename at https://dailies.rstudio.com/rstudio/cherry-blossom/desktop-pro/macos/ and https://dailies.rstudio.com/rstudio/cherry-blossom/electron-pro/macos/. No errors should occur.

### Documentation
N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
~- [ ] This PR passes all local unit tests~

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


