### PR TITLE
use in-memory cache for chunk console outputs

### DIFF
--- a/src/cpp/session/SessionClientInit.cpp
+++ b/src/cpp/session/SessionClientInit.cpp
@@ -179,6 +179,9 @@ Error makePortTokenCookie(boost::shared_ptr<HttpConnection> ptrConnection,
 void handleClientInit(const boost::function<void()>& initFunction,
                       boost::shared_ptr<HttpConnection> ptrConnection)
 {
+   // notify that we're about to initialize
+   module_context::events().onBeforeClientInit();
+   
    // alias options
    Options& options = session::options();
    

--- a/src/cpp/session/SessionHttpMethods.cpp
+++ b/src/cpp/session/SessionHttpMethods.cpp
@@ -302,7 +302,7 @@ void polledEventHandler()
             return;
          }
 
-         if ( isMethod(ptrConnection, kClientInit) )
+         if (isMethod(ptrConnection, kClientInit))
          {
             if (ptrConnection->isAsyncRpc())
             {

--- a/src/cpp/session/include/session/SessionModuleContext.hpp
+++ b/src/cpp/session/include/session/SessionModuleContext.hpp
@@ -342,6 +342,7 @@ struct firstNonEmpty
 // session events
 struct Events : boost::noncopyable
 {
+   RSTUDIO_BOOST_SIGNAL<void()>                                       onBeforeClientInit;
    RSTUDIO_BOOST_SIGNAL<void(core::json::Object*)>                    onSessionInfo;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onClientInit;
    RSTUDIO_BOOST_SIGNAL<void()>                                       onInitComplete;

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -48,6 +48,41 @@ namespace notebook {
 
 namespace {
 
+struct PendingChunkConsoleOutput
+{
+   int type;
+   std::string output;
+};
+
+std::map<FilePath, std::vector<PendingChunkConsoleOutput>> s_pendingChunkOutput;
+
+void flushPendingConsoleOutputImpl(const FilePath& outputCsv)
+{
+   auto&& chunkOutputs = s_pendingChunkOutput[outputCsv];
+   if (chunkOutputs.empty())
+      return;
+   
+   std::stringstream ss;
+   for (auto&& chunkOutput : chunkOutputs)
+   {
+      std::vector<std::string> values;
+      values.push_back(safe_convert::numberToString(chunkOutput.type));
+      values.push_back(chunkOutput.output);
+      ss << text::encodeCsvLine(values) << "\n";
+   }
+   
+   Error error = core::writeStringToFile(outputCsv, ss.str());
+   if (error)
+      LOG_ERROR(error);
+}
+   
+void flushPendingConsoleOutput()
+{
+   for (auto&& entry : s_pendingChunkOutput)
+      flushPendingConsoleOutputImpl(entry.first);
+   s_pendingChunkOutput.clear();
+}
+
 FilePath getNextOutputFile(const std::string& docId, const std::string& chunkId,
    const std::string& nbCtxId, ChunkOutputType outputType, unsigned *pOrdinal)
 {
@@ -446,19 +481,15 @@ void ChunkExecContext::onConsoleText(int type, const std::string& output,
       return;
    }
 
-   // write out as csv
-   std::vector<std::string> vals;
-   vals.push_back(safe_convert::numberToString(type));
-   vals.push_back(output);
-   error = core::writeStringToFile(
-            outputCsv,
-            text::encodeCsvLine(vals) + "\n",
-            string_utils::LineEndingPassthrough,
-            truncate);
-   if (error)
-   {
-      LOG_ERROR(error);
-   }
+   // truncate if necessary
+   if (truncate)
+      s_pendingChunkOutput.erase(outputCsv);
+   
+   // add pending chunk output
+   PendingChunkConsoleOutput chunkOutput;
+   chunkOutput.type = type;
+   chunkOutput.output = output;
+   s_pendingChunkOutput[outputCsv].push_back(chunkOutput);
 
    // if we got some real output, fire event for it
    if (!output.empty())
@@ -469,6 +500,9 @@ void ChunkExecContext::disconnect()
 {
    Error error;
 
+   // flush any pending chunk output
+   flushPendingConsoleOutput();
+   
    // clean up capturing modules (includes plots, errors, and HTML widgets)
    for (boost::shared_ptr<NotebookCapture> pCapture : captures_)
    {

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.cpp
@@ -56,7 +56,7 @@ struct PendingChunkConsoleOutput
 
 std::map<FilePath, std::vector<PendingChunkConsoleOutput>> s_pendingChunkOutput;
 
-void flushPendingConsoleOutputImpl(const FilePath& outputCsv)
+void flushPendingChunkConsoleOutput(const FilePath& outputCsv)
 {
    auto&& chunkOutputs = s_pendingChunkOutput[outputCsv];
    if (chunkOutputs.empty())
@@ -76,13 +76,6 @@ void flushPendingConsoleOutputImpl(const FilePath& outputCsv)
       LOG_ERROR(error);
 }
    
-void flushPendingConsoleOutput()
-{
-   for (auto&& entry : s_pendingChunkOutput)
-      flushPendingConsoleOutputImpl(entry.first);
-   s_pendingChunkOutput.clear();
-}
-
 FilePath getNextOutputFile(const std::string& docId, const std::string& chunkId,
    const std::string& nbCtxId, ChunkOutputType outputType, unsigned *pOrdinal)
 {
@@ -97,6 +90,14 @@ FilePath getNextOutputFile(const std::string& docId, const std::string& chunkId,
 }
 
 } // anonymous namespace
+
+void flushPendingChunkConsoleOutputs(bool clear)
+{
+   for (auto&& entry : s_pendingChunkOutput)
+      flushPendingChunkConsoleOutput(entry.first);
+   if (clear)
+      s_pendingChunkOutput.clear();
+}
 
 core::Error copyLibDirForOutput(const core::FilePath& file,
    const std::string& docId, const std::string& nbCtxId)
@@ -501,7 +502,7 @@ void ChunkExecContext::disconnect()
    Error error;
 
    // flush any pending chunk output
-   flushPendingConsoleOutput();
+   flushPendingChunkConsoleOutputs(true);
    
    // clean up capturing modules (includes plots, errors, and HTML widgets)
    for (boost::shared_ptr<NotebookCapture> pCapture : captures_)

--- a/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookExec.hpp
@@ -41,6 +41,8 @@ namespace modules {
 namespace rmarkdown {
 namespace notebook {
 
+void flushPendingChunkConsoleOutputs(bool clear);
+
 core::Error copyLibDirForOutput(const core::FilePath& file,
    const std::string& docId, const std::string& nbCtxId);
 

--- a/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRmdNotebook.cpp
@@ -220,6 +220,11 @@ void onChunkExecCompleted(const std::string& docId,
    emitOutputFinished(docId, chunkId, callback, ExecScopeChunk);
 }
 
+void onBeforeClientInit()
+{
+   flushPendingChunkConsoleOutputs(false);
+}
+
 void onDeferredInit(bool)
 {
    FilePath root = notebookCacheRoot();
@@ -263,6 +268,7 @@ Error initialize()
 
    events().onChunkExecCompleted.connect(onChunkExecCompleted);
    
+   module_context::events().onBeforeClientInit.connect(onBeforeClientInit);
    module_context::events().onDeferredInit.connect(onDeferredInit);
 
    ExecBlock initBlock;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/8034.

### Approach

Rather than eagerly writing each piece of console output as it's received, we now instead buffer those console outputs, and only write the console output to disk after chunk execution has finished. We also make sure those outputs are flushed to disk when a new client has connected, so that those clients will see an up-to-date view of any currently-running executions.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/8034.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
