### PR TITLE
fix data viewer column navigation bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 ### Fixed
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
+- Fixed bug preventing dataframe column navigation past the default number of display columns (#13220)
 
 ### Accessibility Improvements
 -

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -135,7 +135,9 @@
    if (!is.character(colLabels)) 
       colLabels <- character()
    
-   totalCols <- if (totalCols < 0) ncol(x) else totalCols
+   # we pass totalCols in the rownames col so we can pass this information
+   # along when we retrieve column data, without changing the response format
+   totalCols <- if (totalCols > 0) totalCols else ncol(x)
 
    # the first column is always the row names
    rowNameCol <- list(
@@ -271,18 +273,18 @@
                                              sliceStart = 1,
                                              sliceEnd = 1)
 {
-   colCount <- ncol(x)
+   totalCols <- ncol(x)
 
-   if (colCount == 0)
+   if (totalCols == 0)
       return(NULL)
   
-   if (sliceEnd > colCount || sliceEnd < 1)
-      sliceEnd <- colCount
-   if (sliceStart > colCount || sliceStart < 1 || sliceStart > sliceEnd)
+   if (sliceEnd > totalCols || sliceEnd < 1)
+      sliceEnd <- totalCols
+   if (sliceStart > totalCols || sliceStart < 1 || sliceStart > sliceEnd)
       sliceStart <- 1
    
    colSlice <- x[sliceStart:sliceEnd]
-   .rs.describeCols(colSlice, -1, -1, 64, colCount)
+   .rs.describeCols(colSlice, -1, -1, 64, totalCols)
 })
 
 .rs.addFunction("formatRowNames", function(x, start, len) 

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -263,6 +263,14 @@
    c(list(rowNameCol), colAttrs)
 })
 
+.rs.addFunction("describeColSlice", function(x,
+                                              sliceStart = 1,
+                                              sliceEnd = 1)
+{
+   colSlice <- x[sliceStart:sliceEnd]
+   .rs.describeCols(colSlice, -1, -1, 64)
+})
+
 .rs.addFunction("formatRowNames", function(x, start, len) 
 {
    # detect whether this is a data.frame that contains

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -264,9 +264,19 @@
 })
 
 .rs.addFunction("describeColSlice", function(x,
-                                              sliceStart = 1,
-                                              sliceEnd = 1)
+                                             sliceStart = 1,
+                                             sliceEnd = 1)
 {
+   colCount <- ncol(x)
+
+   if (colCount == 0)
+      return(NULL)
+  
+   if (sliceEnd > colCount || sliceEnd < 1)
+      sliceEnd <- colCount
+   if (sliceStart > colCount || sliceStart < 1 || sliceStart > sliceEnd)
+      sliceStart <- 1
+   
    colSlice <- x[sliceStart:sliceEnd]
    .rs.describeCols(colSlice, -1, -1, 64)
 })

--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -121,7 +121,8 @@
 .rs.addFunction("describeCols", function(x,
                                          maxRows = -1,
                                          maxCols = -1,
-                                         maxFactors = 64)
+                                         maxFactors = 64,
+                                         totalCols = -1)
 {
    # subset the data if requested
    x <- .rs.subsetData(x, maxRows, maxCols)
@@ -134,6 +135,8 @@
    if (!is.character(colLabels)) 
       colLabels <- character()
    
+   totalCols <- if (totalCols < 0) ncol(x) else totalCols
+
    # the first column is always the row names
    rowNameCol <- list(
       col_name        = .rs.scalar(""),
@@ -143,7 +146,8 @@
       col_search_type = .rs.scalar("none"),
       col_label       = .rs.scalar(""),
       col_vals        = "",
-      col_type_r      = .rs.scalar(""))
+      col_type_r      = .rs.scalar(""),
+      total_cols      = .rs.scalar(totalCols))
    
    # if there are no columns, bail out
    if (length(colNames) == 0) {
@@ -278,7 +282,7 @@
       sliceStart <- 1
    
    colSlice <- x[sliceStart:sliceEnd]
-   .rs.describeCols(colSlice, -1, -1, 64)
+   .rs.describeCols(colSlice, -1, -1, 64, colCount)
 })
 
 .rs.addFunction("formatRowNames", function(x, start, len) 

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -584,12 +584,18 @@ options(help_type = "html")
    # Instead, we need to make sure the data viewer references the actual
    # object in the place it's defined.
    
+   # Limit the number of columns to the first `maxDisplayColumns`
+   # number of columns. E.g. if data_viewer_max_columns=50, then
+   # we'll only load and show the first 50 columns of the data frame
+   # in the help preview.
+   maxDisplayColumns <- .rs.readUiPref("data_viewer_max_columns")
+
    # build a uri
    attrs <- c(
       env       = src,
       obj       = name,
       max_rows  = 1000,
-      max_cols  = 100
+      max_cols  = maxDisplayColumns
    )
    
    uri <- paste(

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -500,16 +500,10 @@ json::Value getColSlice(SEXP dataSEXP,
    r::sexp::Protect protect;
    json::Value result;
 
-   LOG_ERROR_MESSAGE("getColSlice: columnOffset=" + std::to_string(columnOffset) + ", maxDisplayColumns=" + std::to_string(maxDisplayColumns));
-
-   // DataTables uses 0-based indexing, but R uses 1-based indexing
-   int sliceStart = columnOffset + 1; // 0 + 1 = 1
-   int maybeEnd = columnOffset + maxDisplayColumns; // 1 + 20 = 21
-   int totalColumns = safeDim(dataSEXP, DIM_COLS); // 60
-   //                  21  < 60           ? 21       : 60 + 1 for 1-indexing
-   int sliceEnd = maybeEnd < totalColumns ? maybeEnd : totalColumns;
-
-   LOG_ERROR_MESSAGE("getColSlice: sliceStart=" + std::to_string(sliceStart) + ", sliceEnd=" + std::to_string(sliceEnd) + ", totalColumns=" + std::to_string(totalColumns));
+   // DataTables use 0-based indexing, but R uses 1-based indexing, so add 1 to the columnOffset
+   int sliceStart = columnOffset + 1;
+   int totalColumns = safeDim(dataSEXP, DIM_COLS);
+   int sliceEnd = columnOffset + maxDisplayColumns < totalColumns ? columnOffset + maxDisplayColumns : totalColumns;
 
    Error error = r::exec::RFunction(".rs.describeColSlice")
          .addParam(dataSEXP)
@@ -608,9 +602,6 @@ json::Value getData(SEXP dataSEXP,
    int nrow = safeDim(dataSEXP, DIM_ROWS);
    int ncol = safeDim(dataSEXP, DIM_COLS);
 
-   // LOG_ERROR_MESSAGE("getData: columnOffset=" + std::to_string(columnOffset) + ", maxDisplayColumns=" + std::to_string(maxDisplayColumns));
-   // LOG_ERROR_MESSAGE("getData: maxRows=" + std::to_string(maxRows) + ", maxCols=" + std::to_string(maxCols));
-   // LOG_ERROR_MESSAGE("getData: nrow=" + std::to_string(nrow) + ", ncol=" + std::to_string(ncol));
    int filteredNRow = 0;
 
    // extract filters
@@ -726,9 +717,6 @@ json::Value getData(SEXP dataSEXP,
    int numFormattedColumns = ncol - columnOffset < maxDisplayColumns ? ncol - columnOffset : maxDisplayColumns;
    SEXP formattedDataSEXP = Rf_allocVector(VECSXP, numFormattedColumns);
    protect.add(formattedDataSEXP);
-
-   LOG_ERROR_MESSAGE("getData: columnOffset=" + std::to_string(columnOffset) + ", maxDisplayColumns=" + std::to_string(maxDisplayColumns));
-   LOG_ERROR_MESSAGE("getData: numFormattedColumns=" + std::to_string(numFormattedColumns) + ", ncol - columnOffset=" + std::to_string(ncol - columnOffset));
 
    int initialIndex = 0 + columnOffset;
    for (int i = initialIndex; i < initialIndex + numFormattedColumns; i++)

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -502,8 +502,8 @@ json::Value getColSlice(SEXP dataSEXP,
 
    // DataTables use 0-based indexing, but R uses 1-based indexing, so add 1 to the columnOffset
    int sliceStart = columnOffset + 1;
-   int totalColumns = safeDim(dataSEXP, DIM_COLS);
-   int sliceEnd = columnOffset + maxDisplayColumns < totalColumns ? columnOffset + maxDisplayColumns : totalColumns;
+   int totalCols = safeDim(dataSEXP, DIM_COLS);
+   int sliceEnd = columnOffset + maxDisplayColumns < totalCols ? columnOffset + maxDisplayColumns : totalCols;
 
    Error error = r::exec::RFunction(".rs.describeColSlice")
          .addParam(dataSEXP)

--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -510,7 +510,7 @@ json::Value getColSlice(SEXP dataSEXP,
          .addParam(sliceStart)
          .addParam(sliceEnd)
          .call(&colsSEXP, &protect);
-   // this appears to be slicing data correctly
+
    if (error || colsSEXP == R_NilValue) 
    {
       json::Object err;

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1129,7 +1129,6 @@
     // for setting constants from dtviewer to dataTables
     window.dataTableMaxColumns = totalColumns;
 
-    // colLimits.forEach(x => console.log(x));
     console.log("maxDisplayColumns = ", maxDisplayColumns);
     console.log("maxRows = ", maxRows);
     console.log("totalColumns = ", totalColumns);
@@ -1155,11 +1154,8 @@
         typeIndices["text"].push(j);
       }
     }
-    console.log('just created table header -- j: ' + j)
     addResizeHandlers(thead);
-    console.log('just added resize handlers')
     addGlobalResizeHandlers();
-    console.log('just added global resize handlers')
 
     var scrollHeight = window.innerHeight - (thead.clientHeight + 2);
 
@@ -1262,13 +1258,6 @@
           : [{}];
     }
 
-    console.log('about to activate the data table')
-    // !!!!!! some index is off here
-    // we are getting the right data, so the columns are okay?
-    console.log('dataTableAjax: ' + JSON.stringify(dataTableAjax))
-    console.log('dataTableData: ' + JSON.stringify(dataTableData))
-    console.log('dataTableColumns: ' + JSON.stringify(dataTableColumns))
-    console.log('dataTableColumnDefs: ' + JSON.stringify(dataTableColumnDefs))
     // activate the data table
     $("#rsGridData").dataTable({
       processing: true,
@@ -1298,13 +1287,10 @@
       ordering: ordering,
     });
 
-    console.log('just activated data table')
     initDataTableLoad();
-    console.log('just initialized data table load')
 
     // update the GWT column widget
     window.columnFrameCallback(columnOffset, maxDisplayColumns);
-    console.log('just updated GWT column widget')
   };
 
   var debouncedSearch = debounce(function (text) {
@@ -1527,7 +1513,6 @@
     addResizeHandlers(newEle);
 
     if (!data) {
-      console.log('bootstrap - !data')
       loadDataFromUrl(function (result) {
         $(document).ready(function () {
           document.body.appendChild(newEle);

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1096,12 +1096,6 @@
     // save reference to column data
     cols = resCols;
 
-    // due to the jquery magic done in dataTables with rewriting variables and
-    // the amount of window parameters we're already using this is a sane fit
-    // for setting constants from dtviewer to dataTables
-    window.dataTableMaxColumns = Math.max(0, cols.length - 1);
-    window.dataTableColumnOffset = columnOffset;
-
     // look up the query parameters
     var parsedLocation = parseLocationUrl();
     var env = parsedLocation.env,
@@ -1125,7 +1119,15 @@
     }
 
     maxRows = parsedLocation.maxRows ?? maxRows;
-    totalColumns = parsedLocation.totalColumns ?? cols.length;
+
+    // totalColumns is the total number of columns in the data set
+    // cols.length includes the row names column so we subtract 1
+    totalColumns = parsedLocation.totalColumns ?? cols.length - 1;
+
+    // due to the jquery magic done in dataTables with rewriting variables and
+    // the amount of window parameters we're already using this is a sane fit
+    // for setting constants from dtviewer to dataTables
+    window.dataTableMaxColumns = totalColumns;
 
     // colLimits.forEach(x => console.log(x));
     console.log("maxDisplayColumns = ", maxDisplayColumns);

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1120,9 +1120,12 @@
 
     maxRows = parsedLocation.maxRows ?? maxRows;
 
-    // totalColumns is the total number of columns in the data set
-    // cols.length includes the row names column so we subtract 1
-    totalColumns = parsedLocation.totalColumns ?? cols.length - 1;
+    // total_cols is returned in the rownames column data (first column) and is
+    // the total number of columns in the dataframe, not including the row names column
+    // if total_cols is not returned, then we use the number of columns in the
+    // data frame, which includes the row names column, so we subtract 1
+    const totalColumnsCount = cols[0].total_cols;
+    totalColumns = totalColumnsCount > 0 ? totalColumnsCount : cols.length - 1;
 
     // due to the jquery magic done in dataTables with rewriting variables and
     // the amount of window parameters we're already using this is a sane fit

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1169,7 +1169,6 @@
           d.obj = obj;
           d.cache_key = cacheKey;
           d.show = "data";
-          d.total_columns = totalColumns;
           d.column_offset = columnOffset;
           d.max_display_columns = maxDisplayColumns;
           d.max_rows = maxRows;

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1743,7 +1743,7 @@
 
   // return whether to show the column frame UI elements
   window.isLimitedColumnFrame = function () {
-    return columnOffset < totalCols;
+    return totalCols > maxDisplayColumns;
   };
 
   var parsedLocation = parseLocationUrl();

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -22,7 +22,7 @@
   var cols;
 
   // the total number of columns for the data table (may be larger than cols.length)
-  let totalColumns;
+  let totalCols;
 
   // the column currently being resized
   var resizingColIdx = null;
@@ -1040,8 +1040,6 @@
         parsedLocation.maxCols = parseInt(queryVar[1], 10);
       } else if (queryVar[0] == "max_rows") {
         parsedLocation.maxRows = parseInt(queryVar[1], 10);
-      } else if (queryVar[0] == "total_columns") {
-        parsedLocation.totalColumns = parseInt(queryVar[1], 10);
       }
     }
 
@@ -1119,16 +1117,16 @@
     maxRows = parsedLocation.maxRows ?? maxRows;
 
     // total_cols is returned in the rownames column data (first column) and is
-    // the total number of columns in the dataframe, not including the row names column
+    // the total number of columns in the dataframe
     // if total_cols is not returned, then we use the number of columns in the
     // data frame, which includes the row names column, so we subtract 1
-    const totalColumnsCount = cols[0].total_cols;
-    totalColumns = totalColumnsCount > 0 ? totalColumnsCount : cols.length - 1;
+    const resTotalCols = cols[0].total_cols;
+    totalCols = resTotalCols > 0 ? resTotalCols : cols.length - 1;
 
     // due to the jquery magic done in dataTables with rewriting variables and
     // the amount of window parameters we're already using this is a sane fit
     // for setting constants from dtviewer to dataTables
-    window.dataTableMaxColumns = totalColumns;
+    window.dataTableMaxColumns = totalCols;
     
     // keep track of column types for later render
     var typeIndices = {
@@ -1680,7 +1678,7 @@
 
     var newOffset = Math.max(
       0,
-      Math.min(totalColumns - maxDisplayColumns, columnOffset + maxDisplayColumns)
+      Math.min(totalCols - maxDisplayColumns, columnOffset + maxDisplayColumns)
     );
     if (columnOffset != newOffset) {
       columnOffset = newOffset;
@@ -1695,7 +1693,7 @@
 
     var newOffset = Math.max(
       0,
-      Math.min(totalColumns - maxDisplayColumns, columnOffset - maxDisplayColumns)
+      Math.min(totalCols - maxDisplayColumns, columnOffset - maxDisplayColumns)
     );
     if (columnOffset != newOffset) {
       columnOffset = newOffset;
@@ -1719,8 +1717,8 @@
       return;
     }
 
-    if (columnOffset != totalColumns - maxDisplayColumns) {
-      columnOffset = totalColumns - maxDisplayColumns;
+    if (columnOffset != totalCols - maxDisplayColumns) {
+      columnOffset = totalCols - maxDisplayColumns;
       bootstrap();
     }
   };
@@ -1729,7 +1727,7 @@
     if (bootstrapping) {
       return;
     }
-    if (newOffset >= totalColumns) {
+    if (newOffset >= totalCols) {
       return;
     }
 
@@ -1737,7 +1735,7 @@
       columnOffset = newOffset;
     }
     if (newMax > 0) {
-      newMax = Math.min(totalColumns - newOffset, newMax);
+      newMax = Math.min(totalCols - newOffset, newMax);
       maxDisplayColumns = newMax;
     }
     bootstrap();
@@ -1745,7 +1743,7 @@
 
   // return whether to show the column frame UI elements
   window.isLimitedColumnFrame = function () {
-    return columnOffset < totalColumns;
+    return columnOffset < totalCols;
   };
 
   var parsedLocation = parseLocationUrl();

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1102,8 +1102,6 @@
       obj = parsedLocation.obj,
       cacheKey = parsedLocation.cacheKey;
 
-    console.log("parsedLocation", JSON.stringify(parsedLocation))
-
     // maxCols overrides maxDisplayColumns if it's specified
     if (parsedLocation.maxCols)
     {
@@ -1131,11 +1129,6 @@
     // the amount of window parameters we're already using this is a sane fit
     // for setting constants from dtviewer to dataTables
     window.dataTableMaxColumns = totalColumns;
-
-    console.log("maxDisplayColumns = ", maxDisplayColumns);
-    console.log("maxRows = ", maxRows);
-    console.log("totalColumns = ", totalColumns);
-    console.log("columnOffset = ", columnOffset);
     
     // keep track of column types for later render
     var typeIndices = {
@@ -1168,12 +1161,6 @@
     var dataTableColumns = null;
 
     if (!data) {
-      console.log(`show=data` +
-       `\n\ttotal_columns=${totalColumns}` +
-       `\n\tcolumn_offset=${columnOffset}` +
-       `\n\tmax_display_columns=${maxDisplayColumns}` +
-       `\n\tmax_rows=${maxRows}`);
-
       dataTableAjax = {
         url: "../grid_data",
         type: "POST",
@@ -1304,7 +1291,6 @@
 
   var loadDataFromUrl = function (callback) {
     // call the server to get data shape
-    console.log("show=cols&" + window.location.search.substring(1) + `&column_offset=${columnOffset}`)
     $.ajax({
       url: "../grid_data",
       data: "show=cols&" + window.location.search.substring(1) + `&column_offset=${columnOffset}`,

--- a/src/cpp/tests/testthat/test-dataviewer.R
+++ b/src/cpp/tests/testthat/test-dataviewer.R
@@ -66,3 +66,29 @@ test_that(".rs.flattenFrame() handles matrices and data frames", {
    expect_equal(names(flat2), c("x", "df_col$y", "df_col$z", 'mat_col[,"a"]', 'mat_col[,"b"]'))
    expect_equal(names(flat3), c("x", "df_col$y", "df_col$z", "df_col$df$y", "df_col$df$z", 'mat_col[,"a"]', 'mat_col[,"b"]'))
 })
+
+test_that(".rs.describeColSlice() describes the correct number of column slices", {
+   tbl <- data.frame(x = 1:2, y = 1:2, x = 1:2)
+   # valid sliceStart and sliceEnd values
+   expect_equal(length(.rs.describeColSlice(tbl, 0, 1)), 2)
+   expect_equal(length(.rs.describeColSlice(tbl, 1, 1)), 2)
+   expect_equal(length(.rs.describeColSlice(tbl, 1, 2)), 3)
+   expect_equal(length(.rs.describeColSlice(tbl, 1, 3)), 4)
+   # sliceStart == 0
+   expect_equal(length(.rs.describeColSlice(tbl, 0, 1)), 2)
+   # negative sliceStart
+   expect_equal(length(.rs.describeColSlice(tbl, -1, 1)), 2)
+   # sliceStart > sliceEnd
+   expect_equal(length(.rs.describeColSlice(tbl, 2, 1)), 2)
+   # sliceEnd == 0, sliceEnd < sliceStart
+   expect_equal(length(.rs.describeColSlice(tbl, 1, 0)), 4)
+   # negative sliceEnd
+   expect_equal(length(.rs.describeColSlice(tbl, 1, -1)), 4)
+   # sliceEnd out of bounds
+   expect_equal(length(.rs.describeColSlice(tbl, 1, 4)), 4)
+})
+
+test_that(".rs.describeColSlice() returns NULL for empty data frames", {
+   tbl <- data.frame()
+   expect_equal(.rs.describeColSlice(tbl, 1, 1), NULL)
+})

--- a/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
+++ b/src/gwt/src/org/rstudio/studio/client/dataviewer/DataTable.java
@@ -171,6 +171,7 @@ public class DataTable
          if (i == 1)
          {
             columnTextWidget_ = new DataTableColumnWidget(this::setOffsetAndMaxColumns);
+            columnTextWidget_.getElement().setId("data-viewer-column-input");
             columnTextWidget_.setVisible(false);
             toolbar.addLeftWidget(columnTextWidget_);
          }


### PR DESCRIPTION
### Intent

Address #13220 

This will be backported to MH as part of https://github.com/rstudio/rstudio/issues/13244.

### Approach

- only retrieve data for the visible slice of column data, not the entire data frame (helps us avoid slow loading for large data sets)
    - search for `getColSlice`, `describeColSlice`
- separate the usage of `max_cols` and `max_display_columns` to avoid the confusing mixed usage
    - `max_cols`/`maxCols` is for specifying the maximum number of columns we want to retrieve from a data frame
        - e.g. sometimes we only want the first 100 columns, to avoid slow loading with large data sets
    - `max_display_columns`/`maxDisplayColumns` is the maximum number of columns to display in a view of the data frame (in autocomplete/help or in the data viewer) and the user preference `data_viewer_max_columns`/`dataViewerMaxColumns` sets the default for this value
        - e.g. the default is viewing 50 columns at a time
- return the total number of columns `total_cols` of the data frame as part of the `rownames` column data
    - search for `totalCols`
    - this is a bit awkward because the `rownames` column is meant to hold data specific to that column, but I wanted to avoid changing the response structure/adding a new endpoint to request the total columns. Perhaps we can rename that column type to be something like `metadata`?

It's possible we no longer need `subsetData` and could refactor that out, but I didn't want to complicate this PR too much!

### Automated Tests

- Added an R test for the new `describeColSlice` function
- Added an id to the column range input element for automated test use -- id = `data-viewer-column-input`

### QA Notes

As noted by Kevin below:
> This has more changes than we would typically want to include in a patch release, so extra scrutiny is warranted in verification.

#### Suggested Test Cases
- autocomplete preview displays the correct data
```
# set a variable to a data frame
df <- data.frame(matrix(rnorm(300), nrow=5, ncol=60))

# type the variable name and hit the tab key to trigger the autocomplete preview
df
```
- test with a large dataset such as https://github.com/rstudio/rstudio/issues/12964#issuecomment-1561916287
    - the data preview should load pretty quickly (shouldn't be longer than 1s or so)
- test reassigning an already viewed dataframe to a different dataframe

```
df1 <- data.frame(matrix(rnorm(300), nrow=5, ncol=60))

df2 <- data.frame(matrix(1, nrow=1, ncol=100))

View(df1)

# After `View`ing, run the below line to reassign `df1` a different data frame value
# the open data viewer of df1 should refresh with the new data, since df1 was assigned the value of df2
df1 <- df2
```
- change the `data_viewer_max_columns` user preference and verify that the data viewer displays the right number of columns
    - note that the autocomplete data viewer has a default maximum display of 100 columns and should not be affected by this user pref

### Documentation
Related documentation issue https://github.com/rstudio/rstudio/issues/13235

### Checklist
- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


