### PR TITLE
allow Quarto completions in Markdown mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - Fixed tooltip to show correct keyboard shortcut when hovering over URLs in the editor (#12504)
 - Fixed Save As dialog on Windows not showing Save As Type field when extensions are hidden (#12965)
 - Fixed GitHub Copilot project preferences not showing correct status message (#14064)
+- Fixed an issue where Quarto chunk option completions were not displayed at the start of a comment (#14074)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/console/shell/assist/DelegatingCompletionManager.java
@@ -181,9 +181,10 @@ public abstract class DelegatingCompletionManager
    }
    
    private boolean isRequestingCompletionsForYamlOptions(DocumentMode.Mode mode)
-   {  
-      // only available in R and Python right now
-      if (mode != Mode.R && mode != Mode.PYTHON)
+   {
+      // available for R, Python, and Markdown
+      // inclusion of Markdown necessary for https://github.com/rstudio/rstudio/issues/14074
+      if (mode != Mode.R && mode != Mode.PYTHON && mode != Mode.MARKDOWN)
          return false;
       
       String line = docDisplay_.getCurrentLineUpToCursor(); 


### PR DESCRIPTION
### Intent

Addresses #14074.

### Approach

Changes to the way Quarto chunk options are tokenized appeared to have also modified how the document mode is inferred for YAML chunk options. As a workaround, we allow inference of a Quarto chunk context when the document mode appears to be Markdown.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14074.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
