### PR TITLE
add pref controlling whether workspace is saved / loaded on build

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -168,6 +168,7 @@ namespace prefs {
 #define kShowInlineToolbarForRCodeChunks "show_inline_toolbar_for_r_code_chunks"
 #define kHighlightCodeChunks "highlight_code_chunks"
 #define kSaveFilesBeforeBuild "save_files_before_build"
+#define kSaveAndReloadWorkspaceOnBuild "save_and_reload_workspace_on_build"
 #define kFontSizePoints "font_size_points"
 #define kHelpFontSizePoints "help_font_size_points"
 #define kEditorTheme "editor_theme"
@@ -937,6 +938,12 @@ public:
     */
    bool saveFilesBeforeBuild();
    core::Error setSaveFilesBeforeBuild(bool val);
+
+   /**
+    * Whether RStudio should save and reload the R workspace when building the project.
+    */
+   bool saveAndReloadWorkspaceOnBuild();
+   core::Error setSaveAndReloadWorkspaceOnBuild(bool val);
 
    /**
     * The default editor font size, in points.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1129,6 +1129,19 @@ core::Error UserPrefValues::setSaveFilesBeforeBuild(bool val)
 }
 
 /**
+ * Whether RStudio should save and reload the R workspace when building the project.
+ */
+bool UserPrefValues::saveAndReloadWorkspaceOnBuild()
+{
+   return readPref<bool>("save_and_reload_workspace_on_build");
+}
+
+core::Error UserPrefValues::setSaveAndReloadWorkspaceOnBuild(bool val)
+{
+   return writePref("save_and_reload_workspace_on_build", val);
+}
+
+/**
  * The default editor font size, in points.
  */
 double UserPrefValues::fontSizePoints()
@@ -3322,6 +3335,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kShowInlineToolbarForRCodeChunks,
       kHighlightCodeChunks,
       kSaveFilesBeforeBuild,
+      kSaveAndReloadWorkspaceOnBuild,
       kFontSizePoints,
       kHelpFontSizePoints,
       kEditorTheme,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -613,6 +613,12 @@
             "title": "Save files before building",
             "description": "Whether to save all open, unsaved files before building the project."
         },
+        "save_and_reload_workspace_on_build": {
+            "type": "boolean",
+            "default": true,
+            "title": "Save and reload R workspace on build",
+            "description": "Whether RStudio should save and reload the R workspace when building the project."
+        },
         "font_size_points": {
             "type": "number",
             "default": 10.0,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1288,6 +1288,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether RStudio should save and reload the R workspace when building the project.
+    */
+   public PrefValue<Boolean> saveAndReloadWorkspaceOnBuild()
+   {
+      return bool(
+         "save_and_reload_workspace_on_build",
+         _constants.saveAndReloadWorkspaceOnBuildTitle(), 
+         _constants.saveAndReloadWorkspaceOnBuildDescription(), 
+         true);
+   }
+
+   /**
     * The default editor font size, in points.
     */
    public PrefValue<Double> fontSizePoints()
@@ -3701,6 +3713,8 @@ public class UserPrefsAccessor extends Prefs
          highlightCodeChunks().setValue(layer, source.getBool("highlight_code_chunks"));
       if (source.hasKey("save_files_before_build"))
          saveFilesBeforeBuild().setValue(layer, source.getBool("save_files_before_build"));
+      if (source.hasKey("save_and_reload_workspace_on_build"))
+         saveAndReloadWorkspaceOnBuild().setValue(layer, source.getBool("save_and_reload_workspace_on_build"));
       if (source.hasKey("font_size_points"))
          fontSizePoints().setValue(layer, source.getDbl("font_size_points"));
       if (source.hasKey("help_font_size_points"))
@@ -4114,6 +4128,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(showInlineToolbarForRCodeChunks());
       prefs.add(highlightCodeChunks());
       prefs.add(saveFilesBeforeBuild());
+      prefs.add(saveAndReloadWorkspaceOnBuild());
       prefs.add(fontSizePoints());
       prefs.add(helpFontSizePoints());
       prefs.add(editorTheme());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -744,6 +744,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String saveFilesBeforeBuildDescription();
 
    /**
+    * Whether RStudio should save and reload the R workspace when building the project.
+    */
+   @DefaultStringValue("Save and reload R workspace on build")
+   String saveAndReloadWorkspaceOnBuildTitle();
+   @DefaultStringValue("Whether RStudio should save and reload the R workspace when building the project.")
+   String saveAndReloadWorkspaceOnBuildDescription();
+
+   /**
     * The default editor font size, in points.
     */
    @DefaultStringValue("Editor font size (points)")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -377,6 +377,10 @@ highlightCodeChunksDescription = Whether to highlight code chunks in R Markdown 
 saveFilesBeforeBuildTitle = Save files before building
 saveFilesBeforeBuildDescription = Whether to save all open, unsaved files before building the project.
 
+# Whether RStudio should save and reload the R workspace when building the project.
+saveAndReloadWorkspaceOnBuildTitle = Save and reload R workspace on build
+saveAndReloadWorkspaceOnBuildDescription = Whether RStudio should save and reload the R workspace when building the project.
+
 # The default editor font size, in points.
 fontSizePointsTitle = Editor font size (points)
 fontSizePointsDescription = The default editor font size, in points.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PackagesPreferencesPane.java
@@ -177,6 +177,7 @@ public class PackagesPreferencesPane extends PreferencesPane
       lessSpaced(useDevtools_);
       development.add(useDevtools_);
 
+      development.add(checkboxPref(uiPrefs.saveAndReloadWorkspaceOnBuild()));
       development.add(checkboxPref(constants_.developmentSaveLabel(), uiPrefs.saveFilesBeforeBuild()));
       development.add(checkboxPref(constants_.developmentNavigateLabel(), uiPrefs.navigateToBuildError()));
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/buildtools/BuildPresenter.java
@@ -14,17 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.views.buildtools;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.dom.client.HasClickHandlers;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.inject.Inject;
-
-import com.google.inject.Provider;
 import org.rstudio.core.client.CodeNavigationTarget;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
@@ -35,6 +24,7 @@ import org.rstudio.core.client.events.SelectionCommitEvent;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.SuspendAndRestartEvent;
+import org.rstudio.studio.client.application.model.SuspendOptions;
 import org.rstudio.studio.client.common.DelayedProgressRequestCallback;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.SimpleRequestCallback;
@@ -70,6 +60,17 @@ import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperatio
 import org.rstudio.studio.client.workbench.views.jobs.model.JobManager;
 import org.rstudio.studio.client.workbench.views.source.Source;
 import org.rstudio.studio.client.workbench.views.terminal.TerminalHelper;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.dom.client.HasClickHandlers;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class BuildPresenter extends BasePresenter
 {
@@ -199,8 +200,14 @@ public class BuildPresenter extends BasePresenter
             view_.buildCompleted();
             if (event.getRestartR())
             {
+               SuspendOptions options = userPrefs_.saveAndReloadWorkspaceOnBuild().getValue()
+                     ? SuspendOptions.createSaveAll(false)
+                     : SuspendOptions.createSaveMinimal(false);
+               
                eventBus_.fireEvent(
-                  new SuspendAndRestartEvent(event.getAfterRestartCommand()));
+                  new SuspendAndRestartEvent(
+                        options,
+                        event.getAfterRestartCommand()));
             }
          }
       });


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/7287.

### Approach

Adds a preference to allow users to control whether or not the R workspace is saved and reloaded when building a package.

### Automated Tests

N/A

### QA Notes

Test that, when building an R package, R objects in the workspace are not saved when this preference is unset:

<img width="653" alt="Screenshot 2023-08-17 at 3 54 19 PM" src="https://github.com/rstudio/rstudio/assets/1976582/d2ec5e0c-60a0-44dc-ad5c-f406a4e51583">

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
