### PR TITLE
preserve whitespace in error message text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Added option to sign Git commits (#1865)
 
 ### Fixed
+- Fixed issue where whitespace in error messages was not properly preserved (#13239)
 - Fixed issue where error messages were not properly translated on Windows in some cases (#10308)
 - Fixed issue where Electron menubar commands are not disabled when modals are displayed (#12972)
 - Fixed bug causing invalid/empty `cacheKey` error when accessing a dataframe variable (#13188)

--- a/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/common/debugging/ui/ConsoleError.ui.xml
@@ -44,6 +44,7 @@
    }
    
    .errorMessage {
+      white-space: pre;
       display: inline;
       word-wrap: break-word;
       word-break: break-word;


### PR DESCRIPTION
### Intent

Addresses #13239.

### Approach

Straightforward CSS update to ensure whitespace is preserved.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13239.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

