### PR TITLE
allow more aggressive lookbehind when determining indentation in pipe

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 - Fixed tooltip to show correct keyboard shortcut when hovering over URLs in the editor (#12504)
 - Fixed Save As dialog on Windows not showing Save As Type field when extensions are hidden (#12965)
 - Fixed GitHub Copilot project preferences not showing correct status message (#14064)
+- Fixed an issue where pipes containing a large number of comments were not indented correctly (#12674)
 
 #### Posit Workbench
 -

--- a/src/gwt/acesupport/acemode/r_code_model.js
+++ b/src/gwt/acesupport/acemode/r_code_model.js
@@ -1555,10 +1555,7 @@ var RCodeModel = function(session, tokenizer,
             column: this.$getLine(row).length
          };
 
-         var prevToken = this.$findPreviousSignificantToken(
-            startPos,
-            row - 10
-         );
+         var prevToken = this.$findPreviousSignificantToken(startPos, 0);
 
          // Special case for new function definitions.
          var line = this.$session.getLine(row);


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/12674.

### Approach

Remove the previous limit when assessing the size of a comment. Note that we do something similar when looking for matching parentheses, e.g.

https://github.com/rstudio/rstudio/blob/0b4b07ffd7b94e5ff38e00ae6051d4bc5f45e101/src/gwt/acesupport/acemode/r_code_model.js#L1606-L1611
