### PR TITLE
gpg signed commits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 - Prometheus metrics are available in Posit Workbench (rstudio-pro:#3273)
 - Update to Electron 25.2.0 (#13322)
 - Additional support for publishing new content types to Posit Cloud (rstudio-pro#4541)
+- Added option to sign Git commits (#1865)
 
 ### Fixed
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -290,6 +290,7 @@ namespace prefs {
 #define kGlobalThemeDefault "default"
 #define kGlobalThemeAlternate "alternate"
 #define kGitDiffIgnoreWhitespace "git_diff_ignore_whitespace"
+#define kGitSignedCommits "git_signed_commits"
 #define kConsoleDoubleClickSelect "console_double_click_select"
 #define kConsoleSuspendBlockedNotice "console_suspend_blocked_notice"
 #define kConsoleSuspendBlockedNoticeDelay "console_suspend_blocked_notice_delay"
@@ -1386,6 +1387,12 @@ public:
     */
    bool gitDiffIgnoreWhitespace();
    core::Error setGitDiffIgnoreWhitespace(bool val);
+
+  /**
+   * Whether to sign git commits.
+   */
+  bool gitSignedCommits();
+  core::Error setGitSignedCommits(bool val);
 
    /**
     * Whether double-clicking should select a word in the Console pane.

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -869,6 +869,7 @@ public:
    core::Error commit(std::string message,
                       bool amend,
                       bool signOff,
+                      bool gpgSign,
                       boost::shared_ptr<ConsoleProcess>* ppCP)
    {
       using namespace string_utils;
@@ -943,6 +944,8 @@ public:
          args << "--amend";
       if (signOff)
          args << "--signoff";
+      if (gpgSign)
+        args << "--gpg-sign";
 
       return createConsoleProc(args,
                                "Git Commit",
@@ -1855,13 +1858,13 @@ Error vcsCommit(const json::JsonRpcRequest& request,
                 json::JsonRpcResponse* pResponse)
 {
    std::string commitMsg;
-   bool amend, signOff;
-   Error error = json::readParams(request.params, &commitMsg, &amend, &signOff);
+   bool amend, signOff, gpgSign;
+   Error error = json::readParams(request.params, &commitMsg, &amend, &signOff, &gpgSign);
    if (error)
       return error;
 
    boost::shared_ptr<ConsoleProcess> pCP;
-   error = s_git_.commit(commitMsg, amend, signOff, &pCP);
+   error = s_git_.commit(commitMsg, amend, signOff, gpgSign, &pCP);
    if (error)
    {
       if (error == systemError(boost::system::errc::illegal_byte_sequence, ErrorLocation()))

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -2104,6 +2104,19 @@ core::Error UserPrefValues::setGitDiffIgnoreWhitespace(bool val)
 }
 
 /**
+ * Whether to sign git commits.
+ */
+bool UserPrefValues::gitSignedCommits()
+{
+   return readPref<bool>("git_signed_commits");
+}
+
+core::Error UserPrefValues::setGitSignedCommits(bool val)
+{
+   return writePref("git_signed_commits", val);
+}
+
+/**
  * Whether double-clicking should select a word in the Console pane.
  */
 bool UserPrefValues::consoleDoubleClickSelect()
@@ -3384,6 +3397,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kWrapTabNavigation,
       kGlobalTheme,
       kGitDiffIgnoreWhitespace,
+      kGitSignedCommits,
       kConsoleDoubleClickSelect,
       kConsoleSuspendBlockedNotice,
       kConsoleSuspendBlockedNoticeDelay,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1101,6 +1101,12 @@
             "title": "Ignore whitespace in VCS diffs",
             "description": "Whether to ignore whitespace when generating diffs of version controlled files."
         },
+        "git_signed_commits": {
+            "type": "boolean",
+            "default": false,
+            "title": "Sign git commits",
+            "description": "Whether to sign git commits."
+        },
         "console_double_click_select": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/vcs/GitServerOperations.java
@@ -85,6 +85,7 @@ public interface GitServerOperations extends VCSServerOperations
    void gitCommit(String message,
                   boolean amend,
                   boolean signOff,
+                  boolean gpgSign,
                   ServerRequestCallback<ConsoleProcess> requestCallback);
 
    void gitDiffFile(String path,

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2857,12 +2857,14 @@ public class RemoteServer implements Server
    public void gitCommit(String message,
                          boolean amend,
                          boolean signOff,
+                         boolean gpgSign,
                          ServerRequestCallback<ConsoleProcess> requestCallback)
    {
       JSONArray params = new JSONArray();
       params.set(0, new JSONString(message));
       params.set(1, JSONBoolean.getInstance(amend));
       params.set(2, JSONBoolean.getInstance(signOff));
+      params.set(3, JSONBoolean.getInstance(gpgSign));
       sendRequest(RPC_SCOPE, GIT_COMMIT, params,
                   new ConsoleProcessCallbackAdapter(requestCallback));
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -2332,6 +2332,17 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether to sign commits.
+    */
+   public PrefValue<Boolean> gitSignedCommits() {
+     return bool(
+         "git_signed_commits",
+         _constants.gitSignedCommitsTitle(),
+         _constants.gitSignedCommitsDescription(),
+         false);
+   }
+
+   /**
     * Whether double-clicking should select a word in the Console pane.
     */
    public PrefValue<Boolean> consoleDoubleClickSelect()
@@ -3839,6 +3850,8 @@ public class UserPrefsAccessor extends Prefs
          globalTheme().setValue(layer, source.getString("global_theme"));
       if (source.hasKey("git_diff_ignore_whitespace"))
          gitDiffIgnoreWhitespace().setValue(layer, source.getBool("git_diff_ignore_whitespace"));
+      if (source.hasKey("git_signed_commits"))
+         gitSignedCommits().setValue(layer, source.getBool("git_signed_commits"));
       if (source.hasKey("console_double_click_select"))
          consoleDoubleClickSelect().setValue(layer, source.getBool("console_double_click_select"));
       if (source.hasKey("console_suspend_blocked_notice"))
@@ -4175,6 +4188,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(wrapTabNavigation());
       prefs.add(globalTheme());
       prefs.add(gitDiffIgnoreWhitespace());
+      prefs.add(gitSignedCommits());
       prefs.add(consoleDoubleClickSelect());
       prefs.add(consoleSuspendBlockedNotice());
       prefs.add(consoleSuspendBlockedNoticeDelay());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -1350,6 +1350,15 @@ public interface UserPrefsAccessorConstants extends Constants {
    String gitDiffIgnoreWhitespaceDescription();
 
    /**
+    * Whether to sign commits.
+    */
+   @DefaultStringValue("Sign commits")
+   String gitSignedCommitsTitle();
+
+   @DefaultStringValue("Whether to sign commits.")
+   String gitSignedCommitsDescription();
+
+   /**
     * Whether double-clicking should select a word in the Console pane.
     */
    @DefaultStringValue("Double click to select in the Console")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -680,6 +680,10 @@ globalThemeDescription = The theme to use for the main RStudio user interface.
 gitDiffIgnoreWhitespaceTitle = Ignore whitespace in VCS diffs
 gitDiffIgnoreWhitespaceDescription = Whether to ignore whitespace when generating diffs of version controlled files.
 
+# Whether to sign git commits with a GPG key
+gitSignedCommitsTitle = Sign commits
+gitSignedCommitsDescription = Whether to sign commits.
+
 # Whether double-clicking should select a word in the Console pane.
 consoleDoubleClickSelectTitle = Double click to select in the Console
 consoleDoubleClickSelectDescription = Whether double-clicking should select a word in the Console pane.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_fr.properties
@@ -663,6 +663,10 @@ globalThemeDescription= Le thème à utiliser pour l''interface utilisateur prin
 gitDiffIgnoreWhitespaceTitle= Ignorer les espaces dans les diffs VCS
 gitDiffIgnoreWhitespaceDescription= Indiquer ou non, si les espaces blancs doivent être ignorés lors de la génération des différences de fichiers contrôlés par version.
 
+# Whether to sign git commits with a GPG key
+gitSignedCommitsTitle= Signer les commits Git avec une clé GPG
+gitSignedCommitsDescription = Si on doit signer les commits git avec une clé GPG
+
 # Whether double-clicking should select a word in the Console pane.
 consoleDoubleClickSelectTitle= Double-cliquer pour sélectionner dans la console
 consoleDoubleClickSelectDescription= Si un double-clic doit sélectionner un mot dans le volet de la console.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.css
@@ -145,3 +145,11 @@
 .ignoreWhitespace label {
    margin-left: 4px;
 }
+
+.signedCommits {
+  margin-left: 10px;
+}
+
+.signedCommits label {
+  margin-left: 4px;
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.java
@@ -120,6 +120,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
 
       String splitPanelCommit();
       String ignoreWhitespace();
+
+      String signedCommits();
    }
 
    @SuppressWarnings("unused")
@@ -574,6 +576,11 @@ public class GitReviewPanel extends ResizeComposite implements Display
    }
 
    @Override
+   public HasValue<Boolean> getSignedCommitsCheckBox() {
+     return signedCommitsCheckbox_;
+   }
+
+   @Override
    public LineTablePresenter.Display getLineTableDisplay()
    {
       return lines_;
@@ -756,6 +763,8 @@ public class GitReviewPanel extends ResizeComposite implements Display
    HorizontalPanel toolbarWrapper_;
    @UiField
    CheckBox ignoreWhitespaceCheckbox_;
+   @UiField
+   CheckBox signedCommitsCheckbox_;
 
    private ListBoxAdapter listBoxAdapter_;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -78,6 +78,10 @@
                                   text="Ignore Whitespace"
                                   checked="false"
                                   styleName="{res.styles.ignoreWhitespace}"><ui:attribute name="text" key="ignoreWhitespaceText"/></g:CheckBox>
+                      <g:CheckBox ui:field="signedCommitsCheckbox_"
+                                  text="Signed Commits"
+                                  checked="false"
+                                  styleName="{res.styles.signedCommits}"><ui:attribute name="text" key="signedCommitsText"/></g:CheckBox>
                   </g:FlowPanel>
                   <rs_widget:Toolbar ui:field="diffToolbar_"/>
                </g:HorizontalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPresenter.java
@@ -93,6 +93,9 @@ public class GitReviewPresenter implements ReviewPresenter
       HasValue<Boolean> getStagedCheckBox();
       HasValue<Boolean> getUnstagedCheckBox();
       HasValue<Boolean> getIgnoreWhitespaceCheckBox();
+
+      HasValue<Boolean> getSignedCommitsCheckBox();
+
       LineTablePresenter.Display getLineTableDisplay();
       ChangelistTable getChangelistTable();
       HasValue<Integer> getContextLines();
@@ -509,6 +512,22 @@ public class GitReviewPresenter implements ReviewPresenter
                }
             });
 
+      view_.getSignedCommitsCheckBox().setValue(
+            uiPrefs_.gitSignedCommits().getGlobalValue());
+
+      view_.getSignedCommitsCheckBox().addValueChangeHandler(
+            new ValueChangeHandler<Boolean>()
+            {
+               @Override
+               public void onValueChange(ValueChangeEvent<Boolean> event)
+               {
+                  boolean value = event.getValue();
+                  uiPrefs_.gitSignedCommits().setGlobalValue(value);
+                  uiPrefs_.writeUserPrefs();
+                  updateDiff(false);
+               }
+            });
+
       view_.getLineTableDisplay().addDiffChunkActionHandler(new ApplyPatchHandler());
       view_.getLineTableDisplay().addDiffLineActionHandler(new ApplyPatchHandler());
 
@@ -640,6 +659,7 @@ public class GitReviewPresenter implements ReviewPresenter
                   view_.getCommitMessage().getText(),
                   view_.getCommitIsAmend().getValue(),
                   false,
+                  view_.getSignedCommitsCheckBox().getValue(),
                   new SimpleRequestCallback<ConsoleProcess>()
                   {
                      @Override


### PR DESCRIPTION
### Intent
Address #1865 

### Approach
Add a checkbox to the commit dialog to sign the commit. If the option is enabled, the commit cli call will add the git flag to sign the commit.

### Automated Tests
n/a

### QA Notes
The commit dialog has a checkbox to sign commits. The user must have a GPG key already added to their key store and configured in git. `git config --global user.sigingkey <gpg key id>`. The git dialog will display an error if there is no signing key present when committing.

### Documentation
The docs will need an update to mention the option to sign commits.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


