### PR TITLE
ensure Ace theme property set when theme applied

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -54,6 +54,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.Brea
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.CursorChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.DocumentChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorLoadedEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.FoldChangeEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.FoldChangeEvent.Handler;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasFoldChangeHandlers;
@@ -366,6 +367,15 @@ public class AceEditorWidget extends Composite
                   clearKeyBuffers(editor_);
                }
             });
+      
+      events_.addHandler(EditorThemeChangedEvent.TYPE, new EditorThemeChangedEvent.Handler()
+      {
+         @Override
+         public void onEditorThemeChanged(EditorThemeChangedEvent event)
+         {
+            editor_.setTheme(event.getTheme());
+         }
+      });
    }
 
    // When the 'keyBinding' field is initialized (the field holding all keyboard

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -20,6 +20,7 @@ import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.js.JsMap;
 import org.rstudio.core.client.widget.CanSetControlId;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceTheme;
 
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
@@ -721,6 +722,13 @@ public class AceEditorNative extends JavaScriptObject
       if (bindings.hasOwnProperty("return")) {
          delete bindings["return"];
       }
+   }-*/;
+   
+   // NOTE: We intentionally bypass Ace's 'setTheme()' API, as that only
+   // allows one to load themes that are bundled with Ace, but we instead
+   // load and manage themes ourselves.
+   public final native void setTheme(AceTheme theme) /*-{
+      this.renderer.theme = theme;
    }-*/;
 
    static { initialize(); }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceTheme.java
@@ -14,12 +14,13 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.themes;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.regex.Pattern;
 import org.rstudio.studio.client.workbench.prefs.model.UserStateAccessor;
 import org.rstudio.studio.client.workbench.views.source.ViewsSourceConstants;
+
+import com.google.gwt.core.client.GWT;
 
 /**
  * Represents an editor theme.
@@ -47,11 +48,11 @@ public class AceTheme extends UserStateAccessor.Theme
 
    public static final native AceTheme create(String name, String url, Boolean isDark)
    /*-{
-      var theme = new Object();
-      theme.name = name;
-      theme.url = url;
-      theme.isDark = isDark;
-      return theme;
+      return {
+         name: name,
+         url: url,
+         isDark: isDark
+      };
    }-*/;
 
    public native final Boolean isDark()

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -14,17 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.text.themes;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayInteger;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.LinkElement;
-import com.google.gwt.dom.client.Style;
-import com.google.gwt.user.client.Timer;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.function.Consumer;
 
 import org.rstudio.core.client.ColorUtil.RGBColor;
 import org.rstudio.core.client.Debug;
@@ -44,8 +35,17 @@ import org.rstudio.studio.client.workbench.views.source.ViewsSourceConstants;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.EditorThemeChangedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.themes.model.ThemeServerOperations;
 
-import java.util.HashMap;
-import java.util.function.Consumer;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayInteger;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.LinkElement;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.user.client.Timer;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
 
 @Singleton
 public class AceThemes
@@ -124,7 +124,6 @@ public class AceThemes
          document.getBody().addClassName("editor_dark");
       else
          document.getBody().removeClassName("editor_dark");
-         
       
       // Deferred so that the browser can render the styles.
       new Timer()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13532. As a side effect, we get a shiny new display for Ace annotations.

<img width="349" alt="Screenshot 2023-08-24 at 10 55 00 AM" src="https://github.com/rstudio/rstudio/assets/1976582/85dd468e-a3f8-4d52-b0b9-c38b6805b5a5">

### Approach

Ace now queries some information about the active theme via the `editor.renderer.theme` property when displaying different pieces of UI. To ensure that RStudio is compatible with those usages, we make sure to set that property when a theme is set or changed.

Note that we intentionally bypass the Ace APIs for setting themes and just set the theme object directly, as we manage Ace themes ourselves.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13532.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
