### PR TITLE
avoid using openExternal for file URIs on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,6 +47,7 @@
 - Fixed an issue where console output could be dropped when rendering large ANSI links. (#13869)
 - Fixed an issue preventing users from copying code from the History pane. (#3219)
 - Fixed WSL terminals not starting on RStudio Desktop for Windows. (#13918)
+- Fixed an issue that prevented users from opening files and vignettes with non-ASCII characters in their paths. (#13886)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -183,7 +183,7 @@ export class DesktopBrowserWindow extends EventEmitter {
           const reHelp = String.raw `/help/library/([^/]+)/doc/(.*)\.pdf`;
           const match = details.url.match(reHelp);
           if (match) {
-            const args = [match[2], match[1]];
+            const args = [decodeURIComponent(match[2]), decodeURIComponent(match[1])];
             this.sendRpcRequest('show_vignette', args);
           }
           return { action: 'deny' };

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -127,6 +127,7 @@ export class GwtCallback extends EventEmitter {
     ipcMain.on('desktop_browse_url', (event, url: string) => {
 
       // shell.openExternal() seems unreliable on Windows
+      // https://github.com/electron/electron/issues/31347
       if (process.platform === 'win32' && url.startsWith('file:///')) {
         const path = decodeURI(url).substring('file:///'.length).replaceAll('/', '\\');
         desktop.openExternal(path);

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -126,14 +126,14 @@ export class GwtCallback extends EventEmitter {
 
     ipcMain.on('desktop_browse_url', (event, url: string) => {
 
-      // shell.openExternal() doesn't handle file URIs containining non-ASCII characters
+      // shell.openExternal() seems unreliable on Windows
       if (process.platform === 'win32' && url.startsWith('file:///')) {
-        const filePath = url.substring('file:///'.length);
-        const shortPath = desktop.shortPathName(filePath);
-        url = `file:///${shortPath}`;
+        const path = decodeURI(url).substring('file:///'.length).replaceAll('/', '\\');
+        desktop.openExternal(path);
+      } else {
+        void shell.openExternal(url);
       }
 
-      void shell.openExternal(url);
     });
 
     ipcMain.handle(

--- a/src/node/desktop/src/native/desktop.node.d.ts
+++ b/src/node/desktop/src/native/desktop.node.d.ts
@@ -52,3 +52,12 @@ export declare function searchRegistryForInstallationsOfR(): string[];
  * @param registryVersionKey The registry version key -- typically 'R' or 'R64'.
  */
 export declare function searchRegistryForDefaultInstallationOfR(registryVersionKey: string): string;
+
+/**
+ * (Windows only)
+ *
+ * Open a file using the default application registered for that file.
+ *
+ * @param path The path to an existing file.
+ */
+export declare function openExternal(path: string): void;

--- a/src/node/desktop/src/native/desktop/desktop.cc
+++ b/src/node/desktop/src/native/desktop/desktop.cc
@@ -710,6 +710,18 @@ Napi::Value searchRegistryForDefaultInstallationOfR(const Napi::CallbackInfo& in
    return Napi::String::From(info.Env(), installPath);
 }
 
+Napi::Value openExternal(const Napi::CallbackInfo& info)
+{
+
+#ifdef _WIN32
+   std::u16string uPath = info[0].As<Napi::String>().Utf16Value();
+   CoInitializeEx(NULL, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+   ShellExecuteW(NULL, L"open", (wchar_t*) &uPath[0], NULL, NULL, SW_SHOWNORMAL);
+#endif
+
+   return Napi::Value();
+
+}
 
 } // end namespace desktop
 } // end namespace rstudio
@@ -732,6 +744,7 @@ Napi::Object Init(Napi::Env env, Napi::Object exports) {
    RS_EXPORT_FUNCTION("defaultCSIDLPersonalHomePath", rstudio::desktop::defaultCSIDLPersonalHomePath);
    RS_EXPORT_FUNCTION("searchRegistryForInstallationsOfR", rstudio::desktop::searchRegistryForInstallationsOfR);
    RS_EXPORT_FUNCTION("searchRegistryForDefaultInstallationOfR", rstudio::desktop::searchRegistryForDefaultInstallationOfR);
+   RS_EXPORT_FUNCTION("openExternal", rstudio::desktop::openExternal);
 
    return exports;
 


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13886.

### Approach

It appears that Electron's `shell.openExternal()` struggles with certain kinds of Windows paths. This PR falls back to using our trusty friend `ShellExecute()` to open these files.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13886.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

