### PR TITLE
Fix no space left on disk creating dmg

### DIFF
--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -454,7 +454,7 @@ if [ "${build_package}" = "1" ]; then
 
       # allocate oversized dmg, which will be compressed
       hdiutil create                       \
-         -size 1g                          \
+         -size 2g                          \
          -fs "APFS"                        \
          -volname "${RSTUDIO_BUNDLE_NAME}" \
          -srcfolder "install"              \


### PR DESCRIPTION
mac builds are still failing on `main`, and only on `main`. The installer disk image seems to run out of space

```bash
[2023-09-12T16:45:47.726Z] [I] Creating 'RStudio-2023.12.0-hourly-8.dmg ...'

[2023-09-12T16:46:03.310Z] could not access /Volumes/RStudio-2023.12.0-hourly-8/RStudio.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework - No space left on devicehdiutil: create failed - No space left on device
```

This is an attempt to fix that following what we did last time, though I'm not sure why other branches are okay. It seems to only affect electron builds, as [non-electron flavour](https://build.posit.it/blue/organizations/jenkins/IDE%2FPro-Builds%2FPlatforms%2Fmacos-pipeline/detail/main/445/pipeline) seems to build okay.