### PR TITLE
update minimum required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 # release name
 include(CMakeRelease.txt)

--- a/package/osx/cmake/prepare-package.cmake
+++ b/package/osx/cmake/prepare-package.cmake
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 # CMake's message is suppressed during install stage so just use echo here
 function(echo MESSAGE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 # don't add gwt for special 32-bit binary builds on windows (since
 # we've already got it from the 64-bit build), for development mode

--- a/src/cpp/CMakeLists.txt
+++ b/src/cpp/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 # read release name
 include("${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeRelease.txt")

--- a/src/cpp/desktop/CMakeLists.txt
+++ b/src/cpp/desktop/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 project(DESKTOP)
 

--- a/src/gwt/CMakeLists.txt
+++ b/src/gwt/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 project (RSTUDIO_GWT)
 
 set(GWT_LIB_DIR "lib")

--- a/src/node/CMakeLists.txt
+++ b/src/node/CMakeLists.txt
@@ -12,7 +12,7 @@
 #
 
 # set minimum version
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 
 # don't add electron for development mode (since faster to work
 # iteratively using "yarn start" and so forth)

--- a/src/node/desktop/CMakeLists.txt
+++ b/src/node/desktop/CMakeLists.txt
@@ -13,7 +13,7 @@
 #
 #
 
-cmake_minimum_required(VERSION 3.4.3)
+cmake_minimum_required(VERSION 3.6.3)
 project(ELECTRON_DESKTOP)
 
 if (LINUX)


### PR DESCRIPTION
Part of https://github.com/rstudio/rstudio/issues/13577.

This is a fairly conservative change, since we already install a fairly new version of CMake where required:

https://github.com/rstudio/rstudio/blob/b7f159d0a210b1215f12a4786c6d900c53f8771a/package/linux/install-dependencies#L20-L37