### PR TITLE
disable tests on opensuse15 for rel-cherry-blossom

### DIFF
--- a/jenkins/Jenkinsfile.linux
+++ b/jenkins/Jenkinsfile.linux
@@ -273,8 +273,13 @@ pipeline {
 
                   stage ('GWT and C++ Tests') {
                     when {
-                      // Disable bionic tests until builds are removed completely
-                      expression { return OS != "bionic" }
+                      allOf {
+                        // Disable opensuse15 while investigating R test failure
+                        expression { return OS != "opensuse15" }
+
+                        // Disable bionic tests until builds are removed completely
+                        expression { return OS != "bionic" }
+                      }
                     }
                     
                     steps {


### PR DESCRIPTION
### Intent

Backport https://github.com/rstudio/rstudio/pull/12941 to unblock cherry-blossom builds.

### Approach

Disable unit tests on opensuse15.

The underlying problem is that opensuse15 leap 15.3 installs R 3.5, which is too old for the `testthat` package to install.

We hope to be able to resume running the tests (for `main`, at least) once we do https://github.com/rstudio/rstudio/issues/13777 (assuming newer opensuse15 leap installs a newer R...).

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


