### PR TITLE
add necessary callback for handling base64 images

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1597,7 +1597,7 @@ Error rmdSaveBase64Images(const json::JsonRpcRequest& request,
    // build list of target image paths
    std::vector<std::string> createdImages;
 
-   // copy each image to the target directory (renaming with a unique stem as required)
+   // start decoding and writing image data to file
    std::vector<std::string> imageData;
    imageDataJson.toVectorString(imageData);
    for (auto&& image : imageData)

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -148,6 +148,8 @@
          <arg value="build"/>
          <arg value="--minify"/>
          <arg value="${panmirror.minify}"/>
+         <arg value="--sourcemap"/>
+         <arg value="true"/>
          <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
       </exec>
       <copy todir="${panmirror.build.dir}">

--- a/src/gwt/build.xml
+++ b/src/gwt/build.xml
@@ -126,8 +126,18 @@
       file="c:\rstudio-tools\src\gwt\lib\quarto\apps\panmirror"/>
 
    <target name="panmirror" description="Compile panmirror library">
+
+      <!-- Make sure a default value for panmirror.minify is set -->
+      <condition property="panmirror.minify" value="true">
+         <not>
+            <isset property="panmirror.minify" />
+         </not>
+      </condition>
+
       <echo message="yarn location: ${yarn.bin}"/>
       <echo message="panmirror location: ${panmirror.dir}"/>
+      <echo message="panmirror minify: ${panmirror.minify}"/>
+
       <mkdir dir="${panmirror.build.dir}"/>
       <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
          <arg value="install"/>
@@ -136,6 +146,8 @@
       </exec>
       <exec executable="${yarn.bin}" dir="${panmirror.dir}" resolveexecutable="true" failonerror="true">
          <arg value="build"/>
+         <arg value="--minify"/>
+         <arg value="${panmirror.minify}"/>
          <env key="PANMIRROR_OUTDIR" value="dist-rstudio"/>
       </exec>
       <copy todir="${panmirror.build.dir}">
@@ -224,6 +236,7 @@
       <antcall target="codeserver">
          <param name="gwt.main.module" value="org.rstudio.studio.RStudioDesktopSuperDevMode"/>
          <param name="panmirror.target" value="ide-dev"/>
+         <param name="panmirror.minify" value="false"/>
       </antcall>
    </target>
 
@@ -232,6 +245,7 @@
       <antcall target="codeserver">
          <param name="gwt.main.module" value="org.rstudio.studio.RStudioSuperDevMode"/>
          <param name="panmirror.target" value="ide-dev"/>
+         <param name="panmirror.minify" value="false"/>
       </antcall>
    </target>
 
@@ -239,6 +253,7 @@
       <antcall target="codeserver">
          <param name="gwt.main.module" value="org.rstudio.studio.RStudioSuperDevMode"/>
          <param name="panmirror.target" value="ide-dev-watch"/>
+         <param name="panmirror.minify" value="false"/>
       </antcall>
    </target>
 

--- a/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/panmirror/ui/PanmirrorUIContext.java
@@ -39,6 +39,7 @@ public class PanmirrorUIContext
    public ClipboardUris clipboardUris;
    public ClipboardImage clipboardImage;
    public ResolveImageUris resolveImageUris;
+   public ResolveBase64Images resolveBase64Images;
    public BooleanGetter isWindowsDesktop;
 
    @JsFunction 
@@ -94,6 +95,13 @@ public class PanmirrorUIContext
    {
       Promise<JsArrayString> resolveImageUris(JsArrayString imageUris);
    }
+   
+   @JsFunction
+   public interface ResolveBase64Images
+   {
+      Promise<JsArrayString> resolveBase64Images(JsArrayString base64Files);
+   }
+   
 }
 
 

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -119,4 +119,8 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
                         String imagesDir,
                         ServerRequestCallback<JsArrayString> requestCallback);
    
+   void rmdSaveBase64Images(JsArrayString images,
+                            String imagesDir,
+                            ServerRequestCallback<JsArrayString> requestCallback);
+   
 }

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5704,6 +5704,19 @@ public class RemoteServer implements Server
       params.set(1,  new JSONString(imagesDir));
       sendRequest(RPC_SCOPE, RMD_IMPORT_IMAGES, params, requestCallback);
    }
+   
+   @Override
+   public void rmdSaveBase64Images(JsArrayString images,
+                                   String imagesDir,
+                                   ServerRequestCallback<JsArrayString> requestCallback)
+   {
+      JSONArray params = new JSONArrayBuilder()
+            .add(images)
+            .add(imagesDir)
+            .get();
+      
+      sendRequest(RPC_SCOPE, RMD_SAVE_BASE64_IMAGES, params, requestCallback);
+   }
 
    @Override
    public void unsatisfiedDependencies(
@@ -7081,6 +7094,7 @@ public class RemoteServer implements Server
    private static final String GET_RMD_TEMPLATES = "get_rmd_templates";
    private static final String GET_RMD_OUTPUT_INFO = "get_rmd_output_info";
    private static final String RMD_IMPORT_IMAGES = "rmd_import_images";
+   private static final String RMD_SAVE_BASE64_IMAGES = "rmd_save_base64_images";
 
    private static final String GET_PACKRAT_PREREQUISITES = "get_packrat_prerequisites";
    private static final String INSTALL_PACKRAT = "install_packrat";

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/ImagePreviewer.java
@@ -510,8 +510,12 @@ public class ImagePreviewer
 
    public static String imgSrcPathFromHref(String docDir, String href)
    {
+      // don't touch base64 data
+      if (href.startsWith("data:"))
+         return href;
+      
       // return paths that have a custom / external protocol as-is
-      Pattern reProtocol = Pattern.create("^\\w+://");
+      Pattern reProtocol = Pattern.create("^\\w+://", "");
       if (reProtocol.test(href))
          return href;
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.BrowseCap;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
@@ -50,6 +49,7 @@ import org.rstudio.studio.client.workbench.views.source.editors.text.TextEditing
 import org.rstudio.studio.client.workbench.views.source.events.XRefNavigationEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DocUpdateSentinel;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
 
@@ -278,7 +278,21 @@ public class VisualModePanmirrorContext
             }
          });
       };
-
+      
+      uiContext.resolveBase64Images = (images) -> {
+         return new Promise<JsArrayString>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
+            FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
+            String imagesDir = resourceDir.completePath(constants_.images());
+            server_.rmdSaveBase64Images(images, imagesDir, new SimpleRequestCallback<JsArrayString>()
+            {
+               @Override
+               public void onResponseReceived(JsArrayString response)
+               {
+                  resolve.onInvoke(response);
+               }
+            });
+         });
+      };
 
       uiContext.isWindowsDesktop = () -> {
          return BrowseCap.isWindowsDesktop();

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 
 import org.rstudio.core.client.BrowseCap;
+import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.JsArrayUtil;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.XRef;
@@ -38,6 +39,8 @@ import org.rstudio.studio.client.panmirror.ui.PanmirrorUIDisplay;
 import org.rstudio.studio.client.quarto.QuartoHelper;
 import org.rstudio.studio.client.quarto.model.QuartoConfig;
 import org.rstudio.studio.client.rmarkdown.model.RMarkdownServerOperations;
+import org.rstudio.studio.client.server.ServerError;
+import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.WorkbenchContext;
 import org.rstudio.studio.client.workbench.model.BlogdownConfig;
 import org.rstudio.studio.client.workbench.model.Session;
@@ -283,12 +286,19 @@ public class VisualModePanmirrorContext
          return new Promise<JsArrayString>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
             FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
             String imagesDir = resourceDir.completePath(constants_.images());
-            server_.rmdSaveBase64Images(images, imagesDir, new SimpleRequestCallback<JsArrayString>()
+            server_.rmdSaveBase64Images(images, imagesDir, new ServerRequestCallback<JsArrayString>()
             {
                @Override
                public void onResponseReceived(JsArrayString response)
                {
                   resolve.onInvoke(response);
+               }
+               
+               @Override
+               public void onError(ServerError error)
+               {
+                  Debug.logError(error);
+                  reject.onInvoke(error);
                }
             });
          });


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12690.

### Approach

Adds the necessary callback for handling base64 image data. We take the base64 clipboard data, then write that to disk and return the resolved path.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12690.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
