### PR TITLE
allow for custom copilot agent helper script

### DIFF
--- a/src/cpp/session/include/session/SessionOptions.gen.hpp
+++ b/src/cpp/session/include/session/SessionOptions.gen.hpp
@@ -377,8 +377,8 @@ protected:
       ("external-node-path",
       value<std::string>(&nodePath_)->default_value(kDefaultNodePath),
       "Specifies the path to node binaries.")
-      ("external-copilot-path",
-      value<std::string>(&copilotPath_)->default_value(std::string()),
+      ("external-copilot-agent-path",
+      value<std::string>(&copilotAgentPath_)->default_value(std::string()),
       "Specifies the path to the GitHub Copilot agent.")
       ("external-libclang-path",
       value<std::string>(&libclangPath_)->default_value(kDefaultRsclangPath),
@@ -424,7 +424,10 @@ protected:
       "The URL to the authentication provider to be used by GitHub Copilot.")
       ("copilot-proxy-strict-ssl",
       value<bool>(&copilotProxyStrictSsl_)->default_value(true),
-      "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?");
+      "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?")
+      ("copilot-agent-helper",
+      value<std::string>(&copilotAgentHelper_)->default_value(std::string()),
+      "The path to an optional shell script, which when invoked, should start the GitHub Copilot agent.");
 
    pMisc->add_options();
 
@@ -531,7 +534,7 @@ public:
    core::FilePath pandocPath() const { return core::FilePath(pandocPath_); }
    core::FilePath quartoPath() const { return core::FilePath(quartoPath_); }
    core::FilePath nodePath() const { return core::FilePath(nodePath_); }
-   core::FilePath copilotPath() const { return core::FilePath(copilotPath_); }
+   core::FilePath copilotAgentPath() const { return core::FilePath(copilotAgentPath_); }
    core::FilePath libclangPath() const { return core::FilePath(libclangPath_); }
    core::FilePath libclangHeadersPath() const { return core::FilePath(libclangHeadersPath_); }
    core::FilePath winptyPath() const { return core::FilePath(winptyPath_); }
@@ -543,6 +546,7 @@ public:
    std::string copilotProxyUrl() const { return copilotProxyUrl_; }
    std::string copilotAuthProvider() const { return copilotAuthProvider_; }
    bool copilotProxyStrictSsl() const { return copilotProxyStrictSsl_; }
+   core::FilePath copilotAgentHelper() const { return core::FilePath(copilotAgentHelper_); }
 
 
 protected:
@@ -642,7 +646,7 @@ protected:
    std::string pandocPath_;
    std::string quartoPath_;
    std::string nodePath_;
-   std::string copilotPath_;
+   std::string copilotAgentPath_;
    std::string libclangPath_;
    std::string libclangHeadersPath_;
    std::string winptyPath_;
@@ -656,6 +660,7 @@ protected:
    std::string copilotProxyUrl_;
    std::string copilotAuthProvider_;
    bool copilotProxyStrictSsl_;
+   std::string copilotAgentHelper_;
    virtual bool allowOverlay() const { return false; };
 };
 

--- a/src/cpp/session/session-options.json
+++ b/src/cpp/session/session-options.json
@@ -732,9 +732,9 @@
             "description": "Specifies the path to node binaries."
          },
          {
-            "name": "external-copilot-path",
+            "name": "external-copilot-agent-path",
             "type": "core::FilePath",
-            "memberName": "copilotPath_",
+            "memberName": "copilotAgentPath_",
             "description": "Specifies the path to the GitHub Copilot agent."
          },
          {
@@ -846,7 +846,14 @@
             "memberName": "copilotProxyStrictSsl_",
             "defaultValue": true,
             "description": "Should the GitHub Copilot agent perform SSL certificate validation when forming web requests?"
+         },
+         {
+            "name": "copilot-agent-helper",
+            "type": "core::FilePath",
+            "memberName": "copilotAgentHelper_",
+            "description": "The path to an optional shell script, which when invoked, should start the GitHub Copilot agent."
          }
+
       ],
       "misc": [
          


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13823.

### Approach

This PR adds the session option `copilot-agent-helper`, which can be set by the administrator to a custom shell script. That shell script is then responsible for running Copilot, but can also perform other tests or diagnostics before running Copilot.

### Automated Tests

N/A

### QA Notes

N/A

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
