### PR TITLE
Fix setting working directory on session resume

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
+- Fixed bug when resuming session not restoring current working directory for Terminal pane (rstudio-pro/#4027)
 
 ### Accessibility Improvements
 -

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -212,7 +212,7 @@ core::json::Object ConsoleProcessInfo::toJson(SerializationMode serialMode) cons
    result["channel_mode"] = static_cast<int>(channelMode_);
    result["channel_id"] = channelId_;
    result["alt_buffer"] = altBufferActive_;
-   result["cwd"] = module_context::createAliasedPath(cwd_);
+   result["cwd"] = module_context::createAliasedPath(cwd_.resolveSymlink());
    result["cols"] = cols_;
    result["rows"] = rows_;
    result["restarted"] = restarted_;


### PR DESCRIPTION
### Intent
Address https://github.com/rstudio/rstudio-pro/issues/4027

### Approach
Resolve the symlink when converting the process info to json. The symlink check will return the target and handles the case if `FilePath` isn't a symlink (returns itself).

### Automated Tests
Added a unit test to convert a `ConsoleProcessInfo` to json and back. The restored `cwd` should match the original when resolving the symlink.

### QA Notes
The terminal should have the directory changed to something else. When the terminal fails to change to the current working directory on session resume, it would be in the same directory as opening a new terminal.

The terminal doesn't attempt to restore the working directory until the pane is shown for the first time after resuming the session.

### Documentation
none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


