### PR TITLE
Update news to mention Copilot Preview in RStudio Desktop

### DIFF
--- a/version/news/NEWS-2023.09.1-desert-sunflower.md
+++ b/version/news/NEWS-2023.09.1-desert-sunflower.md
@@ -2,6 +2,7 @@
 
 ### New
 #### RStudio
+- GitHub Copilot is available as an opt-in integration with RStudio. This feature is currently in public Preview, and has only been tested on RStudio desktop. Copilot support is expected to be generally available in RStudio desktop, RStudio server and Posit Workbench in a future release.
 - Update to Electron 26.2.4 (#13457)
 
 #### Posit Workbench

--- a/version/news/NEWS-2023.09.1-desert-sunflower.md
+++ b/version/news/NEWS-2023.09.1-desert-sunflower.md
@@ -2,7 +2,7 @@
 
 ### New
 #### RStudio
-- GitHub Copilot is available as an opt-in integration with RStudio. This feature is currently in public Preview, and has only been tested on RStudio desktop. Copilot support is expected to be generally available in RStudio desktop, RStudio server and Posit Workbench in a future release.
+- GitHub Copilot is available as an opt-in integration with RStudio. This feature is currently in public Preview, and has only been tested on RStudio Desktop. Copilot support is expected to be generally available in RStudio Desktop, RStudio Server and Posit Workbench in a future release.
 - Update to Electron 26.2.4 (#13457)
 
 #### Posit Workbench


### PR DESCRIPTION
Update news to include details about the Copilot Preview that users can opt into for RStudio Desktop in 2023.09.1