### PR TITLE
Guard against missing edge case

### DIFF
--- a/src/cpp/session/modules/SessionDataViewer.R
+++ b/src/cpp/session/modules/SessionDataViewer.R
@@ -23,10 +23,10 @@
 
 .rs.addFunction("subsetData", function(data, maxRows = -1, maxCols = -1)
 {
-   if (maxRows != -1 && nrow(data) > maxRows)
+   if (!is.na(maxRows) && maxRows != -1 && nrow(data) > maxRows)
       data <- head(data, n = maxRows)
    
-   if (maxCols != -1 && ncol(data) > maxCols)
+   if (!is.na(maxCols) && maxCols != -1 && ncol(data) > maxCols)
       data <- data[1:maxCols]
    
    data


### PR DESCRIPTION
I encountered this somewhat puzzlingly just now:

```
Error in exists(cacheKey, where = .rs.CachedDataEnv, inherits = FALSE) : 
  invalid first argument
Error in if (maxRows != -1 && nrow(data) > maxRows) data <- head(data,  : 
  missing value where TRUE/FALSE needed
```

This PR addresses the latter error. It could conceivably be obviated by debugging the first error, but I'm clueless on that for now and this PR seems benign enough.

RStudio version info:

```
RStudio
2023.06.0 Build 421
© 2009-2023 Posit Software, PBC
"Mountain Hydrangea" Release (583b465e, 2023-06-06) for Ubuntu Focal
Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) rstudio/2023.06.0+421 Chrome/110.0.5481.208 Electron/23.3.0 Safari/537.36
```