### PR TITLE
improve status reporting for Copilot agent

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -131,17 +131,22 @@ private:
    boost::posix_time::ptime time_;
 };
 
-namespace status {
+enum class CopilotAgentNotRunningReason {
+   Unknown,
+   NotInstalled,
+   DisabledByAdministrator,
+   DisabledViaProjectPreferences,
+   DisabledViaGlobalPreferences,
+   LaunchError,
+};
 
-enum CopilotAgentStatus {
+enum class CopilotAgentRuntimeStatus {
    Unknown,
    Starting,
    Running,
    Stopping,
    Stopped,
 };
-
-} // end namespace status
 
 // The log level for Copilot-specific logs. Primarily for developer use.
 int s_copilotLogLevel = 0;
@@ -158,8 +163,12 @@ PidType s_agentPid = -1;
 // Error output (if any) that was written during startup.
 std::string s_agentStartupError;
 
-// Whether the current Copilot agent process is ready.
-status::CopilotAgentStatus s_agentStatus = status::Unknown;
+// The current status of the Copilot agent, mainly around if it's enabled
+// (and why or why not).
+CopilotAgentNotRunningReason s_agentNotRunningReason = CopilotAgentNotRunningReason::Unknown;
+
+// The current runtime status of the Copilot agent process.
+CopilotAgentRuntimeStatus s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
 
 // A queue of pending requests, to be sent via the agent's stdin.
 std::queue<std::string> s_pendingRequests;
@@ -177,18 +186,81 @@ bool s_isSessionShuttingDown = false;
 // Project-specific Copilot options.
 projects::RProjectCopilotOptions s_copilotProjectOptions;
 
+FilePath copilotAgentPath()
+{
+   // Check for configured copilot path.
+   FilePath copilotPath = session::options().copilotPath();
+   if (copilotPath.exists())
+      return copilotPath;
+
+   using namespace core::system::xdg;
+
+#ifdef _WIN32
+   // on Windows, the copilot agent was previously downloaded to a different location.
+   // Delete and remove the old location after sufficient time has passed, in a future
+   // RStudio release.
+   FilePath oldAgentLocation = oldUserCacheDir().completeChildPath("copilot");
+   FilePath newAgentLocation = userCacheDir().completeChildPath("copilot");
+   if (oldAgentLocation.exists() && !newAgentLocation.exists())
+   {
+      Error error = newAgentLocation.copyDirectoryRecursive(newAgentLocation);
+      if (error)
+         LOG_ERROR(error);
+   }
+#endif
+
+   // Otherwise, use a default user location.
+   return userCacheDir().completeChildPath("copilot/dist/agent.js");
+}
+
+bool isCopilotAgentInstalled()
+{
+   return copilotAgentPath().exists();
+}
+
 bool isCopilotEnabled()
 {
+   // Check administrator option
+   if (!session::options().copilotEnabled())
+   {
+      s_agentNotRunningReason = CopilotAgentNotRunningReason::DisabledByAdministrator;
+      return false;
+   }
+   
+   // Check whether the agent is installed
+   if (!isCopilotAgentInstalled())
+   {
+      s_agentNotRunningReason = CopilotAgentNotRunningReason::NotInstalled;
+      return false;
+   }
+   
    // Check project option
    switch (s_copilotProjectOptions.copilotEnabled)
    {
-   case r_util::YesValue: return true;
-   case r_util::NoValue: return false;
+   
+   case r_util::YesValue:
+   {
+      return true;
+   }
+      
+   case r_util::NoValue:
+   {
+      s_agentNotRunningReason = CopilotAgentNotRunningReason::DisabledViaProjectPreferences;
+      return false;
+   }
+      
    default: {}
+      
    }
 
    // Check user preference
-   return prefs::userPrefs().copilotEnabled();
+   if (!prefs::userPrefs().copilotEnabled())
+   {
+      s_agentNotRunningReason = CopilotAgentNotRunningReason::DisabledViaGlobalPreferences;
+      return false;
+   }
+   
+   return true;
 }
 
 bool isCopilotIndexingEnabled()
@@ -319,38 +391,6 @@ Error findNode(FilePath* pNodePath,
 int copilotLogLevel()
 {
    return s_copilotLogLevel;
-}
-
-FilePath copilotAgentPath()
-{
-   // Check for configured copilot path.
-   FilePath copilotPath = session::options().copilotPath();
-   if (copilotPath.exists())
-      return copilotPath;
-
-   using namespace core::system::xdg;
-
-#ifdef _WIN32
-   // on Windows, the copilot agent was previously downloaded to a different location.
-   // Delete and remove the old location after sufficient time has passed, in a future
-   // RStudio release.
-   FilePath oldAgentLocation = oldUserCacheDir().completeChildPath("copilot");
-   FilePath newAgentLocation = userCacheDir().completeChildPath("copilot");
-   if (oldAgentLocation.exists() && !newAgentLocation.exists())
-   {
-      Error error = newAgentLocation.copyDirectoryRecursive(newAgentLocation);
-      if (error)
-         LOG_ERROR(error);
-   }
-#endif
-
-   // Otherwise, use a default user location.
-   return userCacheDir().completeChildPath("copilot/dist/agent.js");
-}
-
-bool isCopilotAgentInstalled()
-{
-   return copilotAgentPath().exists();
 }
 
 Error installCopilotAgent()
@@ -501,7 +541,7 @@ void onStarted(ProcessOperations& operations)
    // Record the PID of the agent.
    DLOG("Copilot agent has started [PID = {}]", operations.getPid());
    s_agentPid = operations.getPid();
-   s_agentStatus = status::Starting;
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Starting;
 }
 
 bool onContinue(ProcessOperations& operations)
@@ -609,7 +649,7 @@ void onStdout(ProcessOperations& operations, const std::string& stdOut)
    }
    
    // Note that the agent is now ready.
-   s_agentStatus = status::Running;
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Running;
 }
 
 void onStderr(ProcessOperations& operations, const std::string& stdErr)
@@ -620,23 +660,34 @@ void onStderr(ProcessOperations& operations, const std::string& stdErr)
  
    // If we get output from stderr while the agent is starting, that means
    // something went wrong and we're about to shut down.
-   if (s_agentStatus == status::Starting || s_agentStatus == status::Stopping)
+   switch (s_agentRuntimeStatus)
+   {
+   
+   case CopilotAgentRuntimeStatus::Starting:
+   case CopilotAgentRuntimeStatus::Stopping:
    {
       s_agentStartupError += stdErr;
-      s_agentStatus = status::Stopping;
+      s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Stopping;
+      break;
    }
+ 
+   // TODO: Is there anything reasonable we can do with errors here?
+   default: {}
+      
+   }
+
 }
 
 void onError(ProcessOperations& operations, const Error& error)
 {
    s_agentPid = -1;
-   s_agentStatus = status::Stopped;
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Stopped;
 }
 
 void onExit(int status)
 {
    s_agentPid = -1;
-   s_agentStatus = status::Stopped;
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Stopped;
 
    if (s_isSessionShuttingDown)
       return;
@@ -720,14 +771,26 @@ Error startAgent()
    //
    // This also has the downside of failing less gracefully if 'node' is able to start
    // successfully, but it later dies after trying to run the 'agent.js' script.
-   s_agentStatus = status::Unknown;
+   s_agentRuntimeStatus = CopilotAgentRuntimeStatus::Unknown;
    s_agentStartupError = std::string();
    waitFor([]() { return s_agentPid != -1; });
    if (s_agentPid == -1)
       return Error(boost::system::errc::no_such_process, ERROR_LOCATION);
    
-   // Wait for Copilot to report that it's started running.
-   waitFor([]() { return s_agentStatus == status::Running || s_agentStatus == status::Stopped; });
+   // Wait for Copilot to report that it's started running, or that it's failed to start.
+   waitFor([]()
+   {
+      switch (s_agentRuntimeStatus)
+      {
+      case CopilotAgentRuntimeStatus::Running:
+      case CopilotAgentRuntimeStatus::Stopped:
+         return true;
+      default:
+         return false;
+      }
+      
+   });
+
    if (s_agentPid == -1)
       return Error(boost::system::errc::no_such_process, ERROR_LOCATION);
 
@@ -765,13 +828,6 @@ bool ensureAgentRunning(Error* pAgentLaunchError = nullptr)
    {
       DLOG("Copilot is already running; nothing to do.");
       return true;
-   }
-
-   // bail if copilot is not allowed
-   if (!session::options().copilotEnabled())
-   {
-      DLOG("Copilot has been disabled by the administrator; not starting agent.");
-      return false;
    }
 
    // bail if we haven't enabled copilot
@@ -1083,12 +1139,18 @@ Error copilotStatus(const json::JsonRpcRequest& request,
       json::JsonRpcResponse response;
       
       json::Object resultJson;
+      
       if (launchError)
       {
          json::Object errorJson;
          launchError.writeJson(&errorJson);
+         resultJson["reason"] = static_cast<int>(CopilotAgentNotRunningReason::LaunchError);
          resultJson["error"] = errorJson;
          resultJson["output"] = s_agentStartupError;
+      }
+      else
+      {
+         resultJson["reason"] = static_cast<int>(s_agentNotRunningReason);
       }
       
       response.setResult(resultJson);
@@ -1120,6 +1182,8 @@ Error copilotInstallAgent(const json::JsonRpcRequest& request,
    if (installError)
       responseJson["error"] = installError.asString();
    pResponse->setResult(responseJson);
+   
+   synchronize();
    return Success();
 }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/Copilot.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/Copilot.java
@@ -39,6 +39,7 @@ import org.rstudio.studio.client.workbench.commands.Commands;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotConstants;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotEvent;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotEvent.CopilotEventType;
+import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotInstallAgentResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignInResponse;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotResponseTypes.CopilotSignInResponseResult;
@@ -430,7 +431,36 @@ public class Copilot implements ProjectOptionsChangedEvent.Handler
          @Override
          protected void onSuccess(CopilotStatusResponse response)
          {
-            if (response.result.status == CopilotConstants.STATUS_NOT_SIGNED_IN)
+            if (response == null)
+            {
+               display_.showMessage(
+                     MessageDisplay.MSG_INFO,
+                     "GitHub Copilot: Check Status",
+                     "RStudio received an unexpected empty response from the GitHub Copilot agent.");
+               
+            }
+            else if (response.error != null)
+            {
+               String message = StringUtil.join(new String[] {
+                     "An error occurred while starting the GitHub Copilot agent.",
+                     "Error: " + response.error.getEndUserMessage(),
+                     "Output: " + response.output
+               }, "\n\n");
+               
+               display_.showMessage(
+                     MessageDisplay.MSG_INFO,
+                     "GitHub Copilot: Check Status",
+                     message);
+            }
+            else if (response.reason != null)
+            {
+               int reason = (int) response.reason.valueOf();
+               display_.showMessage(
+                     MessageDisplay.MSG_INFO,
+                     "GitHub Copilot: Check Status",
+                     CopilotResponseTypes.CopilotAgentNotRunningReason.reasonToString(reason));
+            }
+            else if (response.result.status == CopilotConstants.STATUS_NOT_SIGNED_IN)
             {
                display_.showMessage(
                      MessageDisplay.MSG_INFO,

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/model/CopilotResponseTypes.java
@@ -18,6 +18,7 @@ import org.rstudio.core.client.jsonrpc.RpcError;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotCompletion;
 import org.rstudio.studio.client.workbench.copilot.model.CopilotTypes.CopilotResponse;
 
+import elemental2.core.JsNumber;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.JsArrayLike;
@@ -27,6 +28,50 @@ import jsinterop.base.JsArrayLike;
 // Class names should match method names from CopilotServerOperations.java.
 public class CopilotResponseTypes
 {
+   // This is extra metadata added by us; not part of typical Copilot return values.
+   // Used to communicate to the user why the Copilot Agent might not be running.
+   public static class CopilotAgentNotRunningReason
+   {
+      public static String reasonToString(int reason)
+      {
+         if (reason == Unknown)
+         {
+            return "An unknown error occurred.";
+         }
+         else if (reason == NotInstalled)
+         {
+            return "The GitHub Copilot agent is not installed.";
+         }
+         else if (reason == DisabledByAdministrator)
+         {
+            return "GitHub Copilot has been disabled by the system administrator.";
+         }
+         else if (reason == DisabledViaProjectPreferences)
+         {
+            return "GitHub Copilot has been disabled via project preferences.";
+         }
+         else if (reason == DisabledViaGlobalOptions)
+         {
+            return "GitHub Copilot has been disabled via global options.";
+         }
+         else if (reason == LaunchError)
+         {
+            return "An error occurred while attempting to launch GitHub Copilot.";
+         }
+         else
+         {
+            return "<unknown>";
+         }
+      }
+      
+      public static int Unknown = 0;
+      public static int NotInstalled = 1;
+      public static int DisabledByAdministrator = 2;
+      public static int DisabledViaProjectPreferences = 3;
+      public static int DisabledViaGlobalOptions = 4;
+      public static int LaunchError = 5;
+   }
+   
    @JsType(isNative = true, namespace = JsPackage.GLOBAL, name = "Object")
    public static class CopilotResponseMetadata
    {
@@ -90,7 +135,8 @@ public class CopilotResponseTypes
       public CopilotStatusResponseResult result;
       
       // These aren't part of a normal Copilot status request; we append
-      // this extra information to help report agent startup errors.
+      // this extra information to help report agent launch errors.
+      public JsNumber reason;
       public RpcError error;
       public String output;
    }


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13929.

### Approach

Now, when we synchronize the status of the Copilot agent, we also record the reason why it's not enabled (or not running), and use this when status is queried.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13929.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
