### PR TITLE
add 'dependencies' section

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,7 +21,7 @@
 #### Posit Workbench
 -
 
-### Updated Dependencies
+### Dependencies
 - Updated GWT to version 2.10.0 (#11505; Desktop + Server)
 - Updated Electron to version 28.0.0 (#14055; Desktop)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,10 +2,8 @@
 
 ### New
 #### RStudio
-- Updated GWT to version 2.10.0 (#11505)
-- Updated Electron to version 28.0.0 (#14055)
 - RStudio Desktop on Windows and Linux supports auto-hiding the menu bar. (#8932)
-- The GWT code can now be built with JDKs > 11 (#11242)
+- RStudio's GWT sources can now be built with JDKs > 11 (#11242)
 - R projects can be given a custom display name in Project Options (#1909)
 
 #### Posit Workbench
@@ -22,3 +20,8 @@
 
 #### Posit Workbench
 -
+
+### Updated Dependencies
+- Updated GWT to version 2.10.0 (#11505; Desktop + Server)
+- Updated Electron to version 28.0.0 (#14055; Desktop)
+


### PR DESCRIPTION
This PR gives us a place to collect updated external dependencies in our NEWS file. This should make it easier to see at-a-glance what updates have been made, which should be useful both internally and for users of RStudio.
