### PR TITLE
improve chunking / buffering of console actions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,7 @@
 - Fixed an issue on macOS where '-ne' was erroneously printed to the console with certain versions of Bash. (#13809)
 - Fixed an issue where attempts to open files containing non-ASCII characters from the Files pane could fail on Windows. (#13855, #12467)
 - Fixed an issue where color highlight for Console input could not be disabled. (#13118)
+- Fixed an issue that could cause the RStudio IDE to crash if a large amount of Console output was serialized with a suspended session. (#13857)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/cpp/r/include/r/session/RConsoleActions.hpp
+++ b/src/cpp/r/include/r/session/RConsoleActions.hpp
@@ -78,7 +78,7 @@ private:
    // console output capture threads) can interact with console actions
    mutable boost::mutex mutex_;
    boost::circular_buffer<ConsoleAction> actions_;
-   ConsoleAction pendingAction_;
+   ConsoleAction action_;
    std::vector<std::string> pendingInput_;
 };
 

--- a/src/cpp/r/include/r/session/RConsoleActions.hpp
+++ b/src/cpp/r/include/r/session/RConsoleActions.hpp
@@ -42,6 +42,12 @@ ConsoleActions& consoleActions();
 #define kConsoleActionOutput        2
 #define kConsoleActionOutputError   3
 
+struct ConsoleAction
+{
+   int type;
+   std::string data;
+};
+
 class ConsoleActions : boost::noncopyable
 {
 private:
@@ -71,8 +77,8 @@ private:
    // protect data using a mutex because background threads (e.g.
    // console output capture threads) can interact with console actions
    mutable boost::mutex mutex_;
-   boost::circular_buffer<core::json::Value> actionsType_;
-   boost::circular_buffer<core::json::Value> actionsData_;
+   boost::circular_buffer<ConsoleAction> actions_;
+   ConsoleAction pendingAction_;
    std::vector<std::string> pendingInput_;
 };
 

--- a/src/cpp/r/session/RConsoleActions.cpp
+++ b/src/cpp/r/session/RConsoleActions.cpp
@@ -117,6 +117,8 @@ void ConsoleActions::add(int type, const std::string& data)
       std::size_t offset = 0;
       while (true)
       {
+         // the remaining data in the buffer is less than the chunk size;
+         // now, substring that data to remove any data we've committed
          if (pendingAction_.data.length() < offset + kChunkSize)
          {
             pendingAction_.data = pendingAction_.data.substr(offset);
@@ -129,7 +131,7 @@ void ConsoleActions::add(int type, const std::string& data)
          action.data = pendingAction_.data.substr(offset, kChunkSize);
          actions_.push_back(action);
          
-         // update offset
+         // update offset, indicating data we've committed
          offset += kChunkSize;
       }
    }

--- a/src/cpp/r/session/RConsoleActions.cpp
+++ b/src/cpp/r/session/RConsoleActions.cpp
@@ -121,7 +121,8 @@ void ConsoleActions::add(int type, const std::string& data)
          // now, substring that data to remove any data we've committed
          if (action_.data.length() < offset + kChunkSize)
          {
-            action_.data = action_.data.substr(offset);
+            if (offset > 0)
+               action_.data = action_.data.substr(offset);
             break;
          }
          


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13857.

### Approach

This PR adjust how we handle buffering of console outputs for console actions, which is used to populate the Console history when a suspended session is restored.

In particular, this PR makes a couple of changes:

1. We maintain a single `action_` action, which is used to accumulate outputs of the same type (imagine: lots of output fired into `stdout`);
2. As output is produced, we commit chunks of the `action_` buffer into the circular buffers that host the actual Console history.

This approach ensures that we always properly chunk console outputs, and avoids issues where a single-fire gigantic output was not properly chunked when committing that file to disk.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13857. In particular, we want to make sure the Console history representation remains correct when a suspended session is restored.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
