### PR TITLE
Remove the focal exclude for building arm

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -2,7 +2,7 @@ def utils
 
 def ext_map = 
 [
-  'focal':     'deb',
+  'focal':      'deb',
   'jammy':      'deb',
   'centos7':    'rpm',
   'rhel8':      'rpm',
@@ -12,7 +12,7 @@ def ext_map =
 
 def package_os =
 [
-  'focal':     'Ubuntu Focal',
+  'focal':      'Ubuntu Focal',
   'jammy':      'Ubuntu Jammy',
   'centos7':    'CentOS 7',
   'rhel8':      'RHEL 8',
@@ -174,7 +174,7 @@ pipeline {
           exclude {
             axis {
               name 'OS'
-              values 'focal', 'centos7', 'rhel8', 'opensuse15'
+              values 'centos7', 'rhel8', 'opensuse15'
             }
             axis {
               name 'ARCH'


### PR DESCRIPTION
See: https://github.com/rstudio/rstudio-pro/issues/4470

### Intent / Approach

Re-enable the arm builds for Ubuntu20 Focal. 

We wish to build OS Server and OS Electron Desktop and _NOT_ OS QT Desktop. The current excludes handle this, because we already cancel the entire `Desktop` flavor from building on _any_ arm64 architecture.

Currently this will also build Pro on Focal arm64. I don't necessarily see a problem with that considering our license manager is compatible with Focal arm64, but we may want to exclude all Pro Focal arm64 builds if it struggles.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


