### PR TITLE
Prefer system zlib.h over local

### DIFF
--- a/src/cpp/core/zlib/zlib.cpp
+++ b/src/cpp/core/zlib/zlib.cpp
@@ -19,7 +19,7 @@
 
 #include <core/Log.hpp>
 
-#include "zlib.h"
+#include <zlib.h>
 
 namespace rstudio {
 namespace core {


### PR DESCRIPTION
### Intent

> Describe briefly what problem this pull request resolves, or what new feature it introduces. Include screenshots of any new or altered UI. Link to any Github issues that are related. 

When `zconf.h` was removed in rstudio/rstudio#13641, it revealed an issue with the way we are including `zlib.h` in our `zlib.cpp` wrapper. We only want to use the local zlib.h if zlib is not installed on the system. This should only happen on Windows as we only build the embedded zlib _for_ Windows.

Otherwise, we were essentially including the local `zlib.h` file, even though the actual definitions would be defined by the system library (and in the case of centos7, was actually incompatible).

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

`z_size_t` is not expected to exist on the version of zlib on centos7 (and is incompatible with the embedded version of zlib we have locally).

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

N/A

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

N/A

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

N/A

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


