### PR TITLE
tweak detection of YAML chunk options in R Markdown documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Fixed an issue where underscores in file names were not displayed correctly in menu items. (#13662)
 - Fixed an issue where previewed plots were not rendered at the correct DPI. (#13387)
 - Fixed an issue where warnings could be emitted when parsing YAML options within R Markdown code chunks. (#13326)
+- Fixed an issue where inline YAML chunk options were not properly parsed from SQL chunks. (#13240)
 
 #### Posit Workbench
 -

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 - Improved performance of R Markdown chunk execution for projects running on networked filesystems. (#8034)
 - Fixed an issue where underscores in file names were not displayed correctly in menu items. (#13662)
 - Fixed an issue where previewed plots were not rendered at the correct DPI. (#13387)
+- Fixed an issue where warnings could be emitted when parsing YAML options within R Markdown code chunks. (#13326)
 
 #### Posit Workbench
 -

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 - Updated to Boost 1.83.0. (#13577)
 - RStudio now supports highlighting of inline YAML chunk options in R Markdown / Quarto documents. (#11663)
 - Improved support for development documentation when a package has been loaded via `devtools::load_all()`. (#13526)
+- RStudio now supports the execution of chunks with the 'file' option set. (#13636)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -15,12 +15,13 @@
 assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("extractRmdFromNotebook", function(notebook) {
+   
    # parse the notebook to get the text of the contained R markdown doc
    parsed <- try(rmarkdown::parse_html_notebook(notebook), silent = TRUE)
    if (inherits(parsed, "try-error") || is.null(parsed$rmd)) {
-    return("")
+      return("")
    }
-
+   
    # as this string will be eventually written to (and compared with) files
    # on disk, use native line endings
    return(paste(parsed$rmd,
@@ -38,9 +39,9 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    "^[\t >]*```+\\s*$"
 })
 
-.rs.addFunction("reYamlOptChunkBegin", function()
+.rs.addFunction("reYamlOptChunkBegin", function(commentPrefix = "#")
 {
-   "^#\\| .*"
+   sprintf("^%s\\| .*", commentPrefix)
 })
 
 
@@ -50,22 +51,22 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 })
 
 .rs.addFunction("coalesceCsvOutput", function(chunkData) {
-  # nothing to coalesce if < 2 outputs
-  if (length(chunkData) < 2)
-    return(chunkData)
-    
-  # keep all output by default
-  keep <- rep(TRUE, length(chunkData))
-
-  # coalesce contents for consecutive csv entries
-  csvs <- .rs.endsWith(names(chunkData), ".csv")
-  for (i in seq.int(1, length(csvs) - 1)) {
-    if (keep[[i]] && csvs[[i]] && csvs[[i + 1]]) {
-      chunkData[[i]] <- paste(chunkData[[i]], chunkData[[i + 1]], sep = "")
-      keep[[i + 1]] <- FALSE
-    }
-  }
-  chunkData[keep]
+   # nothing to coalesce if < 2 outputs
+   if (length(chunkData) < 2)
+      return(chunkData)
+   
+   # keep all output by default
+   keep <- rep(TRUE, length(chunkData))
+   
+   # coalesce contents for consecutive csv entries
+   csvs <- .rs.endsWith(names(chunkData), ".csv")
+   for (i in seq.int(1, length(csvs) - 1)) {
+      if (keep[[i]] && csvs[[i]] && csvs[[i + 1]]) {
+         chunkData[[i]] <- paste(chunkData[[i]], chunkData[[i + 1]], sep = "")
+         keep[[i + 1]] <- FALSE
+      }
+   }
+   chunkData[keep]
 })
 
 .rs.addFunction("readRnbCache", function(rmdPath, cachePath)
@@ -101,7 +102,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    names(chunkInfo$chunk_definitions) <-
       unlist(lapply(chunkInfo$chunk_definitions, `[[`, "chunk_id"))
    rnbData[["chunk_info"]] <- chunkInfo
-
+   
    # Read external chunks (code chunks defined in other files)
    rnbData[["external_chunks"]] <- chunkInfo$external_chunks
    
@@ -109,11 +110,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    chunkDirs <- file.path(cachePath, names(chunkInfo$chunk_definitions))
    chunkData <- lapply(chunkDirs, function(dir) {
       files <- list.files(dir, full.names = TRUE)
-
+      
       # exclude directories
       fileInfo <- file.info(files)
       files <- files[!fileInfo$isdir]
-
+      
       # extract the contents from each regular file
       contents <- lapply(files, function(file) {
          
@@ -167,9 +168,9 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    engine <- tolower(engine)
    switch(engine,
-      rcpp = "cpp",
-      sh = "bash",
-      engine)
+          rcpp = "cpp",
+          sh = "bash",
+          engine)
 })
 
 .rs.addFunction("rnb.outputSourcePng", function(fileName,
@@ -314,11 +315,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
             if (identical(context$engine, "js")) {
                htmlOutput <- paste(
                   c('<script type="text/javascript">', code, '</script>'),
-                    collapse = '\n')
+                  collapse = '\n')
             } else if (identical(context$engine, "css")) {
                htmlOutput <- paste(
                   c('<style type="text/css">', code, '</style>'),
-                    collapse = '\n')
+                  collapse = '\n')
             }
          }
          return(knitr::asis_output(htmlOutput))
@@ -408,7 +409,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    if (is.null(outputFile))
       outputFile <- .rs.withChangedExtension(inputFile, ext = ".nb.html")
-
+   
    # specify default encoding (we'll try to infer + convert to UTF-8
    # if necessary)
    encoding <- getOption("encoding")
@@ -424,11 +425,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # reset the knitr chunk counter (it can be modified as a side effect of
    # parse_params, which is called during notebook execution)
    knitr:::chunk_counter(reset = TRUE)
-
+   
    # restore external chunks into the knit environment
    if (!is.null(rnbData$external_chunks)) 
       knitr:::knit_code$restore(rnbData$external_chunks)
-
+   
    # set up output_source
    outputOptions <- list(output_source = .rs.rnb.outputSource(rnbData))
    
@@ -438,7 +439,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # could fail)
    if (exists("eval_lang", envir = asNamespace("knitr")))
    {
-      override <- function(x, envir = knit_global()) {
+      override <- function(x, envir = knitr:::knit_global()) {
          
          # white-list for the commonly-used 'T' and 'F' options
          if (identical(x, as.name("T")))
@@ -455,7 +456,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       original <- .rs.replaceBinding("eval_lang", "knitr", override)
       on.exit(.rs.replaceBinding("eval_lang", "knitr", original), add = TRUE)
    }
-
+   
    # knitr outputs relevant information in the form of messages that we attach to the error
    renderMessages <- list()
    tryCatch({
@@ -474,17 +475,17 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       })
    }, error = function(e) {
       messages <- list(e$message)
-
+      
       lapply(renderMessages, function(m) {
-        if (typeof(m) != "character") return();
-
-        result <- regexec("Quitting from lines ([0-9]+)-([0-9]+) ", text = m)
-        if (result[[1]][[1]] < 0) return();
-
-        groups <- regmatches(m, result)[[1]]
-        messages <<- c(messages, paste("See line ", (strtoi(groups[[2]]) - 1), sep = ""))
+         if (typeof(m) != "character") return();
+         
+         result <- regexec("Quitting from lines ([0-9]+)-([0-9]+) ", text = m)
+         if (result[[1]][[1]] < 0) return();
+         
+         groups <- regmatches(m, result)[[1]]
+         messages <<- c(messages, paste("See line ", (strtoi(groups[[2]]) - 1), sep = ""))
       })
-
+      
       stop(paste(messages, collpase = ". ", sep = ""))
    })
 })
@@ -493,7 +494,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    # presume success unless we fail below
    result <- list(succeeded = .rs.scalar(TRUE))
-
+   
    tryCatch({
       cachePath <- .rs.rnb.cachePathFromRmdPath(rmdPath)
       rnbData <- .rs.readRnbCache(rmdPath, cachePath)
@@ -636,10 +637,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    opts
 })
 
-.rs.addFunction("parseYamlOpt", function(opt)
+.rs.addFunction("parseYamlOpt", function(opt, commentPrefix = "#")
 {
    # remove comment prefix
-   opt <- sub("^#\\|\\s*", "", opt)
+   commentPrefixPattern <- sprintf("^%s\\|\\s*", commentPrefix)
+   opt <- sub(commentPrefixPattern, "", opt)
    
    # check for YAML entry, mimicing code in knitr
    if (grepl("^[^ :]+:($|\\s)", opt[[1]])) {
@@ -653,115 +655,134 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    knitr:::parse_params(opts, label = FALSE)
 })
 
-.rs.addFunction("evaluateChunkOptions", function(code)
+.rs.addFunction("evaluateChunkOptions", function(id, type, code)
 {
-  opts <- list()
-
-  Encoding(code) <- "UTF-8"
-  # if several lines of code are passed, we expect the first line to contain the standard Rmd chunk options
-  # the next several lines may or may not contain YAML-style chunk options
-  code <- unlist(strsplit(code, "\n", fixed = TRUE))
-  rmdChunkOpts <- code[[1]]
-  yamlChunkOpts <- c()
-
-  for (line in code[-1]) {
-    match <- unlist(regmatches(line, regexec(.rs.reYamlOptChunkBegin(), line)))
-    # there may be variable number of yaml chunk opts, but they should all be at the top of the chunk
-    if (length(match) == 0)
-        break
-    yamlChunkOpts <- c(yamlChunkOpts, match)
-  }
-  
-  if (length(yamlChunkOpts) > 0)
-  {
-     opts <- tryCatch(
-     .rs.parseYamlOpt(yamlChunkOpts),
-     error = function(e) {
-        warning("Failed to parse chunk options in body:\n", e)
-     })
-  }
-
-  # strip chunk indicators if present
-  matches <- unlist(regmatches(rmdChunkOpts, regexec(.rs.reRmdChunkBegin(), rmdChunkOpts)))
-  if (length(matches) > 1)
-    rmdChunkOpts <- matches[[2]]
-
-  tryCatch({
-    # if this is the setup chunk, it's not included by default
-    setupIndicator <- "r setup"
-    if (identical(substring(rmdChunkOpts, 1, nchar(setupIndicator)),
-                  setupIndicator)) {
-      opts$include <- FALSE
-    }
-
-    # extract and remove engine name (can be overridden below with engine=)
-    opts$engine <- unlist(strsplit(rmdChunkOpts, split = "(\\s|,)+"))[[1]]
-    rmdChunkOpts <- substring(rmdChunkOpts, nchar(opts$engine) + 1)
-
-    # parse them, then merge with the defaults (evaluate in global environment)
-    opts <- .rs.mergeLists(opts,
-                           eval(substitute(knitr:::parse_params(rmdChunkOpts)),
-                                envir = .GlobalEnv))
-
-    # if a chunk option is provided in both body (yaml chunk options) and header (rmdChunkOpts)
-    # the body should override the header option
-    opts <- opts[unique(names(opts))]
-    
-    # convert T, F for R code chunk options to TRUE, FALSE as appropriate
-    opts <- lapply(opts, function(opt) {
-      if (identical(opt, as.name("T")))
-        TRUE
-      else if (identical(opt, as.name("F")))
-        FALSE
-      else
-        opt
-    })
-
-    # convert language name objects to plain characters (these can occur in
-    # malformed expressions, and cause scalar conversion below to fail)
-    names <- vapply(opts, is.name, TRUE)
-    opts[names] <- as.character(opts[names])
-    
-    # ensure that fields we expect to be logical are actually logical
-    # (sanitize invalid inputs here since they can break notebook execution)
-    fields <- list(
+   Encoding(code) <- "UTF-8"
+   code <- unlist(strsplit(code, "\n", fixed = TRUE))
+   
+   # parsed chunk options
+   opts <- list()
+   
+   # first, parse chunk options embedded in the chunk header
+   rmdChunkOpts <- code[[1]]
+   
+   # strip chunk indicators if present
+   matches <- unlist(regmatches(rmdChunkOpts, regexec(.rs.reRmdChunkBegin(), rmdChunkOpts)))
+   if (length(matches) > 1)
+      rmdChunkOpts <- matches[[2]]
+   
+   # attempt to parse parameters (swallow errors)
+   .rs.tryCatch({
+      
+      # if this is the setup chunk, it's not included by default
+      if (.rs.startsWith(rmdChunkOpts, "r setup"))
+         opts$include <- FALSE
+      
+      # extract and remove engine name (can be overridden below with engine=)
+      opts$engine <- unlist(strsplit(rmdChunkOpts, split = "(\\s|,)+"))[[1]]
+      rmdChunkOpts <- substring(rmdChunkOpts, nchar(opts$engine) + 1)
+      
+      # parse them, then merge with the defaults (evaluate in global environment)
+      parsedParams <- eval(
+         substitute(knitr:::parse_params(rmdChunkOpts)),
+         envir = .GlobalEnv
+      )
+      
+      opts <- .rs.mergeLists(opts, parsedParams)
+                             
+      # if a chunk option is provided in both body (yaml chunk options) and header (rmdChunkOpts)
+      # the body should override the header option
+      opts <- opts[unique(names(opts))]
+      
+      # convert T, F for R code chunk options to TRUE, FALSE as appropriate
+      opts <- lapply(opts, function(opt) {
+         if (identical(opt, as.name("T")))
+            TRUE
+         else if (identical(opt, as.name("F")))
+            FALSE
+         else
+            opt
+      })
+      
+      # convert language name objects to plain characters (these can occur in
+      # malformed expressions, and cause scalar conversion below to fail)
+      names <- vapply(opts, is.name, TRUE)
+      opts[names] <- as.character(opts[names])
+      
+   })
+   
+   # now, try to find inline YAML chunk options
+   yamlChunkOpts <- c()
+   
+   # figure out the appropriate chunk prefix based on the engine
+   commentPrefix <- switch(
+      tolower(.rs.nullCoalesce(opts$engine, "r")),
+      sql = "-{2,}",
+      cpp = "//",
+      "#"
+   )
+   
+   yamlPrefix <- .rs.reYamlOptChunkBegin(commentPrefix)
+   for (line in code[-1]) {
+      
+      # there may be variable number of yaml chunk opts, but they should all be at the top of the chunk
+      match <- unlist(regmatches(line, regexec(yamlPrefix, line)))
+      if (length(match) == 0)
+         break
+      
+      # add the line
+      yamlChunkOpts <- c(yamlChunkOpts, match)
+      
+   }
+   
+   # if we had some YAML chunk options, try to add them
+   if (length(yamlChunkOpts) > 0)
+   {
+      tryCatch({
+         yamlOpts <- .rs.parseYamlOpt(yamlChunkOpts, commentPrefix)
+         opts <- .rs.mergeLists(opts, yamlOpts)
+      }, error = function(e) {
+         warning("Failed to parse chunk options in body:\n", e)
+      })
+   }
+   
+   # ensure that fields we expect to be logical are actually logical
+   # (sanitize invalid inputs here since they can break notebook execution)
+   fields <- list(
       warning = TRUE,
       message = TRUE,
       error   = FALSE
-    )
-    
-    .rs.enumerate(fields, function(key, default) {
-       
+   )
+   
+   .rs.enumerate(fields, function(key, default) {
+      
       if (is.null(opts[[key]]))
-        next
-       
+         return()
+      
       opts[[key]] <<- tryCatch(
-        as.logical(opts[[key]]),
-        error = function(e) default
+         as.logical(opts[[key]]),
+         error = function(e) default
       )
-       
-    })
-    
-  },
-  error = function(e) {})
-
-  .rs.scalarListFromList(opts, expressions = TRUE)
+      
+   })
+   
+   .rs.scalarListFromList(opts, expressions = TRUE)
 })
 
 .rs.addFunction("extractChunkInnerCode", function(code)
 {
-  # split into lines
-  Encoding(code) <- "UTF-8"   
-  code <- unlist(strsplit(code, "\n", fixed = TRUE))
-  
-  # find chunk indicators (safe fallbacks if absent)
-  start <- max(1, grep(.rs.reRmdChunkBegin(), code, perl = TRUE))
-  end   <- min(length(code), grep(.rs.reRmdChunkEnd(), code, perl = TRUE))
-
-  code <- code[(start + 1):(end - 1)]
-  code <- gsub("#[|].*$", "", code)
-  
-  paste(code, collapse = "\n")
+   # split into lines
+   Encoding(code) <- "UTF-8"   
+   code <- unlist(strsplit(code, "\n", fixed = TRUE))
+   
+   # find chunk indicators (safe fallbacks if absent)
+   start <- max(1, grep(.rs.reRmdChunkBegin(), code, perl = TRUE))
+   end   <- min(length(code), grep(.rs.reRmdChunkEnd(), code, perl = TRUE))
+   
+   code <- code[(start + 1):(end - 1)]
+   code <- gsub("#[|].*$", "", code)
+   
+   paste(code, collapse = "\n")
 })
 
 .rs.addFunction("extractRmdChunkInformation", function(rmd)
@@ -799,7 +820,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       rmdPath <- .rs.withChangedExtension(nbPath, ".Rmd")
       cachePath <- .rs.rnb.cachePathFromRmdPath(rmdPath)
    }
-
+   
    # ensure cache directory
    if (!.rs.dirExists(cachePath))
       dir.create(cachePath, recursive = TRUE)
@@ -947,9 +968,9 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       # extract base64 encoded content
       scraped <- .rs.scrapeHtmlAttributes(html)
       ext <- if (.rs.startsWith(scraped$src, "data:image/jpeg;"))
-                 "jpeg" else "png"
+         "jpeg" else "png"
       imgDataEncoded <- substring(scraped$src, 
-         nchar(paste("data:image/", ext, ";base64,", sep = "")) + 1)
+                                  nchar(paste("data:image/", ext, ";base64,", sep = "")) + 1)
       imgData <- .rs.base64decode(imgDataEncoded, binary = TRUE)
       
       # write to file
@@ -959,10 +980,10 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       
       # write metadata if present
       if (!is.null(meta) && !is.null(meta$metadata)) {
-        metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
-        cat(.rs.toJSON(meta, unbox = TRUE), file = metaPath, sep = "\n")
+         metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
+         cat(.rs.toJSON(meta, unbox = TRUE), file = metaPath, sep = "\n")
       }
-
+      
       # update state
       activeIndex <<- activeIndex + 1
    }
@@ -978,25 +999,25 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
          plotMeta  <<- NULL
       }
    }
-
+   
    # Data frame handling ----
    frameRange <- list(start = NULL, end = NULL)
    frameMeta <- NULL
    writeFrame <- function(source, range, meta) {
       if (is.null(meta))
-        return(NULL);
-
+         return(NULL);
+      
       # write out frame metadata
       if (!is.null(meta$metadata)) {
-        metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
-        cat(.rs.toJSON(meta$metadata, unbox = TRUE), file = metaPath, sep = "\n")
+         metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
+         cat(.rs.toJSON(meta$metadata, unbox = TRUE), file = metaPath, sep = "\n")
       }
-
+      
       # write out raw frame data
       if (!is.null(meta$rdf)) {
-        rdfPath <- outputPath(cachePath, activeChunkId, activeIndex, "rdf")
-        writeBin(object = .rs.base64decode(meta$rdf, binary = TRUE), 
-                 con = rdfPath)
+         rdfPath <- outputPath(cachePath, activeChunkId, activeIndex, "rdf")
+         writeBin(object = .rs.base64decode(meta$rdf, binary = TRUE), 
+                  con = rdfPath)
       }
    }
    onFrame <- function(annotation) {
@@ -1025,13 +1046,13 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       
       htmlPath <- outputPath(cachePath, activeChunkId, activeIndex, "html")
       cat(htmlOutput, file = htmlPath, sep = "\n")
-
+      
       # write metadata if present
       if (!is.null(meta) && !is.null(meta$metadata)) {
-        metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
-        cat(.rs.toJSON(meta, unbox = TRUE), file = metaPath, sep = "\n")
+         metaPath <- outputPath(cachePath, activeChunkId, activeIndex, "metadata")
+         cat(.rs.toJSON(meta, unbox = TRUE), file = metaPath, sep = "\n")
       }
-
+      
       # update state
       activeIndex <<- activeIndex + 1
    }
@@ -1147,7 +1168,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 {
    # get the current set of chunk options
    chunkOptions <- knitr::opts_chunk$get()
-
+   
    # make sure global connection lists exists
    if (!exists(".rs.knitr.chunkReferences", envir = .rs.toolsEnv()))
       assign(".rs.knitr.chunkReferences", list(), envir = .rs.toolsEnv())
@@ -1159,14 +1180,14 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       chunkReferences[[idReference]] <- chunkOptions$connection
       chunkOptions$connection <- idReference
    }
-
+   
    # cache the current set of chunk options
    assign(".rs.knitr.chunkOptions", chunkOptions, envir = .rs.toolsEnv())
-
+   
    # cache the set of external code
    knitrCode <- knitr:::knit_code$get()
    assign(".rs.knitr.code", knitrCode, envir = .rs.toolsEnv())
-
+   
    # cache default working dir
    knitrDir <- knitr::opts_knit$get("root.dir")
    assign(".rs.knitr.root.dir", knitrDir, envir = .rs.toolsEnv())
@@ -1212,14 +1233,14 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 
 .rs.addFunction("executeChunkCallback", function(chunkName, chunkCode)
 {
-  if (exists(".rs.notebookChunkCallbacks", envir = .rs.toolsEnv()) &&
-      length(.rs.notebookChunkCallbacks) != 0)
-  {
-     handle <- ls(envir = .rs.notebookChunkCallbacks)
-     chunkCallback <- get(handle, envir = .rs.notebookChunkCallbacks)
-     return(chunkCallback(eval(chunkName), eval(chunkCode)))
-  }
-  NULL
+   if (exists(".rs.notebookChunkCallbacks", envir = .rs.toolsEnv()) &&
+       length(.rs.notebookChunkCallbacks) != 0)
+   {
+      handle <- ls(envir = .rs.notebookChunkCallbacks)
+      chunkCallback <- get(handle, envir = .rs.notebookChunkCallbacks)
+      return(chunkCallback(eval(chunkName), eval(chunkCode)))
+   }
+   NULL
 })
 
 # a list mapping file extensions to its associated output handler

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -640,7 +640,7 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
 .rs.addFunction("parseYamlOpt", function(opt, commentPrefix = "#")
 {
    # remove comment prefix
-   commentPrefixPattern <- sprintf("^%s\\|\\s*", commentPrefix)
+   commentPrefixPattern <- sprintf("^%s\\|\\s+", commentPrefix)
    opt <- sub(commentPrefixPattern, "", opt)
    
    # check for YAML entry, mimicing code in knitr

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -717,11 +717,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # figure out the appropriate chunk prefix based on the engine
    engine <- tolower(.rs.nullCoalesce(opts$engine, "r"))
    commentPrefix <- if (engine %in% c("cc", "cpp", "go", "js", "node", "rcpp", "stan"))
-      "/{2,}"
+      "//"
    else if (engine %in% c("haskell", "sql"))
-      "[-]{2,}"
+      "--"
    else
-      "#+"
+      "#"
    
    yamlPrefix <- .rs.reYamlOptChunkBegin(commentPrefix)
    for (line in code[-1]) {

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -641,15 +641,16 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    # remove comment prefix
    opt <- sub("^#\\|\\s*", "", opt)
    
-   # first, attempt to parse the code as YAML, then fall
-   # back to the regular knitr params parser
-   tryCatch(
-      .rs.parseYamlOptImpl(opt),
-      error = function(cnd) {
-         opts <- paste(opt, collapse = " ")
-         knitr:::parse_params(opts)
-      }
-   )
+   # check for YAML entry, mimicing code in knitr
+   if (grepl("^[^ :]+:($|\\s)", opt[[1]])) {
+      meta <- .rs.tryCatch(.rs.parseYamlOptImpl(opt))
+      if (!inherits(meta, "error"))
+         return(meta)
+   }
+   
+   # fallback to regular params parser
+   opts <- paste(opt, collapse = " ")
+   knitr:::parse_params(opts, label = FALSE)
 })
 
 .rs.addFunction("evaluateChunkOptions", function(code)

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -715,12 +715,13 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
    yamlChunkOpts <- c()
    
    # figure out the appropriate chunk prefix based on the engine
-   commentPrefix <- switch(
-      tolower(.rs.nullCoalesce(opts$engine, "r")),
-      sql = "-{2,}",
-      cpp = "//",
-      "#"
-   )
+   engine <- tolower(.rs.nullCoalesce(opts$engine, "r"))
+   commentPrefix <- if (engine %in% c("cc", "cpp", "go", "js", "node", "rcpp", "stan"))
+      "/{2,}"
+   else if (engine %in% c("haskell", "sql"))
+      "[-]{2,}"
+   else
+      "#+"
    
    yamlPrefix <- .rs.reYamlOptChunkBegin(commentPrefix)
    for (line in code[-1]) {

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -22,6 +22,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include <core/json/JsonRpc.hpp>
+#include <core/FileSerializer.hpp>
 #include <core/StringUtils.hpp>
 
 #include <r/RExec.hpp>
@@ -181,6 +182,21 @@ Error NotebookQueueUnit::parseOptions(json::Object* pOptions)
    else 
    {
       *pOptions = jsonOptions.getObject();
+   }
+   
+   // if this chunk defines a 'file' option, then we'll read
+   // the contents of that file and use it for code. note that
+   // any existing code in the chunk will be ignored.
+   std::string file;
+   Error readError = core::json::readObject(*pOptions, "file", file);
+   if (!readError)
+   {
+      FilePath resolvedPath = module_context::resolveAliasedPath(file);
+      
+      std::string code;
+      Error error = core::readStringFromFile(resolvedPath, &code);
+      if (!error)
+         replaceCode(code);
    }
 
    return Success();

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.cpp
@@ -31,6 +31,7 @@
 #define kQueueUnitCode       "code"
 #define kQueueUnitDocId      "doc_id"
 #define kQueueUnitChunkId    "chunk_id"
+#define kQueueUnitDocType    "doc_type"
 #define kQueueUnitCompleted  "completed"
 #define kQueueUnitPending    "pending"
 #define kQueueUnitExecuting  "executing"
@@ -104,7 +105,8 @@ bool ExecRange::empty()
    return start == 0 && stop == 0;
 }
 
-Error NotebookQueueUnit::fromJson(const json::Object& source, 
+Error NotebookQueueUnit::fromJson(
+      const json::Object& source, 
       boost::shared_ptr<NotebookQueueUnit>* pUnit)
 {
    // extract contained unit for manipulation
@@ -117,6 +119,7 @@ Error NotebookQueueUnit::fromJson(const json::Object& source,
    Error error = json::readObject(source, 
          kQueueUnitCode,      code,
          kQueueUnitDocId,     unit.docId_,
+         kQueueUnitDocType,   unit.docType_,
          kQueueUnitChunkId,   unit.chunkId_,
          kQueueUnitCompleted, completed,
          kQueueUnitPending,   pending,
@@ -149,11 +152,13 @@ Error NotebookQueueUnit::parseOptions(json::Object* pOptions)
       *pOptions = json::Object();
       return Success();
    }
-
+   
    // evaluate this chunk's options in R
    r::sexp::Protect protect;
    SEXP sexpOptions = R_NilValue;
    Error error = r::exec::RFunction(".rs.evaluateChunkOptions")
+         .addUtf8Param(docId_)
+         .addUtf8Param(docType_)
          .addUtf8Param(code_)
          .call(&sexpOptions, &protect);
 
@@ -229,6 +234,7 @@ json::Object NotebookQueueUnit::toJson() const
    json::Object unit;
    unit[kQueueUnitCode]      = code_;
    unit[kQueueUnitDocId]     = docId_;
+   unit[kQueueUnitDocType]   = docType_;
    unit[kQueueUnitChunkId]   = chunkId_;
    unit[kQueueUnitCompleted] = completed;
    unit[kQueueUnitPending]   = pending;

--- a/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookQueueUnit.hpp
@@ -73,6 +73,7 @@ public:
 
    // accessors
    std::string docId() const;
+   std::string docType() const;
    std::string chunkId() const;
    ExecMode execMode() const;
    ExecScope execScope() const;
@@ -81,6 +82,7 @@ public:
 
 private:
    std::string docId_;
+   std::string docType_;
    std::string chunkId_;
    ExecMode execMode_;
    ExecScope execScope_;

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookQueueUnit.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/NotebookQueueUnit.java
@@ -26,11 +26,16 @@ public class NotebookQueueUnit extends JavaScriptObject
    {
    }
    
-   public final static native NotebookQueueUnit create(
-         String docId, String chunkId, int execMode, int execScope, 
-         String code) /*-{
+   public final static native NotebookQueueUnit create(String docId,
+                                                       String docType,
+                                                       String chunkId,
+                                                       int execMode,
+                                                       int execScope,
+                                                       String code)
+   /*-{
       return {
          doc_id:     docId,
+         doc_type:   docType,
          chunk_id:   chunkId,
          exec_mode:  execMode,
          exec_scope: execScope,
@@ -43,6 +48,10 @@ public class NotebookQueueUnit extends JavaScriptObject
    
    public final native String getDocId() /*-{
       return this.doc_id;
+   }-*/;
+   
+   public final native String getDocType() /*-{
+      return this.doc_type;
    }-*/;
 
    public final native String getChunkId() /*-{

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/rmd/NotebookQueueState.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsVectorInteger;
 import org.rstudio.core.client.StringUtil;
@@ -56,8 +55,8 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.assist.RChu
 import org.rstudio.studio.client.workbench.views.source.events.ChunkChangeEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.JsArrayInteger;
 import com.google.gwt.user.client.Command;
 
 public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
@@ -448,8 +447,14 @@ public class NotebookQueueState implements NotebookRangeExecutedEvent.Handler,
       String code = docDisplay_.getCode(
          scope.getPreamble(),
          scope.getEnd());
-      NotebookQueueUnit unit = NotebookQueueUnit.create(sentinel_.getId(), 
-            id, chunk.getExecMode(), chunk.getExecScope(), code);
+      
+      NotebookQueueUnit unit = NotebookQueueUnit.create(
+            sentinel_.getId(), 
+            sentinel_.getType(),
+            id,
+            chunk.getExecMode(),
+            chunk.getExecScope(),
+            code);
       
       // add a pending range (if it has any content)
       if (!range.getStart().isEqualTo(range.getEnd()))

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/model/DocUpdateSentinel.java
@@ -14,17 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.views.source.model;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.Window.ClosingEvent;
-import com.google.gwt.user.client.Window.ClosingHandler;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.rstudio.core.client.Barrier.Token;
 import org.rstudio.core.client.CommandWithArg;
@@ -58,8 +49,17 @@ import org.rstudio.studio.client.workbench.views.source.events.SaveFailedEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SaveFileEvent;
 import org.rstudio.studio.client.workbench.views.source.events.SaveInitiatedEvent;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.Window.ClosingEvent;
+import com.google.gwt.user.client.Window.ClosingHandler;
 
 public class DocUpdateSentinel
       implements ValueChangeHandler<Void>,
@@ -952,6 +952,11 @@ public class DocUpdateSentinel
    public String getId()
    {
       return sourceDoc_.getId();
+   }
+   
+   public String getType()
+   {
+      return sourceDoc_.getType();
    }
 
    private void createAutosaver()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13326.
Addresses https://github.com/rstudio/rstudio/issues/13240.
Addresses https://github.com/rstudio/rstudio/issues/13525.
Addresses https://github.com/rstudio/rstudio/issues/13636.

### Approach

Previously, we used a rather ad-hoc heuristic to try and guess whether inline chunk options were YAML or R code. This PR takes a more permissive approach, whereby we first attempt to parse the code as YAML, and then fall back to R code if that fails.

For reference, the associated knitr code: https://github.com/yihui/knitr/blob/768db6f45525e15399724451df4153e900461e12/R/parser.R#L301-L312

### Automated Tests

N/A

### QA Notes

To be tested via community.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
