### PR TITLE
avoid indexing large / binary files with Copilot 

### DIFF
--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -1141,6 +1141,8 @@ void indexFile(const core::FileInfo& info)
    if (error)
       return;
    
+   DLOG("Indexing document: {}", info.absolutePath());
+   
    json::Object textDocumentJson;
    textDocumentJson["uri"] = uriFromDocumentPath(documentPath.getAbsolutePath());
    textDocumentJson["languageId"] = languageId;

--- a/src/cpp/session/modules/SessionCopilot.cpp
+++ b/src/cpp/session/modules/SessionCopilot.cpp
@@ -194,12 +194,18 @@ bool isIndexableFile(const FilePath& documentPath)
    
    // Don't index R files which might contain secrets.
    std::string name = documentPath.getFilename();
-   if (name == ".Renviron" || name == "Renviron.site")
+   if (name == "Renviron.site")
       return false;
    
-   // Don't try to index SSH secrets.
+   // Don't index files within hidden folders (like .ssh)
    std::string path = documentPath.getAbsolutePath();
-   if (path.find("/.ssh/") != std::string::npos)
+   if (path.find("/.") != std::string::npos)
+      return false;
+   
+   // Don't index binary files.
+   // Perform this check last as it can be expensive; we use the 'file'
+   // utility to determine if a file is a text file as a fallback.
+   if (!module_context::isTextFile(documentPath))
       return false;
    
    return true;

--- a/version/news/NEWS-2023.12.1-ocean-storm.md
+++ b/version/news/NEWS-2023.12.1-ocean-storm.md
@@ -8,6 +8,7 @@
 ### Fixed
 #### RStudio
 - Removed GitHub Copilot preview label and disclaimer in Copilot options panes (#14067)
+- Fixed an issue where GitHub Copilot indexed binary files when project indexing enabled (#14106)
 - Fixed regression that prevented opening help topics in separate window (#14097)
 
 #### Posit Workbench


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14106.

### Approach

Avoid indexing binary / large files with Copilot.

### Automated Tests

Not included.

### QA Notes

To test, try creating a new project, and enabling both Copilot + project indexing for that project.

<img width="572" alt="Screenshot 2024-01-10 at 12 18 34 PM" src="https://github.com/rstudio/rstudio/assets/1976582/6e871485-4941-4098-9517-1db26f4d710c">

Then, run this code:

```
writeLines("COPILOT_LOG_LEVEL = 1", ".Renviron")
saveRDS(mtcars, file = "mtcars.rds")
```

Then, restart the R session. You should see something like:

```
[onStarted]: Copilot agent has started [PID = 95126]
[sendRequest]: Sending request 'initialize' with id 'cc35b6a5-f5dd-4051-81d2-d6488d0a6ed6'.
[indexFile]: Indexing document: /Users/kevin/scratch/copilot-test
[indexFile]: Indexing document: /Users/kevin/scratch/copilot-test/copilot-test.Rproj
[onBackgroundProcessing]: Invoking continuation with id 'cc35b6a5-f5dd-4051-81d2-d6488d0a6ed6'.
[sendRequest]: Sending request 'setEditorInfo' with id 'cc0672c4-ea21-47a4-bdcd-ac8762323701'.
[onBackgroundProcessing]: Invoking continuation with id 'cc0672c4-ea21-47a4-bdcd-ac8762323701'.
```

But most importantly, you should _not_ see any indication that `mtcars.rds` is being indexed.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
