### PR TITLE
fix display issue with project folders containing periods in name

### DIFF
--- a/src/gwt/src/org/rstudio/studio/client/projects/ProjectMRUList.java
+++ b/src/gwt/src/org/rstudio/studio/client/projects/ProjectMRUList.java
@@ -134,7 +134,15 @@ public class ProjectMRUList extends MRUList
          mruPaths.add(mruEntry.getProjectFilePath());
          mruNames.add(StringUtil.notNull(mruEntry.getProjectName()));
       }
-      mruPaths = DuplicateHelper.getPathLabels(mruPaths, includeExt);
+      // Before the project naming feature was added, this generateLabels() method consisted 
+      // of a single of code:
+      //
+      //   return DuplicateHelper.getPathLabels(mruEntries, true);
+      //
+      // Note that it hardcoded true for the "includeExtensions" parameter and did not use
+      // the value of the "includeExt" parameter. Also have to do that here to avoid
+      // https://github.com/rstudio/rstudio/issues/14107.
+      mruPaths = DuplicateHelper.getPathLabels(mruPaths, true);
       
       // recombine paths and names for display
       ArrayList<String> result = new ArrayList<String>();


### PR DESCRIPTION
### Intent

Addresses #14107

### Approach

The culprit was ProjectMRUList.generateLabels(). Before project naming feature:

```java
   protected ArrayList<String> generateLabels(ArrayList<String> mruEntries, boolean includeExt)
   {
      return DuplicateHelper.getPathLabels(mruEntries, true);
   }
```

Note that it never used the `includeExt` parameter (which comes in as `false`), and passed `true` to `getPathLabels`' second parameter (which is also `includeExt`).

When I modified this method I started passing `includeExt` instead of hardcoding `true` and this caused it to strip anything after the final period.

So the fix was to change it back to `true`.

### Automated Tests

None

### QA Notes

Try creating a project in a folder that has periods in the name and confirm that the full name shows in the project dropdown, the mru list, and the titlebar / browser tab.

### Documentation

N/A

### Checklist

- [x] If this PR adds a new feature, or fixes a bug in a previously released version, it includes an entry in `NEWS.md` 
- [x] If this PR adds or changes UI, the updated UI meets [accessibility standards](https://github.com/rstudio/rstudio/wiki/Accessibility)
- [x] A reviewer is assigned to this PR (if unsure who to assign, check Area Owners list)
- [x] This PR passes all local unit tests

<!-- Note for community contributors: Please sign our contributor agreement as described in CONTRIBUTING.md and note that you've done so in this space. Very much appreciate your contributions and support! -->


