### PR TITLE
use display DPI when rendering plots in more scenarios

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 ### Fixed
 #### RStudio
 - Fixed an issue where underscores in file names were not displayed correctly in menu items. (#13662)
+- Fixed an issue where previewed plots were not rendered at the correct DPI. (#13387)
 
 #### Posit Workbench
 -

--- a/src/cpp/r/include/r/session/RGraphics.hpp
+++ b/src/cpp/r/include/r/session/RGraphics.hpp
@@ -136,7 +136,7 @@ public:
                                        const std::string& format,
                                        int widthPx,
                                        int heightPx,
-                                       bool useDevicePixelRatio = false) = 0;
+                                       bool useDevicePixelRatio) = 0;
 
    virtual core::Error savePlotAsImage(const core::FilePath& filePath,
                                        const std::string& format,

--- a/src/cpp/session/modules/SessionFiles.cpp
+++ b/src/cpp/session/modules/SessionFiles.cpp
@@ -582,7 +582,7 @@ void handleFilesRequest(const http::Request& request,
          return;
       }
    }
-
+   
    pResponse->setNoCacheHeaders();
    pResponse->setFile(filePath, request);
 }

--- a/src/cpp/session/modules/SessionPlots.cpp
+++ b/src/cpp/session/modules/SessionPlots.cpp
@@ -157,13 +157,12 @@ Error savePlotAs(const json::JsonRpcRequest& request,
    // save plot
    using namespace rstudio::r::session::graphics;
    Display& display = r::session::graphics::display();
-   error = display.savePlotAsImage(plotPath, format, width, height);
+   error = display.savePlotAsImage(plotPath, format, width, height, true);
    if (error)
    {
        LOG_ERROR(error);
        return error;
    }
-
 
    // set success result
    pResponse->setResult(boolObject(true));
@@ -267,7 +266,7 @@ Error copyPlotToCocoaPasteboard(const json::JsonRpcRequest& request,
    // save as png
    using namespace rstudio::r::session::graphics;
    Display& display = r::session::graphics::display();
-   error = display.savePlotAsImage(targetFile, "png", width, height);
+   error = display.savePlotAsImage(targetFile, "png", width, height, true);
    if (error)
       return error;
 
@@ -313,7 +312,7 @@ Error plotsCreateRPubsHtml(const json::JsonRpcRequest& request,
    using namespace rstudio::r::session::graphics;
    Display& display = r::session::graphics::display();
    FilePath smallPlotPath = tempPath.completeChildPath("plot-small.png");
-   error = display.savePlotAsImage(smallPlotPath, "png", width, height);
+   error = display.savePlotAsImage(smallPlotPath, "png", width, height, false);
    if (error)
    {
        LOG_ERROR(error);
@@ -620,7 +619,8 @@ void handlePngRequest(const http::Request& request,
    Error error = graphics::display().savePlotAsImage(imagePath,
                                                       graphics::kPngFormat,
                                                       width,
-                                                      height);
+                                                      height,
+                                                      true);
    if (error)
    {
       pResponse->setError(http::status::InternalServerError,
@@ -860,7 +860,7 @@ SEXP rs_savePlotAsImage(SEXP fileSEXP,
 
    r::session::graphics::Display& display = r::session::graphics::display();
    if (display.hasOutput())
-      display.savePlotAsImage(filePath, format, width, height);
+      display.savePlotAsImage(filePath, format, width, height, false);
 
    return R_NilValue;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13387.

### Approach

When rendering plots for preview / display, use the display device pixel ratio in more scenarios. Note that on a high DPI display, these plots will generally be larger.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13387.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
