### PR TITLE
Update panmirror cachebust

### DIFF
--- a/dependencies/common/install-panmirror
+++ b/dependencies/common/install-panmirror
@@ -34,6 +34,9 @@ if ! test -e "$QUARTO_DIR"; then
   echo "Cloning quarto repo"
   # git clone https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
   git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git "$QUARTO_DIR"
+  pushd $QUARTO_DIR
+  git rev-parse HEAD
+  popd
 else
   echo "quarto repo already cloned in '$QUARTO_DIR'"
 
@@ -43,5 +46,6 @@ else
   # git checkout main
   git checkout release/rstudio-mountain-hydrangea
   git pull
+  git rev-parse HEAD
   popd
 fi

--- a/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
+++ b/dependencies/windows/install-panmirror/clone-quarto-repo.cmd
@@ -6,6 +6,9 @@ if not exist quarto (
   echo "Cloning quarto repo"
   REM git clone https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
   git clone --branch release/rstudio-mountain-hydrangea https://github.com/quarto-dev/quarto.git ..\..\..\src\gwt\lib\quarto
+  pushd ..\..\..\src\gwt\lib\quarto
+  git rev-parse HEAD
+  popd
 ) else (
   echo "quarto repo already cloned"
 
@@ -16,6 +19,7 @@ if not exist quarto (
   REM git checkout main
   git checkout release/rstudio-mountain-hydrangea
   git pull
+  git rev-parse HEAD
   popd
 )
 

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -101,7 +101,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common bionic

--- a/docker/jenkins/Dockerfile.centos7
+++ b/docker/jenkins/Dockerfile.centos7
@@ -104,7 +104,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && scl enable llvm-toolset-7 "/bin/bash ./install-common centos7"

--- a/docker/jenkins/Dockerfile.focal
+++ b/docker/jenkins/Dockerfile.focal
@@ -96,7 +96,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common focal

--- a/docker/jenkins/Dockerfile.jammy
+++ b/docker/jenkins/Dockerfile.jammy
@@ -89,7 +89,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common jammy

--- a/docker/jenkins/Dockerfile.opensuse15
+++ b/docker/jenkins/Dockerfile.opensuse15
@@ -83,7 +83,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common opensuse15

--- a/docker/jenkins/Dockerfile.rhel8
+++ b/docker/jenkins/Dockerfile.rhel8
@@ -89,7 +89,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel8

--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -92,7 +92,7 @@ COPY dependencies/common/ /opt/rstudio-tools/dependencies/common/
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 # install common dependencies
 RUN cd /opt/rstudio-tools/dependencies/common && /bin/bash ./install-common rhel9

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -75,7 +75,7 @@ COPY dependencies/windows 'C:\rstudio-tools\dependencies\windows'
 
 # panmirror check for changes
 # ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/main panmirror.version.json
-ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-cherry-blossom panmirror.version.json
+ADD https://api.github.com/repos/quarto-dev/quarto/git/refs/heads/release/rstudio-mountain-hydrangea panmirror.version.json
 
 WORKDIR C:/rstudio-tools/dependencies/windows
 RUN C:/rstudio-tools/dependencies/windows/install-dependencies.cmd


### PR DESCRIPTION
### Intent
Address #13131 

### Approach
Partly, this is required to trigger another nightly build but it also updates the Docker image cachebust. It has been updated to check the `release/rstudio-mountain-hydrangea` branch.

Also, the git revision is logged so it'll be easier to check the Docker image build logs to see which changes have been included. This will be useful once the code is switched back to `main` from `release/rstudio-mountain-hydrangea`.

### Automated Tests
none

### QA Notes
none 

### Documentation
none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


