### PR TITLE
add `getNumericEnvVar` util function and tests (#13195)

### DIFF
--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -588,3 +588,12 @@ function registerWebContentsDebugHandlerImpl(webContents: WebContents, event: st
     logger().logDebug(`'${event}': [${json.join(', ')}]`);
   });
 }
+
+export function getNumericEnvVar(envVarName: string): number | undefined {
+  const envVar = getenv(envVarName).trim();
+  if (envVar) {
+    const maybeNum = Number(envVar);
+    return !isNaN(maybeNum) ? maybeNum : undefined;
+  }
+  return undefined;
+}

--- a/src/node/desktop/test/unit/main/utils.test.ts
+++ b/src/node/desktop/test/unit/main/utils.test.ts
@@ -138,4 +138,22 @@ describe('Utils', () => {
     const result = Utils.filterFromQFileDialogFilter(input);
     assert.deepEqual(expected, result);
   });
+  it('getNumericEnvVar returns number for numeric values', () => {
+    const numValues = [0, 1, -1, 1.1];
+    const envVarName = 'NUMERIC_ENV_VAR_VALUE';
+    numValues.forEach((val, index) => {
+      setenv(envVarName, `${val}`);
+      const envVar = Utils.getNumericEnvVar(envVarName);
+      assert.equal(envVar, numValues[index]);
+    });
+  });
+  it('getNumericEnvVar returns undefined for non-numeric values', () => {
+    const nonNumValues = [NaN, undefined, null, 'hi', '', 'H3LL0'];
+    const envVarName = 'NON_NUMERIC_ENV_VAR_VALUE';
+    nonNumValues.forEach((val) => {
+      setenv(envVarName, `${val}`);
+      const envVar = Utils.getNumericEnvVar(envVarName);
+      assert.equal(envVar, undefined);
+    });
+  });
 });


### PR DESCRIPTION
### Intent

Backports
- https://github.com/rstudio/rstudio/pull/13195

For
- rstudio/rstudio-pro#4732

### Approach

Cherry-picked the commit. No merge conflicts. 

### Automated Tests
see #13195

### QA Notes
see #13195

### Documentation
see #13195

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


