### PR TITLE
reduce height of editor theme listbox

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -14,21 +14,10 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.RepeatingCommand;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.SelectElement;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.ui.FlowPanel;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.VerticalPanel;
-import com.google.inject.Inject;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.Debug;
@@ -58,10 +47,21 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceT
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.model.ThemeServerOperations;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Set;
-import java.util.TreeSet;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.RepeatingCommand;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.SelectElement;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.inject.Inject;
 
 public class AppearancePreferencesPane extends PreferencesPane
 {
@@ -263,8 +263,9 @@ public class AppearancePreferencesPane extends PreferencesPane
                                 new String[0],
                                 new String[0],
                                 false);
+      
       theme_.getListBox().getElement().<SelectElement>cast().setSize(7);
-      theme_.getListBox().getElement().getStyle().setHeight(225, Unit.PX);
+      theme_.getListBox().getElement().getStyle().setHeight(themeSelectorHeight(), Unit.PX);
       theme_.getListBox().addChangeHandler(new ChangeHandler()
       {
          @Override
@@ -352,6 +353,23 @@ public class AppearancePreferencesPane extends PreferencesPane
       // asynchronously too. We also need to wait until the next event cycle so that the progress
       // indicator will be ready.
       Scheduler.get().scheduleDeferred(() -> setThemes(themes));
+   }
+   
+   // It looks like theme components are larger in desktop, so we need
+   // to adjust the height of certain UI elements to ensure everything
+   // can fit.
+   //
+   // https://github.com/rstudio/rstudio/issues/13154
+   private int themeSelectorHeight()
+   {
+      if (Desktop.isDesktop())
+      {
+         return 200;
+      }
+      else
+      {
+         return 250;
+      }
    }
 
    private int getInitialZoomIndex(double currentZoomLevel) {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13154.

<img width="610" alt="Screenshot 2023-05-21 at 11 39 40 AM" src="https://github.com/rstudio/rstudio/assets/1976582/66c15075-98d2-4ea4-978f-103c147837af">

### Approach

Lower the height of the listbox showing editor themes, so that the Add + Remove buttons have room to display.

### Automated Tests

N/A

### QA Notes

See https://github.com/rstudio/rstudio/issues/13154.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

