### PR TITLE
Upgrade semver package

### DIFF
--- a/src/node/desktop/package-lock.json
+++ b/src/node/desktop/package-lock.json
@@ -22,6 +22,7 @@
         "node-addon-api": "6.0.0",
         "node-system-fonts": "1.0.1",
         "properties-reader": "2.2.0",
+        "semver": "7.5.2",
         "uuid": "9.0.0",
         "vue": "3.2.47",
         "winston": "3.8.2",
@@ -12580,9 +12581,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -24585,9 +24586,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }

--- a/src/node/desktop/package.json
+++ b/src/node/desktop/package.json
@@ -81,6 +81,7 @@
     "node-addon-api": "6.0.0",
     "node-system-fonts": "1.0.1",
     "properties-reader": "2.2.0",
+    "semver": "7.5.2",
     "uuid": "9.0.0",
     "vue": "3.2.47",
     "winston": "3.8.2",


### PR DESCRIPTION
### Intent
Address #13448 

### Approach
Gets whitespace fix from semver 7.5.2 by upgrading semver explicitly. Nothing that we do depends directly on this package. It's pulled in because of Electron.

### Automated Tests
n/a

### QA Notes
No functional changes from taking this newer package

### Documentation
n/a

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


