### PR TITLE
Fix issue with session protocol debug

### DIFF
--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -79,6 +79,24 @@ test_context("Logging")
       LOG_WARNING_MESSAGE("Warning message");
       LOG_ERROR_MESSAGE("Error message");
 
+      // Turn on debug logging for these LOG_DEBUG_MESSAGE tests
+      log::setFileLogLevel(log::LogLevel::DEBUG_LEVEL);
+
+      // Because the LOG_DEBUG_MESSAGE is a macro with a ? operator, these tests make sure it works
+      // in all important contexts
+      bool dummy = false;
+      if (!dummy) LOG_DEBUG_MESSAGE("Debug in solo if");
+
+      if (dummy)
+         dummy = true;
+      else
+         LOG_DEBUG_MESSAGE("Debug in else");
+
+      if (!dummy)
+         LOG_DEBUG_MESSAGE("Debug in if with else");
+      else
+         dummy = false;
+
       FilePath logFile = tmpConfPath.getParent().completeChildPath("logging-tests-" + id + ".log");
       REQUIRE(logFile.exists());
 
@@ -89,6 +107,9 @@ test_context("Logging")
       REQUIRE(logFileContents.find("Info message") != std::string::npos);
       REQUIRE(logFileContents.find("Warning message") != std::string::npos);
       REQUIRE(logFileContents.find("Error message") != std::string::npos);
+      REQUIRE(logFileContents.find("Debug in solo if") != std::string::npos);
+      REQUIRE(logFileContents.find("Debug in else") != std::string::npos);
+      REQUIRE(logFileContents.find("Debug in if with else") != std::string::npos);
    }
 
    test_that("Can override logging based on env vars and write valid json format")

--- a/src/cpp/core/include/core/Log.hpp
+++ b/src/cpp/core/include/core/Log.hpp
@@ -82,7 +82,9 @@ std::string errorAsLogEntry(const Error& error);
 #define LOG_INFO_MESSAGE_NAMED(logSection, message) rstudio::core::log::logInfoMessage(message, \
                                                                                        logSection)
 
-#define LOG_DEBUG_MESSAGE(message) rstudio::core::log::logDebugMessage(message)
+
+#define LOG_DEBUG_MESSAGE(message) (rstudio::core::log::isLogLevel(rstudio::core::log::LogLevel::DEBUG_LEVEL) ? rstudio::core::log::logDebugMessageReturn(message) : false)
+
 
 #define LOG_DEBUG_MESSAGE_WITH_PROPS(message, props) rstudio::core::log::logDebugMessage(message, \
                                                                                          std::string(), \

--- a/src/cpp/core/system/System.cpp
+++ b/src/cpp/core/system/System.cpp
@@ -375,6 +375,11 @@ void initFileLogDestination(log::LogLevel level, FilePath defaultLogDir)
                                           s_programIdentity,
                                           defaultOptions)));
    }
+   else
+   {
+      if (log::getFileLogLevel() < level)
+         log::setFileLogLevel(level);
+   }
 }
 
 void log(log::LogLevel logLevel,

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -912,16 +912,16 @@ bool hasLogDestination()
 {
    Logger& log = logger();
    WRITE_LOCK_BEGIN(log.Mutex)
-      {
-         LogMap* logMap = &log.DefaultLogDestinations;
+   {
+      LogMap* logMap = &log.DefaultLogDestinations;
 
-         const auto destEnd = logMap->end();
-         for (auto iter = logMap->begin(); iter != destEnd; ++iter)
-         {
-            if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
-               return true;
-         }
+      const auto destEnd = logMap->end();
+      for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+      {
+         if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
+            return true;
       }
+   }
    RW_LOCK_END(false);
    return false;
 }
@@ -931,20 +931,20 @@ void setLogLevel(LogLevel in_newLevel)
 {
    Logger& log = logger();
    WRITE_LOCK_BEGIN(log.Mutex)
-      {
-         LogMap* logMap = &log.DefaultLogDestinations;
+   {
+      LogMap* logMap = &log.DefaultLogDestinations;
 
-         const auto destEnd = logMap->end();
-         for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+      const auto destEnd = logMap->end();
+      for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+      {
+         if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
          {
-            if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
-            {
-               iter->second->setLogLevel(in_newLevel);
-               if (in_newLevel > log.MaxLogLevel)
-                  log.MaxLogLevel = in_newLevel;
-            }
+            iter->second->setLogLevel(in_newLevel);
+            if (in_newLevel > log.MaxLogLevel)
+               log.MaxLogLevel = in_newLevel;
          }
       }
+   }
    RW_LOCK_END(false);
 }
 
@@ -953,16 +953,16 @@ LogLevel getLogLevel()
 {
    Logger& log = logger();
    WRITE_LOCK_BEGIN(log.Mutex)
-      {
-         LogMap* logMap = &log.DefaultLogDestinations;
+   {
+      LogMap* logMap = &log.DefaultLogDestinations;
 
-         const auto destEnd = logMap->end();
-         for (auto iter = logMap->begin(); iter != destEnd; ++iter)
-         {
-            if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
-                return iter->second->getLogLevel();
-         }
+      const auto destEnd = logMap->end();
+      for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+      {
+         if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
+             return iter->second->getLogLevel();
       }
+   }
    RW_LOCK_END(false);
 
    return LogLevel::OFF;

--- a/src/cpp/shared_core/Logger.cpp
+++ b/src/cpp/shared_core/Logger.cpp
@@ -47,6 +47,52 @@ namespace log {
 typedef std::map<std::string, std::shared_ptr<ILogDestination>> LogMap;
 typedef std::map<std::string, LogMap> SectionLogMap;
 
+LogLevel logLevelFromStr(const std::string& in_str)
+{
+   if (in_str == "ERROR")
+      return LogLevel::ERR;
+   else if (in_str == "WARNING")
+      return LogLevel::WARN;
+   else if (in_str == "INFO")
+      return LogLevel::INFO;
+   else if (in_str == "OFF")
+      return LogLevel::OFF;
+   else
+      return LogLevel::DEBUG;
+}
+
+std::string logLevelName(log::LogLevel in_logLevel)
+{
+   switch (in_logLevel)
+   {
+      case LogLevel::ERR:
+      {
+         return "ERROR";
+      }
+      case LogLevel::WARN:
+      {
+         return "WARNING";
+      }
+      case LogLevel::DEBUG:
+      {
+         return "DEBUG";
+      }
+      case LogLevel::INFO:
+      {
+         return "INFO";
+      }
+      case LogLevel::OFF:
+      {
+         return "OFF";
+      }
+      default:
+      {
+         assert(false); // This shouldn't be possible
+         return "OFF";
+      }
+   }
+}
+
 namespace {
 
 constexpr const char* s_loggedFrom = "LOGGED FROM";
@@ -91,18 +137,6 @@ std::ostream& operator<<(std::ostream& io_ostream, LogLevel in_logLevel)
    }
 
    return io_ostream;
-}
-
-LogLevel logLevelFromStr(const std::string& in_str)
-{
-   if (in_str == "ERROR")
-      return LogLevel::ERR;
-   else if (in_str == "WARNING")
-      return LogLevel::WARN;
-   else if (in_str == "INFO")
-      return LogLevel::INFO;
-   else
-      return LogLevel::DEBUG;
 }
 
 json::Object errorLocationToJson(const ErrorLocation& in_location)
@@ -676,6 +710,14 @@ void logWarningMessage(const std::string& in_message,
       log.writeMessageToDestinations(LogLevel::WARN, in_message, in_section, in_properties, in_loggedFrom);
 }
 
+// Exists for the LOG_DEBUG_MESSAGE macro that needs a dummy value here so we can use a ? statement
+// to hide the evaluation of the arguments.
+bool logDebugMessageReturn(const std::string& in_message)
+{
+   logDebugMessage(in_message, std::string());
+   return true;
+}
+
 void logDebugMessage(const std::string& in_message, const std::string& in_section)
 {
    logDebugMessage(in_message, in_section, boost::none, ErrorLocation());
@@ -884,17 +926,81 @@ bool hasLogDestination()
    return false;
 }
 
+template <typename T>
+void setLogLevel(LogLevel in_newLevel)
+{
+   Logger& log = logger();
+   WRITE_LOCK_BEGIN(log.Mutex)
+      {
+         LogMap* logMap = &log.DefaultLogDestinations;
+
+         const auto destEnd = logMap->end();
+         for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+         {
+            if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
+            {
+               iter->second->setLogLevel(in_newLevel);
+               if (in_newLevel > log.MaxLogLevel)
+                  log.MaxLogLevel = in_newLevel;
+            }
+         }
+      }
+   RW_LOCK_END(false);
+}
+
+template <typename T>
+LogLevel getLogLevel()
+{
+   Logger& log = logger();
+   WRITE_LOCK_BEGIN(log.Mutex)
+      {
+         LogMap* logMap = &log.DefaultLogDestinations;
+
+         const auto destEnd = logMap->end();
+         for (auto iter = logMap->begin(); iter != destEnd; ++iter)
+         {
+            if (std::dynamic_pointer_cast<T, ILogDestination>(iter->second) != nullptr)
+                return iter->second->getLogLevel();
+         }
+      }
+   RW_LOCK_END(false);
+
+   return LogLevel::OFF;
+}
+
 } // anonymous namespace
+
 
 bool hasFileLogDestination()
 {
    return hasLogDestination<FileLogDestination>();
 }
 
+LogLevel getFileLogLevel()
+{
+   return getLogLevel<FileLogDestination>();
+}
+
+void setFileLogLevel(LogLevel in_newLevel)
+{
+   setLogLevel<FileLogDestination>(in_newLevel);
+}
+
 bool hasStderrLogDestination()
 {
    return hasLogDestination<StderrLogDestination>();
 }
+
+LogLevel getStderrLogLevel()
+{
+   return getLogLevel<StderrLogDestination>();
+}
+
+void setStderrLogLevel(LogLevel in_newLevel)
+{
+   setLogLevel<StderrLogDestination>(in_newLevel);
+}
+
 
 } // namespace log
 } // namespace core

--- a/src/cpp/shared_core/include/shared_core/ILogDestination.hpp
+++ b/src/cpp/shared_core/include/shared_core/ILogDestination.hpp
@@ -78,6 +78,11 @@ public:
    LogLevel getLogLevel() { return m_logLevel; }
 
    /**
+    * @brief Sets the maximum level of logs that will be written to this log destination.
+    */
+   void setLogLevel(LogLevel newLevel) { m_logLevel = newLevel; }
+
+   /**
     * @brief Gets the log message format type for this log destination.
     *
     * @return This log destination's message format type.

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -92,7 +92,8 @@ enum class LogLevel
    ERR = 1,       // Error messages will be logged.
    WARN = 2,      // Warning and error messages will be logged.
    INFO = 3,      // Info, warning, and error messages will be logged.
-   DEBUG = 4      // All messages will be logged.
+   DEBUG = 4,     // All messages will be logged.
+   DEBUG_LEVEL = 4// All messages will be logged - use to avoid name conflict with DEBUG macro
 };
 
 /**
@@ -171,6 +172,33 @@ bool hasStderrLogDestination();
  * @return true if log messages at this level will be displayed.
  */
 bool isLogLevel(log::LogLevel level);
+
+/**
+ * @brief Returns the current log level for the first file log destination (LogLevel::OFF if there is no file destination)
+ */
+log::LogLevel getFileLogLevel();
+
+
+/**
+ * @brief Returns the current log level for the first stderr log destination (LogLevel::OFF if there is no stderr destination)
+ */
+log::LogLevel getStderrLogLevel();
+
+/**
+ * @brief Use to set the log level an existing file log destination, e.g. to enable debug logging
+ * for a process without restarting. No changes if there is no file log destination.
+ *
+ * @param in_newLevel    The new log level.
+ */
+void setFileLogLevel(log::LogLevel in_newLevel);
+
+/**
+ * @brief Use to set the log level any existing stderr log destination, e.g. to enable debug logging
+ * for a process without restarting. No changes if there is no stderr log destination.
+ *
+ * @param in_newLevel    The new log level.
+ */
+void setStderrLogLevel(log::LogLevel in_newLevel);
 
 /**
  * @brief Replaces logging delimiters with ' ' in the specified string.
@@ -332,6 +360,9 @@ void logWarningMessage(const std::string& in_message,
  */
 void logDebugMessage(const std::string& in_message, const std::string& in_section = std::string());
 
+/* Like the above but used for macros that need a value return */
+bool logDebugMessageReturn(const std::string& in_message);
+
 /**
  * @brief Logs a debug message to all registered destinations.
  *
@@ -418,6 +449,20 @@ void logInfoMessage(const std::string& in_message,
  * @param in_message      The log entire log message (as would be logged by the logging engine).
  */
 void logPassthroughMessage(const std::string& in_source, const std::string& in_message);
+
+/**
+ * @brief Returns string name of given log level
+ *
+ * @return The level name
+ */
+std::string logLevelName(log::LogLevel in_logLevel);
+
+/**
+ * @brief Returns the LogLevel for a give name (ERROR, INFO, etc.)
+ *
+ * @return The level name
+ */
+LogLevel logLevelFromStr(const std::string& in_levelStr);
 
 /**
  * @brief Refreshes all log destinations. May be used after fork to prevent stale file handles.

--- a/src/cpp/shared_core/include/shared_core/Logger.hpp
+++ b/src/cpp/shared_core/include/shared_core/Logger.hpp
@@ -93,7 +93,7 @@ enum class LogLevel
    WARN = 2,      // Warning and error messages will be logged.
    INFO = 3,      // Info, warning, and error messages will be logged.
    DEBUG = 4,     // All messages will be logged.
-   DEBUG_LEVEL = 4// All messages will be logged - use to avoid name conflict with DEBUG macro
+   DEBUG_LEVEL = 4// Same as DEBUG. Preferred to avoid name conflict with core/Macros.hpp's DEBUG(..) macro used in rsession
 };
 
 /**


### PR DESCRIPTION
### Intent

Addresses: https://github.com/rstudio/rstudio-pro/issues/5095

Speedup for LOG_DEBUG_MESSAGE macro

Apis need by an admin page (in development) to turn on/off logging in workbench. 

### Approach

Don't evaluate message unless debugging is enabled.  The macro now uses a ? operator to hide the logDebugMessage call while still making a valid statement.  I tried a few ways to do this and this turned out to be the only one that's robust inside of if/else statements.

Apis to get/set log level for file/stderr destinations

Exposed name to LogLevel mapping for an upcoming rserver admin to change levels on the fly

### Automated Tests

No new automation required. 

### QA Notes

* With this fix, turning on "Session protocol debug" in a session should enable debug logging in ~/.local/share/rstudio/log/rsession-username.log.  
* Debug logging should be unaffected by the macro change

News TBD. 