### PR TITLE
Increase read buffer size from 512 to 8192

### DIFF
--- a/src/cpp/core/include/core/http/AsyncClient.hpp
+++ b/src/cpp/core/include/core/http/AsyncClient.hpp
@@ -101,6 +101,8 @@ public:
         closed_(false),
         requestWritten_(false)
    {
+      // Make sure we read at least 8192 bytes from the socket at a time. The default ends up as 512.
+      responseBuffer_.prepare(8192);
    }
 
    virtual ~AsyncClient()


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/4764

### Approach

Prepare is the way to tell the streambuf how much to read from the socket by default. Is 8K the right value?  I might have chosen larger but noticed nginx uses 4K. 

### Automated Tests

Covered by automation for regressions.  

### QA Notes

Would be nice to compare download latency for > 100K downloads. You can do this with developer tools on the IDE or VS code and just look for the largest static js files downloaded. 

Use strace on rserver or other processes to check the value of the size parameter to recvfrom. 
