### PR TITLE
use default project folder for open project dialog

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -1035,7 +1035,7 @@ public class Projects implements OpenProjectFileEvent.Handler,
                   ProgressOperationWithInput<OpenProjectParams> onCompleted)
    {
       opener_.showOpenProjectDialog(fsContext_, projServer_,
-            "~",
+            pUserPrefs_.get().defaultProjectLocation().getValue(),
             defaultType, allowOpenInNewWindow, onCompleted);
    }
 


### PR DESCRIPTION
### Intent

The problem is that RStudio allows you to set a default project location, and it respects that location for Project|New, but it ignores it for Project|Open

I mentioned this previously in #12514 - although I think I choose the wrong code links and title there.

It was also previously requested in https://community.rstudio.com/t/change-default-location-for-open-project/41130 - Posit employee @kevinushey answered there that people should change their Home path...

### Approach

I've copied the prefs code from project new to project open.

This preference is technically currently only for the NewProject wizard... and I think it is only settable by creating a new project - https://github.com/rstudio/rstudio/blob/e76b763f05f9934e4e10b178506c31cf49e99500/src/gwt/src/org/rstudio/studio/client/projects/Projects.java#L423 

It might be better to also add code that sets this from the Open Project dialog too? Or to add it to the Global Options dialog?

Opening this PR as I think it's a small change - but it really bugs me as a user...

### Automated Tests

Nothing added

### QA Notes

I'm afraid I've been "lazy" and haven't setup a full environment for this change... pushing the work back on to the project owners. Sorry.

### Documentation

None added - not sure any is needed.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests
- [ ] Signed contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Not sure if this is done - I have signed Rstudio/posit individual CLA for other rstudio projects like https://github.com/rstudio/plumber/pull/905 in the past


