### PR TITLE
fix broken column sorting in data viewer

### DIFF
--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -1127,6 +1127,13 @@
     // the amount of window parameters we're already using this is a sane fit
     // for setting constants from dtviewer to dataTables
     window.dataTableMaxColumns = totalCols;
+
+    // we were previously loading the entire data set and using the column offset
+    // in the jquery dataTables magic; however, we now only load the visible data.
+    // to avoid refactoring the dataTables jquery, we hardcode `dataTableColumnOffset`
+    // to 0 so the existing jquery code continues to work and we can avoid refactoring
+    // it for the time being.
+    window.dataTableColumnOffset = 0;
     
     // keep track of column types for later render
     var typeIndices = {


### PR DESCRIPTION
### Intent

Follow-up fix to #13270 to address #13220

Backport issue: https://github.com/rstudio/rstudio/issues/13244

### Approach

In #13270, we switched our data viewer approach to load and display only the visible slice of columns, instead of loading all of the columns in the data frame and then using the column offset to limit the view. With that change, we removed code that sets `window.dataTableColumnOffset`, since it seemed no longer relevant to the new approach.

However, the "jquery datatable magic" still has usages of this variable, and not setting it meant that we'd get `NaN` in places where we expect numeric values. This resulted in the column sorting no longer working.

To avoid doing a refactor of the jquery code, we can simply set `window.dataTableColumnOffset = 0` to prevent creating `NaN` values, fixing the broken column sorting issue.

### Automated Tests

none added

### QA Notes

See this test case https://github.com/rstudio/rstudio/issues/13220#issuecomment-1602847194

### Documentation

N/A

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~ 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


