### PR TITLE
install tzdata-java in rhel9 dockerfile

### DIFF
--- a/docker/jenkins/Dockerfile.rhel9
+++ b/docker/jenkins/Dockerfile.rhel9
@@ -68,6 +68,11 @@ RUN dnf install -y \
     xorg-x11-server-Xvfb \
     zlib-devel
 
+# The latest redhat build of java-11-openjdk (11.0.20.0.8-2.el9) is missing a dependency on tzdata-java
+# https://bugzilla.redhat.com/show_bug.cgi?id=2225018 
+# use the workaround until they resolve the issue
+RUN dnf install -y tzdata-java
+
 # ensure we use the java 11 compiler to build GWT
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk
 


### PR DESCRIPTION
Adresses rhel9 build failures on all branches during the Build & Sign stage.

<details><summary>Error</summary>
<p>

```
2023-07-25 17:50:22  Buildfile: /tmp/jenkins-d32a18b1/workspace/IDE/Pro-Builds/Platforms/linux-pipeline/main/src/gwt/build.xml
2023-07-25 17:50:22  Caught an exception while logging the end of the build.  Exception was:
2023-07-25 17:50:22  java.lang.NoClassDefFoundError: Could not initialize class sun.util.calendar.ZoneInfoFile
2023-07-25 17:50:22  	at java.base/sun.util.calendar.ZoneInfo.getTimeZone(ZoneInfo.java:588)
2023-07-25 17:50:22  	at java.base/java.util.TimeZone.getTimeZone(TimeZone.java:577)
2023-07-25 17:50:22  	at java.base/java.util.TimeZone.setDefaultZone(TimeZone.java:682)
2023-07-25 17:50:22  	at java.base/java.util.TimeZone.getDefaultRef(TimeZone.java:653)
2023-07-25 17:50:22  	at java.base/java.util.TimeZone.getDefault(TimeZone.java:642)
2023-07-25 17:50:22  	at java.base/java.util.Calendar.defaultTimeZone(Calendar.java:1679)
2023-07-25 17:50:22  	at java.base/java.util.Calendar.getInstance(Calendar.java:1660)
2023-07-25 17:50:22  	at java.base/java.text.SimpleDateFormat.initializeCalendar(SimpleDateFormat.java:676)
2023-07-25 17:50:22  	at java.base/java.text.SimpleDateFormat.<init>(SimpleDateFormat.java:620)
2023-07-25 17:50:22  	at org.apache.tools.ant.util.DateUtils.<clinit>(DateUtils.java:72)
2023-07-25 17:50:22  	at org.apache.tools.ant.DefaultLogger.formatTime(DefaultLogger.java:304)
2023-07-25 17:50:22  	at org.apache.tools.ant.DefaultLogger.buildFinished(DefaultLogger.java:175)
2023-07-25 17:50:22  	at org.apache.tools.ant.Project.fireBuildFinished(Project.java:2111)
2023-07-25 17:50:22  	at org.apache.tools.ant.Main.runBuild(Main.java:845)
2023-07-25 17:50:22  	at org.apache.tools.ant.Main.startAnt(Main.java:223)
2023-07-25 17:50:22  	at org.apache.tools.ant.launch.Launcher.run(Launcher.java:284)
2023-07-25 17:50:22  	at org.apache.tools.ant.launch.Launcher.main(Launcher.java:101)
2023-07-25 17:50:22  There has been an error prior to that:
2023-07-25 17:50:22  java.lang.Error: java.io.FileNotFoundException: /usr/lib/jvm/java-11-openjdk-11.0.20.0.8-2.el9.aarch64/lib/tzdb.dat (No such file or directory)
```

</p>
</details> 


@sharon-wang  found this [issue](https://bugzilla.redhat.com/show_bug.cgi?id=2225018) reporting that the latest redhat build of java-11-openjdk version is missing a dependency on `tzdata-java`.

This PR updates the rhel9 dockerfile to explicitly install it using the workaround provided in the linked issue, so that we can get builds working again in the mean time.
