### PR TITLE
require rsconnect 1.0.2 for publishing Quarto manuscripts

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -537,27 +537,27 @@ Error getQmdPublishDetails(const json::JsonRpcRequest& request,
 
    // Look up configuration for this Quarto project, if this file is part of a Quarto book or
    // website.
-   std::string websiteDir, websiteOutputDir;
+   std::string websiteDir, websiteOutputDir, projectType;
    auto projectMeta = inspect.find("project");
    if (projectMeta != inspect.end())
    {
       FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
       if (!quartoConfig.isEmpty())
       {
-          std::string type, outputDir;
-          readQuartoProjectConfig(quartoConfig, &type, &outputDir);
-          if (type == kQuartoProjectBook || type == kQuartoProjectWebsite || type == kQuartoProjectManuscript)
+          std::string outputDir;
+          readQuartoProjectConfig(quartoConfig, &projectType, &outputDir);
+          if (projectType == kQuartoProjectBook || projectType == kQuartoProjectWebsite || projectType == kQuartoProjectManuscript)
           {
              FilePath configPath = quartoConfig.getParent();
              websiteDir = configPath.getAbsolutePath();
              // Infer output directory
              if (outputDir.empty())
              {
-                 if (type == kQuartoProjectBook)
+                 if (projectType == kQuartoProjectBook)
                  {
                      outputDir = "_book";
                  }
-                 else if (type == kQuartoProjectManuscript)
+                 else if (projectType == kQuartoProjectManuscript)
                  {
                      outputDir = "_manuscript";
                  }
@@ -590,6 +590,7 @@ Error getQmdPublishDetails(const json::JsonRpcRequest& request,
 
 
    // Build result object
+   result["project_type"] = projectType;
    result["is_self_contained"] = selfContained;
    result["title"] = title;
    result["is_shiny_qmd"] = isShinyQmd;

--- a/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/Dependency.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dependencies/model/Dependency.java
@@ -44,16 +44,20 @@ public class Dependency extends JavaScriptObject
       return this.location;
    }-*/;
    
-   public final native String setName(String name) /*-{
-      this.name = name;
-   }-*/;
-   
    public final native String getName() /*-{
       return this.name;
    }-*/;
    
+   public final native String setName(String name) /*-{
+      this.name = name;
+   }-*/;
+   
    public final native String getVersion() /*-{
       return this.version;
+   }-*/;
+   
+   public final native void setVersion(String version) /*-{
+      this.version = version;
    }-*/;
    
    public final native boolean getSource() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/QmdPublishDetails.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/QmdPublishDetails.java
@@ -15,12 +15,13 @@
 
 package org.rstudio.studio.client.rsconnect.model;
 
-import jsinterop.annotations.JsType;
 import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
 
 @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
 public class QmdPublishDetails
 {
+   public String project_type;
    public boolean is_shiny_qmd;
    public boolean is_self_contained;
    public String title;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/PublishingPreferencesPane.java
@@ -15,21 +15,6 @@
 
 package org.rstudio.studio.client.workbench.prefs.views;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.dom.client.ChangeEvent;
-import com.google.gwt.event.dom.client.ChangeHandler;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.resources.client.ImageResource;
-import com.google.gwt.user.client.ui.CheckBox;
-import com.google.gwt.user.client.ui.HorizontalPanel;
-import com.google.gwt.user.client.ui.Label;
-import com.google.gwt.user.client.ui.VerticalPanel;
-import com.google.inject.Inject;
-
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.prefs.PreferencesDialogBaseResources;
@@ -54,6 +39,21 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.inject.Inject;
 
 public class PublishingPreferencesPane extends PreferencesPane
 {
@@ -168,7 +168,7 @@ public class PublishingPreferencesPane extends PreferencesPane
          @Override
          public void onClick(ClickEvent arg0)
          {
-            deps_.withRSConnect(constants_.withRSConnectLabel(), false, null,
+            deps_.withRSConnect(constants_.withRSConnectLabel(), false, false, null,
                                 new CommandWithArg<Boolean>()
             {
                @Override
@@ -355,19 +355,14 @@ public class PublishingPreferencesPane extends PreferencesPane
       }
       else
       {
-         deps_.withRSConnect(constants_.getAccountCountLabel(), false, null,
-                             new CommandWithArg<Boolean>()
+         deps_.withRSConnect(constants_.getAccountCountLabel(), false, false, null, (succeeded) ->
          {
-            @Override
-            public void execute(Boolean succeeded)
-            {
-               // refresh the account list in case there are accounts already on
-               // the system (e.g. package was installed at one point and some
-               // metadata remains)
-               accountList_.refreshAccountList();
+            // refresh the account list in case there are accounts already on
+            // the system (e.g. package was installed at one point and some
+            // metadata remains)
+            accountList_.refreshAccountList();
 
-               showAccountWizard();
-            }
+            showAccountWizard();
          });
       }
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13555.

### Approach

Wire in some special handling for publishing of Quarto manuscripts, and explicitly require rsconnect 1.0.2 in that scenario.

### Automated Tests

N/A

### QA Notes

Test that publication of Quarto manuscripts (and only manuscripts!) requires rsconnect 1.0.2. All other publications should still require only rsconnect 0.8.24.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
