### PR TITLE
support dev docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
--
+- Improved support for development documentation when a package has been loaded via `devtools::load_all()`. (#13526)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/SessionRCompletions.R
+++ b/src/cpp/session/modules/SessionRCompletions.R
@@ -3041,13 +3041,27 @@ assign(x = ".rs.acCompletionTypes",
    
 })
 
+.rs.addFunction("readDevAliases", function(path)
+{
+   meta <- pkgload::dev_meta(basename(path))
+   if (!is.null(meta))
+      return(pkgload:::dev_topic_index(path))
+})
+
 .rs.addFunction("readAliases", function(path)
 {
    if (!length(path))
       return(character())
    
-   if (file.exists(f <- file.path(path, "help", "aliases.rds")))
-      names(readRDS(f))
+   # Check for packages loaded via devtools::load_all()
+   devIndex <- .rs.tryCatch(.rs.readDevAliases(path))
+   if (is.character(devIndex))
+      return(names(devIndex))
+   
+   # Otherwise, read aliases directly
+   aliasesPath <- file.path(path, "help/aliases.rds")
+   if (file.exists(aliasesPath))
+      names(readRDS(aliasesPath))
    else
       character()
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13526.

### Approach

Adds some detours for help documentation generated by `devtools` / `pkgload`, for packages loaded via `devtools::load_all()`.

<img width="711" alt="Screenshot 2023-09-19 at 2 50 44 PM" src="https://github.com/rstudio/rstudio/assets/1976582/62b41d83-a18e-42d7-9238-0b3ba5c8c9ba">

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13526.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
