### PR TITLE
report errors when attempting to start Copilot agent

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -177,9 +177,6 @@ bool s_isSessionShuttingDown = false;
 // Project-specific Copilot options.
 projects::RProjectCopilotOptions s_copilotProjectOptions;
 
-// The error (if any) that occurred when trying to launch Copilot.
-Error s_copilotLaunchError = Success();
-
 bool isCopilotEnabled()
 {
    // Check project option
@@ -617,9 +614,9 @@ void onStderr(ProcessOperations& operations, const std::string& stdErr)
  
    // If we get output from stderr while the agent is starting, that means
    // something went wrong and we're about to shut down.
-   if (s_agentStatus == status::Starting)
+   if (s_agentStatus == status::Starting || s_agentStatus == status::Stopping)
    {
-      s_agentStartupError = stdErr;
+      s_agentStartupError += stdErr;
       s_agentStatus = status::Stopping;
    }
 }

--- a/src/cpp/shared_core/Error.cpp
+++ b/src/cpp/shared_core/Error.cpp
@@ -27,6 +27,7 @@
 #include <shared_core/FilePath.hpp>
 #include <shared_core/Logger.hpp>
 #include <shared_core/SafeConvert.hpp>
+#include <shared_core/json/Json.hpp>
 
 #include <boost/optional.hpp>
 
@@ -375,6 +376,36 @@ std::string Error::asString() const
    }
 
    return ostr.str();
+}
+
+void Error::writeJson(json::Object* pJson) const
+{
+   json::Object& json = *pJson;
+   
+   json["code"] = m_impl->Code;
+   json["name"] = m_impl->Name;
+   json["message"] = m_impl->Message;
+   
+   json::Object propertiesJson;
+   for (auto&& pair : m_impl->Properties)
+      propertiesJson[pair.first] = pair.second;
+   json["properties"] = propertiesJson;
+   
+   if (m_impl->Cause)
+   {
+      json::Object causeJson;
+      m_impl->Cause->writeJson(&causeJson);
+      json["cause"] = causeJson;
+   }
+   
+   json::Object locationJson;
+   locationJson["file"]     = m_impl->Location.getFile();
+   locationJson["function"] = m_impl->Location.getFunction();
+   locationJson["line"]     = (double) m_impl->Location.getLine();
+   json["location"] = locationJson;
+   
+   json["expected"] = m_impl->Expected;
+   
 }
 
 bool Error::hasCause() const

--- a/src/cpp/shared_core/include/shared_core/Error.hpp
+++ b/src/cpp/shared_core/include/shared_core/Error.hpp
@@ -41,6 +41,11 @@ class FilePath;
 class Error;
 class Success;
 
+namespace json {
+class Value;
+class Object;
+} // end namespace json
+
 /**
  * @brief A class which can be derived from in order to prevent child classes from being derived from further.
  */
@@ -427,6 +432,13 @@ public:
     */
    std::string asString() const;
 
+   /**
+    * @brief Formats the error as a JSON object.
+    *
+    * @return The error formatted as a JSON object.
+    */
+   void writeJson(json::Object* pJson) const;
+   
    /**
     * @brief Checks whether this error was caused by a separate error.
     *

--- a/src/gwt/src/org/rstudio/core/client/DialogOptions.java
+++ b/src/gwt/src/org/rstudio/core/client/DialogOptions.java
@@ -1,7 +1,7 @@
 /*
- * DialogBuilderFactory.java
+ * DialogOptions.java
  *
- * Copyright (C) 2022 by Posit Software, PBC
+ * Copyright (C) 2023 by Posit Software, PBC
  *
  * Unless you have received this program directly from Posit Software pursuant
  * to the terms of a commercial license agreement with Posit Software, then
@@ -12,12 +12,11 @@
  * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
  *
  */
-package org.rstudio.studio.client.common.dialog;
+package org.rstudio.core.client;
 
-import org.rstudio.core.client.DialogOptions;
-import org.rstudio.core.client.widget.DialogBuilder;
-
-public interface DialogBuilderFactory
+public class DialogOptions
 {
-   DialogBuilder create(int type, String caption, String message, DialogOptions options);
+   public String width = null;
+   public String height = null;
+   public String userSelect = null;
 }

--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -16,10 +16,6 @@ package org.rstudio.core.client;
 
 import java.util.List;
 
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.Focusable;
-
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.widget.CanFocus;
 import org.rstudio.core.client.widget.DialogBuilder;
 import org.rstudio.core.client.widget.FocusHelper;
@@ -28,6 +24,10 @@ import org.rstudio.core.client.widget.OperationWithInput;
 import org.rstudio.core.client.widget.ProgressOperation;
 import org.rstudio.core.client.widget.ProgressOperationWithInput;
 import org.rstudio.studio.client.common.GlobalDisplay;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.Focusable;
 
 public abstract class MessageDisplay
 {

--- a/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
+++ b/src/gwt/src/org/rstudio/core/client/MessageDisplay.java
@@ -129,11 +129,28 @@ public abstract class MessageDisplay
    protected abstract DialogBuilder createDialog(int type,
                                                  String caption,
                                                  String message);
+   
+   protected abstract DialogBuilder createDialog(int type,
+                                                 String caption,
+                                                 String message,
+                                                 DialogOptions options);
+   
 
-   public void showMessage(int type, String caption, String message)
+   public void showMessage(int type,
+                           String caption,
+                           String message)
    {
       createDialog(type, caption, message).showModal();
    }
+   
+   public void showMessage(int type,
+                           String caption,
+                           String message,
+                           DialogOptions options)
+   {
+      createDialog(type, caption, message, options).showModal();
+   }
+   
 
    public void showMessage(int type,
                            String caption,

--- a/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/MessageDialog.java
@@ -14,13 +14,18 @@
  */
 package org.rstudio.core.client.widget;
 
-import com.google.gwt.aria.client.Roles;
-import com.google.gwt.user.client.ui.*;
-
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.resources.ImageResource2x;
 import org.rstudio.core.client.theme.res.ThemeResources;
 import org.rstudio.core.client.widget.images.MessageDialogImages;
+
+import com.google.gwt.aria.client.Roles;
+import com.google.gwt.user.client.ui.HasHorizontalAlignment;
+import com.google.gwt.user.client.ui.HasVerticalAlignment;
+import com.google.gwt.user.client.ui.HorizontalPanel;
+import com.google.gwt.user.client.ui.Image;
+import com.google.gwt.user.client.ui.Label;
+import com.google.gwt.user.client.ui.Widget;
 
 public class MessageDialog extends ModalDialogBase
 {
@@ -154,6 +159,23 @@ public class MessageDialog extends ModalDialogBase
    protected void focusInitialControl()
    {
       focusOkButton();
+   }
+   
+   public void setUserSelect(String userSelect)
+   {
+      messageWidget_.getElement().getStyle().setProperty("userSelect", userSelect);
+   }
+   
+   @Override
+   public void setWidth(String width)
+   {
+      messageWidget_.setWidth(width);
+   }
+   
+   @Override
+   public void setHeight(String height)
+   {
+      messageWidget_.setHeight(height);
    }
 
    private final int type_;

--- a/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/DefaultGlobalDisplay.java
@@ -14,18 +14,17 @@
  */
 package org.rstudio.studio.client.common;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.http.client.URL;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.RootLayoutPanel;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
-
+import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.files.FileSystemItem;
-import org.rstudio.core.client.widget.*;
+import org.rstudio.core.client.widget.DialogBuilder;
+import org.rstudio.core.client.widget.Operation;
+import org.rstudio.core.client.widget.OperationWithInput;
+import org.rstudio.core.client.widget.ProgressIndicator;
+import org.rstudio.core.client.widget.ProgressOperationWithInput;
+import org.rstudio.core.client.widget.SlideLabel;
 import org.rstudio.studio.client.application.ApplicationView;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.application.model.ApplicationServerOperations;
@@ -33,6 +32,13 @@ import org.rstudio.studio.client.common.dialog.DialogBuilderFactory;
 import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.SessionInfo;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.ui.RootLayoutPanel;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 
 public class DefaultGlobalDisplay extends GlobalDisplay
 {
@@ -208,14 +214,24 @@ public class DefaultGlobalDisplay extends GlobalDisplay
             },
             cancelOperation);
    }
+   
+   @Override
+   protected DialogBuilder createDialog(int type,
+                                        String caption,
+                                        String message,
+                                        DialogOptions options)
+   {
+      DialogBuilderFactory factory = GWT.create(DialogBuilderFactory.class);
+      return factory.create(type, caption, message, options);
+   }
+   
 
    @Override
    protected DialogBuilder createDialog(int type,
                                         String caption,
                                         String message)
    {
-      return ((DialogBuilderFactory)GWT.create(DialogBuilderFactory.class))
-            .create(type, caption, message);
+      return createDialog(type, caption, message, null);
    }
 
    public Command showProgress(String message)

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.common.dialog;
 
+import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.DialogBuilder;
@@ -33,10 +34,11 @@ public class DesktopDialogBuilderFactory implements DialogBuilderFactory
 {
    static class Builder extends DialogBuilderBase
    {
-      public Builder(int type, String caption, String message)
+      public Builder(int type, String caption, String message, DialogOptions options)
       {
          super(type, caption);
          message_ = message;
+         options_ = options;
       }
 
       @Override
@@ -138,12 +140,14 @@ public class DesktopDialogBuilderFactory implements DialogBuilderFactory
       }
 
       private final String message_;
+      private final DialogOptions options_;
+      
       private Command dismissProgress_;
    }
 
-   public DialogBuilder create(int type, String caption, String message)
+   public DialogBuilder create(int type, String caption, String message, DialogOptions options)
    {
-      return new Builder(type, caption, message);
+      return new Builder(type, caption, message, options);
    }
    private static final StudioClientCommonConstants constants_ = GWT.create(StudioClientCommonConstants.class);
 }

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/DesktopDialogBuilderFactory.java
@@ -14,10 +14,6 @@
  */
 package org.rstudio.studio.client.common.dialog;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.user.client.Command;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.widget.DialogBuilder;
@@ -27,6 +23,11 @@ import org.rstudio.studio.client.RStudioGinjector;
 import org.rstudio.studio.client.application.Desktop;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.StudioClientCommonConstants;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.user.client.Command;
 
 public class DesktopDialogBuilderFactory implements DialogBuilderFactory
 {

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
@@ -14,9 +14,11 @@
  */
 package org.rstudio.studio.client.common.dialog;
 
-import com.google.gwt.user.client.ui.Widget;
 import org.rstudio.core.client.ElementIds;
-import org.rstudio.core.client.widget.*;
+import org.rstudio.core.client.widget.DialogBuilder;
+import org.rstudio.core.client.widget.MessageDialog;
+
+import com.google.gwt.user.client.ui.Widget;
 
 public class WebDialogBuilderFactory implements DialogBuilderFactory
 {

--- a/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/dialog/WebDialogBuilderFactory.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.common.dialog;
 
+import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.widget.DialogBuilder;
 import org.rstudio.core.client.widget.MessageDialog;
@@ -24,10 +25,11 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
 {
    static class Builder extends DialogBuilderBase
    {
-      Builder(int type, String caption, Widget message)
+      Builder(int type, String caption, Widget message, DialogOptions options)
       {
          super(type, caption);
          message_ = message;
+         options_ = options;
       }
 
       @Override
@@ -41,9 +43,7 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
 
       private MessageDialog createDialog()
       {
-         MessageDialog messageDialog = new MessageDialog(type,
-                                                         caption,
-                                                         message_);
+         MessageDialog messageDialog = new MessageDialog(type, caption, message_);
          for (int i = 0; i < buttons_.size(); i++)
          {
             ButtonSpec button = buttons_.get(i);
@@ -64,20 +64,34 @@ public class WebDialogBuilderFactory implements DialogBuilderFactory
                                        i == buttons_.size() - 1);
             }
          }
+         
+         if (options_ != null)
+         {
+            if (options_.width != null)
+               messageDialog.setWidth(options_.width);
+            
+            if (options_.height != null)
+               messageDialog.setHeight(options_.height);
+            
+            if (options_.userSelect != null)
+               messageDialog.setUserSelect(options_.userSelect);
+            
+         }
          return messageDialog;
       }
 
       private final Widget message_;
+      private final DialogOptions options_;
    }
 
    @Override
-   public DialogBuilder create(int type, String caption, String message)
+   public DialogBuilder create(int type, String caption, String message, DialogOptions options)
    {
-      return new Builder(type, caption, MessageDialog.labelForMessage(message));
+      return new Builder(type, caption, MessageDialog.labelForMessage(message), options);
    }
 
    public DialogBuilder create(int type, String caption, Widget messageWidget)
    {
-      return new Builder(type, caption, messageWidget);
+      return new Builder(type, caption, messageWidget, null);
    }
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
@@ -14,6 +14,7 @@
  */
 package org.rstudio.studio.client.workbench.copilot.model;
 
+import org.rstudio.core.client.jsonrpc.RpcError;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotResponse;
 
@@ -87,6 +88,7 @@ public class CopilotResponseTypes
       public String jsonrpc;
       public String id;
       public CopilotStatusResponseResult result;
+      public RpcError error;
    }
    
    @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
@@ -88,7 +88,11 @@ public class CopilotResponseTypes
       public String jsonrpc;
       public String id;
       public CopilotStatusResponseResult result;
+      
+      // These aren't part of a normal Copilot status request; we append
+      // this extra information to help report agent startup errors.
       public RpcError error;
+      public String output;
    }
    
    @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.css
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.css
@@ -4,6 +4,10 @@
 	margin-top: -2px;
 }
 
+.copilotStatusLabel {
+	height: 20px;
+}
+
 .copilotTosLabel {
 	font-style: oblique;
 }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -96,6 +96,7 @@ public class CopilotPreferencesPane extends PreferencesPane
       projectServer_ = projectServer;
       
       lblCopilotStatus_ = new Label("(Loading...)");
+      lblCopilotStatus_.addStyleName(RES.styles().copilotStatusLabel());
       
       statusButtons_ = new ArrayList<SmallButton>();
       
@@ -306,7 +307,15 @@ public class CopilotPreferencesPane extends PreferencesPane
             
             if (response == null)
             {
-               if (projectOptions_ != null && projectOptions_.getCopilotOptions().copilot_enabled == RProjectConfig.NO_VALUE)
+               lblCopilotStatus_.setText("An unexpected error occurred while checking the status of the GitHub Copilot agent.");
+            }
+            else if (response.result == null)
+            {
+               if (response.error != null)
+               {
+                  lblCopilotStatus_.setText("An error occurred while attempting to start the Copilot agent.\n\n" + response.error.getMessage());
+               }
+               else if (projectOptions_ != null && projectOptions_.getCopilotOptions().copilot_enabled == RProjectConfig.NO_VALUE)
                {
                   lblCopilotStatus_.setText("GitHub Copilot has been disabled in this project.");
                   showButtons(btnProjectOptions_);
@@ -424,6 +433,7 @@ public class CopilotPreferencesPane extends PreferencesPane
    public interface Styles extends CssResource
    {
       String button();
+      String copilotStatusLabel();
       String copilotTosLabel();
       String copilotPreviewBlurb();
    }

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/CopilotPreferencesPane.java
@@ -19,16 +19,19 @@ import java.util.List;
 
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.Debug;
+import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.JSON;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.prefs.RestartRequirement;
 import org.rstudio.core.client.resources.ImageResource2x;
+import org.rstudio.core.client.widget.DialogBuilder;
 import org.rstudio.core.client.widget.SelectWidget;
 import org.rstudio.core.client.widget.SmallButton;
 import org.rstudio.studio.client.application.AriaLiveService;
 import org.rstudio.studio.client.application.events.EventBus;
 import org.rstudio.studio.client.common.GlobalDisplay;
 import org.rstudio.studio.client.common.HelpLink;
+import org.rstudio.studio.client.common.dialog.WebDialogBuilderFactory;
 import org.rstudio.studio.client.projects.model.ProjectsServerOperations;
 import org.rstudio.studio.client.projects.model.RProjectConfig;
 import org.rstudio.studio.client.projects.model.RProjectOptions;
@@ -254,10 +257,22 @@ public class CopilotPreferencesPane extends PreferencesPane
          @Override
          public void onClick(ClickEvent event)
          {
-            display_.showMessage(
+            DialogOptions options = new DialogOptions();
+            options.width = "auto";
+            options.height = "auto";
+            options.userSelect = "text";
+            
+            // Prefer using a web dialog even on Desktop, as we want to allow customization
+            // of how the UI is presented. In particular, we want to allow users to select
+            // and copy text if they need to.
+            WebDialogBuilderFactory builder = GWT.create(WebDialogBuilderFactory.class);
+            DialogBuilder dialog = builder.create(
                   GlobalDisplay.MSG_INFO,
                   "GitHub Copilot: Status",
-                  copilotStartupError_);
+                  copilotStartupError_,
+                  options);
+            
+            dialog.showModal();
          }
       });
       

--- a/src/gwt/test/org/rstudio/studio/client/common/DummyGlobalDisplay.java
+++ b/src/gwt/test/org/rstudio/studio/client/common/DummyGlobalDisplay.java
@@ -1,5 +1,6 @@
 package org.rstudio.studio.client.common;
 
+import org.rstudio.core.client.DialogOptions;
 import org.rstudio.core.client.dom.WindowEx;
 import org.rstudio.core.client.widget.DialogBuilder;
 import org.rstudio.core.client.widget.Operation;
@@ -229,6 +230,16 @@ public class DummyGlobalDisplay extends GlobalDisplay
 
     }
 
+    @Override
+    protected DialogBuilder createDialog(int type,
+                                         String caption,
+                                         String message,
+                                         DialogOptions options)
+    {
+
+        return null;
+    }
+    
     @Override
     protected DialogBuilder createDialog(int type,
                                          String caption,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13499.

Here's an example of the UI presentation, for an error that's captured when trying to start the Copilot agent. In this instance, I modified the `agent.js` script, adding `oops` to the start -- basically ensuring the process would quickly die when trying to run the `agent.js` script.

<img width="643" alt="Screenshot 2023-11-03 at 4 00 19 PM" src="https://github.com/rstudio/rstudio/assets/1976582/a61d9b79-f5eb-496c-97b3-c51af745b74e">

### Approach

Check if an error occurred when attempting to launch the Copilot agent during the status invocation. If an error occurs, report that back to the client.

### Automated Tests

N/A

### QA Notes

I'm not quite sure how to test this -- I'm not sure if there's a great way to simulate a failure to launch in the Copilot agent process?

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
