### PR TITLE
explicitly forward DYLD_FALLBACK_LIBRARY_PATH

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@
 - Add section to theme generation that will use theme-specific color(s) to set colors of vim/emacs-mode cursor
 
 ### Fixed
+- Fixed issue where `DYLD_FALLBACK_LIBRARY_PATH` was not properly forwarded on macOS (#13085)
 - Fixed issue where 'ggrepel' plot annotations could disappear when a plot was redrawn in an R Markdown document (#4330)
 - Fixed issue where whitespace in error messages was not properly preserved (#13239)
 - Fixed issue where the Data Viewer could fail to render data.frames containing AsIs matrices (#13215)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13085.

### Approach

macOS SIP disallows inheritance of certain environment variables -- `DYLD_FALLBACK_LIBRARY_PATH` is one example. We need to explicitly forward it when launching the `rsession` for it to be visible.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13085.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
