### PR TITLE
add handling for backing up existing git hooks

### DIFF
--- a/git_hooks/README.md
+++ b/git_hooks/README.md
@@ -8,9 +8,10 @@
 ## Install Hooks
 The script will copy the hooks to [.git/hooks](/.git/hooks/) and make the hooks executable.
 
-⚠️ Note that this will replace any existing hooks with the same name in your local project! ⚠️
+> [!NOTE]
+> If you have any existing hooks with the same name in your local project's [.git/hooks](/.git/hooks/) directory, they will be renamed with the current timestamp appended to the end of the file name.
 
-💡 Windows: run the commands from a `Git Bash` terminal.
+💡 Running on Windows? Run the commands from a `Git Bash` terminal.
 
 From this directory (`git_hooks`), use the commands below to make the script executable and then run [set-up-git-hooks](./set-up-git-hooks).
 
@@ -20,7 +21,6 @@ chmod +x ./set-up-git-hooks
 ```
 
 ## Uninstall Hooks
-
 Go to [.git/hooks](/.git/hooks/) and delete the file for the hook you want to uninstall.
 - eg. If you want to uninstall the `pre-commit` hook, delete the `.git/hooks/pre-commit` file.
 

--- a/git_hooks/set-up-git-hooks
+++ b/git_hooks/set-up-git-hooks
@@ -21,4 +21,4 @@ do
     chmod +x "$git_hooks_dir"/"$file_name"
 done
 
-echo "${color_highlight}Finished setting up git hooks!"
+echo "${color_highlight}Finished setting up git hooks!${color_none}"

--- a/git_hooks/set-up-git-hooks
+++ b/git_hooks/set-up-git-hooks
@@ -2,15 +2,23 @@
 
 hooks_dir="hooks"
 git_hooks_dir="../.git/hooks"
+color_highlight='\033[1;95m'
+color_none='\033[0m'
 
-echo "Setting up git hooks..."
+echo "${color_highlight}Setting up git hooks in $git_hooks_dir...${color_none}"
 
 for hook in "$hooks_dir"/*
 do
     file_name=$(basename "$hook")
-    echo "\tCopying $file_name hook to $git_hooks_dir and making it executable"
+    echo "\tCopying ${color_highlight}$file_name${color_none} hook to $git_hooks_dir and making it executable"
+    # if the pre-commit hook already exists, back up the existing one
+    if [ -f "$git_hooks_dir"/"$file_name" ]; then
+        backup_file_name="$file_name"-"$(date +%Y-%m-%d-%H-%M-%S)"
+        echo "\t\tbacking up existing $file_name as $backup_file_name"
+        mv "$git_hooks_dir"/"$file_name" "$git_hooks_dir"/"$backup_file_name"
+    fi
     cp "$hook" "$git_hooks_dir"
     chmod +x "$git_hooks_dir"/"$file_name"
 done
 
-echo "Finished setting up git hooks!"
+echo "${color_highlight}Finished setting up git hooks!"


### PR DESCRIPTION
### Intent

A pre-cursor to https://github.com/rstudio/rstudio-pro/issues/5605 to prevent git hooks installed via the `git_hooks/set-up-git-hooks` script from overwriting existing git hooks with the same name (by backing up the existing hook).

<img width="571" alt="image" src="https://github.com/rstudio/rstudio/assets/25834218/1b17d046-663f-4e3d-8d41-184016a5d52b">

### Approach

If a git hook is being installed via `git_hooks/set-up-git-hooks` script, if there is already a git hook with the same name, back up the existing hook by 

### Automated Tests

none

### QA Notes

I've tested this on my Mac, but should work the same on Linux and Windows (using Git Bash).

- expand the `.git/hooks` directory in your local rstudio project
- if you already have git hooks, you can back them up manually just in case, but running the `git_hooks/set-up-git-hooks` script should create a copy of the existing hooks (if they are the pre-commit or pre-push hooks) with the current timestamp appended

### Documentation

Updated the git hooks README to note that existing hooks are now backed up.

### Checklist

~- [ ] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md`~
~- [ ] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)~
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
~- [] This PR passes all local unit tests~

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


