### PR TITLE
only check for Rosetta in Mac Electron build

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/ui/impl/DesktopApplicationHeader.java
@@ -179,7 +179,7 @@ public class DesktopApplicationHeader implements ApplicationHeader,
          });
       });
 
-      if (BrowseCap.isMacintoshDesktop()) {
+      if (BrowseCap.isMacintoshDesktop() && BrowseCap.isElectron()) {
          Desktop.getFrame().detectRosetta();
       }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio-pro/issues/5256 (RDP only, but fix lives entirely in open-source).

### Approach

Only make the Rosetta check on Electron desktop; that code doesn't exist in the Qt build and will throw an exception and prevent app from fully launching.

### Automated Tests

N/A

### QA Notes

Test that the Qt-based RDP build for Mac still launches.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


