### PR TITLE
ensure default translation domain is set on startup

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 - Additional support for publishing new content types to Posit Cloud (rstudio-pro#4541)
 
 ### Fixed
+- Fixed issue where error messages were not properly translated on Windows in some cases (#10308)
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)
 - Fixed bug preventing dataframe column navigation past the default number of display columns (#13220)

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -183,80 +183,6 @@ int askYesNoCancel(const char* question)
    }
 }
 
-bool initializeMaxMemoryDangerously()
-{
-   Error error;
-
-   void* pLibrary = nullptr;
-   error = core::system::loadLibrary("R.dll", &pLibrary);
-   if (error)
-      return false;
-
-   // first, see if we can load the 'R_max_memory' symbol directly
-   size_t* p_R_max_memory = nullptr;
-   error = core::system::loadSymbol(
-            pLibrary,
-            "R_max_memory",
-            (void**) &p_R_max_memory);
-
-   if (error)
-   {
-      // terrible, terrible hack -- for typical builds of R from CRAN,
-      // the memory address for R_max_memory lies just before the
-      // Rwin_graphicsx symbol, so find that symbol, and compute the
-      // position of R_max_memory offset from that
-      char* p_Rwin_graphicsx = nullptr;
-      error = core::system::loadSymbol(
-               pLibrary,
-               "Rwin_graphicsx",
-               (void**) &p_Rwin_graphicsx);
-
-      if (error)
-         return false;
-
-      // get memory address for R_max_memory
-      p_R_max_memory = (size_t*) (p_Rwin_graphicsx - sizeof(size_t));
-   }
-
-   // newer versions of R initialize R_max_memory to SIZE_MAX, while
-   // older versions use INT_MAX. allow either value here when checking
-   bool ok =
-         *p_R_max_memory == SIZE_MAX ||
-         *p_R_max_memory == INT_MAX;
-
-   if (!ok)
-      return false;
-
-   // we found the memory address! let's fill it up
-   MEMORYSTATUSEX status;
-   status.dwLength = sizeof(status);
-   ::GlobalMemoryStatusEx(&status);
-   *p_R_max_memory = status.ullTotalPhys;
-
-   return true;
-}
-
-bool initializeMaxMemoryViaCmdLineOptions()
-{
-   static const int rargc = 2;
-   static const char* rargv[] = {"R.exe", "--vanilla"};
-   ::cmdlineoptions(rargc, (char**) rargv);
-
-   return true;
-}
-
-void initializeMaxMemory(const core::FilePath& rHome)
-{
-   // no action required with newer versions of R
-   const char* dllVersion = getDLLVersion();
-   core::Version rVersion(dllVersion);
-   if (rVersion >= core::Version("4.2.0"))
-      return;
-
-   initializeMaxMemoryDangerously() ||
-         initializeMaxMemoryViaCmdLineOptions();
-}
-
 void initializeParams(RStartup* pRP)
 {
    // use R_DefParams for older versions of R
@@ -301,8 +227,14 @@ void runEmbeddedR(const core::FilePath& rHome,
    // no signal handlers (see comment in REmbeddedPosix.cpp for rationale)
    R_SignalHandlers = 0;
 
-   // initialize R_max_memory
-   initializeMaxMemory(rHome);
+   // setup command line options
+   // note that R does a lot of initialization here that's not accessible
+   // in any other way; e.g. the default translation domain is set within
+   //
+   // https://github.com/rstudio/rstudio/issues/10308
+   static const int rargc = 2;
+   static const char* rargv[] = { "R.exe", "--vanilla" };
+   ::cmdlineoptions(rargc, (char**) rargv);
 
    // setup params structure
    RStartup rp;

--- a/src/cpp/r/session/REmbeddedWin32.cpp
+++ b/src/cpp/r/session/REmbeddedWin32.cpp
@@ -232,8 +232,8 @@ void runEmbeddedR(const core::FilePath& rHome,
    // in any other way; e.g. the default translation domain is set within
    //
    // https://github.com/rstudio/rstudio/issues/10308
-   static const int rargc = 2;
-   static const char* rargv[] = { "R.exe", "--vanilla" };
+   static const int rargc = 1;
+   static const char* rargv[] = { "R.exe" };
    ::cmdlineoptions(rargc, (char**) rargv);
 
    // setup params structure

--- a/src/cpp/session/SessionMain.cpp
+++ b/src/cpp/session/SessionMain.cpp
@@ -1941,9 +1941,7 @@ int main(int argc, char * const argv[])
       //
       // https://github.com/mirror/mingw-w64/blob/eff726c461e09f35eeaed125a3570fa5f807f02b/mingw-w64-crt/crt/crtexe.c#L98-L108
 #ifdef _WIN32
-      std::string enabled = core::system::getenv("RSTUDIO_WIN32_ENABLE_INVALID_PARAMETER_HANDLER");
-      if (core::string_utils::isTruthy(enabled, true))
-         _set_invalid_parameter_handler(win32InvalidParameterHandler);
+      _set_invalid_parameter_handler(win32InvalidParameterHandler);
 #endif
 
       // save fallback library path

--- a/src/cpp/tests/testthat/test-translations.R
+++ b/src/cpp/tests/testthat/test-translations.R
@@ -1,0 +1,10 @@
+
+context("Translations")
+
+# https://github.com/rstudio/rstudio/issues/10308
+test_that("translations work on Windows", {
+   skip_if(Sys.info()[["sysname"]] != "Windows")
+   withr::local_envvar(LANGUAGE = "fr")
+   err <- tryCatch(noSuchVariable, error = identity)
+   expect_equal(conditionMessage(err), "objet 'noSuchVariable' introuvable")
+})


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/10308.

### Approach

R uses [libintl](https://github.com/wch/r-source/tree/trunk/src/extra/intl) for message translation. The default domain for translations is "messages", but R normally tries to set the default domain to "R" here:

https://github.com/wch/r-source/blob/e3d6c3fdd8666ae96bee913e1c0edab7bbaa088d/src/main/main.c#L737

And that only gets called in a few places, e.g.

https://github.com/wch/r-source/blob/e3d6c3fdd8666ae96bee913e1c0edab7bbaa088d/src/gnuwin32/system.c#L1073

So we need to make sure to call `::cmdlineoptions()` so that the default text domain is set. Note that we previously had to avoid using this function as R would crash on startup when we tried to call this, but this issue has now been alleviated by virtue of the invalid parameter handler we install (which just ignores such errors, as R and MinGW do).

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/10308. In particular, we should verify that translations work in this scenario:

```
Sys.setenv(LANGUAGE = "fr")
ouch
```

You should see a message like:

```
Erreur : objet 'ouch' introuvable
```

We should also confirm this works across a variety of versions of R on Windows; e.g. R 3.6.3; R 4.0.3, R 4.1.3, R 4.2.3 and R 4.3.1. This is necessary because this code removes an old workaround for an issue that was causing R to crash on startup, but that issue should now be alleviated via a separate fix.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

