### PR TITLE
Fix modals causing edit commands to be disabled

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 - Fixed bug where clicking "Ignore Update" would fail to ignore the update (#13379)
 - Fixed bug preventing `HOME` from being modified in system init scripts (rstudio-pro:#4584)
 - Fixed issue with alignment of R argument names in Help pane (#13474)
+- Fixed bug with modals disabling copy/paste (#13365)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -286,10 +286,10 @@ export class MenuCallback extends EventEmitter {
    */
   updateMenus(): void {
     const newMainMenuTemplate = this.recursiveCopy(this.mainMenuTemplate);
-    this.mainMenu = Menu.buildFromTemplate(newMainMenuTemplate);
-
+    
     if (appState().modalTracker.numModalsShowing() === 0) {
       // update only if there are no modals showing
+      this.mainMenu = Menu.buildFromTemplate(newMainMenuTemplate);
       Menu.setApplicationMenu(this.mainMenu);
     }
     
@@ -499,12 +499,14 @@ export class MenuCallback extends EventEmitter {
           });
         });
         Menu.setApplicationMenu(disabledMenu);
+        this.mainMenu = disabledMenu;
       }
       return;
     }
-    const restoreSavedMenu = enabled && !!this.savedMenu && appState().modalTracker.numModalsShowing() === 0;
-    if (restoreSavedMenu) {
+    const restoreSavedMenu = enabled && appState().modalTracker.numModalsShowing() === 0;
+    if (restoreSavedMenu && this.savedMenu) {
       Menu.setApplicationMenu(this.savedMenu);
+      this.mainMenu = this.savedMenu;
       this.savedMenu = null;
       return;
     }


### PR DESCRIPTION
### Intent
Address #13365

### Approach
Rebuilds the menus with some commands enabled for editing and hiding the window. This allows the commands to still work. I think Electron shouldn't normally do this but we have dummy commands for these edit actions that might be a GWT necessity.

The recursive menu builder was refactored so it could be called when building the disabled menu.

### Automated Tests
Added a unit test

### QA Notes
There is a menu refresh that occurs when the IDE gains focus. This should maintain the menu state if a modal dialog is open.

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


