### PR TITLE
Move git sign commit option

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanel.ui.xml
@@ -38,6 +38,10 @@
                         <g:layer left="6px" right="6px" bottom="0" height="30px">
                            <g:FlowPanel>
                               <g:CheckBox ui:field="commitIsAmend_" text="Amend previous commit"><ui:attribute name="text" key="amendPreviousCommit"/></g:CheckBox>
+                              <g:CheckBox ui:field="signedCommitsCheckbox_"
+                                          text="Sign commit"
+                                          checked="false"
+                                          styleName="{res.styles.signedCommits}"><ui:attribute name="text" key="signedCommitsText"/></g:CheckBox>
                               <rs_widget:ThemedButton ui:field="commitButton_"/>
                            </g:FlowPanel>
                         </g:layer>
@@ -78,10 +82,6 @@
                                   text="Ignore Whitespace"
                                   checked="false"
                                   styleName="{res.styles.ignoreWhitespace}"><ui:attribute name="text" key="ignoreWhitespaceText"/></g:CheckBox>
-                      <g:CheckBox ui:field="signedCommitsCheckbox_"
-                                  text="Signed Commits"
-                                  checked="false"
-                                  styleName="{res.styles.signedCommits}"><ui:attribute name="text" key="signedCommitsText"/></g:CheckBox>
                   </g:FlowPanel>
                   <rs_widget:Toolbar ui:field="diffToolbar_"/>
                </g:HorizontalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanelBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanelBinderImplGenMessages_en.properties
@@ -3,6 +3,8 @@
 
 amendPreviousCommit=Amend previous commit
 
+signedCommitsText=Sign commit
+
 commitMessage=Commit message
 
 contextText=Context

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanelBinderImplGenMessages_fr.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/vcs/git/dialog/GitReviewPanelBinderImplGenMessages_fr.properties
@@ -3,6 +3,8 @@
 
 amendPreviousCommit=Amender la livraison précédente
 
+signedCommitsText=Signer le commit
+
 commitMessage=Message de validation
 
 contextText=Contexte


### PR DESCRIPTION
### Intent
Address feedback for #1865 

### Approach
Places the signing option in the section directly related to the commit. Add translated string for the option.

### Automated Tests
n/a

### QA Notes
The option now appears under the commit message text area
![image](https://github.com/rstudio/rstudio/assets/9591545/2292746a-d705-4949-937b-a0e8cf0d8e9a)


### Documentation
none

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


