### PR TITLE
use private settings location for copilot settings

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1005,21 +1005,6 @@ Error readProjectFile(const FilePath& projectFilePath,
       pConfig->spellingDictionary = it->second;
    }
    
-   // extract copilot fields
-   it = dcfFields.find("CopilotEnabled");
-   if (it != dcfFields.end())
-   {
-      if (!interpretYesNoAskValue(it->second, false, &(pConfig->copilotEnabled)))
-         return requiredFieldError("CopilotEnabled", pUserErrMsg);
-   }
-   
-   it = dcfFields.find("CopilotIndexingEnabled");
-   if (it != dcfFields.end())
-   {
-      if (!interpretYesNoAskValue(it->second, false, &(pConfig->copilotIndexingEnabled)))
-         return requiredFieldError("CopilotIndexingEnabled", pUserErrMsg);
-   }
-
    return Success();
 }
 
@@ -1307,20 +1292,6 @@ Error writeProjectFile(const FilePath& projectFilePath,
       boost::format fmt("\nSpellingDictionary: %1%\n");
       contents.append(boost::str(fmt % config.spellingDictionary));
    }
-
-   // add copilot information if present
-   if (config.copilotEnabled != DefaultValue)
-   {
-      boost::format fmt("\nCopilotEnabled: %1%\n");
-      contents.append(boost::str(fmt % yesNoAskValueToString(config.copilotEnabled)));
-   }
-   
-   if (config.copilotIndexingEnabled != DefaultValue)
-   {
-      boost::format fmt("CopilotIndexingEnabled: %1%\n");
-      contents.append(boost::str(fmt % yesNoAskValueToString(config.copilotIndexingEnabled)));
-   }
-   
 
    // write it
    return writeStringToFile(projectFilePath,

--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -637,6 +637,23 @@ void handleClientInit(const boost::function<void()>& initFunction,
    
    // copilot
    sessionInfo["copilot_enabled"] = options.copilotEnabled();
+   
+   if (projects::projectContext().hasProject())
+   {
+      projects::RProjectCopilotOptions options;
+      Error error = projects::projectContext().readCopilotOptions(&options);
+      if (error)
+      {
+         LOG_ERROR(error);
+      }
+      else
+      {
+         json::Object copilotOptionsJson;
+         copilotOptionsJson["copilot_enabled"] = options.copilotEnabled;
+         copilotOptionsJson["copilot_indexing_enabled"] = options.copilotIndexingEnabled;
+         sessionInfo["copilot_project_options"] = copilotOptionsJson;
+      }
+   }
 
    module_context::events().onSessionInfo(&sessionInfo);
 

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -361,6 +361,7 @@ struct Events : boost::noncopyable
    RSTUDIO_BOOST_SIGNAL<void()>                                       onPackageLibraryMutated;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onPreferencesSaved;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onProjectConfigUpdated;
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onProjectOptionsUpdated;
    RSTUDIO_BOOST_SIGNAL<void(const core::DistributedEvent&)>          onDistributedEvent;
    RSTUDIO_BOOST_SIGNAL<void(core::FilePath)>                         onPermissionsChanged;
    RSTUDIO_BOOST_SIGNAL<void(bool)>                                   onShutdown;

--- a/src/cpp/session/include/session/projects/SessionProjects.hpp
+++ b/src/cpp/session/include/session/projects/SessionProjects.hpp
@@ -88,6 +88,13 @@ struct RProjectBuildOptions
    bool autoRoxygenizeForBuildAndReload;
 };
 
+// copilot options
+struct RProjectCopilotOptions
+{
+   core::r_util::YesNoAskValue copilotEnabled;
+   core::r_util::YesNoAskValue copilotIndexingEnabled;
+};
+
 class ProjectContext : boost::noncopyable
 {
 public:
@@ -152,6 +159,9 @@ public:
    core::Error readBuildOptions(RProjectBuildOptions* pOptions);
    core::Error writeBuildOptions(const RProjectBuildOptions& options);
 
+   core::Error readCopilotOptions(RProjectCopilotOptions* pOptions) const;
+   core::Error writeCopilotOptions(const RProjectCopilotOptions& options) const;
+   
    // update the website output type
    void setWebsiteOutputFormat(const std::string& websiteOutputFormat);
 
@@ -233,6 +243,7 @@ private:
 
    core::FilePath vcsOptionsFilePath() const;
    core::Error buildOptionsFile(core::Settings* pOptionsFile) const;
+   core::FilePath copilotOptionsFilePath() const;
 
    void updateDefaultEncoding();
    void updateBuildTargetPath();

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -153,6 +153,37 @@ std::queue<std::string> s_pendingResponses;
 // Whether we're about to shut down.
 bool s_isSessionShuttingDown = false;
 
+// Project-specific Copilot options.
+projects::RProjectCopilotOptions s_copilotProjectOptions;
+
+bool isCopilotEnabled()
+{
+   // Check project option
+   switch (s_copilotProjectOptions.copilotEnabled)
+   {
+   case r_util::YesValue: return true;
+   case r_util::NoValue: return false;
+   default: {}
+   }
+
+   // Check user preference
+   return prefs::userPrefs().copilotEnabled();
+}
+
+bool isCopilotIndexingEnabled()
+{
+   // Check project option
+   switch (s_copilotProjectOptions.copilotIndexingEnabled)
+   {
+   case r_util::YesValue: return true;
+   case r_util::NoValue: return false;
+   default: {}
+   }
+
+   // Check user preference
+   return prefs::userPrefs().copilotIndexingEnabled();
+}
+
 std::string uriFromDocumentPath(const std::string& path)
 {
    return fmt::format("file://{}", path);
@@ -783,15 +814,9 @@ void onBackgroundProcessing(bool isIdle)
 
 void synchronize()
 {
-   // Check for preference change
-   bool oldEnabled = s_copilotEnabled;
-   bool newEnabled = prefs::userPrefs().copilotEnabled();
-   if (oldEnabled == newEnabled)
-      return;
-
-   // Update our preference
-   s_copilotEnabled = newEnabled;
-
+   // Update enabled flag
+   s_copilotEnabled = isCopilotEnabled();
+   
    // Start or stop the agent as appropriate
    if (s_copilotEnabled)
    {
@@ -809,8 +834,14 @@ void onPreferencesSaved()
    synchronize();
 }
 
-void onProjectConfigUpdated()
+void onProjectOptionsUpdated()
 {
+   // Update internal cache of project options
+   Error error = projects::projectContext().readCopilotOptions(&s_copilotProjectOptions);
+   if (error)
+      LOG_ERROR(error);
+   
+   // Synchronize other flags
    synchronize();
 }
 
@@ -1014,26 +1045,16 @@ void indexFile(const core::FileInfo& info)
 
 void onMonitoringEnabled(const tree<core::FileInfo>& tree)
 {
-   if (!s_copilotEnabled)
-      return;
-   
-   if (!prefs::userPrefs().copilotIndexingEnabled())
-      return;
-   
-   for (auto&& file : tree)
-      indexFile(file);
+   if (isCopilotIndexingEnabled())
+      for (auto&& file : tree)
+         indexFile(file);
 }
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
 {
-   if (!s_copilotEnabled)
-      return;
-   
-   if (!prefs::userPrefs().copilotIndexingEnabled())
-      return;
-   
-   for (auto&& event : events)
-      indexFile(event.fileInfo());
+   if (isCopilotIndexingEnabled())
+      for (auto&& event : events)
+         indexFile(event.fileInfo());
 }
 
 void onMonitoringDisabled()
@@ -1048,11 +1069,21 @@ Error initialize()
    using boost::bind;
    using namespace module_context;
 
-   s_copilotEnabled = prefs::userPrefs().copilotEnabled();
-   
+   // Read default log level
    std::string copilotLogLevel = core::system::getenv("RSTUDIO_COPILOT_LOG_LEVEL");
    if (!copilotLogLevel.empty())
       s_copilotLogLevel = safe_convert::stringTo<int>(copilotLogLevel, 0);
+   
+   // Read project options
+   if (projects::projectContext().hasProject())
+   {
+      Error error = projects::projectContext().readCopilotOptions(&s_copilotProjectOptions);
+      if (error)
+         LOG_ERROR(error);
+   }
+    
+   // Synchronize user + project preferences with internal caches
+   synchronize();
 
    // subscribe to project context file monitoring state changes
    // (note that if there is no project this will no-op)
@@ -1064,7 +1095,7 @@ Error initialize()
    
    events().onBackgroundProcessing.connect(onBackgroundProcessing);
    events().onPreferencesSaved.connect(onPreferencesSaved);
-   events().onProjectConfigUpdated.connect(onProjectConfigUpdated);
+   events().onProjectOptionsUpdated.connect(onProjectOptionsUpdated);
    events().onDeferredInit.connect(onDeferredInit);
    events().onShutdown.connect(onShutdown);
 

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -137,6 +137,9 @@ int s_copilotLogLevel = 0;
 // Whether Copilot is enabled.
 bool s_copilotEnabled = false;
 
+// Whether Copilot has been allowed to index project files.
+bool s_copilotIndexingEnabled = false;
+
 // The PID of the active Copilot agent process.
 PidType s_agentPid = -1;
 
@@ -814,8 +817,9 @@ void onBackgroundProcessing(bool isIdle)
 
 void synchronize()
 {
-   // Update enabled flag
+   // Update flags
    s_copilotEnabled = isCopilotEnabled();
+   s_copilotIndexingEnabled = s_copilotEnabled && isCopilotIndexingEnabled();
    
    // Start or stop the agent as appropriate
    if (s_copilotEnabled)
@@ -1045,14 +1049,14 @@ void indexFile(const core::FileInfo& info)
 
 void onMonitoringEnabled(const tree<core::FileInfo>& tree)
 {
-   if (isCopilotIndexingEnabled())
+   if (s_copilotIndexingEnabled)
       for (auto&& file : tree)
          indexFile(file);
 }
 
 void onFilesChanged(const std::vector<core::system::FileChangeEvent>& events)
 {
-   if (isCopilotIndexingEnabled())
+   if (s_copilotIndexingEnabled)
       for (auto&& event : events)
          indexFile(event.fileInfo());
 }

--- a/src/cpp/session/projects/SessionProjectContext.cpp
+++ b/src/cpp/session/projects/SessionProjectContext.cpp
@@ -890,6 +890,10 @@ Error ProjectContext::buildOptionsFile(Settings* pOptionsFile) const
    return pOptionsFile->initialize(scratchPath().completeChildPath("build_options"));
 }
 
+FilePath ProjectContext::copilotOptionsFilePath() const
+{
+   return scratchPath().completeChildPath("copilot_options");
+}
 
 Error ProjectContext::readVcsOptions(RProjectVcsOptions* pOptions) const
 {
@@ -968,6 +972,35 @@ Error ProjectContext::writeBuildOptions(const RProjectBuildOptions& options)
 
    // opportunistically sync in-memory representation to what we wrote to disk
    buildOptions_ = options;
+
+   return Success();
+}
+
+Error ProjectContext::readCopilotOptions(RProjectCopilotOptions* pOptions) const
+{
+   core::Settings settings;
+   Error error = settings.initialize(copilotOptionsFilePath());
+   if (error)
+      return error;
+
+   using r_util::YesNoAskValue;
+   pOptions->copilotEnabled = static_cast<YesNoAskValue>(settings.getInt("copilot_enabled"));
+   pOptions->copilotIndexingEnabled = static_cast<YesNoAskValue>(settings.getInt("copilot_indexing_enabled"));
+
+   return Success();
+}
+
+Error ProjectContext::writeCopilotOptions(const RProjectCopilotOptions& options) const
+{
+   core::Settings settings;
+   Error error = settings.initialize(copilotOptionsFilePath());
+   if (error)
+      return error;
+
+   settings.beginUpdate();
+   settings.set("copilot_enabled", options.copilotEnabled);
+   settings.set("copilot_indexing_enabled", options.copilotIndexingEnabled);
+   settings.endUpdate();
 
    return Success();
 }

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -15,7 +15,7 @@
 
 #include <session/projects/SessionProjects.hpp>
 
-
+#include <core/Debug.hpp>
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/http/URL.hpp>
@@ -418,8 +418,6 @@ json::Object projectConfigJson(const r_util::RProjectConfig& config)
       configJson["zotero_libraries"] = json::toJsonArray(config.zoteroLibraries.get());
    else
       configJson["zotero_libraries"] = json::Value(); // null
-   configJson["copilot_enabled"] = config.copilotEnabled;
-   configJson["copilot_indexing_enabled"] = config.copilotIndexingEnabled;
 
    return configJson;
 }
@@ -486,6 +484,19 @@ json::Object projectBuildContextJson()
    return contextJson;
 }
 
+json::Object projectCopilotOptionsJson()
+{
+   RProjectCopilotOptions copilotOptions;
+   Error error = s_projectContext.readCopilotOptions(&copilotOptions);
+   if (error)
+      LOG_ERROR(error);
+   
+   json::Object copilotOptionsJson;
+   copilotOptionsJson["copilot_enabled"] = copilotOptions.copilotEnabled;
+   copilotOptionsJson["copilot_indexing_enabled"] = copilotOptions.copilotIndexingEnabled;
+   return copilotOptionsJson;
+}
+
 void setProjectConfig(const r_util::RProjectConfig& config)
 {
    // set it
@@ -546,12 +557,20 @@ Error readProjectOptions(const json::JsonRpcRequest& request,
    optionsJson["packrat_context"] = module_context::packratContextAsJson();
    optionsJson["renv_options"] = module_context::renvOptionsAsJson();
    optionsJson["renv_context"] = module_context::renvContextAsJson();
-
+   optionsJson["copilot_options"] = projectCopilotOptionsJson();
 
    pResponse->setResult(optionsJson);
    return Success();
 }
 
+
+Error rProjectVcsOptionsFromJson(const json::Object& optionsJson,
+                                 RProjectVcsOptions* pOptions)
+{
+   return json::readObject(
+         optionsJson,
+         "active_vcs_override", pOptions->vcsOverride);
+}
 
 Error rProjectBuildOptionsFromJson(const json::Object& optionsJson,
                                    RProjectBuildOptions* pOptions)
@@ -574,12 +593,21 @@ Error rProjectBuildOptionsFromJson(const json::Object& optionsJson,
        "run_on_build_and_reload", pOptions->autoRoxygenizeForBuildAndReload);
 }
 
-Error rProjectVcsOptionsFromJson(const json::Object& optionsJson,
-                                 RProjectVcsOptions* pOptions)
+Error rProjectCopilotOptionsFromJson(const json::Object& optionsJson,
+                                     RProjectCopilotOptions* pOptions)
 {
-   return json::readObject(
-         optionsJson,
-         "active_vcs_override", pOptions->vcsOverride);
+   int copilotEnabled, copilotIndexingEnabled;
+   Error error = json::readObject(
+            optionsJson,
+            "copilot_enabled", copilotEnabled,
+            "copilot_indexing_enabled", copilotIndexingEnabled);
+   if (error)
+      return error;
+   
+   using r_util::YesNoAskValue;
+   pOptions->copilotEnabled = static_cast<YesNoAskValue>(copilotEnabled);
+   pOptions->copilotIndexingEnabled = static_cast<YesNoAskValue>(copilotIndexingEnabled);
+   return Success();
 }
 
 Error writeProjectConfig(const json::Object& configJson)
@@ -709,21 +737,6 @@ Error writeProjectConfig(const json::Object& configJson)
    if (error)
       return error;
    
-   // read copilot options
-   error = json::readObject(
-            configJson,
-            "copilot_enabled", config.copilotEnabled,
-            "copilot_indexing_enabled", config.copilotIndexingEnabled);
-   if (error)
-      return error;
-
-   // write the config
-   error = r_util::writeProjectFile(s_projectContext.file(),
-                                    ProjectContext::buildDefaults(),
-                                    config);
-   if (error)
-      return error;
-
    // set the config
    setProjectConfig(config);
 
@@ -746,12 +759,12 @@ Error writeProjectConfigRpc(const json::JsonRpcRequest& request,
 Error writeProjectOptions(const json::JsonRpcRequest& request,
                           json::JsonRpcResponse* pResponse)
 {
-   // get the project config, vcs options and build options
-   json::Object configJson, vcsOptionsJson, buildOptionsJson;
+   json::Object configJson, vcsOptionsJson, buildOptionsJson, copilotOptionsJson;
    Error error = json::readObjectParam(request.params, 0,
                                        "config", &configJson,
                                        "vcs_options", &vcsOptionsJson,
-                                       "build_options", &buildOptionsJson);
+                                       "build_options", &buildOptionsJson,
+                                       "copilot_options", &copilotOptionsJson);
    if (error)
       return error;
 
@@ -771,6 +784,12 @@ Error writeProjectOptions(const json::JsonRpcRequest& request,
    error = rProjectBuildOptionsFromJson(buildOptionsJson, &buildOptions);
    if (error)
       return error;
+   
+   // read the copilot options
+   RProjectCopilotOptions copilotOptions;
+   error = rProjectCopilotOptionsFromJson(copilotOptionsJson, &copilotOptions);
+   if (error)
+      return error;
 
    // write the vcs options
    error = s_projectContext.writeVcsOptions(vcsOptions);
@@ -781,6 +800,14 @@ Error writeProjectOptions(const json::JsonRpcRequest& request,
    error = s_projectContext.writeBuildOptions(buildOptions);
    if (error)
       LOG_ERROR(error);
+   
+   // write the copilot options
+   error = s_projectContext.writeCopilotOptions(copilotOptions);
+   if (error)
+      LOG_ERROR(error);
+   
+   // notify modules
+   module_context::events().onProjectOptionsUpdated();
 
    return Success();
 }

--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -15,7 +15,6 @@
 
 #include <session/projects/SessionProjects.hpp>
 
-#include <core/Debug.hpp>
 #include <core/Exec.hpp>
 #include <core/FileSerializer.hpp>
 #include <core/http/URL.hpp>

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectConfig.java
@@ -448,20 +448,4 @@ public class RProjectConfig extends JavaScriptObject
    public native final void setZoteroLibraries(JsArrayString libraries) /*-{
       this.zotero_libraries = libraries;
    }-*/;
-   
-   public native final int getCopilotEnabled() /*-{
-      return this.copilot_enabled;
-   }-*/;
-   
-   public native final void setCopilotEnabled(int enabled) /*-{
-      this.copilot_enabled = enabled;
-   }-*/;
-   
-   public native final int getCopilotIndexingEnabled() /*-{
-      return this.copilot_indexing_enabled;
-   }-*/;
-   
-   public native final void setCopilotIndexingEnabled(int enabled) /*-{
-      this.copilot_indexing_enabled = enabled;
-   }-*/;
 }

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectCopilotOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectCopilotOptions.java
@@ -1,0 +1,34 @@
+/*
+ * RProjectCopilotOptions.java
+ *
+ * Copyright (C) 2022 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.projects.model;
+
+import jsinterop.annotations.JsOverlay;
+import jsinterop.annotations.JsPackage;
+import jsinterop.annotations.JsType;
+
+@JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
+public class RProjectCopilotOptions
+{
+   @JsOverlay
+   public static RProjectCopilotOptions createEmpty()
+   {
+      RProjectCopilotOptions options = new RProjectCopilotOptions();
+      return options;
+   }
+   
+   // NOTE: These map to the 'YesNoAskValue' enum used for project options.
+   public int copilot_enabled;
+   public int copilot_indexing_enabled;
+}

--- a/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectOptions.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/model/RProjectOptions.java
@@ -27,11 +27,13 @@ public class RProjectOptions extends JavaScriptObject
    
    public static final RProjectOptions createEmpty()
    {
-      return create(RProjectConfig.createEmpty(), 
-                    RProjectVcsOptions.createEmpty(),
-                    RProjectBuildOptions.createEmpty(),
-                    RProjectPackratOptions.createEmpty(),
-                    RProjectRenvOptions.createEmpty());
+      return create(
+            RProjectConfig.createEmpty(), 
+            RProjectVcsOptions.createEmpty(),
+            RProjectBuildOptions.createEmpty(),
+            RProjectPackratOptions.createEmpty(),
+            RProjectRenvOptions.createEmpty(),
+            RProjectCopilotOptions.createEmpty());
    }
    
    public native static final RProjectOptions create(
@@ -39,7 +41,8 @@ public class RProjectOptions extends JavaScriptObject
                                     RProjectVcsOptions vcsOptions,
                                     RProjectBuildOptions buildOptions,
                                     RProjectPackratOptions packratOptions,
-                                    RProjectRenvOptions renvOptions)
+                                    RProjectRenvOptions renvOptions,
+                                    RProjectCopilotOptions copilotOptions)
    /*-{
       var options = new Object();
       options.config = config;
@@ -48,6 +51,7 @@ public class RProjectOptions extends JavaScriptObject
       options.build_options = buildOptions;
       options.packrat_options = packratOptions;
       options.renv_options = renvOptions;
+      options.copilot_options = copilotOptions;
       return options;
    }-*/;
    
@@ -69,6 +73,10 @@ public class RProjectOptions extends JavaScriptObject
    
    public native final RProjectRenvOptions getRenvOptions() /*-{
       return this.renv_options;
+   }-*/;
+   
+   public native final RProjectCopilotOptions getCopilotOptions() /*-{
+      return this.copilot_options;
    }-*/;
 
    public native final RProjectVcsContext getVcsContext() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -209,21 +209,6 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                 else
                    uiPrefs.spellingDictionaryLanguage().removeProjectValue(true);
                 
-                // copilot prefs
-                int copilotEnabled = config.getCopilotEnabled();
-                if (copilotEnabled != RProjectConfig.DEFAULT_VALUE)
-                   uiPrefs.copilotEnabled().setProjectValue(copilotEnabled == RProjectConfig.YES_VALUE);
-                else
-                   uiPrefs.copilotEnabled().removeProjectValue(true);
-                
-                // copilot prefs
-                int copilotIndexingEnabled = config.getCopilotEnabled();
-                if (copilotIndexingEnabled != RProjectConfig.DEFAULT_VALUE)
-                   uiPrefs.copilotIndexingEnabled().setProjectValue(copilotIndexingEnabled == RProjectConfig.YES_VALUE);
-                else
-                   uiPrefs.copilotIndexingEnabled().removeProjectValue(true);
-                
-                      
                 // convert packrat option changes to console actions
                 emitRenvConsoleActions(options.getRenvOptions());
 

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/ProjectPreferencesDialog.java
@@ -22,6 +22,7 @@ import org.rstudio.core.client.prefs.PreferencesDialogPaneBase;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.widget.Operation;
 import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.ApplicationQuit;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
@@ -32,6 +33,7 @@ import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.model.RProjectRenvOptions;
 import org.rstudio.studio.client.projects.ui.prefs.buildtools.ProjectBuildToolsPreferencesPane;
 import org.rstudio.studio.client.projects.ui.prefs.buildtools.ProjectCopilotPreferencesPane;
+import org.rstudio.studio.client.projects.ui.prefs.events.ProjectOptionsChangedEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -215,6 +217,8 @@ public class ProjectPreferencesDialog extends PreferencesDialogBase<RProjectOpti
                 if (onCompleted != null)
                    onCompleted.execute();
 
+                RStudioGinjector.INSTANCE.getEventBus().fireEvent(new ProjectOptionsChangedEvent(options));
+                
                 handleRestart(
                       pGlobalDisplay_.get(),
                       pQuit_.get(),

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -29,7 +29,7 @@ import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.HelpLink;
 import org.rstudio.studio.client.projects.model.ProjectsServerOperations;
-import org.rstudio.studio.client.projects.model.RProjectConfig;
+import org.rstudio.studio.client.projects.model.RProjectCopilotOptions;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
 import org.rstudio.studio.client.projects.ui.prefs.ProjectPreferencesPane;
 import org.rstudio.studio.client.projects.ui.prefs.YesNoAskDefault;
@@ -67,9 +67,9 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
    @Override
    public RestartRequirement onApply(RProjectOptions options)
    {
-      RProjectConfig config = options.getConfig();
-      config.setCopilotEnabled(copilotEnabled_.getValue());
-      config.setCopilotIndexingEnabled(copilotIndexingEnabled_.getValue());
+      RProjectCopilotOptions copilotOptions = options.getCopilotOptions();
+      copilotOptions.copilot_enabled = copilotEnabled_.getValue();
+      copilotOptions.copilot_indexing_enabled = copilotIndexingEnabled_.getValue();
       return new RestartRequirement();
    }
    
@@ -152,11 +152,11 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
          
          LayoutGrid grid = new LayoutGrid(2, 2);
     
-         copilotEnabled_.setValue(options.getConfig().getCopilotEnabled());
+         copilotEnabled_.setValue(options.getCopilotOptions().copilot_enabled);
          grid.setWidget(0, 0, new FormLabel(constants.copilotEnabledTitle(), copilotEnabled_));
          grid.setWidget(0, 1, copilotEnabled_);
          
-         copilotIndexingEnabled_.setValue(options.getConfig().getCopilotIndexingEnabled());
+         copilotIndexingEnabled_.setValue(options.getCopilotOptions().copilot_indexing_enabled);
          grid.setWidget(1, 0, new FormLabel(constants.copilotIndexingEnabledTitle(), copilotIndexingEnabled_));
          grid.setWidget(1, 1, copilotIndexingEnabled_);
          
@@ -194,8 +194,8 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
                   {
                      if (isInstalled)
                      {
-                        options_.getConfig().setCopilotEnabled(copilotEnabled);
-                        projectServer_.writeProjectConfig(options_.getConfig(), new ServerRequestCallback<Void>()
+                        options_.getCopilotOptions().copilot_enabled = copilotEnabled;
+                        projectServer_.writeProjectOptions(options_, new ServerRequestCallback<Void>()
                         {
                            @Override
                            public void onResponseReceived(Void response)
@@ -221,8 +221,8 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
             }
             else
             {
-               options_.getConfig().setCopilotEnabled(copilotEnabled);
-               projectServer_.writeProjectConfig(options_.getConfig(), new ServerRequestCallback<Void>()
+               options_.getCopilotOptions().copilot_enabled = copilotEnabled;
+               projectServer_.writeProjectOptions(options_, new ServerRequestCallback<Void>()
                {
                   @Override
                   public void onResponseReceived(Void response)

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/events/ProjectOptionsChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/events/ProjectOptionsChangedEvent.java
@@ -1,0 +1,57 @@
+/*
+ * ProjectOptionsChangedEvent.java
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+package org.rstudio.studio.client.projects.ui.prefs.events;
+
+import org.rstudio.studio.client.projects.model.RProjectOptions;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+public class ProjectOptionsChangedEvent extends GwtEvent<ProjectOptionsChangedEvent.Handler>
+{
+   public ProjectOptionsChangedEvent(RProjectOptions options)
+   {
+      options_ = options;
+   }
+
+   public RProjectOptions getData()
+   {
+      return options_;
+   }
+
+   private final RProjectOptions options_;
+
+   // Boilerplate ----
+
+   public interface Handler extends EventHandler
+   {
+      void onProjectOptionsChanged(ProjectOptionsChangedEvent event);
+   }
+
+   @Override
+   public Type<Handler> getAssociatedType()
+   {
+      return TYPE;
+   }
+
+   @Override
+   protected void dispatch(Handler handler)
+   {
+      handler.onProjectOptionsChanged(this);
+   }
+
+   public static final Type<Handler> TYPE = new Type<Handler>();
+}
+

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -2196,7 +2196,7 @@ public class RemoteServer implements Server
    }
 
    public void writeProjectOptions(RProjectOptions options,
-                                  ServerRequestCallback<Void> callback)
+                                   ServerRequestCallback<Void> callback)
    {
       sendRequest(RPC_SCOPE, WRITE_PROJECT_OPTIONS, options, callback);
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/SessionInfo.java
@@ -26,6 +26,7 @@ import org.rstudio.studio.client.common.console.ConsoleProcessInfo;
 import org.rstudio.studio.client.common.debugging.model.ErrorManagerState;
 import org.rstudio.studio.client.common.dependencies.model.DependencyList;
 import org.rstudio.studio.client.common.rnw.RnwWeave;
+import org.rstudio.studio.client.projects.model.RProjectCopilotOptions;
 import org.rstudio.studio.client.quarto.model.QuartoConfig;
 import org.rstudio.studio.client.workbench.addins.Addins.RAddins;
 import org.rstudio.studio.client.workbench.prefs.model.PrefLayer;
@@ -682,6 +683,10 @@ public class SessionInfo extends JavaScriptObject
 
    public final native boolean getCopilotEnabled() /*-{
       return this.copilot_enabled || false;
+   }-*/;
+   
+   public final native RProjectCopilotOptions getCopilotProjectOptions() /*-{
+      return this.copilot_project_options;
    }-*/;
 
    private static final ModelConstants constants_ = GWT.create(ModelConstants.class);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -292,7 +292,7 @@ public class CopilotPreferencesPane extends PreferencesPane
             
             if (response == null)
             {
-               if (projectOptions_ != null && projectOptions_.getConfig().getCopilotEnabled() == RProjectConfig.NO_VALUE)
+               if (projectOptions_ != null && projectOptions_.getCopilotOptions().copilot_enabled == RProjectConfig.NO_VALUE)
                {
                   lblCopilotStatus_.setText("GitHub Copilot has been disabled in this project.");
                   showButtons(btnProjectOptions_);

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionManagerBase.java
@@ -28,6 +28,7 @@ import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.codetools.CodeToolsServerOperations;
 import org.rstudio.studio.client.common.codetools.Completions;
 import org.rstudio.studio.client.common.codetools.RCompletionType;
+import org.rstudio.studio.client.workbench.copilot.Copilot;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.views.console.ConsoleConstants;
@@ -72,9 +73,9 @@ public abstract class CompletionManagerBase
    }
    
    protected CompletionManagerBase(CompletionPopupDisplay popup,
-                                DocDisplay docDisplay,
-                                CodeToolsServerOperations server,
-                                CompletionContext context)
+                                   DocDisplay docDisplay,
+                                   CodeToolsServerOperations server,
+                                   CompletionContext context)
    {
       RStudioGinjector.INSTANCE.injectMembers(this);
       
@@ -93,10 +94,12 @@ public abstract class CompletionManagerBase
    @Inject
    private void initialize(EventBus events,
                            UserPrefs uiPrefs,
+                           Copilot copilot,
                            HelpStrategy helpStrategy)
    {
       events_ = events;
       userPrefs_ = uiPrefs;
+      copilot_ = copilot;
       helpStrategy_ = helpStrategy;
    }
    
@@ -727,7 +730,7 @@ public abstract class CompletionManagerBase
    
    protected boolean canAutoPopup(char ch, int lookbackLimit)
    {
-      if (userPrefs_.copilotEnabled().getValue())
+      if (copilot_.isEnabled())
          return false;
       
       String codeComplete = userPrefs_.codeCompletion().getValue();
@@ -1135,5 +1138,6 @@ public abstract class CompletionManagerBase
    
    protected EventBus events_;
    protected UserPrefs userPrefs_;
+   protected Copilot copilot_;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -43,6 +43,7 @@ import org.rstudio.studio.client.workbench.codesearch.model.DataDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.FileFunctionDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.ObjectDefinition;
 import org.rstudio.studio.client.workbench.codesearch.model.SearchPathFunctionDefinition;
+import org.rstudio.studio.client.workbench.copilot.Copilot;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.snippets.SnippetHelper;
 import org.rstudio.studio.client.workbench.views.console.ConsoleConstants;
@@ -203,13 +204,15 @@ public class RCompletionManager implements CompletionManager
                           FileTypeRegistry fileTypeRegistry,
                           EventBus eventBus,
                           HelpStrategy helpStrategy,
-                          UserPrefs uiPrefs)
+                          UserPrefs uiPrefs,
+                          Copilot copilot)
    {
       globalDisplay_ = globalDisplay;
       fileTypeRegistry_ = fileTypeRegistry;
       eventBus_ = eventBus;
       helpStrategy_ = helpStrategy;
       userPrefs_ = uiPrefs;
+      copilot_ = copilot;
    }
    
    public void detach()
@@ -1851,7 +1854,7 @@ public class RCompletionManager implements CompletionManager
          }
          else
          {
-            boolean preferBottom = !userPrefs_.copilotEnabled().getValue();
+            boolean preferBottom = !copilot_.isEnabled();
             popup_.showCompletionValues(
                   results,
                   new PopupPositioner(rect, popup_, preferBottom),
@@ -2235,6 +2238,7 @@ public class RCompletionManager implements CompletionManager
    private EventBus eventBus_;
    private HelpStrategy helpStrategy_;
    private UserPrefs userPrefs_;
+   private Copilot copilot_;
 
    private final CodeToolsServerOperations server_;
    private final InputEditorDisplay input_;

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTarget.java
@@ -1864,9 +1864,7 @@ public class TextEditingTarget implements
                   }
                }
             });
-
       
-
       packageDependencyHelper_ = new TextEditingTargetPackageDependencyHelper(this, docUpdateSentinel_, docDisplay_);
 
       // create notebook and forward resize events

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -24,6 +24,7 @@ import org.rstudio.core.client.dom.EventProperty;
 import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.Timers;
+import org.rstudio.studio.client.projects.ui.prefs.events.ProjectOptionsChangedEvent;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
@@ -179,6 +180,11 @@ public class TextEditingTargetCopilotHelper
             });
          }
       };
+      
+      events_.addHandler(ProjectOptionsChangedEvent.TYPE, (event) ->
+      {
+         manageHandlers();
+      });
       
       prefs_.copilotEnabled().addValueChangeHandler((event) ->
       {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetCopilotHelper.java
@@ -182,19 +182,19 @@ public class TextEditingTargetCopilotHelper
       
       prefs_.copilotEnabled().addValueChangeHandler((event) ->
       {
-         manageHandlers(event.getValue());
+         manageHandlers();
       });
       
       Scheduler.get().scheduleDeferred(() ->
       {
-         manageHandlers(prefs_.copilotEnabled().getValue());
+         manageHandlers();
       });
       
    }
    
-   private void manageHandlers(boolean enabled)
+   private void manageHandlers()
    {
-      if (!enabled)
+      if (!copilot_.isEnabled())
       {
          display_.removeGhostText();
          registrations_.removeHandler();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13635.

### Approach

Rather than serialize the Copilot project options as part of the project file, we instead serialize them to their own settings file within the `.Rproj.user` state folder. While there are a lot of changes required to make this happen, the changes are relatively straightforward.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13635. In particular, confirm that the `.Rproj` file is not updated when changing these project options.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
