### PR TITLE
fix help preview error by handling `NA` values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -49,6 +49,7 @@
 - Fixed issue with use of "Whole word" with Find in Files search (#13017)
 - Fixed issue with diagnostics freezing session with documents containing pipebind operator (#13091)
 - Fixed issue with stopping a Quarto Shiny doc render on Windows (#12546)
+- Fixed "Error Retrieving Help" bug when data preview column contains `NA` values (#12918)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -488,7 +488,7 @@ options(help_type = "html")
       bits <- c()
       nchars <- 55
       i <- 1
-      while (nchars > 1 && i < length(column)) {
+      while (nchars > 1 && i <= length(column)) {
          current <- formatted[i]
          currentNChars <- nchar(current, keepNA = FALSE)
          if (currentNChars > nchars) {

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -490,11 +490,12 @@ options(help_type = "html")
       i <- 1
       while (nchars > 1 && i < length(column)) {
          current <- formatted[i]
-         if (nchar(current) > nchars) {
+         currentNChars <- nchar(current, keepNA = FALSE)
+         if (currentNChars > nchars) {
             current <- pillar$str_trunc(current, nchars)
          }
          bits <- c(bits, current)
-         nchars <- nchars - nchar(current) - 2
+         nchars <- nchars - currentNChars - 2
          i <- i + 1
       }
       


### PR DESCRIPTION
### Intent

Addresses #12918.

Fixes error occurring when viewing help preview for data that contains `NA` character type values.
Includes last column of data in help preview (as long as it fits).

### Approach

Use the `nchar()` `keepNA = FALSE` argument to handle when the character vector contains `NA` elements. The length of `NA` (2) will be returned instead of `NA` itself.

Use `<=` in the while loop to include the last element of the formatted column data.

### Automated Tests
none

### QA Notes

Note that the error `Error in if (nchar(current) > nchars)...` is not reproducible anymore, because the errors from session help previews were suppressed (so they won't pop up anymore).

To verify this fix, source the following code:
```R
library(data.table)
library(pillar)

StartDateTime <- as.POSIXct("2023-01-01",origin="1970-01-01")
DateTime10 <- seq(StartDateTime,StartDateTime+10, length.out=11)
test.df <- as.data.table(cbind(c(1:11),DateTime10,shift(DateTime10)))
test.df <- cbind(test.df,test.df$V3)
test.df$V2 <- as.POSIXct(test.df$V2, origin = "1960-01-01")

# try typing 'test.df$' and see what autocomplete produces
```

Then type `test.df$` to loop through the autocomplete preview for each column.

If the data for each column is successfully previewed, then the fix works! In particular:
- column `V1` should should 11 elements, 1 through 11
- column `DateTime10`, `V3` and `V2` should all appear without issue

https://github.com/rstudio/rstudio/assets/25834218/ed288188-fd48-4375-bba8-f4acc5d3d7e2

### Documentation
N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


