### PR TITLE
sprintf_linter() fixes

### DIFF
--- a/dependencies/windows/install-boost/install-boost.R
+++ b/dependencies/windows/install-boost/install-boost.R
@@ -122,7 +122,7 @@ b2_build_args <- function(bitness) {
       "--abbreviate-paths",
       sprintf("variant=%s", variant),
       sprintf("link=%s", link),
-      sprintf("runtime-link=shared", link),
+      "runtime-link=shared",
       "threading=multi",
       "define=BOOST_USE_WINDOWS_H",
       "install"

--- a/src/cpp/generate-options.R
+++ b/src/cpp/generate-options.R
@@ -592,12 +592,12 @@ generateOverlayOptions <- function (overlayOptionsJson) {
          
          optionConstant <- optionName[["constant"]]
          if (is.null(optionConstant)) {
-            stop(sprintf("Overlay option %s specified without a constant. All overlay option names must be constants."))
+            stop(sprintf("Overlay option %s specified without a constant. All overlay option names must be constants.", optionName))
          }
          
          optionConstantValue <- optionName[["value"]]
          if (is.null(optionConstantValue)) {
-            stop(sprintf("Overlay option %s constant specified without a value. All constants must have values for documentation."))
+            stop(sprintf("Overlay option %s constant specified without a value. All constants must have values for documentation.", optionName))
          }
          
          skipDefine <- optionName[["skipDefine"]]


### PR DESCRIPTION
Found during an exploratory {lintr} search: https://github.com/r-lib/lintr/issues/2183

Took a guess at what belongs in `%s`, PTAL to confirm.