### PR TITLE
Support LuaLaTeX for compiling Sweave (Rnw) documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 - RStudio now supports the execution and display of GraphViz (`dot`) graphs in R Markdown / Quarto chunks. (#13187)
 - RStudio now supports the execution of chunks with the 'file' option set. (#13636)
 - With screen reader support enabled, hitting ESC key allows Tabbing away from editor. [accessibility] (#13593)
+- RStudio now supports `LuaLaTeX` to compile Sweave/Rnw documents. (#13812)
 
 #### Posit Workbench
 -

--- a/src/cpp/session/modules/tex/SessionPdfLatex.cpp
+++ b/src/cpp/session/modules/tex/SessionPdfLatex.cpp
@@ -48,6 +48,7 @@ public:
    {
       types_.push_back("pdfLaTeX");
       types_.push_back("XeLaTeX");
+      types_.push_back("LuaLaTeX");
    }
 
    const std::vector<std::string>& allTypes() const


### PR DESCRIPTION
### Intent

Currently we only support `pdflatex` and `xelatex` for compiling Rnw documents; `lualatex` should also be supported: https://tex.stackexchange.com/a/419885/9128

### Approach

Simply adding `LuaLaTeX` to the array.

### Automated Tests

I think the change is simple and obvious enough.

### QA Notes

Currently this `.Rnw` document won't compile in RStudio:

```
% !TeX program = LuaLaTeX
\documentclass{article}
\begin{document}
Test.
\end{document}
```

After this change, it will.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


