### PR TITLE
fix up macOS pasteboard when attempting to paste an image

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
+++ b/src/gwt/src/org/rstudio/studio/client/application/DesktopFrame.java
@@ -236,4 +236,5 @@ public interface DesktopFrame extends JavaScriptPassthrough
    void signOut();
 
    void detectRosetta();
+   void writeClipboardImage();
 }

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -626,6 +626,10 @@ export class GwtCallback extends EventEmitter {
       desktop.cleanClipboard(stripHtml);
     });
 
+    ipcMain.on('desktop_write_clipboard_image', (event) => {
+      desktop.writeClipboardImage();
+    });
+
     ipcMain.handle('desktop_set_pending_quit', (event, pendingQuit: number) => {
       this.pendingQuit = pendingQuit;
     });

--- a/src/node/desktop/src/main/main-window.ts
+++ b/src/node/desktop/src/main/main-window.ts
@@ -111,6 +111,7 @@ export class MainWindow extends GwtWindow {
       // It seems some sort of clash between setting this here and the subsequent set
       // that happens in MenuCallback.updateMenus().
     });
+
     this.menuCallback.on(MenuCallback.COMMAND_INVOKED, (commandId) => {
       this.invokeCommand(commandId);
     });

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -10,6 +10,15 @@
 export declare function cleanClipboard(stripHtml: boolean): void;
 
 /**
+ * (macOS only)
+ *
+ * Write the current clipboard image to a local file, and update the Pasteboard
+ * with a reference to that local content on disk. This works around an apparent
+ * Electron bug with copy + pasting images on the Pasteboard that lack an associated URL.
+ */
+export declare function writeClipboardImage(): void;
+
+/**
  * (Windows only)
  *
  * Detect if the CTRL key is currently being held down.

--- a/src/node/desktop/src/renderer/desktop-bridge.ts
+++ b/src/node/desktop/src/renderer/desktop-bridge.ts
@@ -370,6 +370,10 @@ export function getDesktopBridge() {
       ipcRenderer.send('desktop_clean_clipboard', stripHtml);
     },
 
+    writeClipboardImage: () => {
+      ipcRenderer.send('desktop_write_clipboard_image');
+    },
+
     setPendingQuit: (pendingQuit: number, callback: VoidCallback<unknown>) => {
       ipcRenderer
         .invoke('desktop_set_pending_quit', pendingQuit)


### PR DESCRIPTION
### Intent

Addresses the macOS part of https://github.com/rstudio/rstudio/issues/12690.

### Approach

- Detect the case where an image is on the Pasteboard, without a known path.
- When this happens, write that image to file, and then update the Pasteboard with the image path.
- TODO: Figure out the right time and location for this to all happen.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12690.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
