### PR TITLE
fix WSL terminals so they start

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 - Fixed an issue that could cause errors to occur if an R Markdown document was saved while a chunk was running. (#13860)
 - Fixed an issue where console output could be dropped when rendering large ANSI links. (#13869)
 - Fixed an issue preventing users from copying code from the History pane. (#3219)
+- Fixed WSL terminals not starting on RStudio Desktop for Windows. (#13918)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/cpp/session/modules/SessionTerminalShell.cpp
+++ b/src/cpp/session/modules/SessionTerminalShell.cpp
@@ -124,7 +124,7 @@ void scanAvailableShells(std::vector<TerminalShell>* pShells)
    addShell(bashWSL,
             TerminalShell::ShellType::WSLBash,
             "Bash (Windows Subsystem for Linux)",
-            bashLoginArgs,
+            args, // don't pass bashLoginArgs here (rstudio issue #13918)
             pShells);
 #endif
 


### PR DESCRIPTION
# Don't merge; waiting to hear from QA if they want to take this for Ocean Storm or a future release

### Intent

Addresses #13918

### Approach

Reverts the WSL-specific part of https://github.com/rstudio/rstudio/pull/10283 by not passing any arguments to `system32\bash.exe` when we try starting a WSL terminal pane.

The conda integration mentioned in that issue was aimedat git-bash based terminals. The technique used for that won't work with WSL terminals, plus they are running in a separate subsystem and operating system so even if the WSL terminal was starting the integration would never have worked, near as I can tell.

### Automated Tests

I doubt we have WSL-specific terminal automation (would require running the tests on Windows Desktop with WSL installed).

### QA Notes

This change is very narrowly scoped to just the WSL terminal codepath, so test setting the terminal to use WSL, and see if you can start a terminal (you will need WSL installed, of course).

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


