### PR TITLE
update publish list even on failure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 - Fixed an issue on macOS where '-ne' was erroneously printed to the console with certain versions of Bash. (#13809)
 - Fixed an issue where attempts to open files containing non-ASCII characters from the Files pane could fail on Windows. (#13855, #12467)
 - Fixed an issue where color highlight for Console input could not be disabled. (#13118)
+- RStudio now records the deployment target for newly-published documents, even when deployment fails due to an error in the document. (#12707)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeploy.ui.xml
@@ -17,7 +17,7 @@
       <g:HTMLPanel>
          <g:VerticalPanel ui:field="filePanel_">
            <g:HTMLPanel>
-             <g:InlineLabel text="Publish Files From:" ui:field="fileListLabel_"/>
+             <g:InlineLabel text="Publish files from:" ui:field="fileListLabel_"/>
              <g:InlineLabel styleName="{res.style.deployLabel}" 
                             ui:field="deployLabel_">
              </g:InlineLabel>
@@ -28,11 +28,11 @@
            </g:ScrollPanel>
            <g:HorizontalPanel>
                <rw:ThemedButton ui:field="checkUncheckAllButton_"
-                               text="Uncheck All">
+                               text="Uncheck all">
                                 <ui:attribute name="text" key="uncheckAllButtonText"/>
                </rw:ThemedButton>
               <rw:ThemedButton ui:field="addFileButton_" 
-                               text="Add More..."
+                               text="Add more..."
                                visible="false">
                   <ui:attribute name="text" key="addMoreButtonText"/>
               </rw:ThemedButton>
@@ -57,13 +57,13 @@
       <g:HTMLPanel>
          <g:HorizontalPanel width="100%" ui:field="publishFromPanel_">
             <rw:FormLabel styleName="{res.style.firstControlLabel}"
-                          text="Publish From Account:"
+                          text="Publish from account:"
                           elementId="{ElementIds.getRscAccountListLabel}"
                      ui:field="accountListLabel_">
                 <ui:attribute name="text" key="publishFromAccountText"/>
             </rw:FormLabel>
             <rw:HyperlinkLabel styleName="rstudio-HyperlinkLabel {res.style.accountAnchor}"
-                               ui:field="addAccountAnchor_" text="Add New Account">
+                               ui:field="addAccountAnchor_" text="Add new account">
                 <ui:attribute name="text" key="addNewAccountText"/>
             </rw:HyperlinkLabel>
          </g:HorizontalPanel>
@@ -71,7 +71,7 @@
                                    ui:field="accountList_" elementId="{ElementIds.getRscAccountList}">
          </rsc:RSConnectAccountList>
          <g:Label styleName="{res.style.firstControlLabel}"
-                  text="Publish To Account:"
+                  text="Publish to account:"
                   ui:field="publishToLabel_">
              <ui:attribute name="text" key="publishToAccountText"/>
          </g:Label>
@@ -95,7 +95,7 @@
                     <ui:attribute name="text" key="updateText"/>
                </g:Label>
                <rw:HyperlinkLabel stylePrimaryName="rstudio-HyperlinkLabel {res.style.accountAnchor}" 
-                                  ui:field="createNewAnchor_" text="Create New">
+                                  ui:field="createNewAnchor_" text="Create new">
                   <ui:attribute name="text" key="createNewText"/>
                </rw:HyperlinkLabel>
             </g:HorizontalPanel>

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectDeployRSConnectDeployUiBinderImplGenMessages_en.properties
@@ -1,24 +1,24 @@
 # Messages from org.rstudio.studio.client.rsconnect.ui.RSConnectDeployRSConnectDeployUiBinderImplGenMessages
 # Source locale en
 
-addMoreButtonText=Add More...
+addMoreButtonText=Add more...
 
-addNewAccountText=Add New Account
+addNewAccountText=Add new account
 
-createNewText=Create New
+createNewText=Create new
 
 lookingUpDetailsText=Looking up details for
 
 previewText=Preview...
 
-publishFromAccountText=Publish From Account\:
+publishFromAccountText=Publish from account\:
 
 publishText=Publish\:
 
-publishToAccountText=Publish To Account\:
+publishToAccountText=Publish to account\:
 
 titleText=Title\:
 
-uncheckAllButtonText=Uncheck All
+uncheckAllButtonText=Uncheck all
 
 updateText=Update\:

--- a/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
+++ b/src/gwt/src/org/rstudio/studio/client/rsconnect/ui/RSConnectPublishButton.java
@@ -16,7 +16,6 @@ package org.rstudio.studio.client.rsconnect.ui;
 
 import java.util.ArrayList;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
@@ -49,13 +48,13 @@ import org.rstudio.studio.client.rsconnect.events.RSConnectActionEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeployInitiatedEvent;
 import org.rstudio.studio.client.rsconnect.events.RSConnectDeploymentCompletedEvent;
 import org.rstudio.studio.client.rsconnect.model.PlotPublishMRUList;
+import org.rstudio.studio.client.rsconnect.model.PlotPublishMRUList.Entry;
 import org.rstudio.studio.client.rsconnect.model.PublishHtmlSource;
 import org.rstudio.studio.client.rsconnect.model.RSConnectDeploymentRecord;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishSettings;
 import org.rstudio.studio.client.rsconnect.model.RSConnectPublishSource;
 import org.rstudio.studio.client.rsconnect.model.RSConnectServerOperations;
 import org.rstudio.studio.client.rsconnect.model.RenderedDocPreview;
-import org.rstudio.studio.client.rsconnect.model.PlotPublishMRUList.Entry;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.server.Void;
@@ -66,6 +65,7 @@ import org.rstudio.studio.client.workbench.model.SessionInfo;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.prefs.model.UserState;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JsArray;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -387,14 +387,6 @@ public class RSConnectPublishButton extends Composite
    public void onRSConnectDeploymentCompleted(
          RSConnectDeploymentCompletedEvent event)
    {
-      if (!event.succeeded())
-         return;
-      
-      // when a deployment is successful, refresh ourselves. Consider: it's 
-      // a little wasteful to do this whether or not the deployment was for 
-      // the content on which this button is hosted, but there are unlikely to
-      // be more than a couple publish buttons at any one time, and this is
-      // cheap (just hits the local disk)
       populateDeployments(true);
    }
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12707.

### Approach

Always rebuild the publish button after attempting a deployment, even on failure. This is necessary because the user might've successfully (and intentionally) picked a particular deployment target, but saw that their deployment failed because of an error in the published code / document.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12707.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
