### PR TITLE
fix handling of closing delimiter in raw strings

### DIFF
--- a/src/cpp/core/r_util/RTokenizer.cpp
+++ b/src/cpp/core/r_util/RTokenizer.cpp
@@ -326,15 +326,17 @@ Error RTokenizer::matchRawStringLiteral(RToken* pToken)
       // consume hyphens
       for (int i = 0; i < hyphenCount; i++)
       {
-         ch = eat();
+         ch = peek();
          if (ch != L'-')
             goto LOOP;
+         ++pos_;
       }
       
       // consume quote character
-      ch = eat();
+      ch = peek();
       if (ch != quoteChar)
          goto LOOP;
+      ++pos_;
       
       // we're at the end of the string; break out of the loop
       valid = true;

--- a/src/cpp/session/modules/SessionDiagnosticsTests.cpp
+++ b/src/cpp/session/modules/SessionDiagnosticsTests.cpp
@@ -298,6 +298,8 @@ test_context("Diagnostics")
       
       EXPECT_NO_LINT("apples <- 42; glue(\"{apples} and {bananas}\", bananas = 24)");
       EXPECT_NO_LINT("mtcars %>% stats::lm(mpg ~ cyl, data = .)");
+      
+      EXPECT_NO_LINT("r'())'");
    }
    
    test_that("RStudio files can be successfully linted")


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13157.

### Approach

When parsing the closing delimiter for a raw string, we need to be able to restart parsing in case we fail to parse in the middle of the stream of characters marking the end of the raw string.

### Automated Tests

Included.

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
