### PR TITLE
Tweaks to database config.

### DIFF
--- a/src/cpp/core/Database.cpp
+++ b/src/cpp/core/Database.cpp
@@ -721,7 +721,7 @@ boost::shared_ptr<IConnection> ConnectionPool::getConnection()
       else
       {
          LOG_ERROR_MESSAGE("Potential hang detected: could not get database connection from pool "
-                           "after 30 seconds. If issue persists, please notify RStudio Support");
+                           "after 30 seconds. If issue persists, please notify Posit Support");
       }
    }
 }
@@ -1275,6 +1275,9 @@ Error createConnectionPool(size_t poolSize,
       Error error = connect(options, &connection);
       if (error)
       {
+         // Logging the error before resetting the pool because a customer saw a SEGV when handling this error.
+         LOG_ERROR_MESSAGE("Error allocating database connection: " + std::to_string(i+1) + " with pool-size: " + std::to_string(poolSize) + ": " + error.asString());
+
          // destroy the pool, which will free each previously created connections
          pPool->reset();
          return error;

--- a/src/cpp/server_core/ServerDatabase.cpp
+++ b/src/cpp/server_core/ServerDatabase.cpp
@@ -59,7 +59,7 @@ constexpr const char* kDefaultPostgresqlDatabasePort = "5432";
 constexpr const char* kDatabaseUsername = "username";
 constexpr const char* kDefaultPostgresqlDatabaseUsername = "postgres";
 constexpr const char* kDatabasePassword = "password";
-constexpr const char* kPostgresqlDatabaseConnectionTimeoutSeconds = "connnection-timeout-seconds";
+constexpr const char* kPostgresqlDatabaseConnectionTimeoutSeconds = "connection-timeout-seconds";
 constexpr const int   kDefaultPostgresqlDatabaseConnectionTimeoutSeconds = 10;
 constexpr const char* kPostgresqlDatabaseConnectionUri = "connection-uri";
 constexpr const char* kConnectionPoolSize = "pool-size";
@@ -67,9 +67,10 @@ constexpr const char* kConnectionPoolSize = "pool-size";
 // environment variables
 constexpr const char* kDatabaseMigrationsPathEnvVar = "RS_DB_MIGRATIONS_PATH";
 
-// misc constants
+// Choosing a modest pool size as the db usage of rserver is not high enough to
+// justify anything larger and with 20 a cluster of 5 nodes hits the postgres default limit of 100.
 constexpr const size_t kDefaultMinPoolSize = 4;
-constexpr const size_t kDefaultMaxPoolSize = 20;
+constexpr const size_t kDefaultMaxPoolSize = 6;
 constexpr const int kMinimumSupportedPostgreSqlMajorVersion = 11;
 
 boost::shared_ptr<ConnectionPool> s_connectionPool;


### PR DESCRIPTION
Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/5211

- Max of 6 db connections. Plenty of parallel db activity for the limited uses and avoids overflow
- Better error when failing to populate connection pool
- Fixed typo in config option