### PR TITLE
fix up handling of Help pane redirects

### DIFF
--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -477,7 +477,8 @@ void handleHttpdResult(SEXP httpdSEXP,
    // fix up location header for redirects
    if (code == 302 && pResponse->containsHeader("Location"))
    {
-      // check for a redirect to the R help server
+      // check for a redirect to the R help server. the R help server hard-codes
+      // navigation to the help server at 127.0.0.1 in a number of places
       std::string location = pResponse->headerValue("Location");
       std::string rPort = module_context::rLocalHelpPort();
       std::string rHelpPrefix = fmt::format("http://127.0.0.1:{}/", rPort);

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -485,6 +485,11 @@ void handleHttpdResult(SEXP httpdSEXP,
       {
          // make sure we use the same base URL as the request, otherwise
          // we might not be allowed to display the redirected Help content in the frame
+         //
+         // for example, RStudio Server might've been loaded from 'http://localhost:8787', but the
+         // R help server might try directing to 'http://127.0.0.1:8787'
+         //
+         // https://github.com/rstudio/rstudio/issues/13263
          std::string baseUri = request.baseUri();
          std::string path = request.path();
          std::string pathPrefix = baseUri.substr(0, baseUri.size() - path.size());

--- a/src/cpp/session/modules/SessionHelp.cpp
+++ b/src/cpp/session/modules/SessionHelp.cpp
@@ -490,11 +490,9 @@ void handleHttpdResult(SEXP httpdSEXP,
          // R help server might try directing to 'http://127.0.0.1:8787'
          //
          // https://github.com/rstudio/rstudio/issues/13263
-         std::string baseUri = request.baseUri();
-         std::string path = request.path();
-         std::string pathPrefix = baseUri.substr(0, baseUri.size() - path.size());
-         std::string redirect = fmt::format("{}/help/{}", pathPrefix, location.substr(rHelpPrefix.length()));
-         
+         std::string path = location.substr(rHelpPrefix.length());
+         std::string ref = request.headerValue("Referer");
+         std::string redirect = fmt::format("{}help/{}", ref, path);
          pResponse->setHeader("Location", redirect);
       }
    }

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -202,12 +202,6 @@ export class DesktopBrowserWindow extends EventEmitter {
       }
     });
 
-    // any redirects should be handled by the default browser
-    this.window.webContents.on('will-redirect', (event, url) => {
-      event.preventDefault();
-      void shell.openExternal(url);
-    });
-
     this.window.webContents.on('page-title-updated', (event, title, explicitSet) => {
       this.adjustWindowTitle(title, explicitSet);
     });


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13392.

### Approach

R's help server makes use of redirects in some scenarios. For those cases, we need to re-write the Location header so that the Help requests are made to our Help proxy rather than the R help server directly.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13392. This code only affects redirects, which are somewhat rare for the help server, but I think it would be worth testing https://github.com/rstudio/rstudio/issues/13263 in a variety of scenarios.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
