### PR TITLE
fix "screen reader mode" toggle and "tab key always moves focus" toggle

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,17 @@
+
+## RStudio 2023.09.1 "Desert Sunflower" Release Notes
+
+### New
+#### RStudio IDE
+- 
+
+#### Posit Workbench
+- 
+
+### Fixed
+#### RStudio IDE
+- Fixed issue preventing enabling screen reader mode (#13710)
+
+#### Posit Workbench
+- 
+

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefs.java
@@ -45,7 +45,6 @@ import org.rstudio.studio.client.workbench.prefs.events.UserPrefsChangedEvent;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
-import com.google.gwt.core.client.Scheduler;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -89,12 +88,6 @@ public class UserPrefs extends UserPrefsComputed
       eventBus.addHandler(SessionInitEvent.TYPE, this);
       eventBus.addHandler(UserPrefsChangedEvent.TYPE, this);
       eventBus.addHandler(DeferredInitCompletedEvent.TYPE, this);
-      Scheduler.get().scheduleDeferred(() ->
-      {
-         origScreenReaderLabel_ = commands_.toggleScreenReaderSupport().getMenuLabel(false);
-         announceScreenReaderState();
-         syncToggleTabKeyMovesFocusState();
-      });
    }
 
    public void writeUserPrefs()
@@ -226,6 +219,10 @@ public class UserPrefs extends UserPrefsComputed
    public void onSessionInit(SessionInitEvent event)
    {
       updatePrefs(session_.getSessionInfo().getPrefs());
+
+      origScreenReaderLabel_ = commands_.toggleScreenReaderSupport().getMenuLabel(false);
+      announceScreenReaderState();
+      syncToggleTabKeyMovesFocusState();
    }
 
    @Override


### PR DESCRIPTION
### Intent

Addresses #13710

### Approach

Due to other changes, the previous approach for checking the state of the screen reader flag at startup was no longer getting the current value (I believe it was getting the default value). This code is responsible for deciding if it should announce "screen reader not enabled" and for setting the menu text.

Code that checks the pref later was getting the correct value, hence the mismatches.

There was a second symptom of this problem, also related to accessibility. The "tab key moves focus" toggle (Help / Accessibility / Focus / Tab Key Always Moves Focus) was also not showing the correct state (via a checkmark).

Fixed by moving that startup code to the end of onSessionInit at which point preferences are happy.

### Automated Tests

None that I'm aware of; it would be nice to have a test to check that this screen reader flag is working, but not sure we have the capability to test something that requires a reload of the IDE.

### QA Notes

Test that the menu text both in Help / Accessibility and in the Command Palette now correctly show the current state of the screen reader toggle.

Also test with a screen reader running: when the screen reader flag is off, you should hear an announcement at startup (often after the Console is read) warning that screen reader mode isn't enabled. Once you enable it and restart you should no longer hear that announcement.

Finally, spot-check that the Tab Key Always Moves Focus command is showing the correct state in the menu Help / Accessibility / Focus : Tab Key Always Moves Focus. The text never changes but there should be a checkmark when it is enabled.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


