### PR TITLE
Add Quarto Linux arm64 support

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -233,14 +233,25 @@ endif()
 # pandoc version
 set(PANDOC_VERSION "2.18" CACHE INTERNAL "Pandoc version")
 
+# detect Centos 7, because we don't support Quarto on Centos7 arm64
+set(IS_CENTOS7 FALSE)
+if(LINUX AND EXISTS "/etc/centos-release")
+   file(READ "/etc/centos-release" CENTOS_RELEASE)
+   string(FIND "${CENTOS_RELEASE}" "release 7" CENTOS_RELEASE_POS)
+   if(CENTOS_RELEASE_POS GREATER 0)
+     set(IS_CENTOS7 TRUE)
+   endif()
+endif()
+
 # quarto support
 if(NOT DEFINED QUARTO_ENABLED)
-   if(LINUX AND UNAME_M STREQUAL aarch64)
-      # disabled on linux aarch64
-      message(STATUS "quarto does not yet support aarch64 builds of Linux; disabling quarto")
-      set(QUARTO_ENABLED FALSE CACHE INTERNAL "")
+   if(IS_CENTOS7 AND LINUX AND UNAME_M STREQUAL aarch64)
+      message(STATUS "quarto does not yet support aarch64 builds for CentOS; disabling quarto")
+      set(QUARTO_ENABLED FALSE CACHE INTERNAL "") 
    else()
-      # enable by default
+      if(LINUX AND UNAME_M STREQUAL aarch64)
+        message(STATUS "RStudio aarch64 builds supports quarto experimentally")
+      endif()
       set(QUARTO_ENABLED TRUE CACHE INTERNAL "")
    endif()
 endif()

--- a/dependencies/common/install-quarto
+++ b/dependencies/common/install-quarto
@@ -20,11 +20,6 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../tools/rstudio-tools.sh"
 section "Installing Quarto"
 
-if [ "$(arch)" = "aarch64" ]; then
-  echo "install-quarto not yet available for aarch64"
-  exit 0
-fi
-
 # variables that control download + installation process
 # specify a version to pin for releases
 QUARTO_VERSION="1.3.353"
@@ -70,13 +65,23 @@ case "${PLATFORM}" in
 
 "Linux-64")
   SUBDIR="linux"
+  if [ "$(arch)" == "aarch64" ]; then
+    ARCH="arm64"
+  else
+    ARCH="amd64"
+  fi
   if [ "$OS_DISTRO" == "centos7" ]; then
-    FILES=(
-      "quarto-${QUARTO_VERSION}-linux-rhel7-amd64.tar.gz"
-    )
+    if [ "$ARCH" == "amd64" ]; then
+      FILES=(
+        "quarto-${QUARTO_VERSION}-linux-rhel7-${ARCH}.tar.gz"
+      )
+    else
+      echo "Quarto binaries are not available for CentOS aarch64"
+      exit 0
+    fi
   else
     FILES=(
-      "quarto-${QUARTO_VERSION}-linux-amd64.tar.gz"
+      "quarto-${QUARTO_VERSION}-linux-${ARCH}.tar.gz"
     )
   fi
 


### PR DESCRIPTION
### Intent
Address #12411 to address one issue with #10823 

### Approach
Excludes installing Quarto for Centos and RHEL arm64 since there's no special build for those platforms (specifically CentOS/RHEL 7). It might work on RHEL 8 but testing and more changes are required. See https://github.com/quarto-dev/quarto-cli/discussions/380 for why it there's a specific build for CentOS/RHEL 7.

Modify `CMakeGlobals.txt` so Quarto is enabled when building the session code. This enables the session to check for a packaged Quarto or a user installed Quarto.

Modify `install-quarto` to download and install Quarto.

### Automated Tests
None

### QA Notes
This should handle a specific case where the visual editor hangs on Linux arm64 (see #10823).

### Documentation
I don't think anything specific is required unless arm64 is officially supported. See https://github.com/rstudio/rstudio/issues/8809 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


