### PR TITLE
Handle redirect in Help pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 - Fixed intermittent rsession crash when the linux nscd service was enabled (rstudio-pro:#4648)
 - Fixed bug when resuming session not restoring current working directory for Terminal pane (rstudio-pro:#4027)
 - Fixed bug preventing files from being saved when user `HOME` path includes trailing slashes on Windows (#13105)
+- Fixed broken Help pane after navigating to code demo (#13263)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -201,6 +201,12 @@ export class DesktopBrowserWindow extends EventEmitter {
       }
     });
 
+    // any redirects should be handled by the default browser
+    this.window.webContents.on('will-redirect', (event, url) => {
+      event.preventDefault();
+      void shell.openExternal(url);
+    });
+
     this.window.webContents.on('page-title-updated', (event, title, explicitSet) => {
       this.adjustWindowTitle(title, explicitSet);
     });


### PR DESCRIPTION
### Intent
Address #13263
Fixes navigating to code demos

### Approach
Listen to the `will-redirect` event and open URL in default browser.

### Automated Tests
n/a

### QA Notes
Clicking on "code demos" is enough to trigger the issue since it's the navigation to the demo app that puts the Help pane in a bad state.

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


