### PR TITLE
handle non-ASCII characters in openExternal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 - Improved screen reader support when navigating source files in the editor. [accessibility] (#7337)
 - Fixed viewing or blaming file on GitHub for a newly created branch. (#9798)
 - Fixed an issue on macOS where '-ne' was erroneously printed to the console with certain versions of Bash. (#13809)
+- Fixed an issue where attempts to open files containing non-ASCII characters from the Files pane could fail on Windows. (#13855, #12467)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -125,7 +125,14 @@ export class GwtCallback extends EventEmitter {
     }
 
     ipcMain.on('desktop_browse_url', (event, url: string) => {
-      // TODO: review if we need additional validation of URL
+
+      // shell.openExternal() doesn't handle file URIs containining non-ASCII characters
+      if (process.platform === 'win32' && url.startsWith('file:///')) {
+        const filePath = url.substring('file:///'.length);
+        const shortPath = desktop.shortPathName(filePath);
+        url = `file:///${shortPath}`;
+      }
+
       void shell.openExternal(url);
     });
 

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -12,6 +12,13 @@ export declare function cleanClipboard(stripHtml: boolean): void;
 /**
  * (Windows only)
  *
+ * Convert a file path into a Windows short path name if possible.
+ */
+export declare function shortPathName(path: string): string;
+
+/**
+ * (Windows only)
+ *
  * Detect if the CTRL key is currently being held down.
  */
 export declare function isCtrlKeyDown(): boolean;

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -502,6 +502,7 @@ Napi::Value shortPathName(const Napi::CallbackInfo& info)
       }
 
       wShortPath.assign(buffer);
+      free(buffer);
    }
 
    // Set the resulting path.

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -496,6 +496,10 @@ Napi::Value shortPathName(const Napi::CallbackInfo& info)
       }
 
       wchar_t* buffer = (wchar_t*) malloc(requiredSizeInBytesIncludingTerminator);
+      if (buffer == nullptr) {
+         return path;
+      }
+
       int numBytesWritten = ::GetShortPathNameW(wPath.data(), buffer, requiredSizeInBytesIncludingTerminator);
       if (numBytesWritten == 0) {
          return path;

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -490,13 +490,13 @@ Napi::Value shortPathName(const Napi::CallbackInfo& info)
       // hold the path _and the terminating null character_.
       //
       // Hence, the return value here does include a null terminator.
-      int requiredSizeInBytes = ::GetShortPathNameW(wPath.data(), nullptr, 0);
-      if (requiredSizeInBytes == 0) {
+      int requiredSizeInBytesIncludingTerminator = ::GetShortPathNameW(wPath.data(), nullptr, 0);
+      if (requiredSizeInBytesIncludingTerminator == 0) {
          return path;
       }
 
-      wchar_t* buffer = (wchar_t*) malloc(requiredSizeInBytes * sizeof(wchar_t));
-      int numBytesWritten = ::GetShortPathNameW(wPath.data(), buffer, requiredSizeInBytes);
+      wchar_t* buffer = (wchar_t*) malloc(requiredSizeInBytesIncludingTerminator);
+      int numBytesWritten = ::GetShortPathNameW(wPath.data(), buffer, requiredSizeInBytesIncludingTerminator);
       if (numBytesWritten == 0) {
          return path;
       }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13835.
~Addresses https://github.com/rstudio/rstudio/issues/12467~ EDIT: Nope, that appears to affect macOS; this PR targets Windows only.

### Approach

`shell.openExternal()` does not appear to handle Unicode paths correctly. Work around this the old fashioned way -- convert the path to a so-called "short" path name, and use that path instead.

### Automated Tests

N/A

### QA Notes

Test via notes in the associated issues.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
