### PR TITLE
pin Windows python to 3.11

### DIFF
--- a/dependencies/windows/Install-RStudio-Prereqs.ps1
+++ b/dependencies/windows/Install-RStudio-Prereqs.ps1
@@ -63,6 +63,7 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/in
 refreshenv
 
 # install some deps via chocolatey
+# pin python to 3.11 while this issue is pending: https://github.com/nodejs/node-gyp/issues/2869
 choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output
 refreshenv
 choco install -y jdk8
@@ -74,7 +75,7 @@ choco install -y windows-sdk-10.1 --version 10.1.19041.0
 choco install -y visualstudio2019buildtools --version 16.11.10.0
 choco install -y visualstudio2019-workload-vctools --version 1.0.1
 choco install -y nsis
-choco install -y python
+choco install -y python311
 choco install -y jq
 
 # cpack (an alias from chocolatey) and cmake's cpack conflict.

--- a/docker/jenkins/Dockerfile.windows
+++ b/docker/jenkins/Dockerfile.windows
@@ -22,13 +22,14 @@ RUN $env:chocolateyUseWindowsCompression = 'true'; `
     iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
 
 # install some deps via chocolatey
+# pin python to 3.11 while this issue is pending: https://github.com/nodejs/node-gyp/issues/2869
 RUN choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=""System""' --fail-on-error-output; `
   choco install -y jdk8; `
   choco install -y -i ant; `
   choco install -y windows-sdk-10.1 --version 10.1.19041.0; `
   choco install -y 7zip; `
   choco install -y ninja --version "1.10.0"; `
-  choco install -y python; `
+  choco install -y python311; `
   choco install -y nsis --version "3.08"; `
   choco install -y jq
 


### PR DESCRIPTION
### Intent

Fix Windows build node-gyp failures with error `ModuleNotFoundError: No module named 'distutils'`.

#### Background

- [Python 3.12](https://docs.python.org/3/whatsnew/3.12.html) was just released on Oct 2 and deprecated `distutils` with [PEP 632](https://peps.python.org/pep-0632/)
- we don't pin our version of Python, so our containers are using 3.12 now
- node-gyp depends on distutils and now errors when running with Python 3.12
- node-gyp is [working on fixing the issue for Windows](https://github.com/nodejs/node-gyp/issues/2869)

### Approach

Pin Python to 3.11 until the node-gyp issue is fixed.

- Will merge up to the MH, DS and main branches once the Windows build for CB passes
- Will open an issue to unpin our Python version once the node-gyp issue is fixed.