### PR TITLE
Reduce number of calls to canSuspend/allowSuspend

### DIFF
--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -101,21 +101,20 @@ void consolePrompt(const std::string& prompt, bool addToHistory)
 
 bool canSuspend(const std::string& prompt)
 {
-   bool suspendIsBlocked = session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
-   if (!suspendIsBlocked)
-      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
-   if (!suspendIsBlocked)
-      suspendIsBlocked = session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
-
-   if (!suspendIsBlocked && session::options().sessionConnectionsBlockSuspend())
-      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
+   bool suspendIsBlocked = false;
    
-   if (!suspendIsBlocked && session::options().sessionExternalPointersBlockSuspend())
-      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
-   
-   if (!suspendIsBlocked)
-      suspendIsBlocked = !modules::overlay::isSuspendable();
+   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
+   suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
 
+   if (session::options().sessionConnectionsBlockSuspend())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
+   
+   if (session::options().sessionExternalPointersBlockSuspend())
+      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
+   
+   suspendIsBlocked |= !modules::overlay::isSuspendable();
+   
    return !suspendIsBlocked;
 }
 

--- a/src/cpp/session/SessionConsoleInput.cpp
+++ b/src/cpp/session/SessionConsoleInput.cpp
@@ -101,20 +101,21 @@ void consolePrompt(const std::string& prompt, bool addToHistory)
 
 bool canSuspend(const std::string& prompt)
 {
-   bool suspendIsBlocked = false;
-   
-   suspendIsBlocked |= session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
-   suspendIsBlocked |= session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
+   bool suspendIsBlocked = session::suspend::checkBlockingOp(main_process::haveDurableChildren(), suspend::kChildProcess);
+   if (!suspendIsBlocked)
+      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::jobs::isSuspendable(), suspend::kActiveJob);
+   if (!suspendIsBlocked)
+      suspendIsBlocked = session::suspend::checkBlockingOp(!rstudio::r::session::isSuspendable(prompt), suspend::kCommandPrompt);
 
-   if (session::options().sessionConnectionsBlockSuspend())
-      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
+   if (!suspendIsBlocked && session::options().sessionConnectionsBlockSuspend())
+      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::connections::isSuspendable(), suspend::kConnection);
    
-   if (session::options().sessionExternalPointersBlockSuspend())
-      suspendIsBlocked |= session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
+   if (!suspendIsBlocked && session::options().sessionExternalPointersBlockSuspend())
+      suspendIsBlocked = session::suspend::checkBlockingOp(!modules::environment::isSuspendable(), suspend::kExternalPointer);
    
-   suspendIsBlocked |= !modules::overlay::isSuspendable();
-   
+   if (!suspendIsBlocked)
+      suspendIsBlocked = !modules::overlay::isSuspendable();
+
    return !suspendIsBlocked;
 }
 

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -462,6 +462,8 @@ bool waitForMethod(const std::string& method,
    boost::posix_time::time_duration connectionQueueTimeout =
                                    boost::posix_time::milliseconds(50);
 
+   int checkForIdleCount = 0;
+
    // If this method (and the provided allowSuspend() function) blocks auto suspension,
    // make sure to record it
    suspend::addBlockingOp(method, allowSuspend);
@@ -469,8 +471,8 @@ bool waitForMethod(const std::string& method,
    // wait until we get the method we are looking for
    while (true)
    {
-      // suspend if necessary (does not return if a suspend occurs)
-      suspend::checkForSuspend(allowSuspend);
+      // before waiting, suspend if necessary due to forced or requests suspend (does not return if a suspend occurs)
+      suspend::checkForRequestedSuspend(allowSuspend);
 
       // look for a connection (waiting for the specified interval)
       boost::shared_ptr<HttpConnection> ptrConnection =
@@ -555,6 +557,17 @@ bool waitForMethod(const std::string& method,
             rstudio::r::session::event_loop::initializePolledEventHandler(
                                                      polledEventHandler);
       }
+      else
+      {
+         // avoid calling allowSuspend too often as it iterates through the environment in R
+         // looking to be sure all objects are suspendable
+         if ((++checkForIdleCount % 20) == 0)
+         {
+            // timed-out waiting for (usually) console input 20 times (1s)
+            suspend::checkForIdleSuspend(allowSuspend);
+         }
+      }
+
    }
 
    suspend::removeBlockingOp(suspend::kGenericMethod + method);

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -358,12 +358,12 @@ bool suspendSession(bool force, int status)
 
 void checkForIdleSuspend(const boost::function<bool()>& allowSuspend)
 {
+   bool canSuspend = allowSuspend();
 
    // If there's no suspend-blocking activity, just wait
    // for the inactivity timer to expire
    if (s_timeoutState == kWaitingForTimeout)
    {
-      bool canSuspend = allowSuspend();
       if (canSuspend)
       {
          if (isTimedOut(s_suspendTimeoutTime))
@@ -408,7 +408,6 @@ void checkForIdleSuspend(const boost::function<bool()>& allowSuspend)
    // notifying user that the session is blocked from suspending
    if (s_timeoutState == kWaitingForInactivity)
    {
-      bool canSuspend = allowSuspend();
       if (canSuspend)
       {
          // reset the inactivity timeout before switching waiting modes

--- a/src/cpp/session/SessionSuspend.cpp
+++ b/src/cpp/session/SessionSuspend.cpp
@@ -356,14 +356,14 @@ bool suspendSession(bool force, int status)
    return r::session::suspend(force, status, session::options().ephemeralEnvVars());
 }
 
-void checkForTimeout(const boost::function<bool()>& allowSuspend)
+void checkForIdleSuspend(const boost::function<bool()>& allowSuspend)
 {
-   bool canSuspend = allowSuspend();
 
    // If there's no suspend-blocking activity, just wait
    // for the inactivity timer to expire
    if (s_timeoutState == kWaitingForTimeout)
    {
+      bool canSuspend = allowSuspend();
       if (canSuspend)
       {
          if (isTimedOut(s_suspendTimeoutTime))
@@ -408,6 +408,7 @@ void checkForTimeout(const boost::function<bool()>& allowSuspend)
    // notifying user that the session is blocked from suspending
    if (s_timeoutState == kWaitingForInactivity)
    {
+      bool canSuspend = allowSuspend();
       if (canSuspend)
       {
          // reset the inactivity timeout before switching waiting modes
@@ -433,7 +434,7 @@ void checkForTimeout(const boost::function<bool()>& allowSuspend)
    }
 }
 
-void checkForSuspend(const boost::function<bool()>& allowSuspend)
+void checkForRequestedSuspend(const boost::function<bool()>& allowSuspend)
 {
    // never suspend in desktop mode
    if (options().programMode() == kSessionProgramModeDesktop)
@@ -486,9 +487,6 @@ void checkForSuspend(const boost::function<bool()>& allowSuspend)
       // errors will be logged/reported internally and we will move on
       suspendSession(false);
    }
-
-   // timeout suspend
-   checkForTimeout(allowSuspend);
 }
 
 std::string mostSignificantTimeAgo(const boost::posix_time::ptime& before, const boost::posix_time::ptime& after = boost::posix_time::second_clock::universal_time())

--- a/src/cpp/session/include/session/SessionSuspend.hpp
+++ b/src/cpp/session/include/session/SessionSuspend.hpp
@@ -49,7 +49,8 @@ void addBlockingOp(std::string op);
 void addBlockingOp(std::string method, const boost::function<bool()>& allowSuspend);
 void removeBlockingOp(std::string op);
 bool checkBlockingOp(bool blocking, std::string op);
-void checkForSuspend(const boost::function<bool()>& allowSuspend);
+void checkForRequestedSuspend(const boost::function<bool()>& allowSuspend);
+void checkForIdleSuspend(const boost::function<bool()>& allowSuspend);
 std::string getResumedMessage();
 void initFromResume();
 


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio/issues/13534

### Approach

Split the checkForSuspend method into two pieces:
  1) run before processing each request (like today) to check for explicit suspension - it only
calls allowSuspend if the user requested suspension
  2) another that's run to check for idle suspension that's run periodically.
The rsession waitForMethod, poll handler has a 50ms timeout for background processing while waiting for r console input.  Only if 20 of these go by now do we check for an idle session (i.e. 1/second).

Are there scenario where console input is being processed and we need to allow suspension?  Could use a timer here but trying to avoid extra system calls since this is an inner loop for running R code.

Or we could a check in the offline polling thread so it's done regularly, not based on the rate of console input.

### QA Notes

The key things to test here are that sessions still suspend when idle. This is an important use case that we ignore certain types of background activity but reliably suspend when the user has not interacted with the system for a while.

This PR doesn't change the core suspension logic, but reduces the rate of the 'check for timeout' calls so we need to make sure those calls are still happening in the edge cases for session suspension. 

