### PR TITLE
Update license expired page - OS

### DIFF
--- a/src/gwt/www/expired.htm
+++ b/src/gwt/www/expired.htm
@@ -77,9 +77,9 @@
       <div>
         <h2 id="caption">RStudio Server License Expired</h2>
         <div id="detail">
-          This version of RStudio Server has expired. Please
-          <a href="http://www.rstudio.com">contact us</a> to obtain an up to
-          date license.
+          Your RStudio Server license has expired. Please
+          contact your Customer Success representative or email 
+          sales@posit.co to obtain a current license. 
         </div>
       </div>
     </div>


### PR DESCRIPTION
OS-PR for: https://github.com/rstudio/rstudio-pro/issues/4776

~I think this should merge over without any conflicts with the pro repo, since the lines unique to each file -- name / logo differences between OS Server and Workbench -- were not modified directly.~ This will need a follow-up PR on pro to re-word, following the changes made in this PR.

### Intent

Update the expired link to no longer reference rstudio.com -- point people to our support line instead


