### PR TITLE
avoid materializing duckdb data.frame rownames

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -530,15 +530,20 @@
    {
       # use .row_names_info() to avoid materializing altrep vectors
       # https://github.com/rstudio/rstudio/issues/13540
-      info <- .row_names_info(obj, type = 0L)
-      nr <- if (.rs.isAltrep(info)) "??" else nrow(obj)
-      nc <- length(obj)
+      dims <- .Call("rs_dim", obj, PACKAGE = "(embedding)")
+      if (is.null(dims))
+         dims <- c(-1L, -1L)
       
+      # extract rows, columns
+      nr <- dims[[1L]]
+      nc <- dims[[2L]]
+      
+      # build message
       msg <- sprintf(
          "%s obs. of %s %s",
-         as.character(nr),
-         as.character(nc),
-         if (nc > 1) "variables" else "variable"
+         if (is.na(nr) || nr < 0L) "??" else as.character(nr),
+         if (is.na(nc) || nc < 0L) "??" else as.character(nc),
+         if (!is.na(nc) && nc != 1L) "variables" else "variable"
       )
       
       return(msg)

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -528,11 +528,20 @@
    }
    else if (is.data.frame(obj))
    {
-      return(paste(dim(obj)[1],
-                   "obs. of",
-                   dim(obj)[2],
-                   ifelse(dim(obj)[2] == 1, "variable", "variables"),
-                   sep=" "))
+      # use .row_names_info() to avoid materializing altrep vectors
+      # https://github.com/rstudio/rstudio/issues/13540
+      info <- .row_names_info(obj, type = 0L)
+      nr <- if (.rs.isAltrep(info)) "??" else nrow(obj)
+      nc <- length(obj)
+      
+      msg <- sprintf(
+         "%s obs. of %s %s",
+         as.character(nr),
+         as.character(nc),
+         if (nc > 1) "variables" else "variable"
+      )
+      
+      return(msg)
    }
    else if (is.environment(obj))
    {

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -386,6 +386,65 @@ SEXP rs_isAltrep(SEXP obj)
    return r::sexp::create(isAltrep(obj), &protect);
 }
 
+SEXP rs_dim(SEXP objectSEXP)
+{
+   // For 'data.frame' objects, check the 'row.names' attribute
+   if (Rf_inherits(objectSEXP, "data.frame"))
+   {
+      // default values for rows, columns
+      int numRows = -1;
+      int numCols = r::sexp::length(objectSEXP);
+      
+      SEXP rowNamesInfoSEXP = R_NilValue;
+      r::sexp::Protect protect;
+   
+      Error error = r::exec::RFunction("base:::.row_names_info")
+            .addParam(objectSEXP)
+            .addParam(0)
+            .call(&rowNamesInfoSEXP, &protect);
+      if (error)
+      {
+         LOG_ERROR(error);
+         return R_NilValue;
+      }
+      
+      if (isAltrep(rowNamesInfoSEXP))
+      {
+         if (TYPEOF(rowNamesInfoSEXP) == INTSXP)
+         {
+            const int* data = (const int*) DATAPTR_OR_NULL(rowNamesInfoSEXP);
+            if (data != nullptr)
+               numRows = abs(data[1]);
+         }
+      }
+      else if (TYPEOF(rowNamesInfoSEXP) == INTSXP)
+      {
+         int* data = INTEGER(rowNamesInfoSEXP);
+         numRows = data[0];
+      }
+      else
+      {
+         numRows = Rf_length(rowNamesInfoSEXP);
+      }
+      
+      SEXP resultSEXP = Rf_allocVector(INTSXP, 2);
+      INTEGER(resultSEXP)[0] = numRows;
+      INTEGER(resultSEXP)[1] = numCols;
+      return resultSEXP;
+   }
+   
+   // Otherwise, just call 'dim()' directly
+   r::sexp::Protect protect;
+   SEXP dimSEXP = R_NilValue;
+   Error error = r::exec::RFunction("base:::dim")
+         .addParam(objectSEXP)
+         .call(&dimSEXP, &protect);
+   if (error)
+      LOG_ERROR(error);
+   
+   return dimSEXP;
+}
+
 SEXP rs_newTestExternalPointer(SEXP nullSEXP)
 {
    bool nullPtr = r::sexp::asLogical(nullSEXP);
@@ -1452,6 +1511,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_hasExternalPointer);
    RS_REGISTER_CALL_METHOD(rs_hasAltrep);
    RS_REGISTER_CALL_METHOD(rs_isAltrep);
+   RS_REGISTER_CALL_METHOD(rs_dim);
    RS_REGISTER_CALL_METHOD(rs_dumpContexts);
    RS_REGISTER_CALL_METHOD(rs_newTestExternalPointer);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13540.

### Approach

When computing the dimensions for an R `data.frame`, check whether the `row.names` attribute is an ALTREP vector. If it is, then use ALTREP APIs for querying information about it.

### Automated Tests

N/A

### QA Notes

Will be verified by duckdb users.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
