### PR TITLE
Update release notes for 2023.03.1+446.pro1

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,6 +9,41 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
+## RStudio 2023.03.1
+
+**"Cherry Blossom"**
+
+>Date: 2023-05-12
+
+### New
+
+#### RStudio IDE
+- Upgrade Quarto to 1.2.475 (#12887)
+
+#### Posit Workbench
+- Cache results for user and group lookups (rstudio/rstudio-pro#4451)
+
+### Fixed
+
+#### RStudio IDE
+- Fix no cross references when inserting (#12882)
+- Fix Windows Choose R dialog error after selecting an R installation (#12984)
+- Fix saving files to UNC paths on Windows (#12652)
+- Fix RStudio freeze when copy/pasting on Windows (#12879)
+- Fix inserting an empty citation (#12833)
+
+#### Posit Workbench
+- Increase timeout for stale messages error (rstudio/rstudio-pro#4325)
+- Reduce database queries and remove locking around DB calls (rstudio/rstudio-pro#4492)
+- Eliminate assertion failed error when reloading config with load balancing enabled (rstudio/rstudio-pro#4504)
+- Fix a bug with starting JupyterLab and Jupyter Notebook sessions when ServerApp.token='' is present in the Jupyter settings (rstudio/rstudio-pro#4491)
+- Routine timeouts when watching Job Launcher Kubernetes resources are no longer logged as an error (rstudio/launcher#604)
+- Resolve an issue in the Job Launcher Kubernetes plugin with handling Kubernetes token rotation that would result in the Kubernetes plugin restarting (rstudio/launcher#584)
+- Address a memory leak in the Job Launcher Kubernetes plugin related to the reloading of the Kubernetes API token (rstudio/launcher#645)
+- Kubernetes Service Accounts that contain only numeric characters will now work correctly with templates (rstudio/launcher#650)
+- Resource Profiles now work correctly when the Job Launcher Slurm plugin is configured with `enable-gpus=1` but `gpu-types` is empty (rstudio/launcher#639)
+- Address a crash in the Job Launcher Kubernetes Plugin (rstudio/launcher#660)
+- Fix a bug in Job Launcher Kubernetes Plugin Kubernetes Auth Token reload logic for streaming requests (rstudio/launcher#685)
 ## RStudio 2023.03.0
 
 **"Cherry Blossom"**

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -44,6 +44,7 @@ This page provides the release notes associated with each release of RStudio and
 - Resource Profiles now work correctly when the Job Launcher Slurm plugin is configured with `enable-gpus=1` but `gpu-types` is empty (rstudio/launcher#639)
 - Address a crash in the Job Launcher Kubernetes Plugin (rstudio/launcher#660)
 - Fix a bug in Job Launcher Kubernetes Plugin Kubernetes Auth Token reload logic for streaming requests (rstudio/launcher#685)
+
 ## RStudio 2023.03.0
 
 **"Cherry Blossom"**


### PR DESCRIPTION

Update release notes for IDE / Workbench 2023.03.1+446.pro1 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2023.03.1-cherry-blossom.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
