### PR TITLE
Switch from altool to notarytool

### DIFF
--- a/docker/jenkins/notarize-release.sh
+++ b/docker/jenkins/notarize-release.sh
@@ -45,91 +45,20 @@ fi
 
 # Submit the notarization request to Apple
 echo "Submitting notarization request using account $APPLE_ID_USR..."
-XCRUN_RESULT="$(mktemp)"
-xcrun altool --notarize-app \
-    --primary-bundle-id "org.rstudio.RStudio" \
-    --username $APPLE_ID_USR \
-    --password "@env:APPLE_ID_PSW" \
-    --file $1 \
-    --output-format xml \
-    -itc_provider RStudioInc > $XCRUN_RESULT
+xcrun notarytool submit --wait \
+    --apple-id $APPLE_ID_USR \
+    --password $APPLE_ID_PSW \
+    --team-id FYF2F5GFX4 \
+    --progress \
+    $1
 
 # Check result
 if [ $? -eq 0 ]; then
-    # Extract the request UUID from the result
-    REQUEST_UUID=$(/usr/libexec/PlistBuddy -c "Print :notarization-upload:RequestUUID" $XCRUN_RESULT)
-    echo "Notarization request with UUID $REQUEST_UUID created."
-else
-    echo "Notarization request submission failed. Server response:"
-    cat $XCRUN_RESULT
-    exit 1
-fi
-
-# Counter for the number of queries we have made
-QUERIES=0
-
-# Wait for notarization to complete
-echo "Waiting for notarization to complete. This will take several minutes."
-while true; do 
-
-    # Wait for Apple to do its thing
-    sleep 30
-
-    # Use xcrun to inquire about the status of the notarization request we just made
-    ((QUERIES=QUERIES+1))
-    echo "Checking notarization status (query $QUERIES)..."
-    xcrun altool --notarization-info $REQUEST_UUID --username $APPLE_ID_USR --password "@env:APPLE_ID_PSW" --output-format xml > $XCRUN_RESULT
-
-    # Use PlistBuddy (ships with macOS) to parse the XML and extract the status
-    NOTARIZATION_STATUS=$(/usr/libexec/PlistBuddy -c "Print :notarization-info:Status" $XCRUN_RESULT)
-
-    if [ $? -eq 0 ]; then
-        if [ "$NOTARIZATION_STATUS" != "in progress" ]; then 
-            echo "Notarization ended; result: $NOTARIZATION_STATUS"
-            break
-        fi
-        echo "Notarization still in progress. Waiting 30s to check again."
-    else
-        # Sometimes Apple will give us a request UUID, but then deny it exists
-        # when we query its status. This is somewhat rare (perhaps around 5% of
-        # notarization requests); we hypothesize that it's because the
-        # notarization request UUID may take more than 30s to fully register
-        # with Apple's servers. To work around the problem, we retry again with
-        # the same UUID.
-        ERROR_CODE=$(/usr/libexec/PlistBuddy -c "Print :product-errors:0:code" $XCRUN_RESULT)
-        if [ "$ERROR_CODE" -eq "1519" ]; then
-            # Error code 1519 = "Could not find the RequestUUID."
-            echo "Notarization request UUID not ready. Waiting 30s to try again."
-        elif [ "$ERROR_CODE" -eq "-1011" ]; then
-            # Error code -1011 = "Unable to get notarization info."
-            echo "Temporarily unable to look up notarization info. Waiting 30s to try again."
-        else 
-            # Some other error, which is not something we know how to handle
-            # and should consequently result in termination.
-            echo "Could not determine notarization status; giving up with unknown error $ERROR_CODE. Server response:" 
-            cat $XCRUN_RESULT
-            exit 1
-        fi
-    fi
-    
-    # We don't want to hang the build indefinitely, so stop now if we have
-    # spent more than 60 minutes waiting for a response (Apple indicates that
-    # this should actually take 5 minutes).
-    #
-    # https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow
-    if [ $QUERIES -gt 120 ]; then
-        echo "Notarization not ready after an hour; giving up."
-        exit 1
-    fi
-done
-
-# Staple the notarization ticket to the app bundle
-if [ "$NOTARIZATION_STATUS" == "success" ]; then
-    echo "Notarization successful; stapling ticket to app bundle"
-    xcrun stapler staple $1
+    echo "Notarization completed successfully."
 else
     echo "Notarization failed."
-    cat $XCRUN_RESULT
     exit 1
 fi
 
+# Staple the result to DMG file (allows offline verification of notarization)
+xcrun stapler staple $1

--- a/docker/jenkins/notarize-release.sh
+++ b/docker/jenkins/notarize-release.sh
@@ -45,6 +45,8 @@ fi
 
 # Submit the notarization request to Apple
 echo "Submitting notarization request using account $APPLE_ID_USR..."
+
+# The team-id uniquely identifies the organization with Apple. It does not need to be generated again and is found in the Apple developer account.
 xcrun notarytool submit --wait \
     --apple-id $APPLE_ID_USR \
     --password $APPLE_ID_PSW \


### PR DESCRIPTION
### Intent
Address #11863 

### Approach
Change `notarize-release.sh` to call `notarytool`. Added the `team-id` option as it is now required. The id does not need to be private.

The command uses the `--progress` and `--wait` options so there is no need to poll the notarization service for updates.

When there is a team Apple ID account, the Jenkins credentials can be updated along with the new `team-id`.

### Automated Tests
Successfully built here: https://build.posit.it/job/IDE/job/OS-Builds/job/Platforms/job/macos-pipeline/job/macos-notarytool/3/

### QA Notes
None. 

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


