### PR TITLE
tweak how changes in viewed data are detected

### DIFF
--- a/src/cpp/session/modules/data/DataViewer.cpp
+++ b/src/cpp/session/modules/data/DataViewer.cpp
@@ -237,16 +237,20 @@ struct CachedFrame
 
       // cache list of column names
       r::sexp::Protect protect;
-      SEXP namesSEXP;
+      SEXP namesSEXP = R_NilValue;
       r::exec::RFunction("names", sexp).call(&namesSEXP, &protect);
-      if (namesSEXP != nullptr && TYPEOF(namesSEXP) != NILSXP 
-          && !Rf_isNull(namesSEXP))
+      if (!Rf_isNull(namesSEXP))
       {
          r::sexp::extract(namesSEXP, &colNames);
       }
 
+      // cache number of rows, but only for 'local' data
+      // (avoid potentially expensive queries for remote tables)
+      nrow = Rf_inherits(sexp, "data.frame") || Rf_inherits(sexp, "matrix")
+            ? safeDim(sexp, DIM_ROWS)
+            : -1;
+      
       // cache number of columns
-      nrow = safeDim(sexp, DIM_ROWS);
       ncol = safeDim(sexp, DIM_COLS);
    };
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/data/DataEditingTarget.java
@@ -14,10 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.views.source.editors.data;
 
-import com.google.gwt.aria.client.Roles;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.ui.Widget;
-import com.google.inject.Inject;
+import java.util.HashMap;
 
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.SimplePanelWithProgress;
@@ -37,7 +34,10 @@ import org.rstudio.studio.client.workbench.views.source.events.PopoutDocEvent;
 import org.rstudio.studio.client.workbench.views.source.model.DataItem;
 import org.rstudio.studio.client.workbench.views.source.model.SourceServerOperations;
 
-import java.util.HashMap;
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
 
 public class DataEditingTarget extends UrlContentEditingTarget
                                implements DataViewChangedEvent.Handler
@@ -90,23 +90,25 @@ public class DataEditingTarget extends UrlContentEditingTarget
    @Override
    public void onDataViewChanged(DataViewChangedEvent event)
    {
+      // check whether this editing target is managing the changed data view
       DataViewChangedEvent.Data eventData = event.getData();
-      if (eventData.getCacheKey().equals(getDataItem().getCacheKey()))
+      DataItem item = getDataItem();
+      if (!eventData.getCacheKey().equals(item.getCacheKey()))
+         return;
+      
+      // close if the object no longer exists
+      if (!eventData.getObjectExists())
       {
-         // when this is no longer a data frame, close it
-         if (eventData.typeChanged())
-         {
-            events_.fireEvent(new CloseDataEvent(getDataItem()));
-            return;
-         }
+         events_.fireEvent(new CloseDataEvent(item));
+         return;
+      }
 
-         queuedRefresh_ = QueuedRefreshType.StructureRefresh;
-         // perform the refresh immediately if the tab is active; otherwise,
-         // leave it in the queue and it'll be run when the tab is activated
-         if (isActive_)
-         {
-            doQueuedRefresh();
-         }
+      // perform the refresh immediately if the tab is active; otherwise,
+      // leave it in the queue and it'll be run when the tab is activated
+      queuedRefresh_ = QueuedRefreshType.StructureRefresh;
+      if (isActive_)
+      {
+         doQueuedRefresh();
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/events/DataViewChangedEvent.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.events;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArrayString;
 import com.google.gwt.event.shared.EventHandler;
 import com.google.gwt.event.shared.GwtEvent;
 
@@ -24,17 +25,11 @@ public class DataViewChangedEvent extends GwtEvent<DataViewChangedEvent.Handler>
    {
       protected Data() {}
       
-      public final native String getCacheKey() /*-{
-         return this.cache_key;
-      }-*/;
-
-      public final native boolean structureChanged() /*-{
-         return this.structure_changed || false;
-      }-*/;
-
-      public final native boolean typeChanged() /*-{
-         return this.type_changed || false;
-      }-*/;
+      public final native String getCacheKey()            /*-{ return this.cache_key; }-*/;
+      public final native boolean getTypeChanged()        /*-{ return this.type_changed || false; }-*/;
+      public final native boolean getStructureChanged()   /*-{ return this.structure_changed || false; }-*/;
+      public final native boolean getObjectExists()       /*-{ return this.object_exists || false; }-*/;
+      public final native JsArrayString getObjectClass()  /*-{ return this.object_class; }-*/;
    }
 
    public static final GwtEvent.Type<DataViewChangedEvent.Handler> TYPE = new GwtEvent.Type<>();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13856.

### Approach

This PR removes some logic that tried to transition views from Data Viewer => Object Explorer, when the associated type of the underlying object changed. The old implementation appeared to be overly-sensitive to changes in the underlying object's type.

We could consider adding this back in the future, but given that this is a relatively painful bug, I felt it was worth fixing.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
