### PR TITLE
use `setMenuBarVisibility` instead of `setMenu`

### DIFF
--- a/src/node/desktop/src/ui/modal-dialog.ts
+++ b/src/node/desktop/src/ui/modal-dialog.ts
@@ -61,7 +61,7 @@ export abstract class ModalDialog<T> extends BrowserWindow {
     });
 
     // make this look and behave like a modal
-    this.setMenu(null);
+    this.setMenuBarVisibility(false);
     this.setMinimizable(false);
     this.setMaximizable(false);
     this.setFullScreenable(false);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12972#issuecomment-1591996748

### Approach

`setMenu(null)` seems to trigger the placeholder menu to show on electron modal dialogs, however using `setMenuBarVisibility(false)` hides the menu bar.

This only affects linux and windows.

### Automated Tests
none

### QA Notes

This change should ensure that the License Management modal doesn't have a menu bar on Windows, Linux and Mac and the Choose R dialog doesn't have a menu bar on Windows.

### Documentation
none

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


