### PR TITLE
fix up eslint errors

### DIFF
--- a/src/node/desktop/.eslintrc.js
+++ b/src/node/desktop/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
         tabWidth: 2,
         ignoreUrls: true,
         ignoreStrings: true,
-        ignoreTemplateLiterals: true
+        ignoreTemplateLiterals: true,
       },
     ],
 
@@ -47,7 +47,6 @@ module.exports = {
     '@typescript-eslint/promise-function-async': ['warn'],
     '@typescript-eslint/require-array-sort-compare': ['error'],
     '@typescript-eslint/return-await': ['warn'],
-    '@typescript-eslint/no-implicit-any-catch': ['error'],
     '@typescript-eslint/no-unused-vars': [
       'warn',
       {

--- a/src/node/desktop/src/core/expected.ts
+++ b/src/node/desktop/src/core/expected.ts
@@ -34,6 +34,7 @@ export function expect<T>(callback: () => T): Expected<T> {
     const result = callback();
     return ok(result);
   } catch (error: unknown) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return err(error as any);
   }
 }

--- a/src/node/desktop/src/main/i18n-manager.ts
+++ b/src/node/desktop/src/main/i18n-manager.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-implicit-any-catch */
 /*
  * i18n-manager.ts
  *

--- a/src/node/desktop/src/main/menu-callback.ts
+++ b/src/node/desktop/src/main/menu-callback.ts
@@ -51,9 +51,11 @@ export class MenuCallback extends EventEmitter {
 
   savedMenu: Menu | null = null;
 
+  /* eslint-disable @typescript-eslint/no-explicit-any */
   debounceUpdateMenuLong: any = debounce(() => this.updateMenus(), 5000);
   debounceUpdateMenuMedium: any = debounce(() => this.updateMenus(), 250);
   debounceUpdateMenuShort: any = debounce(() => this.updateMenus(), 10);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
 
   constructor() {
     super();
@@ -286,19 +288,19 @@ export class MenuCallback extends EventEmitter {
    */
   updateMenus(): void {
     const newMainMenuTemplate = this.recursiveCopy(this.mainMenuTemplate);
-    
+
     if (appState().modalTracker.numModalsShowing() === 0) {
       // update only if there are no modals showing
       this.mainMenu = Menu.buildFromTemplate(newMainMenuTemplate);
       Menu.setApplicationMenu(this.mainMenu);
     }
-    
+
     this.isMenuSet = true;
   }
 
   /*
-  * This function will remove items that has a submenu array with no items
-  */
+   * This function will remove items that has a submenu array with no items
+   */
   private removeItemsWithEmptySubmenuList(item: MenuItemConstructorOptions): boolean {
     if (Object.prototype.hasOwnProperty.call(item, 'submenu')) {
       if (Array.isArray(item.submenu)) {
@@ -314,7 +316,7 @@ export class MenuCallback extends EventEmitter {
     }
 
     return true;
-  };
+  }
 
   /**
    * Builds the final list of menu items using the given menu template
@@ -380,7 +382,7 @@ export class MenuCallback extends EventEmitter {
     }
 
     return newMenuTemplate;
-  };
+  }
 
   addCommand(
     cmdId: string,
@@ -492,10 +494,12 @@ export class MenuCallback extends EventEmitter {
       this.savedMenu = Menu.getApplicationMenu();
       if (this.savedMenu) {
         const disabledMenu = Menu.buildFromTemplate(this.recursiveCopy(this.mainMenuTemplate));
-        disabledMenu?.items?.forEach((item) => {
+        disabledMenu.items.forEach((item) => {
           item.submenu?.items.forEach((subItem) => {
             // keep some commands enabled
-            subItem.enabled = ['cut', 'copy', 'paste', 'redo', 'hide', 'hideOthers', 'unhide', 'selectAll'].includes(subItem.role ?? '');
+            subItem.enabled = ['cut', 'copy', 'paste', 'redo', 'hide', 'hideOthers', 'unhide', 'selectAll'].includes(
+              subItem.role ?? '',
+            );
           });
         });
         Menu.setApplicationMenu(disabledMenu);

--- a/src/node/desktop/src/main/modal-dialog-tracker.ts
+++ b/src/node/desktop/src/main/modal-dialog-tracker.ts
@@ -25,6 +25,7 @@ import { appState } from './app-state';
  * Based on src/gwt/src/org/rstudio/core/client/widget/ModalDialogTracker.java
  */
 export class ModalDialogTracker {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private modals: ModalDialog<any>[] = [];
   private electronModalsShowing = 0;
   private gwtModalsShowing = 0;
@@ -50,6 +51,7 @@ export class ModalDialogTracker {
    * Adds a ModalDialog to tracking and disables the main menu
    * @param modal ModalDialog to add to tracking
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async addModalDialog(modal: ModalDialog<any>) {
     this.modals.push(modal);
     appState().gwtCallback?.mainWindow.menuCallback.setMainMenuEnabled(false);
@@ -59,6 +61,7 @@ export class ModalDialogTracker {
    * Removes a ModalDialog from tracking and re-enables the main menu if applicable
    * @param modal ModalDialog to remove from tracking
    */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async removeModalDialog(modal: ModalDialog<any>) {
     this.modals = this.modals.filter((m) => m !== modal);
     this.maybeReenableMainMenu();

--- a/src/node/desktop/src/main/toolbar-manager.ts
+++ b/src/node/desktop/src/main/toolbar-manager.ts
@@ -38,7 +38,7 @@ export class ToolbarManager {
     try {
       await window.webContents.executeJavaScript(jsScript);
 
-      // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       if (err.message !== 'An object could not be cloned.') {
         const error =

--- a/src/node/desktop/src/main/utils.ts
+++ b/src/node/desktop/src/main/utils.ts
@@ -17,7 +17,7 @@ import fs, { existsSync } from 'fs';
 import os from 'os';
 import path from 'path';
 import { sep } from 'path';
-import { app, BrowserWindow, dialog, FileFilter, MessageBoxOptions, WebContents, WebRequest } from 'electron';
+import { app, BrowserWindow, Cookie, dialog, FileFilter, MessageBoxOptions, WebContents, WebRequest } from 'electron';
 
 import { Xdg } from '../core/xdg';
 import { getenv, setenv } from '../core/environment';
@@ -450,7 +450,7 @@ export async function createStandaloneErrorDialog(
     );
 
     if (options.shouldCloseWindow) window.close();
-    // eslint-disable-next-line @typescript-eslint/no-implicit-any-catch
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {
     console.error('[utils.ts] [createStandaloneErrorDialog] Error when creating Standalone Error Dialog: ', error);
   }
@@ -484,8 +484,9 @@ export const handleLocaleCookies = async (window: BrowserWindow, isMainWindow = 
 
   await window.webContents.session.cookies
     .get({})
-    .then(async (cookies) => {
+    .then(async (cookies: Cookie[]) => {
       if (cookies.length === 0) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         await updateLocaleFromCookie({ name: 'LOCALE', value: 'en' } as any, window);
       } else {
         cookies.forEach(async (cookie) => {

--- a/src/node/desktop/src/ui/connect/connect.ts
+++ b/src/node/desktop/src/ui/connect/connect.ts
@@ -15,7 +15,6 @@
  *
  */
 
-/* eslint-disable @typescript-eslint/no-implicit-any-catch */
 import { changeLanguage, initI18n } from '../../main/i18n-manager';
 import i18next from 'i18next';
 import { checkForNewLanguage } from '../utils';
@@ -70,11 +69,13 @@ const loadPageLocalization = () => {
 
   window.addEventListener('load', () => {
     checkForNewLanguage()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(async (newLanguage: any) =>
         changeLanguage('' + newLanguage).then(() => {
           updateLabels();
         }),
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .catch((err: any) => {
         console.error('An error happened when trying to fetch a new locale: ', err);
       });

--- a/src/node/desktop/src/ui/error/error.ts
+++ b/src/node/desktop/src/ui/error/error.ts
@@ -13,7 +13,6 @@
  *
  */
 
-/* eslint-disable @typescript-eslint/no-implicit-any-catch */
 import { changeLanguage, initI18n } from '../../main/i18n-manager';
 import i18next from 'i18next';
 import { checkForNewLanguage } from '../utils';
@@ -76,11 +75,13 @@ const loadPageLocalization = () => {
 
   window.addEventListener('load', () => {
     checkForNewLanguage()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(async (newLanguage: any) =>
         changeLanguage('' + newLanguage).then(() => {
           updateLabels();
         }),
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .catch((err: any) => {
         console.error('An error happened when trying to fetch a new locale: ', err);
       });
@@ -90,6 +91,7 @@ const loadPageLocalization = () => {
 const replaceReportVar = async (report: string, varName: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (window as any).desktop.getStartupErrorInfo('!' + varName, (result: any) => {
         resolve(report.replace(new RegExp('#' + varName + '#', 'g'), result));
       });

--- a/src/node/desktop/src/ui/loading/loading.ts
+++ b/src/node/desktop/src/ui/loading/loading.ts
@@ -13,7 +13,6 @@
  *
  */
 
-/* eslint-disable @typescript-eslint/no-implicit-any-catch */
 import { changeLanguage, initI18n } from '../../main/i18n-manager';
 import i18next from 'i18next';
 import { checkForNewLanguage } from '../utils';
@@ -49,11 +48,13 @@ const loadPageLocalization = () => {
 
   window.addEventListener('load', () => {
     checkForNewLanguage()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .then(async (newLanguage: any) =>
         changeLanguage('' + newLanguage).then(() => {
           updateLabels();
         }),
       )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       .catch((err: any) => {
         console.error('An error happened when trying to fetch a new locale: ', err);
       });

--- a/src/node/desktop/src/ui/widgets/choose-r/load.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/load.ts
@@ -13,7 +13,6 @@
  *
  */
 
-/* eslint-disable @typescript-eslint/no-implicit-any-catch */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 
 import { Callbacks, CallbackData } from './preload';
@@ -118,11 +117,13 @@ window.addEventListener('load', () => {
   );
 
   checkForNewLanguage()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .then(async (newLanguage: any) =>
       changeLanguage('' + newLanguage).then(() => {
         updateLabels();
       }),
     )
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     .catch((err: any) => {
       console.error('An error happened when trying to fetch a new locale: ', err);
     });

--- a/src/node/desktop/src/ui/widgets/choose-r/preload.ts
+++ b/src/node/desktop/src/ui/widgets/choose-r/preload.ts
@@ -116,6 +116,7 @@ ipcRenderer.on('initialize', (_event, data) => {
       selectEl.appendChild(optionEl);
 
       if (isRVersionSelected(data.selectedRVersion as string, r64) && !isDefault64Selected) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const useCustomRadioInput = document.getElementById('use-custom') as any;
         useCustomRadioInput.checked = true;
 
@@ -134,6 +135,7 @@ ipcRenderer.on('initialize', (_event, data) => {
       selectEl.appendChild(optionEl);
 
       if (isRVersionSelected(data.selectedRVersion as string, r32) && !isDefault32Selected) {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const useCustomRadioInput = document.getElementById('use-custom') as any;
         useCustomRadioInput.checked = true;
 

--- a/src/node/desktop/test/unit/main/context-menu.test.ts
+++ b/src/node/desktop/test/unit/main/context-menu.test.ts
@@ -12,6 +12,7 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { describe } from 'mocha';
 import { assert } from 'chai';


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio/issues/13597

### Approach

- remove or replace usages of `@typescript-eslint/no-implicit-any-catch` with the appropriate variable type or an alternative eslint rule applicable to the situation, such as `@typescript-eslint/no-explicit-any`
- fix up any linting errors by adding eslint annotations

### Automated Tests

none

### QA Notes

Running the linter on the desktop typescript files should no longer output any errors.

#### Steps
```
cd src/node/desktop
npm run lint
```

### Documentation

none

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`  -- don't think NEWS is needed in this case
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


