### PR TITLE
stop building RDP for Qt

### DIFF
--- a/CMakeGlobals.txt
+++ b/CMakeGlobals.txt
@@ -123,7 +123,7 @@ if(NOT RSTUDIO_TARGET)
    # for macOS pro builds, default to desktop as otherwise
    # we will try (and fail) to build Linux-only launcher pieces
    if(APPLE AND RSTUDIO_PRO_BUILD)
-      set(RSTUDIO_TARGET "Desktop")
+      set(RSTUDIO_TARGET "Electron")
    else()
       set(RSTUDIO_TARGET "Development")
    endif()

--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -30,12 +30,11 @@ def shouldBuild(boolean isDaily, boolean isPro) {
   def inHourlySubset = true
   if (!isDaily) {
     if (isPro) {
-      // build an x86_64 rhel8 WB, x86_64 rhel9 QT RDP, and an arm64 jammy Electron RDP 
+      // build an x86_64 rhel8 WB, and an arm64 jammy RDP 
       inHourlySubset = ((env.OS == 'rhel8' && env.ARCH == 'x86_64' && env.FLAVOR == 'Server') ||
-        (env.OS == 'centos7' && env.ARCH == 'x86_64' && env.FLAVOR == 'Desktop') || 
         (env.OS == 'jammy' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron'))
     } else {
-      // build an arm64 rhel9 Desktop and an x86_64 focal Server
+      // build an arm64 rhel9 Electron and an x86_64 focal Server
       inHourlySubset = ((env.OS == 'rhel9' && env.ARCH == 'arm64' && env.FLAVOR == 'Electron') ||
         (env.OS == 'focal' && env.ARCH == 'x86_64' && env.FLAVOR == 'Server'))
     }
@@ -55,7 +54,7 @@ def renameFile(String dir, String match) {
 }
 
 def renameTarFile(String dir) {
-  if ((FLAVOR == "Desktop") || (FLAVOR == "Electron")) {
+  if (FLAVOR == "Electron") {
     return renameFile(dir, "*.tar.gz")
   }
 
@@ -169,7 +168,7 @@ pipeline {
           }
           axis {
               name 'FLAVOR'
-              values 'Desktop', 'Server', 'Electron'
+              values 'Server', 'Electron'
           }
         }
 
@@ -185,10 +184,6 @@ pipeline {
             }
           }
           exclude {
-            axis {
-              name 'FLAVOR'
-              values 'Desktop'
-            }
             axis {
               name 'ARCH'
               values 'arm64'
@@ -218,7 +213,6 @@ pipeline {
               anyOf {
                 environment name: 'FLAVOR', value: 'Electron'
                 environment name: 'FLAVOR', value: 'Server'
-                expression { return FLAVOR == 'Desktop' && IS_PRO == true } // Only build Qt on Pro
               }
             }
 
@@ -371,7 +365,7 @@ pipeline {
                         }
 
                         script {
-                          if ((FLAVOR == "Desktop") || (FLAVOR == "Electron")) {
+                          if (FLAVOR == "Electron") {
                             retry(5) {
                               script {
                                 utils.uploadPackageToS3 "${TAR_PACKAGE_DIR}/${TAR_PACKAGE_FILE}", "${AWS_PATH}/"
@@ -433,12 +427,9 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
                     }
 
-                    // for pro, update with Qt
-                    // for open source, update with Electron
                     when { 
                       anyOf {
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -90,14 +90,13 @@ pipeline {
         axes {
           axis {
             name 'FLAVOR'
-            values 'Electron', 'Desktop' // desktop denotes a Qt build
+            values 'Electron'
           }
         }
 
         when {
           anyOf {
             expression { return FLAVOR == 'Electron' }
-            expression { return FLAVOR == 'Desktop' && IS_PRO == true } // Only build Qt on Pro
           }
         }
 
@@ -243,12 +242,9 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
                     }
 
-                    // for pro, update with Qt
-                    // for open source, update with Electron
                     when { 
                       anyOf {
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -84,20 +84,19 @@ pipeline {
       }
     }
 
-    // Build on windows agent, use matrix for electron / desktop
+    // Build on windows agent, use matrix for electron
     stage ('Build Matrix') {
       matrix {
         axes {
           axis {
             name 'FLAVOR'
-              values 'Electron', 'Desktop' // desktop denotes a Qt build
+              values 'Electron'
           }
         }
 
         when {
           anyOf {
             environment name: 'FLAVOR', value: 'Electron'
-            expression { return FLAVOR == 'Desktop' && IS_PRO == true } // Only build Qt on Pro
           }
         }
 
@@ -204,7 +203,7 @@ pipeline {
                     when {
                       allOf {
                         expression { return params.DAILY }
-                        environment name: 'FLAVOR', value: 'Desktop'
+                        environment name: 'FLAVOR', value: 'Desktop' // NOTE: not currently doing this for Electron
                       }
                     }
 
@@ -285,12 +284,9 @@ pipeline {
           stage ("Update Daily Build Redirects") {
             agent { label "linux" } 
 
-            // for pro, update with Qt
-            // for open source, update with Electron
             when { 
               anyOf {
-                expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                 expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
               }
             }

--- a/package/osx/make-package
+++ b/package/osx/make-package
@@ -63,8 +63,11 @@ Options
         Jenkins, otherwise false (0).
 
   --electron, --rstudio-target=Electron
-        Whether to build the Electron version of RStudio; default is to build the Qt
-        version.
+        Whether to build the Electron version of RStudio (default)
+
+  --desktop, --rstudio-target=Desktop
+        Whether to build the deprecated Qt version of RStudio
+
 EOF
 exit 1
 }
@@ -232,7 +235,7 @@ clean=0
 copy_gwt=1
 install=0
 use_creds=0
-rstudio_target=Desktop
+rstudio_target=Electron
 
 # by default, use RStudio credentials for builds on Jenkins
 if is-jenkins; then
@@ -255,6 +258,7 @@ for arg in "$@"; do
    --build-dmg=*)      build_dmg=${arg#*=} ;;
    --use-creds=*)      use_creds=${arg#*=} ;;
    --electron)         rstudio_target=Electron ;;
+   --desktop)          rstudio_target=Desktop ;;
    --rstudio-target=*) rstudio_target=${arg#*=} ;;
    *)                  help ;;
    esac
@@ -263,7 +267,7 @@ done
 
 if [ "${rstudio_target}" != "Desktop" ] && [ "${rstudio_target}" != "Electron" ]
 then
-   echo "error: must specify --rstudio-target=Desktop|Electron (default Desktop)"
+   echo "error: must specify --rstudio-target=Desktop|Electron (default Electron)"
    exit 1
 fi
 

--- a/package/win32/make-package.bat
+++ b/package/win32/make-package.bat
@@ -16,7 +16,7 @@ set BUILD_GWT=1
 set QUICK=
 set NOZIP=
 set CLEANBUILD=
-set RSTUDIO_TARGET=Desktop
+set RSTUDIO_TARGET=Electron
 set PACKAGE_VERSION_SET=
 set DEBUG_BUILD=
 
@@ -247,8 +247,8 @@ echo make-package [clean] [debug] [desktop] [electron] [multiarch] [nogwt] [nozi
 echo.
 echo     clean:      perform full rebuild
 echo     debug:      perform a debug build
-echo     desktop:    build Qt desktop (default)
-echo     electron:   build Electron instead of Qt desktop
+echo     desktop:    build Qt desktop (obsolete)
+echo     electron:   build Electron (default)
 echo     multiarch:  produce both 32-bit and 64-bit rsession executables
 echo     nogwt:      skip GWT build (use previous GWT build)
 echo     nozip:      skip creation of ZIP file


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/5233 (once merged into pro, that is)

### Approach

No longer build RDP with Qt (aka "Desktop"), only Electron.

Also stop updating daily build redirects for Qt RDP and instead update them for Electron.

### Automated Tests

N/A

### QA Notes

Build stuff.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


