### PR TITLE
igraph objects can be safely serialized

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -30,6 +30,7 @@
 - Fixed bug with modals disabling copy/paste (#13365)
 - Fixed issue where column names weren't provided as completion candidates for DBI tables. (#12577)
 - Removed unnecessary files from install packages (rstudo-pro:#4943)
+- Fixed issue where R sessions containing large 'igraph' objects could become slow (#13489)
 
 ### Performance
 - Improved performance of group membership tests (rstudio-pro:#4643)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -937,6 +937,10 @@
    n <- length(value)
    if (n >= 10000L)
       return(TRUE)
+   
+   # 'igraph' objects can be serialized.
+   if (inherits(value, "igraph"))
+      return(TRUE)
 
    # Python objects are connected to the underlying session, and so
    # cannot be restored after a suspend.


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13489.

### Approach

RStudio somewhat eagerly tries to check if the session can be safely suspended, via `.rs.environment.isSuspendable()`. Unfortunately, this check is expensive for large `igraph` objects. Since we know a priori that such objects can be safely serialized, we skip recursing into their internals.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13489.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
