### PR TITLE
use clip overflow for modal dialogs

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
+++ b/src/gwt/src/org/rstudio/core/client/files/filedialog/FileDialogStyles.css
@@ -82,7 +82,7 @@
 
 .contents tr.gwt-MenuItem-selected .columnSize,
 .contents tr.gwt-MenuItem-selected .columnDate {
-   color: white;
+   color: black;
 }
 
 .gwt-CheckBox-FilesSelectAll {

--- a/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.css
+++ b/src/gwt/src/org/rstudio/core/client/widget/ModalDialogBase.css
@@ -1,4 +1,5 @@
 @charset "UTF-8";
 
 .modalDialog {
+	overflow: clip !important;
 }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13895.

<img width="537" alt="Screenshot 2023-11-06 at 1 51 33 PM" src="https://github.com/rstudio/rstudio/assets/1976582/3c730429-eed2-495e-a9a5-04a880c9f470">

### Approach

Update `.modalDialog` CSS.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13895.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
