### PR TITLE
Check for 409 error when publishing builds, even after addressing a 4…

### DIFF
--- a/docker/jenkins/publish-build.ps1
+++ b/docker/jenkins/publish-build.ps1
@@ -134,14 +134,16 @@ try
         $updateSha = $getSha.sha
 
         # This looks messy but the whitespace is meaningful
-        $updatePayload = @"
+        $payload = @"
 { "message": "Update $flower build $version in $build", "content": "$base64", "sha": "$updateSha" }
 "@
         Write-Host "Updating version file..."
-        $updateResponse = Invoke-RestMethod -Body $updatePayload -Method 'PUT' -Headers $headers -Uri $url -UseBasicParsing
+        $updateResponse = Invoke-RestMethod -Body $payload -Method 'PUT' -Headers $headers -Uri $url -UseBasicParsing
         Write-Host $updateResponse
 
-    } elseif ($StatusCode -eq 409) { # Assume the repo has been updated backoff and try again.
+    }
+    
+    if ($StatusCode -eq 409) { # Assume the repo has been updated backoff and try again.
         Write-Host "Received a 409, assuming it's a commit interleaving error, waiting 3 seconds and retrying".
         Start-Sleep -Seconds 3
 

--- a/docker/jenkins/publish-build.sh
+++ b/docker/jenkins/publish-build.sh
@@ -237,7 +237,7 @@ if [[ $httpCode -eq 422 ]]; then
 
    updateSha=$(echo $getShaResponse | jq -r .sha)
 
-   updatePayload="{\"message\":\"Update $flower build $version in $build\",\"content\":\"$base64_contents\",\"sha\":\"$updateSha\"}"
+   payload="{\"message\":\"Update $flower build $version in $build\",\"content\":\"$base64_contents\",\"sha\":\"$updateSha\"}"
    
    httpCode=$(curl \
       -X PUT \
@@ -246,12 +246,15 @@ if [[ $httpCode -eq 422 ]]; then
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: token $pat" \
       $githubUrl \
-      -d "$updatePayload")
+      -d "$payload")
 
    echo "Github's Update Response:"
    echo "Http Code : $httpCode"
    cat $curlOutFname
-elif [[ $httpCode -eq 409 ]]; then
+fi
+
+# Separate this if block so if the 422 retry block above fails with a 409 we can handle that as well
+if [[ $httpCode -eq 409 ]]; then
    echo "Received a 409 error, assuming it's a commit interleaving error, we'll back off for 3 seconds and retry".
    sleep 3
 


### PR DESCRIPTION
…22 error

### Intent

Slight change to the publish build scripts to see if we can recover from a `422` error, followed by a `409` error. Seen in this build: https://build.posit.it/blue/organizations/jenkins/IDE%2FOS-Builds%2FPlatforms%2Flinux-pipeline/detail/rel-mountain-hydrangea/145/pipeline/3806/

I'm not entirely convinced just waiting and retrying will fix it, but we can try this before trying to make the `409` error handling more robust.

Also note this will need to be merged forward into `MH` and `main`

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


