### PR TITLE
check for NULL 'wd' before using it

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -259,17 +259,22 @@
 
    # resolve file path for this srcref
    srcfile <- attr(srcref, "srcfile")
-   filename <- enc2utf8(srcfile$filename)
-
+   if (is.null(srcfile) || is.null(srcfile$filename))
+      return("")
+   
    # check for absolute path in srcref
+   filename <- enc2utf8(srcfile$filename)
    if (.rs.isAbsolutePath(filename))
       return(filename)
 
    # if the path was not absolute, we need to resolve it relative
    # to the working directory associated with the srcref
-   wd <- enc2utf8(srcfile$wd)
-   fullPath <- paste(c(wd, filename), collapse = "/")
-   normalizePath(fullPath, winslash = "/", mustWork = FALSE)
+   if (!is.null(srcfile$wd)) {
+      wd <- enc2utf8(srcfile$wd)
+      filename <- paste(c(wd, filename), collapse = "/")
+   }
+   
+   normalizePath(filename, winslash = "/", mustWork = FALSE)
 })
 
 # Given a function and some content inside that function, returns a vector


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13799#issuecomment-1809305861.

### Approach

Not all `srcfile` objects have a `wd` set; make sure we check it exists before trying to use it.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13799#issuecomment-1809305861.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
