### PR TITLE
defend against invalid TAR envvars

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.R
+++ b/src/cpp/session/modules/SessionCopilot.R
@@ -50,11 +50,21 @@
    
    # Extract the tarball. Make sure things get unpacked into the download dir.
    local({
+      
+      # Move to download directory.
       owd <- setwd(downloadDir)
       on.exit(setwd(owd), add = TRUE)
-      untar(destfile)
+      
+      # Make sure we have a valid tar set up.
+      # https://github.com/rstudio/rstudio/issues/13746
+      tar <- Sys.getenv("TAR")
+      if (!file.exists(tar))
+         tar <- Sys.which("tar")
+      
+      # Extract the archive.
+      untar(destfile, tar = tar)
+      
    })
-   
    
    # Find the unpacked directory.
    # NOTE: The copilot agent used to be bundled within the 'copilot/dist' sub-directory,


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13746.

### Approach

Check the `TAR` environment variable; if it's set to an invalid `tar` executable, then try to find it ourselves on the PATH.

### Automated Tests

N/A

### QA Notes

To test, try the following:

```
Sys.setenv(TAR = "/no/such/tar")
```

Then, use the Command Palette to run the Copilot: Install Agent command, and follow through the dialog. The Copilot agent should still install successfully.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
