### PR TITLE
Allow pkgload links to run automatically

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -278,7 +278,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 .rs.addFunction("isPackageHyperlinkSafe", function(packageName)
 {
    allowed <- setdiff(
-      c(.packages(), "testthat", "rlang", "devtools", "usethis"), 
+      c(.packages(), "testthat", "rlang", "devtools", "usethis", "pkgload"), 
       c("base", "stats", "utils")
    )
    .rs.scalar(


### PR DESCRIPTION
### Intent

Allow to visualize dev help automatically. Addresses #13460 

Before this PR: 

1. run devtools::document() in a package
![image](https://github.com/rstudio/rstudio/assets/52606734/38a49ef8-2bcb-4c0c-97c0-9bf9769ddc06)

2. Click on the link displayed in the console to the package

![image](https://github.com/rstudio/rstudio/assets/52606734/16bc3458-a770-4a54-8566-9b72960abfd0)

3. Press Enter to display dev help
![image](https://github.com/rstudio/rstudio/assets/52606734/695b7983-4f34-4bb3-9215-551f6e07217c)

**This PR suppresses step 3** of the workflow**


### Approach

Add pkgload to allowed packages to automatic packages that can be run.  https://cli.r-lib.org/reference/links.html?q=usethis#security-considerations

### QA Notes

When clicking on the output, it should run automatically, without having to press enter

### Documentation

After checking, I saw that clickable hyperlinks are not in RStudio User Guide.
Will open a PR in cli to update this page. https://cli.r-lib.org/reference/links.html?q=usethis#security-considerations

### Checklist

- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

Edit: another way to do this would be to have devtools export this function and roxygen2 adding an hyperlink to `devtools::dev_help()`, but allowing pkgload in RStudio seems simpler. (also just loading pkgload conflicts with devtools.)

Edit2: I sent the contributing agreement by email.