### PR TITLE
Remove unnecessary exists() test in FilePath.isDirectory()

### DIFF
--- a/src/cpp/shared_core/FilePath.cpp
+++ b/src/cpp/shared_core/FilePath.cpp
@@ -1198,16 +1198,12 @@ bool FilePath::isDirectory() const
 {
    try
    {
-      if (!exists())
-         return false;
-      else
-      {
-         return boost::filesystem::is_directory(m_impl->Path)
+      boost::system::error_code ec;
+      return boost::filesystem::is_directory(m_impl->Path, ec);
 #ifdef _WIN32
-            || isJunction()
+         || isJunction()
 #endif
-            ;
-      }
+         ;
    }
    catch(const boost::filesystem::filesystem_error& e)
    {


### PR DESCRIPTION
Not a high priority but I've seen these 2X stat() calls in straces for a while. This seems like a safe change to me that could lower some electricity bills :)

### Intent

Addresses https://github.com/rstudio/rstudio/issues/13969

### Approach

Use error code variant of is_directory to avoid the exception that the exists() tests was likely introduced to avoid.  I left the try/catch there in the unlikely event some exceptions are still thrown.

### Automated Tests

This api is used all over, and there's a basic unit test. 

### QA Notes

No manual testing required

