### PR TITLE
turn off symbol diagnostics in mutate()

### DIFF
--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1736,12 +1736,17 @@ std::set<std::string> makeNsePrimitives()
 
       // rlang tidy evaluation
       "enexpr",
+      "enexprs",
       "enquo",
       "enquos",
       "eval_tidy",
+      "quo",
+      "quos",
 
-      // dplyr
-      "dplyr_quosures"
+      // dplyr -- not really primitives
+      "dplyr_quosures",
+      "group_by",
+      "group_by_prepare"
       
    };
 }

--- a/src/cpp/r/RSexp.cpp
+++ b/src/cpp/r/RSexp.cpp
@@ -1710,28 +1710,40 @@ bool inherits(SEXP object, const char* S3Class)
    return Rf_inherits(object, S3Class);
 }
 
+// Keep in sync with 'nse.primitives' in SessionCodeTools.R
 std::set<std::string> makeNsePrimitives()
 {
-   std::set<std::string> nsePrimitives;
-   nsePrimitives.insert("quote");
-   nsePrimitives.insert("substitute");
-   nsePrimitives.insert("match.call");
-   nsePrimitives.insert("library");
-   nsePrimitives.insert("require");
-   nsePrimitives.insert("enquote");
-   nsePrimitives.insert("bquote");
-   nsePrimitives.insert("expression");
-   nsePrimitives.insert("evalq");
-   nsePrimitives.insert("subset");
-   nsePrimitives.insert("eval.parent");
-   nsePrimitives.insert("sys.call");
-   nsePrimitives.insert("sys.calls");
-   nsePrimitives.insert("sys.frame");
-   nsePrimitives.insert("sys.frames");
-   nsePrimitives.insert("sys.function");
-   nsePrimitives.insert("sys.parent");
-   nsePrimitives.insert("lazy_dots");
-   return nsePrimitives;
+   return {
+      
+      // base R primitives
+      "bquote",
+      "enquote",
+      "eval.parent",
+      "evalq",
+      "expression",
+      "library",
+      "match.call",
+      "quote",
+      "require",
+      "subset",
+      "substitute",
+      "sys.call",
+      "sys.calls",
+      "sys.frame",
+      "sys.frames",
+      "sys.function",
+      "sys.parent",
+
+      // rlang tidy evaluation
+      "enexpr",
+      "enquo",
+      "enquos",
+      "eval_tidy",
+
+      // dplyr
+      "dplyr_quosures"
+      
+   };
 }
 
 const std::set<std::string>& nsePrimitives()

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1491,6 +1491,8 @@
 # If a function internally calls out to one of these functions,
 # we assume that it may perform non-standard evaluation, and avoid
 # attempting certain diagnostics on its usages.
+#
+# Keep in sync with makeNsePrimitives() in RSexp.cpp
 .rs.setVar("nse.primitives", c(
    
    # base R primitives
@@ -1520,6 +1522,7 @@
    
    # dplyr
    "dplyr_quosures"
+   
 ))
 
 .rs.addFunction("performsNonstandardEvaluation", function(object)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1488,10 +1488,38 @@
  
 })
 
+# If a function internally calls out to one of these functions,
+# we assume that it may perform non-standard evaluation, and avoid
+# attempting certain diagnostics on its usages.
 .rs.setVar("nse.primitives", c(
-   "quote", "substitute", "match.call", "eval.parent",
-   "enquote", "bquote", "evalq", "lazy_dots", "compat_as_lazy_dots",
-   "select_vars", "quo", "quos", "enquo", "named_quos"
+   
+   # base R primitives
+   "bquote",
+   "enquote",
+   "eval.parent",
+   "evalq",
+   "expression",
+   "library",
+   "match.call",
+   "quote",
+   "require",
+   "subset",
+   "substitute",
+   "sys.call",
+   "sys.calls",
+   "sys.frame",
+   "sys.frames",
+   "sys.function",
+   "sys.parent",
+   
+   # rlang tidy evaluation
+   "enexpr",
+   "enquo",
+   "enquos",
+   "eval_tidy",
+   
+   # dplyr
+   "dplyr_quosures"
 ))
 
 .rs.addFunction("performsNonstandardEvaluation", function(object)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -1513,15 +1513,20 @@
    "sys.frames",
    "sys.function",
    "sys.parent",
-   
+
    # rlang tidy evaluation
    "enexpr",
+   "enexprs",
    "enquo",
    "enquos",
    "eval_tidy",
-   
-   # dplyr
-   "dplyr_quosures"
+   "quo",
+   "quos",
+
+   # dplyr -- not really primitives
+   "dplyr_quosures",
+   "group_by",
+   "group_by_prepare"
    
 ))
 

--- a/src/cpp/session/modules/SessionRParser.cpp
+++ b/src/cpp/session/modules/SessionRParser.cpp
@@ -438,9 +438,7 @@ bool mightPerformNonstandardEvaluation(const RTokenCursor& origin,
    // Drop down into R.
    bool cacheable = true;
    r::sexp::Protect protect;
-   SEXP symbolSEXP = resolveFunctionAssociatedWithCall(
-            cursor, &protect, &cacheable);
-   
+   SEXP symbolSEXP = resolveFunctionAssociatedWithCall(cursor, &protect, &cacheable);
    if (symbolSEXP == R_UnboundValue)
       return false;
    


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13512.

<img width="279" alt="Screenshot 2023-08-17 at 3 02 56 PM" src="https://github.com/rstudio/rstudio/assets/1976582/f9e9d47e-7c3a-4806-8b56-fc83a130608d">


### Approach

Since `dplyr::mutate.data.frame` uses `dplyr_quosures` for quasi-quotation and tidy evaluation, add that to our NSE primitives list.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13512.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
