### PR TITLE
ensure satellite prefs are sync'ed on init

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -14,12 +14,6 @@
  */
 package org.rstudio.studio.client.workbench.prefs.model;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import com.google.gwt.core.client.GWT;
-
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.StringUtil;
@@ -35,6 +29,7 @@ import org.rstudio.studio.client.application.events.AriaLiveStatusEvent.Timing;
 import org.rstudio.studio.client.application.events.DeferredInitCompletedEvent;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.application.events.ReloadEvent;
+import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.Timers;
 import org.rstudio.studio.client.common.satellite.Satellite;
 import org.rstudio.studio.client.common.satellite.SatelliteManager;
@@ -43,14 +38,22 @@ import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.server.VoidServerRequestCallback;
 import org.rstudio.studio.client.workbench.commands.Commands;
+import org.rstudio.studio.client.workbench.events.SessionInitEvent;
 import org.rstudio.studio.client.workbench.model.Session;
-import org.rstudio.studio.client.workbench.prefs.events.UserPrefsChangedEvent;
-import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.workbench.prefs.PrefsConstants;
+import org.rstudio.studio.client.workbench.prefs.events.UserPrefsChangedEvent;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JsArray;
+import com.google.gwt.core.client.Scheduler;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 @Singleton
 public class UserPrefs extends UserPrefsComputed
-   implements UserPrefsChangedEvent.Handler, DeferredInitCompletedEvent.Handler
+   implements UserPrefsChangedEvent.Handler,
+              SessionInitEvent.Handler,
+              DeferredInitCompletedEvent.Handler
 {
    public interface Binder
            extends CommandBinder<Commands, UserPrefs> {}
@@ -83,6 +86,7 @@ public class UserPrefs extends UserPrefsComputed
 
       binder.bind(commands_, this);
 
+      eventBus.addHandler(SessionInitEvent.TYPE, this);
       eventBus.addHandler(UserPrefsChangedEvent.TYPE, this);
       eventBus.addHandler(DeferredInitCompletedEvent.TYPE, this);
       Scheduler.get().scheduleDeferred(() ->
@@ -216,6 +220,12 @@ public class UserPrefs extends UserPrefsComputed
          constants_.onClearUserPrefsYesLabel(),
          constants_.cancel(),
          false);
+   }
+   
+   @Override
+   public void onSessionInit(SessionInitEvent event)
+   {
+      updatePrefs(session_.getSessionInfo().getPrefs());
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13657.

### Approach

Ensure that user preferences are loaded when the session is initialized.

As to why this change is needed... my only guess is that something changed with the order that GWT is trying to initialize some of the static / singleton classes we have, and now we're ending up in a state where the UserPrefs class is being initialized before the preferences are actually available, since the constructor seems to assume the preferences are already available:

https://github.com/rstudio/rstudio/blob/8f63e7b629740429f07d6683bdb9e13331f92f5a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java#L72-L75

There's an (unfortunately implicit) contract that anything which wants to make use of certain elements like user preferences need to wait for the session init event. Since the session init event is fired relatively early, we _usually_ get away without requiring sequencing based on that event, but it does look like things can go wrong sometimes.

For reference:

https://github.com/rstudio/rstudio/blob/8f63e7b629740429f07d6683bdb9e13331f92f5a/src/gwt/src/org/rstudio/studio/client/common/satellite/Satellite.java#L254-L256

### Automated Tests

Should be tracked by existing automation.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13657. 

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
