### PR TITLE
Fix bionic and opensuse builds

### DIFF
--- a/dependencies/common/install-packages
+++ b/dependencies/common/install-packages
@@ -24,7 +24,7 @@ PACKAGES=(
   digest@0.6.31  # work around arm64 build failures with digest 0.6.32
   purrr
   rmarkdown
-  testthat
+  testthat@3.1.9 # testthat@3.2.0 requires R >= 3.6.0, but opensuse/leap:15.3 only has R 3.5.0
   xml2
   yaml
 )

--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -13,7 +13,10 @@ RUN set -x \
     && apt-get update 
 
 # add ppa repository so we can install java 8 (not in any official repo for bionic)
+# reinstalling ca-certificates hopefully gets us past errors such as:
+# "The team named '~openjdk-r' has no PPA named 'ubuntu/ppa'"
 RUN apt-get update \
+  && apt-get install --reinstall ca-certificates \
   && apt-get install -y software-properties-common \
   && add-apt-repository ppa:openjdk-r/ppa
 


### PR DESCRIPTION
Trying out a couple potential fixes for Docker Build failures on `bionic` and `opensuse`.

We'll need to bring these changes into the `main` branch and any other branches that might rebuild the docker images.

