### PR TITLE
rmarkdown no longer requires markdown

### DIFF
--- a/src/cpp/session/resources/dependencies/r-packages.json
+++ b/src/cpp/session/resources/dependencies/r-packages.json
@@ -395,7 +395,6 @@
                 "jsonlite",
                 "knitr",
                 "magrittr",
-                "markdown",
                 "mime",
                 "rmarkdown",
                 "stringi",


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/9861.

### Approach

The `markdown` package is no longer required by the `rmarkdown` package, so we removed it.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/9861.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
