### PR TITLE
make sure socket handles aren't inherited

### DIFF
--- a/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
+++ b/src/cpp/core/include/core/http/TcpIpSocketUtils.hpp
@@ -83,7 +83,7 @@ inline Error initTcpIpAcceptor(
    tcp::resolver::query query(address, port);
    
    boost::system::error_code ec;
-   tcp::resolver::iterator entries = resolver.resolve(query,ec);
+   tcp::resolver::iterator entries = resolver.resolve(query, ec);
    if (ec)
       return Error(ec, ERROR_LOCATION);
    
@@ -106,6 +106,11 @@ inline Error initTcpIpAcceptor(
    acceptor.set_option(tcp::acceptor::reuse_address(true), ec);
    if (ec)
       return Error(ec, ERROR_LOCATION);
+   
+   // Make sure socket handles aren't inherited by default
+   // https://github.com/rstudio/rstudio/issues/13272
+   int socketHandle = acceptor.native_handle();
+   ::fcntl(socketHandle, F_SETFD, FD_CLOEXEC);
 #else
    // Allow users to toggle this behavior, as an escape hatch
    // for https://github.com/rstudio/rstudio/issues/11395


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13272.

### Approach

Set `FD_CLOEXEC` on socket handles after creation. Note that this PR changes this setting for _all_ sockets; are there any cases where this is _not_ the desired behaviour?

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13272.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
