### PR TITLE
Fix Workbench Install Guide url

### DIFF
--- a/docs/user/rstudio/_quarto.yml
+++ b/docs/user/rstudio/_quarto.yml
@@ -32,7 +32,7 @@ website:
       - text: "Guides"
         menu:
           - text: "Workbench Install Guide"
-            url: 'https://docs.posit.co/rsw/installation/'
+            url: 'https://docs.posit.co/ide/server-pro/getting_started/installation/'
           - text: "Workbench Admin Guide"
             url: 'https://docs.posit.co/ide/server-pro/'
           - text: "Posit Workbench User Guide"


### PR DESCRIPTION
### Intent

- Addresses https://github.com/rstudio/rstudio/issues/13697

### Approach

The url here is out-of-date and the published docs has an incorrectly constructed url due to a relative path typo. Essentially, the url is incorrect in a few places, but this PR will be merged to the appropriate branches to correct the url in all those places.

### Automated Tests

We should set up a link checker!

### QA Notes

See https://github.com/rstudio/rstudio/issues/13697

### Documentation

See https://github.com/rstudio/rstudio/issues/13697
