### PR TITLE
Increment `RSTUDIO_VERSION_PATCH` to 2

### DIFF
--- a/jenkins/Jenkinsfile.hourly
+++ b/jenkins/Jenkinsfile.hourly
@@ -13,7 +13,7 @@ pipeline {
   }
   
   parameters {
-    string defaultValue: '1', description: 'RStudio Patch Version', name: 'RSTUDIO_VERSION_PATCH', trim: true
+    string defaultValue: '2', description: 'RStudio Patch Version', name: 'RSTUDIO_VERSION_PATCH', trim: true
     string defaultValue: '#ide-builds', description: 'Slack channel to publish build message.', name: 'SLACK_CHANNEL', trim: true
     booleanParam defaultValue: true, description: 'Publish the build to S3.', name: 'PUBLISH'
     booleanParam defaultValue: false, description: 'Force build even if there are no changes.', name: 'FORCE_BUILD'

--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -29,7 +29,7 @@ pipeline {
   }
   
   parameters {
-    string defaultValue: '1', description: 'RStudio Patch Version', name: 'RSTUDIO_VERSION_PATCH', trim: true
+    string defaultValue: '2', description: 'RStudio Patch Version', name: 'RSTUDIO_VERSION_PATCH', trim: true
     string defaultValue: '#ide-builds', description: 'Slack channel to publish build message.', name: 'SLACK_CHANNEL', trim: true
     booleanParam defaultValue: true, description: 'Publish the build to S3 and sentry.', name: 'PUBLISH'
     booleanParam defaultValue: true, description: 'Force build even if there are no changes.', name: 'FORCE_BUILD'


### PR DESCRIPTION
### Intent

Increment the MH patch version to `.2` now that we've released the `.1` patch.

### Approach

Update nightly and hourly Jenkinsfiles with the new patch version `2`.

### Automated Tests
none

### QA Notes
new MH builds should now use the `.2` patch suffix instead of `.1`.

### Documentation
none

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~ 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
~- [ ] This PR passes all local unit tests~

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


