### PR TITLE
remove connection status toolbar from electron

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -146,7 +146,8 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          if (Desktop.isRemoteDesktop())
             addSignoutToolbar();
 
-         overlay_.addConnectionStatusToolbar(DesktopApplicationHeader.this);
+         if (!BrowseCap.isElectron())
+            overlay_.addConnectionStatusToolbar(DesktopApplicationHeader.this);
 
          toolbar_.completeInitialization(sessionInfo);
 


### PR DESCRIPTION
### Intent

Addresses
- rstudio/rstudio-pro#4832

This is for pro electron. This menu item is already hidden in open source.
| current | this PR |
| ------- | -------- |
| <img width="300" alt="image" src="https://github.com/rstudio/rstudio/assets/25834218/6b79c35b-26d6-4e71-954e-320d2ee97b8a"> | <img width="300" alt="image" src="https://github.com/rstudio/rstudio/assets/25834218/dbcf264b-3e86-4016-bf1c-2eed43e69a39"> |

### Approach

- only add the menu item for non-electron desktop IDE

### Automated Tests
none

### QA Notes
no additional notes

### Documentation
already done in rstudio/rstudio-pro#4629

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~ 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


