### PR TITLE
don't dismiss autocomplete target when clicking help text

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Fixed an issue where previewed plots were not rendered at the correct DPI. (#13387)
 - Fixed an issue where warnings could be emitted when parsing YAML options within R Markdown code chunks. (#13326)
 - Fixed an issue where inline YAML chunk options were not properly parsed from SQL chunks. (#13240)
+- Fixed an issue where help text in the autocompletion popup was not selectable. (#13674)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -103,15 +103,14 @@ public class CompletionPopupPanel extends ThemedPopupPanel
             if (previewEvent.getTypeInt() == Event.ONMOUSEDOWN)
             {
                Element targetEl = previewEvent.getNativeEvent().getEventTarget().cast();
-               if (!help_.getElement().isOrHasChild(targetEl) &&
-                  (container_ == null) || 
-                  (container_.getElement() == null) || 
-                  !container_.getElement().isOrHasChild(targetEl))
-               {
+               boolean isActiveClickTarget =
+                     (help_ != null && help_.getElement().isOrHasChild(targetEl)) ||
+                     (container_ != null && container_.getElement().isOrHasChild(targetEl));
+               
+               if (!isActiveClickTarget)
                   hideAll();
-               }
             }
-            if (previewEvent.getTypeInt() == Event.ONKEYDOWN)
+            else if (previewEvent.getTypeInt() == Event.ONKEYDOWN)
             {
                NativeEvent event = previewEvent.getNativeEvent();
                int keyCode = event.getKeyCode();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/CompletionPopupPanel.java
@@ -36,6 +36,7 @@ import org.rstudio.studio.client.workbench.views.console.shell.assist.Completion
 import org.rstudio.studio.client.workbench.views.help.model.HelpInfo.ParsedInfo;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.event.dom.client.BlurEvent;
@@ -48,9 +49,6 @@ import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.SelectionEvent;
 import com.google.gwt.event.logical.shared.SelectionHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.Event;
-import com.google.gwt.user.client.Event.NativePreviewEvent;
-import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Label;
@@ -91,37 +89,6 @@ public class CompletionPopupPanel extends ThemedPopupPanel
             hideAll();
          }
       });
-
-      handler_ = new NativePreviewHandler()
-      {
-         @Override
-         public void onPreviewNativeEvent(NativePreviewEvent previewEvent)
-         {
-            // any click outside the container or help popup should dismiss
-            // (we need this here b/c we don't seem to be getting onBlur
-            // events when the ace editor is in embedded mode
-            if (previewEvent.getTypeInt() == Event.ONMOUSEDOWN)
-            {
-               Element targetEl = previewEvent.getNativeEvent().getEventTarget().cast();
-               boolean isActiveClickTarget =
-                     (help_ != null && help_.getElement().isOrHasChild(targetEl)) ||
-                     (container_ != null && container_.getElement().isOrHasChild(targetEl));
-               
-               if (!isActiveClickTarget)
-                  hideAll();
-            }
-            else if (previewEvent.getTypeInt() == Event.ONKEYDOWN)
-            {
-               NativeEvent event = previewEvent.getNativeEvent();
-               int keyCode = event.getKeyCode();
-               int modifier = KeyboardShortcut.getModifierValue(event);
-               if (modifier != 0 && keyCode == KeyCodes.KEY_ENTER)
-               {
-                  hideAll();
-               }
-            }
-         }
-      };
    }
 
    private void hideAll()
@@ -236,7 +203,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
 
    private void show(PositionCallback callback)
    {
-      registerNativeHandler(handler_);
+      registerNativeFocusHandler();
 
       if (callback != null)
          setPopupPositionAndShow(callback);
@@ -483,19 +450,44 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    {
       return list_.getItems();
    }
-
-   private void registerNativeHandler(NativePreviewHandler handler)
+   
+   private void registerNativeFocusHandler()
    {
-      if (handlerRegistration_ != null)
-         handlerRegistration_.removeHandler();
-      handlerRegistration_ = Event.addNativePreviewHandler(handler);
+      focusHandler_ = registerNativeFocusHandlerImpl();
+   }
+   
+   private final native JavaScriptObject registerNativeFocusHandlerImpl()
+   /*-{
+      var self = this;
+      var handler = $entry(function(event) {
+         self.@org.rstudio.studio.client.workbench.views.console.shell.assist.CompletionPopupPanel::onFocusIn(*)(event);
+      });
+      $doc.addEventListener("focusin", handler);
+      $doc.addEventListener("mousedown", handler);
+      return handler;
+   }-*/;
+
+   private void onFocusIn(NativeEvent event)
+   {
+      Element targetEl = event.getEventTarget().cast();
+      boolean isActiveClickTarget =
+            (container_ != null && container_.getElement().isOrHasChild(targetEl)) ||
+            (help_ != null && help_.getElement().isOrHasChild(targetEl));
+
+      if (!isActiveClickTarget)
+         hideAll();
    }
 
    private void unregisterNativeHandler()
    {
-      if (handlerRegistration_ != null)
-         handlerRegistration_.removeHandler();
+      unregisterNativeFocusHandlerImpl(focusHandler_);
    }
+   
+   private final native void unregisterNativeFocusHandlerImpl(JavaScriptObject focusHandler)
+   /*-{
+      $doc.removeEventListener("focusin", focusHandler);
+      $doc.removeEventListener("mousedown", focusHandler);
+   }-*/;
 
    private void resetIgnoredKeysHandle()
    {
@@ -526,8 +518,7 @@ public class CompletionPopupPanel extends ThemedPopupPanel
    private static QualifiedName lastSelectedValue_;
    private VerticalPanel container_;
    private final Label truncated_;
-   private final NativePreviewHandler handler_;
-   private HandlerRegistration handlerRegistration_;
+   private JavaScriptObject focusHandler_;
    private ShortcutManager.Handle handle_;
    private static final ConsoleConstants constants_ = GWT.create(ConsoleConstants.class);
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/HelpInfoPopupPanel.css
@@ -15,6 +15,8 @@
    z-index: 9001;
    margin-left: 6px;
    margin-top: -3px;
+   user-select: text;
+   cursor: auto;
 }
 
 .rstudio-themes-dark-menus .helpPopup {

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/RCompletionManager.java
@@ -127,14 +127,10 @@ public class RCompletionManager implements CompletionManager
       requester_ = new CompletionRequester(rnwContext, docDisplay, snippets_);
       handlers_ = new HandlerRegistrations();
       
-      handlers_.add(input_.addBlurHandler(event ->
+      handlers_.add(input_.addClickHandler(event ->
       {
-         if (!ignoreNextInputBlur_)
-            invalidatePendingRequests();
-         ignoreNextInputBlur_ = false;
+         invalidatePendingRequests();
       }));
-
-      handlers_.add(input_.addClickHandler(event -> invalidatePendingRequests()));
 
       handlers_.add(popup_.addSelectionCommitHandler(event ->
       {
@@ -151,8 +147,6 @@ public class RCompletionManager implements CompletionManager
          else
             showHelpDeferred(context_, lastSelectedItem_, 600);
       }));
-      
-      handlers_.add(popup_.addMouseDownHandler(event -> ignoreNextInputBlur_ = true));
       
       handlers_.add(popup_.addSelectionHandler(event -> docDisplay_.setPopupVisible(true)));
       
@@ -2247,9 +2241,6 @@ public class RCompletionManager implements CompletionManager
    private final CompletionRequester requester_;
    private final InitCompletionFilter initFilter_;
    
-   // Prevents completion popup from being dismissed when you merely
-   // click on it to scroll.
-   private boolean ignoreNextInputBlur_ = false;
    private String token_;
    
    private final DocDisplay docDisplay_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13674.

https://github.com/rstudio/rstudio/assets/1976582/4c25e56b-b644-4ded-b839-86911da26e6a

### Approach

We had two pieces of code that tried to dismiss the Help popup:

1. Whenever the editor instance lost focus;
2. Whenever the click target was outside of the presented popups.

(1) was too aggressive, so it has been removed; (2) evidently was not functioning as intended, and so was fixed. In addition, now that users can interact with the Help text, we now display the appropriate mouse cursor.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13674.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
