### PR TITLE
Backport don't cache viewed datasets that lack a cache key

### DIFF
--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -851,11 +851,10 @@ Error getGridData(const http::Request& request,
       r::sexp::Protect protect;
 
       // begin observing if we aren't already
-      if (envName != kNoBoundEnv) 
+      if (!cacheKey.empty() && envName != kNoBoundEnv)
       {
          SEXP objSEXP = findInNamedEnvir(envName, objName);
-         std::map<std::string, CachedFrame>::iterator it = 
-            s_cachedFrames.find(cacheKey);
+         auto it = s_cachedFrames.find(cacheKey);
          if (it == s_cachedFrames.end())
             s_cachedFrames[cacheKey] = CachedFrame(envName, objName, objSEXP);
       }
@@ -962,10 +961,9 @@ Error removeRCachedData(const std::string& cacheKey)
 Error removeCacheKey(const std::string& cacheKey)
 {
    // remove from watchlist
-   std::map<std::string, CachedFrame>::iterator pos = 
-      s_cachedFrames.find(cacheKey);
-   if (pos != s_cachedFrames.end())
-      s_cachedFrames.erase(pos);
+   auto it = s_cachedFrames.find(cacheKey);
+   if (it != s_cachedFrames.end())
+      s_cachedFrames.erase(it);
    
     return removeRCachedData(cacheKey);
 }
@@ -1016,9 +1014,7 @@ void onDetectChanges(module_context::ChangeSource source)
       return;
 
    r::sexp::Protect protect;
-   for (std::map<std::string, CachedFrame>::iterator i = s_cachedFrames.begin();
-        i != s_cachedFrames.end();
-        i++) 
+   for (auto i = s_cachedFrames.begin(); i != s_cachedFrames.end(); i++)
    {
       SEXP sexp = findInNamedEnvir(i->second.envName, i->second.objName);
       if (sexp != i->second.observedSEXP) 
@@ -1076,8 +1072,6 @@ void onDetectChanges(module_context::ChangeSource source)
                      LOG_ERROR(error);
                   }
                }
-
-               
             }
          }
       }


### PR DESCRIPTION
### Intent

Backports
https://github.com/rstudio/rstudio/pull/13253 for #13188

Addresses
- #13241

### Approach

Cherry-picked from `main`.

### Automated Tests

none

### QA Notes

simplest repro: https://github.com/rstudio/rstudio/issues/13188#issuecomment-1595212093

### Documentation
none

### Checklist

~- [] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~ 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
