### PR TITLE
use Electron RDP for daily redirects

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -433,12 +433,9 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem') 
                     }
 
-                    // for pro, update with Qt
-                    // for open source, update with Electron
                     when { 
                       anyOf {
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }

--- a/jenkins/Jenkinsfile.macos
+++ b/jenkins/Jenkinsfile.macos
@@ -243,12 +243,9 @@ pipeline {
                       RSTUDIO_ORG_PEM = credentials('www-rstudio-org-pem')
                     }
 
-                    // for pro, update with Qt
-                    // for open source, update with Electron
                     when { 
                       anyOf {
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                        expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                        expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                         expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
                       }
                     }

--- a/jenkins/Jenkinsfile.windows
+++ b/jenkins/Jenkinsfile.windows
@@ -285,12 +285,9 @@ pipeline {
           stage ("Update Daily Build Redirects") {
             agent { label "linux" } 
 
-            // for pro, update with Qt
-            // for open source, update with Electron
             when { 
               anyOf {
-                expression { return params.PUBLISH && params.DAILY && IS_PRO == true && FLAVOR == "Desktop" }
-                expression { return params.PUBLISH && params.DAILY && IS_PRO == false && FLAVOR == "Electron" }
+                expression { return params.PUBLISH && params.DAILY && FLAVOR == "Electron" }
                 expression { return params.PUBLISH && params.DAILY && FLAVOR == "Server" }
               }
             }


### PR DESCRIPTION
### Intent

The daily redirects for Desktop Pro on https://dailies.rstudio.com/links/#rstudio-desktop-pro-daily point to Qt builds, but should point to Electron RDP builds.

### Approach

Use Electron for both open-source and RDP when updating daily links.

### Automated Tests

N/A

### QA Notes

Test daily RDP downloads from that page and confirm they are Electron-based, not Qt-based.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


