### PR TITLE
Permit standalone Quarto file publishing non-root of project

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,7 @@
 - Fixed an issue where inline YAML chunk options were not properly parsed from SQL chunks. (#13240)
 - Fixed an issue where help text in the autocompletion popup was not selectable. (#13674)
 - Fixed an issue where a file could be opened twice when debugging functions sourced from other directories. (#13719)
+- Fixed an issue preventing publishing standalone Quarto content from within larger Quarto projects. (#13637)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage (rstudio/rstudio-pro#5179)

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -536,10 +536,10 @@ Error getQmdPublishDetails(const json::JsonRpcRequest& request,
 
 
    // Look up configuration for this Quarto project, if this file is part of a Quarto book or
-   // website.
+   // website or manuscript.
    std::string websiteDir, websiteOutputDir, projectType;
    FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
-   
+
    if (!quartoConfig.isEmpty())
    {
       std::string outputDir;

--- a/src/cpp/session/modules/quarto/SessionQuarto.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuarto.cpp
@@ -538,36 +538,33 @@ Error getQmdPublishDetails(const json::JsonRpcRequest& request,
    // Look up configuration for this Quarto project, if this file is part of a Quarto book or
    // website.
    std::string websiteDir, websiteOutputDir, projectType;
-   auto projectMeta = inspect.find("project");
-   if (projectMeta != inspect.end())
+   FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
+   
+   if (!quartoConfig.isEmpty())
    {
-      FilePath quartoConfig = quartoProjectConfigFile(qmdPath);
-      if (!quartoConfig.isEmpty())
+      std::string outputDir;
+      readQuartoProjectConfig(quartoConfig, &projectType, &outputDir);
+      if (projectType == kQuartoProjectBook || projectType == kQuartoProjectWebsite || projectType == kQuartoProjectManuscript)
       {
-          std::string outputDir;
-          readQuartoProjectConfig(quartoConfig, &projectType, &outputDir);
-          if (projectType == kQuartoProjectBook || projectType == kQuartoProjectWebsite || projectType == kQuartoProjectManuscript)
-          {
-             FilePath configPath = quartoConfig.getParent();
-             websiteDir = configPath.getAbsolutePath();
-             // Infer output directory
-             if (outputDir.empty())
-             {
-                 if (projectType == kQuartoProjectBook)
-                 {
-                     outputDir = "_book";
-                 }
-                 else if (projectType == kQuartoProjectManuscript)
-                 {
-                     outputDir = "_manuscript";
-                 }
-                 else
-                 {
-                     outputDir = "_site";
-                 }
-             }
-             websiteOutputDir = configPath.completeChildPath(outputDir).getAbsolutePath();
-          }
+         FilePath configPath = quartoConfig.getParent();
+         websiteDir = configPath.getAbsolutePath();
+         // Infer output directory
+         if (outputDir.empty())
+         {
+            if (projectType == kQuartoProjectBook)
+            {
+               outputDir = "_book";
+            }
+            else if (projectType == kQuartoProjectManuscript)
+            {
+               outputDir = "_manuscript";
+            }
+            else
+            {
+               outputDir = "_site";
+            }
+         }
+         websiteOutputDir = configPath.completeChildPath(outputDir).getAbsolutePath();
       }
    }
 


### PR DESCRIPTION
### Intent

Addresses #13637

We basically had two checks for locating metadata for (parts of) a Quarto book, manuscript, or website. One was looking at the output of `quarto inspect`, and the other was looking at the `_quarto.yml` file, which we locate by [looking for any config file in a parent of the target file](https://github.com/rstudio/rstudio/blob/b52a4c2ef54937226aec5c0d4c66b9810d0ce435/src/cpp/session/modules/quarto/SessionQuarto.cpp#L273-L299) until we get to the user's home. But we only actually use the metadata we get from the `_quarto.yml` file. And we don't need to be at the root of the quarto project in order to publish it. So this check basically seems to only throw unnecessary errors? 

I can publish both the standalone `about.qmd` file by itself, or the root `index.qmd` file and entire project contents successfully without the check, just based on finding the `_quarto.yml` file. If there's no `_quarto.yml` file found, we will get the same error as before when attempting to deployApp.