### PR TITLE
improve detection of required plotting packages

### DIFF
--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -115,21 +115,26 @@
    par(mar = c(5.1, 4.1, 2.1, 2.1))
 })
 
+.rs.addFunction("replayNotebookPlotsPackages", function()
+{
+   grid <- asNamespace("grid")
+   names <- vapply(grid$.__S3MethodsTable__., function(method) {
+      environmentName(environment(method))
+   }, FUN.VALUE = character(1))
+   sort(unique(names))
+})
+
 .rs.addFunction("replayNotebookPlots", function(width, height, pixelRatio, tempFile, extraArgs) {
    
    require(grDevices, quietly = TRUE)
    
-   loadedPackages <- Sys.getenv("RS_LOADED_PACKAGES", unset = "")
-   loadedPackages <- strsplit(loadedPackages, ",", fixed = TRUE)[[1L]]
+   requiredPackages <- Sys.getenv("RS_NOTEBOOK_PACKAGES", unset = "")
+   requiredPackages <- strsplit(requiredPackages, ",", fixed = TRUE)[[1L]]
    
-   # TODO: It'd be really nice if we could somehow infer these from
-   # the grobs stored within the plot object.
-   # https://github.com/rstudio/rstudio/issues/4330
-   commonPackages <- c("ggplot2", "ggrepel", "ggforce")
    suppressPackageStartupMessages({
-      for (package in commonPackages)
-         if (package %in% loadedPackages)
-            require(package, character.only = TRUE, quietly = TRUE)
+      for (package in requiredPackages) {
+         library(package, character.only = TRUE, quietly = TRUE)
+      }
    })
    
    # open stdin (for consuming snapshots from parent process)

--- a/src/cpp/session/modules/NotebookPlots.R
+++ b/src/cpp/session/modules/NotebookPlots.R
@@ -133,7 +133,7 @@
    
    suppressPackageStartupMessages({
       for (package in requiredPackages) {
-         library(package, character.only = TRUE, quietly = TRUE)
+         require(package, character.only = TRUE, quietly = TRUE)
       }
    })
    

--- a/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookPlotReplay.cpp
@@ -98,15 +98,15 @@ public:
       core::system::Options environment;
       core::system::environment(&environment);
       
-      // pass along loaded packages
-      std::vector<std::string> loadedPackages;
-      Error error = r::exec::RFunction("base:::loadedNamespaces")
-            .call(&loadedPackages);
+      // pass along packages we might require for plotting
+      std::vector<std::string> requiredPackages;
+      Error error = r::exec::RFunction(".rs.replayNotebookPlotsPackages")
+            .call(&requiredPackages);
       if (error)
          LOG_ERROR(error);
       
       environment.push_back({ "R_LIBS", module_context::libPathsString() });
-      environment.push_back({ "RS_LOADED_PACKAGES", core::algorithm::join(loadedPackages, ",") });
+      environment.push_back({ "RS_NOTEBOOK_PACKAGES", core::algorithm::join(requiredPackages, ",") });
 
       // invoke the asynchronous process
       boost::shared_ptr<ReplayPlots> pReplayer(new ReplayPlots());


### PR DESCRIPTION
### Intent

Follow-up to https://github.com/rstudio/rstudio/issues/4330.

### Approach

Instead of hard-coding the set of packages, try to infer what packages are required based on the registered S3 methods for makeContent and makeContext.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/4330.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
