### PR TITLE
support DBI tbl objects for autocompletions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 - Fixed bug preventing `HOME` from being modified in system init scripts (rstudio-pro:#4584)
 - Fixed issue with alignment of R argument names in Help pane (#13474)
 - Fixed bug with modals disabling copy/paste (#13365)
+- Fixed issue where column names weren't provided as completion candidates for DBI tables. (#12577)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -2942,10 +2942,14 @@ assign(x = ".rs.acCompletionTypes",
 
 .rs.addFunction("hasColumns", function(object)
 {
-   if (inherits(object, c("data.frame")))
+   if (inherits(object, c("data.frame", "tbl")))
       return(TRUE)
 
-   if (isNamespaceLoaded("arrow") && inherits(object, c("ArrowTabular", "Dataset", "arrow_dplyr_query")))
+   arrow <-
+      isNamespaceLoaded("arrow") &&
+      inherits(object, c("ArrowTabular", "Dataset", "arrow_dplyr_query"))
+
+   if (arrow)
       return(TRUE)
 
    FALSE


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12577.

### Approach

RStudio tries to determine whether an object can be successfully queried for column names, but was too restrictive in how it did so. This PR allows `tbl` objects to also be queried for table names.

For reference, all dplyr tables inherit from `tbl` as a "base" class; e.g. using the original issue's example:

```
> class(tbl)
[1] "tbl_SQLiteConnection" "tbl_dbi"              "tbl_sql"              "tbl_lazy"             "tbl"
```

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12577.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
