### PR TITLE
expose document change events for package extensions

### DIFF
--- a/src/cpp/r/R/Api.R
+++ b/src/cpp/r/R/Api.R
@@ -27,7 +27,9 @@
    TYPE_DOCUMENT_ID          = 3L,
    TYPE_DOCUMENT_OPEN        = 4L,
    TYPE_DOCUMENT_NEW         = 5L,
-   TYPE_FILES_PANE_NAVIGATE  = 6L
+   TYPE_FILES_PANE_NAVIGATE  = 6L,
+   TYPE_SET_GHOST_TEXT       = 7L
+   
 ))
 
 # list of potential event targets
@@ -1238,4 +1240,19 @@ options(terminal.manager = list(terminalActivate = .rs.api.terminalActivate,
 .rs.addApiFunction("bugReport", function()
 {
    .rs.bugReport(pro = FALSE)
+})
+
+.rs.addApiFunction("setGhostText", function(text)
+{
+   text <- paste(enc2utf8(text), collapse = "\n")
+   payload <- list(text = .rs.scalar(text))
+   request <- .rs.api.createRequest(
+      type    = .rs.api.eventTypes$TYPE_SET_GHOST_TEXT,
+      sync    = TRUE,
+      target  = .rs.api.eventTargets$TYPE_ACTIVE_WINDOW,
+      payload = payload
+   )
+   
+   .rs.api.sendRequest(request)
+   invisible(text)
 })

--- a/src/cpp/session/CMakeLists.txt
+++ b/src/cpp/session/CMakeLists.txt
@@ -104,7 +104,7 @@ if(WIN32)
 endif()
 
 # include files
-file(GLOB_RECURSE SESSION_HEADER_FILES "*.h*")
+file(GLOB_RECURSE SESSION_HEADER_FILES CONFIGURE_DEPENDS "*.h*")
 
 
 # source files
@@ -375,7 +375,7 @@ else()
 endif()
 
 # R files
-file(GLOB_RECURSE SESSION_R_FILES "modules/*.R")
+file(GLOB_RECURSE SESSION_R_FILES CONFIGURE_DEPENDS "modules/*.R")
 
 # test files
 if (RSTUDIO_UNIT_TESTS_ENABLED)

--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -424,7 +424,6 @@ namespace prefs {
 #define kDisableRendererAccessibility "disable_renderer_accessibility"
 #define kCopilotEnabled "copilot_enabled"
 #define kCopilotCompletionsDelay "copilot_completions_delay"
-#define kCopilotAllowAutomaticCompletions "copilot_allow_automatic_completions"
 #define kCopilotTabKeyBehavior "copilot_tab_key_behavior"
 #define kCopilotTabKeyBehaviorSuggestion "suggestion"
 #define kCopilotTabKeyBehaviorCompletions "completions"
@@ -1921,12 +1920,6 @@ public:
     */
    int copilotCompletionsDelay();
    core::Error setCopilotCompletionsDelay(int val);
-
-   /**
-    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
-    */
-   bool copilotAllowAutomaticCompletions();
-   core::Error setCopilotAllowAutomaticCompletions(bool val);
 
    /**
     * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.

--- a/src/cpp/session/modules/SessionPackageProvidedExtension.R
+++ b/src/cpp/session/modules/SessionPackageProvidedExtension.R
@@ -1,0 +1,35 @@
+#
+# SessionPackageProvidedExtension.R
+#
+# Copyright (C) 2022 by Posit Software, PBC
+#
+# Unless you have received this program directly from Posit Software pursuant
+# to the terms of a commercial license agreement with Posit Software, then
+# this program is licensed to you under the terms of version 3 of the
+# GNU Affero General Public License. This program is distributed WITHOUT
+# ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+# MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+# AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+#
+#
+
+.rs.addFunction("ppe.invokeHook", function(hook, data)
+{
+   # Treat single function as list of functions
+   if (is.function(hook))
+      hook <- list(hook)
+   
+   # Disable warnings in this scope
+   op <- options(warn = -1L)
+   on.exit(options(op), add = TRUE)
+   
+   # Invoke hooks
+   lapply(hook, .rs.ppe.invokeHookImpl, data = data)
+})
+
+.rs.addFunction("ppe.invokeHookImpl", function(hook, data)
+{
+   status <- tryCatch(do.call(hook, data), error = identity)
+   if (inherits(status, "error"))
+      warning(conditionMessage(status))
+})

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -3248,19 +3248,6 @@ core::Error UserPrefValues::setCopilotCompletionsDelay(int val)
 }
 
 /**
- * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
- */
-bool UserPrefValues::copilotAllowAutomaticCompletions()
-{
-   return readPref<bool>("copilot_allow_automatic_completions");
-}
-
-core::Error UserPrefValues::setCopilotAllowAutomaticCompletions(bool val)
-{
-   return writePref("copilot_allow_automatic_completions", val);
-}
-
-/**
  * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
  */
 std::string UserPrefValues::copilotTabKeyBehavior()
@@ -3537,7 +3524,6 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDisableRendererAccessibility,
       kCopilotEnabled,
       kCopilotCompletionsDelay,
-      kCopilotAllowAutomaticCompletions,
       kCopilotTabKeyBehavior,
       kCopilotIndexingEnabled,
    });

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -1686,12 +1686,6 @@
             "title": "GitHub Copilot completions delay",
             "description": "The delay (in milliseconds) before GitHub Copilot completions are requested after the cursor position has changed."
         },
-        "copilot_allow_automatic_completions": {
-            "type": "boolean",
-            "default": true,
-            "title": "Enable as-you-type code completions when Copilot is enabled",
-            "description": "When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled."
-        },
         "copilot_tab_key_behavior": {
             "type": "string",
             "enum": ["suggestion", "completions"],

--- a/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/events/RStudioApiRequestEvent.java
@@ -109,6 +109,7 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
    public static final int TYPE_DOCUMENT_OPEN        = 4;
    public static final int TYPE_DOCUMENT_NEW         = 5;
    public static final int TYPE_FILES_PANE_NAVIGATE  = 6;
+   public static final int TYPE_SET_GHOST_TEXT       = 7;
    
    // list of potential event targets (keep in sync with Api.R)
    public static final int TARGET_UNKNOWN       = 0;
@@ -177,7 +178,14 @@ public class RStudioApiRequestEvent extends GwtEvent<RStudioApiRequestEvent.Hand
       public final native String getPath() /*-{ return this["path"]; }-*/;
    }
    
-   
+   public static class SetGhostTextData extends JavaScriptObject
+   {
+      protected SetGhostTextData()
+      {
+      }
+      
+      public final native String getText() /*-{ return this["text"]; }-*/;
+   }
    
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -3542,18 +3542,6 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
-    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
-    */
-   public PrefValue<Boolean> copilotAllowAutomaticCompletions()
-   {
-      return bool(
-         "copilot_allow_automatic_completions",
-         _constants.copilotAllowAutomaticCompletionsTitle(), 
-         _constants.copilotAllowAutomaticCompletionsDescription(), 
-         true);
-   }
-
-   /**
     * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
     */
    public PrefValue<String> copilotTabKeyBehavior()
@@ -4086,8 +4074,6 @@ public class UserPrefsAccessor extends Prefs
          copilotEnabled().setValue(layer, source.getBool("copilot_enabled"));
       if (source.hasKey("copilot_completions_delay"))
          copilotCompletionsDelay().setValue(layer, source.getInteger("copilot_completions_delay"));
-      if (source.hasKey("copilot_allow_automatic_completions"))
-         copilotAllowAutomaticCompletions().setValue(layer, source.getBool("copilot_allow_automatic_completions"));
       if (source.hasKey("copilot_tab_key_behavior"))
          copilotTabKeyBehavior().setValue(layer, source.getString("copilot_tab_key_behavior"));
       if (source.hasKey("copilot_indexing_enabled"))
@@ -4344,7 +4330,6 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(disableRendererAccessibility());
       prefs.add(copilotEnabled());
       prefs.add(copilotCompletionsDelay());
-      prefs.add(copilotAllowAutomaticCompletions());
       prefs.add(copilotTabKeyBehavior());
       prefs.add(copilotIndexingEnabled());
       return prefs;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -2064,14 +2064,6 @@ public interface UserPrefsAccessorConstants extends Constants {
    String copilotCompletionsDelayDescription();
 
    /**
-    * When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
-    */
-   @DefaultStringValue("Enable as-you-type code completions when Copilot is enabled")
-   String copilotAllowAutomaticCompletionsTitle();
-   @DefaultStringValue("When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.")
-   String copilotAllowAutomaticCompletionsDescription();
-
-   /**
     * Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
     */
    @DefaultStringValue("Pressing Tab key will prefer inserting:")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -1037,10 +1037,6 @@ copilotEnabledDescription = When enabled, RStudio will use GitHub Copilot to pro
 copilotCompletionsDelayTitle = GitHub Copilot completions delay
 copilotCompletionsDelayDescription = The delay (in milliseconds) before GitHub Copilot completions are requested after the cursor position has changed.
 
-# When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
-copilotAllowAutomaticCompletionsTitle = Enable as-you-type code completions when Copilot is enabled
-copilotAllowAutomaticCompletionsDescription = When enabled, RStudio will continue providing as-you-type code completions when Copilot is enabled.
-
 # Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.
 copilotTabKeyBehaviorTitle = Pressing Tab key will prefer inserting:
 copilotTabKeyBehaviorDescription = Control the behavior of the Tab key when both Copilot code suggestions and RStudio code completions are visible.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -417,7 +417,7 @@ public class RCompletionManager implements CompletionManager
       if (docDisplay_.hasGhostText())
       {
          // Let tab insert ghost text if configured to do so
-         if (keycode == KeyCodes.KEY_TAB && modifier == 0)
+         if (keycode == KeyCodes.KEY_TAB && modifier == KeyboardShortcut.NONE)
          {
             invalidatePendingRequests();
             AceGhostText ghostText = docDisplay_.getGhostText();
@@ -651,13 +651,7 @@ public class RCompletionManager implements CompletionManager
    
    private boolean isAutoPopupEnabled()
    {
-      if (userPrefs_.codeCompletion().getValue() != UserPrefs.CODE_COMPLETION_ALWAYS)
-         return false;
-      
-      if (userPrefs_.copilotEnabled().getValue())
-         return userPrefs_.copilotAllowAutomaticCompletions().getValue();
-      
-      return true;
+      return userPrefs_.codeCompletion().getValue() == UserPrefs.CODE_COMPLETION_ALWAYS;
    }
    
    private boolean isValidForRIdentifier(char c)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/Source.java
@@ -14,30 +14,12 @@
  */
 package org.rstudio.studio.client.workbench.views.source;
 
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayString;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.dom.client.NativeEvent;
-import com.google.gwt.event.dom.client.FocusEvent;
-import com.google.gwt.event.dom.client.KeyCodes;
-import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
-import com.google.gwt.event.logical.shared.HasSelectionHandlers;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.Event.NativePreviewEvent;
-import com.google.gwt.user.client.Event.NativePreviewHandler;
-import com.google.gwt.user.client.Timer;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.IsWidget;
-import com.google.gwt.user.client.ui.Widget;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-import com.google.inject.Singleton;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Set;
+
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
@@ -79,8 +61,8 @@ import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Severity;
 import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.CrossWindowEvent;
-import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.DesktopMouseNavigateEvent;
+import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.FileDialogs;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.GlobalProgressDelayer;
@@ -99,9 +81,9 @@ import org.rstudio.studio.client.events.GetEditorContextEvent;
 import org.rstudio.studio.client.events.RStudioApiRequestEvent;
 import org.rstudio.studio.client.events.ReplaceRangesEvent;
 import org.rstudio.studio.client.events.ReplaceRangesEvent.ReplacementData;
+import org.rstudio.studio.client.events.SetSelectionRangesEvent;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntryProvider;
 import org.rstudio.studio.client.palette.model.CommandPaletteEntrySource;
-import org.rstudio.studio.client.events.SetSelectionRangesEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
@@ -132,9 +114,9 @@ import org.rstudio.studio.client.workbench.views.source.NewShinyWebApplication.R
 import org.rstudio.studio.client.workbench.views.source.SourceWindowManager.NavigationResult;
 import org.rstudio.studio.client.workbench.views.source.editors.EditingTarget;
 import org.rstudio.studio.client.workbench.views.source.editors.codebrowser.CodeBrowserEditingTarget;
+import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.CloseObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.OpenObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.RefreshObjectExplorerEvent;
-import org.rstudio.studio.client.workbench.views.source.editors.explorer.events.CloseObjectExplorerEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.explorer.model.ObjectExplorerHandle;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.OpenProfileEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.profiler.model.ProfilerContents;
@@ -148,6 +130,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.ace.Range;
 import org.rstudio.studio.client.workbench.views.source.editors.text.events.NewWorkingCopyEvent;
 import org.rstudio.studio.client.workbench.views.source.editors.text.ui.NewRdDialog;
 import org.rstudio.studio.client.workbench.views.source.events.CloseAllSourceDocsExceptEvent;
+import org.rstudio.studio.client.workbench.views.source.events.CloseDataEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserFinishedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserHighlightEvent;
 import org.rstudio.studio.client.workbench.views.source.events.CodeBrowserNavigationEvent;
@@ -157,10 +140,8 @@ import org.rstudio.studio.client.workbench.views.source.events.CollabEditStarted
 import org.rstudio.studio.client.workbench.views.source.events.DocTabDragInitiatedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocTabDragStartedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.DocWindowChangedEvent;
-import org.rstudio.studio.client.workbench.views.source.events.EditPresentationSourceEvent;
 import org.rstudio.studio.client.workbench.views.source.events.EditPresentation2SourceEvent;
-import org.rstudio.studio.client.workbench.views.source.events.ScrollToPositionEvent;
-import org.rstudio.studio.client.workbench.views.source.events.XRefNavigationEvent;
+import org.rstudio.studio.client.workbench.views.source.events.EditPresentationSourceEvent;
 import org.rstudio.studio.client.workbench.views.source.events.EnsureVisibleSourceWindowEvent;
 import org.rstudio.studio.client.workbench.views.source.events.FileEditEvent;
 import org.rstudio.studio.client.workbench.views.source.events.InsertSourceEvent;
@@ -168,12 +149,13 @@ import org.rstudio.studio.client.workbench.views.source.events.MaximizeSourceWin
 import org.rstudio.studio.client.workbench.views.source.events.NewDocumentWithCodeEvent;
 import org.rstudio.studio.client.workbench.views.source.events.PopoutDocEvent;
 import org.rstudio.studio.client.workbench.views.source.events.PopoutDocInitiatedEvent;
+import org.rstudio.studio.client.workbench.views.source.events.ScrollToPositionEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowContentEvent;
 import org.rstudio.studio.client.workbench.views.source.events.ShowDataEvent;
-import org.rstudio.studio.client.workbench.views.source.events.CloseDataEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceFileSavedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourceNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SourcePathChangedEvent;
+import org.rstudio.studio.client.workbench.views.source.events.XRefNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.ContentItem;
 import org.rstudio.studio.client.workbench.views.source.model.DataItem;
 import org.rstudio.studio.client.workbench.views.source.model.DocTabDragParams;
@@ -183,11 +165,30 @@ import org.rstudio.studio.client.workbench.views.source.model.SourceNavigation;
 import org.rstudio.studio.client.workbench.views.source.model.SourcePosition;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.Queue;
-import java.util.Set;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.JsArrayString;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.KeyCodes;
+import com.google.gwt.event.logical.shared.HasBeforeSelectionHandlers;
+import com.google.gwt.event.logical.shared.HasSelectionHandlers;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Event.NativePreviewEvent;
+import com.google.gwt.user.client.Event.NativePreviewHandler;
+import com.google.gwt.user.client.Timer;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.IsWidget;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.google.inject.Singleton;
 
 @Singleton
 public class Source implements InsertSourceEvent.Handler,
@@ -3236,6 +3237,19 @@ public class Source implements InsertSourceEvent.Handler,
                            new VoidServerRequestCallback());
                   }
                }));
+      }
+      else if (type == RStudioApiRequestEvent.TYPE_SET_GHOST_TEXT)
+      {
+         RStudioApiRequestEvent.SetGhostTextData data = requestEvent.getPayload().cast();
+         invokeEditorApiAction(null, (TextEditingTarget target) ->
+         {
+            DocDisplay editor = target.getDocDisplay();
+            editor.setGhostText(data.getText());
+            
+            JsObject response = JsObject.createJsObject();
+            response.setString("id", target.getId());
+            server_.rstudioApiResponse(response, new VoidServerRequestCallback());
+         });
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -425,6 +425,7 @@ public class AceEditor implements DocDisplay,
       {
          fixVerticalOffsetBug();
          clearLineHighlight();
+         clearGhostText();
          lastCursorChangedTime_ = System.currentTimeMillis();
       });
 
@@ -433,6 +434,7 @@ public class AceEditor implements DocDisplay,
       {
          lastModifiedTime_ = System.currentTimeMillis();
          clearDebugLineHighlight();
+         clearGhostText();
       });
 
       widget_.addAttachHandler(event ->
@@ -3644,6 +3646,14 @@ public class AceEditor implements DocDisplay,
       {
          getSession().removeMarker(lineHighlightMarkerId_);
          lineHighlightMarkerId_ = null;
+      }
+   }
+   
+   private void clearGhostText()
+   {
+      if (widget_.getEditor().hasGhostText())
+      {
+         widget_.getEditor().removeGhostText();
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13278.

### Approach

This PR adds two pieces:

1. An API for setting ghost text in a document;
2. A mechanism to allow R code to listen for document changes.

The second mechanism feels a bit dangerous, but this doesn't add anything that packages couldn't already do since package authors can already see files on the user's filesystem, and also view and modify text buffers in RStudio via functions in `rstudioapi`.

### Automated Tests

N/A

### QA Notes

N/A; to be verified by community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
