### PR TITLE
Fix hang during R shutdown after Quarto render

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
 - Fixed issue with rendering development documentation with R 4.3.0 (#12945)
 - Fixed issue with use of "Whole word" with Find in Files search (#13017)
 - Fixed issue with diagnostics freezing session with documents containing pipebind operator (#13091)
+- Fixed hang when restarting R or closing IDE after rendering a Quarto document (#12836)
 
 #### Posit Workbench
 - Fixed unlabeled buttons for screen reader users when page is narrow [Accessibility] (rstudio/rstudio-pro#4340)

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -612,6 +612,21 @@ void onAllSourceDocsRemoved()
    stopPreview();
 }
 
+#ifdef WIN32
+void onQuit()
+{
+   stopPreview();
+}
+
+void onSuspend(Settings*)
+{
+   stopPreview();
+}
+
+void onResume(const Settings&)
+{
+}
+#endif
 
 } // anonymous namespace
 
@@ -622,6 +637,12 @@ Error initialize()
    source_database::events().onDocRemoved.connect(onSourceDocRemoved);
    source_database::events().onRemoveAll.connect(onAllSourceDocsRemoved);
 
+#ifdef WIN32
+   // Windows has issues with the Quarto background process running when the session shuts down
+   // It requires that the Quarto process is terminated first
+   module_context::events().onQuit.connect(onQuit);
+   addSuspendHandler(SuspendHandler(boost::bind(onSuspend, _2), onResume));
+#endif
 
    // register rpc functions
   ExecBlock initBlock;

--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1607,6 +1607,12 @@ void onShutdown(bool terminatedNormally)
                                                s_renderOutputs);
    if (error)
       LOG_ERROR(error);
+
+   // Windows has issues with the Quarto background process running when the session shuts down
+   // It requires that the Quarto process is terminated first
+#ifdef _WIN32
+   s_pCurrentRender_->terminateProcess(renderTerminateQuiet);
+#endif
 }
  
 void onSuspend(const r::session::RSuspendOptions&, core::Settings*)


### PR DESCRIPTION
### Intent
Address #12836 

### Approach
Subscribe to the quit and suspend events and stop the preview.

### Automated Tests
none

### QA Notes
This issue only affected Windows and the change only applies to Windows. 

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


