### PR TITLE
Fix context menu actions using webContents

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -166,8 +166,9 @@ export class DesktopBrowserWindow extends EventEmitter {
     }
 
     // register context menu (right click) handler
-    this.window.webContents.on('context-menu', (event, params) => {
-      showContextMenu(event as IpcMainEvent, params);
+    this.window.webContents.on('context-menu', (_event, params) => {
+      const wc = this.window.webContents;
+      showContextMenu(wc, params);
     });
 
     this.window.webContents.on('before-input-event', (event, input) => {


### PR DESCRIPTION
### Intent
Address #13336 

### Approach
The Electron 25.2.0 update stopped giving the `sender` in the context menu event. When the context menu is about to be displayed, it now needs the web contents to be retrieved from the window to build the action.

### Automated Tests
n/a

### QA Notes
This should also fix issues with saving/copying images from the Plot pane. Also, this should work with editors that are pulled out into its own window.

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


