### PR TITLE
Fix race condition in build image pipeline

### DIFF
--- a/jenkins/Jenkinsfile.nightly
+++ b/jenkins/Jenkinsfile.nightly
@@ -138,14 +138,11 @@ pipeline {
 
             environment {
               GITHUB_LOGIN = credentials('posit-jenkins')
+              DOCKER_TAG = utils.getDockerTag()
+              DOCKER_FILE = "docker/jenkins/Dockerfile.${utils.getDockerBuildOs(env.os)}"
             }
 
             steps {
-              script {
-                utils = load "${env.WORKSPACE}/utils.groovy"
-                DOCKER_TAG = utils.getDockerTag()
-                DOCKER_FILE = "docker/jenkins/Dockerfile.${utils.getDockerBuildOs(env.os)}"
-              }
               echo "Creating image jenkins/ide:${DOCKER_TAG}"
               pullBuildPush(
                 image_name: 'jenkins/ide',


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

This PR fixes a race condition in the jenkins nightly pipeline where the `DOCKER_TAG` and `DOCKER_FILE` variables were defined as global variables, so parallel builds in the build matrix may end up using the values from another build cell, causing incorrect build images to be produced. See [this build](https://build.posit.it/job/IDE/job/OS-Builds/job/nightly-pipeline/job/main/328/pipeline-console/?selected-node=129) as an example of when this occurred.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

Related to this Jenkins issue: https://issues.jenkins.io/browse/JENKINS-60801

The solution is to set the variables in the environment block instead of in the script block as groovy variables.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

N/A

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

N/A

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


