### PR TITLE
Fix constructing github url for file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 - Inline chunk execution now respects YAML style plot options styled with hyphens. (#11708)
 - Fixed a bug where project options updated in the Project Options pane were not properly persisted in RStudio 2023.09.0. (#13757)
 - Improved screen reader support when navigating source files in the editor. [accessibility] (#7337)
+- Fixed viewing or blaming file on GitHub for a newly created branch. (#9798)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)


### PR DESCRIPTION
### Intent
Address #9798

### Approach
Remove using `master` as upstream branch. If this fails to get the upstream branch name then fallback to using the last commit id for the file. This would provide a url to the exact state of the file.

One case would still fail if the file has a commit that doesn't exist on the remote. Maybe it is better to always use `HEAD` as the branch name instead of the commit id? However, the commit id has the advantage of showing the exact state as seen in RStudio.

The repo url retrieval was changed to use `ls-remote` so that it doesn't need to query by the upstream name. This command was introduced in `git@1.7.5`.

### Automated Tests
none

### QA Notes
The one case this would still fail is making a change to a file and committing it. Do not push the commit and try to use the view on github action. The commit doesn't exist on github so it cannot be viewed.

### Documentation
n/a

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


