### PR TITLE
skip pre-commit hook if lint-staged not present

### DIFF
--- a/git_hooks/hooks/pre-commit
+++ b/git_hooks/hooks/pre-commit
@@ -3,4 +3,9 @@
 # A pre-commit hook script to run linting and formatting on staged files based
 # on the lint-staged, prettier and eslint configurations in src/node/desktop.
 
-cd ./src/node/desktop && npx lint-staged
+if [[ -f ./src/node/desktop/.lintstagedrc ]]
+then
+    cd ./src/node/desktop && npx lint-staged
+fi
+
+exit 0


### PR DESCRIPTION
### Intent

Fixes `✖ No valid configuration found.` error that arises when this pre-commit hook is run, but you're committing to a version of the project that doesn't have lint-staged set up (eg. when committing to the `rel-cherry-blossom` branch).

### Approach

Check that `./src/node/desktop/.lintstagedrc` exists before running `lint-staged`. This file doesn't exist in some branches, so committing can fail.

### Automated Tests
none

### QA Notes

Anyone using the `pre-commit` hooks should run `set-up-git-hooks` again to get this change, or copy the updated `pre-commit` hook changes to your `.git/hooks` directory. See `git_hooks/README.md` for instructions.

### Documentation
none

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~ 
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


