### PR TITLE
Support sign-in for OTP-enabled accounts in SSSD environments

### DIFF
--- a/src/cpp/server/pam/PamMain.cpp
+++ b/src/cpp/server/pam/PamMain.cpp
@@ -95,6 +95,14 @@ int main(int argc, char * const argv[])
       // read password (up to 200 chars in length)
       const int MAXPASS = 200;
       std::string password = string_utils::consumeStdin(string_utils::StdinSingleLine);
+      std::string otp;
+      size_t splitTab = password.find('\t');
+      if (splitTab != std::string::npos)
+      {
+         otp = password.substr(splitTab+1);
+         password = password.substr(0, splitTab);
+      }
+      
       if (password.size() > MAXPASS)
       {
          // would be nice to log some details here but better not to leak any
@@ -106,7 +114,7 @@ int main(int argc, char * const argv[])
 
       // verify password
       core::system::PAM pam(service, false, true, requirePasswordPrompt);
-      if (pam.login(username, password) == PAM_SUCCESS)
+      if (pam.login(username, password, otp) == PAM_SUCCESS)
          return EXIT_SUCCESS;
       else
          return EXIT_FAILURE;

--- a/src/cpp/server_core/include/server_core/system/Pam.hpp
+++ b/src/cpp/server_core/include/server_core/system/Pam.hpp
@@ -55,7 +55,8 @@ public:
    int status() const { return status_; }
 
    virtual int login(const std::string& username,
-                     const std::string& password);
+                     const std::string& password,
+                     const std::string& otp = std::string(""));
 
    virtual void close();
 
@@ -67,7 +68,7 @@ protected:
     bool closeOnDestroy_;
     bool requirePasswordPrompt_;
 
-    std::string password_;
+    std::string password_, otp_;
     friend int core::system::conv(int num_msg,
                                   const struct pam_message** msg,
                                   struct pam_response** resp,

--- a/src/cpp/server_core/system/Pam.cpp
+++ b/src/cpp/server_core/system/Pam.cpp
@@ -81,12 +81,10 @@ int conv(int num_msg,
    try
    {
       MemoryPool pool;
-      *resp = static_cast<pam_response*>(pool.alloc(sizeof(pam_response)*num_msg));
       // resp will be freed by the caller
+      *resp = static_cast<pam_response*>(pool.alloc(sizeof(pam_response)*num_msg));
       if ( *resp==nullptr)
-      {
          return PAM_BUF_ERR;
-      }
       ::memset(*resp, 0, sizeof(pam_response)*num_msg);
 
       for (int i = 0; i < num_msg; i++)

--- a/src/cpp/server_core/system/Pam.cpp
+++ b/src/cpp/server_core/system/Pam.cpp
@@ -210,7 +210,6 @@ int PAM::login(const std::string& username,
          LOG_ERROR_MESSAGE("pam_authenticate failed: " + lastError());
       return status_;
    }
-   LOG_DEBUG_MESSAGE("After pam_authenticate");
 
    status_ = ::pam_acct_mgmt(pamh_, defaultFlags_);
    if (status_ != PAM_SUCCESS)
@@ -218,8 +217,6 @@ int PAM::login(const std::string& username,
       LOG_ERROR_MESSAGE("pam_acct_mgmt failed: " + lastError());
       return status_;
    }
-   LOG_DEBUG_MESSAGE("After pam_acct_mgmt");
-   LOG_DEBUG_MESSAGE("End of PAM::login with OTP");
 
    return PAM_SUCCESS;
 }

--- a/src/gwt/www/js/signin.js
+++ b/src/gwt/www/js/signin.js
@@ -108,6 +108,8 @@ function prepare() {
    try {
       var payload = document.getElementById('username').value + "\n" +
                     document.getElementById('password').value;
+      if (document.getElementById('otp').value !== '') 
+         payload += "\t" + document.getElementById('otp').value;
       var xhr = new XMLHttpRequest();
       var metas = document.getElementsByTagName("meta");
       var url = "";

--- a/src/gwt/www/templates/encrypted-sign-in.htm
+++ b/src/gwt/www/templates/encrypted-sign-in.htm
@@ -87,6 +87,21 @@
                 aria-required="true"
               /><br />
             </p>
+            <p>
+              <label for="otp">OTP:</label><br />
+              <input
+                type="password"
+                name="otp"
+                autocomplete="off"
+                autocorrect="off"
+                autocapitalize="off"
+                spellcheck="false"
+                value=""
+                id="otp"
+                size="45"
+                aria-required="true"
+              /><br />
+            </p>
             <div style="display: #staySignedInDisplay#">
               <input
                 type="checkbox"


### PR DESCRIPTION
### Intent

> SSSD supports enforcing OTP for some accounts. Accounts with OTP enabled will not be able to log in with traditional codes, as the password field will look different and require you to enter a password and OTP. 
> Therefore, it was necessary to modify the code.  I have raised an issue in #14044 to request a resolution of this issue.

### Approach

> We had to modify our sign-in webpages and JavaScript code to accommodate OTP input. Since the UI has changed, it's a good idea to use the code as a reference. 
> In this PR, you'll be passing a password and an OTP number that will be separated by a tab character as the password value to pass the OTP information. This way, the information will be passed safely to the PAM processing module and can be separated at the end. 
> In src/cpp/server_core/system/Pam.cpp was incorrectly using the pam_response array, and we fixed it. The existing method causes a segfault error when processing more than one message. 

### Automated Tests

> Since the code is related to login, an SSSD and an account with OTP applied are required for auto-testing. I don't think it's possible to automate it.


### QA Notes

> This PR has fixes for UI things. We raised the PR as a way to deliver the code to the core developers rather than merge it directly.


### Documentation
> This is something that needs to be discussed.

### Checklist

- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


