### PR TITLE
Allow pkgdown links to run automatically.

### DIFF
--- a/src/cpp/session/modules/SessionPackages.R
+++ b/src/cpp/session/modules/SessionPackages.R
@@ -278,7 +278,7 @@ if (identical(as.character(Sys.info()["sysname"]), "Darwin") &&
 .rs.addFunction("isPackageHyperlinkSafe", function(packageName)
 {
    allowed <- setdiff(
-      c(.packages(), "testthat", "rlang", "devtools", "usethis", "pkgload"), 
+      c(.packages(), "testthat", "rlang", "devtools", "usethis", "pkgload", "pkgdown"), 
       c("base", "stats", "utils")
    )
    .rs.scalar(


### PR DESCRIPTION
### Intent

Addresses #13460 

Visualize development pkgdown site in package development more easily.

### Approach

Same as #13561 

### Automated Tests

None.

### QA Notes

No longer to have pkgdown loaded to run links automatically.

### Documentation

I will create a PR for this in the cli documentation in time for the next RStudio release.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

I have signed the Contributor agreement.

