### PR TITLE
fix bug in `compareVersions()` string splitting (#13386)

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ApplicationUtils.java
@@ -38,14 +38,25 @@ public class ApplicationUtils
       return pattern.replaceAll(url, replaceWith);
    }
    
-   // Returns:
-   // < 0 if version1 is earlier than version 2
-   // 0 if version1 and version2 are the same 
-   // > 0 if version1 is later than version 2
+   /**
+    * Compares two version strings, which may be in these formats:
+    *   * MAJOR.MINOR.PATCH - e.g. 3.6.0
+    *   * YEAR.MONTH.PATCH+COMMITS - e.g. 2023.06.0+421
+    *   * MAJOR.MINOR.PATCH-NUM - e.g. 1.4.1743-4
+    * @example compareVersions("2023.06.0+421", "2023.06.1+524") returns < 0
+    *          compareVersions("2023.06.1+524", "2023.06.1+524") returns 0
+    *          compareVersions("2023.06.2+999", "2023.06.1+524") returns > 0
+    * @param version1 The first version string to compare
+    * @param version2 The second version string to compare
+    * @return < 0 if version1 is earlier than version 2
+    *         0 if version1 and version2 are the same
+    *         > 0 if version1 is later than version 2
+    */
    public static int compareVersions(String version1, String version2)
    {
-      String[] v1parts = version1.split("\\.");
-      String[] v2parts = version2.split("\\.");
+      String versionRegex = "\\.|\\+|\\-";
+      String[] v1parts = version1.split(versionRegex); // example: ["2023", "06", "0", "421"]
+      String[] v2parts = version2.split(versionRegex); // example: ["2023", "06", "1", "524"]
       int numParts = Math.min(v1parts.length, v2parts.length);
       for (int i = 0; i < numParts; i++)
       {

--- a/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
+++ b/src/gwt/test/org/rstudio/studio/client/RStudioUnitTestSuite.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.StringUtilTests;
 import org.rstudio.core.client.URIUtilsTests;
 import org.rstudio.core.client.VirtualConsoleTests;
 import org.rstudio.core.client.dom.DomUtilsTests;
+import org.rstudio.studio.client.application.ApplicationUtilsTests;
 import org.rstudio.studio.client.application.model.SessionScopeTests;
 import org.rstudio.studio.client.common.r.RTokenizerTests;
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManagerTests;
@@ -59,6 +60,7 @@ public class RStudioUnitTestSuite extends GWTTestSuite
       suite.addTestSuite(ChunkContextUiTests.class);
       suite.addTestSuite(SafeHtmlUtilTests.class);
       suite.addTestSuite(TestMocks.class);
+      suite.addTestSuite(ApplicationUtilsTests.class);
 
       return suite;
    }

--- a/src/gwt/test/org/rstudio/studio/client/application/ApplicationUtilsTests.java
+++ b/src/gwt/test/org/rstudio/studio/client/application/ApplicationUtilsTests.java
@@ -1,0 +1,46 @@
+/*
+ * ApplicationUtilsTests.java
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+package org.rstudio.studio.client.application;
+
+import com.google.gwt.junit.client.GWTTestCase;
+
+public class ApplicationUtilsTests extends GWTTestCase {
+
+    @Override
+    public String getModuleName() {
+        return "org.rstudio.studio.RStudioTests";
+    }
+
+    public void testCompareVersions() {
+        // RStudio IDE Versions
+        assertTrue(ApplicationUtils.compareVersions("2022.12.0+353", "2023.06.1+524") < 0);
+        assertTrue(ApplicationUtils.compareVersions("2021.09.3+396", "2021.09.3+396") == 0);
+        assertTrue(ApplicationUtils.compareVersions("2022.03.2+454", "2022.03.2+455") < 0);
+        assertTrue(ApplicationUtils.compareVersions("2022.07.2+576", "2022.07.1+554") > 0);
+        assertTrue(ApplicationUtils.compareVersions("1.4.1743-4", "2023.06.1+524") < 0);
+
+        // R Versions
+        assertTrue(ApplicationUtils.compareVersions("3.6.0", "3.5.3") > 0);
+        assertTrue(ApplicationUtils.compareVersions("4.3.2", "4.3.2") == 0);
+        assertTrue(ApplicationUtils.compareVersions("3.5.3", "4.2.1") < 0);
+
+        // Other Version Formats
+        assertTrue(ApplicationUtils.compareVersions("1.2.3", "0.0") > 0);
+        assertTrue(ApplicationUtils.compareVersions("0.0", "0.0") == 0);
+        assertTrue(ApplicationUtils.compareVersions("0", "0.0") == 0);
+        assertTrue(ApplicationUtils.compareVersions("0.0", "1.2.3") < 0);
+    }
+}

--- a/version/news/NEWS-2023.06.2-mountain-hydrangea.md
+++ b/version/news/NEWS-2023.06.2-mountain-hydrangea.md
@@ -17,6 +17,7 @@
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug preventing Update Available from displaying (#13347)
 - Fixed bug causing dataframe help preview to fail for nested objects (#13291)
+- Fixed bug where clicking "Ignore Update" would fail to ignore the update (#13379)
 
 #### Posit Workbench
 - Caching of passwd lookups for a few more api calls including the process info api used by load balancing (rstudio/rstudio-pro#4800)


### PR DESCRIPTION
### Intent

- Backports PR: #13386
- Main Issue: #13379 
- Backport Issue: #13380 

### Approach

Cherry-picked the commit. Resolved NEWS merge conflict.

### Automated Tests

see #13386

### QA Notes

When a release newer than 2023.06.2 is available (i.e. Desert Sunflower), we will be able to verify this fix in 2023.06.2. We may be able to verify this using the Desert Sunflower dailies?

### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


