### PR TITLE
fix save as dialog not showing types when known file extensions are hidden (Windows)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 - Fixed an issue where the menubar would show on secondary windows if Alt key was pressed (#13973)
 - Fixed Windows installer to delete Start Menu shortcut during uninstall (#13936)
 - Fixed tooltip to show correct keyboard shortcut when hovering over URLs in the editor (#12504)
+- Fixed Save As dialog on Windows not showing Save As Type field when extensions are hidden (#12965)
 
 #### Posit Workbench
 -

--- a/src/node/desktop/src/assets/locales/en.json
+++ b/src/node/desktop/src/assets/locales/en.json
@@ -8,7 +8,8 @@
     "buttonYes": "Yes",
     "buttonNo": "No",
     "buttonQuit": "Quit",
-    "noFileSelected": "No file selected"
+    "noFileSelected": "No file selected",
+    "allFiles": "All Files"
   },
   "imgAlt": {
     "dialogQuestion": "Question Mark Icon",

--- a/src/node/desktop/src/assets/locales/fr.json
+++ b/src/node/desktop/src/assets/locales/fr.json
@@ -8,7 +8,8 @@
     "buttonYes": "Oui",
     "buttonNo": "Non",
     "buttonQuit": "Quitter",
-    "noFileSelected": "Aucun fichier sélectionné"
+    "noFileSelected": "Aucun fichier sélectionné",
+    "allFiles": "Tous les fichiers"
   },
   "imgAlt": {
     "dialogQuestion": "Icône du point d'interrogation",

--- a/src/node/desktop/src/main/gwt-callback.ts
+++ b/src/node/desktop/src/main/gwt-callback.ts
@@ -25,6 +25,7 @@ import {
   shell,
   webFrameMain,
   dialog,
+  FileFilter,
 } from 'electron';
 import { IpcMainEvent, MessageBoxOptions, OpenDialogOptions, SaveDialogOptions } from 'electron/main';
 import EventEmitter from 'events';
@@ -199,10 +200,12 @@ export class GwtCallback extends EventEmitter {
         };
         logger().logDebug(`Using path: ${saveDialogOptions.defaultPath}`);
 
+        const filters: FileFilter[] = [{ name: i18next.t('common.allFiles'), extensions: ['*'] }];
         if (defaultExtension) {
-          saveDialogOptions['filters'] = [{ name: '', extensions: [defaultExtension.replace('.', '')] }];
+          const extension = defaultExtension.replace('.', '');
+          filters.push({ name: extension, extensions: [extension] });
         }
-
+        saveDialogOptions['filters'] = filters;
         let focusedWindow = BrowserWindow.getFocusedWindow();
         if (focusOwner) {
           focusedWindow = this.getSender('desktop_open_minimal_window', event.processId, event.frameId).window;


### PR DESCRIPTION
### Intent

Addresses #12965

### Approach

The main problem is we weren't including a name for the extension filter in the Save As dialog, and when Windows is hiding known file extensions, that leaves nothing to display in the Types dropdown so it was blank.

Since we don't pass a friendly name to the save as callback, I just used the extension itself as the name.

Additionally I added the "All files (*)" filter; that should always be there in a Windows save-as dialog (it was in the Qt dialog).

Now the dialog looks like this when saving an untitled R file.

With file extensions visible in Windows:

![screenshot of save as dialog showing the types dropdown with extensions visible](https://github.com/rstudio/rstudio/assets/10569626/d2ad3fa1-4198-4144-8f04-8d4374bdc59a)

With file extensions hidden in Windows:
![screenshot of save as dialog showing the types dropdown with extensions hidden](https://github.com/rstudio/rstudio/assets/10569626/52edc916-e626-4893-af74-66efaf941cb6)

### Automated Tests

None that I'm aware of.

### QA Notes

Try saving a few different new files of varying types, with Windows file extensions visible, and again with them hidden, and make sure the types dropdown is no longer blank (and is showing expected stuff).

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


