### PR TITLE
ensure project file is written when updating project options

### DIFF
--- a/src/cpp/session/projects/SessionProjects.cpp
+++ b/src/cpp/session/projects/SessionProjects.cpp
@@ -736,6 +736,13 @@ Error writeProjectConfig(const json::Object& configJson)
    if (error)
       return error;
    
+   // write the config
+   error = r_util::writeProjectFile(s_projectContext.file(),
+                                    ProjectContext::buildDefaults(),
+                                    config);
+   if (error)
+      return error;
+   
    // set the config
    setProjectConfig(config);
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13757.

### Approach

Unfortunately, this PR removed code it shouldn't have:

https://github.com/rstudio/rstudio/pull/13638/files#diff-5b7b325564515068ea9e8a5a18e1bee5cabf087aae172bf1f7fe9778a5883f65L721

This effectively means attempts to update project options won't have any effect. This PR adds it back in.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

