### PR TITLE
add copilot project-specific preferences

### DIFF
--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -117,7 +117,8 @@ struct RProjectConfig
         pythonVersion(),
         pythonPath(),
         spellingDictionary(),
-        copilotEnabled(DefaultValue)
+        copilotEnabled(DefaultValue),
+        copilotIndexingEnabled(DefaultValue)
    {
    }
 
@@ -164,6 +165,7 @@ struct RProjectConfig
    std::string pythonPath;
    std::string spellingDictionary;
    int copilotEnabled;
+   int copilotIndexingEnabled;
 };
 
 Error findProjectFile(FilePath filePath,

--- a/src/cpp/core/include/core/r_util/RProjectFile.hpp
+++ b/src/cpp/core/include/core/r_util/RProjectFile.hpp
@@ -116,7 +116,8 @@ struct RProjectConfig
         pythonType(),
         pythonVersion(),
         pythonPath(),
-        spellingDictionary()
+        spellingDictionary(),
+        copilotEnabled(DefaultValue)
    {
    }
 
@@ -162,6 +163,7 @@ struct RProjectConfig
    std::string pythonVersion;
    std::string pythonPath;
    std::string spellingDictionary;
+   int copilotEnabled;
 };
 
 Error findProjectFile(FilePath filePath,

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1010,7 +1010,14 @@ Error readProjectFile(const FilePath& projectFilePath,
    if (it != dcfFields.end())
    {
       if (!interpretYesNoAskValue(it->second, false, &(pConfig->copilotEnabled)))
-         return requiredFieldError("MarkdownCanonical", pUserErrMsg);
+         return requiredFieldError("CopilotEnabled", pUserErrMsg);
+   }
+   
+   it = dcfFields.find("CopilotIndexingEnabled");
+   if (it != dcfFields.end())
+   {
+      if (!interpretYesNoAskValue(it->second, false, &(pConfig->copilotIndexingEnabled)))
+         return requiredFieldError("CopilotIndexingEnabled", pUserErrMsg);
    }
 
    return Success();
@@ -1307,6 +1314,13 @@ Error writeProjectFile(const FilePath& projectFilePath,
       boost::format fmt("\nCopilotEnabled: %1%\n");
       contents.append(boost::str(fmt % yesNoAskValueToString(config.copilotEnabled)));
    }
+   
+   if (config.copilotIndexingEnabled != DefaultValue)
+   {
+      boost::format fmt("CopilotIndexingEnabled: %1%\n");
+      contents.append(boost::str(fmt % yesNoAskValueToString(config.copilotIndexingEnabled)));
+   }
+   
 
    // write it
    return writeStringToFile(projectFilePath,

--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1004,6 +1004,14 @@ Error readProjectFile(const FilePath& projectFilePath,
    {
       pConfig->spellingDictionary = it->second;
    }
+   
+   // extract copilot fields
+   it = dcfFields.find("CopilotEnabled");
+   if (it != dcfFields.end())
+   {
+      if (!interpretYesNoAskValue(it->second, false, &(pConfig->copilotEnabled)))
+         return requiredFieldError("MarkdownCanonical", pUserErrMsg);
+   }
 
    return Success();
 }
@@ -1064,8 +1072,6 @@ Error writeProjectFile(const FilePath& projectFilePath,
 
       if (config.autoAppendNewline)
       {
-
-
          contents.append("AutoAppendNewline: Yes\n");
       }
 
@@ -1295,6 +1301,12 @@ Error writeProjectFile(const FilePath& projectFilePath,
       contents.append(boost::str(fmt % config.spellingDictionary));
    }
 
+   // add copilot information if present
+   if (config.copilotEnabled != DefaultValue)
+   {
+      boost::format fmt("\nCopilotEnabled: %1%\n");
+      contents.append(boost::str(fmt % yesNoAskValueToString(config.copilotEnabled)));
+   }
 
    // write it
    return writeStringToFile(projectFilePath,

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -360,6 +360,7 @@ struct Events : boost::noncopyable
    RSTUDIO_BOOST_SIGNAL<void(const std::string&)>                     onPackageLoaded;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onPackageLibraryMutated;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onPreferencesSaved;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onProjectConfigUpdated;
    RSTUDIO_BOOST_SIGNAL<void(const core::DistributedEvent&)>          onDistributedEvent;
    RSTUDIO_BOOST_SIGNAL<void(core::FilePath)>                         onPermissionsChanged;
    RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onShutdown;

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -624,17 +624,17 @@ bool startAgent()
 
 bool ensureAgentRunning()
 {
-   // bail if we haven't enabled copilot
-   if (!s_copilotEnabled)
-   {
-      DLOG("Copilot is not enabled; not starting agent.");
-      return false;
-   }
-
    // bail if copilot is not allowed
    if (!session::options().copilotEnabled())
    {
       DLOG("Copilot has been disabled by the administrator; not starting agent.");
+      return false;
+   }
+
+   // bail if we haven't enabled copilot
+   if (!s_copilotEnabled)
+   {
+      DLOG("Copilot is not enabled; not starting agent.");
       return false;
    }
 
@@ -781,7 +781,7 @@ void onBackgroundProcessing(bool isIdle)
    }
 }
 
-void onPreferencesSaved()
+void synchronize()
 {
    // Check for preference change
    bool oldEnabled = s_copilotEnabled;
@@ -801,14 +801,25 @@ void onPreferencesSaved()
    {
       stopAgent();
    }
+   
+}
+
+void onPreferencesSaved()
+{
+   synchronize();
+}
+
+void onProjectConfigUpdated()
+{
+   synchronize();
 }
 
 void onUserPrefsChanged(const std::string& layer,
                         const std::string& name)
 {
-   if (name == "copilot_enabled")
+   if (name == kCopilotEnabled)
    {
-      onPreferencesSaved();
+      synchronize();
    }
 }
 
@@ -1053,6 +1064,7 @@ Error initialize()
    
    events().onBackgroundProcessing.connect(onBackgroundProcessing);
    events().onPreferencesSaved.connect(onPreferencesSaved);
+   events().onProjectConfigUpdated.connect(onProjectConfigUpdated);
    events().onDeferredInit.connect(onDeferredInit);
    events().onShutdown.connect(onShutdown);
 

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -775,11 +775,11 @@ json::Object ProjectContext::uiPrefs() const
    json::Object uiPrefs;
    uiPrefs[kUseSpacesForTab] = config_.useSpacesForTab;
    uiPrefs[kNumSpacesForTab] = config_.numSpacesForTab;
+   
    // only set project value if explicitly set to Yes or No
-   if (config_.useNativePipeOperator == r_util::YesValue)
-      uiPrefs[kInsertNativePipeOperator] = true;
-   if (config_.useNativePipeOperator == r_util::NoValue)
-      uiPrefs[kInsertNativePipeOperator] = false;
+   if (config_.useNativePipeOperator != DefaultValue)
+      uiPrefs[kInsertNativePipeOperator] = config_.useNativePipeOperator == YesValue;
+   
    uiPrefs[kAutoAppendNewline] = config_.autoAppendNewline;
    uiPrefs[kStripTrailingWhitespace] = config_.stripTrailingWhitespace;
    uiPrefs[kDefaultEncoding] = defaultEncoding();
@@ -820,6 +820,12 @@ json::Object ProjectContext::uiPrefs() const
    if (!config_.spellingDictionary.empty())
       uiPrefs[kSpellingDictionaryLanguage] = config_.spellingDictionary;
 
+   if (config_.copilotEnabled != DefaultValue)
+      uiPrefs[kCopilotEnabled] = config_.copilotEnabled == YesValue;
+   
+   if (config_.copilotIndexingEnabled != DefaultValue)
+      uiPrefs[kCopilotIndexingEnabled] = config_.copilotIndexingEnabled == YesValue;
+   
    return uiPrefs;
 }
 

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -418,6 +418,8 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
       configJson["zotero_libraries"] = json::toJsonArray(config.zoteroLibraries.get());
    else
       configJson["zotero_libraries"] = json::Value(); // null
+   configJson["copilot_enabled"] = config.copilotEnabled;
+   configJson["copilot_indexing_enabled"] = config.copilotIndexingEnabled;
 
    return configJson;
 }
@@ -488,6 +490,9 @@ void setProjectConfig(const r_util::RProjectConfig& config)
 {
    // set it
    s_projectContext.setConfig(config);
+   
+   // notify listeners
+   module_context::events().onProjectConfigUpdated();
 
    // sync underlying R setting
    module_context::syncRSaveAction();
@@ -701,6 +706,14 @@ Error writeProjectConfig(const json::Object& configJson)
    // read spelling options
    error = json::readObject(configJson,
                             "spelling_dictionary", config.spellingDictionary);
+   if (error)
+      return error;
+   
+   // read copilot options
+   error = json::readObject(
+            configJson,
+            "copilot_enabled", config.copilotEnabled,
+            "copilot_indexing_enabled", config.copilotIndexingEnabled);
    if (error)
       return error;
 

--- a/src/gwt/src/org/rstudio/core/client/StringUtil.java
+++ b/src/gwt/src/org/rstudio/core/client/StringUtil.java
@@ -14,17 +14,6 @@
  */
 package org.rstudio.core.client;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.i18n.client.DateTimeFormat;
-import com.google.gwt.i18n.client.NumberFormat;
-
-import org.rstudio.core.client.container.SafeMap;
-import org.rstudio.core.client.dom.DomMetrics;
-import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.regex.Match;
-import org.rstudio.core.client.regex.Pattern;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,6 +22,17 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+
+import org.rstudio.core.client.container.SafeMap;
+import org.rstudio.core.client.dom.DomMetrics;
+import org.rstudio.core.client.files.FileSystemItem;
+import org.rstudio.core.client.regex.Match;
+import org.rstudio.core.client.regex.Pattern;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.i18n.client.DateTimeFormat;
+import com.google.gwt.i18n.client.NumberFormat;
 
 public class StringUtil
 {
@@ -1498,7 +1498,7 @@ public class StringUtil
       var val2 = str2 ? str2 : "";
       return val1.localeCompare(val2, [], { "numeric": true });
    }-*/;
-
+   
    private static final NumberFormat FORMAT = NumberFormat.getFormat("0.#");
    private static final NumberFormat PRETTY_NUMBER_FORMAT = NumberFormat.getFormat("#,##0.#####");
    private static final DateTimeFormat DATE_FORMAT

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -449,11 +449,19 @@ public class RProjectConfig extends JavaScriptObject
       this.zotero_libraries = libraries;
    }-*/;
    
-   public native final Boolean getCopilotEnabled() /*-{
+   public native final int getCopilotEnabled() /*-{
       return this.copilot_enabled;
    }-*/;
    
-   public native final void setCopilotEnabled(boolean enabled) /*-{
+   public native final void setCopilotEnabled(int enabled) /*-{
       this.copilot_enabled = enabled;
+   }-*/;
+   
+   public native final int getCopilotIndexingEnabled() /*-{
+      return this.copilot_indexing_enabled;
+   }-*/;
+   
+   public native final void setCopilotIndexingEnabled(int enabled) /*-{
+      this.copilot_indexing_enabled = enabled;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -16,13 +16,20 @@ package org.rstudio.studio.client.projects.model;
 
 import java.util.ArrayList;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.StringUtil;
-
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArrayString;
 import org.rstudio.studio.client.projects.StudioClientProjectConstants;
 
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
+
+// This class encompasses project configuration which should be included
+// within a project's .Rproj file. These settings are useful for project-specific
+// settings which should apply to all users in a project.
+//
+// Contrast this with user-specific project settings, like the version of git
+// the user has configured for use in a project -- this could differ from
+// user to user, and so isn't appropriate for the .Rproj file.
 public class RProjectConfig extends JavaScriptObject
 {
    private static final StudioClientProjectConstants constants_ = GWT.create(StudioClientProjectConstants.class);
@@ -36,9 +43,9 @@ public class RProjectConfig extends JavaScriptObject
    }
 
    public native static final RProjectConfig createEmpty() /*-{
-      var config = new Object();
-      config.version = 1.0;
-      return config;
+      return {
+         version: 1.0
+      }
    }-*/;
 
    public native final double getVersion() /*-{
@@ -440,5 +447,13 @@ public class RProjectConfig extends JavaScriptObject
 
    public native final void setZoteroLibraries(JsArrayString libraries) /*-{
       this.zotero_libraries = libraries;
+   }-*/;
+   
+   public native final Boolean getCopilotEnabled() /*-{
+      return this.copilot_enabled;
+   }-*/;
+   
+   public native final void setCopilotEnabled(boolean enabled) /*-{
+      this.copilot_enabled = enabled;
    }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -17,7 +17,6 @@ package org.rstudio.studio.client.projects.ui.prefs;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.prefs.PreferencesDialogBase;
 import org.rstudio.core.client.prefs.PreferencesDialogPaneBase;
 import org.rstudio.core.client.prefs.RestartRequirement;
@@ -32,6 +31,7 @@ import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.model.RProjectRenvOptions;
 import org.rstudio.studio.client.projects.ui.prefs.buildtools.ProjectBuildToolsPreferencesPane;
+import org.rstudio.studio.client.projects.ui.prefs.buildtools.ProjectCopilotPreferencesPane;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -40,6 +40,7 @@ import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 import org.rstudio.studio.client.workbench.views.console.events.SendToConsoleEvent;
 
+import com.google.gwt.core.client.GWT;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -74,6 +75,7 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                                    ProjectRenvPreferencesPane renv,
                                    ProjectPythonPreferencesPane python,
                                    ProjectSharingPreferencesPane sharing,
+                                   ProjectCopilotPreferencesPane copilot,
                                    Provider<ApplicationQuit> pQuit,
                                    Provider<GlobalDisplay> pGlobalDisplay)
    {
@@ -91,7 +93,8 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                   build,
                   source,
                   renv,
-                  sharing));
+                  sharing,
+                  copilot));
 
       pSession_ = session;
       server_ = server;
@@ -205,7 +208,14 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                    uiPrefs.spellingDictionaryLanguage().setProjectValue(config.getSpellingDictionary());
                 else
                    uiPrefs.spellingDictionaryLanguage().removeProjectValue(true);
-
+                
+                // copilot prefs
+                Boolean copilotEnabled = config.getCopilotEnabled();
+                if (copilotEnabled != null)
+                   uiPrefs.copilotEnabled().setProjectValue(copilotEnabled);
+                else
+                   uiPrefs.copilotEnabled().removeProjectValue(true);
+                      
                 // convert packrat option changes to console actions
                 emitRenvConsoleActions(options.getRenvOptions());
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -210,11 +210,19 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                    uiPrefs.spellingDictionaryLanguage().removeProjectValue(true);
                 
                 // copilot prefs
-                Boolean copilotEnabled = config.getCopilotEnabled();
-                if (copilotEnabled != null)
-                   uiPrefs.copilotEnabled().setProjectValue(copilotEnabled);
+                int copilotEnabled = config.getCopilotEnabled();
+                if (copilotEnabled != RProjectConfig.DEFAULT_VALUE)
+                   uiPrefs.copilotEnabled().setProjectValue(copilotEnabled == RProjectConfig.YES_VALUE);
                 else
                    uiPrefs.copilotEnabled().removeProjectValue(true);
+                
+                // copilot prefs
+                int copilotIndexingEnabled = config.getCopilotEnabled();
+                if (copilotIndexingEnabled != RProjectConfig.DEFAULT_VALUE)
+                   uiPrefs.copilotIndexingEnabled().setProjectValue(copilotIndexingEnabled == RProjectConfig.YES_VALUE);
+                else
+                   uiPrefs.copilotIndexingEnabled().removeProjectValue(true);
+                
                       
                 // convert packrat option changes to console actions
                 emitRenvConsoleActions(options.getRenvOptions());

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/YesNoAskDefault.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/YesNoAskDefault.java
@@ -1,28 +1,22 @@
 package org.rstudio.studio.client.projects.ui.prefs;
 
-import com.google.gwt.user.client.ui.ListBox;
 import org.rstudio.studio.client.projects.StudioClientProjectConstants;
 
-class YesNoAskDefault extends ListBox
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.ui.ListBox;
+
+public class YesNoAskDefault extends ListBox
 {
-   private static final StudioClientProjectConstants constants_ = com.google.gwt.core.client.GWT.create(StudioClientProjectConstants.class);
-   static final String USE_DEFAULT = constants_.projectTypeDefault();
-   static final String YES = constants_.yesLabel();
-   static final int YES_VALUE = 1;
-   static final String NO = constants_.noLabel();
-   static final int NO_VALUE = 2;
-   static final String ASK =constants_.askLabel();
-   
    public YesNoAskDefault(boolean includeAsk)
    {
       super();
       setMultipleSelect(false);
 
-      String[] items = includeAsk ? new String[] {USE_DEFAULT, YES, NO, ASK}:
-                                    new String[] {USE_DEFAULT, YES, NO};
-
-      for (int i=0; i<items.length; i++)
-         addItem(items[i]);
+      String[] items = includeAsk ? new String[] { USE_DEFAULT, YES, NO, ASK }:
+                                    new String[] { USE_DEFAULT, YES, NO };
+      
+      for (String item : items)
+         addItem(item);
    }
 
    @Override
@@ -33,4 +27,26 @@ class YesNoAskDefault extends ListBox
       else
          super.setSelectedIndex(0);
    }
+   
+   public int getValue()
+   {
+      return getSelectedIndex();
+   }
+   
+   public void setValue(int value)
+   {
+      setSelectedIndex(value);
+   }
+   
+   private static final StudioClientProjectConstants constants_ = GWT.create(StudioClientProjectConstants.class);
+   
+   public static final String USE_DEFAULT = constants_.projectTypeDefault();
+   public static final String YES         = constants_.yesLabel();
+   public static final String NO          = constants_.noLabel();
+   public static final String ASK         = constants_.askLabel();
+   
+   public static final int USE_DEFAULT_VALUE = 0;
+   public static final int YES_VALUE         = 1;
+   public static final int NO_VALUE          = 2;
+   public static final int ASK_VALUE         = 3;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -18,22 +18,33 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.JSON;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.widget.FormLabel;
 import org.rstudio.core.client.widget.LayoutGrid;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.HelpLink;
+import org.rstudio.studio.client.projects.model.ProjectsServerOperations;
+import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesPane;
 import org.rstudio.studio.client.projects.ui.prefs.YesNoAskDefault;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
+import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.copilot.Copilot;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotConstants;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotStatusResponse;
 import org.rstudio.studio.client.workbench.copilot.server.CopilotServerOperations;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessorConstants;
 import org.rstudio.studio.client.workbench.prefs.views.CopilotPreferencesPane;
+import org.rstudio.studio.client.workbench.prefs.views.events.CopilotEnabledEvent;
 
 import com.google.gwt.aria.client.Roles;
 import com.google.gwt.core.client.GWT;
@@ -45,23 +56,37 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.resources.client.ImageResource;
 import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.inject.Inject;
 
 public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
 {
+   @Override
+   public RestartRequirement onApply(RProjectOptions options)
+   {
+      RProjectConfig config = options.getConfig();
+      config.setCopilotEnabled(copilotEnabled_.getValue());
+      config.setCopilotIndexingEnabled(copilotIndexingEnabled_.getValue());
+      return new RestartRequirement();
+   }
+   
    @Inject
-   public ProjectCopilotPreferencesPane(Session session,
+   public ProjectCopilotPreferencesPane(EventBus events,
+                                        Session session,
                                         UserPrefs prefs,
                                         AriaLiveService ariaLive,
                                         Copilot copilot,
-                                        CopilotServerOperations server)
+                                        CopilotServerOperations server,
+                                        ProjectsServerOperations projectServer)
    {
+      events_ = events;
       session_ = session;
       prefs_ = prefs;
       copilot_ = copilot;
       server_ = server;
+      projectServer_ = projectServer;
       
       lblCopilotStatus_ = new Label("(Loading...)");
       
@@ -102,21 +127,29 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
             false);
       
       lblCopilotTos_ = new Label(
-            "By using GitHub Copilot, you agree to abide by the terms of service.");
+            "By using GitHub Copilot, you agree to abide by its terms of service.");
       lblCopilotTos_.addStyleName(RES.styles().copilotTosLabel());
    }
    
-   private void initDisplay()
+   private void initDisplay(RProjectOptions options)
    {
       add(headerLabel("GitHub Copilot (Preview)"));
       
       if (session_.getSessionInfo().getCopilotEnabled())
       {
-         LayoutGrid grid = new LayoutGrid(2, 2);
+         HorizontalPanel statusPanel = new HorizontalPanel();
+         statusPanel.add(lblCopilotStatus_);
+         for (SmallButton button : statusButtons_)
+            statusPanel.add(button);
+         add(spaced(statusPanel));
          
+         LayoutGrid grid = new LayoutGrid(2, 2);
+    
+         copilotEnabled_.setValue(options.getConfig().getCopilotEnabled());
          grid.setWidget(0, 0, new FormLabel(constants.copilotEnabledTitle(), copilotEnabled_));
          grid.setWidget(0, 1, copilotEnabled_);
          
+         copilotIndexingEnabled_.setValue(options.getConfig().getCopilotIndexingEnabled());
          grid.setWidget(1, 0, new FormLabel(constants.copilotIndexingEnabledTitle(), copilotIndexingEnabled_));
          grid.setWidget(1, 1, copilotIndexingEnabled_);
          
@@ -137,6 +170,7 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    
    private void initModel()
    {
+      final int initialCopilotEnabled = copilotEnabled_.getValue();
       copilotEnabled_.addChangeHandler(new ChangeHandler()
       {
          @Override
@@ -152,28 +186,49 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
                   {
                      if (isInstalled)
                      {
-                        // TODO: how to synchronize the preferences eagerly here?
-                        //  prefs_.copilotEnabled().setProjectValue(true);
-                        //  prefs_.writeUserPrefs((completed) ->
-                        //  {
-                        //     refresh();
-                        //  });
+                        options_.getConfig().setCopilotEnabled(copilotEnabled);
+                        projectServer_.writeProjectConfig(options_.getConfig(), new ServerRequestCallback<Void>()
+                        {
+                           @Override
+                           public void onResponseReceived(Void response)
+                           {
+                              events_.fireEvent(new CopilotEnabledEvent(true, true));
+                              refresh();
+                           }
+                           
+                           @Override
+                           public void onError(ServerError error)
+                           {
+                              Debug.logError(error);
+                              
+                           }
+                        });
                      }
                      else
                      {
-                        copilotEnabled_.setValue(copilotEnabled);
+                        copilotEnabled_.setValue(initialCopilotEnabled);
                      }
                   }
                });
             }
             else
             {
-               // TODO: how to synchronize the preference eagerly here?
-               // prefs_.copilotEnabled().setProjectValue(false);
-               // prefs_.writeUserPrefs((completed) ->
-               // {
-               //    refresh();
-               // });
+               options_.getConfig().setCopilotEnabled(copilotEnabled);
+               projectServer_.writeProjectConfig(options_.getConfig(), new ServerRequestCallback<Void>()
+               {
+                  @Override
+                  public void onResponseReceived(Void response)
+                  {
+                     refresh();
+                  }
+
+                  @Override
+                  public void onError(ServerError error)
+                  {
+                     Debug.logError(error);
+
+                  }
+               });
             }
          }
       });
@@ -210,7 +265,60 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    
    private void refresh()
    {
-      // TODO
+      hideButtons();
+      
+      server_.copilotStatus(new ServerRequestCallback<CopilotStatusResponse>()
+      {
+         @Override
+         public void onResponseReceived(CopilotStatusResponse response)
+         {
+            hideButtons();
+            
+            if (response == null)
+            {
+               if (prefs_.copilotEnabled().getValue())
+               {
+                  lblCopilotStatus_.setText("The GitHub Copilot agent is not currently running.");
+               }
+               else
+               {
+                  lblCopilotStatus_.setText("The GitHub Copilot agent has not been enabled.");
+               }
+            }
+            else if (response.result.status == CopilotConstants.STATUS_OK ||
+                     response.result.status == CopilotConstants.STATUS_ALREADY_SIGNED_IN)
+            {
+               showButtons(btnSignOut_);
+               lblCopilotStatus_.setText("You are currently signed in as: " + response.result.user);
+            }
+            else if (response.result.status == CopilotConstants.STATUS_NOT_AUTHORIZED)
+            {
+               showButtons(btnActivate_, btnRefresh_);
+               lblCopilotStatus_.setText(
+                     "You are currently signed in as " + response.result.user + ", but " +
+                     "you haven't yet activated your GitHub Copilot account.");
+            }
+            else if (response.result.status == CopilotConstants.STATUS_NOT_SIGNED_IN)
+            {
+               showButtons(btnSignIn_);
+               lblCopilotStatus_.setText("You are not currently signed in.");
+            }
+            else
+            {
+               String message =
+                     "RStudio received a Copilot response that it does not understand.\n" +
+                     JSON.stringify(response);
+               
+               lblCopilotStatus_.setText(message);
+            }
+         }
+         
+         @Override
+         public void onError(ServerError error)
+         {
+            Debug.logError(error);
+         }
+      });
    }
 
    @Override
@@ -218,7 +326,7 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    {
       options_ = options;
       
-      initDisplay();
+      initDisplay(options);
       initModel();
       refresh();
    }
@@ -235,21 +343,29 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
       return "Copilot";
    }
 
-   @Override
-   public RestartRequirement onApply(RProjectOptions prefs)
+   private void hideButtons()
    {
-      // TODO Auto-generated method stub
-      return null;
+      for (SmallButton button : statusButtons_)
+      {
+         button.setEnabled(false);
+         button.setVisible(false);
+      }
    }
    
-   public static final CopilotPreferencesPane.Resources RES = CopilotPreferencesPane.RES;
+   private void showButtons(SmallButton... buttons)
+   {
+      for (SmallButton button : buttons)
+      {
+         button.setEnabled(true);
+         button.setVisible(true);
+      }
+   }
    
    private RProjectOptions options_;
    
-   private final Session session_;
-   private final UserPrefs prefs_;
-   private final Copilot copilot_;
-   private final CopilotServerOperations server_;
+   // UI
+   private final YesNoAskDefault copilotEnabled_;
+   private final YesNoAskDefault copilotIndexingEnabled_;
    private final Label lblCopilotStatus_;
    private final List<SmallButton> statusButtons_;
    private final SmallButton btnSignIn_;
@@ -259,9 +375,15 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    private final HelpLink linkCopilotTos_;
    private final Label lblCopilotTos_;
    
-   private final YesNoAskDefault copilotEnabled_;
-   private final YesNoAskDefault copilotIndexingEnabled_;
+   // Injected
+   private final EventBus events_;
+   private final Session session_;
+   private final UserPrefs prefs_;
+   private final Copilot copilot_;
+   private final CopilotServerOperations server_;
+   private final ProjectsServerOperations projectServer_;
    
+   private static final CopilotPreferencesPane.Resources RES = CopilotPreferencesPane.RES;
    private static final UserPrefsAccessorConstants constants = GWT.create(UserPrefsAccessorConstants.class);
    
    

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -1,0 +1,268 @@
+/*
+ * ProjectCopilotPreferencesPane.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.projects.ui.prefs.buildtools;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.rstudio.core.client.CommandWithArg;
+import org.rstudio.core.client.prefs.RestartRequirement;
+import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.FormLabel;
+import org.rstudio.core.client.widget.LayoutGrid;
+import org.rstudio.core.client.widget.SmallButton;
+import org.rstudio.studio.client.application.AriaLiveService;
+import org.rstudio.studio.client.common.HelpLink;
+import org.rstudio.studio.client.projects.model.RProjectOptions;
+import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesPane;
+import org.rstudio.studio.client.projects.ui.prefs.YesNoAskDefault;
+import org.rstudio.studio.client.workbench.copilot.Copilot;
+import org.rstudio.studio.client.workbench.copilot.server.CopilotServerOperations;
+import org.rstudio.studio.client.workbench.model.Session;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
+import org.rstudio.studio.client.workbench.prefs.model.UserPrefsAccessorConstants;
+import org.rstudio.studio.client.workbench.prefs.views.CopilotPreferencesPane;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Position;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.dom.client.ChangeEvent;
+import com.google.gwt.event.dom.client.ChangeHandler;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
+import com.google.gwt.resources.client.ImageResource;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.VerticalPanel;
+import com.google.inject.Inject;
+
+public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
+{
+   @Inject
+   public ProjectCopilotPreferencesPane(Session session,
+                                        UserPrefs prefs,
+                                        AriaLiveService ariaLive,
+                                        Copilot copilot,
+                                        CopilotServerOperations server)
+   {
+      session_ = session;
+      prefs_ = prefs;
+      copilot_ = copilot;
+      server_ = server;
+      
+      lblCopilotStatus_ = new Label("(Loading...)");
+      
+      statusButtons_ = new ArrayList<SmallButton>();
+      
+      btnSignIn_ = new SmallButton("Sign In");
+      btnSignIn_.addStyleName(RES.styles().button());
+      statusButtons_.add(btnSignIn_);
+      
+      btnSignOut_ = new SmallButton("Sign Out");
+      btnSignOut_.addStyleName(RES.styles().button());
+      statusButtons_.add(btnSignOut_);
+      
+      btnActivate_ = new SmallButton("Activate");
+      Roles.getLinkRole().set(btnActivate_.getElement());
+      btnActivate_.getElement().setPropertyString("href", "https://github.com/settings/copilot");
+      btnActivate_.addStyleName(RES.styles().button());
+      statusButtons_.add(btnActivate_);
+      
+      btnRefresh_ = new SmallButton("Refresh");
+      btnRefresh_.addStyleName(RES.styles().button());
+      statusButtons_.add(btnRefresh_);
+      
+      LayoutGrid grid = new LayoutGrid(2, 2);
+      grid.addStyleName(RESOURCES.styles().workspaceGrid());
+
+      copilotEnabled_ = new YesNoAskDefault(false);
+      grid.setWidget(0, 0, new FormLabel(constants.copilotEnabledTitle(), copilotEnabled_));
+      grid.setWidget(0, 1, copilotEnabled_);
+      
+      copilotIndexingEnabled_ = new YesNoAskDefault(false);
+      grid.setWidget(1, 0, new FormLabel(constants.copilotIndexingEnabledTitle(), copilotIndexingEnabled_));
+      grid.setWidget(1, 1, copilotIndexingEnabled_);
+      
+      linkCopilotTos_ = new HelpLink(
+            "GitHub Copilot: Terms of Service",
+            "github-copilot-terms-of-service",
+            false);
+      
+      lblCopilotTos_ = new Label(
+            "By using GitHub Copilot, you agree to abide by the terms of service.");
+      lblCopilotTos_.addStyleName(RES.styles().copilotTosLabel());
+   }
+   
+   private void initDisplay()
+   {
+      add(headerLabel("GitHub Copilot (Preview)"));
+      
+      if (session_.getSessionInfo().getCopilotEnabled())
+      {
+         LayoutGrid grid = new LayoutGrid(2, 2);
+         
+         grid.setWidget(0, 0, new FormLabel(constants.copilotEnabledTitle(), copilotEnabled_));
+         grid.setWidget(0, 1, copilotEnabled_);
+         
+         grid.setWidget(1, 0, new FormLabel(constants.copilotIndexingEnabledTitle(), copilotIndexingEnabled_));
+         grid.setWidget(1, 1, copilotIndexingEnabled_);
+         
+         add(grid);
+      }
+      else
+      {
+         add(new Label("GitHub Copilot integration has been disabled by the administrator."));
+      }
+      
+      VerticalPanel bottomPanel = new VerticalPanel();
+      bottomPanel.getElement().getStyle().setBottom(0, Unit.PX);
+      bottomPanel.getElement().getStyle().setPosition(Position.ABSOLUTE);
+      bottomPanel.add(spaced(lblCopilotTos_));
+      bottomPanel.add(spaced(linkCopilotTos_));
+      add(bottomPanel);
+   }
+   
+   private void initModel()
+   {
+      copilotEnabled_.addChangeHandler(new ChangeHandler()
+      {
+         @Override
+         public void onChange(ChangeEvent event)
+         {
+            int copilotEnabled = copilotEnabled_.getValue();
+            if (copilotEnabled == YesNoAskDefault.YES_VALUE)
+            {
+               copilot_.ensureAgentInstalled(new CommandWithArg<Boolean>()
+               {
+                  @Override
+                  public void execute(Boolean isInstalled)
+                  {
+                     if (isInstalled)
+                     {
+                        // TODO: how to synchronize the preferences eagerly here?
+                        //  prefs_.copilotEnabled().setProjectValue(true);
+                        //  prefs_.writeUserPrefs((completed) ->
+                        //  {
+                        //     refresh();
+                        //  });
+                     }
+                     else
+                     {
+                        copilotEnabled_.setValue(copilotEnabled);
+                     }
+                  }
+               });
+            }
+            else
+            {
+               // TODO: how to synchronize the preference eagerly here?
+               // prefs_.copilotEnabled().setProjectValue(false);
+               // prefs_.writeUserPrefs((completed) ->
+               // {
+               //    refresh();
+               // });
+            }
+         }
+      });
+      
+      btnSignIn_.addClickHandler(new ClickHandler()
+      {
+         @Override
+         public void onClick(ClickEvent event)
+         {
+            copilot_.onCopilotSignIn((response) -> refresh());
+         }
+      });
+      
+      btnSignOut_.addClickHandler(new ClickHandler()
+      {
+         
+         @Override
+         public void onClick(ClickEvent event)
+         {
+            copilot_.onCopilotSignOut((response) -> refresh());
+         }
+      });
+      
+      btnActivate_.addClickHandler(new ClickHandler()
+      {
+         @Override
+         public void onClick(ClickEvent event)
+         {
+            String href = btnActivate_.getElement().getPropertyString("href");
+            Window.open(href, "_blank", "");
+         }
+      }); 
+   }
+   
+   private void refresh()
+   {
+      // TODO
+   }
+
+   @Override
+   protected void initialize(RProjectOptions options)
+   {
+      options_ = options;
+      
+      initDisplay();
+      initModel();
+      refresh();
+   }
+   
+   @Override
+   public ImageResource getIcon()
+   {
+      return new ImageResource2x(CopilotPreferencesPane.RES.iconCopilotLight2x());
+   }
+
+   @Override
+   public String getName()
+   {
+      return "Copilot";
+   }
+
+   @Override
+   public RestartRequirement onApply(RProjectOptions prefs)
+   {
+      // TODO Auto-generated method stub
+      return null;
+   }
+   
+   public static final CopilotPreferencesPane.Resources RES = CopilotPreferencesPane.RES;
+   
+   private RProjectOptions options_;
+   
+   private final Session session_;
+   private final UserPrefs prefs_;
+   private final Copilot copilot_;
+   private final CopilotServerOperations server_;
+   private final Label lblCopilotStatus_;
+   private final List<SmallButton> statusButtons_;
+   private final SmallButton btnSignIn_;
+   private final SmallButton btnSignOut_;
+   private final SmallButton btnActivate_;
+   private final SmallButton btnRefresh_;
+   private final HelpLink linkCopilotTos_;
+   private final Label lblCopilotTos_;
+   
+   private final YesNoAskDefault copilotEnabled_;
+   private final YesNoAskDefault copilotIndexingEnabled_;
+   
+   private static final UserPrefsAccessorConstants constants = GWT.create(UserPrefsAccessorConstants.class);
+   
+   
+}

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -362,7 +362,7 @@ public class CopilotPreferencesPane extends PreferencesPane
       
    }
 
-   private static Resources RES = GWT.create(Resources.class);
+   public static Resources RES = GWT.create(Resources.class);
    static
    {
       RES.styles().ensureInjected();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/events/CopilotEnabledEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/events/CopilotEnabledEvent.java
@@ -1,0 +1,77 @@
+/*
+ * CopilotEnabledEvent.java
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.workbench.prefs.views.events;
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+// This dummy event is only used to communicate between the global Copilot
+// preferences pane and the project Copilot preference pane, so they can
+// notify each other of changes (for an improved UI experience)
+public class CopilotEnabledEvent extends GwtEvent<CopilotEnabledEvent.Handler>
+{
+   public static class Data extends JavaScriptObject
+   {
+      protected Data()
+      {
+      }
+
+      // Event data accessors ----
+      
+      
+   }
+
+   public CopilotEnabledEvent(boolean isEnabled, boolean isProject)
+   {
+      isEnabled_ = isEnabled;
+      isProject_ = isProject;
+   }
+
+   public boolean isEnabled()
+   {
+      return isEnabled_;
+   }
+   
+   public boolean isProject()
+   {
+      return isProject_;
+   }
+
+   private final boolean isEnabled_;
+   private final boolean isProject_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onCopilotEnabled(CopilotEnabledEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onCopilotEnabled(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13580.

### Approach

Introduces project-specific options for enabling Copilot, and also for project indexing. These are encoded into the project's `.Rproj` file, and so are set for all users of the project. (The intention being that some projects might not be appropriate to use with Copilot for any user.)

<img width="570" alt="Screenshot 2023-09-08 at 1 21 00 PM" src="https://github.com/rstudio/rstudio/assets/1976582/3bd46253-6a33-422c-8b01-0f06a61b61d8">

The UI here is somewhat duplicated from the Global Options version. To avoid confusion, if Copilot has been disabled in project-specific settings, we also display that in the global options.

<img width="644" alt="Screenshot 2023-09-08 at 1 21 52 PM" src="https://github.com/rstudio/rstudio/assets/1976582/22811601-f4cd-4c35-8dfa-ca8126fb1f0b">

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
