### PR TITLE
handle execution of 'dot' engine chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Updated Electron to version 26.2.4. (#13577)
 - RStudio now supports highlighting of inline YAML chunk options in R Markdown / Quarto documents. (#11663)
 - Improved support for development documentation when a package has been loaded via `devtools::load_all()`. (#13526)
+- RStudio now supports the execution and display of GraphViz (`dot`) graphs in R Markdown / Quarto chunks. (#13187)
 - RStudio now supports the execution of chunks with the 'file' option set. (#13636)
 
 #### Posit Workbench

--- a/src/cpp/session/modules/SessionRmdNotebook.R
+++ b/src/cpp/session/modules/SessionRmdNotebook.R
@@ -791,6 +791,11 @@ assign(".rs.notebookVersion", envir = .rs.toolsEnv(), "1.0")
       
    }
    
+   # knitr sets a default fig.ext of 'png', so we'll set that too
+   # this is necessary for some engines, e.g. dot
+   # https://github.com/rstudio/rstudio/issues/13187
+   opts$dev <- .rs.nullCoalesce(opts$dev, "png")
+   
    .rs.scalarListFromList(opts, expressions = TRUE)
 })
 

--- a/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookAlternateEngines.cpp
@@ -644,7 +644,18 @@ Error runUserDefinedEngine(const std::string& docId,
    if (isString(outputSEXP))
    {
       std::string text = asUtf8String(outputSEXP);
-      emitText(text, kChunkConsoleOutput);
+      
+      // handle path outputs
+      if (engine == "dot")
+      {
+         Error error = emitImage(text);
+         if (error)
+            LOG_ERROR(error);
+      }
+      else
+      {
+         emitText(text, kChunkConsoleOutput);
+      }
    }
    else if (inherits(outputSEXP, "htmlwidget"))
    {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13187.

### Approach

- Make sure the `png` figure extension is set for chunks, since `knitr` seems to set that by default.
- Since the `dot` engine returns the path to an image file, treat the return value as an image.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13187.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
