### PR TITLE
allow user to control behavior of autocomplete + Tab key

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -424,6 +424,10 @@ namespace prefs {
 #define kDisableRendererAccessibility "disable_renderer_accessibility"
 #define kCopilotEnabled "copilot_enabled"
 #define kCopilotCompletionsDelay "copilot_completions_delay"
+#define kCopilotAllowAutomaticCompletions "copilot_allow_automatic_completions"
+#define kCopilotTabKeyBehavior "copilot_tab_key_behavior"
+#define kCopilotTabKeyBehaviorSuggestion "suggestion"
+#define kCopilotTabKeyBehaviorCompletions "completions"
 
 class UserPrefValues: public Preferences
 {
@@ -1916,6 +1920,18 @@ public:
     */
    int copilotCompletionsDelay();
    core::Error setCopilotCompletionsDelay(int val);
+
+   /**
+    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+    */
+   bool copilotAllowAutomaticCompletions();
+   core::Error setCopilotAllowAutomaticCompletions(bool val);
+
+   /**
+    * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+    */
+   std::string copilotTabKeyBehavior();
+   core::Error setCopilotTabKeyBehavior(std::string val);
 
 };
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -316,6 +316,7 @@ void setEditorInfo()
    editorInfoJson["name"] = "RStudio";
    editorInfoJson["version"] = RSTUDIO_VERSION;
    paramsJson["editorInfo"] = editorInfoJson;
+   paramsJson["editorPluginInfo"] = editorInfoJson;
    
    SEXP networkProxySEXP = r::options::getOption("rstudio.copilot.networkProxy");
    if (networkProxySEXP != R_NilValue)
@@ -425,6 +426,17 @@ void onStdout(ProcessOperations& operations, const std::string& stdOut)
       if (contentLength.empty())
       {
          ELOG("Internal error: response contains no Content-Length header.");
+         
+         if (copilotLogLevel() >= 2)
+         {
+            std::cerr << std::endl;
+            std::cerr << "RESPONSE" << std::endl;
+            std::cerr << "------------------" << std::endl;
+            std::cerr << stdOut << std::endl;
+            std::cerr << "------------------" << std::endl;
+            std::cerr << std::endl << std::endl;
+         }
+
          break;
       }
 

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3247,6 +3247,32 @@ core::Error UserPrefValues::setCopilotCompletionsDelay(int val)
    return writePref("copilot_completions_delay", val);
 }
 
+/**
+ * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+ */
+bool UserPrefValues::copilotAllowAutomaticCompletions()
+{
+   return readPref<bool>("copilot_allow_automatic_completions");
+}
+
+core::Error UserPrefValues::setCopilotAllowAutomaticCompletions(bool val)
+{
+   return writePref("copilot_allow_automatic_completions", val);
+}
+
+/**
+ * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+ */
+std::string UserPrefValues::copilotTabKeyBehavior()
+{
+   return readPref<std::string>("copilot_tab_key_behavior");
+}
+
+core::Error UserPrefValues::setCopilotTabKeyBehavior(std::string val)
+{
+   return writePref("copilot_tab_key_behavior", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3498,6 +3524,8 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDisableRendererAccessibility,
       kCopilotEnabled,
       kCopilotCompletionsDelay,
+      kCopilotAllowAutomaticCompletions,
+      kCopilotTabKeyBehavior,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1685,6 +1685,19 @@
             "default": 300,
             "title": "GitHub Copilot completions delay",
             "description": "The delay (in milliseconds) before GitHub Copilot completions are requested after the cursor position has changed."
+        },
+        "copilot_allow_automatic_completions": {
+            "type": "boolean",
+            "default": false,
+            "title": "Enable as-you-type code completions when Copilot is enabled",
+            "description": "When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled."
+        },
+        "copilot_tab_key_behavior": {
+            "type": "string",
+            "enum": ["suggestion", "completions"],
+            "enumReadable": ["Copilot Suggestion", "Code Completion"],
+            "title": "Pressing Tab key will prefer inserting:",
+            "description": "Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible."
         }
      }
 }

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1696,6 +1696,7 @@
             "type": "string",
             "enum": ["suggestion", "completions"],
             "enumReadable": ["Copilot Suggestion", "Code Completion"],
+            "default": "suggestion",
             "title": "Pressing Tab key will prefer inserting:",
             "description": "Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible."
         }

--- a/src/gwt/acesupport/acemode/auto_brace_insert.js
+++ b/src/gwt/acesupport/acemode/auto_brace_insert.js
@@ -132,13 +132,16 @@ define("mode/auto_brace_insert", ["require", "exports", "module"], function(requ
 
       this.allowAutoInsert = function(session, pos, text)
       {
-         return true;
+         return session.renderer.$ghostText == null;
       };
 
       // To enable this, call "this.allowAutoInsert = this.smartAllowAutoInsert"
       // in the mode subclass
       this.smartAllowAutoInsert = function(session, pos, text)
       {
+         if (session.renderer.$ghostText != null)
+            return false;
+
          // Always allow auto-insert for other insertion types
          if (text !== "'" && text !== '"' && text !== '`')
             return true;

--- a/src/gwt/acesupport/loader.js
+++ b/src/gwt/acesupport/loader.js
@@ -41,6 +41,7 @@ require("mixins/token_iterator"); // adds mixins to TokenIterator.prototype
 // RStudioEditor ----
 
 var RStudioEditor = function(renderer, session) {
+   session.renderer = renderer;
    Editor.call(this, renderer, session);
    this.setBehavioursEnabled(true);
 };

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3566,7 +3566,7 @@ public class UserPrefsAccessor extends Prefs
             COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION,
             COPILOT_TAB_KEY_BEHAVIOR_COMPLETIONS
          },
-         "",
+         "suggestion",
          new String[] {
             _constants.copilotTabKeyBehaviorEnum_suggestion(),
             _constants.copilotTabKeyBehaviorEnum_completions()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3541,6 +3541,41 @@ public class UserPrefsAccessor extends Prefs
          300);
    }
 
+   /**
+    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+    */
+   public PrefValue<Boolean> copilotAllowAutomaticCompletions()
+   {
+      return bool(
+         "copilot_allow_automatic_completions",
+         _constants.copilotAllowAutomaticCompletionsTitle(), 
+         _constants.copilotAllowAutomaticCompletionsDescription(), 
+         false);
+   }
+
+   /**
+    * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+    */
+   public PrefValue<String> copilotTabKeyBehavior()
+   {
+      return enumeration(
+         "copilot_tab_key_behavior",
+         _constants.copilotTabKeyBehaviorTitle(), 
+         _constants.copilotTabKeyBehaviorDescription(), 
+         new String[] {
+            COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION,
+            COPILOT_TAB_KEY_BEHAVIOR_COMPLETIONS
+         },
+         "",
+         new String[] {
+            _constants.copilotTabKeyBehaviorEnum_suggestion(),
+            _constants.copilotTabKeyBehaviorEnum_completions()
+         });
+   }
+
+   public final static String COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION = "suggestion";
+   public final static String COPILOT_TAB_KEY_BEHAVIOR_COMPLETIONS = "completions";
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -4039,6 +4074,10 @@ public class UserPrefsAccessor extends Prefs
          copilotEnabled().setValue(layer, source.getBool("copilot_enabled"));
       if (source.hasKey("copilot_completions_delay"))
          copilotCompletionsDelay().setValue(layer, source.getInteger("copilot_completions_delay"));
+      if (source.hasKey("copilot_allow_automatic_completions"))
+         copilotAllowAutomaticCompletions().setValue(layer, source.getBool("copilot_allow_automatic_completions"));
+      if (source.hasKey("copilot_tab_key_behavior"))
+         copilotTabKeyBehavior().setValue(layer, source.getString("copilot_tab_key_behavior"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -4291,6 +4330,8 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(disableRendererAccessibility());
       prefs.add(copilotEnabled());
       prefs.add(copilotCompletionsDelay());
+      prefs.add(copilotAllowAutomaticCompletions());
+      prefs.add(copilotTabKeyBehavior());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2063,6 +2063,26 @@ public interface UserPrefsAccessorConstants extends Constants {
    @DefaultStringValue("The delay (in milliseconds) before GitHub Copilot completions are requested after the cursor position has changed.")
    String copilotCompletionsDelayDescription();
 
+   /**
+    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+    */
+   @DefaultStringValue("Enable as-you-type code completions when Copilot is enabled")
+   String copilotAllowAutomaticCompletionsTitle();
+   @DefaultStringValue("When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.")
+   String copilotAllowAutomaticCompletionsDescription();
+
+   /**
+    * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+    */
+   @DefaultStringValue("Pressing Tab key will prefer inserting:")
+   String copilotTabKeyBehaviorTitle();
+   @DefaultStringValue("Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.")
+   String copilotTabKeyBehaviorDescription();
+   @DefaultStringValue("Copilot Suggestion")
+   String copilotTabKeyBehaviorEnum_suggestion();
+   @DefaultStringValue("Code Completion")
+   String copilotTabKeyBehaviorEnum_completions();
+
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1037,4 +1037,14 @@ copilotEnabledDescription = When enabled, RStudio will use GitHub Copilot to pro
 copilotCompletionsDelayTitle = GitHub Copilot completions delay
 copilotCompletionsDelayDescription = The delay (in milliseconds) before GitHub Copilot completions are requested after the cursor position has changed.
 
+# When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+copilotAllowAutomaticCompletionsTitle = Enable as-you-type code completions when Copilot is enabled
+copilotAllowAutomaticCompletionsDescription = When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
+
+# Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+copilotTabKeyBehaviorTitle = Pressing Tab key will prefer inserting:
+copilotTabKeyBehaviorDescription = Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
+copilotTabKeyBehaviorEnum_suggestion=Copilot Suggestion
+copilotTabKeyBehaviorEnum_completions=Code Completion
+
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -114,6 +114,8 @@ public class CopilotPreferencesPane extends PreferencesPane
             true,
             false);
       
+      selCopilotTabKeyBehavior_.setValue(prefs_.copilotTabKeyBehavior().getGlobalValue());
+      
       linkCopilotTos_ = new HelpLink(
             "GitHub Copilot: Terms of Service",
             "github-copilot-terms-of-service",

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -128,7 +128,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    
    private void initDisplay()
    {
-      add(headerLabel("GitHub Copilot"));
+      add(headerLabel("GitHub Copilot (Preview)"));
       
       if (session_.getSessionInfo().getCopilotEnabled())
       {
@@ -142,8 +142,8 @@ public class CopilotPreferencesPane extends PreferencesPane
          add(spaced(statusPanel));
 
          add(headerLabel("Copilot Completions"));
-         add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
-         add(selCopilotTabKeyBehavior_);
+         // add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
+         // add(selCopilotTabKeyBehavior_);
          add(numericPref("Show code suggestions after keyboard idle (ms):", 10, 5000, prefs_.copilotCompletionsDelay()));
          
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -20,7 +20,9 @@ import java.util.List;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JSON;
+import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.common.HelpLink;
@@ -32,6 +34,8 @@ import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.Co
 import org.rstudio.studio.client.workbench.copilot.server.CopilotServerOperations;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessor;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessorConstants;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
@@ -54,6 +58,13 @@ import com.google.inject.Inject;
 
 public class CopilotPreferencesPane extends PreferencesPane
 {
+   @Override
+   public RestartRequirement onApply(UserPrefs prefs)
+   {
+      prefs.copilotTabKeyBehavior().setGlobalValue(selCopilotTabKeyBehavior_.getValue());
+      return super.onApply(prefs);
+   }
+   
    @Inject
    public CopilotPreferencesPane(Session session,
                                  UserPrefs prefs,
@@ -89,6 +100,20 @@ public class CopilotPreferencesPane extends PreferencesPane
       btnRefresh_.addStyleName(RES.styles().button());
       statusButtons_.add(btnRefresh_);
       
+      selCopilotTabKeyBehavior_ = new SelectWidget(
+            constants.copilotTabKeyBehaviorTitle(),
+            new String[] {
+                  constants.copilotTabKeyBehaviorEnum_suggestion(),
+                  constants.copilotTabKeyBehaviorEnum_completions()
+            },
+            new String[] {
+                  UserPrefsAccessor.COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION,
+                  UserPrefsAccessor.COPILOT_TAB_KEY_BEHAVIOR_COMPLETIONS
+            },
+            false,
+            true,
+            false);
+      
       linkCopilotTos_ = new HelpLink(
             "GitHub Copilot: Terms of Service",
             "github-copilot-terms-of-service",
@@ -115,7 +140,10 @@ public class CopilotPreferencesPane extends PreferencesPane
          add(spaced(statusPanel));
 
          add(headerLabel("Copilot Completions"));
+         add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
+         add(selCopilotTabKeyBehavior_);
          add(numericPref("Show code suggestions after keyboard idle (ms):", 10, 5000, prefs_.copilotCompletionsDelay()));
+         
       }
       else
       {
@@ -345,8 +373,10 @@ public class CopilotPreferencesPane extends PreferencesPane
    private final SmallButton btnSignOut_;
    private final SmallButton btnActivate_;
    private final SmallButton btnRefresh_;
+   private final SelectWidget selCopilotTabKeyBehavior_;
    private final HelpLink linkCopilotTos_;
    private final Label lblCopilotTos_;
-
+   
+   private static final UserPrefsAccessorConstants constants = GWT.create(UserPrefsAccessorConstants.class);
    
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -184,7 +184,11 @@ public class CompletionPopupPanel extends ThemedPopupPanel
          values = names.toArray(new QualifiedName[0]);
       }
       
-      int numVisibleItems = 7;
+      // Since completion popups are usually displayed from the Source pane,
+      // if we're trying to display completions on top of the cursor location,
+      // we'll have relatively less space available. In that case, try to display
+      // fewer items, so we can fit the visible space.
+      int numVisibleItems = isShowingOnBottom ? 9 : 6;
       CompletionList<QualifiedName> list = new CompletionList<>(values, numVisibleItems, true, true);
 
       list.addSelectionCommitHandler((SelectionCommitEvent<QualifiedName> event) ->

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/PopupPositioner.java
@@ -14,21 +14,42 @@
  */
 package org.rstudio.studio.client.workbench.views.console.shell.assist;
 
+import org.rstudio.core.client.Rectangle;
+
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.PopupPanel;
 import com.google.gwt.user.client.ui.PopupPanel.PositionCallback;
 
-import org.rstudio.core.client.Rectangle;
-
 public class PopupPositioner implements PositionCallback
 {
-   private Rectangle cursorBounds_;
-   private CompletionPopupDisplay popup_;
-   
-   public PopupPositioner(Rectangle cursorBounds, CompletionPopupDisplay popup)
+   public static class Coordinates
    {
-      this.cursorBounds_ = cursorBounds;
+      public Coordinates(int left, int top)
+      {
+         left_ = left;
+         top_ = top;
+      }
+      
+      public int getLeft() { return left_; }
+      public int getTop() { return top_; }
+      
+      private final int left_;
+      private final int top_;
+   }
+   
+   public PopupPositioner(Rectangle cursorBounds,
+                          CompletionPopupDisplay popup,
+                          boolean preferBottom)
+   {
+      cursorBounds_ = cursorBounds;
       popup_ = popup;
+      preferBottom_ = preferBottom;
+   }
+   
+   public PopupPositioner(Rectangle cursorBounds,
+                          CompletionPopupDisplay popup)
+   {
+      this(cursorBounds, popup, true);
    }
 
    public void setPosition(int popupWidth, int popupHeight)
@@ -45,24 +66,9 @@ public class PopupPositioner implements PositionCallback
             cursorBounds_.getLeft(),
             cursorBounds_.getBottom(),
             5,
-            true);
+            preferBottom_);
       
       popup_.setPopupPosition(coords.getLeft(), coords.getTop());
-   }
-   
-   public static class Coordinates
-   {
-      public Coordinates(int left, int top)
-      {
-         left_ = left;
-         top_ = top;
-      }
-      
-      public int getLeft() { return left_; }
-      public int getTop() { return top_; }
-      
-      private final int left_;
-      private final int top_;
    }
    
    public static Coordinates getPopupPosition(int width,
@@ -96,13 +102,13 @@ public class PopupPositioner implements PositionCallback
          boolean showOnBottom = pageY + height + fudgeFactor < windowBottom;
          pageY = showOnBottom
                ? pageY + fudgeFactor
-               : pageY - height - fudgeFactor - 10;
+               : pageY - height - fudgeFactor - 20;
       }
       else
       {
          boolean showOnTop = pageY - height - fudgeFactor > 0;
          pageY = showOnTop
-               ? pageY - height - fudgeFactor - 10
+               ? pageY - height - fudgeFactor - 20
                : pageY + fudgeFactor;
       }
       
@@ -143,4 +149,14 @@ public class PopupPositioner implements PositionCallback
             transformed.getLeft(),
             transformed.getTop());
    }
+   
+   public boolean getPreferBottom()
+   {
+      return preferBottom_;
+   }
+   
+   private final Rectangle cursorBounds_;
+   private final CompletionPopupDisplay popup_;
+   private final boolean preferBottom_;
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1853,9 +1853,10 @@ public class RCompletionManager implements CompletionManager
          }
          else
          {
+            boolean preferBottom = !userPrefs_.copilotAllowAutomaticCompletions().getValue();
             popup_.showCompletionValues(
                   results,
-                  new PopupPositioner(rect, popup_),
+                  new PopupPositioner(rect, popup_, preferBottom),
                   false);
          }
       }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -521,9 +521,10 @@ public class RCompletionManager implements CompletionManager
                else if (keycode == KeyCodes.KEY_TAB)
                {
                   // Let tab insert ghost text if configured to do so
+                  String tabKeyBehavior = userPrefs_.copilotTabKeyBehavior().getValue();
                   boolean preferGhostText =
                         docDisplay_.hasGhostText() &&
-                        userPrefs_.copilotTabKeyBehavior().getValue() == UserPrefsAccessor.COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION;
+                        tabKeyBehavior == UserPrefsAccessor.COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION;
                   
                   if (preferGhostText)
                   {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -1853,7 +1853,7 @@ public class RCompletionManager implements CompletionManager
          }
          else
          {
-            boolean preferBottom = !userPrefs_.copilotAllowAutomaticCompletions().getValue();
+            boolean preferBottom = !userPrefs_.copilotEnabled().getValue();
             popup_.showCompletionValues(
                   results,
                   new PopupPositioner(rect, popup_, preferBottom),

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -83,6 +83,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEdit
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorCommandEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceEditorNative;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceGhostText;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceInputEditorPosition;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceKeyboardActivityEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceResources;
@@ -4587,9 +4588,19 @@ public class AceEditor implements DocDisplay,
       s_lastFocusedEditor = null;
    }
    
+   public AceGhostText getGhostText()
+   {
+      return widget_.getEditor().getGhostText();
+   }
+   
    public void setGhostText(String text)
    {
       widget_.getEditor().setGhostText(text);
+   }
+   
+   public void applyGhostText()
+   {
+      widget_.getEditor().applyGhostText();
    }
    
    public boolean hasGhostText()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -34,6 +34,7 @@ import org.rstudio.studio.client.workbench.views.output.lint.model.LintItem;
 import org.rstudio.studio.client.workbench.views.source.editors.text.AceEditor.EditorBehavior;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceCommandManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceFold;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceGhostText;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Anchor;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.LineWidget;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Marker;
@@ -486,6 +487,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void toggleTokenInfo();
    void setTextInputAriaLabel(String label);
    
+   AceGhostText getGhostText();
    void setGhostText(String text);
    boolean hasGhostText();
    void removeGhostText();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -19,6 +19,7 @@ import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.MathUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
+import org.rstudio.core.client.dom.EventProperty;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.Timers;
@@ -204,6 +205,13 @@ public class TextEditingTargetCopilotHelper
 
                display_.addCursorChangedHandler((event) ->
                {
+                  // Allow one-time suppression of cursor change handler
+                  if (suppressCursorChangeHandler_)
+                  {
+                     suppressCursorChangeHandler_ = false;
+                     return;
+                  }
+                  
                   // Don't do anything if we have a selection.
                   if (display_.hasSelection())
                   {
@@ -235,6 +243,17 @@ public class TextEditingTargetCopilotHelper
                      // TODO: If we have a completion popup, should that take precedence?
                      if (display_.isPopupVisible())
                         return;
+                     
+                     // Check if the user just inserted some text matching the current
+                     // ghost text. If so, we'll suppress the next cursor change handler,
+                     // so we can continue presenting the current ghost text.
+                     String key = EventProperty.key(keyEvent.getNativeEvent());
+                     if (activeCompletion_.displayText.startsWith(key))
+                     {
+                        updateCompletion(key);
+                        suppressCursorChangeHandler_ = true;
+                        return;
+                     }
 
                      NativeEvent event = keyEvent.getNativeEvent();
                      if (event.getKeyCode() == KeyCodes.KEY_TAB)
@@ -270,6 +289,24 @@ public class TextEditingTargetCopilotHelper
       completionTimer_.schedule(0);
    }
    
+   private void updateCompletion(String key)
+   {
+      int n = key.length();
+      activeCompletion_.displayText = activeCompletion_.displayText.substring(n);
+      activeCompletion_.text = activeCompletion_.text.substring(n);
+      activeCompletion_.position.character += n;
+      activeCompletion_.range.start.character += n;
+      activeCompletion_.range.end.character += n;
+      
+      // Ace's ghost text uses a custom token appended to the current line,
+      // and lines are eagerly re-tokenized when new text is inserted. To
+      // dodge this effect, we reset the ghost text at the end of the event loop.
+      Timers.singleShot(() ->
+      {
+         display_.setGhostText(activeCompletion_.displayText);
+      });
+   }
+   
    @Inject
    private void initialize(Copilot copilot,
                            EventBus events,
@@ -292,6 +329,7 @@ public class TextEditingTargetCopilotHelper
    private final HandlerRegistrations registrations_;
    
    private int requestId_;
+   private boolean suppressCursorChangeHandler_;
    
    private CopilotCompletion activeCompletion_;
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -192,6 +192,7 @@ public class TextEditingTargetCopilotHelper
    {
       if (!enabled)
       {
+         display_.removeGhostText();
          registrations_.removeHandler();
          requestId_ = 0;
          completionTimer_.cancel();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -697,8 +697,17 @@ public class AceEditorNative extends JavaScriptObject
       }
    }-*/;
    
+   public final native AceGhostText getGhostText() /*-{
+      return this.renderer.$ghostText;
+   }-*/;
+   
    public final native void setGhostText(String text) /*-{
       this.setGhostText(text);
+   }-*/;
+   
+   public final native void applyGhostText() /*-{
+      var ghostText = this.renderer.$ghostText;
+      
    }-*/;
    
    public final native boolean hasGhostText() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceGhostText.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceGhostText.java
@@ -1,0 +1,26 @@
+/*
+ * AceGhostText.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.views.source.editors.text.ace;
+
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class AceGhostText
+{
+   public String text;
+   public Position position;
+
+}


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13446.

##### TODO

- [x] Confirm that Tab works as expected here.
- [x] Provide a command / keyboard shortcut for requesting Copilot suggestions.
- [x] Prefer displaying the code completion panel on top, so it doesn't obscure ghost text.

### Approach

This PR gives the user some options controlling how GitHub Copilot's code suggestions will live + work together with the existing autocompletion system.

<img width="641" alt="Screenshot 2023-08-18 at 12 55 53 PM" src="https://github.com/rstudio/rstudio/assets/1976582/00775edc-3aeb-499d-a52b-a06e902c7ed3">

The intention here is that, for users who'd still like to get as-you-type autocompletions, they can enable the preference, and then when a user is in this state:

<img width="393" alt="Screenshot 2023-08-18 at 12 57 38 PM" src="https://github.com/rstudio/rstudio/assets/1976582/1dbd5609-2fe0-449c-8fdf-a3e894886a86">

they can still use Tab to insert the Copilot code suggestion, rather than the selected completion from the list. (The Enter key can be used to insert that completion.)

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


