### PR TITLE
force appMode to 'static' for Quarto manuscript projects

### DIFF
--- a/src/cpp/session/modules/SessionRSConnect.cpp
+++ b/src/cpp/session/modules/SessionRSConnect.cpp
@@ -255,6 +255,16 @@ public:
       // determine quarto version and engines
       std::string quarto = (isQuarto && !asStatic) ? quartoMetadata(dir, file, contentCategory) : "";
 
+
+      // Quarto manuscripts contain .qmd files, and the default app mode for these is 'qmd-static';
+      // but we don't want Connect to attempt to render them, so force the app mode to 'static'.
+      std::string appModeOverride = "";
+      if (isQuarto &&
+          quarto::quartoConfig().project_type == "manuscript" &&
+          asStatic) {
+         appModeOverride = "appMode = 'static', ";
+      }
+
       // form the deploy command to hand off to the async deploy process
       cmd += "rsconnect::deployApp("
              "appDir = '" + string_utils::singleQuotedStrEscape(appDir) + "'," +
@@ -278,7 +288,8 @@ public:
              "launch.browser = function (url) { "
              "   message('" kFinishedMarker "', url) "
              "}, "
-             "lint = FALSE,"
+             "lint = FALSE," +
+             appModeOverride +
              "metadata = list(" +
                  quarto +
              "   asMultiple = " + (asMultiple ? "TRUE" : "FALSE") + ", "

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -251,7 +251,7 @@
             "source": false
         },
         "rsconnect": {
-            "version": "1.1.0",
+            "version": "0.8.24",
             "location": "cran",
             "source": true
         },

--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -251,7 +251,7 @@
             "source": false
         },
         "rsconnect": {
-            "version": "0.8.24",
+            "version": "1.1.0",
             "location": "cran",
             "source": true
         },


### PR DESCRIPTION
### Intent

Quarto Manuscripts, even when published statically, can include `qmd` files, which are included as downloadable source for qmd files which provided embedded plots, tables, or other resources for the manuscript. Prior to this change, when publishing to Connect, the presence of these `qmd` files would lead Connect to attempt to render the document (even for a static publish). 

### Approach

This change uses a new argument in deployApp which allows us to specify that static manuscript publishes should be treated completely statically.

### QA Notes

- This requires the most recent version of the reconnect package which is not yet published to CRAN
- Once published to CRAN, I will update package dependencies for RStudio to reflect that version
- A simple project which shows the behavior is attached

**[manuscript.zip](https://github.com/rstudio/rstudio/files/12362863/manuscript.zip)**

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


