### PR TITLE
remove textmate theme from Ace preview

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.java
@@ -14,21 +14,27 @@
  */
 package org.rstudio.studio.client.workbench.prefs.views;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.*;
-import com.google.gwt.dom.client.Style.BorderStyle;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.resources.client.ClientBundle;
-import com.google.gwt.resources.client.TextResource;
-
 import org.rstudio.core.client.ExternalJavaScriptLoader;
 import org.rstudio.core.client.ExternalJavaScriptLoader.Callback;
 import org.rstudio.core.client.theme.ThemeFonts;
 import org.rstudio.core.client.widget.DynamicIFrame;
 import org.rstudio.core.client.widget.FontSizer;
 import org.rstudio.studio.client.application.Desktop;
-import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceResources;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
+import org.rstudio.studio.client.workbench.views.source.editors.text.ace.AceResources;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.BodyElement;
+import com.google.gwt.dom.client.DivElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.LinkElement;
+import com.google.gwt.dom.client.Style;
+import com.google.gwt.dom.client.Style.BorderStyle;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.dom.client.StyleElement;
+import com.google.gwt.resources.client.ClientBundle;
+import com.google.gwt.resources.client.TextResource;
 
 public class AceEditorPreview extends DynamicIFrame
 {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.js
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AceEditorPreview.js
@@ -17,7 +17,17 @@ editor.setHighlightActiveLine(false);
 editor.renderer.setHScrollBarAlwaysVisible(false);
 editor.renderer.setShowGutter(false);
 editor.renderer.setDisplayIndentGuides(false);
+editor.renderer.setScrollMargin(3, 3, 3, 3);
+
+// Set up line height
+editor.container.style.lineHeight = 1.4;
+editor.renderer.updateFontSize();
 
 // Load R mode
 editor.getSession().setMode(new RMode(false, editor.getSession()));
- 
+
+// Remove Textmate theme, as we'll be applying our own themes for display
+var el = document.getElementById("ace-tm");
+if (el != null) {
+    el.parentNode.removeChild(el);
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.R
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.R
@@ -1,0 +1,23 @@
+# compute five-number summary
+fivenum <- function(x) {
+  
+  # handle empty input
+  n <- length(x)
+  if (n == 0)
+     return(rep.int(NA, 5))
+  
+  # compute quartile indices
+  n5 <- 1
+  n4 <- ((n + 3) %/% 2) / 2
+  n3 <- (n + 1) / 2
+  n2 <- n + 1 - n4
+  n1 <- n
+  i <- c(n5, n4, n3, n2, n1)
+  
+  # compute quartile values
+  x <- sort(x)
+  xf <- x[floor(i)]
+  xc <- x[ceiling(i)]
+  0.5 * (xf + xc)
+
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/AppearancePreferencesPane.java
@@ -57,7 +57,9 @@ import com.google.gwt.dom.client.Style;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.resources.client.ClientBundle;
 import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.resources.client.TextResource;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.VerticalPanel;
@@ -333,7 +335,7 @@ public class AppearancePreferencesPane extends PreferencesPane
       FlowPanel previewPanel = new FlowPanel();
 
       previewPanel.setSize("100%", "100%");
-      preview_ = new AceEditorPreview(CODE_SAMPLE);
+      preview_ = new AceEditorPreview(RES.codeSample().getText());
       preview_.setHeight(previewDefaultHeight_);
       preview_.setWidth("278px");
       preview_.setFontSize(Double.parseDouble(fontSize_.getValue()));
@@ -864,35 +866,15 @@ public class AppearancePreferencesPane extends PreferencesPane
 
    private final static String DEFAULT_FONT_NAME = "(Default)";
    private final static String DEFAULT_FONT_VALUE = "__default__";
+   
    private final static PrefsConstants constants_ = GWT.create(PrefsConstants.class);
-   private static final String CODE_SAMPLE =
-         "# plotting of R objects\n" +
-         "plot <- function (x, y, ...)\n" +
-         "{\n" +
-         "  if (is.function(x) && \n" +
-         "      is.null(attr(x, \"class\")))\n" +
-         "  {\n" +
-         "    if (missing(y))\n" +
-         "      y <- NULL\n" +
-         "    \n" +
-         "    # check for ylab argument\n" +
-         "    hasylab <- function(...) \n" +
-         "      !all(is.na(\n" +
-         "        pmatch(names(list(...)),\n" +
-         "              \"ylab\")))\n" +
-         "    \n" +
-         "    if (hasylab(...))\n" +
-         "      plot.function(x, y, ...)\n" +
-         "    \n" +
-         "    else \n" +
-         "      plot.function(\n" +
-         "        x, y, \n" +
-         "        ylab = paste(\n" +
-         "          deparse(substitute(x)),\n" +
-         "          \"(x)\"), \n" +
-         "        ...)\n" +
-         "  }\n" +
-         "  else \n" +
-         "    UseMethod(\"plot\")\n" +
-         "}\n";
+   
+   public interface Resources extends ClientBundle
+   {
+      @Source("AppearancePreferencesPane.R")
+      TextResource codeSample();
+   }
+   
+   private static final Resources RES = GWT.create(Resources.class);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1041,7 +1041,7 @@ public class TextEditingTarget implements
                }
             });
       
-      events_.addHandler(
+      releaseOnDismiss_.add(events_.addHandler(
             CopilotEvent.TYPE,
             new CopilotEvent.Handler()
             {
@@ -1088,7 +1088,7 @@ public class TextEditingTarget implements
                      
                   }
                }
-            });
+            }));
 
       releaseOnDismiss_.add(
          prefs.autoSaveOnBlur().addValueChangeHandler((ValueChangeEvent<Boolean> val) ->


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13552.

### Approach

Newer versions of Ace now try to apply a Textmate theme by default. We need to remove that theme from the preview when Ace is loaded.

I also tried to use a somewhat more relatable code example for the preview pane. We now show an R function computing the [five-number summary](https://en.wikipedia.org/wiki/Five-number_summary) of a vector, which is a basic and common set of descriptive statistics that almost everyone will be familiar with.

<img width="642" alt="Screenshot 2023-08-25 at 2 37 12 PM" src="https://github.com/rstudio/rstudio/assets/1976582/5aee16c7-2ecd-456a-87b6-168613c3f83f">

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13552.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
