### PR TITLE
include "build" folders in github file finder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 /NEWS*.md merge=union
-
+build/** linguist-generated=false


### PR DESCRIPTION
### Intent

Addresses #1602 

### Approach

Updated .gitattributes folder per instructions at https://docs.github.com/en/search-github/searching-on-github/finding-files-on-github#customizing-excluded-files.

I tested this on my own fork of the repo.

### Automated Tests

None, this is purely a github setting, doesn't impact product behaviour.

### QA Notes

Product code not impacted; if you want to try it, go to https://github.com/rstudio/rstudio, hit the `t` key, then search for SessionBuild.cpp (a file in a `build` folder). Now it can be found, before it couldn't.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


