### PR TITLE
Open Source Companion for 4470 reenable bionic for debian builds

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -1,0 +1,131 @@
+ARG ARCH=amd64
+FROM --platform=linux/$ARCH ubuntu:bionic
+ARG ARCH
+
+ENV OPERATING_SYSTEM=ubuntu_bionic
+
+ARG AWS_REGION=us-east-1
+
+# install needed packages. replace httpredir apt source with cloudfront
+RUN set -x \
+    && sed -i "s/archive.ubuntu.com/$AWS_REGION.ec2.archive.ubuntu.com/" /etc/apt/sources.list \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get update 
+
+# add ppa repository so we can install java 8 (not in any official repo for bionic)
+RUN apt-get update \
+  && apt-get install -y software-properties-common \
+  && add-apt-repository ppa:openjdk-r/ppa
+
+RUN apt-get update && \
+    export DEBIAN_FRONTEND=noninteractive && \
+    apt-get install -y \
+    ant \
+    build-essential \
+    clang \
+    curl \
+    debsigs \
+    dpkg-sig \
+    expect \
+    fakeroot \
+    git-core \
+    gnupg1 \
+    jq \
+    libattr1-dev \
+    libacl1-dev \
+    libbz2-dev \
+    libcap-dev \
+    libcurl4-openssl-dev \
+    libfuse2 \
+    libgtk-3-0 \
+    libgl1-mesa-dev \
+    libegl1-mesa \
+    libpam-dev \
+    libpango1.0-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libuser1-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    lsof \
+    ninja-build \
+    openjdk-8-jdk \
+    p7zip-full \
+    pkg-config \
+    python \
+    r-base \
+    sudo \
+    unzip \
+    uuid-dev \
+    valgrind \
+    wget \
+    xvfb \
+    zlib1g-dev
+
+# ensure we use the java 8 compiler
+RUN update-alternatives --set java /usr/lib/jvm/java-8-openjdk-$(dpkg --print-architecture)/jre/bin/java
+
+## build patchelf
+RUN cd /tmp \
+    && wget https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.gz \
+    && tar xzvf patchelf-0.9.tar.gz \
+    && cd patchelf-0.9 \
+    && ./configure \
+    && make \
+    && make install
+
+# copy RStudio tools (needed so that our other dependency scripts can find it)
+RUN mkdir -p /tools
+COPY dependencies/tools/rstudio-tools.sh /tools/rstudio-tools.sh
+
+RUN mkdir -p /opt/rstudio-tools/dependencies/tools
+COPY dependencies/tools/rstudio-tools.sh /opt/rstudio-tools/dependencies/tools/rstudio-tools.sh
+
+# run install-boost twice - boost exits 1 even though it has installed good enough for our uses.
+# https://github.com/rstudio/rstudio/blob/master/vagrant/provision-primary-user.sh#L12-L15
+COPY dependencies/common/install-boost /tmp/
+RUN bash /tmp/install-boost || bash /tmp/install-boost
+
+# install cmake
+COPY package/linux/install-dependencies /tmp/
+RUN /bin/bash /tmp/install-dependencies
+
+# install crashpad and its dependencies
+COPY dependencies/common/install-crashpad /tmp/
+RUN bash /tmp/install-crashpad bionic
+
+# copy common dependency installation scripts
+RUN mkdir -p /opt/rstudio-tools/dependencies/common
+COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
+
+# panmirror check for changes
+# ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+
+# install common dependencies
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic
+# panmirror needs to be able to build in this location
+RUN chmod -R 777 /opt/rstudio-tools/src
+
+# install Qt SDK
+COPY dependencies/common/install-qt.sh /tmp/
+COPY dependencies/linux/install-qt-linux /tmp/
+RUN export QT_VERSION=5.12.8 && \
+    cd /tmp && /bin/bash ./install-qt-linux
+
+# cachebust for Quarto release
+ADD https://quarto.org/docs/download/_download.json quarto_releases
+RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-quarto
+
+# set github login from build argument if defined
+ARG GITHUB_LOGIN
+ENV RSTUDIO_GITHUB_LOGIN=$GITHUB_LOGIN
+
+# create jenkins user, make sudo. try to keep this toward the bottom for less cache busting
+ARG JENKINS_GID=999
+ARG JENKINS_UID=999
+RUN groupadd -g $JENKINS_GID jenkins && \
+    useradd -m -d /var/lib/jenkins -u $JENKINS_UID -g jenkins jenkins && \
+    echo "jenkins ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -203,12 +203,12 @@ pipeline {
             }
 
             environment {
-              FINAL_OS_NAME = utils.getBionicFocalOsName("${OS}")
+              DOCKER_OS_NAME = utils.getBionicFocalOsName("${OS}")
             }
 
             agent {
               docker {
-                image "jenkins/ide:${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
+                image "jenkins/ide:${IS_PRO? 'pro-' : '' }${DOCKER_OS_NAME}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
                 registryCredentialsId 'ecr:us-east-1:aws-build-role'
                 registryUrl 'https://263245908434.dkr.ecr.us-east-1.amazonaws.com'
                 label "${getAgentLabel(ARCH)}"

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -203,7 +203,7 @@ pipeline {
             }
 
             environment {
-              DOCKER_OS_NAME = utils.getBionicFocalOsName("${OS}")
+              DOCKER_OS_NAME = utils.getDockerBuildOs("${OS}")
             }
 
             agent {

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -202,9 +202,13 @@ pipeline {
               timeout(time: 2, unit: 'HOURS', activity: true)
             }
 
+            environment {
+              FINAL_OS_NAME = utils.getBionicFocalOsName("${OS}")
+            }
+
             agent {
               docker {
-                image "jenkins/ide:${IS_PRO? 'pro-' : '' }${OS}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
+                image "jenkins/ide:${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${ARCH}-${RSTUDIO_VERSION_FLOWER}"
                 registryCredentialsId 'ecr:us-east-1:aws-build-role'
                 registryUrl 'https://263245908434.dkr.ecr.us-east-1.amazonaws.com'
                 label "${getAgentLabel(ARCH)}"

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -132,17 +132,18 @@ pipeline {
 
             environment {
               GITHUB_LOGIN = credentials('github-rstudio-jenkins')
+              FINAL_OS_NAME = utils.getBionicFocalOsName("${os}")
             }
 
             steps {
-              echo "Creating image jenkins/ide:${IS_PRO? 'pro-' : '' }${os}-${arch}-${RSTUDIO_VERSION_FLOWER}"
+              echo "Creating image jenkins/ide:${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}"
               pullBuildPush(
                 image_name: 'jenkins/ide',
-                image_tag: "${IS_PRO? 'pro-' : '' }${os}-${arch}-${RSTUDIO_VERSION_FLOWER}",
+                image_tag: "${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}",
                 latest_tag: false,
                 build_arg_jenkins_uid: 'JENKINS_UID',
                 build_arg_jenkins_gid: 'JENKINS_GID',
-                dockerfile: "docker/jenkins/Dockerfile.${os}",
+                dockerfile: "docker/jenkins/Dockerfile.${FINAL_OS_NAME}",
                 build_args: "--build-arg ARCH=${arch} --build-arg GITHUB_LOGIN=${GITHUB_LOGIN}",
                 push: "${params.PUBLISH}"
               )

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -132,18 +132,18 @@ pipeline {
 
             environment {
               GITHUB_LOGIN = credentials('github-rstudio-jenkins')
-              FINAL_OS_NAME = utils.getBionicFocalOsName("${os}")
+              DOCKER_OS_NAME = utils.getBionicFocalOsName("${os}")
             }
 
             steps {
-              echo "Creating image jenkins/ide:${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}"
+              echo "Creating image jenkins/ide:${IS_PRO? 'pro-' : '' }${DOCKER_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}"
               pullBuildPush(
                 image_name: 'jenkins/ide',
-                image_tag: "${IS_PRO? 'pro-' : '' }${FINAL_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}",
+                image_tag: "${IS_PRO? 'pro-' : '' }${DOCKER_OS_NAME}-${arch}-${RSTUDIO_VERSION_FLOWER}",
                 latest_tag: false,
                 build_arg_jenkins_uid: 'JENKINS_UID',
                 build_arg_jenkins_gid: 'JENKINS_GID',
-                dockerfile: "docker/jenkins/Dockerfile.${FINAL_OS_NAME}",
+                dockerfile: "docker/jenkins/Dockerfile.${DOCKER_OS_NAME}",
                 build_args: "--build-arg ARCH=${arch} --build-arg GITHUB_LOGIN=${GITHUB_LOGIN}",
                 push: "${params.PUBLISH}"
               )

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -132,7 +132,7 @@ pipeline {
 
             environment {
               GITHUB_LOGIN = credentials('github-rstudio-jenkins')
-              DOCKER_OS_NAME = utils.getBionicFocalOsName("${os}")
+              DOCKER_OS_NAME = utils.getDockerBuildOs("${os}")
             }
 
             steps {

--- a/utils.groovy
+++ b/utils.groovy
@@ -199,4 +199,12 @@ def updateDailyRedirects(String path) {
   sh 'docker/jenkins/publish-daily-binary.sh https://s3.amazonaws.com/rstudio-ide-build/' + path + ' ${RSTUDIO_ORG_PEM}'
 }
 
+def getBionicFocalOsName(String osName) {
+  if(osName == "focal"){
+    return "bionic"
+  } else {
+    return osName
+  }
+}
+
 return this

--- a/utils.groovy
+++ b/utils.groovy
@@ -199,7 +199,13 @@ def updateDailyRedirects(String path) {
   sh 'docker/jenkins/publish-daily-binary.sh https://s3.amazonaws.com/rstudio-ide-build/' + path + ' ${RSTUDIO_ORG_PEM}'
 }
 
-def getBionicFocalOsName(String osName) {
+/**
+  * This method exists to quickly reenable our builds with 
+  * a bionic docker image, however our builds still need to
+  * be labeled focal. This is to support Debian 10 and
+  * should be retired once Debian 10 falls out of support
+  */
+def getDockerBuildOs(String osName) {
   if(osName == "focal"){
     return "bionic"
   } else {


### PR DESCRIPTION
addresses rstudio/rstudio-pro#4470
companion pr: rstudio/rstudio-pro#4674
### Intent

Reenable bionic builds as they're used by Debian10

### Approach

Build our focal/deb10/deb11 builds on bionic still, to allow for deb 10 compatibility

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


