### PR TITLE
filter accounts publishing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ### New
 - Prometheus metrics are available in Posit Workbench (rstudio-pro:#3273)
 - Update to Electron 25.2.0 (#13322)
+- Additional support for publishing new content types to Posit Cloud (rstudio-pro#4541)
 
 ### Fixed
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishDocServicePage.java
@@ -19,10 +19,10 @@ import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.WizardNavigationPage;
 import org.rstudio.core.client.widget.WizardPage;
-import org.rstudio.studio.client.rsconnect.RSConnect;
 import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishInput;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishResult;
+import org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.ServerType;
 
 import com.google.gwt.resources.client.ImageResource;
 
@@ -49,7 +49,8 @@ public class PublishDocServicePage
       if (input.isMultiRmd() && !input.isWebsiteRmd())
       {
          connectPage = new PublishMultiplePage(rscTitle, rscDesc,
-               new ImageResource2x(RSConnectResources.INSTANCE.localAccountIcon2x()), input);
+               new ImageResource2x(RSConnectResources.INSTANCE.localAccountIcon2x()), input,
+               ServerType.RSCONNECT);
       }
       else 
       {
@@ -58,14 +59,14 @@ public class PublishDocServicePage
             // static input implies static output
             connectPage = new PublishFilesPage(rscTitle, rscDesc,
                   new ImageResource2x(RSConnectResources.INSTANCE.localAccountIcon2x()), input,
-                  false, true);
+                  false, true, ServerType.RSCONNECT);
          }
          else
          {
             connectPage = new PublishReportSourcePage(rscTitle, rscDesc,
                   constants_.publishToRstudioConnect(),
                   new ImageResource2x(RSConnectResources.INSTANCE.localAccountIcon2x()), input, 
-                  false, true);
+                  false, true, ServerType.RSCONNECT);
          }
       }
       WizardPage<RSConnectPublishInput, RSConnectPublishResult> rpubsPage  =
@@ -79,7 +80,8 @@ public class PublishDocServicePage
       if (input.isMultiRmd() && !input.isWebsiteRmd())
       {
          cloudPage = new PublishMultiplePage(cloudTitle, cloudSubtitle,
-            new ImageResource2x(RSConnectResources.INSTANCE.positCloudAccountIcon2x()), input);
+            new ImageResource2x(RSConnectResources.INSTANCE.positCloudAccountIcon2x()), input,
+            ServerType.POSITCLOUD);
       } else
       {
          if (input.isStaticDocInput())
@@ -87,14 +89,14 @@ public class PublishDocServicePage
             // static input implies static output
             cloudPage = new PublishFilesPage(cloudTitle, cloudSubtitle,
                new ImageResource2x(RSConnectResources.INSTANCE.positCloudAccountIcon2x()), input,
-               false, true);
+               false, true, ServerType.POSITCLOUD);
          }
          else
          {
             cloudPage = new PublishReportSourcePage(cloudTitle, cloudSubtitle,
                constants_.publishToPositCloud(),
                new ImageResource2x(RSConnectResources.INSTANCE.positCloudAccountIcon2x()), input,
-               false, false);
+               false, false, ServerType.POSITCLOUD);
          }
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishFilesPage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishFilesPage.java
@@ -23,6 +23,7 @@ import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishInput;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishResult;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishSource;
+import org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.ServerType;
 
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.ui.Widget;
@@ -31,7 +32,8 @@ public class PublishFilesPage
    extends WizardPage<RSConnectPublishInput, RSConnectPublishResult>
 {
    public PublishFilesPage(String title, String subTitle, ImageResource icon,
-         RSConnectPublishInput input, boolean asMultiple, boolean asStatic)
+         RSConnectPublishInput input, boolean asMultiple, boolean asStatic,
+         ServerType serverType)
    {
       super(title, subTitle, constants_.publish(), icon, null);
       
@@ -41,7 +43,7 @@ public class PublishFilesPage
          // publish the HTML file or the original R Markdown doc, as requested
          if (asStatic)
          {
-            RSConnectPublishSource source = null;
+            RSConnectPublishSource source;
             if (input.getOriginatingEvent().getFromPreview() != null)
             {
                source = new RSConnectPublishSource(
@@ -67,7 +69,7 @@ public class PublishFilesPage
                               input.getContentType());
             }
             contents_.setPublishSource(source, input.getContentType(), 
-                  asMultiple, true);
+                  asMultiple, true, serverType);
          }
          else
          {
@@ -84,7 +86,7 @@ public class PublishFilesPage
                   input.getDescription(),
                   input.getContentType()),
                input.getContentType(),
-               asMultiple, false);
+               asMultiple, false, serverType);
          }
       }
    }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishMultiplePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishMultiplePage.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishInput;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishResult;
+import org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.ServerType;
 
 import com.google.gwt.resources.client.ImageResource;
 
@@ -30,15 +31,15 @@ public class PublishMultiplePage
    extends WizardNavigationPage<RSConnectPublishInput, RSConnectPublishResult>
 {
    public PublishMultiplePage(String title, String subTitle, ImageResource icon,
-         RSConnectPublishInput input)
+         RSConnectPublishInput input, ServerType serverType)
    {
       super(title, subTitle, constants_.publishMultiplePageCaption(),
-            icon, null, createPages(input));
+            icon, null, createPages(input, serverType));
    }
    
    private static ArrayList<WizardPage<RSConnectPublishInput, 
                                        RSConnectPublishResult>> 
-           createPages(RSConnectPublishInput input)
+           createPages(RSConnectPublishInput input, ServerType serverType)
    {
       ArrayList<WizardPage<RSConnectPublishInput, 
                            RSConnectPublishResult>> pages = new ArrayList<>();
@@ -50,30 +51,32 @@ public class PublishMultiplePage
       {
          pages.add(new PublishFilesPage(singleTitle, singleSubtitle, 
                new ImageResource2x(RSConnectResources.INSTANCE.publishSingleRmd2x()), 
-               input, false, false));
+               input, false, false, serverType));
          pages.add(new PublishFilesPage(multipleTitle, multipleSubtitle,
                new ImageResource2x(RSConnectResources.INSTANCE.publishMultipleRmd2x()), 
-               input, true, false));
+               input, true, false, serverType));
       }
       else if (input.isStaticDocInput())
       {
          pages.add(new PublishFilesPage(singleTitle, singleSubtitle, 
                new ImageResource2x(RSConnectResources.INSTANCE.publishSingleRmd2x()), 
-               input, false, true));
+               input, false, true, serverType));
          pages.add(new PublishFilesPage(multipleTitle, multipleSubtitle,
                new ImageResource2x(RSConnectResources.INSTANCE.publishMultipleRmd2x()), 
-               input, true, true));
+               input, true, true, serverType));
       }
       else
       {
          pages.add(new PublishReportSourcePage(singleTitle, singleSubtitle,
                constants_.publishToRstudioConnect(),
                new ImageResource2x(
-                  RSConnectResources.INSTANCE.publishSingleRmd2x()), input, false, true));
+                  RSConnectResources.INSTANCE.publishSingleRmd2x()), input, false, true,
+               ServerType.RSCONNECT));
          pages.add(new PublishReportSourcePage(multipleTitle, multipleSubtitle,
                constants_.publishToRstudioConnect(),
                new ImageResource2x(
-                  RSConnectResources.INSTANCE.publishMultipleRmd2x()), input, true, true));
+                  RSConnectResources.INSTANCE.publishMultipleRmd2x()), input, true, true,
+               ServerType.RSCONNECT));
       }
       return pages;
    }

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/PublishReportSourcePage.java
@@ -23,8 +23,10 @@ import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishInput;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishResult;
+import org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.ServerType;
 
 import com.google.gwt.resources.client.ImageResource;
+
 
 public class PublishReportSourcePage 
    extends WizardNavigationPage<RSConnectPublishInput, RSConnectPublishResult>
@@ -37,15 +39,17 @@ public class PublishReportSourcePage
          ImageResource icon,
          RSConnectPublishInput input,
          boolean asMultiple,
-         boolean allowScheduling)
+         boolean allowScheduling,
+         ServerType serverType)
    {
       super(title, subTitle, pageCaption, icon, null,
-            createPages(input, asMultiple, allowScheduling));
+            createPages(input, asMultiple, allowScheduling, serverType));
    }
 
    private static ArrayList<WizardPage<RSConnectPublishInput, 
                                        RSConnectPublishResult>> 
-           createPages(RSConnectPublishInput input, boolean asMultiple, boolean allowScheduling)
+           createPages(RSConnectPublishInput input, boolean asMultiple, boolean allowScheduling,
+                       ServerType serverType)
    {
       ArrayList<WizardPage<RSConnectPublishInput, 
                            RSConnectPublishResult>> pages = new ArrayList<>();
@@ -68,12 +72,12 @@ public class PublishReportSourcePage
       pages.add(new PublishFilesPage(constants_.publishFilesPageTitle(descriptor),
             publishSourceSubtitle,
             new ImageResource2x(RSConnectResources.INSTANCE.publishDocWithSource2x()), 
-            input, asMultiple, false));
+            input, asMultiple, false, serverType));
       String staticTitle = constants_.publishReportSourcePageStaticTitle(descriptor);
       String staticSubtitle = constants_.publishReportSourcePageStaticSubtitle();
       pages.add(new PublishFilesPage(staticTitle, staticSubtitle, 
             new ImageResource2x(RSConnectResources.INSTANCE.publishDocWithoutSource2x()), 
-            input, asMultiple, true));
+            input, asMultiple, true, serverType));
       return pages;
    }
    private static final RsconnectConstants constants_ = GWT.create(RsconnectConstants.class);

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountList.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectAccountList.java
@@ -41,14 +41,16 @@ public class RSConnectAccountList extends Composite implements CanSetControlId
    public RSConnectAccountList(RSConnectServerOperations server, 
          GlobalDisplay display,
          boolean refreshImmediately,
-         boolean showCloudAccounts,
+         boolean showShinyAppsAccounts,
          boolean showPositCloudAccounts,
+         boolean showConnectAccounts,
          String ariaLabel)
    {
       server_ = server;
       display_ = display;
-      showCloudAccounts_ = showCloudAccounts;
+      showShinyAppsAccounts_ = showShinyAppsAccounts;
       showPositCloudAccounts_ = showPositCloudAccounts;
+      showConnectAccounts_ = showConnectAccounts;
       accountList_ = new WidgetListBox<>();
       accountList_.setEmptyText(constants_.noAccountsConnected());
       if (refreshImmediately)
@@ -89,19 +91,17 @@ public class RSConnectAccountList extends Composite implements CanSetControlId
       for (int i = 0; i < accounts.length(); i++)
       {
          RSConnectAccount account = accounts.get(i);
-         // hide ShinyApps and Posit.cloud accounts from the list if non-cloud supported content type
-         if (account.isShinyAppsAccount() && showCloudAccounts_)
+         if (account.isShinyAppsAccount() && showShinyAppsAccounts_)
          {
             accounts_.add(account);
             accountList_.addItem(new RSConnectAccountEntry(account));
          }
-         else if (account.isCloudAccount() && (showCloudAccounts_ || showPositCloudAccounts_))
+         else if (account.isCloudAccount() && showPositCloudAccounts_)
          {
             accounts_.add(account);
             accountList_.addItem(new RSConnectAccountEntry(account));
          }
-         // Connect accounts support all content types
-         else if (!account.isShinyAppsAccount() && !account.isCloudAccount())
+         else if (!account.isShinyAppsAccount() && !account.isCloudAccount() && showConnectAccounts_)
          {
             accounts_.add(account);
             accountList_.addItem(new RSConnectAccountEntry(account));
@@ -170,32 +170,34 @@ public class RSConnectAccountList extends Composite implements CanSetControlId
          return accounts_.size();
    }
    
-   public void setShowCloudAccounts(boolean show)
-   {
-      showCloudAccounts_ = show;
-   }
+   public void setShowShinyAppsAccounts(boolean show) { showShinyAppsAccounts_ = show; }
    
-   public boolean getShowCloudAccounts()
-   {
-      return showCloudAccounts_;
-   }
+   public boolean getShowShinyAppsAccounts() { return showShinyAppsAccounts_; }
 
-   public void setShowPositCloudAccounts(boolean show)
-   {
-      showPositCloudAccounts_ = show;
-   }
+   public void setShowPositCloudAccounts(boolean show) { showPositCloudAccounts_ = show; }
 
    public boolean getShowPositCloudAccounts()
    {
       return showPositCloudAccounts_;
+   }
+
+   public void setShowConnectAccounts(boolean show)
+   {
+      showConnectAccounts_ = show;
+   }
+
+   public boolean getShowConnectAccounts()
+   {
+      return showConnectAccounts_;
    }
    
    private final WidgetListBox<RSConnectAccountEntry> accountList_;
    private final RSConnectServerOperations server_; 
    private final GlobalDisplay display_;
    
-   private boolean showCloudAccounts_;
+   private boolean showShinyAppsAccounts_;
    private boolean showPositCloudAccounts_;
+   private boolean showConnectAccounts_;
    
    private ArrayList<RSConnectAccount> accounts_ = new ArrayList<>();
    private Operation onRefreshCompleted_ = null;

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -429,7 +429,6 @@ public class RSConnectDeploy extends Composite
                                 int contentType, boolean asMultipleRmd, boolean asStatic,
                                 ServerType serverType)
    {
-      Debug.logToConsole("serverType: " + serverType);
       source_ = source;
       contentType_ = contentType;
       asMultipleRmd_ = asMultipleRmd;
@@ -439,7 +438,6 @@ public class RSConnectDeploy extends Composite
       boolean positCloudEnabled =
          userPrefs_.enableCloudPublishUi().getGlobalValue() &&
             (serverType == ServerType.POSITCLOUD || serverType == null);
-      Debug.logToConsole("positCloudEnabled: " + positCloudEnabled);
 
       boolean rsConnectEnabled =
          userState_.enableRsconnectPublishUi().getGlobalValue() &&

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -200,7 +200,7 @@ public class RSConnectDeploy extends Composite
       }
 
       final boolean rsConnectEnabled = 
-            userState_.enableRsconnectPublishUi().getGlobalValue();
+         userState_.enableRsconnectPublishUi().getGlobalValue();
       final boolean positCloudEnabled =
          userPrefs_.enableCloudPublishUi().getGlobalValue();
       
@@ -295,7 +295,7 @@ public class RSConnectDeploy extends Composite
       userState_ = state;
       // posit.cloud should be enabled for static and non-static content
       accountList_ = new RSConnectAccountList(server_, display_, false, 
-            !asStatic_, true, constants_.publishFromAccount());
+            !asStatic_, true, true, constants_.publishFromAccount());
       appName_ = new AppNameTextbox(this);
       
       // when the account list finishes populating, select the account from the
@@ -429,30 +429,38 @@ public class RSConnectDeploy extends Composite
                                 int contentType, boolean asMultipleRmd, boolean asStatic,
                                 ServerType serverType)
    {
+      Debug.logToConsole("serverType: " + serverType);
       source_ = source;
       contentType_ = contentType;
       asMultipleRmd_ = asMultipleRmd;
 
+      // In order to display Posit.cloud accounts, it needs to be enabled in Prefs AND
+      // the server type needs to be Posit.cloud, or null (which means the user hasn't specified)
       boolean positCloudEnabled =
-         userPrefs_.enableCloudPublishUi().getGlobalValue();
+         userPrefs_.enableCloudPublishUi().getGlobalValue() &&
+            (serverType == ServerType.POSITCLOUD || serverType == null);
+      Debug.logToConsole("positCloudEnabled: " + positCloudEnabled);
+
+      boolean rsConnectEnabled =
+         userState_.enableRsconnectPublishUi().getGlobalValue() &&
+            (serverType == ServerType.RSCONNECT || serverType == null);
 
       if (positCloudEnabled != accountList_.getShowPositCloudAccounts())
       {
-         if (positCloudEnabled && (serverType == ServerType.POSITCLOUD || serverType == null))
-         {
-            accountList_.setShowPositCloudAccounts(true);
-         }
-         else if (!positCloudEnabled && serverType != ServerType.POSITCLOUD && serverType != null)
-         {
-            accountList_.setShowPositCloudAccounts(false);
-         }
+         accountList_.setShowPositCloudAccounts(positCloudEnabled);
          accountList_.refreshAccountList();
       }
 
-      // we want to show cloud accounts only for non-static content
-      if (source.isShiny() != accountList_.getShowCloudAccounts())
+      if (rsConnectEnabled != accountList_.getShowConnectAccounts())
       {
-         accountList_.setShowCloudAccounts(source.isShiny());
+         accountList_.setShowConnectAccounts(rsConnectEnabled);
+         accountList_.refreshAccountList();
+      }
+
+      // we want to show ShinyApps.io accounts only for Shiny content
+      if (source.isShiny() != accountList_.getShowShinyAppsAccounts())
+      {
+         accountList_.setShowShinyAppsAccounts(source.isShiny());
          accountList_.refreshAccountList();
       }
       

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.java
@@ -146,6 +146,13 @@ public class RSConnectDeploy extends Composite
    }
    
    public static DeployResources RESOURCES = GWT.create(DeployResources.class);
+
+   public enum ServerType {
+      RSCONNECT,
+      RSPUBS,
+      POSITCLOUD,
+      SHINYAPPS
+   }
    
    public RSConnectDeploy(RSConnectPublishSource source,
                           final int contentType,
@@ -214,23 +221,7 @@ public class RSConnectDeploy extends Composite
                      }
                   });
          });
-      }
-      else if (positCloudEnabled) // also invoke if Connect disabled but Cloud enabled
-      {
-         addAccountAnchor_.setClickHandler(() ->
-         {
-            connector_.showAccountWizard(false,
-               true,
-               successful ->
-               {
-                  if (successful)
-                  {
-                     accountList_.refreshAccountList();
-                  }
-               });
-         });
-      }
-      else {
+      } else {
          // if not deploying a Shiny app and RSConnect UI/ Posit Cloud UI are not enabled, then
          // there's no account we can add suitable for this content
          addAccountAnchor_.setVisible(false);
@@ -434,8 +425,9 @@ public class RSConnectDeploy extends Composite
       populateDeploymentFiles(indicator);
    }
    
-   public void setPublishSource(RSConnectPublishSource source, 
-         int contentType, boolean asMultipleRmd, boolean asStatic)
+   public void setPublishSource(RSConnectPublishSource source,
+                                int contentType, boolean asMultipleRmd, boolean asStatic,
+                                ServerType serverType)
    {
       source_ = source;
       contentType_ = contentType;
@@ -446,7 +438,14 @@ public class RSConnectDeploy extends Composite
 
       if (positCloudEnabled != accountList_.getShowPositCloudAccounts())
       {
-         accountList_.setShowPositCloudAccounts(positCloudEnabled);
+         if (positCloudEnabled && (serverType == ServerType.POSITCLOUD || serverType == null))
+         {
+            accountList_.setShowPositCloudAccounts(true);
+         }
+         else if (!positCloudEnabled && serverType != ServerType.POSITCLOUD && serverType != null)
+         {
+            accountList_.setShowPositCloudAccounts(false);
+         }
          accountList_.refreshAccountList();
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployDialog.java
@@ -108,7 +108,7 @@ public class RSConnectDeployDialog
       {
          // we know what the previous deployment settings are, so use them
          contents_.setPublishSource(source, contentType, 
-               fromPrevious.getAsMultiple(), fromPrevious.getAsStatic());
+               fromPrevious.getAsMultiple(), fromPrevious.getAsStatic(), null);
       }
       else
       {
@@ -117,7 +117,7 @@ public class RSConnectDeployDialog
          // an unambiguously single, non-static asset (such as a Shiny app or
          // an R Markdown document in its own directory)
          contents_.setPublishSource(source, contentType, 
-               false, false);
+               false, false, null);
       }
   
       contents_.setOnDeployDisabled(new Command()

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishWizard.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishWizard.java
@@ -23,6 +23,7 @@ import org.rstudio.core.client.widget.WizardPage;
 import org.rstudio.studio.client.rsconnect.RsconnectConstants;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishInput;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishResult;
+import org.rstudio.studio.client.rsconnect.ui.RSConnectDeploy.ServerType;
 
 public class RSConnectPublishWizard 
    extends Wizard<RSConnectPublishInput, RSConnectPublishResult>
@@ -38,8 +39,9 @@ public class RSConnectPublishWizard
    {
       if (!input.hasDocOutput() && input.isMultiRmd() && !input.isWebsiteRmd())
       {
-         // multiple docs -- see if we should send them all up
-         return new PublishMultiplePage(constants_.publish(), constants_.publish(), null, input);
+         // multiple docs -- ask user if we should send them all up
+         // can be published to Connect or Posit Cloud if user has accounts configured
+         return new PublishMultiplePage(constants_.publish(), constants_.publish(), null, input, null);
       }
       else if (!input.isCloudUIEnabled() &&
                (input.isWebsiteRmd() ||
@@ -51,7 +53,7 @@ public class RSConnectPublishWizard
          // so it has to go to Connect -- don't prompt the user for a destination
          return new PublishReportSourcePage(constants_.publish(), constants_.publish(),
                constants_.publishToRstudioConnect(),null, input,
-               false, true);
+               false, true, ServerType.RSCONNECT);
       }
       else
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -77,7 +77,8 @@ public class PublishingPreferencesPane extends PreferencesPane
       HorizontalPanel hpanel = new HorizontalPanel();
 
       String accountListLabel = constants_.accountListLabel();
-      accountList_ = new RSConnectAccountList(server, globalDisplay, true, true, true, accountListLabel);
+      // The preferences pane does not filter connected accounts
+      accountList_ = new RSConnectAccountList(server, globalDisplay, true, true, true, true, accountListLabel);
       accountList_.setHeight("150px");
       accountList_.setWidth("300px");
       accountList_.getElement().getStyle().setMarginBottom(15, Unit.PX);


### PR DESCRIPTION
### Intent

Addresses [#12204](https://github.com/rstudio/rstudio/issues/12204)
Followup to publishing work in [rstudio/rstudio-pro#4541](https://github.com/rstudio/rstudio-pro/issues/4541)

### Approach

when the user chooses a publishing service in PublishDocServicePage, that should get passed through to RSConnectAccountList via setPublishSource, so we can add some new params and check their values to filter the account list

Also fix a couple of outstanding bugs where we kind of ignore the global preferences for Connect enabled/Cloud enabled in the account list
### Automated Tests
No

### QA Notes

Should be tested as part of the testing process for rstudio/rstudio-pro#4541
