### PR TITLE
track and apply current theme on creation

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditorWidget.java
@@ -61,6 +61,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.events.HasF
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.PasteEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.RenderFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.UndoRedoEvent;
+import org.rstudio.studio.client.workbench.views.source.editors.text.themes.AceThemes;
 import org.rstudio.studio.client.workbench.views.source.events.ScrollYEvent;
 
 import com.google.gwt.core.client.JavaScriptObject;
@@ -145,6 +146,7 @@ public class AceEditorWidget extends Composite
       editor_.setHighlightGutterLine(false);
       editor_.setFixedWidthGutter(true);
       editor_.setIndentedSoftWrap(false);
+      editor_.setTheme(themes_.getCurrentTheme());
       editor_.delegateEventsTo(AceEditorWidget.this);
       editor_.onChange(new CommandWithArg<AceDocumentChangeEventNative>()
       {
@@ -465,10 +467,13 @@ public class AceEditorWidget extends Composite
    }-*/;
 
    @Inject
-   private void initialize(EventBus events, UserPrefs uiPrefs)
+   private void initialize(EventBus events,
+                           UserPrefs uiPrefs,
+                           AceThemes themes)
    {
       events_ = events;
       uiPrefs_ = uiPrefs;
+      themes_ = themes;
    }
 
    public HandlerRegistration addCursorChangedHandler(CursorChangedEvent.Handler handler)
@@ -1321,4 +1326,5 @@ public class AceEditorWidget extends Composite
    // injected
    private EventBus events_;
    private UserPrefs uiPrefs_;
+   private AceThemes themes_;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -728,6 +728,7 @@ public class AceEditorNative extends JavaScriptObject
    // allows one to load themes that are bundled with Ace, but we instead
    // load and manage themes ourselves.
    public final native void setTheme(AceTheme theme) /*-{
+      theme = theme || { isDark: false };
       this.renderer.theme = theme;
    }-*/;
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/themes/AceThemes.java
@@ -65,8 +65,18 @@ public class AceThemes
       state.get().theme().bind(theme -> applyTheme((AceTheme)theme.cast()));
    }
    
+   public AceTheme getCurrentTheme()
+   {
+      return currentTheme_;
+   }
+   
    private void applyTheme(Document document, final AceTheme theme)
    {
+      if (Document.get() == document)
+      {
+         currentTheme_ = theme;
+      }
+      
       final String linkId = "rstudio-acethemes-linkelement";
 
       // Build the URL.
@@ -279,6 +289,8 @@ public class AceThemes
          },
          themeLocation);
    }
+   
+   private AceTheme currentTheme_;
 
    private ThemeServerOperations themeServerOperations_;
    private final EventBus events_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13532.

### Approach

Ensure that Ace is made aware of the current theme when Ace instances are created.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13532#issuecomment-1695930685.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
