### PR TITLE
fix bug in `compareVersions()` string splitting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Fixed broken Help pane after navigating to code demo (#13263)
 - Fixed bug preventing Update Available from displaying (#13347)
 - Fixed bug causing dataframe help preview to fail for nested objects (#13291)
+- Fixed bug where clicking "Ignore Update" would fail to ignore the update (#13379)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -38,14 +38,22 @@ public class ApplicationUtils
       return pattern.replaceAll(url, replaceWith);
    }
    
-   // Returns:
-   // < 0 if version1 is earlier than version 2
-   // 0 if version1 and version2 are the same 
-   // > 0 if version1 is later than version 2
+   /**
+    * Compares two version strings of the format "MAJOR.MINOR.PATCH" or "YEAR.MONTH.PATCH+COMMITS".
+    * @example compareVersions("2023.06.0+421", "2023.06.1+524") returns -1
+    *          compareVersions("2023.06.1+524", "2023.06.1+524") returns 0
+    *          compareVersions("2023.06.2+999", "2023.06.1+524") returns 1
+    * @param version1 The first version string to compare
+    * @param version2 The second version string to compare
+    * @return < 0 if version1 is earlier than version 2
+    *         0 if version1 and version2 are the same
+    *         > 0 if version1 is later than version 2
+    */
    public static int compareVersions(String version1, String version2)
    {
-      String[] v1parts = version1.split("\\.");
-      String[] v2parts = version2.split("\\.");
+      String versionRegex = "\\.|\\+";
+      String[] v1parts = version1.split(versionRegex); // example: ["2023", "06", "0", "421"]
+      String[] v2parts = version2.split(versionRegex); // example: ["2023", "06", "1", "524"]
       int numParts = Math.min(v1parts.length, v2parts.length);
       for (int i = 0; i < numParts; i++)
       {

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -43,9 +43,9 @@ public class ApplicationUtils
     *   * MAJOR.MINOR.PATCH - e.g. 3.6.0
     *   * YEAR.MONTH.PATCH+COMMITS - e.g. 2023.06.0+421
     *   * MAJOR.MINOR.PATCH-NUM - e.g. 1.4.1743-4
-    * @example compareVersions("2023.06.0+421", "2023.06.1+524") returns -1
+    * @example compareVersions("2023.06.0+421", "2023.06.1+524") returns < 0
     *          compareVersions("2023.06.1+524", "2023.06.1+524") returns 0
-    *          compareVersions("2023.06.2+999", "2023.06.1+524") returns 1
+    *          compareVersions("2023.06.2+999", "2023.06.1+524") returns > 0
     * @param version1 The first version string to compare
     * @param version2 The second version string to compare
     * @return < 0 if version1 is earlier than version 2

--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -39,7 +39,10 @@ public class ApplicationUtils
    }
    
    /**
-    * Compares two version strings of the format "MAJOR.MINOR.PATCH" or "YEAR.MONTH.PATCH+COMMITS".
+    * Compares two version strings, which may be in these formats:
+    *   * MAJOR.MINOR.PATCH - e.g. 3.6.0
+    *   * YEAR.MONTH.PATCH+COMMITS - e.g. 2023.06.0+421
+    *   * MAJOR.MINOR.PATCH-NUM - e.g. 1.4.1743-4
     * @example compareVersions("2023.06.0+421", "2023.06.1+524") returns -1
     *          compareVersions("2023.06.1+524", "2023.06.1+524") returns 0
     *          compareVersions("2023.06.2+999", "2023.06.1+524") returns 1
@@ -51,7 +54,7 @@ public class ApplicationUtils
     */
    public static int compareVersions(String version1, String version2)
    {
-      String versionRegex = "\\.|\\+";
+      String versionRegex = "\\.|\\+|\\-";
       String[] v1parts = version1.split(versionRegex); // example: ["2023", "06", "0", "421"]
       String[] v2parts = version2.split(versionRegex); // example: ["2023", "06", "1", "524"]
       int numParts = Math.min(v1parts.length, v2parts.length);

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.URIUtilsTests;
 import org.rstudio.core.client.VirtualConsoleTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
+import org.rstudio.studio.client.application.ApplicationUtilsTests;
 import org.rstudio.studio.client.application.model.SessionScopeTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
@@ -59,6 +60,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(ChunkContextUiTests.class);
       suite.addTestSuite(SafeHtmlUtilTests.class);
       suite.addTestSuite(TestMocks.class);
+      suite.addTestSuite(ApplicationUtilsTests.class);
 
       return suite;
    }

--- a/src/gwt/test/org/rstudio/studio/client/application/ApplicationUtilsTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/application/ApplicationUtilsTests.java
@@ -1,0 +1,46 @@
+/*
+ * ApplicationUtilsTests.java
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.application;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class ApplicationUtilsTests extends GWTTestCase {
+
+    @Override
+    public String getModuleName() {
+        return "org.rstudio.studio.RStudioTests";
+    }
+
+    public void testCompareVersions() {
+        // RStudio IDE Versions
+        assertTrue(ApplicationUtils.compareVersions("2022.12.0+353", "2023.06.1+524") < 0);
+        assertTrue(ApplicationUtils.compareVersions("2021.09.3+396", "2021.09.3+396") == 0);
+        assertTrue(ApplicationUtils.compareVersions("2022.03.2+454", "2022.03.2+455") < 0);
+        assertTrue(ApplicationUtils.compareVersions("2022.07.2+576", "2022.07.1+554") > 0);
+        assertTrue(ApplicationUtils.compareVersions("1.4.1743-4", "2023.06.1+524") < 0);
+
+        // R Versions
+        assertTrue(ApplicationUtils.compareVersions("3.6.0", "3.5.3") > 0);
+        assertTrue(ApplicationUtils.compareVersions("4.3.2", "4.3.2") == 0);
+        assertTrue(ApplicationUtils.compareVersions("3.5.3", "4.2.1") < 0);
+
+        // Other Version Formats
+        assertTrue(ApplicationUtils.compareVersions("1.2.3", "0.0") > 0);
+        assertTrue(ApplicationUtils.compareVersions("0.0", "0.0") == 0);
+        assertTrue(ApplicationUtils.compareVersions("0", "0.0") == 0);
+        assertTrue(ApplicationUtils.compareVersions("0.0", "1.2.3") < 0);
+    }
+}


### PR DESCRIPTION
### Intent

- `+` is used in the YYYY.MM.PATCH+COMMITS format since Ghost Orchid and `-` is used in the MAJOR.MINOR.X-Y format in Juliet Rose
- neither of these characters `+` / `-` are accounted for in the version comparison, so the numeric comparison fails

In the session log, the following error would show:

```
ERROR CLIENT EXCEPTION (rsession): For input string: "1+524";|||rstudio-0.js#-1::new zve|||com/google/gwt/emul/java/lang/Number.java#207::__parseAndValidateInt|||org/rstudio/studio/client/application/ApplicationUtils.java#45::compareVersions|||org/rstudio/studio/client/application/IgnoredUpdates.java#36::addIgnoredUpdate|||org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java#231::addIgnoredUpdate|||org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java#559::execute|||org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java#84::execute|||com/google/gwt/core/client/impl/SchedulerImpl.java#167::runScheduledTasks|||com/google/gwt/core/client/impl/SchedulerImpl.java#338::flushPostEventPumpCommands|||com/google/gwt/core/client/impl/SchedulerImpl.java#76::execute|||com/google/gwt/core/client/impl/SchedulerImpl.java#140::execute|||com/google/gwt/core/client/impl/Impl.java#306::apply|||com/google/gwt/core/client/impl/Impl.java#345::entry0|||rstudio-0.js#-1::eval|||com/google/gwt/cell/client/AbstractEditableCell.java#41::viewDataMap.......
```

Addresses: https://github.com/rstudio/rstudio/issues/13379
Backport Issue: https://github.com/rstudio/rstudio/issues/13380

### Approach

- Include the symbols `+` and `-` (in addition to the existing `.`) when splitting a version string

### Automated Tests

- Added unit tests to test `compareVersions()`

### QA Notes

We'll have to wait until Desert Sunflower is released to properly test the following scenario using a 2023.06.2 release.

I will provide custom builds to test this in the meantime!

Pre req: you've previously ignored a version (e.g. `2023.06.0+421`) and there is an even newer update available (e.g. Desert Sunflower). (_I can help with "artificially" ignoring a version if needed during testing_)

1. Open RStudio
2. You get prompted to install Desert Sunflower
3. Ignore Update
4. Quit RStudio
5. Reopen RStudio
6. You should not be prompted to install Desert Sunflower

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


