### PR TITLE
ensure event handlers are cleaned up on detach

### DIFF
--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1688,7 +1688,7 @@
         },
         "copilot_allow_automatic_completions": {
             "type": "boolean",
-            "default": false,
+            "default": true,
             "title": "Enable as-you-type code completions when Copilot is enabled",
             "description": "When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled."
         },

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/CodeBrowserType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/CodeBrowserType.java
@@ -14,11 +14,12 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.StudioClientCommonConstants;
+
+import com.google.gwt.core.client.GWT;
 
 public class CodeBrowserType extends EditableFileType
 {
@@ -33,5 +34,6 @@ public class CodeBrowserType extends EditableFileType
    {
       assert false : "CodeBrowserType doesn't operate on filesystem files";
    }
+   
    private static final StudioClientCommonConstants constants_ = GWT.create(StudioClientCommonConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/EditableFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/EditableFileType.java
@@ -24,6 +24,16 @@ public abstract class EditableFileType extends FileType
       label_ = label;
       defaultIcon_ = defaultIcon;
    }
+   
+   public long getFileSizeLimit()
+   {
+      return Long.MAX_VALUE;
+   }
+
+   public long getLargeFileSize()
+   {
+      return Long.MAX_VALUE;
+   }
 
    public String getLabel()
    {

--- a/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/filetypes/TextFileType.java
@@ -14,8 +14,7 @@
  */
 package org.rstudio.studio.client.common.filetypes;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.resources.client.ImageResource;
+import java.util.HashSet;
 
 import org.rstudio.core.client.FilePosition;
 import org.rstudio.core.client.UnicodeLetters;
@@ -32,7 +31,8 @@ import org.rstudio.studio.client.workbench.views.source.SourceWindowManager;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.CharClassifier;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ace.spelling.TokenPredicate;
 
-import java.util.HashSet;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.resources.client.ImageResource;
 
 public class TextFileType extends EditableFileType
 {
@@ -71,6 +71,18 @@ public class TextFileType extends EditableFileType
       canCheckSpelling_ = canCheckSpelling;
       canShowScopeTree_ = canShowScopeTree;
       canPreviewFromR_ = canPreviewFromR;
+   }
+   
+   @Override
+   public long getFileSizeLimit()
+   {
+      return 5 * 1024 * 1024;
+   }
+
+   @Override
+   public long getLargeFileSize()
+   {
+      return 2 * 1024 * 1024;
    }
 
    @Override

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3550,7 +3550,7 @@ public class UserPrefsAccessor extends Prefs
          "copilot_allow_automatic_completions",
          _constants.copilotAllowAutomaticCompletionsTitle(), 
          _constants.copilotAllowAutomaticCompletionsDescription(), 
-         false);
+         true);
    }
 
    /**


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13543.

### Approach

Event handlers attached through the global EventBus are never automatically released, unless we use the three-argument `addHandler()` call. Make use of those in TextEditingTarget.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
