### PR TITLE
use cache when tracking if objects in global environment can be serialized

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -50,6 +50,7 @@
 - Fixed an issue preventing users from copying code from the History pane. (#3219)
 - Fixed WSL terminals not starting on RStudio Desktop for Windows. (#13918)
 - Fixed an issue that prevented users from opening files and vignettes with non-ASCII characters in their paths. (#13886)
+- Fixed an issue where large, heavily-nested objects could slow down code execution in the R session. (#13965)
 
 #### Posit Workbench
 - Fixed opening job details in new windows more than once for Workbench jobs on the homepage. (rstudio/rstudio-pro#5179)

--- a/src/cpp/core/LoggingTests.cpp
+++ b/src/cpp/core/LoggingTests.cpp
@@ -676,7 +676,7 @@ test_context("Logging")
       boost::replace_all(logFileContents, "INFO", "DEBUG");
       LOG_PASSTHROUGH_MESSAGE("mysource", logFileContents);
 
-      logFileContents.empty();
+      (void) logFileContents.empty();
       REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
       REQUIRE(logFileContents.find("DEBUG") == std::string::npos);
 
@@ -685,7 +685,7 @@ test_context("Logging")
       boost::replace_all(logFileContents, "[logging-tests-" + id + "]", "[subproc]");
       LOG_PASSTHROUGH_MESSAGE("mysource", logFileContents);
 
-      logFileContents.empty();
+      (void) logFileContents.empty();
       REQUIRE_FALSE(core::readStringFromFile(logFile, &logFileContents));
 
       REQUIRE(logFileContents.find("WARNING") != std::string::npos);

--- a/src/cpp/r/include/r/RHelpers.hpp
+++ b/src/cpp/r/include/r/RHelpers.hpp
@@ -102,7 +102,7 @@ bool recursiveFindImpl(SEXP valueSEXP,
       
       break;
    }
-      
+
    case VECSXP:
    {
       R_xlen_t n = Rf_xlength(valueSEXP);

--- a/src/cpp/r/include/r/RHelpers.hpp
+++ b/src/cpp/r/include/r/RHelpers.hpp
@@ -1,0 +1,104 @@
+/*
+ * RHelpers.hpp
+ *
+ * Copyright (C) 2023 by Posit Software, PBC
+ *
+ * Unless you have received this program directly from Posit Software pursuant
+ * to the terms of a commercial license agreement with Posit Software, then
+ * this program is licensed to you under the terms of version 3 of the
+ * GNU Affero General Public License. This program is distributed WITHOUT
+ * ANY EXPRESS OR IMPLIED WARRANTY, INCLUDING THOSE OF NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Please refer to the
+ * AGPL (http://www.gnu.org/licenses/agpl-3.0.txt) for more details.
+ *
+ */
+
+#ifndef R_HELPERS_HPP
+#define R_HELPERS_HPP
+
+#include <utility>
+
+#define R_INTERNAL_FUNCTIONS
+#include <r/RInternal.hpp>
+
+namespace rstudio {
+namespace r {
+
+template <typename F>
+bool recursiveFind(SEXP valueSEXP, F&& callback)
+{
+   // Apply result to value.
+   if (callback(valueSEXP))
+      return true;
+   
+   // Recurse into other values.
+   switch (TYPEOF(valueSEXP))
+   {
+   
+   case ENVSXP:
+   {
+      SEXP hashTableSEXP = HASHTAB(valueSEXP);
+      if (hashTableSEXP != R_NilValue)
+      {
+         R_xlen_t numCells = Rf_xlength(hashTableSEXP);
+         for (R_xlen_t i = 0; i < numCells; i++)
+         {
+            SEXP frameSEXP = VECTOR_ELT(hashTableSEXP, i);
+            for (; frameSEXP != R_NilValue; frameSEXP = CDR(frameSEXP))
+            {
+               SEXP elSEXP = CAR(frameSEXP);
+               if (recursiveFind(elSEXP, std::forward<F>(callback)))
+                  return true;
+            }
+         }
+      }
+      else
+      {
+         SEXP frameSEXP = FRAME(valueSEXP);
+         for (; frameSEXP != R_NilValue; frameSEXP = CDR(frameSEXP))
+         {
+            SEXP elSEXP = CAR(frameSEXP);
+            if (recursiveFind(elSEXP, std::forward<F>(callback)))
+               return true;
+         }
+      }
+      
+      break;
+   }
+      
+   case VECSXP:
+   {
+      R_xlen_t n = Rf_xlength(valueSEXP);
+      for (R_xlen_t i = 0; i < n; i++)
+      {
+         SEXP elSEXP = VECTOR_ELT(valueSEXP, i);
+         if (recursiveFind(elSEXP, std::forward<F>(callback)))
+            return true;
+      }
+      
+      break;
+   }
+      
+   case LISTSXP:
+   case LANGSXP:
+   {
+      for (; valueSEXP != R_NilValue; valueSEXP = CDR(valueSEXP))
+      {
+         SEXP elSEXP = CAR(valueSEXP);
+         if (recursiveFind(elSEXP, std::forward<F>(callback)))
+            return true;
+      }
+      
+      break;
+   }
+      
+   } // switch (TYPEOF(valueSEXP))
+   
+   return false;
+}
+
+} // end namespace r
+} // end namespace rstudio
+
+#endif /* R_HELPERS_HPP */
+

--- a/src/cpp/r/include/r/RHelpers.hpp
+++ b/src/cpp/r/include/r/RHelpers.hpp
@@ -36,6 +36,11 @@ inline bool isImmediateBinding(SEXP frameSEXP)
 }
 
 template <typename F>
+bool recursiveFindImpl(SEXP valueSEXP,
+                       std::set<SEXP>& visitedEnvironments,
+                       F&& callback);
+
+template <typename F>
 bool recursiveFindFrame(SEXP frameSEXP,
                         std::set<SEXP>& visitedEnvironments,
                         F&& callback)

--- a/src/cpp/session/modules/SessionRUtil.R
+++ b/src/cpp/session/modules/SessionRUtil.R
@@ -201,3 +201,8 @@
 {
    .Call("rs_utf8ToSystem", as.character(text), PACKAGE = "(embedding)")
 })
+
+.rs.addFunction("isSerializable", function(object)
+{
+   .Call("rs_isSerializable", object, PACKAGE = "(embedding)")
+})

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -167,15 +167,15 @@ bool isSerializableImpl(SEXP valueSEXP)
    if (valueSEXP == R_BaseEnv || valueSEXP == R_BaseNamespace)
       return true;
    
-   // Assume package environments + namespaces can be serialized.
    if (TYPEOF(valueSEXP) == ENVSXP)
    {
+      // Assume package environments + namespaces can be serialized.
       if (R_IsNamespaceEnv(valueSEXP) || R_IsPackageEnv(valueSEXP))
          return true;
    }
    
    // Check for 'known-safe' object classes.
-   auto safeClasses = { "data.frame", "igraph" };
+   auto safeClasses = { "data.frame", "grf", "igraph" };
    for (auto&& safeClass : safeClasses)
       if (Rf_inherits(valueSEXP, safeClass))
          return true;

--- a/src/cpp/session/modules/environment/SessionEnvironment.cpp
+++ b/src/cpp/session/modules/environment/SessionEnvironment.cpp
@@ -18,11 +18,14 @@
 
 #include <algorithm>
 
+#include <boost/container/flat_map.hpp>
+
 #include <core/Exec.hpp>
 #include <core/RecursionGuard.hpp>
 #include <core/system/LibraryLoader.hpp>
 
 #define INTERNAL_R_FUNCTIONS
+#include <r/RHelpers.hpp>
 #include <r/RJson.hpp>
 #include <r/RSexp.hpp>
 #include <r/RExec.hpp>
@@ -55,6 +58,8 @@ namespace session {
 namespace modules { 
 namespace environment {
 
+namespace {
+
 // which language is currently active on the front-end? this state is
 // synchronized between client and server so that we can tell when to
 // active environment monitors for different languages
@@ -81,7 +86,9 @@ bool s_monitoring = true;
 // whether or not the global environment can safely be serialized
 bool s_isGlobalEnvironmentSerializable = true;
 
-namespace {
+// whether or not particular objects can be safely serialized
+using SerializationCache = boost::container::flat_map<SEXP, bool>;
+SerializationCache s_serializationCache;
 
 // by default, use regular 'INTEGER' accessor; 'INTEGER_OR_NULL' will be loaded
 // if provided by this version of R
@@ -126,17 +133,112 @@ bool isCompactRowNames(SEXP rowNamesInfoSEXP)
          INTEGER(rowNamesInfoSEXP)[0] == NA_INTEGER;
 }
 
+bool isSerializableImpl(SEXP valueSEXP)
+{
+   // Check for SEXP types that we know can be safely serialized.
+   switch (TYPEOF(valueSEXP))
+   {
+   
+   // Assume that promises can be safely serialized.
+   // (We just want to avoid evaluating them here.)
+   case PROMSXP:
+      return true;
+      
+   // Assume that functions can be serialized.
+   // Technically, a function's closure _could_ contain arbitrary objects,
+   // which might not be serializable, but that should be exceedingly rare.
+   case CLOSXP:
+      return true;
+      
+   }
+   
+   // Check for SEXP types that we know cannot be safely serialized.
+   switch (TYPEOF(valueSEXP))
+   {
+   
+   // External pointers and weak references cannot be serialized.
+   case EXTPTRSXP:
+   case WEAKREFSXP:
+      return false;
+      
+   }
+   
+   // Assume base environments can be serialized.
+   if (valueSEXP == R_BaseEnv || valueSEXP == R_BaseNamespace)
+      return true;
+   
+   // Assume package environments + namespaces can be serialized.
+   if (TYPEOF(valueSEXP) == ENVSXP)
+   {
+      if (R_IsNamespaceEnv(valueSEXP) || R_IsPackageEnv(valueSEXP))
+         return true;
+   }
+   
+   // Check for 'known-safe' object classes.
+   auto safeClasses = { "data.frame", "igraph" };
+   for (auto&& safeClass : safeClasses)
+      if (Rf_inherits(valueSEXP, safeClass))
+         return true;
+   
+   // Check for 'known-unsafe' object classes.
+   auto unsafeClasses = { "ArrowObject", "DBIConnection", "python.builtin.object" };
+   for (auto&& unsafeClass : unsafeClasses)
+      if (Rf_inherits(valueSEXP, unsafeClass))
+         return false;
+   
+   // Assume other objects can be serialized.
+   return true;
+}
+
+bool isSerializable(SEXP valueSEXP)
+{
+   // An object is serializable if it is not, or does not contain, any non-serializable objects.
+   return !r::recursiveFind(valueSEXP, [&](SEXP elSEXP)
+   {
+      return !isSerializableImpl(elSEXP);
+   });
+}
+
 bool isGlobalEnvironmentSerializable()
 {
-   bool serializable = false;
+   // Start building a new cache of serialized object state.
+   SerializationCache newCache;
    
-   Error error =
-         r::exec::RFunction(".rs.environment.isSerializable")
-         .call(&serializable);
-   if (error)
-      LOG_ERROR(error);
+   // Iterate over values in the global environment, and compute whether they can be serialized.
+   SEXP hashTableSEXP = HASHTAB(R_GlobalEnv);
+   R_xlen_t n = Rf_xlength(hashTableSEXP);
+   for (R_xlen_t i = 0; i < n; i++)
+   {
+      SEXP frameSEXP = VECTOR_ELT(hashTableSEXP, i);
+      for (; frameSEXP != R_NilValue; frameSEXP = CDR(frameSEXP))
+      {
+         // Compute whether the value can be serialized.
+         // If we already have a cached value from a prior computation, use it.
+         //
+         // TODO: If an R environment is updated in-place with a value that
+         // makes it no longer serializable, we would fail to detect this.
+         // Is this okay? Or should we avoid caching results for environments?
+         SEXP valueSEXP = CAR(frameSEXP);
+         bool canBeSerialized = s_serializationCache.contains(valueSEXP)
+               ? s_serializationCache.at(valueSEXP)
+               : isSerializable(valueSEXP);
+         newCache[valueSEXP] = canBeSerialized;
+      }
+   }
    
-   return serializable;
+   // Set the new cache.
+   s_serializationCache.clear();
+   s_serializationCache = newCache;
+   
+   // Return true only if all variables in the global environment can be serialized.
+   for (auto&& entry : s_serializationCache)
+   {
+      bool canBeSerialized = entry.second;
+      if (!canBeSerialized)
+         return false;
+   }
+   
+   return true;
 }
 
 bool isValidSrcref(SEXP srcref)
@@ -506,6 +608,12 @@ SEXP rs_newTestExternalPointer(SEXP nullSEXP)
 {
    bool nullPtr = r::sexp::asLogical(nullSEXP);
    return r::sexp::makeExternalPtr(nullPtr ? nullptr : R_EmptyEnv, R_NilValue, R_NilValue);
+}
+
+SEXP rs_isSerializable(SEXP valueSEXP)
+{
+   bool result = isSerializable(valueSEXP);
+   return Rf_ScalarLogical(result);
 }
 
 // Construct a simulated source reference from a context containing a
@@ -1575,6 +1683,7 @@ Error initialize()
    RS_REGISTER_CALL_METHOD(rs_dim);
    RS_REGISTER_CALL_METHOD(rs_dumpContexts);
    RS_REGISTER_CALL_METHOD(rs_newTestExternalPointer);
+   RS_REGISTER_CALL_METHOD(rs_isSerializable);
 
    // subscribe to events
    using boost::bind;

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -277,6 +277,23 @@ test_that(".rs.isSerializable() works as expected", {
    expect_false(.rs.isSerializable(envir))
    
    # test that promises are not evaluated
-   delayedAssign("error", stop("error"), assign.env = envir)
+   value <- FALSE
+   delayedAssign("value", value <<- TRUE, assign.env = envir)
    expect_false(.rs.isSerializable(envir))
+   expect_false(value)
+   
+   # force the promise, just to confirm it does what we expect it to
+   force(envir$value)
+   expect_true(value)
+   
+   # test that active bindings are not evaluated
+   value <- FALSE
+   makeActiveBinding("active", function() value <<- TRUE, env = envir)
+   expect_false(.rs.isSerializable(envir))
+   expect_false(value)
+   
+   # trigger the active binding, just to confirm it does what we expected
+   force(envir$active)
+   expect_true(value)
+   
 })

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -296,4 +296,9 @@ test_that(".rs.isSerializable() works as expected", {
    force(envir$active)
    expect_true(value)
    
+   # for loops create immediate bindings; check that we don't barf when
+   # attempting to scan the environment in such cases
+   for (binding in 1)
+      expect_true(.rs.isSerializable(environment()))
+   
 })

--- a/src/cpp/tests/testthat/test-environment.R
+++ b/src/cpp/tests/testthat/test-environment.R
@@ -278,7 +278,7 @@ test_that(".rs.isSerializable() works as expected", {
    
    # test that promises are not evaluated
    value <- FALSE
-   delayedAssign("value", value <<- TRUE, assign.env = envir)
+   delayedAssign("value", { value <- TRUE }, assign.env = envir)
    expect_false(.rs.isSerializable(envir))
    expect_false(value)
    
@@ -299,6 +299,6 @@ test_that(".rs.isSerializable() works as expected", {
    # for loops create immediate bindings; check that we don't barf when
    # attempting to scan the environment in such cases
    for (binding in 1)
-      expect_true(.rs.isSerializable(environment()))
+      .rs.isSerializable(environment())
    
 })


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/13965.

### Approach

- Move the logic for computing whether an object can be safely serialized into C++ land.
- Cache the results of these computations. The cache is refreshed on each use, so values removed from the global environment are also eagerly removed from the cache.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/13965.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
