### PR TITLE
don't log copilot errors to console by default

### DIFF
--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -42,8 +42,8 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_ERROR(error) rstudio::core::log::logError(error, \
                                                       ERROR_LOCATION)
 
-#define LOG_ERROR_NAMED(logSection, error) rstudio::core::log::logError(logSection, \
-                                                                        error, \
+#define LOG_ERROR_NAMED(logSection, error) rstudio::core::log::logError(error, \
+                                                                        logSection, \
                                                                         ERROR_LOCATION)
 
 #define LOG_ERROR_MESSAGE(message) rstudio::core::log::logErrorMessage(message, \

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -50,14 +50,14 @@
       std::string message = fmt::format(__FMT__, ##__VA_ARGS__);               \
       std::string formatted =                                                  \
           fmt::format("[{}]: {}", __func__, message);                          \
-      __LOGGER__(formatted);                                                   \
+      __LOGGER__("copilot", formatted);                                        \
       if (copilotLogLevel() >= 1)                                              \
          std::cerr << formatted << std::endl;                                  \
    } while (0)
 
-#define DLOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_DEBUG_MESSAGE,   __FMT__, ##__VA_ARGS__)
-#define WLOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_WARNING_MESSAGE, __FMT__, ##__VA_ARGS__)
-#define ELOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_ERROR_MESSAGE,   __FMT__, ##__VA_ARGS__)
+#define DLOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_DEBUG_MESSAGE_NAMED,   __FMT__, ##__VA_ARGS__)
+#define WLOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_WARNING_MESSAGE_NAMED, __FMT__, ##__VA_ARGS__)
+#define ELOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_ERROR_MESSAGE_NAMED,   __FMT__, ##__VA_ARGS__)
 
 #ifndef _WIN32
 # define kNodeExe "node"
@@ -484,7 +484,9 @@ void onStdout(ProcessOperations& operations, const std::string& stdOut)
 
 void onStderr(ProcessOperations& operations, const std::string& stdErr)
 {
-   std::cerr << stdErr << std::endl;
+   LOG_ERROR_MESSAGE_NAMED("copilot", stdErr);
+   if (copilotLogLevel() >= 1)
+      std::cerr << stdErr << std::endl;
 }
 
 void onExit(int status)

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -59,6 +59,13 @@
 #define WLOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_WARNING_MESSAGE_NAMED, __FMT__, ##__VA_ARGS__)
 #define ELOG(__FMT__, ...) COPILOT_LOG_IMPL(LOG_ERROR_MESSAGE_NAMED,   __FMT__, ##__VA_ARGS__)
 
+// Use a default section of 'copilot' for errors / warnings
+#ifdef LOG_ERROR
+# undef LOG_ERROR
+# define LOG_ERROR(error) LOG_ERROR_NAMED("copilot", error)
+#endif
+
+
 #ifndef _WIN32
 # define kNodeExe "node"
 #else

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -612,6 +612,12 @@ void logError(const Error& in_error, const ErrorLocation& in_location)
       logger().writeMessageToDestinations(LogLevel::ERR, std::string(), "", boost::none, in_location, in_error);
 }
 
+void logError(const Error& in_error, const std::string& in_section, const ErrorLocation& in_location)
+{
+   if (!in_error.isExpected())
+      logger().writeMessageToDestinations(LogLevel::ERR, std::string(), in_section, boost::none, in_location, in_error);
+}
+
 void logErrorAsWarning(const Error& in_error)
 {
    if (!in_error.isExpected())

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -204,6 +204,18 @@ void logError(const Error& in_error);
 void logError(const Error& in_error, const ErrorLocation& in_location);
 
 /**
+ * @brief Logs an error to all registered destinations.
+ *
+ * If no destinations are registered, no log will be written.
+ * If the configured log level is below LogLevel::ERR, no log will be written.
+ *
+ * @param in_error        The error to log.
+ * @param in_section      The section of the log that the message belongs in.
+ * @param in_location     The location from which the message was logged.
+ */
+void logError(const Error& in_error, const std::string& in_section, const ErrorLocation& in_loggedFrom);
+
+/**
  * @brief Logs an error as a warning to all registered destinations.
  *
  * If no destinations are registered, no log will be written.


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13411.

### Approach

Previously, we were logging all Copilot errors to the R console to make development simpler. This PR changes that so logging to the console only happens when one has explicitly opted in to Copilot debugging.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13411.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
