### PR TITLE
prepend user-defined LD_LIBRARY_PATH var instead of appending to the end

### DIFF
--- a/src/node/desktop/src/main/detect-r.ts
+++ b/src/node/desktop/src/main/detect-r.ts
@@ -214,6 +214,7 @@ writeLines(sep = "\x1F", c(
   delete envCopy['R_INCLUDE_DIR'];
   delete envCopy['R_RUNTIME'];
   delete envCopy['R_SHARE_DIR'];
+  delete envCopy[kLdLibraryPathVariable];
 
   const [result, error] = expect(() => {
     return spawnSync(rExecutable.getAbsolutePath(), ['--vanilla', '-s'], {
@@ -264,7 +265,11 @@ writeLines(sep = "\x1F", c(
   stdout = stdout.substring(index + 1);
 
   // unwrap query results
-  const [rVersion, rHome, rDocDir, rIncludeDir, rShareDir, rRuntime, rArch, rLdLibraryPath] = stdout.split('\x1F');
+  let [rVersion, rHome, rDocDir, rIncludeDir, rShareDir, rRuntime, rArch, rLdLibraryPath] = stdout.split('\x1F');
+  if (process.platform !== 'win32' && getenv(kLdLibraryPathVariable) != '') {
+    logger().logDebug(`Pre-pending user-defined ${kLdLibraryPathVariable} to path set by R: ${rLdLibraryPath}`);
+    rLdLibraryPath = getenv(kLdLibraryPathVariable) + ":" + rLdLibraryPath;
+  }
 
   // put it all together
   return ok({


### PR DESCRIPTION
### Intent

Addresses (part of) https://github.com/rstudio/rstudio/issues/12585

### Approach

On Desktop, with Electron, we use R to determine the value of `LD_LIBRARY_PATH` (and the Mac equivalent), which appends a user-defined environment variable to the end of the path generated by R. This is inconsistent with the behavior on Server/Workbench. There have been some other inconsistencies noted by QA, but they are not addressed here

### QA Notes

See  https://github.com/rstudio/rstudio/issues/12585. We would like to get the same value in the Terminal and in the Console, and in server products and desktop products. 
