### PR TITLE
avoid exception in copilot project options pane

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 - Fixed current Git branch not always showing correctly in external editor windows (#14029)
 - Fixed tooltip to show correct keyboard shortcut when hovering over URLs in the editor (#12504)
 - Fixed Save As dialog on Windows not showing Save As Type field when extensions are hidden (#12965)
+- Fixed GitHub Copilot project preferences not showing correct status message (#14064)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ui/prefs/buildtools/ProjectCopilotPreferencesPane.java
@@ -290,7 +290,15 @@ public class ProjectCopilotPreferencesPane extends ProjectPreferencesPane
             
             if (response == null)
             {
-               if (prefs_.copilotEnabled().getValue())
+               lblCopilotStatus_.setText("An unexpected error occurred while checking the status of the GitHub Copilot agent.");
+            }
+            else if (response.result == null)
+            {
+               if (response.error != null)
+               {
+                  lblCopilotStatus_.setText("An error occurred while starting the Copilot agent.");
+               }
+               else if (prefs_.copilotEnabled().getValue())
                {
                   lblCopilotStatus_.setText("The GitHub Copilot agent is not currently running.");
                }


### PR DESCRIPTION
### Intent

Addresses #14064

### Approach

The core problem was an exception being thrown in the Copilot Project Prefs pane due to trying to access a null `response.result`. This bypassed the rest of the code that would set the label.

I copied the pattern used in the Copilot Global Prefs Pane for checking this scenario. That code got out of sync with the project prefs code in #14064. I didn't port over the extra support for showing Copilot error details that were added in that PR; figure if a user is having trouble they can troubleshoot via global prefs.

### Automated Tests

None that I know of.

### QA Notes

Should now see appropriate message when viewing Project Preferences / Copilot with Copilot disabled.

### Documentation
> Specify which documentation has been added or modified and why (User Guide? Admin Guide?). If no documentation was added for a new feature, indicate why. 

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->
