### PR TITLE
Fix cwd on first session suspend

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1377,7 +1377,7 @@ FilePath currentWorkingDirViaProcFs(PidType pid)
 
    // /proc/PID/cwd is a symbolic link to the process' current working directory
    FilePath pidPath = procFsPath.completePath(procId).completePath("cwd");
-   if (pidPath.isSymlink())
+   if (pidPath.isSymlink() && pidPath.exists())
       return pidPath.resolveSymlink();
    else
       return FilePath();

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -726,13 +726,14 @@ void ConsoleProcess::onHasSubprocs(bool hasNonIgnoredSubprocs, bool hasIgnoredSu
 
 void ConsoleProcess::reportCwd(const core::FilePath& cwd)
 {
-   if (procInfo_->getCwd() != cwd)
+   if (procInfo_->getCwd() != cwd && cwd.exists())
    {
-      procInfo_->setCwd(cwd);
+      FilePath resolvedCwd = cwd.resolveSymlink();
+      procInfo_->setCwd(resolvedCwd);
 
       json::Object termCwd;
       termCwd["handle"] = handle();
-      termCwd["cwd"] = module_context::createAliasedPath(cwd);
+      termCwd["cwd"] = module_context::createAliasedPath(resolvedCwd);
       module_context::enqueClientEvent(
             ClientEvent(client_events::kTerminalCwd, termCwd));
       childProcsSent_ = true;

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -254,6 +254,7 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(sameCpi(cpiOrig, *pCpiRestored));
    }
 
+#ifdef __linux__
    SECTION("Restore with cwd symlink")
    {
       // ensure file does not exist so symlink can be created
@@ -277,6 +278,7 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(pCpiRestored->getCwd().getAbsolutePath() == cpiOrig.getCwd().resolveSymlink().getAbsolutePath());
       cwdLink.remove();
    }
+#endif
 
    SECTION("Persist and restore for non-terminals")
    {


### PR DESCRIPTION
### Intent
Address rstudio/rstudio-pro#4027

### Approach
Checking that the path exists prevents saving a bad path after the process has exited. The cwd poll happens often enough that it tried to update the cwd after the process exited.

Also, set the test to run on Linux only.

### Automated Tests
n/a

### QA Notes
This fixes the first session suspend where it updated the cwd after the session exited. Subsequent session suspends will save the cwd properly and was fixed by https://github.com/rstudio/rstudio/pull/13268

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


