### PR TITLE
improve check for compact / ALTREP row names in dataframe

### DIFF
--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -118,6 +118,14 @@ private:
    int& counter_;
 };
 
+bool isCompactRowNames(SEXP rowNamesInfoSEXP)
+{
+   return
+         TYPEOF(rowNamesInfoSEXP) == INTSXP &&
+         Rf_length(rowNamesInfoSEXP) == 2 &&
+         INTEGER(rowNamesInfoSEXP)[0] == NA_INTEGER;
+}
+
 bool isGlobalEnvironmentSerializable()
 {
    bool serializable = false;
@@ -437,14 +445,13 @@ SEXP rs_dim(SEXP objectSEXP)
          return R_NilValue;
       }
       
-      // Detect compact row names
-      if (TYPEOF(rowNamesInfoSEXP) == INTSXP && LENGTH(rowNamesInfoSEXP) == 2)
+      if (isAltrep(rowNamesInfoSEXP))
       {
-         // Use INTEGER_OR_NULL to allow for ALTREP vectors
-         // https://github.com/rstudio/rstudio/pull/13544
-         const int* data = INTEGER_OR_NULL(rowNamesInfoSEXP);
-         if (data != nullptr && data[0] == NA_INTEGER)
-            numRows = abs(data[1]);
+         numRows = Rf_length(rowNamesInfoSEXP);
+      }
+      else if (isCompactRowNames(rowNamesInfoSEXP))
+      {
+         numRows = INTEGER(rowNamesInfoSEXP)[1];
       }
       else
       {

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -122,7 +122,7 @@ bool isCompactRowNames(SEXP rowNamesInfoSEXP)
 {
    return
          TYPEOF(rowNamesInfoSEXP) == INTSXP &&
-         Rf_length(rowNamesInfoSEXP) == 2 &&
+         r::sexp::length(rowNamesInfoSEXP) == 2 &&
          INTEGER(rowNamesInfoSEXP)[0] == NA_INTEGER;
 }
 
@@ -445,17 +445,43 @@ SEXP rs_dim(SEXP objectSEXP)
          return R_NilValue;
       }
       
+      // Avoid materializing certain ALTREP representations.
+      //
+      // https://github.com/rstudio/rstudio/issues/13907
+      // https://github.com/rstudio/rstudio/pull/13544
+      bool canComputeRows = true;
       if (isAltrep(rowNamesInfoSEXP))
       {
-         numRows = Rf_length(rowNamesInfoSEXP);
+         // This code makes use of some internal details about ALTREP class metadata.
+         // In particular, for an ALTREP object, the class information is stored as
+         // a raw vector as a TAG on the associated object. The attributes of that
+         // class give some metadata information about the ALTREP class.
+         //
+         // https://github.com/wch/r-source/blob/e26e3f02a5e4255c4aad0842a46e141c03eed379/src/main/altrep.c#L38-L42
+         //
+         // The second entry in the table is the name of the package providing the
+         // ALTREP class definition, as a symbol.
+         SEXP altrepClassSEXP = TAG(rowNamesInfoSEXP);
+         SEXP altrepAttribSEXP = ATTRIB(altrepClassSEXP);
+         if (TYPEOF(altrepAttribSEXP) == LISTSXP && r::sexp::length(altrepAttribSEXP) >= 2)
+         {
+            SEXP packageSEXP = CADR(altrepAttribSEXP);
+            if (packageSEXP == Rf_install("duckdb"))
+               canComputeRows = false;
+         }
       }
-      else if (isCompactRowNames(rowNamesInfoSEXP))
+      
+      // Detect compact row names.
+      if (canComputeRows)
       {
-         numRows = INTEGER(rowNamesInfoSEXP)[1];
-      }
-      else
-      {
-         numRows = Rf_length(rowNamesInfoSEXP);
+         if (isCompactRowNames(rowNamesInfoSEXP))
+         {
+            numRows = abs(INTEGER(rowNamesInfoSEXP)[1]);
+         }
+         else
+         {
+            numRows = r::sexp::length(rowNamesInfoSEXP);
+         }
       }
       
       SEXP resultSEXP = Rf_allocVector(INTSXP, 2);
@@ -465,7 +491,6 @@ SEXP rs_dim(SEXP objectSEXP)
    }
    
    // Otherwise, just call 'dim()' directly
-   
    r::sexp::Protect protect;
    SEXP dimSEXP = R_NilValue;
    Error error = r::exec::RFunction("base:::dim")


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13907.

### Approach

Limit the check for compact row names to `duckdb` data frames, by poking at the internal ALTREP class details.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13907.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
