### PR TITLE
Don't install whois on bionic

### DIFF
--- a/dependencies/linux/install-dependencies-bionic
+++ b/dependencies/linux/install-dependencies-bionic
@@ -69,7 +69,6 @@ sudo apt-get -y install \
   unzip \
   uuid-dev \
   wget \
-  whois \
   zlib1g-dev
 
 # Java 8 (not in official repo for bionic)

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -64,7 +64,6 @@ RUN apt-get update && \
     uuid-dev \
     valgrind \
     wget \
-    whois \
     xvfb \
     zlib1g-dev
 


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Removes the `whois` dependency from our bionic build dependencies since we do not want to run the mkpasswd tests for the user service on bionic due to limitations.

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

On bionic, there is a 127 character limit for running `mkpasswd` with stdin input which interferes with the user service tests. Removing the `whois` dependency will cause the mkpasswd test to be skipped on `bionic`, preventing this false failure. 

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

Skipping a specific unit test on `bionic` due to an incompatible dependency.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

N/A

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


