### PR TITLE
Add 'multivariable' as a domain specific word

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
+++ b/src/gwt/src/org/rstudio/studio/client/common/spelling/domain_specific_words.csv
@@ -244,6 +244,7 @@ morem
 msg
 mtcars
 multithreaded
+multivariable
 natbib
 natively
 navbar


### PR DESCRIPTION
This quick change adds the world "multivariable" to the list of domain-specific words RStudio accepts. Inspired by https://mastodon.online/@sims@fosstodon.org/111126223668522084. 