### PR TITLE
Backport  for 4027 - terminal resume current working directory

### DIFF
--- a/src/cpp/core/system/PosixSystem.cpp
+++ b/src/cpp/core/system/PosixSystem.cpp
@@ -1377,7 +1377,7 @@ FilePath currentWorkingDirViaProcFs(PidType pid)
 
    // /proc/PID/cwd is a symbolic link to the process' current working directory
    FilePath pidPath = procFsPath.completePath(procId).completePath("cwd");
-   if (pidPath.isSymlink())
+   if (pidPath.isSymlink() && pidPath.exists())
       return pidPath.resolveSymlink();
    else
       return FilePath();

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -726,13 +726,14 @@ void ConsoleProcess::onHasSubprocs(bool hasNonIgnoredSubprocs, bool hasIgnoredSu
 
 void ConsoleProcess::reportCwd(const core::FilePath& cwd)
 {
-   if (procInfo_->getCwd() != cwd)
+   if (procInfo_->getCwd() != cwd && cwd.exists())
    {
-      procInfo_->setCwd(cwd);
+      FilePath resolvedCwd = cwd.resolveSymlink();
+      procInfo_->setCwd(resolvedCwd);
 
       json::Object termCwd;
       termCwd["handle"] = handle();
-      termCwd["cwd"] = module_context::createAliasedPath(cwd);
+      termCwd["cwd"] = module_context::createAliasedPath(resolvedCwd);
       module_context::enqueClientEvent(
             ClientEvent(client_events::kTerminalCwd, termCwd));
       childProcsSent_ = true;

--- a/src/cpp/session/SessionConsoleProcessInfo.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfo.cpp
@@ -212,7 +212,7 @@ core::json::Object ConsoleProcessInfo::toJson(SerializationMode serialMode) cons
    result["channel_mode"] = static_cast<int>(channelMode_);
    result["channel_id"] = channelId_;
    result["alt_buffer"] = altBufferActive_;
-   result["cwd"] = module_context::createAliasedPath(cwd_);
+   result["cwd"] = module_context::createAliasedPath(cwd_.resolveSymlink());
    result["cols"] = cols_;
    result["rows"] = rows_;
    result["restarted"] = restarted_;

--- a/src/cpp/session/SessionConsoleProcessInfoTests.cpp
+++ b/src/cpp/session/SessionConsoleProcessInfoTests.cpp
@@ -254,6 +254,7 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(sameCpi(cpiOrig, *pCpiRestored));
    }
 
+#ifdef __linux__
    SECTION("Restore with cwd symlink")
    {
       // ensure file does not exist so symlink can be created
@@ -277,6 +278,7 @@ TEST_CASE("ConsoleProcessInfo")
       CHECK(pCpiRestored->getCwd().getAbsolutePath() == cpiOrig.getCwd().resolveSymlink().getAbsolutePath());
       cwdLink.remove();
    }
+#endif
 
    SECTION("Persist and restore for non-terminals")
    {

--- a/version/news/NEWS-2023.06.2-mountain-hydrangea.md
+++ b/version/news/NEWS-2023.06.2-mountain-hydrangea.md
@@ -17,6 +17,7 @@
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug preventing Update Available from displaying (#13347)
 - Fixed bug causing dataframe help preview to fail for nested objects (#13291)
+- Fixed bug when resuming session not restoring current working directory for Terminal pane (rstudio/rstudio-pro#4027)
 
 #### Posit Workbench
 - Caching of passwd lookups for a few more api calls including the process info api used by load balancing (rstudio/rstudio-pro#4800)


### PR DESCRIPTION
### Intent
Address #13251 

### Approach
Cherry picked commits

Updated readme for patch 2

### Automated Tests
n/a

### QA Notes
none 

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


