### PR TITLE
Update release notes for 2023.06.1+524.pro1

### DIFF
--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -9,6 +9,29 @@ format:
 
 This page provides the release notes associated with each release of RStudio and Posit Workbench. Please contact customer support (<a href="mailto:support@posit.co">support@posit.co</a>) for questions about the described changes.
 
+## RStudio 2023.06.1
+
+**"Mountain Hydrangea"**
+
+>Date: 2023-07-07
+
+### New
+
+#### RStudio IDE
+- 
+
+#### Posit Workbench
+- 
+
+### Fixed
+
+#### RStudio IDE
+- Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
+- Fixed bug preventing dataframe column navigation past the default number of display columns (#13220)
+
+#### Posit Workbench
+- 
+
 ## RStudio 2023.06.0
 
 **"Mountain Hydrangea"**

--- a/docs/news/index.qmd
+++ b/docs/news/index.qmd
@@ -18,10 +18,8 @@ This page provides the release notes associated with each release of RStudio and
 ### New
 
 #### RStudio IDE
-- 
 
 #### Posit Workbench
-- 
 
 ### Fixed
 
@@ -30,7 +28,6 @@ This page provides the release notes associated with each release of RStudio and
 - Fixed bug preventing dataframe column navigation past the default number of display columns (#13220)
 
 #### Posit Workbench
-- 
 
 ## RStudio 2023.06.0
 


### PR DESCRIPTION

Update release notes for IDE / Workbench 2023.06.1+524.pro1 release.

:warning: **Before converting from Draft PR:** :warning:

This change has been generated by the release script. Content is generated based on `version/news/NEWS-2023.06.1-mountain-hydrangea.md`. If this file was not in sync with Pro or did not include items from other sources (i.e. the vscode extension), then some items may be missing.  Please verify content/formatting is correct and make changes if necessary.
