### PR TITLE
wrap `cacheKey` usages with zero length check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 
 ### Fixed
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
+- Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
 
 ### Accessibility Improvements
 -

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -584,7 +584,8 @@
       }
    }
    
-   if (.rs.isNonEmptyScalarString(cacheKey)) {
+   if (.rs.isNonEmptyScalarString(cacheKey))
+   {
       # if the object exists in the cache environment, return it. objects
       # in the cache environment have already been coerced to data frames.
       if (exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))
@@ -603,6 +604,7 @@
             return(get(cacheKey, envir = .rs.CachedDataEnv, inherits = FALSE))
       }
    }
+
    # failure
    return(NULL)
 })
@@ -823,7 +825,8 @@
    if (Encoding(cacheDir) == "unknown")
       Encoding(cacheDir) <- "UTF-8"
    
-   if (.rs.isNonEmptyScalarString(cacheKey)) {
+   if (.rs.isNonEmptyScalarString(cacheKey))
+   {
       # remove data from the cache environment
       if (exists(".rs.CachedDataEnv") &&
          exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -584,7 +584,7 @@
       }
    }
    
-   if (!.rs.isZeroLength(cacheKey)) {
+   if (.rs.isNonEmptyScalarString(cacheKey)) {
       # if the object exists in the cache environment, return it. objects
       # in the cache environment have already been coerced to data frames.
       if (exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))
@@ -753,7 +753,7 @@
    # save a copy into the cached environment
    cacheKey <- .rs.addCachedData(force(x), name)
    
-   if (.rs.isZeroLength(cacheKey))
+   if (!.rs.isNonEmptyScalarString(cacheKey))
       return(invisible(NULL))
 
    # call viewData 
@@ -786,7 +786,7 @@
 
 .rs.addFunction("viewDataFrame", function(x, title, preview) {
    cacheKey <- .rs.addCachedData(force(x), "")
-   if (!.rs.isZeroLength(cacheKey))
+   if (.rs.isNonEmptyScalarString(cacheKey))
       invisible(.Call("rs_viewData", x, "", title, "", emptyenv(), cacheKey, preview))
 })
 
@@ -813,7 +813,7 @@
    # coerce to data frame before assigning, and don't assign if we can't coerce
    frame <- .rs.toDataFrame(obj, objName, TRUE)
    if (!is.null(frame) &&
-       !.rs.isZeroLength(cacheKey))
+       .rs.isNonEmptyScalarString(cacheKey))
       assign(cacheKey, frame, .rs.CachedDataEnv)
 })
 
@@ -823,7 +823,7 @@
    if (Encoding(cacheDir) == "unknown")
       Encoding(cacheDir) <- "UTF-8"
    
-   if (!.rs.isZeroLength(cacheKey)) {
+   if (.rs.isNonEmptyScalarString(cacheKey)) {
       # remove data from the cache environment
       if (exists(".rs.CachedDataEnv") &&
          exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE))
@@ -852,7 +852,7 @@
    
    # save each active cache file from the cache environment
    lapply(ls(.rs.CachedDataEnv), function(cacheKey) {
-      if (!.rs.isZeroLength(cacheKey))
+      if (.rs.isNonEmptyScalarString(cacheKey))
          save(list = cacheKey, 
             file = file.path(cacheDir, paste(cacheKey, "Rdata", sep = ".")),
             envir = .rs.CachedDataEnv)
@@ -868,7 +868,7 @@
 
 .rs.addFunction("findWorkingData", function(cacheKey)
 {
-   if (!.rs.isZeroLength(cacheKey) &&
+   if (.rs.isNonEmptyScalarString(cacheKey) &&
        exists(".rs.WorkingDataEnv") &&
        exists(cacheKey, where = .rs.WorkingDataEnv, inherits = FALSE))
       get(cacheKey, envir = .rs.WorkingDataEnv, inherits = FALSE)
@@ -878,7 +878,7 @@
 
 .rs.addFunction("removeWorkingData", function(cacheKey)
 {
-   if (!.rs.isZeroLength(cacheKey) &&
+   if (.rs.isNonEmptyScalarString(cacheKey) &&
        exists(".rs.WorkingDataEnv") &&
        exists(cacheKey, where = .rs.WorkingDataEnv, inherits = FALSE))
       rm(list = cacheKey, envir = .rs.WorkingDataEnv, inherits = FALSE)
@@ -887,7 +887,7 @@
 
 .rs.addFunction("assignWorkingData", function(cacheKey, obj)
 {
-   if (!.rs.isZeroLength(cacheKey))
+   if (.rs.isNonEmptyScalarString(cacheKey))
       assign(cacheKey, obj, .rs.WorkingDataEnv)
 })
 
@@ -901,8 +901,8 @@
    invisible("")
 })
 
-.rs.addFunction("isZeroLength", function(x)
+.rs.addFunction("isNonEmptyScalarString", function(x)
 {
-   (x == "") || is.null(x) || is.na(x)
+   is.character(x) && length(x) == 1 && nzchar(x)
 })
 


### PR DESCRIPTION
### Intent

Addresses #13188.

avoids hitting the following error:
```
Error in exists(cacheKey, where = .rs.WorkingDataEnv, inherits = FALSE) : 
  invalid first argument
Error in assign(cacheKey, frame, .rs.CachedDataEnv) : 
  attempt to use zero-length variable name
```

Backport issue: https://github.com/rstudio/rstudio/issues/13241

### Approach

Wraps usages of `cacheKey` in `SessionDataViewer.R` with a zero-length check.

In particular, the usage in `assignCachedData` was problematic (causing #13188).

### Automated Tests

none

### QA Notes

[Simplest repro steps](https://github.com/rstudio/rstudio/issues/13188#issuecomment-1589910695):
1. create a dataframe (any # rows/columns) eg. `df <- data.frame(matrix(rnorm(1), nrow=1, ncol=1))`
2. trigger autocomplete: type `df` + tab key
3. try to reassign the same variable eg. `df <- 'hi'`
4. see error

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


