### PR TITLE
allow administrators to set a proxy URL for Copilot

### DIFF
--- a/src/cpp/r/RJson.cpp
+++ b/src/cpp/r/RJson.cpp
@@ -447,10 +447,12 @@ Error jsonValueFromVector(SEXP vectorSEXP, core::json::Value* pValue)
 {
    int vectorLength = Rf_length(vectorSEXP);
 
-   if (Rf_inherits(vectorSEXP, "rs.scalar"))
+   if (Rf_inherits(vectorSEXP, "rs.scalar") || Rf_inherits(vectorSEXP, "AsIs"))
    {
       if (vectorLength > 0)
+      {
          return jsonValueFromVectorElement(vectorSEXP, 0, pValue);
+      }
       else
       {
          // return null
@@ -460,7 +462,7 @@ Error jsonValueFromVector(SEXP vectorSEXP, core::json::Value* pValue)
    }
 
    core::json::Array vectorValues;
-   for (int i=0; i<vectorLength; i++)
+   for (int i = 0; i < vectorLength; i++)
    {
       core::json::Value elementValue;
       Error error = jsonValueFromVectorElement(vectorSEXP, i, &elementValue);

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -415,7 +415,10 @@ protected:
    pCopilot->add_options()
       ("copilot-enabled",
       value<bool>(&copilotEnabled_)->default_value(false),
-      "Indicates whether or not GitHub Copilot integration can be enabled.");
+      "Indicates whether or not GitHub Copilot integration can be enabled.")
+      ("copilot-proxy-url",
+      value<std::string>(&copilotProxyUrl_)->default_value(""),
+      "The proxy URL that the Copilot agent should use for outgoing network requests. Only plain HTTP proxy URLs are supported.");
 
    pMisc->add_options();
 
@@ -531,6 +534,7 @@ public:
    bool showUserIdentity() const { return showUserIdentity_; }
    std::string launcherToken() const { return launcherToken_; }
    bool copilotEnabled() const { return copilotEnabled_; }
+   std::string copilotProxyUrl() const { return copilotProxyUrl_; }
 
 
 protected:
@@ -641,6 +645,7 @@ protected:
    std::string scopeId_;
    std::string launcherToken_;
    bool copilotEnabled_;
+   std::string copilotProxyUrl_;
    virtual bool allowOverlay() const { return false; };
 };
 

--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -418,7 +418,10 @@ protected:
       "Indicates whether or not GitHub Copilot integration can be enabled.")
       ("copilot-proxy-url",
       value<std::string>(&copilotProxyUrl_)->default_value(""),
-      "The proxy URL that the Copilot agent should use for outgoing network requests. Only plain HTTP proxy URLs are supported.");
+      "The proxy URL that the Copilot agent should use for outgoing network requests. Only plain HTTP proxy URLs are supported.")
+      ("copilot-proxy-strict-ssl",
+      value<bool>(&copilotProxyStrictSsl_)->default_value(true),
+      "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?");
 
    pMisc->add_options();
 
@@ -535,6 +538,7 @@ public:
    std::string launcherToken() const { return launcherToken_; }
    bool copilotEnabled() const { return copilotEnabled_; }
    std::string copilotProxyUrl() const { return copilotProxyUrl_; }
+   bool copilotProxyStrictSsl() const { return copilotProxyStrictSsl_; }
 
 
 protected:
@@ -646,6 +650,7 @@ protected:
    std::string launcherToken_;
    bool copilotEnabled_;
    std::string copilotProxyUrl_;
+   bool copilotProxyStrictSsl_;
    virtual bool allowOverlay() const { return false; };
 };
 

--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -94,3 +94,35 @@
    # return as scalar list  
    .rs.scalarListFromList(proxy)
 })
+
+.rs.addFunction("copilot.parseNetworkProxyUrl", function(url)
+{
+   # build regex
+   reProxyUrl <- paste0(
+      "(?:(\\w+)://)?",         # protocol (optional)
+      "(?:([^:]+):([^@]+)@)?",  # username + password (optional)
+      "([^:]+):(\\d+)"          # host + port (required)
+   )
+   
+   # attempt to match
+   networkProxy <- as.list(regmatches(url, regexec(reProxyUrl, url))[[1L]])
+   if (length(networkProxy) != 6L)
+      warning("couldn't parse network proxy url '", url, "'")
+   
+   # set names of matched values
+   names(networkProxy) <- c("url", "protocol", "user", "pass", "host", "port")
+   
+   # drop empty strings
+   networkProxy[!nzchar(networkProxy)] <- NULL
+   
+   # validate the protocol, if it was set
+   protocol <- .rs.nullCoalesce(networkProxy$protocol, "http")
+   if (protocol != "http")
+      warning("only 'http' network proxies are supported")
+   
+   # drop the 'url' and 'protocol' fields as they are not used by copilot
+   networkProxy[c("url", "protocol")] <- NULL
+
+   # return rest of the data   
+   .rs.scalarListFromList(networkProxy)
+})

--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -122,6 +122,9 @@
    
    # drop the 'url' and 'protocol' fields as they are not used by copilot
    networkProxy[c("url", "protocol")] <- NULL
+   
+   # port needs to be a number
+   networkProxy[["port"]] <- as.numeric(networkProxy[["port"]])
 
    # return rest of the data   
    .rs.scalarListFromList(networkProxy)

--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -83,3 +83,14 @@
    
    TRUE
 })
+
+.rs.addFunction("copilot.networkProxy", function()
+{
+   # check for proxy from option
+   proxy <- getOption("rstudio.copilot.networkProxy")
+   if (is.null(proxy))
+      return(NULL)
+ 
+   # return as scalar list  
+   .rs.scalarListFromList(proxy)
+})

--- a/src/cpp/session/modules/SessionRMarkdown.R
+++ b/src/cpp/session/modules/SessionRMarkdown.R
@@ -106,7 +106,7 @@
 {
    # hint that every non-list element of the hierarchical list l
    # is a scalar value if it is of length 1
-   l <- lapply(l, function(ele) {
+   lapply(l, function(ele) {
       if (is.null(ele))
          NULL
       else if (is.list(ele)) 

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -832,6 +832,13 @@
             "memberName": "copilotProxyUrl_",
             "defaultValue": "",
             "description": "The proxy URL that the Copilot agent should use for outgoing network requests. Only plain HTTP proxy URLs are supported."
+         },
+         {
+            "name": "copilot-proxy-strict-ssl",
+            "type": "bool",
+            "memberName": "copilotProxyStrictSsl_",
+            "defaultValue": true,
+            "description": "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?"
          }
       ],
       "misc": [

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -825,6 +825,13 @@
             "memberName": "copilotEnabled_",
             "defaultValue": false,
             "description": "Indicates whether or not GitHub Copilot integration can be enabled."
+         },
+         {
+            "name": "copilot-proxy-url",
+            "type": "string",
+            "memberName": "copilotProxyUrl_",
+            "defaultValue": "",
+            "description": "The proxy URL that the Copilot agent should use for outgoing network requests. Only plain HTTP proxy URLs are supported."
          }
       ],
       "misc": [

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -173,7 +173,7 @@ public class CopilotPreferencesPane extends PreferencesPane
          add(headerLabel("Copilot Indexing"));
          add(spaced(cbCopilotIndexingEnabled_));
 
-         add(headerLabel("Copilot Completions"));
+         add(spacedBefore(headerLabel("Copilot Completions")));
          // add(checkboxPref(prefs_.copilotAllowAutomaticCompletions()));
          // add(selCopilotTabKeyBehavior_);
          add(numericPref("Show code suggestions after keyboard idle (ms):", 10, 5000, prefs_.copilotCompletionsDelay()));


### PR DESCRIPTION
Allow Workbench system administrators to set a Copilot proxy URL for requests.
