### PR TITLE
Fix update available ignored update error

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - Fixed bug when resuming session not restoring current working directory for Terminal pane (rstudio-pro:#4027)
 - Fixed bug preventing files from being saved when user `HOME` path includes trailing slashes on Windows (#13105)
 - Fixed broken Help pane after navigating to code demo (#13263)
+- Fixed bug preventing Update Available from displaying (#13347)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -233,7 +233,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          ignoredUpdatesDirty_ = true;
       }
 
-      private IgnoredUpdates ignoredUpdates_;
+      private IgnoredUpdates ignoredUpdates_ = IgnoredUpdates.create();
       private boolean ignoredUpdatesDirty_ = false;
    }
 
@@ -549,15 +549,22 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          // Only provide the option to ignore the update if it's not urgent.
          if (result.getUpdateUrgency() == 0)
          {
+            // We need to use a final variable here because we're using it in an
+            // anonymous inner class
+            final boolean finalIgnoredUpdate = ignoredUpdate;
             buttonLabels.add(constants_.ignoreUpdateButtonLabel());
             elementIds.add(ElementIds.DIALOG_CANCEL_BUTTON);
             buttonOperations.add(new Operation() {
                @Override
                public void execute()
                {
-                  ignoredUpdatesState_.addIgnoredUpdate(result.getUpdateVersion());
-                  // Trigger an update to the persistent updates state file
-                  eventBus_.fireEvent(new PushClientStateEvent(true));
+                  // only run the following code if we didn't already ignore the update
+                  if (!finalIgnoredUpdate)
+                  {
+                     ignoredUpdatesState_.addIgnoredUpdate(result.getUpdateVersion());
+                     // Trigger an update to the persistent updates state file
+                     eventBus_.fireEvent(new PushClientStateEvent(true));
+                  }
                }
             });
          }


### PR DESCRIPTION
### Intent

Addresses: #13347 
Backport issue: #13351

### Approach

- Ensure we initialize the `ignoredUpdates_` object
- Only run code to "ignore update" if we haven't already ignored the update

### Automated Tests

none

### QA Notes

I will create custom builds so we can test this (because the dailies/hourlies are considered "up to date" already, and won't trigger the Update Available dialog).

The first released version we can test this in will be Desert Sunflower, as long as we backport this to the 2023.06.2 release.

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
`- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)`
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


