### PR TITLE
avoid listing files in directory when opening a file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,7 @@
 - Fixed GitHub Copilot project preferences not showing correct status message (#14064)
 - Fixed an issue where Quarto chunk option completions were not displayed at the start of a comment (#14074)
 - Fixed an issue where pipes containing a large number of comments were not indented correctly (#12674)
+- Fixed an issue where RStudio would unnecessarily list directory contents when opening a file (#14096)
 
 #### Posit Workbench
 -

--- a/src/gwt/src/org/rstudio/core/client/files/FileSystemContext.java
+++ b/src/gwt/src/org/rstudio/core/client/files/FileSystemContext.java
@@ -48,6 +48,12 @@ public interface FileSystemContext
     * @param relativeOrAbsolutePath
     */
    void cd(String relativeOrAbsolutePath);
+   
+   /**
+    * Like the above, but only sets the working directory; does not attempt
+    * to list file contents.
+    */
+   void setwd(String relativeOrAbsolutePath);
 
    /**
     * Get the contents of the current directory

--- a/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
+++ b/src/gwt/src/org/rstudio/studio/client/common/impl/DesktopFileDialogs.java
@@ -14,11 +14,6 @@
  */
 package org.rstudio.studio.client.common.impl;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.core.client.Scheduler;
-import com.google.gwt.core.client.Scheduler.ScheduledCommand;
-import com.google.inject.Inject;
-
 import org.rstudio.core.client.CommandWithArg;
 import org.rstudio.core.client.StringUtil;
 import org.rstudio.core.client.files.FileSystemContext;
@@ -33,6 +28,11 @@ import org.rstudio.studio.client.common.StudioClientCommonConstants;
 import org.rstudio.studio.client.server.ServerError;
 import org.rstudio.studio.client.server.ServerRequestCallback;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.inject.Inject;
 
 public class DesktopFileDialogs implements FileDialogs
 {
@@ -313,10 +313,9 @@ public class DesktopFileDialogs implements FileDialogs
    {
       if (fileName != null)
       {
-         String parentPath =
-               FileSystemItem.createFile(fileName).getParentPathString();
+         String parentPath = FileSystemItem.createFile(fileName).getParentPathString();
          if (!StringUtil.isNullOrEmpty(parentPath))
-            fsContext.cd(parentPath);
+            fsContext.setwd(parentPath);
       }
    }
 

--- a/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/model/RemoteFileSystemContext.java
@@ -14,8 +14,8 @@
  */
 package org.rstudio.studio.client.workbench.model;
 
-import com.google.gwt.core.client.JsArray;
-import com.google.inject.Inject;
+import java.util.ArrayList;
+
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.files.FileSystemItem;
 import org.rstudio.core.client.files.PosixFileSystemContext;
@@ -29,7 +29,8 @@ import org.rstudio.studio.client.server.Void;
 import org.rstudio.studio.client.workbench.views.files.model.DirectoryListing;
 import org.rstudio.studio.client.workbench.views.files.model.FilesServerOperations;
 
-import java.util.ArrayList;
+import com.google.gwt.core.client.JsArray;
+import com.google.inject.Inject;
 
 public class RemoteFileSystemContext extends PosixFileSystemContext
 {
@@ -49,6 +50,14 @@ public class RemoteFileSystemContext extends PosixFileSystemContext
    public MessageDisplay messageDisplay()
    {
       return globalDisplay_;
+   }
+   
+   public void setwd(String relativeOrAbsolutePath)
+   {
+      workingDir_ = combine(pwd(), relativeOrAbsolutePath);
+      contents_ = null;
+      if (callbacks_ != null)
+         callbacks_.onNavigated();
    }
 
    public void cd(String relativeOrAbsolutePath)

--- a/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
+++ b/src/gwt/src/org/rstudio/studio/client/workbench/views/files/ui/FilePathToolbar.java
@@ -14,11 +14,9 @@
  */
 package org.rstudio.studio.client.workbench.views.files.ui;
 
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.dom.client.Style.Unit;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.user.client.ui.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+
 import org.rstudio.core.client.ElementIds;
 import org.rstudio.core.client.MessageDisplay;
 import org.rstudio.core.client.StringUtil;
@@ -35,8 +33,14 @@ import org.rstudio.studio.client.common.filetypes.FileIcon;
 import org.rstudio.studio.client.workbench.views.files.Files;
 import org.rstudio.studio.client.workbench.views.files.FilesConstants;
 
-import java.util.ArrayList;
-import java.util.Arrays;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Style.Unit;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.user.client.ui.Composite;
+import com.google.gwt.user.client.ui.LayoutPanel;
+import com.google.gwt.user.client.ui.ProvidesResize;
+import com.google.gwt.user.client.ui.RequiresResize;
 
 public class FilePathToolbar extends Composite
       implements RequiresResize, ProvidesResize
@@ -46,6 +50,11 @@ public class FilePathToolbar extends Composite
       public MessageDisplay messageDisplay()
       {
          return RStudioGinjector.INSTANCE.getGlobalDisplay();
+      }
+      
+      public void setwd(String relativeOrAbsolutePath)
+      {
+         cd(relativeOrAbsolutePath);
       }
 
       public void cd(String relativeOrAbsolutePath)


### PR DESCRIPTION
### Intent

Addresses https://github.com/rstudio/rstudio/issues/14096.

### Approach

We have a file system context class, which tries to maintain a working directory + the contents of that directory. I suspect the latter is primarily used for the Files pane; however, because that class is apparently shared in a couple places (e.g. preserving the default directory to be used when opening files) we end up unnecessarily listing files in the directory hosting the file we're opening.

The fix here is fairly narrow; in desktop file dialogs, when we open a document, we define and use a separate helper called `setwd()` rather than `cd()`, and allow `setwd()` to do less work.

An alternate fix would be to defer listing of a directory's contents until `ls()` itself is actually called. That might be preferable, but that also feels like a relatively more dangerous change as it would affect more existing code paths.

### Automated Tests

Not included.

### QA Notes

Test via notes in https://github.com/rstudio/rstudio/issues/14096.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests
