### PR TITLE
prefer 'true' and 'false' for logical YAML values

### DIFF
--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -357,8 +357,16 @@
       })
    }
    
+   # define handler for logical values
+   handlers <- list(
+      logical = function(x) {
+         value <- ifelse(x %in% TRUE, "true", "false")
+         structure(value, class = "verbatim")
+      }
+   )
+   
    # substitute ticks and convert to yaml
-   yaml <- yaml::as.yaml(tick_sub(input))
+   yaml <- yaml::as.yaml(tick_sub(input), handlers = handlers)
 
    # the yaml package produces UTF-8 output strings, but doesn't mark them
    # as such, which leads to trouble (in particular: on Windows the string


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/5227.

### Approach

The R `yaml` package attempts to conform to the YAML 1.1 specification, and chooses to emit `yes` and `no` for logical values. YAML 1.2 requires these constants to instead be called `true` and `false`. Since these constants are also recognized by YAML 1.1, we just choose to always emit `true` and `false` for logical vectors.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio-pro/issues/5227.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
