### PR TITLE
allow copy of text from History pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 - Fixed an issue that could cause the RStudio IDE to crash if a large amount of Console output was serialized with a suspended session. (#13857)
 - RStudio now records the deployment target for newly-published documents, even when deployment fails due to an error in the document. (#12707)
 - Fixed an issue that could cause errors to occur if an R Markdown document was saved while a chunk was running. (#13860)
+- Fixed an issue preventing users from copying code from the History pane. (#3219)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -404,11 +404,6 @@ public class DomUtils
    public static final native boolean contains(Element container, Node descendant) /*-{
       return container.contains(descendant);
    }-*/;
-   
-   public static final native boolean containsElement(Element container, Element descendant)
-   /*-{
-      return container.contains(descendant);
-   }-*/;
 
    /**
     * CharacterData.deleteData(node, index, offset)

--- a/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
+++ b/src/gwt/src/org/rstudio/core/client/dom/DomUtils.java
@@ -401,17 +401,14 @@ public class DomUtils
       return impl.selectionExists();
    }
 
-   public static boolean contains(Element container, Node descendant)
-   {
-      while (descendant != null)
-      {
-         if (descendant == container)
-            return true;
-
-         descendant = descendant.getParentNode();
-      }
-      return false;
-   }
+   public static final native boolean contains(Element container, Node descendant) /*-{
+      return container.contains(descendant);
+   }-*/;
+   
+   public static final native boolean containsElement(Element container, Element descendant)
+   /*-{
+      return container.contains(descendant);
+   }-*/;
 
    /**
     * CharacterData.deleteData(node, index, offset)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/history/view/HistoryPane.css
@@ -47,6 +47,12 @@
    padding-right: 3px;
    text-overflow: ellipsis;
    overflow: hidden;
+   user-select: all;
+}
+
+/* Disable the default CSS for selected text -- we manually style this ourselves. */
+.historyTable div::selection {
+   background: none;
 }
 
 .historyTable .selected td:first-child div {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/3219.

### Approach

We have a custom GWT implementation called FastSelectTable governing the behavior of the table displayed in the History pane. Unfortunately, the extra customization around focus handling prevents copy from working in the default way.

This PR implements a custom copy handler that allows the table to handle copy events, in the case that it has focus and the user has selected one or more rows of data.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/3219.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
