### PR TITLE
allow copilot proxy SSL override; tweak output error display

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -530,10 +530,18 @@ void setEditorInfo()
    // check strict ssl flag
    bool proxyStrictSsl = session::options().copilotProxyStrictSsl();
    
+   // allow override from envvar
+   std::string proxyStrictSslOverride = core::system::getenv("COPILOT_PROXY_STRICT_SSL");
+   if (!proxyStrictSslOverride.empty())
+      proxyStrictSsl = core::string_utils::isTruthy(proxyStrictSslOverride, true);
+   
    // check for server-configured proxy URL
    std::string proxyUrl = session::options().copilotProxyUrl();
-   if (proxyUrl.empty())
-      proxyUrl = core::system::getenv("COPILOT_PROXY_URL");
+   
+   // allow override from envvar
+   std::string proxyUrlOverride = core::system::getenv("COPILOT_PROXY_URL");
+   if (!proxyUrlOverride.empty())
+      proxyUrl = proxyUrlOverride;
    
    // if we have one now, try to parse it
    if (!proxyUrl.empty())

--- a/src/gwt/src/org/rstudio/studio/client/workbench/copilot/Copilot.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/copilot/Copilot.java
@@ -452,10 +452,14 @@ public class Copilot implements ProjectOptionsChangedEvent.Handler
             }
             else if (response.error != null)
             {
+               String output = response.output;
+               if (StringUtil.isNullOrEmpty(output))
+                  output = "(no output available)";
+               
                String message = StringUtil.join(new String[] {
                      "An error occurred while starting the GitHub Copilot agent.",
                      "Error: " + response.error.getEndUserMessage(),
-                     "Output: " + response.output
+                     "Output: " + output
                }, "\n\n");
                
                display_.showMessage(


### PR DESCRIPTION
- The environment variable might be necessary for RStudio Desktop users.
- Make it clear when an error occurs but no output was available.