### PR TITLE
Add quarto version update news

### DIFF
--- a/version/news/NEWS-2023.12.0-ocean-storm.md
+++ b/version/news/NEWS-2023.12.0-ocean-storm.md
@@ -6,7 +6,9 @@
 - Updated Boost to version 1.83.0. (#13577)
 - Updated Electron to version 26.2.4. (#13577)
 - Updated the default version of the GitHub Copilot agent to 1.10.3. (#13729)
-- Update openssl to 1.1.1w on Mac and Windows (#13683)
+- Updated openssl to 1.1.1w on Mac and Windows. (#13683)
+- Updated Electron Forge to 6.4.2 and Webpack to 5.89.0. (rstudio-pro#5383)
+- Updated Quarto to version 1.3.450. (#13914)
 - RStudio now supports highlighting of inline YAML chunk options in R Markdown / Quarto documents. (#11663)
 - Improved support for development documentation when a package has been loaded via `devtools::load_all()`. (#13526)
 - RStudio now supports autocompletion following `@` via `.AtNames`. (#13451)
@@ -15,11 +17,9 @@
 - With screen reader support enabled, hitting ESC key allows Tabbing away from editor. [accessibility] (#13593)
 - RStudio now supports `LuaLaTeX` to compile Sweave/Rnw documents. (#13812)
 - Better error message when user preferences fail to save due to folder permissions. (#12974)
-- Update Electon Forge to 6.4.2 and Webpack to 5.89.0. (rstudio-pro#5383)
 - RStudio now supports pasting of file paths for files copied to the clipboard. (#4572)
 - RStudio now supports duplicate connection names for Posit drivers. (rstudio-pro#5437)
 - Enabled search breadcrumbs in RStudio IDE User Guide. (#13618)
-- Updated Quarto to version 1.3.450. (#13914)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)

--- a/version/news/NEWS-2023.12.0-ocean-storm.md
+++ b/version/news/NEWS-2023.12.0-ocean-storm.md
@@ -19,14 +19,12 @@
 - Better error message when user preferences fail to save due to folder permissions. (#12974)
 - RStudio now supports pasting of file paths for files copied to the clipboard. (#4572)
 - RStudio now supports duplicate connection names for Posit drivers. (rstudio-pro#5437)
-- Enabled search breadcrumbs in RStudio IDE User Guide. (#13618)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)
 - Increased the built-in nginx server's max connection limit, enabled nginx error logging and allow both to be configured (rstudio-pro#4652, rstudio-pro#4747, rstudio-pro#5452)
 - Improved Admin: The Logs tab now allows viewing other server log files. A new Server tab provides real-time performance info and on-the-fly adjustment of the rserver log-level (rstudio-pro#5212)
 - Added requestTime to nginx access logs when rserver.conf's server-access-log=1. Format for rserver-http-access.log has changed to add a request time field useful for seeing how long it takes rserver to respond to requests. WARNING: if you have code that processes the log file, expect a new field.
-- Enabled search breadcrumbs in the Workbench Administration Guide, RStudio Desktop Administration Guide, and Workbench User Guide. (#5088)
 - Replaced Administration Guide section PRO markers with Workbench tags. (#5416)
 - Added Licenses guide that includes open source software components and full copies of license agreements used by the components. (#5027)
 - Restored database password encryption support removed in 2023.09.1 (rstudio-pro#5365)

--- a/version/news/NEWS-2023.12.0-ocean-storm.md
+++ b/version/news/NEWS-2023.12.0-ocean-storm.md
@@ -19,6 +19,7 @@
 - RStudio now supports pasting of file paths for files copied to the clipboard. (#4572)
 - RStudio now supports duplicate connection names for Posit drivers. (rstudio-pro#5437)
 - Enabled search breadcrumbs in RStudio IDE User Guide. (#13618)
+- Updated Quarto to version 1.3.450. (#13914)
 
 #### Posit Workbench
 - Removed link for opening sessions in RStudio Desktop Pro from Session Info dialog. (rstudio-pro#5263)


### PR DESCRIPTION
### Intent

Add news entry for updating quarto to `1.3.450` (#13914).
- see https://github.com/rstudio/rstudio/blob/rel-ocean-storm/dependencies/common/install-quarto

### Approach

- Added news for updating quarto to `1.3.450` 
- Removed docs breadcrumbs related entries which were based on quarto 1.4 (see rstudio/rstudio-pro#5561) -- these docs items were removed in pro, but not open source NEWS
- Grouped dependency version updates to the top of NEWS so it's easier to check dependency changes at a glance