### PR TITLE
fix a variety of sorting / filtering issues

### DIFF
--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -572,6 +572,10 @@ json::Value getData(SEXP dataSEXP,
 
    std::string cacheKey = http::util::urlDecode(
          http::util::fieldValue<std::string>(fields, "cache_key", ""));
+   
+   // Parameters from the client to delimit the column slice to return
+   int columnOffset = http::util::fieldValue<int>(fields, "column_offset", 0);
+   int maxDisplayColumns = http::util::fieldValue<int>(fields, "max_display_columns", 0);
 
    // loop through sort columns
    std::vector<int> ordercols;
@@ -588,16 +592,12 @@ json::Value getData(SEXP dataSEXP,
 
       if (ordercol > 0)
       {
-         ordercols.push_back(ordercol);
+         ordercols.push_back(ordercol + columnOffset);
          orderdirs.push_back(orderdir);
       }
 
       orderIdx++;
    } while (ordercol > 0);
-
-   // Parameters from the client to delimit the column slice to return
-   int columnOffset = http::util::fieldValue<int>(fields, "column_offset", 0);
-   int maxDisplayColumns = http::util::fieldValue<int>(fields, "max_display_columns", 0);
 
    int nrow = safeDim(dataSEXP, DIM_ROWS);
    int ncol = safeDim(dataSEXP, DIM_COLS);

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -978,7 +978,7 @@
     if (col.col_type === "rownames") {
       th.title = "row names";
     } else {
-      th.title = "column " + (idx - columnOffset) + ": " + col.col_type;
+      th.title = "column " + (idx + columnOffset) + ": " + col.col_type;
     }
     if (col.col_type === "numeric") {
       th.title +=

--- a/src/cpp/session/resources/grid/dtviewer.js
+++ b/src/cpp/session/resources/grid/dtviewer.js
@@ -842,12 +842,9 @@
   };
 
   var createFilterUI = function (idx, col) {
-    // the index coming into this function is for absolute data purposes
-    // since this is a visual-centric function we operate based on the visible index
-    var visualIndex = idx - columnOffset;
 
     // don't filter rownames column
-    if (visualIndex < 1) {
+    if (idx < 1) {
       return;
     }
 
@@ -866,7 +863,7 @@
     };
 
     var onDismiss = function () {
-      if (table.columns(visualIndex).search()[0].length === 0) {
+      if (table.columns(idx).search()[0].length === 0) {
         setUnfiltered();
       }
     };
@@ -877,7 +874,7 @@
     clear.style.display = "none";
     clear.addEventListener("click", function (evt) {
       if (dismissActivePopup) dismissActivePopup(true);
-      table.columns(visualIndex).search("").draw();
+      table.columns(idx).search("").draw();
       setUnfiltered();
       evt.preventDefault();
       evt.stopPropagation();
@@ -888,13 +885,13 @@
     val.textContent = "All";
     val.addEventListener("click", function (evt) {
       if (col.col_search_type === "numeric") {
-        ui = createNumericFilterUI(visualIndex, col, onDismiss);
+        ui = createNumericFilterUI(idx, col, onDismiss);
       } else if (col.col_search_type === "factor") {
-        ui = createFactorFilterUI(visualIndex, col, onDismiss);
+        ui = createFactorFilterUI(idx, col, onDismiss);
       } else if (col.col_search_type === "character") {
-        ui = createTextFilterUI(visualIndex, col, onDismiss);
+        ui = createTextFilterUI(idx, col, onDismiss);
       } else if (col.col_search_type === "boolean") {
-        ui = createBooleanFilterUI(visualIndex, col, onDismiss);
+        ui = createBooleanFilterUI(idx, col, onDismiss);
       }
       if (ui) {
         ui.className += " filterValue";
@@ -1559,7 +1556,7 @@
       if (dismissActivePopup) dismissActivePopup(true);
     }
     for (var i = 0; i < thead.children.length; i++) {
-      var colIdx = i + (rowNumbers ? 0 : 1) + columnOffset;
+      var colIdx = i + (rowNumbers ? 0 : 1);
       var col = cols[colIdx];
       var th = thead.children[i];
       if (visible) {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13328.

### Approach

We made some recent changes to the Data Viewer, such that only the data actually presented to the user is sent over the wire. This necessitated a number of changes to how column offsets were handled both on the server + client side. It looks like we might've missed a couple spots around sorting / filtering, and also in displaying column titles.

### Automated Tests

N/A

### QA Notes

Test that sorting + filtering work even in paginated tables, when paginating to later columns. Here's an example to play with:

```
.rs.writeUiPref("data_viewer_max_columns", 15L)
data <- replicate(100, 0:9, simplify = FALSE)
for (i in seq_along(data)) {
  data[[i]] <- (data[[i]] + i) %% 10
}

names(data) <- paste0("V", 1:100)
df <- as.data.frame(data)
View(df)

# .rs.writeUiPref("data_viewer_max_columns", 50L) when you're done
```

### Documentation

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
