### PR TITLE
Speedup and bugfix for rsession metadata

### DIFF
--- a/src/cpp/core/http/Util.cpp
+++ b/src/cpp/core/http/Util.cpp
@@ -558,13 +558,21 @@ bool isNetworkAddress(const std::string& str)
    return (!ec && iter != boost::asio::ip::tcp::resolver::iterator());
 }
 
+namespace {
+
+// look for the Upgrade token in the Connection request header; in most cases it will be the
+// exact value of the the header, but some browsers (Firefox) include other tokens. (RFC 6455)
+boost::regex s_webSocketUpgradePattern("\\<Upgrade\\>", boost::regex::icase);
+
+}
+
+
 bool isWSUpgradeRequest(const Request& request)
 {
-   // look for the Upgrade token in the Connection request header; in most cases it will be the
-   // exact value of the the header, but some browsers (Firefox) include other tokens. (RFC 6455)
-   boost::regex upgrade("\\<Upgrade\\>", boost::regex::icase);
    std::string connection = request.headerValue("Connection");
-   return boost::regex_search(connection, upgrade);
+   if (connection.empty())
+      return false;
+   return boost::regex_search(connection, s_webSocketUpgradePattern);
 }
 
 #ifndef _WIN32

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -301,7 +301,8 @@ Error writeStringToFile(const core::FilePath& filePath,
                         const std::string& str,
                         string_utils::LineEnding lineEnding=string_utils::LineEndingPassthrough,
                         bool truncate = true,
-                        int maxOpenRetrySeconds = 0);
+                        int maxOpenRetrySeconds = 0,
+                        bool logError = true);
 
 // lineEnding is the type of line ending you want the resulting string to have
 Error readStringFromFile(const core::FilePath& filePath,

--- a/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessionStorage.hpp
@@ -65,7 +65,10 @@ private:
    FilePath scratchPath_;
    const std::string propertiesDirName_ = "properites";
 
+   Error ensurePropertyDir() const;
+
    FilePath getPropertyDir() const;
+
    FilePath getPropertyFile(const std::string& name) const;
    
    static const std::map<std::string, std::string> fileNames;

--- a/src/cpp/core/include/core/r_util/RActiveSessions.hpp
+++ b/src/cpp/core/include/core/r_util/RActiveSessions.hpp
@@ -554,7 +554,7 @@ public:
       Error storageError = storage_->isValid(&validStorage);
       if (storageError || !validStorage)
       {
-         LOG_DEBUG_MESSAGE("ActiveSession validation failed: properties storage not valid");
+         LOG_DEBUG_MESSAGE("ActiveSession validation failed - no session metadata for: " + id());
          if(storageError)
             LOG_ERROR(storageError);
          return false;

--- a/src/cpp/core/r_util/RActiveSessions.cpp
+++ b/src/cpp/core/r_util/RActiveSessions.cpp
@@ -102,6 +102,8 @@ Error ActiveSessions::create(const std::string& project,
    if (editor == kWorkbenchRStudio)
      initialMetadata.emplace(ActiveSession::kLastResumed, ActiveSession::getNowAsPTimestamp());
 
+   LOG_DEBUG_MESSAGE("Creating new session: " + id + ":" + editor + " project: " + project + " dir: " + workingDir);
+
    auto session = get(id);
    session->writeProperties(initialMetadata);
 


### PR DESCRIPTION
### Intent

Addresses part of https://github.com/rstudio/rstudio-pro/issues/4746 and 
part of https://github.com/rstudio/rstudio-pro/issues/4085

### Approach

* Don't create the session directory as part of creating the storage object as this implicitly creates a session that's not valid just by looking to see if a session exists with a given id. We don't ordinarily do that in OS but for workbench, that happens occasionally for rworkspaces and that causes a delay while that session is determined to be invalid. 

* Don't use ensureDirectory for the properties directory on each property access. This adds overhead and improperly creates a session just by trying to read a property from it. Instead, catch the "no such file or directory" error when trying to write the first property and create the directory at that point.

* Bonus - speedup of test for web-socket upgrade (don't create the regex on every request) - this showed up in the flame-graph I did of the rserver under load.

### Automated Tests

Our automation will cover all of the relevant code paths for regressions.

### QA Notes

To validate that the performance part is included, run strace against the rworkspaces process. Capture 30 seconds with a homepage open that has several sessions listed (suspended, running, or whatever) (make sure at least one workspaces/model request gets handled)

Grep for `sessions/active` in that strace and further grep for `statx` calls. You should see 2 or 3X fewer with the fix for each model refresh captured in the strace.  You can probably tell when there's a gap in the timestamp for the statx calls. 