### PR TITLE
add `aarch64` `libSegFault.so` path

### DIFF
--- a/src/cpp/rstudio-tests.in
+++ b/src/cpp/rstudio-tests.in
@@ -54,6 +54,7 @@ findLibSegFault() {
    CANDIDATES=(
       /lib/x86_64-linux-gnu/libSegFault.so
       /lib/i386-linux-gnu/libSegFault.so
+      /lib/aarch64-linux-gnu/libSegFault.so
       /lib64/libSegFault.so
       /lib/libSegFault.so
    )


### PR DESCRIPTION
### Intent

CPP tests running on `aarch64` machines are not locating `libSegFault.so` because we haven't included the path in the locations we try to search. "WARNING: Could not find libSegFault.so"

This file is not necessary for our tests to run successfully, but if a seg fault occurs during a test and this file is not located by the tests, we will not be able to view detailed information about the failure.

### Approach

On `aarch64` machines, `libSegFault` is located at `/lib/aarch64-linux-gnu/libSegFault.so` (if it is installed). Include this path in the list of locations we search.

### Automated Tests
none

### QA Notes

- CPP tests on aarch64 machines that have libSegFault.so installed should no longer echo "WARNING: Could not find libSegFault.so" in the test output

### Documentation
none

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


