### PR TITLE
tweak behavior of enter in YAML chunk options

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetQuartoHelper.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/source/editors/text/TextEditingTargetQuartoHelper.java
@@ -15,6 +15,7 @@
 package org.rstudio.studio.client.workbench.views.source.editors.text;
 
 
+import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.command.KeyboardShortcut;
 import org.rstudio.core.client.regex.Match;
 import org.rstudio.core.client.regex.Pattern;
@@ -113,21 +114,31 @@ public class TextEditingTargetQuartoHelper
       // line is blank other than the comment prefix, remove that
       // prefix and insert a newline (terminating the block)
       {
-         Pattern pattern = Pattern.create("^\\s*#\\s*[|]\\s*$", "");
-         Match match = pattern.match(line, 0);
-         if (match != null)
+         String currentLine = docDisplay.getCurrentLine();
+         if (StringUtil.equals(currentLine.trim(), line.trim()))
          {
-            Position cursorPos = docDisplay.getCursorPosition();
-            Range range = Range.create(
-                  cursorPos.getRow(), 0,
-                  cursorPos.getRow() + 1, 0);
-            
-            event.stopPropagation();
-            event.preventDefault();
-            docDisplay.replaceRange(range, "\n\n");
-            docDisplay.moveCursorBackward();
-            docDisplay.ensureCursorVisible();
-            return true;
+            Pattern pattern = Pattern.create("^\\s*#\\s*[|]\\s*$", "");
+            Match match = pattern.match(currentLine, 0);
+            if (match != null)
+            {
+               String nextLine = docDisplay.getLine(docDisplay.getCursorRow() + 1);
+               pattern = Pattern.create("^\\s*#\\s*[|]", "");
+               match = pattern.match(nextLine, 0);
+               if (match == null)
+               {
+                  Position cursorPos = docDisplay.getCursorPosition();
+                  Range range = Range.create(
+                        cursorPos.getRow(), 0,
+                        cursorPos.getRow() + 1, 0);
+
+                  event.stopPropagation();
+                  event.preventDefault();
+                  docDisplay.replaceRange(range, "\n\n");
+                  docDisplay.moveCursorBackward();
+                  docDisplay.ensureCursorVisible();
+                  return true;
+               }
+            }
          }
       }
       


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12968.

### Approach

We have some code logic that tries to determine if we can terminate a YAML chunk block after the user presses Enter. This PR tightens up that logic, so that we only do this in more specific circumstances.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/12968.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
