### PR TITLE
Revert "Backport/4584"

### DIFF
--- a/src/cpp/session/resources/terminal/bash/.bash_profile
+++ b/src/cpp/session/resources/terminal/bash/.bash_profile
@@ -5,11 +5,6 @@ _FAKEHOME="${HOME}"
 HOME="${_REALHOME}"
 
 # source the user startup file, if any
-for PROFILE in /etc/profile.d/*.sh; do
-  if [ -f "${PROFILE}" ]; then
-    source "${PROFILE}"
-  fi
-done
 if [ -f ~/.bash_profile ]; then
 	source ~/.bash_profile
 elif [ -f ~/.bash_login ]; then

--- a/version/news/NEWS-2023.06.1-mountain-hydrangea.md
+++ b/version/news/NEWS-2023.06.1-mountain-hydrangea.md
@@ -13,8 +13,6 @@
 
 #### RStudio IDE
 - Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
-- Fixed bug preventing system-wide init scripts in etc/profile.d from 
-running when Python terminal integration is turned on (pro-#4584)
 
 #### Posit Workbench
 - 


### PR DESCRIPTION
Reverts rstudio/rstudio#13246 Probably moving to 2023.06.02 patch