### PR TITLE
always use relative paths for Quarto images

### DIFF
--- a/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
+++ b/src/cpp/session/modules/rmarkdown/SessionRMarkdown.cpp
@@ -1582,9 +1582,8 @@ Error rmdSaveBase64Images(const json::JsonRpcRequest& request,
 {
    // read params
    json::Array imageDataJson;
-   std::string documentPath;
    std::string imagesDir;
-   Error error = json::readParams(request.params, &imageDataJson, &documentPath, &imagesDir);
+   Error error = json::readParams(request.params, &imageDataJson, &imagesDir);
    if (error)
       return error;
 
@@ -1638,14 +1637,8 @@ Error rmdSaveBase64Images(const json::JsonRpcRequest& request,
          if (error)
             LOG_ERROR(error);
          
-         // return a relative path to the generated image
-         std::string resolvedPath = imagePath.getAbsolutePath();
-         if (!documentPath.empty())
-         {
-            FilePath resolvedDocumentPath = module_context::resolveAliasedPath(documentPath);
-            resolvedPath = imagePath.getRelativePath(resolvedDocumentPath.getParent());
-         }
-         
+         // return path to generated image
+         std::string resolvedPath = fmt::format("images/{}", fileName);
          createdImages.push_back(resolvedPath);
       }
       else

--- a/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
+++ b/src/gwt/src/org/rstudio/studio/client/rmarkdown/model/RMarkdownServerOperations.java
@@ -120,7 +120,6 @@ public interface RMarkdownServerOperations extends CryptoServerOperations
                         ServerRequestCallback<JsArrayString> requestCallback);
    
    void rmdSaveBase64Images(JsArrayString images,
-                            String documentPath,
                             String imagesDir,
                             ServerRequestCallback<JsArrayString> requestCallback);
    

--- a/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
+++ b/src/gwt/src/org/rstudio/studio/client/server/remote/RemoteServer.java
@@ -5707,13 +5707,11 @@ public class RemoteServer implements Server
    
    @Override
    public void rmdSaveBase64Images(JsArrayString images,
-                                   String documentPath,
                                    String imagesDir,
                                    ServerRequestCallback<JsArrayString> requestCallback)
    {
       JSONArray params = new JSONArrayBuilder()
             .add(images)
-            .add(StringUtil.notNull(documentPath))
             .add(imagesDir)
             .get();
       

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/visualmode/VisualModePanmirrorContext.java
@@ -156,7 +156,15 @@ public class VisualModePanmirrorContext
       };
 
       uiContext.mapResourceToURL = path -> {
+         
+         // resolve asset path
          path = resolvePath(path);
+         
+         // root paths should be resolved relative to the resource directory,
+         // so if the path starts with a leading slash, just remove it
+         if (path.startsWith("/"))
+            path = path.substring(1);
+         
          FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
          return ImagePreviewer.imgSrcPathFromHref(resourceDir.getPath(), path);
       };
@@ -284,10 +292,9 @@ public class VisualModePanmirrorContext
       
       uiContext.resolveBase64Images = (images) -> {
          return new Promise<JsArrayString>((ResolveCallbackFn<JsArrayString> resolve, RejectCallbackFn reject) -> {
-            String documentPath = uiContext.getDocumentPath.get();
             FileSystemItem resourceDir = FileSystemItem.createDir(uiContext.getDefaultResourceDir.get());
             String imagesDir = resourceDir.completePath("images");
-            server_.rmdSaveBase64Images(images, documentPath, imagesDir, new ServerRequestCallback<JsArrayString>()
+            server_.rmdSaveBase64Images(images, imagesDir, new ServerRequestCallback<JsArrayString>()
             {
                @Override
                public void onResponseReceived(JsArrayString response)


### PR DESCRIPTION
### Intent

Follows up on https://github.com/rstudio/rstudio/issues/12690.

### Approach

Always use relative paths to the Quarto resource directory.

Also fixes an issue that could prevent previewing a rendered Quarto document if the project directory itself is non-canonical, e.g. the canonical path != canonical path.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12690.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
