### PR TITLE
Reverse order of test to avoid isDirectory call for each file

### DIFF
--- a/src/cpp/core/r_util/RProjectFile.cpp
+++ b/src/cpp/core/r_util/RProjectFile.cpp
@@ -1332,7 +1332,7 @@ FilePath projectFromDirectory(const FilePath& path)
         it != children.end();
         ++it)
    {
-      if (!it->isDirectory() && (it->getExtensionLowerCase() == ".rproj"))
+      if ((it->getExtensionLowerCase() == ".rproj") && !it->isDirectory())
       {
          if (string_utils::toLower(it->getFilename()) == projFileLower)
             return *it;


### PR DESCRIPTION

### Intent

Reviewed in PR: https://github.com/rstudio/rstudio-pro/pull/5456

### Approach

- For large directories over nfs, this is a major speedup

