### PR TITLE
improvements to data preview in completion

### DIFF
--- a/src/cpp/session/modules/SessionDataImportV2.R
+++ b/src/cpp/session/modules/SessionDataImportV2.R
@@ -664,7 +664,7 @@
    
    columns <- list()
    if (ncol(data)) {
-      columns <- .rs.describeCols(data, maxFactors)
+      columns <- .rs.describeCols(data, -1, -1, maxFactors)
       if (ncol(data) > maxCols) {
          columns <- head(columns, maxCols)
          data <- data[1:maxCols]

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -21,6 +21,17 @@
 # data without recomputing on the original object every time
 .rs.setVar("WorkingDataEnv", new.env(parent = emptyenv()))
 
+.rs.addFunction("subsetData", function(data, maxRows = -1, maxCols = -1)
+{
+   if (maxRows != -1 && nrow(data) > maxRows)
+      data <- head(data, n = maxRows)
+   
+   if (maxCols != -1 && ncol(data) > maxCols)
+      data <- data[1:maxCols]
+   
+   data
+})
+
 .rs.addFunction("formatDataColumn", function(x, start, len, ...)
 {
    # extract the visible part of the column
@@ -107,18 +118,21 @@
    as.character(col)
 })
 
-.rs.addFunction("describeCols", function(x, maxFactors) 
+.rs.addFunction("describeCols", function(x,
+                                         maxRows = -1,
+                                         maxCols = -1,
+                                         maxFactors = 64)
 {
-   colNames <- names(x)
+   # subset the data if requested
+   x <- .rs.subsetData(x, maxRows, maxCols)
    
    # get the variable labels, if any--labels may be provided either by this 
    # global attribute or by a 'label' attribute on an individual column (as in
    # e.g. Hmisc), which takes precedence if both are present
+   colNames <- names(x)
    colLabels <- attr(x, "variable.labels", exact = TRUE)
    if (!is.character(colLabels)) 
-   {
       colLabels <- character()
-   }
    
    # the first column is always the row names
    rowNameCol <- list(
@@ -570,7 +584,7 @@
       }
    }
    
-   # if the object exists in the cache environment, return it. Objects
+   # if the object exists in the cache environment, return it. objects
    # in the cache environment have already been coerced to data frames.
    if (exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))
       return(get(cacheKey, envir = .rs.CachedDataEnv, inherits = FALSE))

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -567,7 +567,8 @@ options(help_type = "html")
          sep = ""
       )
       
-      html <- sprintf(fmt, name, nrow(data), ncol(data), if (ncol(data) == 1) "variable" else "")
+      vbls <- if (ncol(data) == 1) "variable" else "variables"
+      html <- sprintf(fmt, name, nrow(data), ncol(data), vbls)
       
       out <- list(
          html = html,

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -527,45 +527,83 @@ options(help_type = "html")
 
 .rs.addFunction("getHelpDataFrame", function(name, src, envir = parent.frame())
 {
+   # try and retrieve the help documentation
    out <- .rs.getHelp(name, src)
+   
+   # Return help page as-is if requested by user
+   showDataPreview <- getOption("rstudio.help.showDataPreview", default = TRUE)
+   if (!showDataPreview)
+      return(out)
 
-   # If 'src' is the name of something on the searchpath, grad the data
+   # try and figure out the data + title
    data <- NULL
    title <- name
+   
+   # If 'src' is the name of something on the search path, grab the data
    pos <- match(src, search(), nomatch = -1L)
    if (pos >= 0)
    {
       data <- tryCatch(get(name, pos = pos), error = function(e) NULL)
    }
 
-   if (is.null(data)) {
+   # if that failed, try to look it up anywhere
+   if (is.null(data))
+   {
       title <- paste0(src, "$", name)
       data <- .rs.getAnywhere(title, envir)
    }
 
+   # if we still couldn't find any data, just use the help document
    if (is.null(data))
       return(out)
 
+   # Generate the help pre-amble
    if (is.null(out))
    {
-      ncol <- ncol(data)
+      fmt <- paste(
+         "<h2>%s</h2>",
+         "<h3>Description</h3>",
+         "<p>%i obs. of %i %s</p>",
+         sep = ""
+      )
+      
+      html <- sprintf(fmt, name, nrow(data), ncol(data), if (ncol(data) == 1) "variable" else "")
+      
       out <- list(
-         html = paste0("<h2>", name, "</h2><h3>Description</h3><p>", nrow(data), " obs. of ", ncol, " variable", if(ncol > 1) "s", "</p>"),
+         html = html,
          signature = "-", 
          pkgname = src, 
          help = FALSE   
       )
    }
    
-   .rs.assignCachedData("completion_popup_dataframe", data, "")
-   out$view <- paste0("grid_resource/gridviewer.html?env=_rs_no_env&cache_key=completion_popup_dataframe&max_cols=50")
-
+   # NOTE: We previously tried assigning and using cached data, but this is
+   # not safe since help documents are cached after they are first created.
+   #
+   # Instead, we need to make sure the data viewer references the actual
+   # object in the place it's defined.
+   
+   # build a uri
+   attrs <- c(
+      env       = src,
+      obj       = name,
+      max_rows  = 1000,
+      max_cols  = 100
+   )
+   
+   uri <- paste(
+      "grid_resource/gridviewer.html",
+      paste(names(attrs), attrs, sep = "=", collapse = "&"),
+      sep = "?"
+   )
+   
+   out$view <- uri
    out
 })
 
 .rs.addFunction("getHelpFunction", function(name, src, envir = parent.frame())
 {
-   # If 'src' is the name of something on the searchpath, get that object
+   # If 'src' is the name of something on the search path, get that object
    # from the search path, then attempt to get help based on that object
    pos <- match(src, search(), nomatch = -1L)
    if (pos >= 0)

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -821,6 +821,7 @@ Error getGridData(const http::Request& request,
       // find the data frame we're going to be pulling data from
       http::Fields fields;
       http::util::parseForm(request.body(), &fields);
+
       std::string envName = http::util::urlDecode(
             http::util::fieldValue<std::string>(fields, "env", ""));
 

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -162,6 +162,9 @@
   var defaultMaxColumns = 50;
   var maxColumns = defaultMaxColumns;
 
+  // maximum number of rows to draw
+  var maxRows = -1;
+
   // boolean for whether bootstrapping is occurring, used to
   // rate limit certain events
   var bootstrapping = false;
@@ -1030,6 +1033,8 @@
         parsedLocation.id = queryVar[1];
       } else if (queryVar[0] == "max_cols") {
         parsedLocation.maxCols = parseInt(queryVar[1], 10);
+      } else if (queryVar[0] == "max_rows") {
+        parsedLocation.maxRows = parseInt(queryVar[1], 10);
       }
     }
 
@@ -1096,10 +1101,16 @@
     var env = parsedLocation.env,
       obj = parsedLocation.obj,
       cacheKey = parsedLocation.cacheKey;
+
     maxColumns = parsedLocation.maxCols;
     if (maxColumns == -1) 
     {
       maxColumns = cols.length;
+    }
+
+    if (parsedLocation.maxRows)
+    {
+      maxRows = parsedLocation.maxRows;
     }
     
     // keep track of column types for later render
@@ -1147,7 +1158,8 @@
           d.cache_key = cacheKey;
           d.show = "data";
           d.column_offset = columnOffset;
-          d.max_columns = maxColumns;
+          d.max_rows = maxRows;
+          d.max_cols = maxColumns;
         },
         error: function (jqXHR) {
           if (jqXHR.responseText[0] !== "{") showError(jqXHR.responseText);

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -162,7 +162,7 @@
   var defaultMaxColumns = 50;
   var maxColumns = defaultMaxColumns;
 
-  // maximum number of rows to draw
+  // maximum number of rows to draw; -1 implies all rows
   var maxRows = -1;
 
   // boolean for whether bootstrapping is occurring, used to
@@ -1158,8 +1158,8 @@
           d.cache_key = cacheKey;
           d.show = "data";
           d.column_offset = columnOffset;
+          d.max_columns = maxColumns;
           d.max_rows = maxRows;
-          d.max_cols = maxColumns;
         },
         error: function (jqXHR) {
           if (jqXHR.responseText[0] !== "{") showError(jqXHR.responseText);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.java
@@ -16,11 +16,8 @@ package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
 import java.util.Map;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.ui.*;
-
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.SafeHtmlUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.RStudioFrame;
@@ -29,6 +26,15 @@ import org.rstudio.studio.client.common.codetools.RCompletionType;
 import org.rstudio.studio.client.workbench.views.console.ConsoleConstants;
 import org.rstudio.studio.client.workbench.views.console.ConsoleResources;
 import org.rstudio.studio.client.workbench.views.help.model.HelpInfo;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.HTML;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.PopupPanel;
+import com.google.gwt.user.client.ui.ScrollPanel;
+import com.google.gwt.user.client.ui.VerticalPanel;
 
 public class HelpInfoPopupPanel extends PopupPanel
 {
@@ -240,8 +246,8 @@ public class HelpInfoPopupPanel extends PopupPanel
       f1prompt_.setVisible(showF1Prompt);
       scrollPanel_.setVisible(true);
       
-      String newHeight = Math.min(179, vpanel_.getOffsetHeight()) + "px";
-      scrollPanel_.setHeight(newHeight);
+      int height = MathUtil.clamp(vpanel_.getOffsetHeight(), 40, 240);
+      scrollPanel_.setHeight(height + "px");
    }
    
    private final ScrollPanel scrollPanel_ = new ScrollPanel();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12964.

<img width="699" alt="Screenshot 2023-05-24 at 3 45 42 PM" src="https://github.com/rstudio/rstudio/assets/1976582/be875776-6428-43c8-a943-803d77828b6d">

### Approach

- Introduce a new parameter `max_rows` when viewing an object with the Data Viewer, and use this to limit the size of datasets previewed in the completion popup.
- Avoid caching datasets used for the completion popup; we don't have a well-defined place where we can clean those cached data objects up.
- Minor patch to the data viewer to pass along `max_rows`.

### Automated Tests

N/A

### QA Notes

https://github.com/rstudio/rstudio/issues/12964

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
