### PR TITLE
tweak location of XDG cache for Windows

### DIFF
--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -73,6 +73,13 @@ FilePath userLogDir();
 FilePath userCacheDir(const boost::optional<std::string>& user = boost::none,
                       const boost::optional<FilePath>& homeDir = boost::none);
 
+// Older versions of RStudio used FOLDERID_InternetCache for cached data files.
+// This function allows callers to query that older location, to allow resources
+// to be migrated transparently.
+FilePath oldUserCacheDir(
+    const boost::optional<std::string>& user = boost::none,
+    const boost::optional<FilePath>& homeDir = boost::none);
+
 // This function verifies that the userConfigDir() and userDataDir() exist and are owned by the running user.
 // 
 // It should be invoked once. Any issues with these directories will be emitted to the session log.

--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -69,11 +69,11 @@ FilePath userLogDir();
 // Returns the RStudio XDG user cache directory.
 //
 // On Unix-alikes, this is ~/.cache, or XDG_CACHE_HOME.
-// On Windows, this is 'FOLDERID_InternetCache' (typically 'AppData/Local/Microsoft/Windows/Temporary Files')
+// On Windows, this resolves to %LOCALAPPDATA%/RStudio/Cache by default.
 FilePath userCacheDir(const boost::optional<std::string>& user = boost::none,
                       const boost::optional<FilePath>& homeDir = boost::none);
 
-// Older versions of RStudio used FOLDERID_InternetCache for cached data files.
+// Older versions of RStudio on Windows used FOLDERID_InternetCache for cached data files.
 // This function allows callers to query that older location, to allow resources
 // to be migrated transparently.
 FilePath oldUserCacheDir(

--- a/src/cpp/core/include/core/system/Xdg.hpp
+++ b/src/cpp/core/include/core/system/Xdg.hpp
@@ -73,12 +73,16 @@ FilePath userLogDir();
 FilePath userCacheDir(const boost::optional<std::string>& user = boost::none,
                       const boost::optional<FilePath>& homeDir = boost::none);
 
+#ifdef _WIN32
+
 // Older versions of RStudio on Windows used FOLDERID_InternetCache for cached data files.
 // This function allows callers to query that older location, to allow resources
 // to be migrated transparently.
 FilePath oldUserCacheDir(
     const boost::optional<std::string>& user = boost::none,
     const boost::optional<FilePath>& homeDir = boost::none);
+
+#endif
 
 // This function verifies that the userConfigDir() and userDataDir() exist and are owned by the running user.
 // 

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -239,6 +239,22 @@ FilePath userCacheDir(
    );
 }
 
+FilePath oldUserCacheDir(
+        const boost::optional<std::string>& user,
+        const boost::optional<FilePath>& homeDir)
+{
+   return resolveXdgDir("RSTUDIO_CACHE_HOME",
+         "XDG_CACHE_HOME",
+#ifdef _WIN32
+         FOLDERID_InternetCache,
+#endif
+         "~/.cache",
+         user,
+         homeDir
+   );
+}
+
+
 FilePath userLogDir()
 {
    return userDataDir().completePath("log");

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -239,6 +239,8 @@ FilePath userCacheDir(
    );
 }
 
+#ifdef _WIN32
+
 FilePath oldUserCacheDir(
         const boost::optional<std::string>& user,
         const boost::optional<FilePath>& homeDir)
@@ -254,6 +256,7 @@ FilePath oldUserCacheDir(
    );
 }
 
+#endif
 
 FilePath userLogDir()
 {

--- a/src/cpp/core/system/Xdg.cpp
+++ b/src/cpp/core/system/Xdg.cpp
@@ -89,6 +89,7 @@ std::string getHostname()
  *   current user is used
  * @param homeDir Optionally, the home directory to resolve against; if omitted
  *   the current user's home directory is used
+ * @param suffix An optional path component to append to the computed path.
  */
 FilePath resolveXdgDir(
       const std::string& rstudioEnvVar,
@@ -179,7 +180,7 @@ FilePath resolveXdgDir(
    // resolve aliases in the path
    xdgHome = FilePath::resolveAliasedPath(expanded, homeDir ? *homeDir : userHomePath());
 
-   // if this is the final path, we can return it as-is
+   // if this is not a final path, then append the RStudio data folder name
    if (!finalPath)
       xdgHome = xdgHome.completePath(kRStudioDataFolderName);
    

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -310,8 +310,24 @@ FilePath copilotAgentPath()
    if (copilotPath.exists())
       return copilotPath;
 
+   using namespace core::system::xdg;
+
+#ifdef _WIN32
+   // on Windows, the copilot agent was previously downloaded to a different location.
+   // Delete and remove the old location after sufficient time has passed, in a future
+   // RStudio release.
+   FilePath oldAgentLocation = oldUserCacheDir().completeChildPath("copilot");
+   FilePath newAgentLocation = userCacheDir().completeChildPath("copilot");
+   if (oldAgentLocation.exists() && !newAgentLocation.exists())
+   {
+      Error error = newAgentLocation.copyDirectoryRecursive(newAgentLocation);
+      if (error)
+         LOG_ERROR(error);
+   }
+#endif
+
    // Otherwise, use a default user location.
-   return core::system::xdg::userCacheDir().completeChildPath("copilot/dist/agent.js");
+   return userCacheDir().completeChildPath("copilot/dist/agent.js");
 }
 
 bool isCopilotAgentInstalled()


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13878.

### Approach

With this PR, the XDG cache directory is computed as a directory within the user's LocalAppData directory.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

