### PR TITLE
Don't log pending launch errors for handleRpcError and handleContentError

### DIFF
--- a/src/cpp/server/session/ServerSessionManager.cpp
+++ b/src/cpp/server/session/ServerSessionManager.cpp
@@ -425,7 +425,7 @@ void SessionManager::removePendingLaunch(const r_util::SessionContext& context, 
                            " in " + std::to_string(startDuration.total_seconds()) + "." +
                                     std::to_string(startDuration.total_milliseconds() % 1000) + "s");
       }
-      else
+      else if (!errorMsg.empty())
          LOG_ERROR_MESSAGE(context.scope.workbench() + " session start failed for: " + context.username + ":" + context.scope.id() +
                            " in " + std::to_string(startDuration.total_seconds()) + "." +
                                     std::to_string(startDuration.total_milliseconds() % 1000) + "s error: " + errorMsg);

--- a/src/cpp/server/session/ServerSessionProxy.cpp
+++ b/src/cpp/server/session/ServerSessionProxy.cpp
@@ -519,7 +519,7 @@ void handleContentError(
       const Error& error)
 {   
    // if there was a launch pending then remove it
-   sessionManager().removePendingLaunch(context, false, "content error: " + error.asString());
+   sessionManager().removePendingLaunch(context, false, std::string());
 
 
    // check for authentication error
@@ -606,7 +606,7 @@ void handleRpcError(
       const Error& error)
 {
    // if there was a launch pending then remove it
-   sessionManager().removePendingLaunch(context, false, "rpc error: " + error.asString());
+   sessionManager().removePendingLaunch(context, false, std::string());
 
    // check for authentication error
    if (server::isAuthenticationError(error))


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio/issues/13369

### Approach

Removes a recently added error that shows up during restart session process. The IDE sends a get_environment_state request right after the message to restart which will always generate an error and remove the pending launch. This eliminates the error part of the bug only.

### QA

Reproduces easily in server version.  See issue for details. 