### PR TITLE
add preference controlling dataset preview in Help

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -125,6 +125,7 @@ namespace prefs {
 #define kCodeCompletionDelay "code_completion_delay"
 #define kCodeCompletionCharacters "code_completion_characters"
 #define kShowFunctionSignatureTooltips "show_function_signature_tooltips"
+#define kShowDataPreview "show_data_preview"
 #define kShowDiagnosticsR "show_diagnostics_r"
 #define kShowDiagnosticsCpp "show_diagnostics_cpp"
 #define kShowDiagnosticsYaml "show_diagnostics_yaml"
@@ -714,6 +715,12 @@ public:
     */
    bool showFunctionSignatureTooltips();
    core::Error setShowFunctionSignatureTooltips(bool val);
+
+   /**
+    * Whether a data preview is shown in the autocompletion help popup for datasets and values.
+    */
+   bool showDataPreview();
+   core::Error setShowDataPreview(bool val);
 
    /**
     * Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.

--- a/src/cpp/session/modules/SessionHelp.R
+++ b/src/cpp/session/modules/SessionHelp.R
@@ -550,6 +550,10 @@ options(help_type = "html")
    showDataPreview <- getOption("rstudio.help.showDataPreview", default = TRUE)
    if (!showDataPreview)
       return(out)
+   
+   showDataPreview <- .rs.readUserPref("show_data_preview")
+   if (!identical(showDataPreview, TRUE))
+      return(out)
 
    # try and figure out the data + title
    data <- NULL

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -635,6 +635,19 @@ core::Error UserPrefValues::setShowFunctionSignatureTooltips(bool val)
 }
 
 /**
+ * Whether a data preview is shown in the autocompletion help popup for datasets and values.
+ */
+bool UserPrefValues::showDataPreview()
+{
+   return readPref<bool>("show_data_preview");
+}
+
+core::Error UserPrefValues::setShowDataPreview(bool val)
+{
+   return writePref("show_data_preview", val);
+}
+
+/**
  * Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.
  */
 bool UserPrefValues::showDiagnosticsR()
@@ -3323,6 +3336,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kCodeCompletionDelay,
       kCodeCompletionCharacters,
       kShowFunctionSignatureTooltips,
+      kShowDataPreview,
       kShowDiagnosticsR,
       kShowDiagnosticsCpp,
       kShowDiagnosticsYaml,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -382,6 +382,12 @@
             "title": "Show function signature tooltips",
             "description": "Whether to show function signature tooltips during autocompletion."
         },
+        "show_data_preview": {
+            "type": "boolean",
+            "default": true,
+            "title": "Show data preview in autocompletion help popup",
+            "description": "Whether a data preview is shown in the autocompletion help popup for datasets and values."
+        },
         "show_diagnostics_r": {
             "type": "boolean",
             "default": true,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -812,6 +812,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * Whether a data preview is shown in the autocompletion help popup for datasets and values.
+    */
+   public PrefValue<Boolean> showDataPreview()
+   {
+      return bool(
+         "show_data_preview",
+         _constants.showDataPreviewTitle(), 
+         _constants.showDataPreviewDescription(), 
+         true);
+   }
+
+   /**
     * Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.
     */
    public PrefValue<Boolean> showDiagnosticsR()
@@ -3672,6 +3684,8 @@ public class UserPrefsAccessor extends Prefs
          codeCompletionCharacters().setValue(layer, source.getInteger("code_completion_characters"));
       if (source.hasKey("show_function_signature_tooltips"))
          showFunctionSignatureTooltips().setValue(layer, source.getBool("show_function_signature_tooltips"));
+      if (source.hasKey("show_data_preview"))
+         showDataPreview().setValue(layer, source.getBool("show_data_preview"));
       if (source.hasKey("show_diagnostics_r"))
          showDiagnosticsR().setValue(layer, source.getBool("show_diagnostics_r"));
       if (source.hasKey("show_diagnostics_cpp"))
@@ -4129,6 +4143,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(codeCompletionDelay());
       prefs.add(codeCompletionCharacters());
       prefs.add(showFunctionSignatureTooltips());
+      prefs.add(showDataPreview());
       prefs.add(showDiagnosticsR());
       prefs.add(showDiagnosticsCpp());
       prefs.add(showDiagnosticsYaml());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -436,6 +436,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String showFunctionSignatureTooltipsDescription();
 
    /**
+    * Whether a data preview is shown in the autocompletion help popup for datasets and values.
+    */
+   @DefaultStringValue("Show data preview in autocompletion help popup")
+   String showDataPreviewTitle();
+   @DefaultStringValue("Whether a data preview is shown in the autocompletion help popup for datasets and values.")
+   String showDataPreviewDescription();
+
+   /**
     * Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.
     */
    @DefaultStringValue("Show diagnostics in R code")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -223,6 +223,10 @@ codeCompletionCharactersDescription = The number of characters in a symbol that 
 showFunctionSignatureTooltipsTitle = Show function signature tooltips
 showFunctionSignatureTooltipsDescription = Whether to show function signature tooltips during autocompletion.
 
+# Whether a data preview is shown in the autocompletion help popup for datasets and values.
+showDataPreviewTitle = Show data preview in autocompletion help popup
+showDataPreviewDescription = Whether a data preview is shown in the autocompletion help popup for datasets and values.
+
 # Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.
 showDiagnosticsRTitle = Show diagnostics in R code
 showDiagnosticsRDescription = Whether to show diagnostic messages (such as syntax and usage errors) for R code as you type.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/EditingPreferencesPane.java
@@ -395,6 +395,8 @@ public class EditingPreferencesPane extends PreferencesPane
       completionPanel.add(checkboxPref(
             constants_.completionTabMultilineCompletionLabel(),
             prefs_.tabMultilineCompletion()));
+      completionPanel.add(
+            checkboxPref(prefs_.showDataPreview()));
       
       Label otherLabel = headerLabel(constants_.editingDiagOtherLabel());
       otherLabel.getElement().getStyle().setMarginTop(8, Unit.PX);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13579.

### Approach

Adds a user preference, and uses it!

### Automated Tests

N/A

### QA Notes

A simple way to test is to type:

```
mt
```

and then press Tab. You should get an autocompletion popup like the following:

<img width="659" alt="Screenshot 2023-11-08 at 2 20 24 PM" src="https://github.com/rstudio/rstudio/assets/1976582/57da45ec-9c8a-460f-b300-fec7f4a9bf3b">

Whether or not you see the dataset preview should depend on the value of the preference here:

<img width="646" alt="Screenshot 2023-11-08 at 2 21 06 PM" src="https://github.com/rstudio/rstudio/assets/1976582/c663e2ff-8ef0-43f3-adb8-312ca9022a53">

Note that you may need to restart the R session after changing this preference.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
