### PR TITLE
fix handling of shell startup scripts on macOS with default Bash

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -33,6 +33,7 @@
 - Fixed a bug where project options updated in the Project Options pane were not properly persisted in RStudio 2023.09.0. (#13757)
 - Improved screen reader support when navigating source files in the editor. [accessibility] (#7337)
 - Fixed viewing or blaming file on GitHub for a newly created branch. (#9798)
+- Fixed an issue on macOS where '-ne' was erroneously printed to the console with certain versions of Bash. (#13809)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -180,9 +180,9 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    
    case TerminalShell::ShellType::PosixBash:
    {
-      // NOTE: We don't use `${string//pattern/replacement}`-style variable substituion
-      // on Bash, as the way tilde is handling seems to have changed across different
-      // versions of Bash. `dirs` is more stable and portable across different Bash versions.
+      // NOTE: We don't use `${string//pattern/replacement}`-style variable substitution
+      // on Bash, as the way tilde is handled as a replacement character seems to depend
+      // on some unknown factors (sometimes it needs to be escaped like '\~'?)
       const char* kPromptCommand = R"((_RS_PWD=$(dirs +0); echo -ne "\033]0;${_RS_PWD}\007"; unset _RS_PWD))"; 
       core::system::setenv(&shellEnv, "PROMPT_COMMAND", kPromptCommand);
       break;

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -945,9 +945,20 @@ void useTerminalHooks(ConsoleProcessPtr cp)
       core::FilePath bashProfile = bashDotDir.completeChildPath(".bash_profile");
 
 #ifdef __APPLE__
-      // use --rcfile to set startup scripts
-      cp->appendArgument("--rcfile");
-      cp->appendArgument(bashProfile.getAbsolutePath());
+      if (cp->getShellType() == TerminalShell::ShellType::PosixBash)
+      {
+         // use --rcfile to set startup scripts when using default bash shell
+         auto&& options = cp->getProcessOptions();
+         options.args.push_back("--rcfile");
+         options.args.push_back(bashProfile.getAbsolutePath());
+      }
+      else
+      {
+         // use ENV with other custom shells (presumedly a modern Bash shell)
+         const char* env = ::getenv("ENV");
+         cp->setenv("_REALENV", env ? env : "<unset>");
+         cp->setenv("ENV", bashProfile.getAbsolutePath());
+      }
 #else
       // set ENV so that our terminal hooks are run
       const char* env = ::getenv("ENV");

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -129,8 +129,8 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
    // set options
    core::system::ProcessOptions options;
    options.workingDir = procInfo.getCwd().isEmpty()
-         ? module_context::shellWorkingDirectory() :
-           procInfo.getCwd();
+         ? module_context::shellWorkingDirectory()
+         : procInfo.getCwd();
    
    options.smartTerminal = true;
 #ifdef _WIN32

--- a/src/cpp/session/SessionConsoleProcess.cpp
+++ b/src/cpp/session/SessionConsoleProcess.cpp
@@ -107,8 +107,9 @@ core::system::ProcessOptions ConsoleProcess::createTerminalProcOptions(
 
 #ifndef _WIN32
    // set xterm title to show current working directory after each command
-   core::system::setenv(&shellEnv, "PROMPT_COMMAND",
-                        R"(echo -ne "\033]0;${PWD/#${HOME}/~}\007")");
+   // use 'dirs' to allow for substitution of home directory in a portable way
+   const char* kPromptCommand = R"((set +o posix; _RS_PWD=$(dirs +0); echo -ne "\033]0;${_RS_PWD}\007"); unset _RS_PWD)";
+   core::system::setenv(&shellEnv, "PROMPT_COMMAND", kPromptCommand);
 
    // don't add commands starting with a space to shell history
    if (procInfo.getTrackEnv())

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -153,6 +153,7 @@ public:
    InteractionMode interactionMode() const { return procInfo_->getInteractionMode(); }
    
    void setenv(const std::string& name, const std::string& value);
+   core::system::ProcessOptions& getProcessOptions() { return options_; }
 
    core::Error start();
    void enqueInput(const Input& input);
@@ -206,11 +207,6 @@ public:
 
    void setZombie();
    static bool useWebsockets();
-   
-   void appendArgument(const std::string& argument)
-   {
-      args_.push_back(argument);
-   }
 
 private:
    core::system::ProcessCallbacks createProcessCallbacks();
@@ -238,7 +234,9 @@ private:
    static void loadEnvironment(const std::string& handle, core::system::Options* pEnv);
 
 private:
-   // Command and options that will be used when start() is called
+   // Command and options that will be used when start() is called.
+   // NOTE: args_ is ignored for interactive terminals; options_.args
+   // is used instead.
    std::string command_;
    std::string program_;
    std::vector<std::string> args_;

--- a/src/cpp/session/include/session/SessionConsoleProcess.hpp
+++ b/src/cpp/session/include/session/SessionConsoleProcess.hpp
@@ -206,6 +206,11 @@ public:
 
    void setZombie();
    static bool useWebsockets();
+   
+   void appendArgument(const std::string& argument)
+   {
+      args_.push_back(argument);
+   }
 
 private:
    core::system::ProcessCallbacks createProcessCallbacks();

--- a/src/cpp/session/include/session/SessionTerminalShell.hpp
+++ b/src/cpp/session/include/session/SessionTerminalShell.hpp
@@ -70,6 +70,7 @@ struct TerminalShell
    core::FilePath path;
    std::vector<std::string> args;
 
+   ShellType getEffectiveShellType() const;
    core::json::Object toJson() const;
 
    // get a user-friendly name for the given shell type

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -393,13 +393,13 @@ bool AvailableTerminalShells::getCustomShell(TerminalShell* pShellInfo)
       args = core::algorithm::split(prefs::userPrefs().customShellOptions(), " ");
    }
    
-#ifndef __APPLE__
    if (prefs::userPrefs().terminalHooks())
    {
       // build the extra args
       std::vector<std::string> extraArgs;
       
       // if this appears to be a bash shell, make sure we launch it as a POSIX shell
+      // TODO: should we also launch these as --login shells? Or just rely on the user to request that?
       if (customShellPath.getFilename() == "bash" || customShellPath.getFilename() == "bash.exe")
       {
          bool hasPosixFlag = core::algorithm::contains(args, "--posix");
@@ -410,7 +410,6 @@ bool AvailableTerminalShells::getCustomShell(TerminalShell* pShellInfo)
       // insert the arguments at the front
       args.insert(args.begin(), extraArgs.begin(), extraArgs.end());
    }
-#endif
    
    pShellInfo->args = args;
    return true;

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -155,6 +155,25 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
 
 } // anonymous namespace
 
+TerminalShell::ShellType TerminalShell::getEffectiveShellType() const
+{
+   // keep non-custom shell types as-is
+   if (type != TerminalShell::ShellType::CustomShell)
+      return type;
+   
+   // otherwise, see if we can resolve the type
+#ifndef _WIN32
+   std::string filename = path.getFilename();
+   if (filename == "bash")
+      return TerminalShell::ShellType::PosixBash;
+   else if (filename == "zsh")
+      return TerminalShell::ShellType::PosixZsh;
+#endif
+   
+   // continue returning 'Custom' if we couldn't infer a known internal type
+   return type;
+}
+
 core::json::Object TerminalShell::toJson() const
 {
    core::json::Object resultJson;

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -363,31 +363,8 @@ bool AvailableTerminalShells::getCustomShell(TerminalShell* pShellInfo)
    core::FilePath customShellPath =
          module_context::resolveAliasedPath(prefs::userPrefs().customShellCommand());
    
-   // figure out name and type for the custom shell
-   std::string shellName = "Custom";
-   ShellType shellType = ShellType::CustomShell;
-   
-#ifndef _WIN32
-   // try to provide helpful names / types
-   std::string shellFilename = customShellPath.getFilename();
-   if (shellFilename == "bash" || shellFilename == "bash.exe")
-   {
-      shellName = "Bash";
-      shellType = ShellType::PosixBash;
-   }
-   else if (shellFilename == "zsh" || shellFilename == "zsh.exe")
-   {
-      shellName = "Zsh";
-      shellType = ShellType::PosixZsh;
-   }
-   else if (shellFilename == "fish" || shellFilename == "fish.exe")
-   {
-      shellName = "Fish";
-   }
-#endif
-   
-   pShellInfo->name = shellName;
-   pShellInfo->type = shellType;
+   pShellInfo->name = "Custom";
+   pShellInfo->type = ShellType::CustomShell;
    pShellInfo->path = customShellPath;
 
    // arguments are space separated, currently no way to represent a literal space


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13809.

### Approach

- On macOS, `/bin/bash --login --posix` does not respect the `ENV` environment variable, so we have no choice but to use a non-login shell. Made this a macOS-only change just to avoid fallout in Workbench installations.
- Instead of using the opaque "Custom" shell type for custom shells, try to guess if the Shell is instead Bash or Zsh or another shell we provide specific support for.

We also use a slightly more portable prompt command for Bash. In my shells, it seems like `~` needs to be escaped in replacements, e.g.

```
$ NAME=kevin; echo ${NAME/kevin/~}
/Users/kevin
$ NAME=kevin; echo ${NAME/kevin/\~}
~
```

but because I don't know what affects this (Bash version? some other shell option?) I figure it's best to skirt the issue altogether.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13809.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
