### PR TITLE
guard against `NA` length()

### DIFF
--- a/src/cpp/session/modules/SessionEnvironment.R
+++ b/src/cpp/session/modules/SessionEnvironment.R
@@ -261,7 +261,7 @@
    srcfile <- attr(srcref, "srcfile")
    if (is.null(srcfile) || is.null(srcfile$filename))
       return("")
-   
+
    # check for absolute path in srcref
    filename <- enc2utf8(srcfile$filename)
    if (.rs.isAbsolutePath(filename))
@@ -273,7 +273,7 @@
       wd <- enc2utf8(srcfile$wd)
       filename <- paste(c(wd, filename), collapse = "/")
    }
-   
+
    normalizePath(filename, winslash = "/", mustWork = FALSE)
 })
 
@@ -963,7 +963,7 @@
 
    # Skip overly-large objects.
    n <- length(value)
-   if (n >= 10000L)
+   if (isTRUE(n >= 10000L))
       return(TRUE)
 
    # Objects containing external pointers cannot be serialized.


### PR DESCRIPTION
### Intent

User defined `length()` methods can return things other than a scalar integer. The IDE should guard against that when inspecting the environment with `isSerializable()`.

This was encountered with the IDE inspecting reticulate objects that intentionally raise an exception from `__bool__`(), and thus resetting the value presented by `reticulate::py_last_error()`



### QA Notes

`isTRUE()` was added in R 3.5. If this is an issue, we can avoid using it. 


- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [ ] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [ ] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


