### PR TITLE
run search as program instead of command

### DIFF
--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -271,7 +271,7 @@ Error runProgram(const std::string& executable,
 // by a command shell (/bin/sh on posix, cmd.exe on windows).
 //
 // NOTE: UNC paths are not supported by cmd.exe on Windows, so prefer using
-// runProgram() if running a program that might injest a file path. Note that
+// runProgram() if running a program that might ingest a file path. Note that
 // this might happen just by virtue of having a project on a network share,
 // since the working directory might then be the project directory itself!
 Error runCommand(const std::string& command,

--- a/src/cpp/core/include/core/system/Process.hpp
+++ b/src/cpp/core/include/core/system/Process.hpp
@@ -270,6 +270,10 @@ Error runProgram(const std::string& executable,
 // Run a command synchronously. The command will be passed to and executed
 // by a command shell (/bin/sh on posix, cmd.exe on windows).
 //
+// NOTE: UNC paths are not supported by cmd.exe on Windows, so prefer using
+// runProgram() if running a program that might injest a file path. Note that
+// this might happen just by virtue of having a project on a network share,
+// since the working directory might then be the project directory itself!
 Error runCommand(const std::string& command,
                  const ProcessOptions& options,
                  ProcessResult* pResult);

--- a/src/cpp/session/modules/SessionGit.cpp
+++ b/src/cpp/session/modules/SessionGit.cpp
@@ -3137,6 +3137,11 @@ bool isWithinGitRoot(const core::FilePath& filePath)
    return isGitEnabled() && filePath.isWithin(s_git_.root());
 }
 
+FilePath gitExePath()
+{
+   return s_gitExePath.empty() ? detectedGitExePath() : FilePath(s_gitExePath);
+}
+
 FilePath detectedGitExePath()
 {
 #ifdef _WIN32

--- a/src/cpp/session/modules/SessionGit.hpp
+++ b/src/cpp/session/modules/SessionGit.hpp
@@ -64,6 +64,7 @@ bool isGithubRepository();
 
 core::Error initializeGit(const core::FilePath& workingDir);
 
+core::FilePath gitExePath();
 core::FilePath detectedGitExePath();
 
 std::string nonPathGitBinDir();


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13015.

### Approach

Use `runProgram()` rather than `runCommand()`, so that we can support UNC paths on Windows. This also helps us obviate the need to escape paths and other shell-specific characters.

### Automated Tests

Covered by existing automation.

### QA Notes

To test locally, you can add 'localhost' (that is, your own machine) as a network location. To do this, open the File Explorer, click on "This PC" on the left bar, then use the More (...) dropdown and select Add a Network Location.

![image](https://github.com/rstudio/rstudio/assets/1976582/a353d236-720b-4a8f-8e0b-699bb3d6781e)

Then, as the network location, type `\\localhost\c$`:

![image](https://github.com/rstudio/rstudio/assets/1976582/c3e3143a-642e-48b0-94b7-132dde4ccec9)

Give that the default name. Now, when you use File -> New Project or File -> Open Project in RStudio, you can use that network location (which is really just your own machine). Then, try and test Find in Files in one of these projects, both with and without git enabled.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
