### PR TITLE
install shortcut correctly so it will uninstall

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,7 @@
 - Fixed an issue where console output could be dropped when rendering large ANSI links. (#13869)
 - Fixed an issue preventing users from copying code from the History pane. (#3219)
 - Fixed WSL terminals not starting on RStudio Desktop for Windows. (#13918)
+- Fixed Windows installer to delete Start Menu shortcut during uninstall (#13936)
 - Fixed an issue that prevented users from opening files and vignettes with non-ASCII characters in their paths. (#13886)
 
 #### Posit Workbench

--- a/package/win32/CMakeLists.txt
+++ b/package/win32/CMakeLists.txt
@@ -26,14 +26,13 @@ string(REPLACE "+" "-" CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}")
 
 if(RSTUDIO_ELECTRON)
    set(CPACK_NSIS_INSTALLED_ICON_NAME "rstudio.exe")
+   set(CPACK_NSIS_EXECUTABLES_DIRECTORY ".")
 else()
    set(CPACK_NSIS_INSTALLED_ICON_NAME "bin\\\\rstudio.exe")
 endif()
 
 set(CPACK_PACKAGE_INSTALL_REGISTRY_KEY "RStudio")
-if(NOT RSTUDIO_ELECTRON)
-   set(CPACK_PACKAGE_EXECUTABLES "rstudio" "RStudio")
-endif()
+set(CPACK_PACKAGE_EXECUTABLES "rstudio" "RStudio")
 set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY 0)
 
 # To keep pathnames from getting too long, use a temp directory

--- a/package/win32/cmake/modules/NSIS.template.in.electron
+++ b/package/win32/cmake/modules/NSIS.template.in.electron
@@ -750,7 +750,6 @@ Section "-Core installation"
   CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER"
 @CPACK_NSIS_CREATE_ICONS@
 @CPACK_NSIS_CREATE_ICONS_EXTRA@
-  CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\RStudio.lnk" "$INSTDIR\RStudio.exe"
   CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
   
   ;


### PR DESCRIPTION
# For Chocolate Cosmos; don't merge until we branch Ocean Storm for release.

### Intent

Addresses #13936

When I tweaked our NSIS template to adjust for Electron having RStudio.exe in the root of the install folder (instead of in a bin subfolder), I didn't do it correctly. I directly created the RStudio shortcut on install instead of letting `CPACK_NSIS_CREATE_ICONS` handle it and didn't add an accompanying uninstall command.

### Approach

Use the correct cmake/nsis magic incantations to install the shortcut correctly (and now it also uninstalls, which then allows the entire start menu "rstudio" folder to be deleted).

### Automated Tests

N/A

### QA Notes

Test on Windows:

- install RStudio
- confirm RStudio is in the Windows Start Menu (in the UI and/or by looking at `C:\programdata\microsoft\windows\Start Menu\Programs\RStudio`
- confirm you can start RStudio with that icon
- uninstall RStudio
- confirm the `C:\programdata\microsoft\windows\Start Menu\Programs\RStudio` folder is gone (and thus it is gone from the Start Menu)

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


