### PR TITLE
Update connection pane deduplication for Posit drivers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 - Better error message when user preferences fail to save due to folder permissions. (#12974)
 - Update Electon Forge to 6.4.2 and Webpack to 5.89.0. (rstudio-pro#5383)
 - RStudio now supports pasting of file paths for files copied to the clipboard. (#4572)
+- RStudio now supports duplicate connection names for Posit drivers. (rstudio-pro#5437)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -531,7 +531,7 @@ options(
    tryCatch({
       currentDriver <- drivers[drivers$attribute == "Driver" & drivers$name == driver, ]$value
       driverInstaller <- drivers[drivers$attribute == "Installer" & drivers$name == driver, ]$value
-      driverId <- gsub(.rs.connectionOdbcRStudioDriver(), "", driver)
+      driverId <- .rs.connectionStripRStudioDriver(driver)
 
       # Instead of assuming the location of the snippets directory, we instead
       # walk up the directory tree to find the snippets directory
@@ -832,6 +832,7 @@ options(
 })
 
 .rs.addJsonRpcHandler("get_new_odbc_connection_context", function(name, retries = 1) {
+   name <- .rs.connectionStripRStudioDriver(name)
    singleEntryFilter <- function(e) {
       identical(as.character(e$name), name)
    }
@@ -937,7 +938,7 @@ options(
    connectionContext <- Filter(function(e) {
       identical(
          as.character(e$name),
-         gsub(.rs.connectionOdbcRStudioDriver(), "", driverName)
+         .rs.connectionStripRStudioDriver(driverName)
       )
    }, .rs.connectionReadInstallers())[[1]]
 
@@ -992,6 +993,7 @@ options(
 
 .rs.addJsonRpcHandler("uninstall_odbc_driver", function(driverName) {
    tryCatch({
+      driverName <- .rs.connectionStripRStudioDriver(driverName)
       defaultInstallPath <- file.path(.rs.connectionOdbcInstallPath(), tolower(driverName))
       defaultInstallExists <- dir.exists(defaultInstallPath)
 

--- a/src/cpp/session/modules/SessionConnections.R
+++ b/src/cpp/session/modules/SessionConnections.R
@@ -703,7 +703,7 @@ options(
 
             snippet <- paste(
                "library(DBI)\n",
-               "con <- dbConnect(odbc::odbc(), \"${1:Data Source Name=", 
+               "con <- dbConnect(odbc::odbc(), dsn=\"${1:Data Source Name=",
                dataSource$name,
                "}\", timeout = 10)",
                sep = "")

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -516,7 +516,7 @@
    )
    
    osExtension <- osExtensions[[.rs.odbcBundleOsName()]]
-   driverName <- gsub(paste(" |", trimws(.rs.connectionOdbcRStudioDriver()), sep = ""), "", name)
+   driverName <- .rs.connectionStripRStudioDriver(name)
    
    if (is.null(libraryPattern) || nchar(libraryPattern) == 0) {
       libraryPattern <- paste(
@@ -573,6 +573,7 @@
    md5 = NULL,
    version = "") {
 
+   name <- .rs.connectionStripRStudioDriver(name)
    installPath <- file.path(
       normalizePath(installPath, mustWork = FALSE),
       tolower(name)
@@ -612,4 +613,8 @@
 
 .rs.addFunction("connectionOdbcRStudioDriver", function() {
    " with Posit Driver"
+})
+
+.rs.addFunction("connectionStripRStudioDriver", function(connection) {
+   gsub(paste(" |", trimws(.rs.connectionOdbcRStudioDriver()), sep = ""), "", connection)
 })

--- a/src/cpp/session/modules/SessionConnectionsInstaller.R
+++ b/src/cpp/session/modules/SessionConnectionsInstaller.R
@@ -611,5 +611,5 @@
 })
 
 .rs.addFunction("connectionOdbcRStudioDriver", function() {
-   " with RStudio Driver"
+   " with Posit Driver"
 })


### PR DESCRIPTION
### Intent

The connection pane allows for drivers with a duplicate name to be listed as a duplicate with the suffix of ` with RStudio Drivers`.

Currently duplicates are only allowed if the ODBC installation entries that have `Installer = RStudio`, which is set during the installation of drivers through Desktop Pro.

This change will allow duplicates to be listed with the following entries for `Installer`:
- `RStudio Pro Drivers`
- `Posit Pro Drivers`

### Approach

- Change connection pane suffix to "with Posit Driver"
- Allow duplicate connection pane entries from pro drivers
- Find connection snippet by walking the directory
    The original logic for determining the R snippet path was quite fragile.
    We now walk up the directory tree from driver library until we find the `snippets` directory instead of using a simple regex

- Add `dsn=` to connection snippet from DSNs
    Make the Connection snippet explicit that the second argument is the DSN

- Set path of desktop driver install to match original name
    In cases where the driver name is a duplicate of a previous entry, Desktop Pro would include the `with posit driver` in the directory path
    Installation and uninstallation now only include the original driver name in the path

### Automated Tests

A test was added to [test-connections.R](https://github.com/rstudio/rstudio/commits/main/src/cpp/tests/testthat/test-connections.R) for `.rs.connectionListFilter`

### QA Notes

The easiest way to test this is to add a few placeholder entries in `/etc/odbc.ini` that will then be listed by DSN entries.

```ini
[Athena]
Driver = /my/fake/path

[MySQL]
Driver = /another/fake/path

[PostgreSQL]
Driver = /try/this/path

[Snowflake]
Driver = /yet/another/path
```

#### Test on Workbench

1. Install the Pro Drivers
2. Add the above entries to `/etc/odbc.ini` (on Linux)
3. Start Workbench and open the Connections Pane

Expected result:
* Two entries in the list for every driver that was included in `/etc/odbc.ini`
* The second entry will have ` with Posit Driver` appended to it

#### Test on Desktop Pro

1. Add the above entries to the appropriate `SYSTEM DATA SOURCES` from `odbcinst -j`
2. Start Desktop Pro and open the Connections Pane
3. Install one or more of the drivers that have `with Posit Driver` included in the title

Expected result:
* Two entries in the list for every driver that was included in `/etc/odbc.ini`
* The second entry will have ` with Posit Driver` appended to it
* The installation path of the driver only includes the base name of the driver
* The driver can successfully be installed and uninstalled

### Documentation

No documentation was added because this is an internal behavior change.

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


