### PR TITLE
provide user pref for default open project location

### DIFF
--- a/src/cpp/session/include/session/prefs/UserPrefValues.hpp
+++ b/src/cpp/session/include/session/prefs/UserPrefValues.hpp
@@ -178,6 +178,7 @@ namespace prefs {
 #define kDefaultEncoding "default_encoding"
 #define kToolbarVisible "toolbar_visible"
 #define kDefaultProjectLocation "default_project_location"
+#define kDefaultOpenProjectLocation "default_open_project_location"
 #define kSourceWithEcho "source_with_echo"
 #define kDefaultSweaveEngine "default_sweave_engine"
 #define kDefaultLatexProgram "default_latex_program"
@@ -1003,6 +1004,12 @@ public:
     */
    std::string defaultProjectLocation();
    core::Error setDefaultProjectLocation(std::string val);
+
+   /**
+    * The default directory to use in file dialogs when opening a project.
+    */
+   std::string defaultOpenProjectLocation();
+   core::Error setDefaultOpenProjectLocation(std::string val);
 
    /**
     * Whether to echo R code when sourcing it.

--- a/src/cpp/session/prefs/UserPrefValues.cpp
+++ b/src/cpp/session/prefs/UserPrefValues.cpp
@@ -1259,6 +1259,19 @@ core::Error UserPrefValues::setDefaultProjectLocation(std::string val)
 }
 
 /**
+ * The default directory to use in file dialogs when opening a project.
+ */
+std::string UserPrefValues::defaultOpenProjectLocation()
+{
+   return readPref<std::string>("default_open_project_location");
+}
+
+core::Error UserPrefValues::setDefaultOpenProjectLocation(std::string val)
+{
+   return writePref("default_open_project_location", val);
+}
+
+/**
  * Whether to echo R code when sourcing it.
  */
 bool UserPrefValues::sourceWithEcho()
@@ -3384,6 +3397,7 @@ std::vector<std::string> UserPrefValues::allKeys()
       kDefaultEncoding,
       kToolbarVisible,
       kDefaultProjectLocation,
+      kDefaultOpenProjectLocation,
       kSourceWithEcho,
       kDefaultSweaveEngine,
       kDefaultLatexProgram,

--- a/src/cpp/session/resources/schema/user-prefs-schema.json
+++ b/src/cpp/session/resources/schema/user-prefs-schema.json
@@ -673,6 +673,12 @@
             "title": "Default new project location",
             "description": "The directory path under which to place new projects by default."
         },
+        "default_open_project_location": {
+            "type": "string",
+            "default": "~",
+            "title": "Default open project location",
+            "description": "The default directory to use in file dialogs when opening a project."
+        },
         "source_with_echo": {
             "type": "boolean",
             "default": false,

--- a/src/gwt/src/org/rstudio/core/client/ElementIds.java
+++ b/src/gwt/src/org/rstudio/core/client/ElementIds.java
@@ -14,11 +14,12 @@
  */
 package org.rstudio.core.client;
 
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.regex.Pattern;
+
 import com.google.gwt.aria.client.Id;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.ui.Widget;
-import org.rstudio.core.client.dom.DomUtils;
-import org.rstudio.core.client.regex.Pattern;
 
 public class ElementIds
 {
@@ -318,6 +319,7 @@ public class ElementIds
       BUILD_SCRIPT("build_Script"),
       CA_BUNDLE("ca_bundle"),
       DEFAULT_WORKING_DIR("default_working_dir"),
+      DEFAULT_OPEN_PROJECT_DIR("default_open_project_dir"),
       ZOTERO_DATA_DIRECTORY("zotero_data_directory"),
       EXISTING_PROJECT_DIR("existing_project_dir"),
       FIND_IN("find_in"),

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBase.css
@@ -96,5 +96,6 @@
    margin-top: 8px;
 }
 
-
-
+.extraSpacedBefore {
+	margin-top: 12px;
+}

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBaseResources.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogBaseResources.java
@@ -42,6 +42,7 @@ public interface PreferencesDialogBaseResources extends ClientBundle
       String infoLabel();
       String headerLabel();
       String spacedBefore();
+      String extraSpacedBefore();
    }
 
    @Source("PreferencesDialogBase.css")

--- a/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
+++ b/src/gwt/src/org/rstudio/core/client/prefs/PreferencesDialogPaneBase.java
@@ -107,6 +107,13 @@ public abstract class PreferencesDialogPaneBase<T> extends VerticalPanel
       widget.addStyleName(res_.styles().spacedBefore());
       return widget;
    }
+   
+   protected Widget extraSpacedBefore(Widget widget)
+   {
+      widget.addStyleName(res_.styles().extraSpacedBefore());
+      return widget;
+   }
+   
 
    protected Widget spaced(Widget widget)
    {

--- a/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
+++ b/src/gwt/src/org/rstudio/core/client/widget/TextBoxWithButton.java
@@ -14,6 +14,12 @@
  */
 package org.rstudio.core.client.widget;
 
+import org.rstudio.core.client.CoreClientConstants;
+import org.rstudio.core.client.ElementIds;
+import org.rstudio.core.client.StringUtil;
+import org.rstudio.core.client.dom.DomUtils;
+import org.rstudio.core.client.theme.res.ThemeResources;
+
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style.Unit;
 import com.google.gwt.event.dom.client.ClickEvent;
@@ -22,17 +28,10 @@ import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
 import com.google.gwt.event.logical.shared.ValueChangeHandler;
 import com.google.gwt.event.shared.HandlerRegistration;
-
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.TextBox;
-
-import org.rstudio.core.client.CoreClientConstants;
-import org.rstudio.core.client.ElementIds;
-import org.rstudio.core.client.StringUtil;
-import org.rstudio.core.client.dom.DomUtils;
-import org.rstudio.core.client.theme.res.ThemeResources;
 
 public class TextBoxWithButton extends Composite
                                implements HasValueChangeHandlers<String>,
@@ -128,6 +127,9 @@ public class TextBoxWithButton extends Composite
       {
          assert existingLabel == null : "Invalid usage, cannot provide both label and existingLabel";
 
+         if (!label.endsWith(":"))
+            label = label + ":";
+         
          lblCaption_ = new FormLabel(label, true);
          if (helpButton != null)
          {

--- a/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/Projects.java
@@ -16,8 +16,8 @@ package org.rstudio.studio.client.projects;
 
 
 import java.util.ArrayList;
+import java.util.function.Consumer;
 
-import com.google.gwt.core.client.GWT;
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.SerializedCommand;
@@ -46,15 +46,15 @@ import org.rstudio.studio.client.common.dependencies.model.Dependency;
 import org.rstudio.studio.client.common.vcs.GitServerOperations;
 import org.rstudio.studio.client.common.vcs.VCSConstants;
 import org.rstudio.studio.client.common.vcs.VcsCloneOptions;
+import org.rstudio.studio.client.projects.events.NewProjectEvent;
+import org.rstudio.studio.client.projects.events.NewProjectFolderEvent;
+import org.rstudio.studio.client.projects.events.NewProjectFromVcsEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectErrorEvent;
+import org.rstudio.studio.client.projects.events.OpenProjectEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectFileEvent;
 import org.rstudio.studio.client.projects.events.OpenProjectNewWindowEvent;
 import org.rstudio.studio.client.projects.events.RequestOpenProjectEvent;
 import org.rstudio.studio.client.projects.events.SwitchToProjectEvent;
-import org.rstudio.studio.client.projects.events.NewProjectEvent;
-import org.rstudio.studio.client.projects.events.NewProjectFolderEvent;
-import org.rstudio.studio.client.projects.events.NewProjectFromVcsEvent;
-import org.rstudio.studio.client.projects.events.OpenProjectEvent;
 import org.rstudio.studio.client.projects.model.NewProjectContext;
 import org.rstudio.studio.client.projects.model.NewProjectInput;
 import org.rstudio.studio.client.projects.model.NewProjectResult;
@@ -81,11 +81,11 @@ import org.rstudio.studio.client.workbench.model.SessionOpener;
 import org.rstudio.studio.client.workbench.prefs.model.UserPrefs;
 import org.rstudio.studio.client.workbench.views.vcs.common.ConsoleProgressDialog;
 
+import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Command;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import java.util.function.Consumer;
 
 @Singleton
 public class Projects implements OpenProjectFileEvent.Handler,
@@ -1034,9 +1034,12 @@ public class Projects implements OpenProjectFileEvent.Handler,
                   boolean allowOpenInNewWindow,
                   ProgressOperationWithInput<OpenProjectParams> onCompleted)
    {
+      String defaultLocation = pUserPrefs_.get().defaultOpenProjectLocation().getValue();
+      if (StringUtil.isNullOrEmpty(defaultLocation))
+         defaultLocation = "~";
+      
       opener_.showOpenProjectDialog(fsContext_, projServer_,
-            pUserPrefs_.get().defaultProjectLocation().getValue(),
-            defaultType, allowOpenInNewWindow, onCompleted);
+            defaultLocation, defaultType, allowOpenInNewWindow, onCompleted);
    }
 
    @Handler

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessor.java
@@ -1408,6 +1408,18 @@ public class UserPrefsAccessor extends Prefs
    }
 
    /**
+    * The default directory to use in file dialogs when opening a project.
+    */
+   public PrefValue<String> defaultOpenProjectLocation()
+   {
+      return string(
+         "default_open_project_location",
+         _constants.defaultOpenProjectLocationTitle(), 
+         _constants.defaultOpenProjectLocationDescription(), 
+         "~");
+   }
+
+   /**
     * Whether to echo R code when sourcing it.
     */
    public PrefValue<Boolean> sourceWithEcho()
@@ -3780,6 +3792,8 @@ public class UserPrefsAccessor extends Prefs
          toolbarVisible().setValue(layer, source.getBool("toolbar_visible"));
       if (source.hasKey("default_project_location"))
          defaultProjectLocation().setValue(layer, source.getString("default_project_location"));
+      if (source.hasKey("default_open_project_location"))
+         defaultOpenProjectLocation().setValue(layer, source.getString("default_open_project_location"));
       if (source.hasKey("source_with_echo"))
          sourceWithEcho().setValue(layer, source.getBool("source_with_echo"));
       if (source.hasKey("default_sweave_engine"))
@@ -4191,6 +4205,7 @@ public class UserPrefsAccessor extends Prefs
       prefs.add(defaultEncoding());
       prefs.add(toolbarVisible());
       prefs.add(defaultProjectLocation());
+      prefs.add(defaultOpenProjectLocation());
       prefs.add(sourceWithEcho());
       prefs.add(defaultSweaveEngine());
       prefs.add(defaultLatexProgram());

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants.java
@@ -824,6 +824,14 @@ public interface UserPrefsAccessorConstants extends Constants {
    String defaultProjectLocationDescription();
 
    /**
+    * The default directory to use in file dialogs when opening a project.
+    */
+   @DefaultStringValue("Default open project location")
+   String defaultOpenProjectLocationTitle();
+   @DefaultStringValue("The default directory to use in file dialogs when opening a project.")
+   String defaultOpenProjectLocationDescription();
+
+   /**
     * Whether to echo R code when sourcing it.
     */
    @DefaultStringValue("Source with echo by default")

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/model/UserPrefsAccessorConstants_en.properties
@@ -417,6 +417,10 @@ toolbarVisibleDescription = Whether to show the toolbar at the top of the RStudi
 defaultProjectLocationTitle = Default new project location
 defaultProjectLocationDescription = The directory path under which to place new projects by default.
 
+# The default directory to use in file dialogs when opening a project.
+defaultOpenProjectLocationTitle = Default open project location
+defaultOpenProjectLocationDescription = The default directory to use in file dialogs when opening a project.
+
 # Whether to echo R code when sourcing it.
 sourceWithEchoTitle = Source with echo by default
 sourceWithEchoDescription = Whether to echo R code when sourcing it.

--- a/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/prefs/views/GeneralPreferencesPane.java
@@ -115,6 +115,7 @@ public class GeneralPreferencesPane extends PreferencesPane
          spaced(rVersion_);
          basic.add(rVersion_);
       }
+      
       if (versionsInfo.isMultiVersion())
       {
          rServerRVersion_ = new RVersionSelectWidget(
@@ -148,12 +149,12 @@ public class GeneralPreferencesPane extends PreferencesPane
       lessSpaced(restoreLastProject_);
       basic.add(restoreLastProject_);
 
-        basic.add(checkboxPref(constants_.rRestorePreviousOpenTitle(), prefs_.restoreSourceDocuments()));
+      basic.add(checkboxPref(constants_.rRestorePreviousOpenTitle(), prefs_.restoreSourceDocuments()));
 
       rProfileOnResume_ = new CheckBox(constants_.rRunProfileTitle());
       if (!Desktop.isDesktop())
          basic.add(rProfileOnResume_);
-
+      
       basic.add(spacedBefore(headerLabel(constants_.workspaceCaption())));
       basic.add(loadRData_ = new CheckBox(constants_.workspaceLabel()));
       lessSpaced(loadRData_);
@@ -239,6 +240,14 @@ public class GeneralPreferencesPane extends PreferencesPane
 
       VerticalTabPanel advanced = new VerticalTabPanel(ElementIds.GENERAL_ADVANCED_PREFS);
 
+      advanced.add(headerLabel("Projects"));
+      advanced.add(defaultOpenProjectLocationChooser_ = new DirectoryChooserTextBox(
+            prefs_.defaultOpenProjectLocation().getTitle(),
+            ElementIds.TextBoxButtonId.DEFAULT_OPEN_PROJECT_DIR,
+            null,
+            fileDialogs_,
+            fsContext_));
+
       showServerHomePage_ = new SelectWidget(
               constants_.serverHomePageLabel(),
             new String[] {
@@ -257,7 +266,6 @@ public class GeneralPreferencesPane extends PreferencesPane
 
       reuseSessionsForProjectLinks_ = new CheckBox(constants_.reUseIdleSessionLabel());
       lessSpaced(reuseSessionsForProjectLinks_);
-      boolean firstHeader = true;
 
       if (!Desktop.hasDesktopFrame())
       {
@@ -267,7 +275,6 @@ public class GeneralPreferencesPane extends PreferencesPane
             Label homePageLabel = headerLabel(constants_.desktopCaption());
             spacedBefore(homePageLabel);
             advanced.add(homePageLabel);
-            firstHeader = false;
          }
          if (session_.getSessionInfo().getShowUserHomePage())
          {
@@ -279,12 +286,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       }
 
      Label debuggingLabel = headerLabel(constants_.advancedDebuggingCaption());
-     if (!firstHeader)
-     {
-        spacedBefore(debuggingLabel);
-        firstHeader = false;
-     }
-     advanced.add(debuggingLabel);
+     advanced.add(extraSpacedBefore(debuggingLabel));
      advanced.add(checkboxPref(
            constants_.advancedDebuggingLabel(),
            prefs_.handleErrorsInUserCodeOnly()));
@@ -388,6 +390,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       saveWorkspace_.setEnabled(false);
       loadRData_.setEnabled(false);
       dirChooser_.setEnabled(false);
+      defaultOpenProjectLocationChooser_.setEnabled(false);
       alwaysSaveHistory_.setEnabled(false);
       removeHistoryDuplicates_.setEnabled(false);
       rProfileOnResume_.setEnabled(false);
@@ -413,6 +416,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       saveWorkspace_.setEnabled(true);
       loadRData_.setEnabled(true);
       dirChooser_.setEnabled(true);
+      defaultOpenProjectLocationChooser_.setEnabled(true);
 
       if (!isLauncherSession)
          showServerHomePage_.setValue(prefs.showUserHomePage().getValue());
@@ -446,8 +450,12 @@ public class GeneralPreferencesPane extends PreferencesPane
       String workingDir = prefs.initialWorkingDirectory().getValue();
       if (StringUtil.isNullOrEmpty(workingDir))
          workingDir = "~";
-      
       dirChooser_.setText(workingDir);
+      
+      String defaultOpenProjectLocation = prefs.defaultOpenProjectLocation().getValue();
+      if (StringUtil.isNullOrEmpty(defaultOpenProjectLocation))
+         defaultOpenProjectLocation = "~";
+      defaultOpenProjectLocationChooser_.setText(defaultOpenProjectLocation);
 
       alwaysSaveHistory_.setEnabled(true);
       removeHistoryDuplicates_.setEnabled(true);
@@ -552,6 +560,7 @@ public class GeneralPreferencesPane extends PreferencesPane
       prefs.loadWorkspace().setGlobalValue(loadRData_.getValue());
       prefs.runRprofileOnResume().setGlobalValue(rProfileOnResume_.getValue());
       prefs.initialWorkingDirectory().setGlobalValue(dirChooser_.getText());
+      prefs.defaultOpenProjectLocation().setGlobalValue(defaultOpenProjectLocationChooser_.getText());
       prefs.showLastDotValue().setGlobalValue(showLastDotValue_.getValue());
       prefs.alwaysSaveHistory().setGlobalValue(alwaysSaveHistory_.getValue());
       prefs.removeHistoryDuplicates().setGlobalValue(removeHistoryDuplicates_.getValue());
@@ -714,6 +723,7 @@ public class GeneralPreferencesPane extends PreferencesPane
    private SelectWidget saveWorkspace_;
    private TextBoxWithButton rVersion_;
    private TextBoxWithButton dirChooser_;
+   private TextBoxWithButton defaultOpenProjectLocationChooser_;
    private CheckBox loadRData_;
    private final CheckBox alwaysSaveHistory_;
    private final CheckBox removeHistoryDuplicates_;


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13717.

### Approach

Adds a user preference "default_open_project_location", which is accessible here:

<img width="649" alt="Screenshot 2023-11-08 at 2 53 36 PM" src="https://github.com/rstudio/rstudio/assets/1976582/c3c4773f-a6cc-4c24-9747-e0ea9ea7c2b5">

The directory set here is then used as the default "starting" location when opening a new project.

### Automated Tests

N/A

### QA Notes

To be verified by user.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
