### PR TITLE
Limit rate of writes to 'executing' property metadata

### DIFF
--- a/src/cpp/session/SessionConsoleInput.hpp
+++ b/src/cpp/session/SessionConsoleInput.hpp
@@ -31,6 +31,7 @@ namespace console_input {
 
 void clearConsoleInputBuffer();
 bool executing();
+void updateSessionExecuting();
 core::Error extractConsoleInput(const core::json::JsonRpcRequest& request);
 void reissueLastConsolePrompt();
 void addToConsoleInputBuffer(

--- a/src/cpp/session/SessionOfflineService.cpp
+++ b/src/cpp/session/SessionOfflineService.cpp
@@ -128,7 +128,7 @@ bool offlineConnectionMatcher(boost::shared_ptr<HttpConnection> ptrHttpConn,
 
    if (now < ptrHttpConn->receivedTime())
    {
-      LOG_ERROR_MESSAGE("offlineConnectionMatcher: ignoring connection received in the future");
+      // this can happen because 'now' gets computed before the lock is taken
       return false;
    }
 
@@ -222,6 +222,9 @@ void OfflineService::run()
             // Wait for the client to be initialized before any offline handling
             if (!httpConnectionListener().eventsActive())
                continue;
+
+            // Periodically sync the state of the executing status (set it to false if idle)
+            console_input::updateSessionExecuting();
 
             // If R is not occupying the main thread, we'll continue to wait.
             if (!console_input::executing())


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/4922

### Approach

In Posit Workbench, updating the 'executing' metadata property causes a file system write. If that happens too frequently it causes performance issues, especially with some customers that have network file systems that limit the number of writes to a file per second. 

In this PR the rate of writes it not controlled by the number of console-input statements but instead limited to a few times a second. The transition to the executing state happens right away, but the transition from executing to idle happens in the offline service at no more than 4X second, so no more than 8X/second.

### Automated Tests

I don't think we have any automated tests for the 'executing' state so that might be worth doing?  

### QA Notes

Capture an strace of the rsession while running a script like: 

```
system("sleep 0.01")
system("sleep 0.01")
system("sleep 0.01")
...
(200 or 300 times)
```

Count the number of 'open' calls to the executing file in the properites directory.  Should see no more than 8X/second with the PR. Without it, you'll see one per line. 


