### PR TITLE
use full type for ChangeListener to avoid deprecation warning on import

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/manipulator/ManipulatorControlSlider.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/plots/ui/manipulator/ManipulatorControlSlider.java
@@ -18,17 +18,16 @@ import org.rstudio.core.client.StringUtil;
 import org.rstudio.studio.client.workbench.views.plots.model.Manipulator;
 
 import com.google.gwt.json.client.JSONNumber;
-import com.google.gwt.user.client.ui.ChangeListener;
 import com.google.gwt.user.client.ui.HorizontalPanel;
 import com.google.gwt.user.client.ui.Label;
 import com.google.gwt.user.client.ui.VerticalPanel;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.widgetideas.client.SliderBar;
 
-@SuppressWarnings("deprecation")
 public class ManipulatorControlSlider extends ManipulatorControl
                                       implements SliderBar.LabelFormatter
 {
+   @SuppressWarnings("deprecation")
    public ManipulatorControlSlider(String variable, 
                                    double value,
                                    Manipulator.Slider slider,
@@ -90,8 +89,9 @@ public class ManipulatorControlSlider extends ManipulatorControl
          sliderBar_.setNumTicks(1); 
       }
       
-      // update label on change
-      sliderBar_.addChangeListener(new ChangeListener() {
+      // update label on change (using full type for ChangeListener instead of import to avoid
+      // deprecation warnings on import which aren't suppressed by @SuppressWarnings)
+      sliderBar_.addChangeListener(new com.google.gwt.user.client.ui.ChangeListener() {
          @Override
          public void onChange(Widget sender)
          {
@@ -102,7 +102,7 @@ public class ManipulatorControlSlider extends ManipulatorControl
       sliderBar_.setCurrentValue(value);
       
       // fire changed even on slide completed
-      sliderBar_.addSlideCompletedListener(new ChangeListener() {
+      sliderBar_.addSlideCompletedListener(new com.google.gwt.user.client.ui.ChangeListener() {
          @Override
          public void onChange(Widget sender)
          {


### PR DESCRIPTION
### Intent

Addresses #13962

This warning was introduced by https://github.com/rstudio/rstudio/pull/13883.

### Approach

`@SuppressWarnings("deprecation")` doesn't prevent warnings when importing a deprecated class. This source file used to use a wildcard import to avoid this (not sure if that was on purpose), but it was changed to a specific import of the deprecated class.

Switched to using the full type and moved the @SuppressWarnings("deprecation") to a narrower scope.

I did look at changing to the recommended non-deprecated API, but didn't seem worth the non-trivial change required.

### Automated Tests

None

### QA Notes

This is purely to suppress a warning message during compilation, the generated code isn't changed.

This touches the widget used for plot slider manipulator controls. If you wanted to test it, try something like this (click on the gear icon on the resulting plot to see the slider).

```R
library(manipulate)

## Create a plot with a slider
manipulate(plot(1:x), x = slider(5, 10))
```

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


