### PR TITLE
be more permissive when parsing quarto preview URLs

### DIFF
--- a/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoJob.cpp
@@ -108,7 +108,13 @@ Error QuartoJob::start()
 
 ParsedServerLocation quartoServerLocationFromOutput(const std::string& output)
 {
-   boost::regex browseRe("http:\\/\\/localhost:(\\d{2,})\\/(web\\/viewer\\.html)?");
+   // Attempt to divine the Quarto server URL from output.
+   //
+   // Note that the URL itself might be colored via ANSI escapes;
+   // when parsing the URL path, avoid capturing those escapes.
+   //
+   // https://github.com/rstudio/rstudio/issues/14027
+   boost::regex browseRe("http:\\/\\/localhost:(\\d{2,})\\/([^\033\n]+)");
    boost::smatch match;
    if (regex_utils::search(output, match, browseRe))
    {

--- a/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
+++ b/src/cpp/session/modules/quarto/SessionQuartoPreview.cpp
@@ -259,7 +259,8 @@ private:
       }
 
       // detect browse directive
-      if (port_ == 0) {
+      if (port_ == 0)
+      {
          auto location = quartoServerLocationFromOutput(output);
          if (location.port > 0)
          {


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14027.

### Approach

Allow for arbitrary Quarto document preview paths when parsing the location from the generated quarto output.

### Automated Tests

N/A

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14027.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
