### PR TITLE
use renamed autocompletion options for threshold and delay

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ace/AceEditorNative.java
@@ -114,8 +114,8 @@ public class AceEditorNative extends JavaScriptObject
         enableBasicAutocompletion: enabled,
         enableSnippets: enabled && snippets,
         enableLiveAutocompletion: enabled && live,
-        completionCharacterThreshold: characterThreshold,
-        completionDelay: delayMilliseconds
+        liveAutocompletionThreshold: characterThreshold,
+        liveAutocompletionDelay: delayMilliseconds
       });
    }-*/;
    


### PR DESCRIPTION
Addresses #13789. 

See https://github.com/rstudio/rstudio-ace/commit/013ba30d29d8363d37e32f5e41593af902411d69 and https://github.com/rstudio/rstudio-ace/commit/d67ce4a80241a7a5ba75ee07a76ac5aa459ba6bb 
for the change that introduced this rename. 

QA testing details added to issue