### PR TITLE
Fix package build

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - Fixed bug preventing `HOME` from being modified in system init scripts (rstudio-pro:#4584)
 - Fixed issue with alignment of R argument names in Help pane (#13474)
 - Fixed bug with modals disabling copy/paste (#13365)
+- Removed unnecessary files from install packages (rstudo-pro:#4943)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -626,7 +626,9 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
    # templates
    install(DIRECTORY "resources/templates"
-           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
+           DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources
+           PATTERN ".gitignore"
+           EXCLUDE)
    # pandoc
    install(DIRECTORY "resources/pandoc"
            DESTINATION ${RSTUDIO_INSTALL_SUPPORTING}/resources)
@@ -695,15 +697,21 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
          if (RSTUDIO_ELECTRON)
             install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}" 
                   DESTINATION "${RSTUDIO_INSTALL_RESOURCES}/app"
-                  USE_SOURCE_PERMISSIONS)
+                  USE_SOURCE_PERMISSIONS
+                  PATTERN ".gitignore"
+                  EXCLUDE)
          else()
             install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"
                   DESTINATION "${RSTUDIO_INSTALL_BIN}"
                   USE_SOURCE_PERMISSIONS
-                  PATTERN "*/share" EXCLUDE)
+                  PATTERN "*/share"
+                  PATTERN ".gitignore"
+                  EXCLUDE)
             install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 
                   DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}/quarto"
-                  USE_SOURCE_PERMISSIONS)
+                  USE_SOURCE_PERMISSIONS
+                  PATTERN ".gitignore"
+                  EXCLUDE)
          endif()
       else()
          install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}"

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -705,6 +705,7 @@ if(NOT RSTUDIO_SESSION_WIN32 AND NOT RSESSION_ALTERNATE_BUILD)
                   DESTINATION "${RSTUDIO_INSTALL_BIN}"
                   USE_SOURCE_PERMISSIONS
                   PATTERN "*/share"
+                  EXCLUDE
                   PATTERN ".gitignore"
                   EXCLUDE)
             install(DIRECTORY "${RSTUDIO_DEPENDENCIES_QUARTO_DIR}/share" 

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -138,13 +138,17 @@ if(GWT_COPY)
    install(
       DIRECTORY www
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
-      PATTERN "WEB-INF" EXCLUDE)
+      PATTERN "WEB-INF"
+      PATTERN ".gitignore"
+      EXCLUDE)
 
    # install compiled GWT artefacts
    install(
       DIRECTORY "${GWT_WWW_DIR}"
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
-      PATTERN "WEB-INF" EXCLUDE)
+      PATTERN "WEB-INF"
+      PATTERN ".gitignore"
+      EXCLUDE)
 
    # copy symbol maps
    install(

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -139,6 +139,7 @@ if(GWT_COPY)
       DIRECTORY www
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
       PATTERN "WEB-INF"
+      EXCLUDE
       PATTERN ".gitignore"
       EXCLUDE)
 
@@ -147,6 +148,7 @@ if(GWT_COPY)
       DIRECTORY "${GWT_WWW_DIR}"
       DESTINATION "${RSTUDIO_INSTALL_SUPPORTING}"
       PATTERN "WEB-INF"
+      EXCLUDE
       PATTERN ".gitignore"
       EXCLUDE)
 


### PR DESCRIPTION
### Intent
Address rstudio/rstudio-pro#4943

### Approach
Add exclude rules for cmake install. A separate PR will handle the part of the package that is pro only. https://github.com/rstudio/rstudio-pro/pull/4966

### Automated Tests
n/a

### QA Notes
The package should not include `.gitignore` at all. This includes all platforms since any common parts like Quarto or GWT would have this unnecessary file included.

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


