### PR TITLE
fix parsing of YAML chunk labels

### DIFF
--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -752,7 +752,7 @@ var RCodeModel = function(session, tokenizer,
 
    this.$buildScopeTreeUpToRow = function(maxRow)
    {
-      function getChunkLabel(reOptions, comment, iterator) {
+      function getChunkLabel(session, reOptions, comment, iterator) {
 
          if (typeof reOptions === "undefined")
             return "";
@@ -785,17 +785,15 @@ var RCodeModel = function(session, tokenizer,
          // ```{r}
          // #| label: foo
          var it = iterator.clone();
-         
-         var tok = it.moveToNextToken();
-         while(tok != null && tok.type.startsWith("comment"))
+         var token = it.moveToNextToken();
+         while (token != null && token.type.startsWith("comment"))
          {
-            var value = tok.value;
-            
+            var value = session.getLine(it.$row);
             var labelRegex = /^#\|\s*label\s*:\s*(.*)$/;
             if (labelRegex.test(value))
                return value.replace(labelRegex, "$1");
             
-            tok = it.moveToNextToken();
+            token = it.moveToStartOfNextRowWithTokens();
          }
          
          return null;
@@ -1081,7 +1079,7 @@ var RCodeModel = function(session, tokenizer,
             var chunkPos = {row: chunkStartPos.row + 1, column: 0};
             var chunkNum = chunkCount;
 
-            var chunkLabel = getChunkLabel(this.$codeBeginPattern, value, iterator);
+            var chunkLabel = getChunkLabel(this.$session, this.$codeBeginPattern, value, iterator);
             var scopeName = "Chunk " + chunkNum;
             if (chunkLabel && value !== "YAML Header")
                scopeName += ": " + chunkLabel;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13831.

### Approach

A recent PR enabled highlighting for YAML chunk options. Unfortunately, this interfered with some older code which expected the YAML text contents to be left tokenized as part of a comment.

This PR alleviates the issue by just pulling out the whole line for the matched token, rather than by looking at the token value.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13831.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
