### PR TITLE
always overwrite chunk migration files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
 - Fixed an issue where color highlight for Console input could not be disabled. (#13118)
 - Fixed an issue that could cause the RStudio IDE to crash if a large amount of Console output was serialized with a suspended session. (#13857)
 - RStudio now records the deployment target for newly-published documents, even when deployment fails due to an error in the document. (#12707)
+- Fixed an issue that could cause errors to occur if an R Markdown document was saved while a chunk was running. (#13860)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/cpp/core/include/core/FileSerializer.hpp
+++ b/src/cpp/core/include/core/FileSerializer.hpp
@@ -299,7 +299,7 @@ Error readStringVectorFromFile(const core::FilePath& filePath,
 // note: this only has an effect on Windows
 Error writeStringToFile(const core::FilePath& filePath,
                         const std::string& str,
-                        string_utils::LineEnding lineEnding=string_utils::LineEndingPassthrough,
+                        string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough,
                         bool truncate = true,
                         int maxOpenRetrySeconds = 0,
                         bool logError = true);
@@ -307,7 +307,7 @@ Error writeStringToFile(const core::FilePath& filePath,
 // lineEnding is the type of line ending you want the resulting string to have
 Error readStringFromFile(const core::FilePath& filePath,
                          std::string* pStr,
-                         string_utils::LineEnding lineEnding=string_utils::LineEndingPassthrough,
+                         string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough,
                          int startLine = 0,
                          int endLine = 0,
                          int startCharacter = 0,
@@ -319,7 +319,7 @@ Error readStringFromFile(
    const core::FilePath& filePath,
    const Filter& filter,
    std::string* pContents,
-   string_utils::LineEnding lineEnding=string_utils::LineEndingPassthrough)
+   string_utils::LineEnding lineEnding = string_utils::LineEndingPassthrough)
 {
    try
    {

--- a/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
+++ b/src/cpp/session/modules/rmarkdown/NotebookCache.cpp
@@ -407,21 +407,10 @@ Error createMigrationFile(const FilePath& source, const FilePath& target)
    Error error;
    FilePath migrationFile = source.completePath(kMigrationTarget);
 
-   // Ensure migration file doesn't already exist. This shouldn't happen unless a crash occurred
-   // during a previous chunk execution.
-   if (migrationFile.exists())
-   {
-      LOG_WARNING_MESSAGE("Notebook output migration file " kMigrationTarget " already exists in " + 
-            source.getAbsolutePath());
-      error = migrationFile.remove();
-      if (error)
-      {
-         error.addProperty("description", "Unable to remove notebook output migration file");
-         return error;
-      }
-   }
-
-   error = writeStringToFile(migrationFile, target.getAbsolutePath()); 
+   // Write the migration file. Note that this file might already exist; this
+   // can happen if the document was saved mulitple times while the document
+   // was executing. In that case, we just overwrite it.
+   error = writeStringToFile(migrationFile, target.getAbsolutePath());
    if (error)
    {
       error.addProperty("description", "Unable to write notebook output migration file");


### PR DESCRIPTION
### Intent

Addresses #13860.

### Approach

Avoid treating an already-existing migration file as an error -- such files can exist if an R Markdown document is saved multiple times while a document is running.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
