### PR TITLE
show custom error message when prefs save fails even if file is completely unreachable

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - RStudio now supports the execution of chunks with the 'file' option set. (#13636)
 - With screen reader support enabled, hitting ESC key allows Tabbing away from editor. [accessibility] (#13593)
 - RStudio now supports `LuaLaTeX` to compile Sweave/Rnw documents. (#13812)
+- Better error message when use preferences fail to save due to folder permissions. (#12974)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
 - RStudio now supports the execution of chunks with the 'file' option set. (#13636)
 - With screen reader support enabled, hitting ESC key allows Tabbing away from editor. [accessibility] (#13593)
 - RStudio now supports `LuaLaTeX` to compile Sweave/Rnw documents. (#13812)
-- Better error message when use preferences fail to save due to folder permissions. (#12974)
+- Better error message when user preferences fail to save due to folder permissions. (#12974)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)

--- a/src/cpp/session/prefs/UserPrefsLayer.cpp
+++ b/src/cpp/session/prefs/UserPrefsLayer.cpp
@@ -110,7 +110,7 @@ Error UserPrefsLayer::writePrefs(const core::json::Object &prefs)
    }
 
    // Modify the error to be more descriptive
-   if (isFileNotFoundError(error) && prefsFile_.exists())
+   if (isFileNotFoundError(error))
    {
       error = Error(
          error.getName(),


### PR DESCRIPTION
### Intent

Addresses #12974

Background: When saving user preferences fails due to permissions issues we show a custom error message, added in https://github.com/rstudio/rstudio/pull/7742.

However, if the folder containing the preferences file doesn't allow checking existence of the file (e.g. folder is owned by a different user and doesn't allow "anybody" access), we show a generic "File Not Found" error.

### Approach

Show the custom error message even if we weren't able to detect whether the file exists.

### Automated Tests

Not aware of any.

### QA Notes

To test this, you'll need to do something like:

```
chmod 0700 ~/.config/rstudio
chown ~/.config/rstudio SomeOtherUser
```

Then load RStudio and try to change and save a user preference via the options dialog. 

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


