### PR TITLE
Hoping to avoid deparse by not calling length on language objects

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -906,6 +906,6 @@
 
 .rs.addFunction("isNonEmptyScalarString", function(x)
 {
-   is.character(x) && length(x) == 1 && nzchar(x)
+   !is.language(x) && is.character(x) && length(x) == 1 && nzchar(x)
 })
 


### PR DESCRIPTION
Attempt to fix rsession-tests that are crashing