### PR TITLE
silence warning/errors from infering reticulate python

### DIFF
--- a/src/cpp/session/modules/SessionReticulate.R
+++ b/src/cpp/session/modules/SessionReticulate.R
@@ -2121,8 +2121,10 @@ options(reticulate.repl.teardown = function()
       py_config <- NULL
       tryCatch({
          py_config <- .rs.executeFunctionInChildProcess(
-            callback   = function() reticulate::py_discover_config()
-         )
+            callback = function() {
+               suppressWarnings(tryCatch(reticulate::py_discover_config(),
+                                         error = function(e) NULL))
+      })
        }, finally = {
          Sys.setenv(RETICULATE_MINICONDA_ENABLED = prev_miniconda)
       })


### PR DESCRIPTION
### Intent

On startup, the IDE will attempt to infer what what Python installation reticulate would select to load.

Part of this inference routine may involve launching a subprocess that calls `reticulate::py_discover_config()`. 

`reticulate::py_discover_config()` may raise warnings or errors if it encounters a python installation that would be preferred, but is broken for some reason (e.g., a virtual environment where the python installation it is derived from has been removed).

The intent of this PR is to not present those warnings or errors to the user as part of the IDE session startup routine. In that context they are not actionable, and the text of the warning can be occasionally cryptic. 

The user will may still encounter the same error message if/when they attempt to use Python via reticulate.


> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

Closes https://github.com/rstudio/reticulate/issues/1449

### Approach

Wrap the `reticulate::py_discover_config()` call with `suppressWarnings(tryCatch())`

### Automated Tests


### QA Notes

To test, create a broken python installation in a reticulate prefered location, and confirm that no warnings/errors are shown until the user explicitly causes reticulate to initialize python. 

1. Create the broken state
```r
reticulate:::rm_all_reticulate_state()
install_python()
virtualenv_create(force=TRUE) # r-reticulate
unlink("~/.pyenv", recursive = TRUE)
```
2. restart R session in the IDE (cmd+shift+0). Confirm no warnings/errors are shown
3. Load reticulate namespace, `library(reticulate)` confirm no warnings/errors.
4. Cause reticulate to initialize python, confirm warning or error is shown: `py_eval('1')`
