### PR TITLE
Add new fr strings

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/application/StudioClientApplicationConstants_fr.properties
@@ -160,3 +160,5 @@ activeText=(active)
 requestLogVisualization=<p>Cliquez sur une demande pour voir les détails. Cliquez sur l''arrière-plan pour afficher à nouveau ces instructions.</p><h4>Commandes disponibles:</h4><ul><li>Esc: Fermer</li><li>P: Lecture/pause</li><li>E: Exporter</li><li>I: Importer</li><li>+/-: Zoom avant/arrière</li></ul>
 visitWebsiteForNewVersionText=Veuillez visiter https://posit.co/download/rstudio-desktop/ pour vérifier si une nouvelle version est disponible.
 updateDisabledForVersionText=Les notifications de mise à jour automatique ont été désactivées pour {0}.
+reallyCrashCaption=Danger!
+reallyCrashMessage=Vous êtes sur le point de forcer RStudio à planter. Cela peut entraîner la perte de données. Voulez-vous vraiment continuer?

--- a/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/commands/CmdConstants_fr.properties
@@ -2564,6 +2564,9 @@ focusSourceColumnSeparatorMenuLabel = Ajuster le sépara_teur de la colonne sour
 # showShortcutCommand
 showShortcutCommandMenuLabel = Afficher les commandes de raccourci clavier
 
+# crashDesktopApplication
+crashDesktopApplicationMenuLabel = Faire planter RStudio (DA_NGER)
+
 # showCommandPalette
 showCommandPaletteLabel = Afficher la palette de commandes
 showCommandPaletteMenuLabel = Afficher la Palette de _commande


### PR DESCRIPTION
### Intent
This is not directly related to rstudio/rstudio-pro#4494 but it's a few strings related to the crash RStudio action. The translation is not really necessary but will be a simpler diff result when running `locdiff`. The action is only for diagnostic use.

### Approach
Add fr strings to properties file

### Automated Tests
none

### QA Notes
none

### Documentation
none
### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


