### PR TITLE
Allow non-zero exit codes when env variable RSTUDIO_FORCE_NON_ZERO_EX…

### DIFF
--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -768,12 +768,14 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
 
             // exit status
             int status = switchToProject.empty() ? EXIT_SUCCESS : EX_CONTINUE;
-            if (options().getBoolOverlayOption(kLauncherSessionOption))
+            if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") == "1"))
             {
                // Avoid generating nonzero exit codes when running under
                // Launcher. Error codes from normal behaviour like this are
                // confusing for Slurm and Kubernetes administrators unfamiliar
                // with our workloads.
+               // However, non-zero exit codes are needed by Sagemaker, so we allow
+               // them when requested by setting env var RSTUDIO_FORCE_NON_ZERO_EXIT_CODE=1.
                status = EXIT_SUCCESS;
             }
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -768,7 +768,7 @@ void handleConnection(boost::shared_ptr<HttpConnection> ptrConnection,
 
             // exit status
             int status = switchToProject.empty() ? EXIT_SUCCESS : EX_CONTINUE;
-            if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") == "1"))
+            if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") != "1"))
             {
                // Avoid generating nonzero exit codes when running under
                // Launcher. Error codes from normal behaviour like this are

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -461,7 +461,7 @@ void checkForSuspend(const boost::function<bool()>& allowSuspend)
 
       // exit status
       int status = EX_FORCE;
-      if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") == "1"))
+      if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") != "1"))
       {
          // Avoid generating nonzero exit codes when running under Launcher.
          // Error codes from normal behaviour like this are confusing for Slurm

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -461,11 +461,13 @@ void checkForSuspend(const boost::function<bool()>& allowSuspend)
 
       // exit status
       int status = EX_FORCE;
-      if (options().getBoolOverlayOption(kLauncherSessionOption))
+      if (options().getBoolOverlayOption(kLauncherSessionOption) && (core::system::getenv("RSTUDIO_FORCE_NON_ZERO_EXIT_CODE") == "1"))
       {
          // Avoid generating nonzero exit codes when running under Launcher.
          // Error codes from normal behaviour like this are confusing for Slurm
          // and Kubernetes administrators unfamiliar with our workloads.
+         // However, non-zero exit codes are needed by Sagemaker, so we allow
+         // them when requested by setting env var RSTUDIO_FORCE_NON_ZERO_EXIT_CODE=1.
          status = EXIT_SUCCESS;
       }
 


### PR DESCRIPTION
…IT_CODE=1


### Intent

Sagemaker requires non-zero exit codes that were removed as part of Cherry Blossom. In order to keep Kubernetes and Slurm happy with zero exit codes, we add an environment variable check for `RSTUDIO_FORCE_NON_ZERO_EXIT_CODE=1` that Sagemaker can set in their environment to allow the old behavior

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


