### PR TITLE
respect color preview pref in console

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,7 @@
 - Fixed viewing or blaming file on GitHub for a newly created branch. (#9798)
 - Fixed an issue on macOS where '-ne' was erroneously printed to the console with certain versions of Bash. (#13809)
 - Fixed an issue where attempts to open files containing non-ASCII characters from the Files pane could fail on Windows. (#13855, #12467)
+- Fixed an issue where color highlight for Console input could not be disabled. (#13118)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -477,18 +477,19 @@ public class AceEditor implements DocDisplay,
 
       addFocusHandler((FocusEvent event) -> s_lastFocusedEditor = this);
       
-      // Need to set this here so that it's respected by all Ace instances,
-      // including the instance used for console input
       // https://github.com/rstudio/rstudio/issues/13118
-      setColorPreview(userPrefs_.colorPreview().getValue());
-      userPrefs_.colorPreview().addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      if (behavior_ == EditorBehavior.AceBehaviorConsole)
       {
-         @Override
-         public void onValueChange(ValueChangeEvent<Boolean> event)
+         setColorPreview(userPrefs_.colorPreview().getValue());
+         userPrefs_.colorPreview().addValueChangeHandler(new ValueChangeHandler<Boolean>()
          {
-            setColorPreview(event.getValue());
-         }
-      });
+            @Override
+            public void onValueChange(ValueChangeEvent<Boolean> event)
+            {
+               setColorPreview(event.getValue());
+            }
+         });
+      }
 
       events_.addHandler(
             AceEditorCommandEvent.TYPE,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/AceEditor.java
@@ -476,6 +476,19 @@ public class AceEditor implements DocDisplay,
       });
 
       addFocusHandler((FocusEvent event) -> s_lastFocusedEditor = this);
+      
+      // Need to set this here so that it's respected by all Ace instances,
+      // including the instance used for console input
+      // https://github.com/rstudio/rstudio/issues/13118
+      setColorPreview(userPrefs_.colorPreview().getValue());
+      userPrefs_.colorPreview().addValueChangeHandler(new ValueChangeHandler<Boolean>()
+      {
+         @Override
+         public void onValueChange(ValueChangeEvent<Boolean> event)
+         {
+            setColorPreview(event.getValue());
+         }
+      });
 
       events_.addHandler(
             AceEditorCommandEvent.TYPE,

--- a/src/node/desktop/envvars.bat
+++ b/src/node/desktop/envvars.bat
@@ -4,6 +4,7 @@ REM Run this script with 'call envvars.bat' to update the PATH in your
 REM cmd.exe shell, so that the appropriate versions of node are found
 set NODE_PATHS=^
 	..\..\..\dependencies\common\node\16.20.2^
+	..\..\dependencies\common\node\16.20.2^
 	c:\rstudio-tools\dependencies\common\node\16.20.2
 
 call :SetNodePath


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13118.

### Approach

We normally try to respect preference changes for editor instances here:

https://github.com/rstudio/rstudio/blob/main/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetPrefsHelper.java#L128-L132

However, this only applies to Ace instances in the Source pane; not in the Console pane. This PR makes sure we apply the preference for Ace instances in the Console as well.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
