### PR TITLE
ensure paths are normalized when debugging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -22,6 +22,7 @@
 - Fixed an issue where warnings could be emitted when parsing YAML options within R Markdown code chunks. (#13326)
 - Fixed an issue where inline YAML chunk options were not properly parsed from SQL chunks. (#13240)
 - Fixed an issue where help text in the autocompletion popup was not selectable. (#13674)
+- Fixed an issue where a file could be opened twice when debugging functions sourced from other directories. (#13719)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage (rstudio/rstudio-pro#5179)

--- a/src/cpp/session/modules/SessionCodeTools.R
+++ b/src/cpp/session/modules/SessionCodeTools.R
@@ -2724,3 +2724,8 @@
    )
    
 })
+
+.rs.addFunction("isAbsolutePath", function(path)
+{
+   grepl("^(?:/|~|[a-zA-Z]:[/\\])", path)
+})

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -254,13 +254,18 @@
 
 .rs.addFunction("sourceFileFromRef", function(srcref)
 {
-   if (!is.null(srcref))
-   {
-      fileattr <- attr(srcref, "srcfile")
-      enc2utf8(fileattr$filename)
-   }
-   else
-      ""
+   if (is.null(srcref))
+      return("")
+   
+   # check for absolute path in srcref
+   srcfile <- attr(srcref, "srcfile")
+   if (.rs.isAbsolutePath(srcfile$filename))
+      return(srcfile$filename)
+   
+   # if the path was not absolute, we need to resolve it relative
+   # to the working directory associated with the srcref
+   fullPath <- file.path(srcfile$wd, srcfile$filename)
+   normalizePath(fullPath, winslash = "/", mustWork = FALSE)
 })
 
 # Given a function and some content inside that function, returns a vector

--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -257,14 +257,18 @@
    if (is.null(srcref))
       return("")
    
-   # check for absolute path in srcref
+   # resolve file path + working directory for this srcref
    srcfile <- attr(srcref, "srcfile")
-   if (.rs.isAbsolutePath(srcfile$filename))
-      return(srcfile$filename)
+   wd <- enc2utf8(srcfile$wd)
+   filename <- enc2utf8(srcfile$filename)
+   
+   # check for absolute path in srcref
+   if (.rs.isAbsolutePath(filename))
+      return(filename)
    
    # if the path was not absolute, we need to resolve it relative
    # to the working directory associated with the srcref
-   fullPath <- file.path(srcfile$wd, srcfile$filename)
+   fullPath <- paste(c(wd, filename), collapse = "/")
    normalizePath(fullPath, winslash = "/", mustWork = FALSE)
 })
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13719.

### Approach

R uses so-called source references to record the origin of a function within an R session. This data structure records both the file name (as the user-requested path to the file), and the working directory used when the file was sourced. Because of this, we need to be careful when resolving the file path from a source reference; in particular, we need to take that recorded working directory into account.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13719.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
