### PR TITLE
Remove ppa repo that's no longer needed

### DIFF
--- a/docker/jenkins/Dockerfile.bionic
+++ b/docker/jenkins/Dockerfile.bionic
@@ -12,14 +12,6 @@ RUN set -x \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update 
 
-# add ppa repository so we can install java 8 (not in any official repo for bionic)
-# reinstalling ca-certificates hopefully gets us past errors such as:
-# "The team named '~openjdk-r' has no PPA named 'ubuntu/ppa'"
-RUN apt-get update \
-  && apt-get install -y --reinstall ca-certificates \
-  && apt-get install -y software-properties-common \
-  && add-apt-repository ppa:openjdk-r/ppa
-
 RUN apt-get update && \
     export DEBIAN_FRONTEND=noninteractive && \
     apt-get install -y \


### PR DESCRIPTION
### Intent

We don't need the `ppa` repo because bionic repos have `openjdk-8` now:

```
root@f806b68ea8c8:/# apt policy openjdk-8-jdk
openjdk-8-jdk:
  Installed: (none)
  Candidate: 8u372-ga~us1-0ubuntu1~18.04
  Version table:
     8u372-ga~us1-0ubuntu1~18.04 500
        500 http://archive.ubuntu.com/ubuntu bionic-updates/universe amd64 Packages
        500 http://security.ubuntu.com/ubuntu bionic-security/universe amd64 Packages
     8u162-b12-1 500
        500 http://archive.ubuntu.com/ubuntu bionic/universe amd64 Packages
```

### Approach

> Describe the approach taken and the tradeoffs involved if non-obvious; add an overview of the solution if it's complicated.

### Automated Tests

> Indicate whether this change includes unit tests or integration tests, or link a work item or pull request to add those tests to another repo. If the change cannot or will not be covered by a test, indicate why.

### QA Notes

> Add additional information for QA on how to validate the change, paying special attention to the level of risk, adjacent areas that could be affected by the change, and any important contextual information not present in the linked issues. 

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


