### PR TITLE
Set logic to run updateDailyRedirects

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -375,11 +375,13 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
                     }
 
+                    // for pro, update with Qt
+                    // for open source, update with Electron
                     when { 
-                      allOf {
-                        expression { return params.PUBLISH }
-                        expression { return params.DAILY}
-                        expression { return !env.IS_PRO } 
+                      anyOf {
+                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
+                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }
 

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -243,10 +243,13 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
                     }
 
-                    when {
-                      allOf {
-                        environment name: 'FLAVOR', value: 'Electron'
-                        expression { return !env.IS_PRO }
+                    // for pro, update with Qt
+                    // for open source, update with Electron
+                    when { 
+                      anyOf {
+                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
+                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }
 

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -283,12 +283,13 @@ pipeline {
           stage ("Update Daily Build Redirects") {
             agent { label "linux" } 
 
-            when {
-              allOf {
-                expression { return !env.IS_PRO }
-                expression { return params.PUBLISH }
-                expression { return params.DAILY }
-                environment name: 'FLAVOR', value: 'Electron'
+            // for pro, update with Qt
+            // for open source, update with Electron
+            when { 
+              anyOf {
+                expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
+                expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
               }
             }
 
@@ -300,7 +301,7 @@ pipeline {
               // the updateDailyRedirects uses a bash script, so much be run on linux
               // Also depends on flavor, so must be in the matrix
               script {
-                utils.updateDailyRedirects "desktop/windows/${PACKAGE_NAME}.exe"
+                utils.updateDailyRedirects "${AWS_PATH}/${PACKAGE_NAME}.exe"
               }
             }
 


### PR DESCRIPTION
### Intent
Run the Update Daily Build Redirects stage

### Approach
It seems that using `env.IS_PRO` was always false since it is set as a script variable instead of an environment variable. This was causing the stage to never run.

Updated the stage condition to run if `PUBLISH` and `DAILY` are set. In addition, it updates Desktop Pro to point to Qt and open source Desktop to Electron.

### Automated Tests
none

### QA Notes
https://dailies.rstudio.com/links/ all the daily links, pro and open source, should update to the latest build

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


