### PR TITLE
Don't build monitor image

### DIFF
--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -16,18 +16,13 @@ def dockerTag() {
 }
 
 def getImagePrefix() {
-  if (env.imageType == 'monitor')
-    return 'monitor-'
-  else if (env.IS_PRO) 
+  if (env.IS_PRO) 
     return 'pro-'
 
   return ''
 }
 
 def dockerFile() {
-  if (env.imageType == 'monitor')
-    return "monitor/docker/Dockerfile.${utils.getDockerBuildOs(env.os)}"
-
   return "docker/jenkins/Dockerfile.${utils.getDockerBuildOs(env.os)}"
 }
 
@@ -134,10 +129,6 @@ pipeline {
           axis {
             name 'arch'
             values 'x86_64', 'arm64'
-          }
-          axis {
-            name 'imageType'
-            values 'default', 'monitor'
           }
         }
 


### PR DESCRIPTION
### Intent

Building the monitor image in the nightly dispatcher has made the jenkins job too large. So now we'll just use the same image used to build the IDE to build monitor.

Companion Pro PR here: https://github.com/rstudio/rstudio-pro/pull/4694

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


