### PR TITLE
Use cached api to lookup users in several more places

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -83,11 +83,12 @@
 #include <core/system/PosixGroup.hpp>
 #include <core/system/Process.hpp>
 #include <core/system/ShellUtils.hpp>
-
+#include <core/system/User.hpp>
 
 #include <shared_core/Error.hpp>
 #include <shared_core/FilePath.hpp>
 #include <shared_core/system/User.hpp>
+
 
 #include "config.h"
 
@@ -1736,7 +1737,7 @@ Error processInfo(pid_t pid, ProcessInfo* pInfo)
 
    // get the username
    core::system::User user;
-   error = User::getUserFromIdentifier(st.st_uid, user);
+   error = getUserFromUserId(st.st_uid, user);
    if (error)
       return error;
 
@@ -2544,7 +2545,7 @@ Error temporarilyDropPriv(const std::string& newUsername,
 {
    // get user info
    User user;
-   Error error = User::getUserFromIdentifier(newUsername, user);
+   Error error = getUserFromUsername(newUsername, user);
    if (error)
       return error;
 
@@ -2596,7 +2597,7 @@ Error permanentlyDropPriv(const std::string& newUsername, const std::string& new
 {
    // get user info
    User user;
-   Error error = User::getUserFromIdentifier(newUsername, user);
+   Error error = getUserFromUsername(newUsername, user);
    if (error)
       return error;
 
@@ -2679,7 +2680,7 @@ Error permanentlyDropPriv(const std::string& newUsername, const std::string& new
 
    // get user info
    User user;
-   Error error = User::getUserFromIdentifier(newUsername, user);
+   Error error = getUserFromUsername(newUsername, user);
    if (error)
       return error;
 

--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -30,6 +30,7 @@
 #include <core/system/PosixChildProcess.hpp>
 #include <core/system/PosixSystem.hpp>
 #include <core/system/Crypto.hpp>
+#include <core/system/User.hpp>
 
 #include <core/http/URL.hpp>
 #include <core/http/AsyncUriHandler.hpp>
@@ -681,7 +682,7 @@ int main(int argc, char * const argv[])
          };
 
          system::User serverUserObj;
-         error = system::User::getUserFromIdentifier(options.serverUser(), serverUserObj);
+         error = system::getUserFromUsername(options.serverUser(), serverUserObj);
          if (error)
             return core::system::exitFailure(error, ERROR_LOCATION);
 

--- a/src/cpp/server/ServerOptions.cpp
+++ b/src/cpp/server/ServerOptions.cpp
@@ -24,6 +24,9 @@
 #include <core/FileSerializer.hpp>
 #include <core/r_util/RSessionContext.hpp>
 
+
+#include <core/system/User.hpp>
+
 using namespace rstudio::core;
 
 namespace rstudio {
@@ -265,7 +268,7 @@ ProgramStatus Options::read(int argc,
 
       // look up details for the proposed user
       system::User user;
-      Error error = system::User::getUserFromIdentifier(serverUser_, user);
+      Error error = system::getUserFromUsername(serverUser_, user);
 
       if (core::system::realUserIsRoot())
       {

--- a/src/cpp/server/session/ServerSessionMetadataRpc.cpp
+++ b/src/cpp/server/session/ServerSessionMetadataRpc.cpp
@@ -29,6 +29,7 @@
 #include <core/r_util/RActiveSessions.hpp>
 #include <core/r_util/RActiveSessionsStorage.hpp>
 #include <core/system/Xdg.hpp>
+#include <core/system/User.hpp>
 
 #include <server/ServerOptions.hpp>
 #include <server/auth/ServerAuthHandler.hpp>
@@ -222,14 +223,14 @@ Error authorizeRequest(
 {
    using namespace rstudio::core::system;
 
-   Error error = User::getUserFromIdentifier(requester, *pRequesterUser);
+   Error error = system::getUserFromUsername(requester, *pRequesterUser);
    if (error)
       return error;
 
    if (sessionOwner)
    {
       User sessionUser;
-      error = User::getUserFromIdentifier(sessionOwner.get(), sessionUser);
+      error = system::getUserFromUserId(sessionOwner.get(), sessionUser);
       if (error)
          return error;
 

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -52,6 +52,7 @@
 #include <core/system/PosixSystem.hpp>
 #include <core/system/PosixGroup.hpp>
 #include <core/system/PosixUser.hpp>
+#include <core/system/User.hpp>
 #include <core/r_util/RSessionContext.hpp>
 
 #include <core/json/JsonRpc.hpp>
@@ -720,7 +721,7 @@ Error userIdForUsername(const std::string& username, UidType* pUID)
    else
    {
       core::system::User user;
-      Error error = core::system::User::getUserFromIdentifier(username, user);
+      Error error = system::getUserFromUsername(username, user);
       if (error)
          return error;
 

--- a/src/cpp/server/session/ServerSessionRpc.cpp
+++ b/src/cpp/server/session/ServerSessionRpc.cpp
@@ -19,6 +19,7 @@
 
 #include <core/SocketRpc.hpp>
 #include <core/http/LocalStreamAsyncServer.hpp>
+#include <core/system/User.hpp>
 
 #include <server_core/http/SecureCookie.hpp>
 #include <server_core/SecureKeyFile.hpp>
@@ -150,7 +151,7 @@ void validationHandler(
       if (uid != -1)
       {
          core::system::User user;
-         Error error = core::system::User::getUserFromIdentifier(uid, user);
+         Error error = system::getUserFromUserId(uid, user);
          if (error)
          {
             LOG_WARNING_MESSAGE("Couldn't determine user for Server RPC request");


### PR DESCRIPTION
Make sure all getUser passwd entry database lookup calls use the cached api 

### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/4800

- in processInfo call for looking up process owner (main issue)
- at startup time for the server-user
- session metadata rpc for authorizing metadata lookups
- for authorizing server session rpc requests
- for authorizing local stream requests authenticated by a uid

### Approach

Found the rest of the places we make these getUserFromIdentifier calls and replaced them with the cached equivalent: either getUserFromUserId or getUserFromUsername. 

### QA Notes

All of these code paths will be tested by automation. I don't think manual testing is necessary. 