### PR TITLE
hide show session settings command in Electron RDP

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/Application.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/Application.java
@@ -1182,6 +1182,11 @@ public class Application implements ApplicationEventHandlers
             commands_.showLicenseDialog().remove();
             commands_.showSessionServerOptionsDialog().remove();
          }
+         else if (BrowseCap.isElectron())
+         {
+         // Electron RDP does not support remote sessons
+            commands_.showSessionServerOptionsDialog().remove();
+         }
       }
 
       // toolbar (must be after call to showWorkbenchView because


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/5093 (Desktop Pro, but entire fix is in open-source code).

### Approach

Remove this command in Electron RDP but leave it alone for Qt RDP.

### Automated Tests

N/A

### QA Notes

Check that the Session Server Settings command is gone in Electron RDP (under the Session menu and in the command palette). For bonus points, also check that it's still in Qt RDP.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


