### PR TITLE
keep Ace's enableKeyboardAccessibility flag in sync with IDE's screen reader mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - RStudio now supports autocompletion following `@` via `.AtNames`. (#13451)
 - RStudio now supports the execution and display of GraphViz (`dot`) graphs in R Markdown / Quarto chunks. (#13187)
 - RStudio now supports the execution of chunks with the 'file' option set. (#13636)
+- With screen reader support enabled, hitting ESC key allows Tabbing away from editor. [accessibility] (#13593)
 
 #### Posit Workbench
 -
@@ -29,6 +30,7 @@
 - Fixed an issue that prevented RStudio from opening PDF vignettes from the Help pane. (#13041)
 - Inline chunk execution now respects YAML style plot options styled with hyphens. (#11708)
 - Fixed a bug where project options updated in the Project Options pane were not properly persisted in RStudio 2023.09.0. (#13757)
+- Improved screen reader support when navigating source files in the editor. [accessibility] (#7337)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -2420,6 +2420,11 @@ public class AceEditor implements DocDisplay,
       widget_.getEditor().setRelativeLineNumbers(relative);
    }
 
+   public void setEnableKeyboardAccessibility(boolean keyboardAccessible)
+   {
+      widget_.getEditor().setEnableKeyboardAccessibility(keyboardAccessible);
+   }
+
    public boolean getUseSoftTabs()
    {
       return getSession().getUseSoftTabs();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/DocDisplay.java
@@ -189,6 +189,7 @@ public interface DocDisplay extends HasValueChangeHandlers<Void>,
    void setHighlightSelectedWord(boolean on);
    void setShowLineNumbers(boolean on);
    void setRelativeLineNumbers(boolean relative);
+   void setEnableKeyboardAccessibility(boolean keyboardAccessible);
    void setUseSoftTabs(boolean on);
    void setUseWrapMode(boolean on);
    boolean getUseWrapMode();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java
@@ -229,6 +229,11 @@ public class TextEditingTargetPrefsHelper
                {
                   docDisplay.setFoldStyle(FoldStyle.fromPref(arg));
                }));
+         releaseOnDismiss.add(prefs.enableScreenReader().bind(
+               (arg) ->
+               {
+                  docDisplay.setEnableKeyboardAccessibility(arg);
+               }));
       }
       
       // Embedded mode specific prefs

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -80,7 +80,11 @@ public class AceEditorNative extends JavaScriptObject
    public native final void setRelativeLineNumbers(boolean relative) /*-{
       this.setOption("relativeLineNumbers", relative);
    }-*/;
-   
+
+    public native final void setEnableKeyboardAccessibility(boolean keyboardAccessible) /*-{
+      this.setOption("enableKeyboardAccessibility", keyboardAccessible);
+   }-*/;
+
    public native final void setHighlightGutterLine(boolean highlight) /*-{
       this.setHighlightGutterLine(highlight);
    }-*/;


### PR DESCRIPTION
### Intent

Addresses #13593 and #7337

### Approach

Ace has a flag that needs to be turned on for screen reader users. This change keeps that flag in sync with the IDE's "screen reader" mode flag.

Turning this on improves screen reader support for the editor, including better announcements of content as you navigate around a document.

It also enables a feature where hitting the ESC key moves focus outside the editor surface, allowing a keyboard-only user to break out of the inherent keyboard trap and use Tab to move elsewhere.

It also enables the ability to interact with controls in the editor gutter region such as expanding/collapsing regions of code, but that isn't quite working (something specific to the IDE, it works on the Ace kitchen sink). I will open a separate issue on that (#13787).

Finally, Ace now has screen reader support for its autocomplete suggestion popups, but currently that only works for the ones supplied BY Ace (e.g. for JavaScript). The custom popups implemented by the IDE itself (e.g. for R code) still don't support the screenreader. That is tracked by #6167.

### Automated Tests

None currently.

### QA Notes

To test, turn on screen reader then start RStudio. Be sure RStudio's screen reader mode is on RStudio (Help / Accessibility / Screen Reader Support, then open something in the editor and put focus on it (Ctrl+1).

Now hit ESC and focus should change to the whole editor, and you'll hear an announcement "Editor Content: Press Enter to start editing, press Escape to exit editor". Hitting Tab at that point should move focus away from the editor.

The improvements in source code navigation are best observed on Windows using JAWS or NVDA. The experience on the Mac using Chrome or RStudio Desktop and VoiceOver still isn't ideal, but slightly less terrible than before. Still terrible with Safari and VoiceOver. 

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


