### PR TITLE
add `getNumericEnvVar` util function and tests

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -588,3 +588,12 @@ function registerWebContentsDebugHandlerImpl(webContents: WebContents, event: st
     logger().logDebug(`'${event}': [${json.join(', ')}]`);
   });
 }
+
+export function getNumericEnvVar(envVarName: string): number | undefined {
+  const envVar = getenv(envVarName).trim();
+  if (envVar) {
+    const maybeNum = Number(envVar);
+    return !isNaN(maybeNum) ? maybeNum : undefined;
+  }
+  return undefined;
+}

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -138,4 +138,22 @@ describe('Utils', () => {
     const result = Utils.filterFromQFileDialogFilter(input);
     assert.deepEqual(expected, result);
   });
+  it('getNumericEnvVar returns number for numeric values', () => {
+    const numValues = [0, 1, -1, 1.1];
+    const envVarName = 'NUMERIC_ENV_VAR_VALUE';
+    numValues.forEach((val, index) => {
+      setenv(envVarName, `${val}`);
+      const envVar = Utils.getNumericEnvVar(envVarName);
+      assert.equal(envVar, numValues[index]);
+    });
+  });
+  it('getNumericEnvVar returns undefined for non-numeric values', () => {
+    const nonNumValues = [NaN, undefined, null, 'hi', '', 'H3LL0'];
+    const envVarName = 'NON_NUMERIC_ENV_VAR_VALUE';
+    nonNumValues.forEach((val) => {
+      setenv(envVarName, `${val}`);
+      const envVar = Utils.getNumericEnvVar(envVarName);
+      assert.equal(envVar, undefined);
+    });
+  });
 });


### PR DESCRIPTION
### Intent
open source companion to rstudio/rstudio-pro#4718 (already reviewed)

### Approach
Util function that:
1. retrieves an env var we expect to be set to a numeric value
2. if the value is in fact a number, we return it as a `number`
3. if the value is not a number, then we return `undefined`

### Automated Tests
2  unit tests added
