### PR TITLE
Companion commit to add back db password encryption

### DIFF
--- a/src/cpp/server/ServerMain.cpp
+++ b/src/cpp/server/ServerMain.cpp
@@ -93,7 +93,6 @@ Error startup();
 bool reloadConfiguration();
 void shutdown();
 bool requireLocalR();
-bool isLoadBalanced();
 
 } // namespace overlay
 } // namespace server
@@ -737,6 +736,11 @@ int main(int argc, char * const argv[])
       // initialize crypto utils
       core::system::crypto::initialize();
 
+      // initialize secure cookie module
+      error = core::http::secure_cookie::initialize(options.secureCookieKeyFile());
+      if (error)
+         return core::system::exitFailure(error, ERROR_LOCATION);
+
       if (!options.dbCommand().empty())
       {
          Error error = server_core::database::execute(options.databaseConfigFile(), serverUser, options.dbCommand());
@@ -748,11 +752,6 @@ int main(int argc, char * const argv[])
 
       // initialize database connectivity
       error = server_core::database::initialize(options.databaseConfigFile(), true, serverUser);
-      if (error)
-         return core::system::exitFailure(error, ERROR_LOCATION);
-
-      // initialize secure cookie module 
-      error = core::http::secure_cookie::initialize(overlay::isLoadBalanced(), options.secureCookieKeyFile());
       if (error)
          return core::system::exitFailure(error, ERROR_LOCATION);
 


### PR DESCRIPTION
### Intent

Reviewed in: https://github.com/rstudio/rstudio-pro/pull/5553

### Approach

Init the secure cookie key before the database.  Add back the DB code that supported encrypted passwords. 