### PR TITLE
Enable cancelling copilot auth

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/ui/CopilotSignInDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/ui/CopilotSignInDialog.java
@@ -4,6 +4,7 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ElementPanel;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
 
 import com.google.gwt.aria.client.Roles;
@@ -45,11 +46,10 @@ public class CopilotSignInDialog extends ModalDialogBase
       Event.sinkEvents(verificationUri_, Event.ONMOUSEUP);
       Event.setEventListener(verificationUri_, (event) ->
       {
-         progress_.onProgress("Authenticating...");
+         progress_.onProgress("Authenticating...", () -> progress_.clearProgress());
       });
-      
+
       addCancelButton();
-      
    }
    
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/ui/CopilotSignInDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/ui/CopilotSignInDialog.java
@@ -4,14 +4,15 @@ import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.ElementPanel;
 import org.rstudio.core.client.widget.ModalDialogBase;
 import org.rstudio.core.client.widget.ProgressIndicator;
-import org.rstudio.core.client.widget.ThemedButton;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.AnchorElement;
+import com.google.gwt.dom.client.BrowserEvents;
 import com.google.gwt.dom.client.DivElement;
 import com.google.gwt.dom.client.SpanElement;
+import com.google.gwt.event.dom.client.KeyCodes;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Event;
@@ -34,7 +35,7 @@ public class CopilotSignInDialog extends ModalDialogBase
    {
       super(Roles.getDialogRole());
       setText("GitHub Copilot: Sign in");
-      
+
       ui_ = uiBinder.createAndBindUi(this);
       progress_ = addProgressIndicator();
       verificationUri_.setInnerText(verificationUri);
@@ -42,10 +43,11 @@ public class CopilotSignInDialog extends ModalDialogBase
       verificationCode_.setInnerText(verificationCode);
       verificationCode_.getStyle().setProperty("userSelect", "all");
       
-      Event.sinkEvents(verificationUri_, Event.ONCLICK);
-      Event.sinkEvents(verificationUri_, Event.ONMOUSEUP);
+      Event.sinkEvents(verificationUri_, Event.ONCLICK | Event.ONMOUSEUP | Event.ONKEYDOWN);
       Event.setEventListener(verificationUri_, (event) ->
       {
+         if (BrowserEvents.KEYDOWN.equals(event.getType()) && event.getKeyCode() != KeyCodes.KEY_ENTER)
+            return;
          progress_.onProgress("Authenticating...", () -> progress_.clearProgress());
       });
 


### PR DESCRIPTION
### Intent

- Addresses #13312
- Also adds Enter key support on the verification URI

#### Demo
https://github.com/rstudio/rstudio/assets/25834218/d050bb5d-5927-4237-9fb3-097464e81906

### Approach

- add `onCancel` to verification URI progress indicator
- check for Enter keydown to also trigger progress indicator

### Automated Tests

none

### QA Notes

A user can now cancel the auth progress indicator and continue using RStudio without having to quit the application first.

### Documentation

none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


