### PR TITLE
improve handling of missing / empty workbench lists

### DIFF
--- a/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
+++ b/src/gwt/src/org/rstudio/core/client/layout/DualWindowLayoutPanel.java
@@ -14,11 +14,12 @@
  */
 package org.rstudio.core.client.layout;
 
-import com.google.gwt.core.client.JavaScriptObject;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.gwt.user.client.Window;
-import com.google.gwt.user.client.ui.*;
+import static org.rstudio.core.client.layout.WindowState.EXCLUSIVE;
+import static org.rstudio.core.client.layout.WindowState.HIDE;
+import static org.rstudio.core.client.layout.WindowState.MAXIMIZE;
+import static org.rstudio.core.client.layout.WindowState.MINIMIZE;
+import static org.rstudio.core.client.layout.WindowState.NORMAL;
+
 import org.rstudio.core.client.Debug;
 import org.rstudio.core.client.HandlerRegistrations;
 import org.rstudio.core.client.events.EnsureHeightEvent;
@@ -32,7 +33,18 @@ import org.rstudio.studio.client.workbench.model.ClientState;
 import org.rstudio.studio.client.workbench.model.Session;
 import org.rstudio.studio.client.workbench.model.helper.JSObjectStateValue;
 
-import static org.rstudio.core.client.layout.WindowState.*;
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.ui.ProvidesResize;
+import com.google.gwt.user.client.ui.RequiresResize;
+import com.google.gwt.user.client.ui.SimplePanel;
+import com.google.gwt.user.client.ui.SplitterBeforeResizeEvent;
+import com.google.gwt.user.client.ui.SplitterBeforeResizeHandler;
+import com.google.gwt.user.client.ui.SplitterResizedEvent;
+import com.google.gwt.user.client.ui.SplitterResizedHandler;
+import com.google.gwt.user.client.ui.Widget;
 
 
 /**
@@ -61,17 +73,23 @@ public class DualWindowLayoutPanel extends SimplePanel
 
       public int getContainerHeight(int defaultValue)
       {
-         assert defaultValue > 0;
          if (containerHeight_ == null)
+         {
+            assert defaultValue > 0;
             containerHeight_ = defaultValue;
+         }
+         
          return containerHeight_.intValue();
       }
 
       public int getWindowHeight(int defaultValue)
       {
-         assert defaultValue > 0;
          if (windowHeight_ == null)
+         {
+            assert defaultValue > 0;
             windowHeight_ = defaultValue;
+         }
+         
          return windowHeight_.intValue();
       }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchLists.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/WorkbenchLists.java
@@ -34,7 +34,7 @@ public class WorkbenchLists extends JavaScriptObject
    
   
    private native final JsArrayString getListNative(String name) /*-{
-      return this[name];
+      return this[name] || [];
    }-*/;
    
    private ArrayList<String> convertList(JsArrayString jsList)


### PR DESCRIPTION
I'm currently getting a "blank screen" on startup due to errors when trying to read workbench lists. This PR makes the IDE startup a bit more permissive, so we can handle the case where a particular workbench list is missing.

I'm not sure if we should be logging or reporting if this happens? I am a bit worried that this might be masking a different sort of error.

<img width="2032" alt="Screenshot 2024-01-10 at 2 00 09 PM" src="https://github.com/rstudio/rstudio/assets/1976582/48f14f08-0ceb-4707-9493-ccf3d573e3ce">
