### PR TITLE
fix showing help in separate window

### DIFF
--- a/src/node/desktop/src/main/desktop-browser-window.ts
+++ b/src/node/desktop/src/main/desktop-browser-window.ts
@@ -185,8 +185,8 @@ export class DesktopBrowserWindow extends EventEmitter {
           if (match) {
             const args = [decodeURIComponent(match[2]), decodeURIComponent(match[1])];
             this.sendRpcRequest('show_vignette', args);
+            return { action: 'deny' };
           }
-          return { action: 'deny' };
         }
       }
 

--- a/version/news/NEWS-2023.12.1-ocean-storm.md
+++ b/version/news/NEWS-2023.12.1-ocean-storm.md
@@ -11,5 +11,6 @@
 - Fixed regression that prevented opening help topics in separate window (#14097)
 
 #### Posit Workbench
+- Fixed join session when ready control not responding to mouse clicks in all areas. (rstudio/rstudio-pro#5609)
 - Fixed intermittent rserver crash when joining a session started with the job launcher that is not immediately available (rstudio-pro#5579)
 - Fixed regression introduced in 2023.06 with `rstudio-server reload` where permission changed on nginx directories caused intermittent content loading errors (rstudio-pro#5636)

--- a/version/news/NEWS-2023.12.1-ocean-storm.md
+++ b/version/news/NEWS-2023.12.1-ocean-storm.md
@@ -8,6 +8,7 @@
 ### Fixed
 #### RStudio
 - Removed GitHub Copilot preview label and disclaimer in Copilot options panes (#14067)
+- Fixed regression that prevented opening help topics in separate window (#14097)
 
 #### Posit Workbench
 - Fixed intermittent rserver crash when joining a session started with the job launcher that is not immediately available (rstudio-pro#5579)


### PR DESCRIPTION
## NOTE: Targetting ocean-storm patch, but not yet approved for that. Don't merge.

### Intent

Addresses #14097 (regression in Ocean Storm).

Without this fix, you cannot open R Package help topics in a separate window, and attempting to open a data viewer in a separate window after a failed attempt to pop-out help results in a mostly blank window. There may be other symptoms, too, but this is the one I know about.

### Approach

A return statement was in the wrong place, moved it up to the right place. Was introduced by this change: https://github.com/rstudio/rstudio/pull/13754

### Automated Tests

Going to guess "no" given we missed this! It is Electron desktop-specific.

### QA Notes

See comments in issue on repro steps to try.

### Documentation

None

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


