### PR TITLE
display executed command for Quarto jobs

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -84,6 +84,7 @@ Error QuartoJob::start()
    // create job and emit some output (to prevent the "has not emitted output" message)
    using namespace jobs;
    JobActions jobActions;
+   
    // note that we pass raw 'this' b/c the "stop" action will never be executed after we
    // hit onCompleted (because our status won't be "running"). if we passed shared_from_this
    // then we'd be keeping this object around forever (because jobs are never discarded).
@@ -100,7 +101,6 @@ Error QuartoJob::start()
                   jobActions,
                   true,
                   {"quarto", kJobTagTransient});
-   pJob_->addOutput("\n", true);
 
    // return success
    return Success();

--- a/src/cpp/session/modules/quarto/SessionQuartoJob.hpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.hpp
@@ -17,12 +17,15 @@
 #define SESSION_QUARTO_JOB_HPP
 
 #include <string>
+
 #include <boost/noncopyable.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/enable_shared_from_this.hpp>
 
 #include <shared_core/FilePath.hpp>
 #include <shared_core/SafeConvert.hpp>
+
+#include <core/Algorithm.hpp>
 #include <core/system/Types.hpp>
 #include <core/system/ShellUtils.hpp>
 #include <core/system/Process.hpp>
@@ -60,7 +63,7 @@ public:
    {
       stopRequested_ = true;
 
-      // on windows we need to be a bit more aggressive (as we've seen cases where
+      // on windows we need to be a bit more aggressive, as we've seen cases where
       // the 'stop' doesn't actually work esp. when deno is running a web server
 #ifdef _WIN32
       using namespace core::shell_utils;
@@ -121,6 +124,9 @@ protected:
    virtual void onStarted(core::system::ProcessOperations& process)
    {
       pid_ = process.getPid();
+      
+      std::string command = fmt::format("==> quarto {}\n\n", core::algorithm::join(args(), " "));
+      pJob_->addOutput(command, false);
    }
 
    virtual bool onContinue()

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -158,10 +158,10 @@ protected:
       return "Preview: " + previewTarget_.getFilename();
    }
 
-   virtual std::vector<std::string> args()
+   std::vector<std::string> computeArgs()
    {
       // preview target file
-      std::vector<std::string> args({"preview"});
+      std::vector<std::string> args = { "preview" };
       if (!previewTarget_.isDirectory())
       {
          args.push_back(string_utils::utf8ToSystem(previewTarget_.getFilename()));
@@ -185,7 +185,13 @@ protected:
 
       return args;
    }
-
+   
+   virtual std::vector<std::string> args()
+   {
+      static std::vector<std::string> instance = computeArgs();
+      return instance;
+   }
+   
    virtual void environment(core::system::Options* pEnv)
    {
       // set render token


### PR DESCRIPTION
Addresses https://github.com/rstudio/rstudio/issues/13876.

This helps make it more clear what was actually executed, in the scenario where an error occurs.

<img width="669" alt="Screenshot 2023-11-01 at 2 19 12 PM" src="https://github.com/rstudio/rstudio/assets/1976582/98fcf0e2-6c94-4ac0-bcd8-e608c987ee61">
