### PR TITLE
allow indexing of project source files with copilot

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -428,6 +428,7 @@ namespace prefs {
 #define kCopilotTabKeyBehavior "copilot_tab_key_behavior"
 #define kCopilotTabKeyBehaviorSuggestion "suggestion"
 #define kCopilotTabKeyBehaviorCompletions "completions"
+#define kCopilotIndexingEnabled "copilot_indexing_enabled"
 
 class UserPrefValues: public Preferences
 {
@@ -1932,6 +1933,12 @@ public:
     */
    std::string copilotTabKeyBehavior();
    core::Error setCopilotTabKeyBehavior(std::string val);
+
+   /**
+    * When enabled, RStudio will index project files with GitHub Copilot.
+    */
+   bool copilotIndexingEnabled();
+   core::Error setCopilotIndexingEnabled(bool val);
 
 };
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -950,6 +950,7 @@ Error copilotInstallAgent(const json::JsonRpcRequest& request,
 
 } // end anonymous namespace
 
+
 namespace file_monitor {
 
 namespace {
@@ -996,6 +997,9 @@ void onMonitoringEnabled(const tree<core::FileInfo>& tree)
    if (!s_copilotEnabled)
       return;
    
+   if (!prefs::userPrefs().copilotIndexingEnabled())
+      return;
+   
    for (auto&& file : tree)
       indexFile(file);
 }
@@ -1003,6 +1007,9 @@ void onMonitoringEnabled(const tree<core::FileInfo>& tree)
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
 {
    if (!s_copilotEnabled)
+      return;
+   
+   if (!prefs::userPrefs().copilotIndexingEnabled())
       return;
    
    for (auto&& event : events)
@@ -1014,7 +1021,6 @@ void onMonitoringDisabled()
 }
 
 } // end namespace file_monitor
-
 
 
 Error initialize()

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -23,6 +23,7 @@
 #include <shared_core/json/Json.hpp>
 
 #include <core/Exec.hpp>
+#include <core/FileSerializer.hpp>
 #include <core/http/Header.hpp>
 #include <core/json/JsonRpc.hpp>
 #include <core/system/Process.hpp>
@@ -37,6 +38,7 @@
 #include <r/RSexp.hpp>
 #include <r/session/REventLoop.hpp>
 
+#include <session/projects/SessionProjects.hpp>
 #include <session/prefs/UserPrefs.hpp>
 #include <session/SessionModuleContext.hpp>
 
@@ -144,9 +146,28 @@ std::queue<std::string> s_pendingResponses;
 // Whether we're about to shut down.
 bool s_isSessionShuttingDown = false;
 
-std::string uriFromDocumentId(const std::string& documentId)
+std::string uriFromDocumentPath(const std::string& path)
 {
-   return fmt::format("rstudio-document://{}", documentId);
+   return fmt::format("file://{}", path);
+}
+
+
+std::string uriFromDocumentId(const std::string& id)
+{
+   return fmt::format("rstudio-document://{}", id);
+}
+
+std::string uriFromDocumentImpl(const std::string& id,
+                                const std::string& path,
+                                bool isUntitled)
+{
+   FilePath resolvedPath = module_context::resolveAliasedPath(path);
+   return isUntitled ? uriFromDocumentId(id) : uriFromDocumentPath(resolvedPath.getAbsolutePath());
+   
+}
+std::string uriFromDocument(const boost::shared_ptr<source_database::SourceDocument>& pDoc)
+{
+   return uriFromDocumentImpl(pDoc->id(), pDoc->path(), pDoc->isUntitled());
 }
 
 std::string languageIdFromDocument(boost::shared_ptr<source_database::SourceDocument> pDoc)
@@ -632,7 +653,7 @@ void onDocAdded(boost::shared_ptr<source_database::SourceDocument> pDoc)
       return;
 
    json::Object textDocumentJson;
-   textDocumentJson["uri"] = uriFromDocumentId(pDoc->id());
+   textDocumentJson["uri"] = uriFromDocument(pDoc);
    textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
    textDocumentJson["version"] = 1;
    textDocumentJson["text"] = "";
@@ -650,7 +671,7 @@ void onDocUpdated(boost::shared_ptr<source_database::SourceDocument> pDoc)
 
    // Synchronize document contents with Copilot
    json::Object textDocumentJson;
-   textDocumentJson["uri"] = uriFromDocumentId(pDoc->id());
+   textDocumentJson["uri"] = uriFromDocument(pDoc);
    textDocumentJson["languageId"] = languageIdFromDocument(pDoc);
    textDocumentJson["version"] = 1;
    textDocumentJson["text"] = pDoc->contents();
@@ -667,7 +688,7 @@ void onDocRemoved(const std::string& id, const std::string& path)
       return;
 
    json::Object textDocumentJson;
-   textDocumentJson["uri"] = uriFromDocumentId(id);
+   textDocumentJson["uri"] = uriFromDocumentImpl(id, path, path.empty());
 
    json::Object paramsJson;
    paramsJson["textDocument"] = textDocumentJson;
@@ -823,9 +844,11 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
 
    // Read params
    std::string documentId;
+   std::string documentPath;
+   bool isUntitled;
    int cursorRow, cursorColumn;
 
-   Error error = core::json::readParams(request.params, &documentId, &cursorRow, &cursorColumn);
+   Error error = core::json::readParams(request.params, &documentId, &documentPath, &isUntitled, &cursorRow, &cursorColumn);
    if (error)
    {
       LOG_ERROR(error);
@@ -839,7 +862,7 @@ Error copilotGenerateCompletions(const json::JsonRpcRequest& request,
 
    json::Object docJson;
    docJson["position"] = positionJson;
-   docJson["uri"] = uriFromDocumentId(documentId);
+   docJson["uri"] = uriFromDocumentImpl(documentId, documentPath, isUntitled);
    docJson["version"] = 1;
 
    json::Object paramsJson;
@@ -927,6 +950,73 @@ Error copilotInstallAgent(const json::JsonRpcRequest& request,
 
 } // end anonymous namespace
 
+namespace file_monitor {
+
+namespace {
+
+void indexFile(const core::FileInfo& info)
+{
+   FilePath documentPath = module_context::resolveAliasedPath(info.absolutePath());
+   std::string ext = documentPath.getExtensionLowerCase();
+   
+   // TODO: Stop hard-coding this list?
+   std::string languageId;
+   if (ext == ".r")
+      languageId = "r";
+   else if (ext == ".py")
+      languageId = "python";
+   else if (ext == ".sql")
+      languageId = "sql";
+   else
+      return;
+   
+   DLOG("Indexing document: {}", info.absolutePath());
+   
+   std::string contents;
+   Error error = core::readStringFromFile(documentPath, &contents);
+   if (error)
+      return;
+   
+   json::Object textDocumentJson;
+   textDocumentJson["uri"] = uriFromDocumentPath(documentPath.getAbsolutePath());
+   textDocumentJson["languageId"] = languageId;
+   textDocumentJson["version"] = 1;
+   textDocumentJson["text"] = contents;
+
+   json::Object paramsJson;
+   paramsJson["textDocument"] = textDocumentJson;
+
+   sendNotification("textDocument/didOpen", paramsJson);
+}
+
+} // end anonymous namespace
+
+void onMonitoringEnabled(const tree<core::FileInfo>& tree)
+{
+   if (!s_copilotEnabled)
+      return;
+   
+   for (auto&& file : tree)
+      indexFile(file);
+}
+
+void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
+{
+   if (!s_copilotEnabled)
+      return;
+   
+   for (auto&& event : events)
+      indexFile(event.fileInfo());
+}
+
+void onMonitoringDisabled()
+{
+}
+
+} // end namespace file_monitor
+
+
+
 Error initialize()
 {
    using boost::bind;
@@ -938,6 +1028,14 @@ Error initialize()
    if (!copilotLogLevel.empty())
       s_copilotLogLevel = safe_convert::stringTo<int>(copilotLogLevel, 0);
 
+   // subscribe to project context file monitoring state changes
+   // (note that if there is no project this will no-op)
+   session::projects::FileMonitorCallbacks callbacks;
+   callbacks.onMonitoringEnabled = file_monitor::onMonitoringEnabled;
+   callbacks.onFilesChanged = file_monitor::onFilesChanged;
+   callbacks.onMonitoringDisabled = file_monitor::onMonitoringDisabled;
+   projects::projectContext().subscribeToFileMonitor("Copilot indexing", callbacks);
+   
    events().onBackgroundProcessing.connect(onBackgroundProcessing);
    events().onPreferencesSaved.connect(onPreferencesSaved);
    events().onDeferredInit.connect(onDeferredInit);

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3273,6 +3273,19 @@ core::Error UserPrefValues::setCopilotTabKeyBehavior(std::string val)
    return writePref("copilot_tab_key_behavior", val);
 }
 
+/**
+ * When enabled, RStudio will index project files with GitHub Copilot.
+ */
+bool UserPrefValues::copilotIndexingEnabled()
+{
+   return readPref<bool>("copilot_indexing_enabled");
+}
+
+core::Error UserPrefValues::setCopilotIndexingEnabled(bool val)
+{
+   return writePref("copilot_indexing_enabled", val);
+}
+
 std::vector<std::string> UserPrefValues::allKeys()
 {
    return std::vector<std::string>({
@@ -3526,6 +3539,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCopilotCompletionsDelay,
       kCopilotAllowAutomaticCompletions,
       kCopilotTabKeyBehavior,
+      kCopilotIndexingEnabled,
    });
 }
    

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1699,6 +1699,12 @@
             "default": "suggestion",
             "title": "Pressing Tab key will prefer inserting:",
             "description": "Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible."
+        },
+        "copilot_indexing_enabled": {
+            "type": "boolean",
+            "default": false,
+            "title": "Index project files with GitHub Copilot",
+            "description": "When enabled, RStudio will index project files with GitHub Copilot."
         }
      }
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -622,12 +622,16 @@ public class RemoteServer implements Server
    
    @Override
    public void copilotGenerateCompletions(String documentId,
+                                          String documentPath,
+                                          boolean isUntitled,
                                           int cursorRow,
                                           int cursorColumn,
                                           ServerRequestCallback<CopilotGenerateCompletionsResponse> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(documentId)
+            .add(documentPath)
+            .add(isUntitled)
             .add(cursorRow)
             .add(cursorColumn)
             .get();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/server/CopilotServerOperations.java
@@ -35,6 +35,8 @@ public interface CopilotServerOperations
    public void copilotStatus(ServerRequestCallback<CopilotStatusResponse> requestCallback);
    
    public void copilotGenerateCompletions(String documentId,
+                                          String documentPath,
+                                          boolean isUntitled,
                                           int cursorRow,
                                           int cursorColumn,
                                           ServerRequestCallback<CopilotGenerateCompletionsResponse> requestCallback);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3576,6 +3576,18 @@ public class UserPrefsAccessor extends Prefs
    public final static String COPILOT_TAB_KEY_BEHAVIOR_SUGGESTION = "suggestion";
    public final static String COPILOT_TAB_KEY_BEHAVIOR_COMPLETIONS = "completions";
 
+   /**
+    * When enabled, RStudio will index project files with GitHub Copilot.
+    */
+   public PrefValue<Boolean> copilotIndexingEnabled()
+   {
+      return bool(
+         "copilot_indexing_enabled",
+         _constants.copilotIndexingEnabledTitle(), 
+         _constants.copilotIndexingEnabledDescription(), 
+         false);
+   }
+
    public void syncPrefs(String layer, JsObject source)
    {
       if (source.hasKey("run_rprofile_on_resume"))
@@ -4078,6 +4090,8 @@ public class UserPrefsAccessor extends Prefs
          copilotAllowAutomaticCompletions().setValue(layer, source.getBool("copilot_allow_automatic_completions"));
       if (source.hasKey("copilot_tab_key_behavior"))
          copilotTabKeyBehavior().setValue(layer, source.getString("copilot_tab_key_behavior"));
+      if (source.hasKey("copilot_indexing_enabled"))
+         copilotIndexingEnabled().setValue(layer, source.getBool("copilot_indexing_enabled"));
    }
    public List<PrefValue<?>> allPrefs()
    {
@@ -4332,6 +4346,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(copilotCompletionsDelay());
       prefs.add(copilotAllowAutomaticCompletions());
       prefs.add(copilotTabKeyBehavior());
+      prefs.add(copilotIndexingEnabled());
       return prefs;
    }
    

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2083,6 +2083,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    @DefaultStringValue("Code Completion")
    String copilotTabKeyBehaviorEnum_completions();
 
+   /**
+    * When enabled, RStudio will index project files with GitHub Copilot.
+    */
+   @DefaultStringValue("Index project files with GitHub Copilot")
+   String copilotIndexingEnabledTitle();
+   @DefaultStringValue("When enabled, RStudio will index project files with GitHub Copilot.")
+   String copilotIndexingEnabledDescription();
+
 
 
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1047,4 +1047,8 @@ copilotTabKeyBehaviorDescription = Control the behavior of the Tab key when both
 copilotTabKeyBehaviorEnum_suggestion=Copilot Suggestion
 copilotTabKeyBehaviorEnum_completions=Code Completion
 
+# When enabled, RStudio will index project files with GitHub Copilot.
+copilotIndexingEnabledTitle = Index project files with GitHub Copilot
+copilotIndexingEnabledDescription = When enabled, RStudio will index project files with GitHub Copilot.
+
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -77,7 +77,6 @@ public class CopilotPreferencesPane extends PreferencesPane
       copilot_ = copilot;
       server_ = server;
       
-      cbCopilotEnabled_ = checkboxPref(prefs_.copilotEnabled(), true);
       lblCopilotStatus_ = new Label("(Loading...)");
       
       statusButtons_ = new ArrayList<SmallButton>();
@@ -99,6 +98,9 @@ public class CopilotPreferencesPane extends PreferencesPane
       btnRefresh_ = new SmallButton("Refresh");
       btnRefresh_.addStyleName(RES.styles().button());
       statusButtons_.add(btnRefresh_);
+      
+      cbCopilotEnabled_ = checkboxPref(prefs_.copilotEnabled(), true);
+      cbCopilotIndexingEnabled_ = checkboxPref(prefs_.copilotIndexingEnabled(), true);
       
       selCopilotTabKeyBehavior_ = new SelectWidget(
             constants.copilotTabKeyBehaviorTitle(),
@@ -140,12 +142,14 @@ public class CopilotPreferencesPane extends PreferencesPane
          statusPanel.add(btnSignOut_);
          statusPanel.add(btnActivate_);
          add(spaced(statusPanel));
+         
+         add(headerLabel("Copilot Indexing"));
+         add(spaced(cbCopilotIndexingEnabled_));
 
          add(headerLabel("Copilot Completions"));
          // add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
          // add(selCopilotTabKeyBehavior_);
          add(numericPref("Show code suggestions after keyboard idle (ms):", 10, 5000, prefs_.copilotCompletionsDelay()));
-         
       }
       else
       {
@@ -368,8 +372,9 @@ public class CopilotPreferencesPane extends PreferencesPane
    private final UserPrefs prefs_;
    private final Copilot copilot_;
    private final CopilotServerOperations server_;
-   private final CheckBox cbCopilotEnabled_;
    private final Label lblCopilotStatus_;
+   private final CheckBox cbCopilotEnabled_;
+   private final CheckBox cbCopilotIndexingEnabled_;
    private final List<SmallButton> statusButtons_;
    private final SmallButton btnSignIn_;
    private final SmallButton btnSignOut_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -17,6 +17,7 @@ package org.rstudio.studio.client.workbench.views.source.editors.text;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.MathUtil;
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.CommandBinder;
 import org.rstudio.core.client.command.Handler;
 import org.rstudio.core.client.dom.EventProperty;
@@ -82,6 +83,8 @@ public class TextEditingTargetCopilotHelper
                
                server_.copilotGenerateCompletions(
                      target_.getId(),
+                     StringUtil.notNull(target_.getPath()),
+                     StringUtil.isNullOrEmpty(target_.getPath()),
                      display_.getCursorRow(),
                      display_.getCursorColumn(),
                      new ServerRequestCallback<CopilotGenerateCompletionsResponse>()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13547.

### Approach

This PR adds a preference that controls whether RStudio will index project files with GitHub Copilot. When enabled, RStudio will tell GitHub Copilot about these files, which should (theoretically) allow it to provide better code suggestions within that project.

<img width="644" alt="Screenshot 2023-08-30 at 2 12 47 PM" src="https://github.com/rstudio/rstudio/assets/1976582/5518007f-8dae-4910-b4a2-35e61c0a82ef">


### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
