### PR TITLE
Re-enable completions for ellipses `...` parameter

### DIFF
--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -1030,7 +1030,7 @@ assign(x = ".rs.acCompletionTypes",
       
       # arguments that are already used by the matched call
       used <- names(as.list(matchedCall)[-1]) 
-      keep <- !names(formals$formals) %in% c("...", used)
+      keep <- !names(formals$formals) %in% used
 
       result <- .rs.appendCompletions(
          argCompletions,


### PR DESCRIPTION
### Intent

- Addresses part of https://github.com/rstudio/rstudio/issues/13196

<img width="812" alt="image" src="https://github.com/rstudio/rstudio/assets/25834218/e426efe4-d174-45c5-9bca-94a1fd546acd">


### Approach

- Reverted commit 6786f041d98d214c4ed89f81aa45ef04c043ca95

### Automated Tests

none

### QA Notes

When viewing the autocompletion / help for an R function that has a triple ellipses parameter `...`, a user should see the `...` parameter in the completions list and view the help text associated with it.

Steps
- `dplyr::left_join(` + tab
- `...` should show in the completion list as seen in the screenshot above

Note that the user will be able to "select" the `...` parameter which inserts `... = ` into their code. Although this is invalid code, we don't currently have a way to show completions/help text while also disabling the code insert when the completion is selected. See discussion in #13196 for more context.

### Documentation
none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
~- [] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


