### PR TITLE
Add null check to widget label

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/SelectWidget.java
@@ -136,7 +136,7 @@ public class SelectWidget extends Composite
       if (values == null)
          values = options;
       
-      if (!label.endsWith(":"))
+      if ((label != null) && !label.endsWith(":"))
          label = label + ":";
 
       listBox_ = new ListBox();


### PR DESCRIPTION
### Intent

Addresses a regression tracked by https://github.com/rstudio/rstudio-pro/issues/4965. Working with a null string was causing GWT to crash and not complete the request for a new session.

Not including a NEWS.md entry since the regression happened during DS development

### Approach

### Automated Tests

This was caught by automated tests

### QA Notes

N/A

### Documentation
N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


