### PR TITLE
fix 404 site category bug for Rmd website publishing

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/model/RSConnectPublishSource.java
@@ -59,7 +59,8 @@ public class RSConnectPublishSource
       isSingleFileShiny_ = false;
       websiteDir_ = websiteDir;
       isQuarto_ = isQuarto;
-      boolean isWebsite = type == RSConnect.CONTENT_TYPE_WEBSITE || type == RSConnect.CONTENT_TYPE_QUARTO_WEBSITE;
+      boolean isWebsite = type == RSConnect.CONTENT_TYPE_WEBSITE || type == RSConnect.CONTENT_TYPE_QUARTO_WEBSITE || (
+         type == RSConnect.CONTENT_TYPE_DOCUMENT && !StringUtil.isNullOrEmpty(websiteDir));
 
       String category = null;
       if (isWebsite)


### PR DESCRIPTION
### Intent

Addresses #13535

### QA notes
Follow repro in issue, publish to Cloud, ensure that all pages load without 404. Download source and inspect manifest.json and ensure `"content_category": "site"` has been set.

<img width="1107" alt="image" src="https://github.com/rstudio/rstudio/assets/7817881/e4c4fc0e-7011-4d97-856b-0d5277e5a1ed">
